### PR TITLE
XQuery optimizer fails on several types of expressions

### DIFF
--- a/build/scripts/junit.xml
+++ b/build/scripts/junit.xml
@@ -130,6 +130,7 @@
             <!--test fork="yes" name="xquery.xmlcalabash.XMLCalabashTests" todir="${junit.reports.dat}"/-->
             <!--test fork="yes" name="xquery.xproc.XProcTests" todir="${junit.reports.dat}"/-->
             <test fork="yes" name="xquery.xquery3.XQuery3Tests" todir="${junit.reports.dat}"/>
+            <test fork="yes" name="xquery.optimizer.OptimizerTests" todir="${junit.reports.dat}"/>
 
             <!--  //-->            
             <test fork="yes" name="org.exist.util.SortTests" todir="${junit.reports.dat}"/>

--- a/src/org/exist/xquery/AttributeConstructor.java
+++ b/src/org/exist/xquery/AttributeConstructor.java
@@ -181,4 +181,9 @@ public class AttributeConstructor extends NodeConstructor {
     public Iterator<Object> contentIterator() {
         return contents.iterator();
     }
+
+    @Override
+    public void accept(ExpressionVisitor visitor) {
+        visitor.visitAttribConstructor(this);
+    }
 }

--- a/src/org/exist/xquery/DefaultExpressionVisitor.java
+++ b/src/org/exist/xquery/DefaultExpressionVisitor.java
@@ -111,6 +111,11 @@ public class DefaultExpressionVisitor extends BasicExpressionVisitor {
     
     public void visitElementConstructor(ElementConstructor constructor) {
         constructor.getNameExpr().accept(this);
+        if (constructor.getAttributes() != null) {
+            for (AttributeConstructor attrConstr: constructor.getAttributes()) {
+                attrConstr.accept(this);
+            }
+        }
         if (constructor.getContent() != null)
             {constructor.getContent().accept(this);}
     }
@@ -146,5 +151,13 @@ public class DefaultExpressionVisitor extends BasicExpressionVisitor {
     @Override
     public void visitVariableDeclaration(VariableDeclaration decl) {
     	decl.getExpression().accept(this);
+    }
+
+    @Override
+    public void visitTryCatch(TryCatchExpression tryCatch) {
+        tryCatch.getTryTargetExpr().accept(this);
+        for (TryCatchExpression.CatchClause clause : tryCatch.getCatchClauses()) {
+            clause.getCatchExpr().accept(this);
+        }
     }
 }

--- a/src/org/exist/xquery/ElementConstructor.java
+++ b/src/org/exist/xquery/ElementConstructor.java
@@ -70,6 +70,10 @@ public class ElementConstructor extends NodeConstructor {
     public PathExpr getContent() {
         return content;
     }
+
+    public AttributeConstructor[] getAttributes() {
+        return attributes;
+    }
     
     public void setNameExpr(Expression expr) {
 		//Deferred atomization (we could have a QNameValue)

--- a/src/org/exist/xquery/SwitchExpression.java
+++ b/src/org/exist/xquery/SwitchExpression.java
@@ -163,6 +163,7 @@ public class SwitchExpression extends AbstractExpression {
         for (final Case next : cases) {
             next.returnClause.accept(visitor);
         }
+        defaultClause.returnClause.accept(visitor);
     }
 
     public void resetState(boolean postOptimization) {

--- a/src/org/exist/xquery/TypeswitchExpression.java
+++ b/src/org/exist/xquery/TypeswitchExpression.java
@@ -187,6 +187,7 @@ public class TypeswitchExpression extends AbstractExpression {
         for (final Case next : cases) {
             next.returnClause.accept(visitor);
         }
+        defaultClause.returnClause.accept(visitor);
     }
 
     public void setContextDocSet(DocumentSet contextSet) {

--- a/src/org/exist/xquery/functions/map/MapExpr.java
+++ b/src/org/exist/xquery/functions/map/MapExpr.java
@@ -52,6 +52,15 @@ public class MapExpr extends AbstractExpression {
         return Type.MAP;
     }
 
+    @Override
+    public void accept(ExpressionVisitor visitor) {
+        super.accept(visitor);
+        for (final Mapping mapping: this.mappings) {
+            mapping.key.accept(visitor);
+            mapping.value.accept(visitor);
+        }
+    }
+
     public void dump(ExpressionDumper dumper) {
         dumper.display("map {");
         for (final Mapping mapping : this.mappings) {

--- a/src/org/exist/xquery/functions/system/FunctionTrace.java
+++ b/src/org/exist/xquery/functions/system/FunctionTrace.java
@@ -98,6 +98,7 @@ public class FunctionTrace extends BasicFunction {
             
         } else {
         	logger.info("Entering the " + SystemModule.PREFIX + ":trace XQuery function");
+            context.getProfiler().reset();
             final MemTreeBuilder builder = context.getDocumentBuilder();
 
             builder.startDocument();

--- a/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -18,6 +18,8 @@ xquery version "3.0";
  :)
 module namespace test="http://exist-db.org/xquery/xqsuite";
 
+declare namespace stats="http://exist-db.org/xquery/profiling";
+
 declare variable $test:TEST_NAMESPACE := "http://exist-db.org/xquery/xqsuite";
 
 declare variable $test:UNKNOWN_ASSERTION := QName($test:TEST_NAMESPACE, "no-such-assertion");
@@ -165,6 +167,17 @@ declare %private function test:test($func as function(*), $meta as element(funct
             ()
 };
 
+declare function test:enable-tracing($meta as element(function)) {
+    let $statsAnno := $meta//annotation[contains(@name, ":stats")]
+    return
+        if (exists($statsAnno)) then (
+            system:clear-trace(),
+            system:enable-tracing(true(), false()),
+            true()
+        ) else
+            false()
+};
+
 (:~
  : Get all %assertXXX annotations of the function. If %args is used multiple times,
  : assertions apply to the result of running the function with the parameters given
@@ -303,8 +316,9 @@ declare %private function test:cast($targs as xs:string*, $farg as element(argum
 };
 
 declare function test:apply($func as function(*), $meta as element(function), $args as item()*) {
+    let $trace := test:enable-tracing($meta)
     let $userAnno := $meta/annotation[contains(@name, ":user")]
-    return
+    let $result :=
         if ($userAnno) then
             let $user := $userAnno/value[1]/string()
             let $pass := $userAnno/value[2]/string()
@@ -312,6 +326,17 @@ declare function test:apply($func as function(*), $meta as element(function), $a
                 system:as-user($user, $pass, test:apply($func, $args))
         else
             test:apply($func, $args)
+    return
+        if ($trace) then
+            (: Get trace output and filter out stats :)
+            let $traceOutput :=
+                (system:trace(), system:clear-trace(), system:enable-tracing(false()))
+            return
+                element { node-name($traceOutput) } {
+                    $traceOutput/stats:*[not(starts-with(@source, "org.exist") or contains(@source, "xqsuite.xql"))]
+                }
+        else
+            $result
 };
 
 (:~

--- a/test/src/xquery/optimizer/OptimizerTests.java
+++ b/test/src/xquery/optimizer/OptimizerTests.java
@@ -1,0 +1,14 @@
+package xquery.optimizer;
+
+import xquery.TestRunner;
+
+/**
+ * XQuery optimizer tests
+ */
+public class OptimizerTests extends TestRunner {
+
+    @Override
+    protected String getDirectory() {
+        return "test/src/xquery/optimizer";
+    }
+}

--- a/test/src/xquery/optimizer/optimizer.xql
+++ b/test/src/xquery/optimizer/optimizer.xql
@@ -1,0 +1,375 @@
+xquery version "3.0";
+
+(:~
+ : Test all kinds of XQuery expressions to see if optimizer does properly 
+ : analyze them and indexes are used in fully optimized manner.
+ : 
+ : Expressions use the @test:stats annotation to retrieve execution statistics
+ : for each test function.
+ :)
+module namespace ot="http://exist-db.org/xquery/optimizer/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace stats="http://exist-db.org/xquery/profiling";
+
+declare variable $ot:COLLECTION_CONFIG := 
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <fulltext default="none" attributes="false"/>
+            <create qname="name" type="xs:string"/>
+        </index>
+    </collection>;
+
+declare variable $ot:DATA :=
+    <test>
+        <address id="muh">
+            <name>Berta Muh</name>
+            <street>Wiesenweg 14</street>
+            <city code="65463">Almweide</city>
+        </address>
+        <address id="rüssel">
+            <name>Rudi Rüssel</name>
+            <street>Elefantenweg 67</street>
+            <city code="65428">Rüsselsheim</city>
+        </address>
+        <address id="amsel">
+            <name>Albert Amsel</name>
+            <street>Birkenstraße 77</street>
+            <city code="76878">Waldstadt</city>
+        </address>
+        <address id="reh">
+            <name>Pü Reh</name>
+            <street>Am Waldrand 4</street>
+            <city code="89283">Wiesental</city>
+        </address>
+    </test>;
+
+declare variable $ot:COLLECTION_NAME := "optimizertest";
+declare variable $ot:COLLECTION := "/db/" || $ot:COLLECTION_NAME;
+
+declare
+    %test:setUp
+function ot:setup() {
+    xmldb:create-collection("/db/system/config/db", $ot:COLLECTION_NAME),
+    xmldb:store("/db/system/config/db/" || $ot:COLLECTION_NAME, "collection.xconf", $ot:COLLECTION_CONFIG),
+    xmldb:create-collection("/db", $ot:COLLECTION_NAME),
+    xmldb:store($ot:COLLECTION, "test.xml", $ot:DATA)
+};
+
+declare
+    %test:tearDown
+function ot:cleanup() {
+    xmldb:remove($ot:COLLECTION),
+    xmldb:remove("/db/system/config/db/" || $ot:COLLECTION_NAME)
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-simple-comparison($name as xs:string) {
+    collection($ot:COLLECTION)//address[name = $name]/city/text()
+};
+
+declare
+    %test:stats
+    %test:args("Rüsselsheim")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 0]")
+function ot:no-optimize-simple-comparison($name as xs:string) {
+    collection($ot:COLLECTION)//address[city = $name]/city/text()
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-sequence($name as xs:string) {
+    (collection($ot:COLLECTION)//address[name = $name]/city/text(), "xxx")
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-let($name as xs:string) {
+    let $city := collection($ot:COLLECTION)//address[name = $name]/city/text()
+    return
+        $city
+};
+
+declare
+    %test:stats
+    %test:args("Rüsselsheim")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 0]")
+function ot:no-optimize-let($name as xs:string) {
+    let $city := collection($ot:COLLECTION)//address[city = $name]/city/text()
+    return
+        $city
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-for($name as xs:string) {
+    for $city in collection($ot:COLLECTION)//address[name = $name]/city/text()
+    return
+        $city
+};
+
+declare
+    %test:stats
+    %test:args("Rüsselsheim")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 0]")
+function ot:no-optimize-for($name as xs:string) {
+    for $city in collection($ot:COLLECTION)//address[city = $name]/city/text()
+    return
+        $city
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-if-then($name as xs:string) {
+    if (1 = 1) then
+        collection($ot:COLLECTION)//address[name = $name]/city/text()
+    else
+        ()
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-if-else($name as xs:string) {
+    if (1 = 2) then
+        ()
+    else
+        collection($ot:COLLECTION)//address[name = $name]/city/text()
+};
+
+declare %private function ot:find-by-name($name as xs:string) {
+    collection($ot:COLLECTION)//address[name = $name]/city/text()
+};
+
+declare %private function ot:find-by-city($name as xs:string) {
+    collection($ot:COLLECTION)//address[city = $name]/city/text()
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-function-call($name as xs:string) {
+    ot:find-by-name($name)
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:no-optimize-function-call($name as xs:string) {
+    ot:find-by-name($name)
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-try($name as xs:string) {
+    try {
+        collection($ot:COLLECTION)//address[name = $name]/city/text()
+    } catch * {
+        ()
+    }
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-catch($name as xs:string) {
+    try {
+        xs:int("abc")
+    } catch * {
+        collection($ot:COLLECTION)//address[name = $name]/city/text()
+    }
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-attribute-enclosed($name as xs:string) {
+    <a title="{collection($ot:COLLECTION)//address[name = $name]/city/text()}"></a>
+};
+
+declare
+    %test:stats
+    %test:args("Rüsselsheim")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 0]")
+function ot:no-optimize-attribute-enclosed($name as xs:string) {
+    <a title="{collection($ot:COLLECTION)//address[city = $name]/city/text()}"></a>
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-element-enclosed($name as xs:string) {
+    <a>{collection($ot:COLLECTION)//address[name = $name]/city/text()}</a>
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-element-dynamic-enclosed($name as xs:string) {
+    element a {
+        collection($ot:COLLECTION)//address[name = $name]/city/text()
+    }
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-attribute-dynamic-enclosed($name as xs:string) {
+    <a>
+    {
+        attribute title {
+            collection($ot:COLLECTION)//address[name = $name]/city/text()
+        }
+    }
+    </a>
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-inline-function($name as xs:string) {
+    let $f := function() {
+        collection($ot:COLLECTION)//address[name = $name]/city/text()
+    }
+    return
+        $f()
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-inline-function-enclosed-attribute($name as xs:string) {
+    let $f := function() {
+        collection($ot:COLLECTION)//address[name = $name]/city/text()
+    }
+    return
+        <a title="{$f()}"></a>
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-inline-function-enclosed($name as xs:string) {
+    let $f := function() {
+        collection($ot:COLLECTION)//address[name = $name]/city/text()
+    }
+    return
+        <a>{$f()}</a>
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-function-reference($name as xs:string) {
+    let $f := ot:find-by-name#1
+    return
+        $f($name)
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-function-map($name as xs:string) {
+    let $f := ot:find-by-name#1
+    return
+        map($f, $name)
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-function-partial($name as xs:string) {
+    let $f1 := function($foo, $name) {
+        ot:find-by-name($name)
+    }
+    let $f2 := $f1("xxx", ?)
+    return
+        $f2($name)
+};
+
+declare
+    %test:stats
+    %test:args(1, "Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+    %test:args(2, "Rüsselsheim")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 0]")
+    %test:args(3, "Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-switch($case as xs:int, $name as xs:string) {
+    switch($case)
+        case 1 return
+            collection($ot:COLLECTION)//address[name = $name]/city/text()
+        case 2 return
+            collection($ot:COLLECTION)//address[city = $name]/city/text()
+        default return
+            collection($ot:COLLECTION)//address[name = $name]/city/text()
+};
+
+declare
+    %test:stats
+    %test:args("<a/>", "Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+    %test:args("<b/>", "Rüsselsheim")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 0]")
+    %test:args("<c/>", "Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-typeswitch($case as element(), $name as xs:string) {
+    typeswitch($case)
+        case element(a) return
+            collection($ot:COLLECTION)//address[name = $name]/city/text()
+        case element(b) return
+            collection($ot:COLLECTION)//address[city = $name]/city/text()
+        default return
+            collection($ot:COLLECTION)//address[name = $name]/city/text()
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-map($name as xs:string) {
+    let $map := map {
+        "key" := collection($ot:COLLECTION)//address[name = $name]/city/text()
+    }
+    return
+        $map("key")
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-map-entry($name as xs:string) {
+    let $map := map:entry(
+        "key", collection($ot:COLLECTION)//address[name = $name]/city/text()
+    )
+    return
+        $map("key")
+};

--- a/test/src/xquery/optimizer/suite.xql
+++ b/test/src/xquery/optimizer/suite.xql
@@ -1,0 +1,7 @@
+xquery version "3.0";
+
+import module namespace test="http://exist-db.org/xquery/xqsuite" 
+at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+import module namespace ot="http://exist-db.org/xquery/optimizer/test" at "optimizer.xql";
+
+test:suite(util:list-functions("http://exist-db.org/xquery/optimizer/test"))


### PR DESCRIPTION
XQuery optimizer fails to properly analyze: 
- enclosed expressions in attributes
- default clause in switch and typeswitch
- try and catch clause in try/catch
- map constructor

This may lead to a massive performance loss for some complex queries. Added tests for all relevant XQuery expression types to make sure the optimizer analyzes them properly.
