### PR TITLE
[feature] Added support for XQuery 3.0 computed namespace constructor.

### DIFF
--- a/src/org/exist/memtree/DocumentImpl.java
+++ b/src/org/exist/memtree/DocumentImpl.java
@@ -1104,6 +1104,9 @@ public class DocumentImpl extends NodeImpl implements DocumentAtExist {
             final String data = new String(document.characters, document.alpha[nr], document.alphaLen[nr]);
             receiver.processingInstruction(qn.getLocalName(), data);
             break;
+        case NodeImpl.NAMESPACE_NODE:
+            receiver.addNamespaceNode(document.namespaceCode[nr]);
+            break;
         case NodeImpl.REFERENCE_NODE:
             if (expandRefs) {
                 DBBroker broker = null;

--- a/src/org/exist/memtree/MemTreeBuilder.java
+++ b/src/org/exist/memtree/MemTreeBuilder.java
@@ -446,13 +446,18 @@ public class MemTreeBuilder
     public int namespaceNode( QName qn )
     {
         final int    lastNode   = doc.getLastNode();
-        final QName  elemQN     = doc.nodeName[lastNode];
-        final String elemPrefix = ( elemQN.getPrefix() == null ) ? "" : elemQN.getPrefix();
+        boolean addNode = true;
+        if (doc.nodeName != null) {
+            final QName  elemQN     = doc.nodeName[lastNode];
+            if (elemQN != null) {
+                final String elemPrefix = ( elemQN.getPrefix() == null ) ? "" : elemQN.getPrefix();
 
-        if( elemPrefix.equals( qn.getLocalName() ) && ( elemQN.getNamespaceURI() != null ) && !elemQN.getNamespaceURI().equals( qn.getNamespaceURI() ) ) {
-            return( -1 );
+                if( elemPrefix.equals( qn.getLocalName() ) && ( elemQN.getNamespaceURI() != null ) && !elemQN.getNamespaceURI().equals( qn.getNamespaceURI() ) ) {
+                    addNode = false;
+                }
+            }
         }
-        return( doc.addNamespace( lastNode, qn ) );
+        return( addNode ? doc.addNamespace( lastNode, qn ) : -1 );
     }
 
 

--- a/src/org/exist/memtree/NamespaceNode.java
+++ b/src/org/exist/memtree/NamespaceNode.java
@@ -65,7 +65,7 @@ public class NamespaceNode extends NodeImpl implements Attr, QNameable
         //XQuery doesn't support namespace nodes
         //so, mapping as an attribute at *serialization tile*  makes sense
         //however, the Query parser should not accept them in constructors !
-        return( Node.ATTRIBUTE_NODE );
+        return( NodeImpl.NAMESPACE_NODE);
     }
 
 
@@ -142,6 +142,15 @@ public class NamespaceNode extends NodeImpl implements Attr, QNameable
     {
     }
 
+    @Override
+    public Node getFirstChild() {
+        return null;
+    }
+
+    @Override
+    public Node getLastChild() {
+        return null;
+    }
 
     public String getNodeValue() throws DOMException
     {

--- a/src/org/exist/xquery/parser/XQueryLexer.java
+++ b/src/org/exist/xquery/parser/XQueryLexer.java
@@ -2331,17 +2331,17 @@ tryAgain:
 		int _saveIndex;
 		
 		{
-		int _cnt546=0;
-		_loop546:
+		int _cnt541=0;
+		_loop541:
 		do {
 			if ((_tokenSet_2.member(LA(1)))) {
 				mDIGIT(false);
 			}
 			else {
-				if ( _cnt546>=1 ) { break _loop546; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt541>=1 ) { break _loop541; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt546++;
+			_cnt541++;
 		} while (true);
 		}
 		if ( _createToken && _token==null && _ttype!=Token.SKIP ) {
@@ -2482,8 +2482,8 @@ tryAgain:
 		int _saveIndex;
 		
 		{
-		int _cnt549=0;
-		_loop549:
+		int _cnt544=0;
+		_loop544:
 		do {
 			switch ( LA(1)) {
 			case '0':  case '1':  case '2':  case '3':
@@ -2507,10 +2507,10 @@ tryAgain:
 			}
 			default:
 			{
-				if ( _cnt549>=1 ) { break _loop549; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt544>=1 ) { break _loop544; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
 			}
 			}
-			_cnt549++;
+			_cnt544++;
 		} while (true);
 		}
 		if ( _createToken && _token==null && _ttype!=Token.SKIP ) {
@@ -3234,13 +3234,13 @@ tryAgain:
 		
 		mNMSTART(false);
 		{
-		_loop556:
+		_loop551:
 		do {
 			if ((_tokenSet_5.member(LA(1)))) {
 				mNMCHAR(false);
 			}
 			else {
-				break _loop556;
+				break _loop551;
 			}
 			
 		} while (true);
@@ -3259,8 +3259,8 @@ tryAgain:
 		int _saveIndex;
 		
 		{
-		int _cnt559=0;
-		_loop559:
+		int _cnt554=0;
+		_loop554:
 		do {
 			if ((LA(1)==' ') && (true) && (true) && (true)) {
 				match(' ');
@@ -3278,10 +3278,10 @@ tryAgain:
 				match('\r');
 			}
 			else {
-				if ( _cnt559>=1 ) { break _loop559; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt554>=1 ) { break _loop554; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt559++;
+			_cnt554++;
 		} while (true);
 		}
 		if ( _createToken && _token==null && _ttype!=Token.SKIP ) {
@@ -3298,10 +3298,10 @@ tryAgain:
 		
 		match("(:~");
 		{
-		_loop563:
+		_loop558:
 		do {
 			// nongreedy exit test
-			if ((LA(1)==':') && (LA(2)==')') && (true)) break _loop563;
+			if ((LA(1)==':') && (LA(2)==')') && (true)) break _loop558;
 			if (((LA(1) >= '\u0003' && LA(1) <= '\ufffe')) && ((LA(2) >= '\u0003' && LA(2) <= '\ufffe')) && ((LA(3) >= '\u0003' && LA(3) <= '\ufffe'))) {
 				{
 				if ((LA(1)=='(') && (LA(2)==':') && ((LA(3) >= '\u0003' && LA(3) <= '\ufffe')) && ((LA(4) >= '\u0003' && LA(4) <= '\ufffe'))) {
@@ -3317,7 +3317,7 @@ tryAgain:
 				}
 			}
 			else {
-				break _loop563;
+				break _loop558;
 			}
 			
 		} while (true);
@@ -3337,10 +3337,10 @@ tryAgain:
 		
 		match("(:");
 		{
-		_loop567:
+		_loop562:
 		do {
 			// nongreedy exit test
-			if ((LA(1)==':') && (LA(2)==')') && (true) && (true)) break _loop567;
+			if ((LA(1)==':') && (LA(2)==')') && (true) && (true)) break _loop562;
 			if (((LA(1) >= '\u0003' && LA(1) <= '\ufffe')) && ((LA(2) >= '\u0003' && LA(2) <= '\ufffe')) && ((LA(3) >= '\u0003' && LA(3) <= '\ufffe')) && (true)) {
 				{
 				if ((LA(1)=='(') && (LA(2)==':') && ((LA(3) >= '\u0003' && LA(3) <= '\ufffe')) && ((LA(4) >= '\u0003' && LA(4) <= '\ufffe'))) {
@@ -3356,7 +3356,7 @@ tryAgain:
 				}
 			}
 			else {
-				break _loop567;
+				break _loop562;
 			}
 			
 		} while (true);
@@ -3407,13 +3407,13 @@ tryAgain:
 			{
 				match('.');
 				{
-				_loop575:
+				_loop570:
 				do {
 					if ((_tokenSet_2.member(LA(1)))) {
 						mDIGIT(false);
 					}
 					else {
-						break _loop575;
+						break _loop570;
 					}
 					
 				} while (true);
@@ -3501,13 +3501,13 @@ tryAgain:
 			if ((LA(1)=='.')) {
 				match('.');
 				{
-				_loop583:
+				_loop578:
 				do {
 					if ((_tokenSet_2.member(LA(1)))) {
 						mDIGIT(false);
 					}
 					else {
-						break _loop583;
+						break _loop578;
 					}
 					
 				} while (true);
@@ -3615,7 +3615,7 @@ tryAgain:
 			match('"');
 			text.setLength(_saveIndex);
 			{
-			_loop593:
+			_loop588:
 			do {
 				if ((LA(1)=='&') && (LA(2)=='a'||LA(2)=='g'||LA(2)=='l'||LA(2)=='q')) {
 					mPREDEFINED_ENTITY_REF(false);
@@ -3637,7 +3637,7 @@ tryAgain:
 					}
 				}
 				else {
-					break _loop593;
+					break _loop588;
 				}
 				
 			} while (true);
@@ -3653,7 +3653,7 @@ tryAgain:
 			match('\'');
 			text.setLength(_saveIndex);
 			{
-			_loop597:
+			_loop592:
 			do {
 				if ((LA(1)=='&') && (LA(2)=='a'||LA(2)=='g'||LA(2)=='l'||LA(2)=='q')) {
 					mPREDEFINED_ENTITY_REF(false);
@@ -3675,7 +3675,7 @@ tryAgain:
 					}
 				}
 				else {
-					break _loop597;
+					break _loop592;
 				}
 				
 			} while (true);
@@ -3703,8 +3703,8 @@ tryAgain:
 		int _saveIndex;
 		
 		{
-		int _cnt601=0;
-		_loop601:
+		int _cnt596=0;
+		_loop596:
 		do {
 			if ((_tokenSet_8.member(LA(1)))) {
 				{
@@ -3712,10 +3712,10 @@ tryAgain:
 				}
 			}
 			else {
-				if ( _cnt601>=1 ) { break _loop601; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt596>=1 ) { break _loop596; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt601++;
+			_cnt596++;
 		} while (true);
 		}
 		if ( _createToken && _token==null && _ttype!=Token.SKIP ) {
@@ -3737,8 +3737,8 @@ tryAgain:
 		int _saveIndex;
 		
 		{
-		int _cnt605=0;
-		_loop605:
+		int _cnt600=0;
+		_loop600:
 		do {
 			if ((_tokenSet_9.member(LA(1)))) {
 				{
@@ -3746,10 +3746,10 @@ tryAgain:
 				}
 			}
 			else {
-				if ( _cnt605>=1 ) { break _loop605; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt600>=1 ) { break _loop600; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt605++;
+			_cnt600++;
 		} while (true);
 		}
 		if ( _createToken && _token==null && _ttype!=Token.SKIP ) {
@@ -3799,8 +3799,8 @@ tryAgain:
 		int _saveIndex;
 		
 		{
-		int _cnt610=0;
-		_loop610:
+		int _cnt605=0;
+		_loop605:
 		do {
 			switch ( LA(1)) {
 			case '\t':
@@ -3862,10 +3862,10 @@ tryAgain:
 					matchRange('\u007e','\uFFFD');
 				}
 			else {
-				if ( _cnt610>=1 ) { break _loop610; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt605>=1 ) { break _loop605; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
 			}
 			}
-			_cnt610++;
+			_cnt605++;
 		} while (true);
 		}
 		if ( _createToken && _token==null && _ttype!=Token.SKIP ) {
@@ -3884,7 +3884,7 @@ tryAgain:
 		match("<!--");
 		text.setLength(_saveIndex);
 		{
-		_loop617:
+		_loop612:
 		do {
 			if ((_tokenSet_10.member(LA(1)))) {
 				{
@@ -3892,10 +3892,10 @@ tryAgain:
 				}
 			}
 			else {
-				boolean synPredMatched616 = false;
+				boolean synPredMatched611 = false;
 				if (((LA(1)=='-'))) {
-					int _m616 = mark();
-					synPredMatched616 = true;
+					int _m611 = mark();
+					synPredMatched611 = true;
 					inputState.guessing++;
 					try {
 						{
@@ -3906,16 +3906,16 @@ tryAgain:
 						}
 					}
 					catch (RecognitionException pe) {
-						synPredMatched616 = false;
+						synPredMatched611 = false;
 					}
-					rewind(_m616);
+					rewind(_m611);
 inputState.guessing--;
 				}
-				if ( synPredMatched616 ) {
+				if ( synPredMatched611 ) {
 					match('-');
 				}
 				else {
-					break _loop617;
+					break _loop612;
 				}
 				}
 			} while (true);
@@ -3940,7 +3940,7 @@ inputState.guessing--;
 		if ((LA(1)==' ')) {
 			match(' ');
 			{
-			_loop625:
+			_loop620:
 			do {
 				if ((_tokenSet_11.member(LA(1)))) {
 					{
@@ -3948,10 +3948,10 @@ inputState.guessing--;
 					}
 				}
 				else {
-					boolean synPredMatched624 = false;
+					boolean synPredMatched619 = false;
 					if (((LA(1)=='?'))) {
-						int _m624 = mark();
-						synPredMatched624 = true;
+						int _m619 = mark();
+						synPredMatched619 = true;
 						inputState.guessing++;
 						try {
 							{
@@ -3962,16 +3962,16 @@ inputState.guessing--;
 							}
 						}
 						catch (RecognitionException pe) {
-							synPredMatched624 = false;
+							synPredMatched619 = false;
 						}
-						rewind(_m624);
+						rewind(_m619);
 inputState.guessing--;
 					}
-					if ( synPredMatched624 ) {
+					if ( synPredMatched619 ) {
 						match('?');
 					}
 					else {
-						break _loop625;
+						break _loop620;
 					}
 					}
 				} while (true);
@@ -3997,12 +3997,12 @@ inputState.guessing--;
 		mXML_CDATA_START(false);
 		text.setLength(_saveIndex);
 		{
-		_loop636:
+		_loop631:
 		do {
-			boolean synPredMatched631 = false;
+			boolean synPredMatched626 = false;
 			if (((LA(1)==']') && ((LA(2) >= '\u0003' && LA(2) <= '\ufffe')) && ((LA(3) >= '\u0003' && LA(3) <= '\ufffe')) && ((LA(4) >= '\u0003' && LA(4) <= '\ufffe')))) {
-				int _m631 = mark();
-				synPredMatched631 = true;
+				int _m626 = mark();
+				synPredMatched626 = true;
 				inputState.guessing++;
 				try {
 					{
@@ -4013,19 +4013,19 @@ inputState.guessing--;
 					}
 				}
 				catch (RecognitionException pe) {
-					synPredMatched631 = false;
+					synPredMatched626 = false;
 				}
-				rewind(_m631);
+				rewind(_m626);
 inputState.guessing--;
 			}
-			if ( synPredMatched631 ) {
+			if ( synPredMatched626 ) {
 				match(']');
 			}
 			else {
-				boolean synPredMatched634 = false;
+				boolean synPredMatched629 = false;
 				if (((LA(1)==']') && (LA(2)==']') && ((LA(3) >= '\u0003' && LA(3) <= '\ufffe')) && ((LA(4) >= '\u0003' && LA(4) <= '\ufffe')))) {
-					int _m634 = mark();
-					synPredMatched634 = true;
+					int _m629 = mark();
+					synPredMatched629 = true;
 					inputState.guessing++;
 					try {
 						{
@@ -4037,12 +4037,12 @@ inputState.guessing--;
 						}
 					}
 					catch (RecognitionException pe) {
-						synPredMatched634 = false;
+						synPredMatched629 = false;
 					}
-					rewind(_m634);
+					rewind(_m629);
 inputState.guessing--;
 				}
-				if ( synPredMatched634 ) {
+				if ( synPredMatched629 ) {
 					{
 					match(']');
 					match(']');
@@ -4054,7 +4054,7 @@ inputState.guessing--;
 					}
 				}
 				else {
-					break _loop636;
+					break _loop631;
 				}
 				}
 			} while (true);
@@ -4075,8 +4075,8 @@ inputState.guessing--;
 		int _saveIndex;
 		
 		{
-		int _cnt640=0;
-		_loop640:
+		int _cnt635=0;
+		_loop635:
 		do {
 			if ((LA(1)=='\t'||LA(1)=='\n'||LA(1)=='\r'||LA(1)==' ')) {
 				{
@@ -4109,10 +4109,10 @@ inputState.guessing--;
 				}
 			}
 			else {
-				if ( _cnt640>=1 ) { break _loop640; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
+				if ( _cnt635>=1 ) { break _loop635; } else {throw new NoViableAltForCharException((char)LA(1), getFilename(), getLine(), getColumn());}
 			}
 			
-			_cnt640++;
+			_cnt635++;
 		} while (true);
 		}
 		if ( _createToken && _token==null && _ttype!=Token.SKIP ) {
@@ -4159,15 +4159,15 @@ inputState.guessing--;
 			mWS(false);
 			text.setLength(_saveIndex);
 			{
-			_loop646:
+			_loop641:
 			do {
 				// nongreedy exit test
-				if ((LA(1)=='#') && (LA(2)==')') && (true)) break _loop646;
+				if ((LA(1)=='#') && (LA(2)==')') && (true)) break _loop641;
 				if (((LA(1) >= '\u0003' && LA(1) <= '\ufffe')) && ((LA(2) >= '\u0003' && LA(2) <= '\ufffe')) && ((LA(3) >= '\u0003' && LA(3) <= '\ufffe'))) {
 					matchNot(EOF_CHAR);
 				}
 				else {
-					break _loop646;
+					break _loop641;
 				}
 				
 			} while (true);
@@ -4227,10 +4227,10 @@ inputState.guessing--;
 			break;
 		}
 		default:
-			boolean synPredMatched651 = false;
+			boolean synPredMatched646 = false;
 			if (((LA(1)=='(') && (LA(2)==':') && (LA(3)=='~') && ((LA(4) >= '\u0003' && LA(4) <= '\ufffe')))) {
-				int _m651 = mark();
-				synPredMatched651 = true;
+				int _m646 = mark();
+				synPredMatched646 = true;
 				inputState.guessing++;
 				try {
 					{
@@ -4240,12 +4240,12 @@ inputState.guessing--;
 					}
 				}
 				catch (RecognitionException pe) {
-					synPredMatched651 = false;
+					synPredMatched646 = false;
 				}
-				rewind(_m651);
+				rewind(_m646);
 inputState.guessing--;
 			}
-			if ( synPredMatched651 ) {
+			if ( synPredMatched646 ) {
 				mXQDOC_COMMENT(false);
 				if ( inputState.guessing==0 ) {
 					
@@ -4288,10 +4288,10 @@ inputState.guessing--;
 				}
 			}
 			else {
-				boolean synPredMatched658 = false;
+				boolean synPredMatched653 = false;
 				if (((_tokenSet_14.member(LA(1))) && (_tokenSet_15.member(LA(2))) && (_tokenSet_16.member(LA(3))) && (true))) {
-					int _m658 = mark();
-					synPredMatched658 = true;
+					int _m653 = mark();
+					synPredMatched653 = true;
 					inputState.guessing++;
 					try {
 						{
@@ -4318,22 +4318,22 @@ inputState.guessing--;
 						}
 					}
 					catch (RecognitionException pe) {
-						synPredMatched658 = false;
+						synPredMatched653 = false;
 					}
-					rewind(_m658);
+					rewind(_m653);
 inputState.guessing--;
 				}
-				if ( synPredMatched658 ) {
+				if ( synPredMatched653 ) {
 					mDOUBLE_LITERAL(false);
 					if ( inputState.guessing==0 ) {
 						_ttype = DOUBLE_LITERAL;
 					}
 				}
 				else {
-					boolean synPredMatched667 = false;
+					boolean synPredMatched662 = false;
 					if (((_tokenSet_14.member(LA(1))) && (_tokenSet_15.member(LA(2))) && (_tokenSet_16.member(LA(3))) && (true))) {
-						int _m667 = mark();
-						synPredMatched667 = true;
+						int _m662 = mark();
+						synPredMatched662 = true;
 						inputState.guessing++;
 						try {
 							{
@@ -4387,12 +4387,12 @@ inputState.guessing--;
 							}
 						}
 						catch (RecognitionException pe) {
-							synPredMatched667 = false;
+							synPredMatched662 = false;
 						}
-						rewind(_m667);
+						rewind(_m662);
 inputState.guessing--;
 					}
-					if ( synPredMatched667 ) {
+					if ( synPredMatched662 ) {
 						mDOUBLE_LITERAL(false);
 						if ( inputState.guessing==0 ) {
 							_ttype = DOUBLE_LITERAL;
@@ -4411,10 +4411,10 @@ inputState.guessing--;
 						}
 					}
 					else {
-						boolean synPredMatched649 = false;
+						boolean synPredMatched644 = false;
 						if (((LA(1)=='<') && (LA(2)=='?'))) {
-							int _m649 = mark();
-							synPredMatched649 = true;
+							int _m644 = mark();
+							synPredMatched644 = true;
 							inputState.guessing++;
 							try {
 								{
@@ -4422,12 +4422,12 @@ inputState.guessing--;
 								}
 							}
 							catch (RecognitionException pe) {
-								synPredMatched649 = false;
+								synPredMatched644 = false;
 							}
-							rewind(_m649);
+							rewind(_m644);
 inputState.guessing--;
 						}
-						if ( synPredMatched649 ) {
+						if ( synPredMatched644 ) {
 							mXML_PI(false);
 							if ( inputState.guessing==0 ) {
 								_ttype = XML_PI;
@@ -4474,10 +4474,10 @@ inputState.guessing--;
 							}
 						}
 						else {
-							boolean synPredMatched653 = false;
+							boolean synPredMatched648 = false;
 							if (((LA(1)=='|') && (LA(2)=='|') && (true) && (true))) {
-								int _m653 = mark();
-								synPredMatched653 = true;
+								int _m648 = mark();
+								synPredMatched648 = true;
 								inputState.guessing++;
 								try {
 									{
@@ -4486,22 +4486,22 @@ inputState.guessing--;
 									}
 								}
 								catch (RecognitionException pe) {
-									synPredMatched653 = false;
+									synPredMatched648 = false;
 								}
-								rewind(_m653);
+								rewind(_m648);
 inputState.guessing--;
 							}
-							if ( synPredMatched653 ) {
+							if ( synPredMatched648 ) {
 								mCONCAT(false);
 								if ( inputState.guessing==0 ) {
 									_ttype = CONCAT;
 								}
 							}
 							else {
-								boolean synPredMatched655 = false;
+								boolean synPredMatched650 = false;
 								if ((((LA(1)=='.') && (LA(2)=='.') && (true) && (true))&&( !(inAttributeContent || inElementContent) ))) {
-									int _m655 = mark();
-									synPredMatched655 = true;
+									int _m650 = mark();
+									synPredMatched650 = true;
 									inputState.guessing++;
 									try {
 										{
@@ -4510,12 +4510,12 @@ inputState.guessing--;
 										}
 									}
 									catch (RecognitionException pe) {
-										synPredMatched655 = false;
+										synPredMatched650 = false;
 									}
-									rewind(_m655);
+									rewind(_m650);
 inputState.guessing--;
 								}
-								if ( synPredMatched655 ) {
+								if ( synPredMatched650 ) {
 									mPARENT(false);
 									if ( inputState.guessing==0 ) {
 										_ttype = PARENT;
@@ -4640,10 +4640,10 @@ inputState.guessing--;
 									}
 								}
 								else {
-									boolean synPredMatched660 = false;
+									boolean synPredMatched655 = false;
 									if (((_tokenSet_14.member(LA(1))) && (true) && (true) && (true))) {
-										int _m660 = mark();
-										synPredMatched660 = true;
+										int _m655 = mark();
+										synPredMatched655 = true;
 										inputState.guessing++;
 										try {
 											{
@@ -4652,22 +4652,22 @@ inputState.guessing--;
 											}
 										}
 										catch (RecognitionException pe) {
-											synPredMatched660 = false;
+											synPredMatched655 = false;
 										}
-										rewind(_m660);
+										rewind(_m655);
 inputState.guessing--;
 									}
-									if ( synPredMatched660 ) {
+									if ( synPredMatched655 ) {
 										mDECIMAL_LITERAL(false);
 										if ( inputState.guessing==0 ) {
 											_ttype = DECIMAL_LITERAL;
 										}
 									}
 									else {
-										boolean synPredMatched662 = false;
+										boolean synPredMatched657 = false;
 										if (((LA(1)=='.') && (true) && (true) && (true))) {
-											int _m662 = mark();
-											synPredMatched662 = true;
+											int _m657 = mark();
+											synPredMatched657 = true;
 											inputState.guessing++;
 											try {
 												{
@@ -4675,22 +4675,22 @@ inputState.guessing--;
 												}
 											}
 											catch (RecognitionException pe) {
-												synPredMatched662 = false;
+												synPredMatched657 = false;
 											}
-											rewind(_m662);
+											rewind(_m657);
 inputState.guessing--;
 										}
-										if ( synPredMatched662 ) {
+										if ( synPredMatched657 ) {
 											mSELF(false);
 											if ( inputState.guessing==0 ) {
 												_ttype = SELF;
 											}
 										}
 										else {
-											boolean synPredMatched669 = false;
+											boolean synPredMatched664 = false;
 											if (((_tokenSet_14.member(LA(1))) && (true) && (true) && (true))) {
-												int _m669 = mark();
-												synPredMatched669 = true;
+												int _m664 = mark();
+												synPredMatched664 = true;
 												inputState.guessing++;
 												try {
 													{
@@ -4699,12 +4699,12 @@ inputState.guessing--;
 													}
 												}
 												catch (RecognitionException pe) {
-													synPredMatched669 = false;
+													synPredMatched664 = false;
 												}
-												rewind(_m669);
+												rewind(_m664);
 inputState.guessing--;
 											}
-											if ( synPredMatched669 ) {
+											if ( synPredMatched664 ) {
 												mDECIMAL_LITERAL(false);
 												if ( inputState.guessing==0 ) {
 													_ttype = DECIMAL_LITERAL;

--- a/src/org/exist/xquery/parser/XQueryParser.java
+++ b/src/org/exist/xquery/parser/XQueryParser.java
@@ -7442,6 +7442,11 @@ inputState.guessing--;
 						match(185);
 						break;
 					}
+					case LITERAL_namespace:
+					{
+						match(LITERAL_namespace);
+						break;
+					}
 					case LITERAL_comment:
 					{
 						match(LITERAL_comment);
@@ -8518,6 +8523,11 @@ inputState.guessing--;
 						match(LITERAL_comment);
 						break;
 					}
+					case LITERAL_namespace:
+					{
+						match(LITERAL_namespace);
+						break;
+					}
 					default:
 					{
 						throw new NoViableAltException(LT(1), getFilename());
@@ -8940,6 +8950,13 @@ inputState.guessing--;
 		case LITERAL_text:
 		{
 			compTextConstructor();
+			astFactory.addASTChild(currentAST, returnAST);
+			computedConstructor_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
+			break;
+		}
+		case LITERAL_namespace:
+		{
+			compNamespaceConstructor();
 			astFactory.addASTChild(currentAST, returnAST);
 			computedConstructor_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
 			break;
@@ -10672,10 +10689,10 @@ inputState.guessing--;
 		//lexer.wsExplicit = true;
 		
 		
-		boolean synPredMatched465 = false;
+		boolean synPredMatched460 = false;
 		if (((LA(1)==LT))) {
-			int _m465 = mark();
-			synPredMatched465 = true;
+			int _m460 = mark();
+			synPredMatched460 = true;
 			inputState.guessing++;
 			try {
 				{
@@ -10687,12 +10704,12 @@ inputState.guessing--;
 				}
 			}
 			catch (RecognitionException pe) {
-				synPredMatched465 = false;
+				synPredMatched460 = false;
 			}
-			rewind(_m465);
+			rewind(_m460);
 inputState.guessing--;
 		}
-		if ( synPredMatched465 ) {
+		if ( synPredMatched460 ) {
 			elementWithAttributes();
 			astFactory.addASTChild(currentAST, returnAST);
 			elementConstructor_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
@@ -10895,7 +10912,7 @@ inputState.guessing--;
 			case LITERAL_collection:
 			case LITERAL_validate:
 			{
-				compElemBody();
+				expr();
 				astFactory.addASTChild(currentAST, returnAST);
 				break;
 			}
@@ -11047,7 +11064,7 @@ inputState.guessing--;
 			case LITERAL_collection:
 			case LITERAL_validate:
 			{
-				compElemBody();
+				expr();
 				e3_AST = (org.exist.xquery.parser.XQueryAST)returnAST;
 				astFactory.addASTChild(currentAST, returnAST);
 				break;
@@ -11092,10 +11109,10 @@ inputState.guessing--;
 			String qn;
 		
 		
-		boolean synPredMatched452 = false;
+		boolean synPredMatched443 = false;
 		if (((LA(1)==LITERAL_attribute))) {
-			int _m452 = mark();
-			synPredMatched452 = true;
+			int _m443 = mark();
+			synPredMatched443 = true;
 			inputState.guessing++;
 			try {
 				{
@@ -11104,12 +11121,12 @@ inputState.guessing--;
 				}
 			}
 			catch (RecognitionException pe) {
-				synPredMatched452 = false;
+				synPredMatched443 = false;
 			}
-			rewind(_m452);
+			rewind(_m443);
 inputState.guessing--;
 		}
-		if ( synPredMatched452 ) {
+		if ( synPredMatched443 ) {
 			match(LITERAL_attribute);
 			match(LCURLY);
 			expr();
@@ -11181,6 +11198,347 @@ inputState.guessing--;
 		returnAST = compTextConstructor_AST;
 	}
 	
+	public final void compNamespaceConstructor() throws RecognitionException, TokenStreamException, XPathException {
+		
+		returnAST = null;
+		ASTPair currentAST = new ASTPair();
+		org.exist.xquery.parser.XQueryAST compNamespaceConstructor_AST = null;
+		org.exist.xquery.parser.XQueryAST e3_AST = null;
+		
+			String qn;
+		
+		
+		boolean synPredMatched454 = false;
+		if (((LA(1)==LITERAL_namespace))) {
+			int _m454 = mark();
+			synPredMatched454 = true;
+			inputState.guessing++;
+			try {
+				{
+				match(LITERAL_namespace);
+				match(LCURLY);
+				}
+			}
+			catch (RecognitionException pe) {
+				synPredMatched454 = false;
+			}
+			rewind(_m454);
+inputState.guessing--;
+		}
+		if ( synPredMatched454 ) {
+			match(LITERAL_namespace);
+			match(LCURLY);
+			expr();
+			astFactory.addASTChild(currentAST, returnAST);
+			match(RCURLY);
+			match(LCURLY);
+			{
+			switch ( LA(1)) {
+			case LITERAL_xpointer:
+			case LPAREN:
+			case NCNAME:
+			case LITERAL_xquery:
+			case LITERAL_version:
+			case LITERAL_module:
+			case LITERAL_namespace:
+			case STRING_LITERAL:
+			case LITERAL_declare:
+			case LITERAL_default:
+			case 72:
+			case LITERAL_ordering:
+			case LITERAL_construction:
+			case 75:
+			case LITERAL_option:
+			case LITERAL_function:
+			case LITERAL_variable:
+			case MOD:
+			case LITERAL_import:
+			case LITERAL_encoding:
+			case LITERAL_collation:
+			case LITERAL_element:
+			case LITERAL_order:
+			case LITERAL_empty:
+			case LITERAL_preserve:
+			case LITERAL_strip:
+			case LITERAL_ordered:
+			case LITERAL_unordered:
+			case 94:
+			case LITERAL_inherit:
+			case 96:
+			case DOLLAR:
+			case LITERAL_external:
+			case LITERAL_schema:
+			case LITERAL_as:
+			case LITERAL_at:
+			case STAR:
+			case PLUS:
+			case LITERAL_item:
+			case LITERAL_map:
+			case LITERAL_for:
+			case LITERAL_let:
+			case LITERAL_try:
+			case LITERAL_some:
+			case LITERAL_every:
+			case LITERAL_if:
+			case LITERAL_switch:
+			case LITERAL_typeswitch:
+			case LITERAL_update:
+			case LITERAL_replace:
+			case LITERAL_value:
+			case LITERAL_insert:
+			case LITERAL_delete:
+			case LITERAL_rename:
+			case LITERAL_with:
+			case LITERAL_into:
+			case LITERAL_preceding:
+			case LITERAL_following:
+			case LITERAL_catch:
+			case LITERAL_where:
+			case LITERAL_return:
+			case LITERAL_in:
+			case LITERAL_by:
+			case LITERAL_stable:
+			case LITERAL_group:
+			case LITERAL_case:
+			case LITERAL_then:
+			case LITERAL_else:
+			case LITERAL_or:
+			case LITERAL_and:
+			case LITERAL_instance:
+			case LITERAL_of:
+			case LITERAL_treat:
+			case LITERAL_cast:
+			case LITERAL_eq:
+			case LITERAL_ne:
+			case LITERAL_lt:
+			case LITERAL_le:
+			case LITERAL_gt:
+			case LITERAL_ge:
+			case LT:
+			case LITERAL_is:
+			case LITERAL_isnot:
+			case LITERAL_to:
+			case MINUS:
+			case LITERAL_div:
+			case LITERAL_mod:
+			case PRAGMA_START:
+			case LITERAL_union:
+			case LITERAL_intersect:
+			case LITERAL_except:
+			case SLASH:
+			case DSLASH:
+			case LITERAL_text:
+			case LITERAL_node:
+			case LITERAL_attribute:
+			case LITERAL_comment:
+			case 185:
+			case 186:
+			case LITERAL_document:
+			case SELF:
+			case XML_COMMENT:
+			case XML_PI:
+			case AT:
+			case PARENT:
+			case LITERAL_child:
+			case LITERAL_self:
+			case LITERAL_descendant:
+			case 199:
+			case 200:
+			case LITERAL_parent:
+			case LITERAL_ancestor:
+			case 203:
+			case 204:
+			case DOUBLE_LITERAL:
+			case DECIMAL_LITERAL:
+			case INTEGER_LITERAL:
+			case LITERAL_collection:
+			case LITERAL_validate:
+			{
+				expr();
+				astFactory.addASTChild(currentAST, returnAST);
+				break;
+			}
+			case RCURLY:
+			{
+				break;
+			}
+			default:
+			{
+				throw new NoViableAltException(LT(1), getFilename());
+			}
+			}
+			}
+			match(RCURLY);
+			if ( inputState.guessing==0 ) {
+				compNamespaceConstructor_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
+				compNamespaceConstructor_AST = (org.exist.xquery.parser.XQueryAST)astFactory.make( (new ASTArray(2)).add((org.exist.xquery.parser.XQueryAST)astFactory.create(COMP_NS_CONSTRUCTOR)).add(compNamespaceConstructor_AST));
+				currentAST.root = compNamespaceConstructor_AST;
+				currentAST.child = compNamespaceConstructor_AST!=null &&compNamespaceConstructor_AST.getFirstChild()!=null ?
+					compNamespaceConstructor_AST.getFirstChild() : compNamespaceConstructor_AST;
+				currentAST.advanceChildToEnd();
+			}
+			compNamespaceConstructor_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
+		}
+		else if ((LA(1)==LITERAL_namespace)) {
+			match(LITERAL_namespace);
+			qn=qName();
+			astFactory.addASTChild(currentAST, returnAST);
+			match(LCURLY);
+			{
+			switch ( LA(1)) {
+			case LITERAL_xpointer:
+			case LPAREN:
+			case NCNAME:
+			case LITERAL_xquery:
+			case LITERAL_version:
+			case LITERAL_module:
+			case LITERAL_namespace:
+			case STRING_LITERAL:
+			case LITERAL_declare:
+			case LITERAL_default:
+			case 72:
+			case LITERAL_ordering:
+			case LITERAL_construction:
+			case 75:
+			case LITERAL_option:
+			case LITERAL_function:
+			case LITERAL_variable:
+			case MOD:
+			case LITERAL_import:
+			case LITERAL_encoding:
+			case LITERAL_collation:
+			case LITERAL_element:
+			case LITERAL_order:
+			case LITERAL_empty:
+			case LITERAL_preserve:
+			case LITERAL_strip:
+			case LITERAL_ordered:
+			case LITERAL_unordered:
+			case 94:
+			case LITERAL_inherit:
+			case 96:
+			case DOLLAR:
+			case LITERAL_external:
+			case LITERAL_schema:
+			case LITERAL_as:
+			case LITERAL_at:
+			case STAR:
+			case PLUS:
+			case LITERAL_item:
+			case LITERAL_map:
+			case LITERAL_for:
+			case LITERAL_let:
+			case LITERAL_try:
+			case LITERAL_some:
+			case LITERAL_every:
+			case LITERAL_if:
+			case LITERAL_switch:
+			case LITERAL_typeswitch:
+			case LITERAL_update:
+			case LITERAL_replace:
+			case LITERAL_value:
+			case LITERAL_insert:
+			case LITERAL_delete:
+			case LITERAL_rename:
+			case LITERAL_with:
+			case LITERAL_into:
+			case LITERAL_preceding:
+			case LITERAL_following:
+			case LITERAL_catch:
+			case LITERAL_where:
+			case LITERAL_return:
+			case LITERAL_in:
+			case LITERAL_by:
+			case LITERAL_stable:
+			case LITERAL_group:
+			case LITERAL_case:
+			case LITERAL_then:
+			case LITERAL_else:
+			case LITERAL_or:
+			case LITERAL_and:
+			case LITERAL_instance:
+			case LITERAL_of:
+			case LITERAL_treat:
+			case LITERAL_cast:
+			case LITERAL_eq:
+			case LITERAL_ne:
+			case LITERAL_lt:
+			case LITERAL_le:
+			case LITERAL_gt:
+			case LITERAL_ge:
+			case LT:
+			case LITERAL_is:
+			case LITERAL_isnot:
+			case LITERAL_to:
+			case MINUS:
+			case LITERAL_div:
+			case LITERAL_mod:
+			case PRAGMA_START:
+			case LITERAL_union:
+			case LITERAL_intersect:
+			case LITERAL_except:
+			case SLASH:
+			case DSLASH:
+			case LITERAL_text:
+			case LITERAL_node:
+			case LITERAL_attribute:
+			case LITERAL_comment:
+			case 185:
+			case 186:
+			case LITERAL_document:
+			case SELF:
+			case XML_COMMENT:
+			case XML_PI:
+			case AT:
+			case PARENT:
+			case LITERAL_child:
+			case LITERAL_self:
+			case LITERAL_descendant:
+			case 199:
+			case 200:
+			case LITERAL_parent:
+			case LITERAL_ancestor:
+			case 203:
+			case 204:
+			case DOUBLE_LITERAL:
+			case DECIMAL_LITERAL:
+			case INTEGER_LITERAL:
+			case LITERAL_collection:
+			case LITERAL_validate:
+			{
+				expr();
+				e3_AST = (org.exist.xquery.parser.XQueryAST)returnAST;
+				astFactory.addASTChild(currentAST, returnAST);
+				break;
+			}
+			case RCURLY:
+			{
+				break;
+			}
+			default:
+			{
+				throw new NoViableAltException(LT(1), getFilename());
+			}
+			}
+			}
+			match(RCURLY);
+			if ( inputState.guessing==0 ) {
+				compNamespaceConstructor_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
+				compNamespaceConstructor_AST = (org.exist.xquery.parser.XQueryAST)astFactory.make( (new ASTArray(3)).add((org.exist.xquery.parser.XQueryAST)astFactory.create(COMP_NS_CONSTRUCTOR,qn)).add((org.exist.xquery.parser.XQueryAST)astFactory.create(STRING_LITERAL,qn)).add(e3_AST));
+				currentAST.root = compNamespaceConstructor_AST;
+				currentAST.child = compNamespaceConstructor_AST!=null &&compNamespaceConstructor_AST.getFirstChild()!=null ?
+					compNamespaceConstructor_AST.getFirstChild() : compNamespaceConstructor_AST;
+				currentAST.advanceChildToEnd();
+			}
+			compNamespaceConstructor_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
+		}
+		else {
+			throw new NoViableAltException(LT(1), getFilename());
+		}
+		
+		returnAST = compNamespaceConstructor_AST;
+	}
+	
 	public final void compDocumentConstructor() throws RecognitionException, TokenStreamException, XPathException {
 		
 		returnAST = null;
@@ -11188,9 +11546,9 @@ inputState.guessing--;
 		org.exist.xquery.parser.XQueryAST compDocumentConstructor_AST = null;
 		org.exist.xquery.parser.XQueryAST e_AST = null;
 		
-		org.exist.xquery.parser.XQueryAST tmp412_AST = null;
-		tmp412_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-		astFactory.addASTChild(currentAST, tmp412_AST);
+		org.exist.xquery.parser.XQueryAST tmp420_AST = null;
+		tmp420_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+		astFactory.addASTChild(currentAST, tmp420_AST);
 		match(LITERAL_document);
 		match(LCURLY);
 		expr();
@@ -11221,10 +11579,10 @@ inputState.guessing--;
 			String qn;
 		
 		
-		boolean synPredMatched459 = false;
+		boolean synPredMatched450 = false;
 		if (((LA(1)==185))) {
-			int _m459 = mark();
-			synPredMatched459 = true;
+			int _m450 = mark();
+			synPredMatched450 = true;
 			inputState.guessing++;
 			try {
 				{
@@ -11233,12 +11591,12 @@ inputState.guessing--;
 				}
 			}
 			catch (RecognitionException pe) {
-				synPredMatched459 = false;
+				synPredMatched450 = false;
 			}
-			rewind(_m459);
+			rewind(_m450);
 inputState.guessing--;
 		}
-		if ( synPredMatched459 ) {
+		if ( synPredMatched450 ) {
 			match(185);
 			match(LCURLY);
 			expr();
@@ -11289,9 +11647,9 @@ inputState.guessing--;
 		org.exist.xquery.parser.XQueryAST compXmlComment_AST = null;
 		org.exist.xquery.parser.XQueryAST e_AST = null;
 		
-		org.exist.xquery.parser.XQueryAST tmp419_AST = null;
-		tmp419_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-		astFactory.addASTChild(currentAST, tmp419_AST);
+		org.exist.xquery.parser.XQueryAST tmp427_AST = null;
+		tmp427_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+		astFactory.addASTChild(currentAST, tmp427_AST);
 		match(LITERAL_comment);
 		match(LCURLY);
 		expr();
@@ -11310,124 +11668,6 @@ inputState.guessing--;
 		returnAST = compXmlComment_AST;
 	}
 	
-	public final void compElemBody() throws RecognitionException, TokenStreamException, XPathException {
-		
-		returnAST = null;
-		ASTPair currentAST = new ASTPair();
-		org.exist.xquery.parser.XQueryAST compElemBody_AST = null;
-		
-		{
-		boolean synPredMatched444 = false;
-		if (((LA(1)==LITERAL_namespace))) {
-			int _m444 = mark();
-			synPredMatched444 = true;
-			inputState.guessing++;
-			try {
-				{
-				match(LITERAL_namespace);
-				ncnameOrKeyword();
-				match(LCURLY);
-				}
-			}
-			catch (RecognitionException pe) {
-				synPredMatched444 = false;
-			}
-			rewind(_m444);
-inputState.guessing--;
-		}
-		if ( synPredMatched444 ) {
-			localNamespaceDecl();
-			astFactory.addASTChild(currentAST, returnAST);
-		}
-		else if ((_tokenSet_5.member(LA(1)))) {
-			exprSingle();
-			astFactory.addASTChild(currentAST, returnAST);
-		}
-		else {
-			throw new NoViableAltException(LT(1), getFilename());
-		}
-		
-		}
-		{
-		_loop449:
-		do {
-			if ((LA(1)==COMMA)) {
-				match(COMMA);
-				{
-				boolean synPredMatched448 = false;
-				if (((LA(1)==LITERAL_namespace))) {
-					int _m448 = mark();
-					synPredMatched448 = true;
-					inputState.guessing++;
-					try {
-						{
-						match(LITERAL_namespace);
-						ncnameOrKeyword();
-						match(LCURLY);
-						}
-					}
-					catch (RecognitionException pe) {
-						synPredMatched448 = false;
-					}
-					rewind(_m448);
-inputState.guessing--;
-				}
-				if ( synPredMatched448 ) {
-					localNamespaceDecl();
-					astFactory.addASTChild(currentAST, returnAST);
-				}
-				else if ((_tokenSet_5.member(LA(1)))) {
-					exprSingle();
-					astFactory.addASTChild(currentAST, returnAST);
-				}
-				else {
-					throw new NoViableAltException(LT(1), getFilename());
-				}
-				
-				}
-			}
-			else {
-				break _loop449;
-			}
-			
-		} while (true);
-		}
-		compElemBody_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
-		returnAST = compElemBody_AST;
-	}
-	
-	public final void localNamespaceDecl() throws RecognitionException, TokenStreamException {
-		
-		returnAST = null;
-		ASTPair currentAST = new ASTPair();
-		org.exist.xquery.parser.XQueryAST localNamespaceDecl_AST = null;
-		Token  l = null;
-		org.exist.xquery.parser.XQueryAST l_AST = null;
-		
-			String nc = null;
-		
-		
-		match(LITERAL_namespace);
-		nc=ncnameOrKeyword();
-		astFactory.addASTChild(currentAST, returnAST);
-		match(LCURLY);
-		l = LT(1);
-		l_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(l);
-		astFactory.addASTChild(currentAST, l_AST);
-		match(STRING_LITERAL);
-		match(RCURLY);
-		if ( inputState.guessing==0 ) {
-			localNamespaceDecl_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
-			localNamespaceDecl_AST = (org.exist.xquery.parser.XQueryAST)astFactory.make( (new ASTArray(2)).add((org.exist.xquery.parser.XQueryAST)astFactory.create(COMP_NS_CONSTRUCTOR,nc)).add(l_AST));
-			currentAST.root = localNamespaceDecl_AST;
-			currentAST.child = localNamespaceDecl_AST!=null &&localNamespaceDecl_AST.getFirstChild()!=null ?
-				localNamespaceDecl_AST.getFirstChild() : localNamespaceDecl_AST;
-			currentAST.advanceChildToEnd();
-		}
-		localNamespaceDecl_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
-		returnAST = localNamespaceDecl_AST;
-	}
-	
 	public final void compConstructorValue() throws RecognitionException, TokenStreamException, XPathException {
 		
 		returnAST = null;
@@ -11435,9 +11675,9 @@ inputState.guessing--;
 		org.exist.xquery.parser.XQueryAST compConstructorValue_AST = null;
 		org.exist.xquery.parser.XQueryAST e2_AST = null;
 		
-		org.exist.xquery.parser.XQueryAST tmp426_AST = null;
-		tmp426_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-		astFactory.makeASTRoot(currentAST, tmp426_AST);
+		org.exist.xquery.parser.XQueryAST tmp430_AST = null;
+		tmp430_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+		astFactory.makeASTRoot(currentAST, tmp430_AST);
 		match(LCURLY);
 		{
 		switch ( LA(1)) {
@@ -11703,9 +11943,9 @@ inputState.guessing--;
 		String name = null, cname = null;
 		
 		try {      // for error handling
-			org.exist.xquery.parser.XQueryAST tmp434_AST = null;
-			tmp434_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp434_AST);
+			org.exist.xquery.parser.XQueryAST tmp438_AST = null;
+			tmp438_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp438_AST);
 			match(LT);
 			name=qName();
 			q_AST = (org.exist.xquery.parser.XQueryAST)returnAST;
@@ -11811,14 +12051,14 @@ inputState.guessing--;
 		org.exist.xquery.parser.XQueryAST mixedElementContent_AST = null;
 		
 		{
-		_loop490:
+		_loop485:
 		do {
 			if ((_tokenSet_19.member(LA(1)))) {
 				elementContent();
 				astFactory.addASTChild(currentAST, returnAST);
 			}
 			else {
-				break _loop490;
+				break _loop485;
 			}
 			
 		} while (true);
@@ -11834,18 +12074,18 @@ inputState.guessing--;
 		org.exist.xquery.parser.XQueryAST attributeList_AST = null;
 		
 		{
-		int _cnt476=0;
-		_loop476:
+		int _cnt471=0;
+		_loop471:
 		do {
 			if ((_tokenSet_1.member(LA(1)))) {
 				attributeDef();
 				astFactory.addASTChild(currentAST, returnAST);
 			}
 			else {
-				if ( _cnt476>=1 ) { break _loop476; } else {throw new NoViableAltException(LT(1), getFilename());}
+				if ( _cnt471>=1 ) { break _loop471; } else {throw new NoViableAltException(LT(1), getFilename());}
 			}
 			
-			_cnt476++;
+			_cnt471++;
 		} while (true);
 		}
 		attributeList_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
@@ -11900,14 +12140,14 @@ inputState.guessing--;
 					
 			}
 			{
-			_loop480:
+			_loop475:
 			do {
 				if ((_tokenSet_20.member(LA(1)))) {
 					quotAttrValueContent();
 					astFactory.addASTChild(currentAST, returnAST);
 				}
 				else {
-					break _loop480;
+					break _loop475;
 				}
 				
 			} while (true);
@@ -11932,14 +12172,14 @@ inputState.guessing--;
 					
 			}
 			{
-			_loop482:
+			_loop477:
 			do {
 				if ((_tokenSet_21.member(LA(1)))) {
 					aposAttrValueContent();
 					astFactory.addASTChild(currentAST, returnAST);
 				}
 				else {
-					break _loop482;
+					break _loop477;
 				}
 				
 			} while (true);
@@ -12090,10 +12330,10 @@ inputState.guessing--;
 		ASTPair currentAST = new ASTPair();
 		org.exist.xquery.parser.XQueryAST attrCommonContent_AST = null;
 		
-		boolean synPredMatched487 = false;
+		boolean synPredMatched482 = false;
 		if (((LA(1)==LCURLY))) {
-			int _m487 = mark();
-			synPredMatched487 = true;
+			int _m482 = mark();
+			synPredMatched482 = true;
 			inputState.guessing++;
 			try {
 				{
@@ -12102,19 +12342,19 @@ inputState.guessing--;
 				}
 			}
 			catch (RecognitionException pe) {
-				synPredMatched487 = false;
+				synPredMatched482 = false;
 			}
-			rewind(_m487);
+			rewind(_m482);
 inputState.guessing--;
 		}
-		if ( synPredMatched487 ) {
-			org.exist.xquery.parser.XQueryAST tmp445_AST = null;
-			tmp445_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp445_AST);
+		if ( synPredMatched482 ) {
+			org.exist.xquery.parser.XQueryAST tmp449_AST = null;
+			tmp449_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp449_AST);
 			match(LCURLY);
-			org.exist.xquery.parser.XQueryAST tmp446_AST = null;
-			tmp446_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp446_AST);
+			org.exist.xquery.parser.XQueryAST tmp450_AST = null;
+			tmp450_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp450_AST);
 			match(LCURLY);
 			if ( inputState.guessing==0 ) {
 				attrCommonContent_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
@@ -12131,13 +12371,13 @@ inputState.guessing--;
 			attrCommonContent_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
 		}
 		else if ((LA(1)==RCURLY)) {
-			org.exist.xquery.parser.XQueryAST tmp447_AST = null;
-			tmp447_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp447_AST);
+			org.exist.xquery.parser.XQueryAST tmp451_AST = null;
+			tmp451_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp451_AST);
 			match(RCURLY);
-			org.exist.xquery.parser.XQueryAST tmp448_AST = null;
-			tmp448_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp448_AST);
+			org.exist.xquery.parser.XQueryAST tmp452_AST = null;
+			tmp452_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp452_AST);
 			match(RCURLY);
 			if ( inputState.guessing==0 ) {
 				attrCommonContent_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
@@ -12167,9 +12407,9 @@ inputState.guessing--;
 		ASTPair currentAST = new ASTPair();
 		org.exist.xquery.parser.XQueryAST attributeEnclosedExpr_AST = null;
 		
-		org.exist.xquery.parser.XQueryAST tmp449_AST = null;
-		tmp449_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-		astFactory.makeASTRoot(currentAST, tmp449_AST);
+		org.exist.xquery.parser.XQueryAST tmp453_AST = null;
+		tmp453_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+		astFactory.makeASTRoot(currentAST, tmp453_AST);
 		match(LCURLY);
 		if ( inputState.guessing==0 ) {
 			
@@ -12208,13 +12448,13 @@ inputState.guessing--;
 		}
 		case RCURLY:
 		{
-			org.exist.xquery.parser.XQueryAST tmp451_AST = null;
-			tmp451_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp451_AST);
+			org.exist.xquery.parser.XQueryAST tmp455_AST = null;
+			tmp455_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp455_AST);
 			match(RCURLY);
-			org.exist.xquery.parser.XQueryAST tmp452_AST = null;
-			tmp452_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp452_AST);
+			org.exist.xquery.parser.XQueryAST tmp456_AST = null;
+			tmp456_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp456_AST);
 			match(RCURLY);
 			if ( inputState.guessing==0 ) {
 				elementContent_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
@@ -12266,10 +12506,10 @@ inputState.guessing--;
 			break;
 		}
 		default:
-			boolean synPredMatched493 = false;
+			boolean synPredMatched488 = false;
 			if (((LA(1)==LCURLY))) {
-				int _m493 = mark();
-				synPredMatched493 = true;
+				int _m488 = mark();
+				synPredMatched488 = true;
 				inputState.guessing++;
 				try {
 					{
@@ -12278,19 +12518,19 @@ inputState.guessing--;
 					}
 				}
 				catch (RecognitionException pe) {
-					synPredMatched493 = false;
+					synPredMatched488 = false;
 				}
-				rewind(_m493);
+				rewind(_m488);
 inputState.guessing--;
 			}
-			if ( synPredMatched493 ) {
-				org.exist.xquery.parser.XQueryAST tmp453_AST = null;
-				tmp453_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-				astFactory.addASTChild(currentAST, tmp453_AST);
+			if ( synPredMatched488 ) {
+				org.exist.xquery.parser.XQueryAST tmp457_AST = null;
+				tmp457_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+				astFactory.addASTChild(currentAST, tmp457_AST);
 				match(LCURLY);
-				org.exist.xquery.parser.XQueryAST tmp454_AST = null;
-				tmp454_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-				astFactory.addASTChild(currentAST, tmp454_AST);
+				org.exist.xquery.parser.XQueryAST tmp458_AST = null;
+				tmp458_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+				astFactory.addASTChild(currentAST, tmp458_AST);
 				match(LCURLY);
 				if ( inputState.guessing==0 ) {
 					elementContent_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
@@ -12323,9 +12563,9 @@ inputState.guessing--;
 		ASTPair currentAST = new ASTPair();
 		org.exist.xquery.parser.XQueryAST cdataSection_AST = null;
 		
-		org.exist.xquery.parser.XQueryAST tmp455_AST = null;
-		tmp455_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-		astFactory.addASTChild(currentAST, tmp455_AST);
+		org.exist.xquery.parser.XQueryAST tmp459_AST = null;
+		tmp459_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+		astFactory.addASTChild(currentAST, tmp459_AST);
 		match(XML_CDATA);
 		cdataSection_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
 		returnAST = cdataSection_AST;
@@ -12337,9 +12577,9 @@ inputState.guessing--;
 		ASTPair currentAST = new ASTPair();
 		org.exist.xquery.parser.XQueryAST enclosedExpr_AST = null;
 		
-		org.exist.xquery.parser.XQueryAST tmp456_AST = null;
-		tmp456_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-		astFactory.makeASTRoot(currentAST, tmp456_AST);
+		org.exist.xquery.parser.XQueryAST tmp460_AST = null;
+		tmp460_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+		astFactory.makeASTRoot(currentAST, tmp460_AST);
 		match(LCURLY);
 		if ( inputState.guessing==0 ) {
 			
@@ -12372,9 +12612,9 @@ inputState.guessing--;
 		switch ( LA(1)) {
 		case LITERAL_element:
 		{
-			org.exist.xquery.parser.XQueryAST tmp458_AST = null;
-			tmp458_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp458_AST);
+			org.exist.xquery.parser.XQueryAST tmp462_AST = null;
+			tmp462_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp462_AST);
 			match(LITERAL_element);
 			if ( inputState.guessing==0 ) {
 				name = "element";
@@ -12384,9 +12624,9 @@ inputState.guessing--;
 		}
 		case LITERAL_to:
 		{
-			org.exist.xquery.parser.XQueryAST tmp459_AST = null;
-			tmp459_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp459_AST);
+			org.exist.xquery.parser.XQueryAST tmp463_AST = null;
+			tmp463_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp463_AST);
 			match(LITERAL_to);
 			if ( inputState.guessing==0 ) {
 				name = "to";
@@ -12396,9 +12636,9 @@ inputState.guessing--;
 		}
 		case LITERAL_div:
 		{
-			org.exist.xquery.parser.XQueryAST tmp460_AST = null;
-			tmp460_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp460_AST);
+			org.exist.xquery.parser.XQueryAST tmp464_AST = null;
+			tmp464_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp464_AST);
 			match(LITERAL_div);
 			if ( inputState.guessing==0 ) {
 				name= "div";
@@ -12408,9 +12648,9 @@ inputState.guessing--;
 		}
 		case LITERAL_mod:
 		{
-			org.exist.xquery.parser.XQueryAST tmp461_AST = null;
-			tmp461_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp461_AST);
+			org.exist.xquery.parser.XQueryAST tmp465_AST = null;
+			tmp465_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp465_AST);
 			match(LITERAL_mod);
 			if ( inputState.guessing==0 ) {
 				name= "mod";
@@ -12420,9 +12660,9 @@ inputState.guessing--;
 		}
 		case LITERAL_text:
 		{
-			org.exist.xquery.parser.XQueryAST tmp462_AST = null;
-			tmp462_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp462_AST);
+			org.exist.xquery.parser.XQueryAST tmp466_AST = null;
+			tmp466_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp466_AST);
 			match(LITERAL_text);
 			if ( inputState.guessing==0 ) {
 				name= "text";
@@ -12432,9 +12672,9 @@ inputState.guessing--;
 		}
 		case LITERAL_node:
 		{
-			org.exist.xquery.parser.XQueryAST tmp463_AST = null;
-			tmp463_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp463_AST);
+			org.exist.xquery.parser.XQueryAST tmp467_AST = null;
+			tmp467_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp467_AST);
 			match(LITERAL_node);
 			if ( inputState.guessing==0 ) {
 				name= "node";
@@ -12444,9 +12684,9 @@ inputState.guessing--;
 		}
 		case LITERAL_or:
 		{
-			org.exist.xquery.parser.XQueryAST tmp464_AST = null;
-			tmp464_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp464_AST);
+			org.exist.xquery.parser.XQueryAST tmp468_AST = null;
+			tmp468_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp468_AST);
 			match(LITERAL_or);
 			if ( inputState.guessing==0 ) {
 				name= "or";
@@ -12456,9 +12696,9 @@ inputState.guessing--;
 		}
 		case LITERAL_and:
 		{
-			org.exist.xquery.parser.XQueryAST tmp465_AST = null;
-			tmp465_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp465_AST);
+			org.exist.xquery.parser.XQueryAST tmp469_AST = null;
+			tmp469_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp469_AST);
 			match(LITERAL_and);
 			if ( inputState.guessing==0 ) {
 				name= "and";
@@ -12468,9 +12708,9 @@ inputState.guessing--;
 		}
 		case LITERAL_child:
 		{
-			org.exist.xquery.parser.XQueryAST tmp466_AST = null;
-			tmp466_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp466_AST);
+			org.exist.xquery.parser.XQueryAST tmp470_AST = null;
+			tmp470_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp470_AST);
 			match(LITERAL_child);
 			if ( inputState.guessing==0 ) {
 				name= "child";
@@ -12480,9 +12720,9 @@ inputState.guessing--;
 		}
 		case LITERAL_parent:
 		{
-			org.exist.xquery.parser.XQueryAST tmp467_AST = null;
-			tmp467_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp467_AST);
+			org.exist.xquery.parser.XQueryAST tmp471_AST = null;
+			tmp471_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp471_AST);
 			match(LITERAL_parent);
 			if ( inputState.guessing==0 ) {
 				name= "parent";
@@ -12492,9 +12732,9 @@ inputState.guessing--;
 		}
 		case LITERAL_self:
 		{
-			org.exist.xquery.parser.XQueryAST tmp468_AST = null;
-			tmp468_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp468_AST);
+			org.exist.xquery.parser.XQueryAST tmp472_AST = null;
+			tmp472_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp472_AST);
 			match(LITERAL_self);
 			if ( inputState.guessing==0 ) {
 				name= "self";
@@ -12504,9 +12744,9 @@ inputState.guessing--;
 		}
 		case LITERAL_attribute:
 		{
-			org.exist.xquery.parser.XQueryAST tmp469_AST = null;
-			tmp469_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp469_AST);
+			org.exist.xquery.parser.XQueryAST tmp473_AST = null;
+			tmp473_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp473_AST);
 			match(LITERAL_attribute);
 			if ( inputState.guessing==0 ) {
 				name= "attribute";
@@ -12516,9 +12756,9 @@ inputState.guessing--;
 		}
 		case LITERAL_comment:
 		{
-			org.exist.xquery.parser.XQueryAST tmp470_AST = null;
-			tmp470_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp470_AST);
+			org.exist.xquery.parser.XQueryAST tmp474_AST = null;
+			tmp474_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp474_AST);
 			match(LITERAL_comment);
 			if ( inputState.guessing==0 ) {
 				name= "comment";
@@ -12528,9 +12768,9 @@ inputState.guessing--;
 		}
 		case LITERAL_document:
 		{
-			org.exist.xquery.parser.XQueryAST tmp471_AST = null;
-			tmp471_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp471_AST);
+			org.exist.xquery.parser.XQueryAST tmp475_AST = null;
+			tmp475_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp475_AST);
 			match(LITERAL_document);
 			if ( inputState.guessing==0 ) {
 				name= "document";
@@ -12540,9 +12780,9 @@ inputState.guessing--;
 		}
 		case 186:
 		{
-			org.exist.xquery.parser.XQueryAST tmp472_AST = null;
-			tmp472_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp472_AST);
+			org.exist.xquery.parser.XQueryAST tmp476_AST = null;
+			tmp476_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp476_AST);
 			match(186);
 			if ( inputState.guessing==0 ) {
 				name= "document-node";
@@ -12552,9 +12792,9 @@ inputState.guessing--;
 		}
 		case LITERAL_collection:
 		{
-			org.exist.xquery.parser.XQueryAST tmp473_AST = null;
-			tmp473_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp473_AST);
+			org.exist.xquery.parser.XQueryAST tmp477_AST = null;
+			tmp477_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp477_AST);
 			match(LITERAL_collection);
 			if ( inputState.guessing==0 ) {
 				name= "collection";
@@ -12564,9 +12804,9 @@ inputState.guessing--;
 		}
 		case LITERAL_ancestor:
 		{
-			org.exist.xquery.parser.XQueryAST tmp474_AST = null;
-			tmp474_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp474_AST);
+			org.exist.xquery.parser.XQueryAST tmp478_AST = null;
+			tmp478_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp478_AST);
 			match(LITERAL_ancestor);
 			if ( inputState.guessing==0 ) {
 				name= "ancestor";
@@ -12576,9 +12816,9 @@ inputState.guessing--;
 		}
 		case LITERAL_descendant:
 		{
-			org.exist.xquery.parser.XQueryAST tmp475_AST = null;
-			tmp475_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp475_AST);
+			org.exist.xquery.parser.XQueryAST tmp479_AST = null;
+			tmp479_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp479_AST);
 			match(LITERAL_descendant);
 			if ( inputState.guessing==0 ) {
 				name= "descendant";
@@ -12588,9 +12828,9 @@ inputState.guessing--;
 		}
 		case 199:
 		{
-			org.exist.xquery.parser.XQueryAST tmp476_AST = null;
-			tmp476_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp476_AST);
+			org.exist.xquery.parser.XQueryAST tmp480_AST = null;
+			tmp480_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp480_AST);
 			match(199);
 			if ( inputState.guessing==0 ) {
 				name= "descendant-or-self";
@@ -12600,9 +12840,9 @@ inputState.guessing--;
 		}
 		case 203:
 		{
-			org.exist.xquery.parser.XQueryAST tmp477_AST = null;
-			tmp477_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp477_AST);
+			org.exist.xquery.parser.XQueryAST tmp481_AST = null;
+			tmp481_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp481_AST);
 			match(203);
 			if ( inputState.guessing==0 ) {
 				name= "ancestor-or-self";
@@ -12612,9 +12852,9 @@ inputState.guessing--;
 		}
 		case 204:
 		{
-			org.exist.xquery.parser.XQueryAST tmp478_AST = null;
-			tmp478_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp478_AST);
+			org.exist.xquery.parser.XQueryAST tmp482_AST = null;
+			tmp482_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp482_AST);
 			match(204);
 			if ( inputState.guessing==0 ) {
 				name= "preceding-sibling";
@@ -12624,9 +12864,9 @@ inputState.guessing--;
 		}
 		case 200:
 		{
-			org.exist.xquery.parser.XQueryAST tmp479_AST = null;
-			tmp479_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp479_AST);
+			org.exist.xquery.parser.XQueryAST tmp483_AST = null;
+			tmp483_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp483_AST);
 			match(200);
 			if ( inputState.guessing==0 ) {
 				name= "following-sibling";
@@ -12636,9 +12876,9 @@ inputState.guessing--;
 		}
 		case LITERAL_following:
 		{
-			org.exist.xquery.parser.XQueryAST tmp480_AST = null;
-			tmp480_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp480_AST);
+			org.exist.xquery.parser.XQueryAST tmp484_AST = null;
+			tmp484_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp484_AST);
 			match(LITERAL_following);
 			if ( inputState.guessing==0 ) {
 				name = "following";
@@ -12648,9 +12888,9 @@ inputState.guessing--;
 		}
 		case LITERAL_preceding:
 		{
-			org.exist.xquery.parser.XQueryAST tmp481_AST = null;
-			tmp481_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp481_AST);
+			org.exist.xquery.parser.XQueryAST tmp485_AST = null;
+			tmp485_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp485_AST);
 			match(LITERAL_preceding);
 			if ( inputState.guessing==0 ) {
 				name = "preceding";
@@ -12660,9 +12900,9 @@ inputState.guessing--;
 		}
 		case LITERAL_item:
 		{
-			org.exist.xquery.parser.XQueryAST tmp482_AST = null;
-			tmp482_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp482_AST);
+			org.exist.xquery.parser.XQueryAST tmp486_AST = null;
+			tmp486_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp486_AST);
 			match(LITERAL_item);
 			if ( inputState.guessing==0 ) {
 				name= "item";
@@ -12672,9 +12912,9 @@ inputState.guessing--;
 		}
 		case LITERAL_empty:
 		{
-			org.exist.xquery.parser.XQueryAST tmp483_AST = null;
-			tmp483_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp483_AST);
+			org.exist.xquery.parser.XQueryAST tmp487_AST = null;
+			tmp487_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp487_AST);
 			match(LITERAL_empty);
 			if ( inputState.guessing==0 ) {
 				name= "empty";
@@ -12684,9 +12924,9 @@ inputState.guessing--;
 		}
 		case LITERAL_version:
 		{
-			org.exist.xquery.parser.XQueryAST tmp484_AST = null;
-			tmp484_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp484_AST);
+			org.exist.xquery.parser.XQueryAST tmp488_AST = null;
+			tmp488_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp488_AST);
 			match(LITERAL_version);
 			if ( inputState.guessing==0 ) {
 				name= "version";
@@ -12696,9 +12936,9 @@ inputState.guessing--;
 		}
 		case LITERAL_xquery:
 		{
-			org.exist.xquery.parser.XQueryAST tmp485_AST = null;
-			tmp485_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp485_AST);
+			org.exist.xquery.parser.XQueryAST tmp489_AST = null;
+			tmp489_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp489_AST);
 			match(LITERAL_xquery);
 			if ( inputState.guessing==0 ) {
 				name= "xquery";
@@ -12708,9 +12948,9 @@ inputState.guessing--;
 		}
 		case LITERAL_variable:
 		{
-			org.exist.xquery.parser.XQueryAST tmp486_AST = null;
-			tmp486_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp486_AST);
+			org.exist.xquery.parser.XQueryAST tmp490_AST = null;
+			tmp490_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp490_AST);
 			match(LITERAL_variable);
 			if ( inputState.guessing==0 ) {
 				name= "variable";
@@ -12720,9 +12960,9 @@ inputState.guessing--;
 		}
 		case LITERAL_namespace:
 		{
-			org.exist.xquery.parser.XQueryAST tmp487_AST = null;
-			tmp487_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp487_AST);
+			org.exist.xquery.parser.XQueryAST tmp491_AST = null;
+			tmp491_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp491_AST);
 			match(LITERAL_namespace);
 			if ( inputState.guessing==0 ) {
 				name= "namespace";
@@ -12732,9 +12972,9 @@ inputState.guessing--;
 		}
 		case LITERAL_if:
 		{
-			org.exist.xquery.parser.XQueryAST tmp488_AST = null;
-			tmp488_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp488_AST);
+			org.exist.xquery.parser.XQueryAST tmp492_AST = null;
+			tmp492_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp492_AST);
 			match(LITERAL_if);
 			if ( inputState.guessing==0 ) {
 				name= "if";
@@ -12744,9 +12984,9 @@ inputState.guessing--;
 		}
 		case LITERAL_then:
 		{
-			org.exist.xquery.parser.XQueryAST tmp489_AST = null;
-			tmp489_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp489_AST);
+			org.exist.xquery.parser.XQueryAST tmp493_AST = null;
+			tmp493_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp493_AST);
 			match(LITERAL_then);
 			if ( inputState.guessing==0 ) {
 				name= "then";
@@ -12756,9 +12996,9 @@ inputState.guessing--;
 		}
 		case LITERAL_else:
 		{
-			org.exist.xquery.parser.XQueryAST tmp490_AST = null;
-			tmp490_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp490_AST);
+			org.exist.xquery.parser.XQueryAST tmp494_AST = null;
+			tmp494_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp494_AST);
 			match(LITERAL_else);
 			if ( inputState.guessing==0 ) {
 				name= "else";
@@ -12768,9 +13008,9 @@ inputState.guessing--;
 		}
 		case LITERAL_for:
 		{
-			org.exist.xquery.parser.XQueryAST tmp491_AST = null;
-			tmp491_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp491_AST);
+			org.exist.xquery.parser.XQueryAST tmp495_AST = null;
+			tmp495_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp495_AST);
 			match(LITERAL_for);
 			if ( inputState.guessing==0 ) {
 				name= "for";
@@ -12780,9 +13020,9 @@ inputState.guessing--;
 		}
 		case LITERAL_where:
 		{
-			org.exist.xquery.parser.XQueryAST tmp492_AST = null;
-			tmp492_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp492_AST);
+			org.exist.xquery.parser.XQueryAST tmp496_AST = null;
+			tmp496_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp496_AST);
 			match(LITERAL_where);
 			if ( inputState.guessing==0 ) {
 				name= "where";
@@ -12792,9 +13032,9 @@ inputState.guessing--;
 		}
 		case LITERAL_in:
 		{
-			org.exist.xquery.parser.XQueryAST tmp493_AST = null;
-			tmp493_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp493_AST);
+			org.exist.xquery.parser.XQueryAST tmp497_AST = null;
+			tmp497_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp497_AST);
 			match(LITERAL_in);
 			if ( inputState.guessing==0 ) {
 				name = "in";
@@ -12804,9 +13044,9 @@ inputState.guessing--;
 		}
 		case LITERAL_let:
 		{
-			org.exist.xquery.parser.XQueryAST tmp494_AST = null;
-			tmp494_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp494_AST);
+			org.exist.xquery.parser.XQueryAST tmp498_AST = null;
+			tmp498_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp498_AST);
 			match(LITERAL_let);
 			if ( inputState.guessing==0 ) {
 				name= "let";
@@ -12816,9 +13056,9 @@ inputState.guessing--;
 		}
 		case LITERAL_try:
 		{
-			org.exist.xquery.parser.XQueryAST tmp495_AST = null;
-			tmp495_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp495_AST);
+			org.exist.xquery.parser.XQueryAST tmp499_AST = null;
+			tmp499_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp499_AST);
 			match(LITERAL_try);
 			if ( inputState.guessing==0 ) {
 				name="try";
@@ -12828,9 +13068,9 @@ inputState.guessing--;
 		}
 		case LITERAL_catch:
 		{
-			org.exist.xquery.parser.XQueryAST tmp496_AST = null;
-			tmp496_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp496_AST);
+			org.exist.xquery.parser.XQueryAST tmp500_AST = null;
+			tmp500_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp500_AST);
 			match(LITERAL_catch);
 			if ( inputState.guessing==0 ) {
 				name="catch";
@@ -12840,9 +13080,9 @@ inputState.guessing--;
 		}
 		case LITERAL_default:
 		{
-			org.exist.xquery.parser.XQueryAST tmp497_AST = null;
-			tmp497_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp497_AST);
+			org.exist.xquery.parser.XQueryAST tmp501_AST = null;
+			tmp501_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp501_AST);
 			match(LITERAL_default);
 			if ( inputState.guessing==0 ) {
 				name= "default";
@@ -12852,9 +13092,9 @@ inputState.guessing--;
 		}
 		case LITERAL_function:
 		{
-			org.exist.xquery.parser.XQueryAST tmp498_AST = null;
-			tmp498_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp498_AST);
+			org.exist.xquery.parser.XQueryAST tmp502_AST = null;
+			tmp502_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp502_AST);
 			match(LITERAL_function);
 			if ( inputState.guessing==0 ) {
 				name= "function";
@@ -12864,9 +13104,9 @@ inputState.guessing--;
 		}
 		case LITERAL_external:
 		{
-			org.exist.xquery.parser.XQueryAST tmp499_AST = null;
-			tmp499_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp499_AST);
+			org.exist.xquery.parser.XQueryAST tmp503_AST = null;
+			tmp503_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp503_AST);
 			match(LITERAL_external);
 			if ( inputState.guessing==0 ) {
 				name = "external";
@@ -12876,9 +13116,9 @@ inputState.guessing--;
 		}
 		case LITERAL_as:
 		{
-			org.exist.xquery.parser.XQueryAST tmp500_AST = null;
-			tmp500_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp500_AST);
+			org.exist.xquery.parser.XQueryAST tmp504_AST = null;
+			tmp504_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp504_AST);
 			match(LITERAL_as);
 			if ( inputState.guessing==0 ) {
 				name = "as";
@@ -12888,9 +13128,9 @@ inputState.guessing--;
 		}
 		case LITERAL_union:
 		{
-			org.exist.xquery.parser.XQueryAST tmp501_AST = null;
-			tmp501_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp501_AST);
+			org.exist.xquery.parser.XQueryAST tmp505_AST = null;
+			tmp505_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp505_AST);
 			match(LITERAL_union);
 			if ( inputState.guessing==0 ) {
 				name = "union";
@@ -12900,9 +13140,9 @@ inputState.guessing--;
 		}
 		case LITERAL_intersect:
 		{
-			org.exist.xquery.parser.XQueryAST tmp502_AST = null;
-			tmp502_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp502_AST);
+			org.exist.xquery.parser.XQueryAST tmp506_AST = null;
+			tmp506_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp506_AST);
 			match(LITERAL_intersect);
 			if ( inputState.guessing==0 ) {
 				name = "intersect";
@@ -12912,9 +13152,9 @@ inputState.guessing--;
 		}
 		case LITERAL_except:
 		{
-			org.exist.xquery.parser.XQueryAST tmp503_AST = null;
-			tmp503_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp503_AST);
+			org.exist.xquery.parser.XQueryAST tmp507_AST = null;
+			tmp507_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp507_AST);
 			match(LITERAL_except);
 			if ( inputState.guessing==0 ) {
 				name = "except";
@@ -12924,9 +13164,9 @@ inputState.guessing--;
 		}
 		case LITERAL_order:
 		{
-			org.exist.xquery.parser.XQueryAST tmp504_AST = null;
-			tmp504_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp504_AST);
+			org.exist.xquery.parser.XQueryAST tmp508_AST = null;
+			tmp508_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp508_AST);
 			match(LITERAL_order);
 			if ( inputState.guessing==0 ) {
 				name = "order";
@@ -12936,9 +13176,9 @@ inputState.guessing--;
 		}
 		case LITERAL_stable:
 		{
-			org.exist.xquery.parser.XQueryAST tmp505_AST = null;
-			tmp505_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp505_AST);
+			org.exist.xquery.parser.XQueryAST tmp509_AST = null;
+			tmp509_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp509_AST);
 			match(LITERAL_stable);
 			if ( inputState.guessing==0 ) {
 				name = "stable";
@@ -12948,9 +13188,9 @@ inputState.guessing--;
 		}
 		case LITERAL_by:
 		{
-			org.exist.xquery.parser.XQueryAST tmp506_AST = null;
-			tmp506_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp506_AST);
+			org.exist.xquery.parser.XQueryAST tmp510_AST = null;
+			tmp510_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp510_AST);
 			match(LITERAL_by);
 			if ( inputState.guessing==0 ) {
 				name = "by";
@@ -12960,9 +13200,9 @@ inputState.guessing--;
 		}
 		case LITERAL_group:
 		{
-			org.exist.xquery.parser.XQueryAST tmp507_AST = null;
-			tmp507_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp507_AST);
+			org.exist.xquery.parser.XQueryAST tmp511_AST = null;
+			tmp511_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp511_AST);
 			match(LITERAL_group);
 			if ( inputState.guessing==0 ) {
 				name = "group";
@@ -12972,9 +13212,9 @@ inputState.guessing--;
 		}
 		case LITERAL_some:
 		{
-			org.exist.xquery.parser.XQueryAST tmp508_AST = null;
-			tmp508_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp508_AST);
+			org.exist.xquery.parser.XQueryAST tmp512_AST = null;
+			tmp512_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp512_AST);
 			match(LITERAL_some);
 			if ( inputState.guessing==0 ) {
 				name = "some";
@@ -12984,9 +13224,9 @@ inputState.guessing--;
 		}
 		case LITERAL_every:
 		{
-			org.exist.xquery.parser.XQueryAST tmp509_AST = null;
-			tmp509_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp509_AST);
+			org.exist.xquery.parser.XQueryAST tmp513_AST = null;
+			tmp513_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp513_AST);
 			match(LITERAL_every);
 			if ( inputState.guessing==0 ) {
 				name = "every";
@@ -12996,9 +13236,9 @@ inputState.guessing--;
 		}
 		case LITERAL_is:
 		{
-			org.exist.xquery.parser.XQueryAST tmp510_AST = null;
-			tmp510_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp510_AST);
+			org.exist.xquery.parser.XQueryAST tmp514_AST = null;
+			tmp514_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp514_AST);
 			match(LITERAL_is);
 			if ( inputState.guessing==0 ) {
 				name = "is";
@@ -13008,9 +13248,9 @@ inputState.guessing--;
 		}
 		case LITERAL_isnot:
 		{
-			org.exist.xquery.parser.XQueryAST tmp511_AST = null;
-			tmp511_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp511_AST);
+			org.exist.xquery.parser.XQueryAST tmp515_AST = null;
+			tmp515_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp515_AST);
 			match(LITERAL_isnot);
 			if ( inputState.guessing==0 ) {
 				name = "isnot";
@@ -13020,9 +13260,9 @@ inputState.guessing--;
 		}
 		case LITERAL_module:
 		{
-			org.exist.xquery.parser.XQueryAST tmp512_AST = null;
-			tmp512_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp512_AST);
+			org.exist.xquery.parser.XQueryAST tmp516_AST = null;
+			tmp516_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp516_AST);
 			match(LITERAL_module);
 			if ( inputState.guessing==0 ) {
 				name = "module";
@@ -13032,9 +13272,9 @@ inputState.guessing--;
 		}
 		case LITERAL_import:
 		{
-			org.exist.xquery.parser.XQueryAST tmp513_AST = null;
-			tmp513_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp513_AST);
+			org.exist.xquery.parser.XQueryAST tmp517_AST = null;
+			tmp517_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp517_AST);
 			match(LITERAL_import);
 			if ( inputState.guessing==0 ) {
 				name = "import";
@@ -13044,9 +13284,9 @@ inputState.guessing--;
 		}
 		case LITERAL_at:
 		{
-			org.exist.xquery.parser.XQueryAST tmp514_AST = null;
-			tmp514_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp514_AST);
+			org.exist.xquery.parser.XQueryAST tmp518_AST = null;
+			tmp518_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp518_AST);
 			match(LITERAL_at);
 			if ( inputState.guessing==0 ) {
 				name = "at";
@@ -13056,9 +13296,9 @@ inputState.guessing--;
 		}
 		case LITERAL_cast:
 		{
-			org.exist.xquery.parser.XQueryAST tmp515_AST = null;
-			tmp515_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp515_AST);
+			org.exist.xquery.parser.XQueryAST tmp519_AST = null;
+			tmp519_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp519_AST);
 			match(LITERAL_cast);
 			if ( inputState.guessing==0 ) {
 				name = "cast";
@@ -13068,9 +13308,9 @@ inputState.guessing--;
 		}
 		case LITERAL_return:
 		{
-			org.exist.xquery.parser.XQueryAST tmp516_AST = null;
-			tmp516_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp516_AST);
+			org.exist.xquery.parser.XQueryAST tmp520_AST = null;
+			tmp520_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp520_AST);
 			match(LITERAL_return);
 			if ( inputState.guessing==0 ) {
 				name = "return";
@@ -13080,9 +13320,9 @@ inputState.guessing--;
 		}
 		case LITERAL_instance:
 		{
-			org.exist.xquery.parser.XQueryAST tmp517_AST = null;
-			tmp517_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp517_AST);
+			org.exist.xquery.parser.XQueryAST tmp521_AST = null;
+			tmp521_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp521_AST);
 			match(LITERAL_instance);
 			if ( inputState.guessing==0 ) {
 				name = "instance";
@@ -13092,9 +13332,9 @@ inputState.guessing--;
 		}
 		case LITERAL_of:
 		{
-			org.exist.xquery.parser.XQueryAST tmp518_AST = null;
-			tmp518_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp518_AST);
+			org.exist.xquery.parser.XQueryAST tmp522_AST = null;
+			tmp522_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp522_AST);
 			match(LITERAL_of);
 			if ( inputState.guessing==0 ) {
 				name = "of";
@@ -13104,9 +13344,9 @@ inputState.guessing--;
 		}
 		case LITERAL_declare:
 		{
-			org.exist.xquery.parser.XQueryAST tmp519_AST = null;
-			tmp519_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp519_AST);
+			org.exist.xquery.parser.XQueryAST tmp523_AST = null;
+			tmp523_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp523_AST);
 			match(LITERAL_declare);
 			if ( inputState.guessing==0 ) {
 				name = "declare";
@@ -13116,9 +13356,9 @@ inputState.guessing--;
 		}
 		case LITERAL_collation:
 		{
-			org.exist.xquery.parser.XQueryAST tmp520_AST = null;
-			tmp520_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp520_AST);
+			org.exist.xquery.parser.XQueryAST tmp524_AST = null;
+			tmp524_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp524_AST);
 			match(LITERAL_collation);
 			if ( inputState.guessing==0 ) {
 				name = "collation";
@@ -13128,9 +13368,9 @@ inputState.guessing--;
 		}
 		case 72:
 		{
-			org.exist.xquery.parser.XQueryAST tmp521_AST = null;
-			tmp521_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp521_AST);
+			org.exist.xquery.parser.XQueryAST tmp525_AST = null;
+			tmp525_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp525_AST);
 			match(72);
 			if ( inputState.guessing==0 ) {
 				name = "boundary-space";
@@ -13140,9 +13380,9 @@ inputState.guessing--;
 		}
 		case LITERAL_preserve:
 		{
-			org.exist.xquery.parser.XQueryAST tmp522_AST = null;
-			tmp522_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp522_AST);
+			org.exist.xquery.parser.XQueryAST tmp526_AST = null;
+			tmp526_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp526_AST);
 			match(LITERAL_preserve);
 			if ( inputState.guessing==0 ) {
 				name = "preserve";
@@ -13152,9 +13392,9 @@ inputState.guessing--;
 		}
 		case LITERAL_strip:
 		{
-			org.exist.xquery.parser.XQueryAST tmp523_AST = null;
-			tmp523_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp523_AST);
+			org.exist.xquery.parser.XQueryAST tmp527_AST = null;
+			tmp527_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp527_AST);
 			match(LITERAL_strip);
 			if ( inputState.guessing==0 ) {
 				name = "strip";
@@ -13164,9 +13404,9 @@ inputState.guessing--;
 		}
 		case LITERAL_ordering:
 		{
-			org.exist.xquery.parser.XQueryAST tmp524_AST = null;
-			tmp524_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp524_AST);
+			org.exist.xquery.parser.XQueryAST tmp528_AST = null;
+			tmp528_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp528_AST);
 			match(LITERAL_ordering);
 			if ( inputState.guessing==0 ) {
 				name = "ordering";
@@ -13176,9 +13416,9 @@ inputState.guessing--;
 		}
 		case LITERAL_construction:
 		{
-			org.exist.xquery.parser.XQueryAST tmp525_AST = null;
-			tmp525_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp525_AST);
+			org.exist.xquery.parser.XQueryAST tmp529_AST = null;
+			tmp529_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp529_AST);
 			match(LITERAL_construction);
 			if ( inputState.guessing==0 ) {
 				name = "construction";
@@ -13188,9 +13428,9 @@ inputState.guessing--;
 		}
 		case LITERAL_ordered:
 		{
-			org.exist.xquery.parser.XQueryAST tmp526_AST = null;
-			tmp526_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp526_AST);
+			org.exist.xquery.parser.XQueryAST tmp530_AST = null;
+			tmp530_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp530_AST);
 			match(LITERAL_ordered);
 			if ( inputState.guessing==0 ) {
 				name = "ordered";
@@ -13200,9 +13440,9 @@ inputState.guessing--;
 		}
 		case LITERAL_unordered:
 		{
-			org.exist.xquery.parser.XQueryAST tmp527_AST = null;
-			tmp527_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp527_AST);
+			org.exist.xquery.parser.XQueryAST tmp531_AST = null;
+			tmp531_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp531_AST);
 			match(LITERAL_unordered);
 			if ( inputState.guessing==0 ) {
 				name = "unordered";
@@ -13212,9 +13452,9 @@ inputState.guessing--;
 		}
 		case LITERAL_typeswitch:
 		{
-			org.exist.xquery.parser.XQueryAST tmp528_AST = null;
-			tmp528_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp528_AST);
+			org.exist.xquery.parser.XQueryAST tmp532_AST = null;
+			tmp532_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp532_AST);
 			match(LITERAL_typeswitch);
 			if ( inputState.guessing==0 ) {
 				name = "typeswitch";
@@ -13224,9 +13464,9 @@ inputState.guessing--;
 		}
 		case LITERAL_switch:
 		{
-			org.exist.xquery.parser.XQueryAST tmp529_AST = null;
-			tmp529_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp529_AST);
+			org.exist.xquery.parser.XQueryAST tmp533_AST = null;
+			tmp533_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp533_AST);
 			match(LITERAL_switch);
 			if ( inputState.guessing==0 ) {
 				name = "switch";
@@ -13236,9 +13476,9 @@ inputState.guessing--;
 		}
 		case LITERAL_encoding:
 		{
-			org.exist.xquery.parser.XQueryAST tmp530_AST = null;
-			tmp530_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp530_AST);
+			org.exist.xquery.parser.XQueryAST tmp534_AST = null;
+			tmp534_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp534_AST);
 			match(LITERAL_encoding);
 			if ( inputState.guessing==0 ) {
 				name = "encoding";
@@ -13248,9 +13488,9 @@ inputState.guessing--;
 		}
 		case 75:
 		{
-			org.exist.xquery.parser.XQueryAST tmp531_AST = null;
-			tmp531_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp531_AST);
+			org.exist.xquery.parser.XQueryAST tmp535_AST = null;
+			tmp535_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp535_AST);
 			match(75);
 			if ( inputState.guessing==0 ) {
 				name = "base-uri";
@@ -13260,9 +13500,9 @@ inputState.guessing--;
 		}
 		case LITERAL_update:
 		{
-			org.exist.xquery.parser.XQueryAST tmp532_AST = null;
-			tmp532_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp532_AST);
+			org.exist.xquery.parser.XQueryAST tmp536_AST = null;
+			tmp536_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp536_AST);
 			match(LITERAL_update);
 			if ( inputState.guessing==0 ) {
 				name = "update";
@@ -13272,9 +13512,9 @@ inputState.guessing--;
 		}
 		case LITERAL_replace:
 		{
-			org.exist.xquery.parser.XQueryAST tmp533_AST = null;
-			tmp533_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp533_AST);
+			org.exist.xquery.parser.XQueryAST tmp537_AST = null;
+			tmp537_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp537_AST);
 			match(LITERAL_replace);
 			if ( inputState.guessing==0 ) {
 				name = "replace";
@@ -13284,9 +13524,9 @@ inputState.guessing--;
 		}
 		case LITERAL_delete:
 		{
-			org.exist.xquery.parser.XQueryAST tmp534_AST = null;
-			tmp534_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp534_AST);
+			org.exist.xquery.parser.XQueryAST tmp538_AST = null;
+			tmp538_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp538_AST);
 			match(LITERAL_delete);
 			if ( inputState.guessing==0 ) {
 				name = "delete";
@@ -13296,9 +13536,9 @@ inputState.guessing--;
 		}
 		case LITERAL_value:
 		{
-			org.exist.xquery.parser.XQueryAST tmp535_AST = null;
-			tmp535_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp535_AST);
+			org.exist.xquery.parser.XQueryAST tmp539_AST = null;
+			tmp539_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp539_AST);
 			match(LITERAL_value);
 			if ( inputState.guessing==0 ) {
 				name = "value";
@@ -13308,9 +13548,9 @@ inputState.guessing--;
 		}
 		case LITERAL_insert:
 		{
-			org.exist.xquery.parser.XQueryAST tmp536_AST = null;
-			tmp536_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp536_AST);
+			org.exist.xquery.parser.XQueryAST tmp540_AST = null;
+			tmp540_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp540_AST);
 			match(LITERAL_insert);
 			if ( inputState.guessing==0 ) {
 				name = "insert";
@@ -13320,9 +13560,9 @@ inputState.guessing--;
 		}
 		case LITERAL_with:
 		{
-			org.exist.xquery.parser.XQueryAST tmp537_AST = null;
-			tmp537_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp537_AST);
+			org.exist.xquery.parser.XQueryAST tmp541_AST = null;
+			tmp541_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp541_AST);
 			match(LITERAL_with);
 			if ( inputState.guessing==0 ) {
 				name = "with";
@@ -13332,9 +13572,9 @@ inputState.guessing--;
 		}
 		case LITERAL_into:
 		{
-			org.exist.xquery.parser.XQueryAST tmp538_AST = null;
-			tmp538_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp538_AST);
+			org.exist.xquery.parser.XQueryAST tmp542_AST = null;
+			tmp542_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp542_AST);
 			match(LITERAL_into);
 			if ( inputState.guessing==0 ) {
 				name = "into";
@@ -13344,9 +13584,9 @@ inputState.guessing--;
 		}
 		case LITERAL_rename:
 		{
-			org.exist.xquery.parser.XQueryAST tmp539_AST = null;
-			tmp539_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp539_AST);
+			org.exist.xquery.parser.XQueryAST tmp543_AST = null;
+			tmp543_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp543_AST);
 			match(LITERAL_rename);
 			if ( inputState.guessing==0 ) {
 				name = "rename";
@@ -13356,9 +13596,9 @@ inputState.guessing--;
 		}
 		case LITERAL_option:
 		{
-			org.exist.xquery.parser.XQueryAST tmp540_AST = null;
-			tmp540_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp540_AST);
+			org.exist.xquery.parser.XQueryAST tmp544_AST = null;
+			tmp544_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp544_AST);
 			match(LITERAL_option);
 			if ( inputState.guessing==0 ) {
 				name = "option";
@@ -13368,9 +13608,9 @@ inputState.guessing--;
 		}
 		case LITERAL_case:
 		{
-			org.exist.xquery.parser.XQueryAST tmp541_AST = null;
-			tmp541_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp541_AST);
+			org.exist.xquery.parser.XQueryAST tmp545_AST = null;
+			tmp545_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp545_AST);
 			match(LITERAL_case);
 			if ( inputState.guessing==0 ) {
 				name = "case";
@@ -13380,9 +13620,9 @@ inputState.guessing--;
 		}
 		case LITERAL_validate:
 		{
-			org.exist.xquery.parser.XQueryAST tmp542_AST = null;
-			tmp542_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp542_AST);
+			org.exist.xquery.parser.XQueryAST tmp546_AST = null;
+			tmp546_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp546_AST);
 			match(LITERAL_validate);
 			if ( inputState.guessing==0 ) {
 				name = "validate";
@@ -13392,9 +13632,9 @@ inputState.guessing--;
 		}
 		case LITERAL_schema:
 		{
-			org.exist.xquery.parser.XQueryAST tmp543_AST = null;
-			tmp543_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp543_AST);
+			org.exist.xquery.parser.XQueryAST tmp547_AST = null;
+			tmp547_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp547_AST);
 			match(LITERAL_schema);
 			if ( inputState.guessing==0 ) {
 				name = "schema";
@@ -13404,9 +13644,9 @@ inputState.guessing--;
 		}
 		case LITERAL_treat:
 		{
-			org.exist.xquery.parser.XQueryAST tmp544_AST = null;
-			tmp544_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp544_AST);
+			org.exist.xquery.parser.XQueryAST tmp548_AST = null;
+			tmp548_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp548_AST);
 			match(LITERAL_treat);
 			if ( inputState.guessing==0 ) {
 				name = "treat";
@@ -13416,9 +13656,9 @@ inputState.guessing--;
 		}
 		case 94:
 		{
-			org.exist.xquery.parser.XQueryAST tmp545_AST = null;
-			tmp545_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp545_AST);
+			org.exist.xquery.parser.XQueryAST tmp549_AST = null;
+			tmp549_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp549_AST);
 			match(94);
 			if ( inputState.guessing==0 ) {
 				name = "no-preserve";
@@ -13428,9 +13668,9 @@ inputState.guessing--;
 		}
 		case LITERAL_inherit:
 		{
-			org.exist.xquery.parser.XQueryAST tmp546_AST = null;
-			tmp546_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp546_AST);
+			org.exist.xquery.parser.XQueryAST tmp550_AST = null;
+			tmp550_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp550_AST);
 			match(LITERAL_inherit);
 			if ( inputState.guessing==0 ) {
 				name = "inherit";
@@ -13440,9 +13680,9 @@ inputState.guessing--;
 		}
 		case 96:
 		{
-			org.exist.xquery.parser.XQueryAST tmp547_AST = null;
-			tmp547_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp547_AST);
+			org.exist.xquery.parser.XQueryAST tmp551_AST = null;
+			tmp551_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp551_AST);
 			match(96);
 			if ( inputState.guessing==0 ) {
 				name = "no-inherit";
@@ -13452,9 +13692,9 @@ inputState.guessing--;
 		}
 		case LITERAL_eq:
 		{
-			org.exist.xquery.parser.XQueryAST tmp548_AST = null;
-			tmp548_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp548_AST);
+			org.exist.xquery.parser.XQueryAST tmp552_AST = null;
+			tmp552_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp552_AST);
 			match(LITERAL_eq);
 			if ( inputState.guessing==0 ) {
 				name="eq";
@@ -13464,9 +13704,9 @@ inputState.guessing--;
 		}
 		case LITERAL_ne:
 		{
-			org.exist.xquery.parser.XQueryAST tmp549_AST = null;
-			tmp549_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp549_AST);
+			org.exist.xquery.parser.XQueryAST tmp553_AST = null;
+			tmp553_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp553_AST);
 			match(LITERAL_ne);
 			if ( inputState.guessing==0 ) {
 				name = "ne";
@@ -13476,9 +13716,9 @@ inputState.guessing--;
 		}
 		case LITERAL_lt:
 		{
-			org.exist.xquery.parser.XQueryAST tmp550_AST = null;
-			tmp550_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp550_AST);
+			org.exist.xquery.parser.XQueryAST tmp554_AST = null;
+			tmp554_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp554_AST);
 			match(LITERAL_lt);
 			if ( inputState.guessing==0 ) {
 				name = "lt";
@@ -13488,9 +13728,9 @@ inputState.guessing--;
 		}
 		case LITERAL_le:
 		{
-			org.exist.xquery.parser.XQueryAST tmp551_AST = null;
-			tmp551_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp551_AST);
+			org.exist.xquery.parser.XQueryAST tmp555_AST = null;
+			tmp555_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp555_AST);
 			match(LITERAL_le);
 			if ( inputState.guessing==0 ) {
 				name = "le";
@@ -13500,9 +13740,9 @@ inputState.guessing--;
 		}
 		case LITERAL_gt:
 		{
-			org.exist.xquery.parser.XQueryAST tmp552_AST = null;
-			tmp552_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp552_AST);
+			org.exist.xquery.parser.XQueryAST tmp556_AST = null;
+			tmp556_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp556_AST);
 			match(LITERAL_gt);
 			if ( inputState.guessing==0 ) {
 				name = "gt";
@@ -13512,9 +13752,9 @@ inputState.guessing--;
 		}
 		case LITERAL_ge:
 		{
-			org.exist.xquery.parser.XQueryAST tmp553_AST = null;
-			tmp553_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp553_AST);
+			org.exist.xquery.parser.XQueryAST tmp557_AST = null;
+			tmp557_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp557_AST);
 			match(LITERAL_ge);
 			if ( inputState.guessing==0 ) {
 				name = "ge";
@@ -13524,9 +13764,9 @@ inputState.guessing--;
 		}
 		case LITERAL_xpointer:
 		{
-			org.exist.xquery.parser.XQueryAST tmp554_AST = null;
-			tmp554_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp554_AST);
+			org.exist.xquery.parser.XQueryAST tmp558_AST = null;
+			tmp558_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp558_AST);
 			match(LITERAL_xpointer);
 			if ( inputState.guessing==0 ) {
 				name = "xpointer";
@@ -13536,9 +13776,9 @@ inputState.guessing--;
 		}
 		case LITERAL_map:
 		{
-			org.exist.xquery.parser.XQueryAST tmp555_AST = null;
-			tmp555_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
-			astFactory.addASTChild(currentAST, tmp555_AST);
+			org.exist.xquery.parser.XQueryAST tmp559_AST = null;
+			tmp559_AST = (org.exist.xquery.parser.XQueryAST)astFactory.create(LT(1));
+			astFactory.addASTChild(currentAST, tmp559_AST);
 			match(LITERAL_map);
 			if ( inputState.guessing==0 ) {
 				name = "map";
@@ -13908,7 +14148,7 @@ inputState.guessing--;
 	}
 	public static final BitSet _tokenSet_12 = new BitSet(mk_tokenSet_12());
 	private static final long[] mk_tokenSet_13() {
-		long[] data = { 0L, 1048576L, 837669530690912256L, 0L, 0L, 0L};
+		long[] data = { 0L, 1048584L, 837669530690912256L, 0L, 0L, 0L};
 		return data;
 	}
 	public static final BitSet _tokenSet_13 = new BitSet(mk_tokenSet_13());

--- a/src/org/exist/xquery/parser/XQueryTree.g
+++ b/src/org/exist/xquery/parser/XQueryTree.g
@@ -2714,15 +2714,27 @@ throws PermissionDeniedException, EXistException, XPathException
 		
 		qnameExpr=expr [qnamePathExpr]
 		(
-			#( prefix:COMP_NS_CONSTRUCTOR uri:STRING_LITERAL )
-			{
-				c.addNamespaceDecl(prefix.getText(), uri.getText());
-			}
-			|
 			{ elementContent = new PathExpr(context); }
 			contentExpr=expr[elementContent]
 			{ construct.addPath(elementContent); }
 		)*
+	)
+	|
+	#(
+		qns:COMP_NS_CONSTRUCTOR
+		{ 
+			NamespaceConstructor c = new NamespaceConstructor(context);
+			c.setASTNode(qns);
+			step = c;
+			PathExpr qnamePathExpr = new PathExpr(context); 
+			c.setNameExpr(qnamePathExpr);
+            elementContent = new PathExpr(context);
+            c.setContentExpr(elementContent);
+		}
+		qnameExpr=expr [qnamePathExpr]
+        (
+            contentExpr=expr [elementContent]
+        )?
 	)
 	|
 	#(

--- a/src/org/exist/xquery/parser/XQueryTreeParser.java
+++ b/src/org/exist/xquery/parser/XQueryTreeParser.java
@@ -443,6 +443,7 @@ public XQueryTreeParser() {
 					case COMP_TEXT_CONSTRUCTOR:
 					case COMP_COMMENT_CONSTRUCTOR:
 					case COMP_PI_CONSTRUCTOR:
+					case COMP_NS_CONSTRUCTOR:
 					case COMP_DOC_CONSTRUCTOR:
 					case PRAGMA:
 					case GTEQ:
@@ -631,6 +632,7 @@ public XQueryTreeParser() {
 					case COMP_TEXT_CONSTRUCTOR:
 					case COMP_COMMENT_CONSTRUCTOR:
 					case COMP_PI_CONSTRUCTOR:
+					case COMP_NS_CONSTRUCTOR:
 					case COMP_DOC_CONSTRUCTOR:
 					case PRAGMA:
 					case GTEQ:
@@ -857,6 +859,7 @@ public XQueryTreeParser() {
 							case COMP_TEXT_CONSTRUCTOR:
 							case COMP_COMMENT_CONSTRUCTOR:
 							case COMP_PI_CONSTRUCTOR:
+							case COMP_NS_CONSTRUCTOR:
 							case COMP_DOC_CONSTRUCTOR:
 							case PRAGMA:
 							case GTEQ:
@@ -970,6 +973,7 @@ public XQueryTreeParser() {
 						case COMP_TEXT_CONSTRUCTOR:
 						case COMP_COMMENT_CONSTRUCTOR:
 						case COMP_PI_CONSTRUCTOR:
+						case COMP_NS_CONSTRUCTOR:
 						case COMP_DOC_CONSTRUCTOR:
 						case PRAGMA:
 						case GTEQ:
@@ -1083,6 +1087,7 @@ public XQueryTreeParser() {
 					case COMP_TEXT_CONSTRUCTOR:
 					case COMP_COMMENT_CONSTRUCTOR:
 					case COMP_PI_CONSTRUCTOR:
+					case COMP_NS_CONSTRUCTOR:
 					case COMP_DOC_CONSTRUCTOR:
 					case PRAGMA:
 					case GTEQ:
@@ -1274,6 +1279,7 @@ public XQueryTreeParser() {
 							case COMP_TEXT_CONSTRUCTOR:
 							case COMP_COMMENT_CONSTRUCTOR:
 							case COMP_PI_CONSTRUCTOR:
+							case COMP_NS_CONSTRUCTOR:
 							case COMP_DOC_CONSTRUCTOR:
 							case PRAGMA:
 							case GTEQ:
@@ -1396,6 +1402,7 @@ public XQueryTreeParser() {
 							case COMP_TEXT_CONSTRUCTOR:
 							case COMP_COMMENT_CONSTRUCTOR:
 							case COMP_PI_CONSTRUCTOR:
+							case COMP_NS_CONSTRUCTOR:
 							case COMP_DOC_CONSTRUCTOR:
 							case PRAGMA:
 							case GTEQ:
@@ -1566,6 +1573,7 @@ public XQueryTreeParser() {
 							case COMP_TEXT_CONSTRUCTOR:
 							case COMP_COMMENT_CONSTRUCTOR:
 							case COMP_PI_CONSTRUCTOR:
+							case COMP_NS_CONSTRUCTOR:
 							case COMP_DOC_CONSTRUCTOR:
 							case PRAGMA:
 							case GTEQ:
@@ -1724,6 +1732,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -1872,6 +1881,7 @@ public XQueryTreeParser() {
 						case COMP_TEXT_CONSTRUCTOR:
 						case COMP_COMMENT_CONSTRUCTOR:
 						case COMP_PI_CONSTRUCTOR:
+						case COMP_NS_CONSTRUCTOR:
 						case COMP_DOC_CONSTRUCTOR:
 						case PRAGMA:
 						case GTEQ:
@@ -2056,6 +2066,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -2234,6 +2245,7 @@ public XQueryTreeParser() {
 						case COMP_TEXT_CONSTRUCTOR:
 						case COMP_COMMENT_CONSTRUCTOR:
 						case COMP_PI_CONSTRUCTOR:
+						case COMP_NS_CONSTRUCTOR:
 						case COMP_DOC_CONSTRUCTOR:
 						case PRAGMA:
 						case GTEQ:
@@ -2392,6 +2404,7 @@ public XQueryTreeParser() {
 						case COMP_TEXT_CONSTRUCTOR:
 						case COMP_COMMENT_CONSTRUCTOR:
 						case COMP_PI_CONSTRUCTOR:
+						case COMP_NS_CONSTRUCTOR:
 						case COMP_DOC_CONSTRUCTOR:
 						case PRAGMA:
 						case GTEQ:
@@ -2521,6 +2534,7 @@ public XQueryTreeParser() {
 						case COMP_TEXT_CONSTRUCTOR:
 						case COMP_COMMENT_CONSTRUCTOR:
 						case COMP_PI_CONSTRUCTOR:
+						case COMP_NS_CONSTRUCTOR:
 						case COMP_DOC_CONSTRUCTOR:
 						case PRAGMA:
 						case GTEQ:
@@ -2644,6 +2658,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -3040,6 +3055,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -3292,6 +3308,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -3426,6 +3443,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -3617,6 +3635,7 @@ public XQueryTreeParser() {
 		case COMP_TEXT_CONSTRUCTOR:
 		case COMP_COMMENT_CONSTRUCTOR:
 		case COMP_PI_CONSTRUCTOR:
+		case COMP_NS_CONSTRUCTOR:
 		case COMP_DOC_CONSTRUCTOR:
 		case STRING_LITERAL:
 		case LCURLY:
@@ -3818,6 +3837,7 @@ public XQueryTreeParser() {
 		case COMP_TEXT_CONSTRUCTOR:
 		case COMP_COMMENT_CONSTRUCTOR:
 		case COMP_PI_CONSTRUCTOR:
+		case COMP_NS_CONSTRUCTOR:
 		case COMP_DOC_CONSTRUCTOR:
 		case PRAGMA:
 		case GTEQ:
@@ -3952,6 +3972,7 @@ public XQueryTreeParser() {
 		case COMP_TEXT_CONSTRUCTOR:
 		case COMP_COMMENT_CONSTRUCTOR:
 		case COMP_PI_CONSTRUCTOR:
+		case COMP_NS_CONSTRUCTOR:
 		case COMP_DOC_CONSTRUCTOR:
 		case PRAGMA:
 		case GTEQ:
@@ -4550,6 +4571,7 @@ public XQueryTreeParser() {
 				case COMP_TEXT_CONSTRUCTOR:
 				case COMP_COMMENT_CONSTRUCTOR:
 				case COMP_PI_CONSTRUCTOR:
+				case COMP_NS_CONSTRUCTOR:
 				case COMP_DOC_CONSTRUCTOR:
 				case PRAGMA:
 				case GTEQ:
@@ -4665,6 +4687,7 @@ public XQueryTreeParser() {
 				case COMP_TEXT_CONSTRUCTOR:
 				case COMP_COMMENT_CONSTRUCTOR:
 				case COMP_PI_CONSTRUCTOR:
+				case COMP_NS_CONSTRUCTOR:
 				case COMP_DOC_CONSTRUCTOR:
 				case PRAGMA:
 				case GTEQ:
@@ -6289,7 +6312,7 @@ public XQueryTreeParser() {
 		switch ( _t.getType()) {
 		case LITERAL_cast:
 		{
-			AST __t321 = _t;
+			AST __t322 = _t;
 			castAST = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,LITERAL_cast);
 			_t = _t.getFirstChild();
@@ -6327,13 +6350,13 @@ public XQueryTreeParser() {
 						path.add(castExpr);
 						step = castExpr;
 					
-			_t = __t321;
+			_t = __t322;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case LITERAL_castable:
 		{
-			AST __t323 = _t;
+			AST __t324 = _t;
 			castableAST = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,LITERAL_castable);
 			_t = _t.getFirstChild();
@@ -6371,7 +6394,7 @@ public XQueryTreeParser() {
 						path.add(castExpr);
 						step = castExpr;
 					
-			_t = __t323;
+			_t = __t324;
 			_t = _t.getNextSibling();
 			break;
 		}
@@ -6860,6 +6883,7 @@ public XQueryTreeParser() {
 		case COMP_TEXT_CONSTRUCTOR:
 		case COMP_COMMENT_CONSTRUCTOR:
 		case COMP_PI_CONSTRUCTOR:
+		case COMP_NS_CONSTRUCTOR:
 		case COMP_DOC_CONSTRUCTOR:
 		case LCURLY:
 		case XML_COMMENT:
@@ -6911,6 +6935,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -7824,6 +7849,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -7973,6 +7999,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -8129,12 +8156,12 @@ public XQueryTreeParser() {
 		
 		
 		{
-		int _cnt329=0;
-		_loop329:
+		int _cnt330=0;
+		_loop330:
 		do {
 			if (_t==null) _t=ASTNULL;
 			if ((_t.getType()==PRAGMA)) {
-				AST __t327 = _t;
+				AST __t328 = _t;
 				p = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 				match(_t,PRAGMA);
 				_t = _t.getFirstChild();
@@ -8166,14 +8193,14 @@ public XQueryTreeParser() {
 									ext.addPragma(pragma);
 								}
 							
-				_t = __t327;
+				_t = __t328;
 				_t = _t.getNextSibling();
 			}
 			else {
-				if ( _cnt329>=1 ) { break _loop329; } else {throw new NoViableAltException(_t);}
+				if ( _cnt330>=1 ) { break _loop330; } else {throw new NoViableAltException(_t);}
 			}
 			
-			_cnt329++;
+			_cnt330++;
 		} while (true);
 		}
 		expr(_t,pathExpr);
@@ -8391,7 +8418,7 @@ public XQueryTreeParser() {
 		
 		
 		
-		AST __t331 = _t;
+		AST __t332 = _t;
 		updateAST = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 		match(_t,LITERAL_update);
 		_t = _t.getFirstChild();
@@ -8502,6 +8529,7 @@ public XQueryTreeParser() {
 		case COMP_TEXT_CONSTRUCTOR:
 		case COMP_COMMENT_CONSTRUCTOR:
 		case COMP_PI_CONSTRUCTOR:
+		case COMP_NS_CONSTRUCTOR:
 		case COMP_DOC_CONSTRUCTOR:
 		case PRAGMA:
 		case GTEQ:
@@ -8615,7 +8643,7 @@ public XQueryTreeParser() {
 					path.add(mod);
 					step = mod;
 				
-		_t = __t331;
+		_t = __t332;
 		_t = _t.getNextSibling();
 		_retTree = _t;
 		return step;
@@ -8628,8 +8656,7 @@ public XQueryTreeParser() {
 		
 		org.exist.xquery.parser.XQueryAST constructor_AST_in = (_t == ASTNULL) ? null : (org.exist.xquery.parser.XQueryAST)_t;
 		org.exist.xquery.parser.XQueryAST qn = null;
-		org.exist.xquery.parser.XQueryAST prefix = null;
-		org.exist.xquery.parser.XQueryAST uri = null;
+		org.exist.xquery.parser.XQueryAST qns = null;
 		org.exist.xquery.parser.XQueryAST attr = null;
 		org.exist.xquery.parser.XQueryAST qna = null;
 		org.exist.xquery.parser.XQueryAST pid = null;
@@ -8674,174 +8701,42 @@ public XQueryTreeParser() {
 			qnameExpr=expr(_t,qnamePathExpr);
 			_t = _retTree;
 			{
-			_loop296:
+			_loop295:
 			do {
 				if (_t==null) _t=ASTNULL;
-				switch ( _t.getType()) {
-				case COMP_NS_CONSTRUCTOR:
-				{
-					AST __t295 = _t;
-					prefix = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
-					match(_t,COMP_NS_CONSTRUCTOR);
-					_t = _t.getFirstChild();
-					uri = (org.exist.xquery.parser.XQueryAST)_t;
-					match(_t,STRING_LITERAL);
-					_t = _t.getNextSibling();
-					_t = __t295;
-					_t = _t.getNextSibling();
-					
-									c.addNamespaceDecl(prefix.getText(), uri.getText());
-								
-					break;
-				}
-				case EOF:
-				case QNAME:
-				case PARENTHESIZED:
-				case ABSOLUTE_SLASH:
-				case ABSOLUTE_DSLASH:
-				case WILDCARD:
-				case PREFIX_WILDCARD:
-				case FUNCTION:
-				case UNARY_MINUS:
-				case UNARY_PLUS:
-				case VARIABLE_REF:
-				case ELEMENT:
-				case TEXT:
-				case FUNCTION_DECL:
-				case ATTRIBUTE_TEST:
-				case COMP_ELEM_CONSTRUCTOR:
-				case COMP_ATTR_CONSTRUCTOR:
-				case COMP_TEXT_CONSTRUCTOR:
-				case COMP_COMMENT_CONSTRUCTOR:
-				case COMP_PI_CONSTRUCTOR:
-				case COMP_DOC_CONSTRUCTOR:
-				case PRAGMA:
-				case GTEQ:
-				case SEQUENCE:
-				case NCNAME:
-				case EQ:
-				case STRING_LITERAL:
-				case LITERAL_element:
-				case COMMA:
-				case LCURLY:
-				case STAR:
-				case PLUS:
-				case LITERAL_map:
-				case LITERAL_try:
-				case LITERAL_some:
-				case LITERAL_every:
-				case LITERAL_if:
-				case LITERAL_switch:
-				case LITERAL_typeswitch:
-				case LITERAL_update:
-				case LITERAL_preceding:
-				case LITERAL_following:
-				case UNION:
-				case LITERAL_return:
-				case LITERAL_or:
-				case LITERAL_and:
-				case LITERAL_instance:
-				case LITERAL_treat:
-				case LITERAL_castable:
-				case LITERAL_cast:
-				case BEFORE:
-				case AFTER:
-				case LITERAL_eq:
-				case LITERAL_ne:
-				case LITERAL_lt:
-				case LITERAL_le:
-				case LITERAL_gt:
-				case LITERAL_ge:
-				case GT:
-				case NEQ:
-				case LT:
-				case LTEQ:
-				case LITERAL_is:
-				case LITERAL_isnot:
-				case ANDEQ:
-				case OREQ:
-				case CONCAT:
-				case LITERAL_to:
-				case MINUS:
-				case LITERAL_div:
-				case LITERAL_idiv:
-				case LITERAL_mod:
-				case LITERAL_intersect:
-				case LITERAL_except:
-				case SLASH:
-				case DSLASH:
-				case BANG:
-				case LITERAL_text:
-				case LITERAL_node:
-				case LITERAL_attribute:
-				case LITERAL_comment:
-				case 185:
-				case 186:
-				case HASH:
-				case SELF:
-				case XML_COMMENT:
-				case XML_PI:
-				case AT:
-				case PARENT:
-				case LITERAL_child:
-				case LITERAL_self:
-				case LITERAL_descendant:
-				case 199:
-				case 200:
-				case LITERAL_parent:
-				case LITERAL_ancestor:
-				case 203:
-				case 204:
-				case DOUBLE_LITERAL:
-				case DECIMAL_LITERAL:
-				case INTEGER_LITERAL:
-				case XML_CDATA:
-				{
+				if ((_tokenSet_0.member(_t.getType()))) {
 					elementContent = new PathExpr(context);
 					contentExpr=expr(_t,elementContent);
 					_t = _retTree;
 					construct.addPath(elementContent);
-					break;
 				}
-				default:
-				{
-					break _loop296;
+				else {
+					break _loop295;
 				}
-				}
+				
 			} while (true);
 			}
 			_t = __t293;
 			_t = _t.getNextSibling();
 			break;
 		}
-		case COMP_ATTR_CONSTRUCTOR:
+		case COMP_NS_CONSTRUCTOR:
 		{
-			AST __t297 = _t;
-			attr = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
-			match(_t,COMP_ATTR_CONSTRUCTOR);
+			AST __t296 = _t;
+			qns = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
+			match(_t,COMP_NS_CONSTRUCTOR);
 			_t = _t.getFirstChild();
 			
-						DynamicAttributeConstructor a= new DynamicAttributeConstructor(context);
-			a.setASTNode(attr);
-			step = a;
-			PathExpr qnamePathExpr = new PathExpr(context);
-			a.setNameExpr(qnamePathExpr);
+						NamespaceConstructor c = new NamespaceConstructor(context);
+						c.setASTNode(qns);
+						step = c;
+						PathExpr qnamePathExpr = new PathExpr(context); 
+						c.setNameExpr(qnamePathExpr);
 			elementContent = new PathExpr(context);
-			a.setContentExpr(elementContent);
+			c.setContentExpr(elementContent);
 					
-			qna = _t==ASTNULL ? null : (org.exist.xquery.parser.XQueryAST)_t;
 			qnameExpr=expr(_t,qnamePathExpr);
 			_t = _retTree;
-			
-			QName qname = QName.parse(staticContext, qna.getText());
-			if (Namespaces.XMLNS_NS.equals(qname.getNamespaceURI()) 
-			|| ("".equals(qname.getNamespaceURI()) && qname.getLocalName().equals("xmlns")))
-			throw new XPathException("err:XQDY0044: the node-name property of the node constructed by a computed attribute constructor is in the namespace http://www.w3.org/2000/xmlns/ (corresponding to namespace prefix xmlns), or is in no namespace and has local name xmlns.");
-			
-			AST __t298 = _t;
-			org.exist.xquery.parser.XQueryAST tmp116_AST_in = (org.exist.xquery.parser.XQueryAST)_t;
-			match(_t,LCURLY);
-			_t = _t.getFirstChild();
 			{
 			if (_t==null) _t=ASTNULL;
 			switch ( _t.getType()) {
@@ -8865,6 +8760,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -8962,15 +8858,168 @@ public XQueryTreeParser() {
 			}
 			}
 			}
-			_t = __t298;
+			_t = __t296;
 			_t = _t.getNextSibling();
-			_t = __t297;
+			break;
+		}
+		case COMP_ATTR_CONSTRUCTOR:
+		{
+			AST __t298 = _t;
+			attr = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
+			match(_t,COMP_ATTR_CONSTRUCTOR);
+			_t = _t.getFirstChild();
+			
+						DynamicAttributeConstructor a= new DynamicAttributeConstructor(context);
+			a.setASTNode(attr);
+			step = a;
+			PathExpr qnamePathExpr = new PathExpr(context);
+			a.setNameExpr(qnamePathExpr);
+			elementContent = new PathExpr(context);
+			a.setContentExpr(elementContent);
+					
+			qna = _t==ASTNULL ? null : (org.exist.xquery.parser.XQueryAST)_t;
+			qnameExpr=expr(_t,qnamePathExpr);
+			_t = _retTree;
+			
+			QName qname = QName.parse(staticContext, qna.getText());
+			if (Namespaces.XMLNS_NS.equals(qname.getNamespaceURI()) 
+			|| ("".equals(qname.getNamespaceURI()) && qname.getLocalName().equals("xmlns")))
+			throw new XPathException("err:XQDY0044: the node-name property of the node constructed by a computed attribute constructor is in the namespace http://www.w3.org/2000/xmlns/ (corresponding to namespace prefix xmlns), or is in no namespace and has local name xmlns.");
+			
+			AST __t299 = _t;
+			org.exist.xquery.parser.XQueryAST tmp116_AST_in = (org.exist.xquery.parser.XQueryAST)_t;
+			match(_t,LCURLY);
+			_t = _t.getFirstChild();
+			{
+			if (_t==null) _t=ASTNULL;
+			switch ( _t.getType()) {
+			case EOF:
+			case QNAME:
+			case PARENTHESIZED:
+			case ABSOLUTE_SLASH:
+			case ABSOLUTE_DSLASH:
+			case WILDCARD:
+			case PREFIX_WILDCARD:
+			case FUNCTION:
+			case UNARY_MINUS:
+			case UNARY_PLUS:
+			case VARIABLE_REF:
+			case ELEMENT:
+			case TEXT:
+			case FUNCTION_DECL:
+			case ATTRIBUTE_TEST:
+			case COMP_ELEM_CONSTRUCTOR:
+			case COMP_ATTR_CONSTRUCTOR:
+			case COMP_TEXT_CONSTRUCTOR:
+			case COMP_COMMENT_CONSTRUCTOR:
+			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
+			case COMP_DOC_CONSTRUCTOR:
+			case PRAGMA:
+			case GTEQ:
+			case SEQUENCE:
+			case NCNAME:
+			case EQ:
+			case STRING_LITERAL:
+			case LITERAL_element:
+			case COMMA:
+			case LCURLY:
+			case STAR:
+			case PLUS:
+			case LITERAL_map:
+			case LITERAL_try:
+			case LITERAL_some:
+			case LITERAL_every:
+			case LITERAL_if:
+			case LITERAL_switch:
+			case LITERAL_typeswitch:
+			case LITERAL_update:
+			case LITERAL_preceding:
+			case LITERAL_following:
+			case UNION:
+			case LITERAL_return:
+			case LITERAL_or:
+			case LITERAL_and:
+			case LITERAL_instance:
+			case LITERAL_treat:
+			case LITERAL_castable:
+			case LITERAL_cast:
+			case BEFORE:
+			case AFTER:
+			case LITERAL_eq:
+			case LITERAL_ne:
+			case LITERAL_lt:
+			case LITERAL_le:
+			case LITERAL_gt:
+			case LITERAL_ge:
+			case GT:
+			case NEQ:
+			case LT:
+			case LTEQ:
+			case LITERAL_is:
+			case LITERAL_isnot:
+			case ANDEQ:
+			case OREQ:
+			case CONCAT:
+			case LITERAL_to:
+			case MINUS:
+			case LITERAL_div:
+			case LITERAL_idiv:
+			case LITERAL_mod:
+			case LITERAL_intersect:
+			case LITERAL_except:
+			case SLASH:
+			case DSLASH:
+			case BANG:
+			case LITERAL_text:
+			case LITERAL_node:
+			case LITERAL_attribute:
+			case LITERAL_comment:
+			case 185:
+			case 186:
+			case HASH:
+			case SELF:
+			case XML_COMMENT:
+			case XML_PI:
+			case AT:
+			case PARENT:
+			case LITERAL_child:
+			case LITERAL_self:
+			case LITERAL_descendant:
+			case 199:
+			case 200:
+			case LITERAL_parent:
+			case LITERAL_ancestor:
+			case 203:
+			case 204:
+			case DOUBLE_LITERAL:
+			case DECIMAL_LITERAL:
+			case INTEGER_LITERAL:
+			case XML_CDATA:
+			{
+				contentExpr=expr(_t,elementContent);
+				_t = _retTree;
+				break;
+			}
+			case 3:
+			{
+				break;
+			}
+			default:
+			{
+				throw new NoViableAltException(_t);
+			}
+			}
+			}
+			_t = __t299;
+			_t = _t.getNextSibling();
+			_t = __t298;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case COMP_PI_CONSTRUCTOR:
 		{
-			AST __t300 = _t;
+			AST __t301 = _t;
 			pid = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,COMP_PI_CONSTRUCTOR);
 			_t = _t.getFirstChild();
@@ -8985,7 +9034,7 @@ public XQueryTreeParser() {
 					
 			qnameExpr=expr(_t,qnamePathExpr);
 			_t = _retTree;
-			AST __t301 = _t;
+			AST __t302 = _t;
 			org.exist.xquery.parser.XQueryAST tmp117_AST_in = (org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,LCURLY);
 			_t = _t.getFirstChild();
@@ -9012,6 +9061,7 @@ public XQueryTreeParser() {
 			case COMP_TEXT_CONSTRUCTOR:
 			case COMP_COMMENT_CONSTRUCTOR:
 			case COMP_PI_CONSTRUCTOR:
+			case COMP_NS_CONSTRUCTOR:
 			case COMP_DOC_CONSTRUCTOR:
 			case PRAGMA:
 			case GTEQ:
@@ -9114,15 +9164,15 @@ public XQueryTreeParser() {
 			}
 			}
 			}
-			_t = __t301;
+			_t = __t302;
 			_t = _t.getNextSibling();
-			_t = __t300;
+			_t = __t301;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case ELEMENT:
 		{
-			AST __t303 = _t;
+			AST __t304 = _t;
 			e = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,ELEMENT);
 			_t = _t.getFirstChild();
@@ -9133,11 +9183,11 @@ public XQueryTreeParser() {
 						staticContext.pushInScopeNamespaces();
 					
 			{
-			_loop309:
+			_loop310:
 			do {
 				if (_t==null) _t=ASTNULL;
 				if ((_t.getType()==ATTRIBUTE)) {
-					AST __t305 = _t;
+					AST __t306 = _t;
 					attrName = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 					match(_t,ATTRIBUTE);
 					_t = _t.getFirstChild();
@@ -9146,7 +9196,7 @@ public XQueryTreeParser() {
 										attrib.setASTNode(attrName);
 									
 					{
-					_loop308:
+					_loop309:
 					do {
 						if (_t==null) _t=ASTNULL;
 						switch ( _t.getType()) {
@@ -9162,7 +9212,7 @@ public XQueryTreeParser() {
 						}
 						case LCURLY:
 						{
-							AST __t307 = _t;
+							AST __t308 = _t;
 							org.exist.xquery.parser.XQueryAST tmp118_AST_in = (org.exist.xquery.parser.XQueryAST)_t;
 							match(_t,LCURLY);
 							_t = _t.getFirstChild();
@@ -9170,13 +9220,13 @@ public XQueryTreeParser() {
 							expr(_t,enclosed);
 							_t = _retTree;
 							attrib.addEnclosedExpr(enclosed);
-							_t = __t307;
+							_t = __t308;
 							_t = _t.getNextSibling();
 							break;
 						}
 						default:
 						{
-							break _loop308;
+							break _loop309;
 						}
 						}
 					} while (true);
@@ -9189,17 +9239,17 @@ public XQueryTreeParser() {
 					}
 					
 					
-					_t = __t305;
+					_t = __t306;
 					_t = _t.getNextSibling();
 				}
 				else {
-					break _loop309;
+					break _loop310;
 				}
 				
 			} while (true);
 			}
 			{
-			_loop311:
+			_loop312:
 			do {
 				if (_t==null) _t=ASTNULL;
 				if ((_tokenSet_9.member(_t.getType()))) {
@@ -9214,7 +9264,7 @@ public XQueryTreeParser() {
 					elementContent.add(contentExpr);
 				}
 				else {
-					break _loop311;
+					break _loop312;
 				}
 				
 			} while (true);
@@ -9222,13 +9272,13 @@ public XQueryTreeParser() {
 			
 			staticContext.popInScopeNamespaces();
 			
-			_t = __t303;
+			_t = __t304;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case TEXT:
 		{
-			AST __t312 = _t;
+			AST __t313 = _t;
 			pcdata = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,TEXT);
 			_t = _t.getFirstChild();
@@ -9237,13 +9287,13 @@ public XQueryTreeParser() {
 			text.setASTNode(pcdata);
 						step= text;
 					
-			_t = __t312;
+			_t = __t313;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case COMP_TEXT_CONSTRUCTOR:
 		{
-			AST __t313 = _t;
+			AST __t314 = _t;
 			t = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,COMP_TEXT_CONSTRUCTOR);
 			_t = _t.getFirstChild();
@@ -9255,13 +9305,13 @@ public XQueryTreeParser() {
 					
 			contentExpr=expr(_t,elementContent);
 			_t = _retTree;
-			_t = __t313;
+			_t = __t314;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case COMP_COMMENT_CONSTRUCTOR:
 		{
-			AST __t314 = _t;
+			AST __t315 = _t;
 			tc = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,COMP_COMMENT_CONSTRUCTOR);
 			_t = _t.getFirstChild();
@@ -9273,13 +9323,13 @@ public XQueryTreeParser() {
 					
 			contentExpr=expr(_t,elementContent);
 			_t = _retTree;
-			_t = __t314;
+			_t = __t315;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case COMP_DOC_CONSTRUCTOR:
 		{
-			AST __t315 = _t;
+			AST __t316 = _t;
 			d = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,COMP_DOC_CONSTRUCTOR);
 			_t = _t.getFirstChild();
@@ -9291,13 +9341,13 @@ public XQueryTreeParser() {
 					
 			contentExpr=expr(_t,elementContent);
 			_t = _retTree;
-			_t = __t315;
+			_t = __t316;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case XML_COMMENT:
 		{
-			AST __t316 = _t;
+			AST __t317 = _t;
 			cdata = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,XML_COMMENT);
 			_t = _t.getFirstChild();
@@ -9306,13 +9356,13 @@ public XQueryTreeParser() {
 			comment.setASTNode(cdata);
 						step= comment;
 					
-			_t = __t316;
+			_t = __t317;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case XML_PI:
 		{
-			AST __t317 = _t;
+			AST __t318 = _t;
 			p = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,XML_PI);
 			_t = _t.getFirstChild();
@@ -9321,13 +9371,13 @@ public XQueryTreeParser() {
 			pi.setASTNode(p);
 						step= pi;
 					
-			_t = __t317;
+			_t = __t318;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case XML_CDATA:
 		{
-			AST __t318 = _t;
+			AST __t319 = _t;
 			cdataSect = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,XML_CDATA);
 			_t = _t.getFirstChild();
@@ -9336,13 +9386,13 @@ public XQueryTreeParser() {
 						cd.setASTNode(cdataSect);
 						step= cd;
 					
-			_t = __t318;
+			_t = __t319;
 			_t = _t.getNextSibling();
 			break;
 		}
 		case LCURLY:
 		{
-			AST __t319 = _t;
+			AST __t320 = _t;
 			l = _t==ASTNULL ? null :(org.exist.xquery.parser.XQueryAST)_t;
 			match(_t,LCURLY);
 			_t = _t.getFirstChild();
@@ -9353,7 +9403,7 @@ public XQueryTreeParser() {
 			step=expr(_t,subexpr);
 			_t = _retTree;
 			step= subexpr;
-			_t = __t319;
+			_t = __t320;
 			_t = _t.getNextSibling();
 			break;
 		}
@@ -9455,6 +9505,7 @@ public XQueryTreeParser() {
 						case COMP_TEXT_CONSTRUCTOR:
 						case COMP_COMMENT_CONSTRUCTOR:
 						case COMP_PI_CONSTRUCTOR:
+						case COMP_NS_CONSTRUCTOR:
 						case COMP_DOC_CONSTRUCTOR:
 						case PRAGMA:
 						case GTEQ:
@@ -9584,7 +9635,7 @@ public XQueryTreeParser() {
 		
 		
 		
-		AST __t336 = _t;
+		AST __t337 = _t;
 		org.exist.xquery.parser.XQueryAST tmp121_AST_in = (org.exist.xquery.parser.XQueryAST)_t;
 		match(_t,LITERAL_map);
 		_t = _t.getFirstChild();
@@ -9594,11 +9645,11 @@ public XQueryTreeParser() {
 					step = expr;
 				
 		{
-		_loop339:
+		_loop340:
 		do {
 			if (_t==null) _t=ASTNULL;
 			if ((_t.getType()==COLON)) {
-				AST __t338 = _t;
+				AST __t339 = _t;
 				org.exist.xquery.parser.XQueryAST tmp122_AST_in = (org.exist.xquery.parser.XQueryAST)_t;
 				match(_t,COLON);
 				_t = _t.getFirstChild();
@@ -9611,16 +9662,16 @@ public XQueryTreeParser() {
 				step=expr(_t,value);
 				_t = _retTree;
 				expr.map(key, value);
-				_t = __t338;
+				_t = __t339;
 				_t = _t.getNextSibling();
 			}
 			else {
-				break _loop339;
+				break _loop340;
 			}
 			
 		} while (true);
 		}
-		_t = __t336;
+		_t = __t337;
 		_t = _t.getNextSibling();
 		_retTree = _t;
 		return step;
@@ -9684,6 +9735,7 @@ public XQueryTreeParser() {
 				case COMP_TEXT_CONSTRUCTOR:
 				case COMP_COMMENT_CONSTRUCTOR:
 				case COMP_PI_CONSTRUCTOR:
+				case COMP_NS_CONSTRUCTOR:
 				case COMP_DOC_CONSTRUCTOR:
 				case PRAGMA:
 				case GTEQ:
@@ -10217,7 +10269,7 @@ public XQueryTreeParser() {
 	
 	private static final long[] mk_tokenSet_0() {
 		long[] data = new long[8];
-		data[0]=5169850899401858962L;
+		data[0]=5187865297911340946L;
 		data[1]=143182819933290544L;
 		data[2]=-576707042908635093L;
 		data[3]=134283260L;
@@ -10226,7 +10278,7 @@ public XQueryTreeParser() {
 	public static final BitSet _tokenSet_0 = new BitSet(mk_tokenSet_0());
 	private static final long[] mk_tokenSet_1() {
 		long[] data = new long[8];
-		data[0]=5169850899938729874L;
+		data[0]=5187865298448211858L;
 		data[1]=143184056883871792L;
 		data[2]=-576707042908635093L;
 		data[3]=134283260L;
@@ -10235,7 +10287,7 @@ public XQueryTreeParser() {
 	public static final BitSet _tokenSet_1 = new BitSet(mk_tokenSet_1());
 	private static final long[] mk_tokenSet_2() {
 		long[] data = new long[8];
-		data[0]=5169850899401858962L;
+		data[0]=5187865297911340946L;
 		data[1]=143184056883871792L;
 		data[2]=-576707042908635093L;
 		data[3]=134283260L;
@@ -10275,7 +10327,7 @@ public XQueryTreeParser() {
 	public static final BitSet _tokenSet_7 = new BitSet(mk_tokenSet_7());
 	private static final long[] mk_tokenSet_8() {
 		long[] data = new long[8];
-		data[0]=5169850899401858970L;
+		data[0]=5187865297911340954L;
 		data[1]=143182819933290544L;
 		data[2]=-576707042908635093L;
 		data[3]=134283260L;
@@ -10284,7 +10336,7 @@ public XQueryTreeParser() {
 	public static final BitSet _tokenSet_8 = new BitSet(mk_tokenSet_8());
 	private static final long[] mk_tokenSet_9() {
 		long[] data = new long[8];
-		data[0]=53480245584461824L;
+		data[0]=71494644093943808L;
 		data[1]=17179869184L;
 		data[2]=-4611686018427387904L;
 		data[3]=134217728L;
@@ -10293,7 +10345,7 @@ public XQueryTreeParser() {
 	public static final BitSet _tokenSet_9 = new BitSet(mk_tokenSet_9());
 	private static final long[] mk_tokenSet_10() {
 		long[] data = new long[8];
-		data[0]=5169850899401858962L;
+		data[0]=5187865297911340946L;
 		data[1]=143191616026312752L;
 		data[2]=-576707042908635093L;
 		data[3]=134283260L;

--- a/test/src/xquery/namespaces.xql
+++ b/test/src/xquery/namespaces.xql
@@ -1,0 +1,55 @@
+xquery version "3.0";
+
+module namespace nt="http://exist-db.org/xquery/test/namespaces";
+
+import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+declare 
+    %test:assertEquals("<test xmlns:foo='http://foo.com'/>")
+function nt:dynamicNSConstr1() {
+    <test>
+    { namespace foo { "http://foo.com" } }
+    </test>
+};
+
+declare 
+    %test:assertEquals("<test xmlns:foo='http://foo.com'>bla</test>")
+function nt:dynamicNSConstr2() {
+    element { "test" } {
+        namespace foo { "http://foo.com" },
+        "bla"
+    }
+};
+
+declare 
+    %test:assertEquals("<test xmlns:foo1='http://foo.com'/>")
+function nt:dynamicNSConstr3() {
+    <test>
+    { namespace { "foo" || 1 } { "http://foo.com" } }
+    </test>
+};
+
+declare 
+    %test:assertEquals("<html xmlns:ev='http://www.w3.org/2001/xml-events'></html>")
+function nt:dynamicNSConstr4() {
+    let $xml :=
+        <html xmlns:ev="http://www.w3.org/2001/xml-events"></html>
+    return
+        element { node-name($xml) } {
+            nt:copy-ns($xml)
+        }
+};
+
+declare %private function nt:copy-ns($node) {
+    for $prefix in in-scope-prefixes($node)
+    return
+        namespace { $prefix } { namespace-uri-for-prefix($prefix, $node) } 
+};
+
+declare 
+    %test:assertError
+function nt:dynamicNSConstrError() {
+    <test>
+    { namespace { (1, 2) } { "http://foo.com" } }
+    </test>
+};

--- a/test/src/xquery/suite.xql
+++ b/test/src/xquery/suite.xql
@@ -3,6 +3,7 @@ xquery version "3.0";
 import module namespace test="http://exist-db.org/xquery/xqsuite"
 at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
 
-test:suite(
-    inspect:module-functions(xs:anyURI("last.xql"))
-)
+test:suite((
+    inspect:module-functions(xs:anyURI("last.xql")),
+    inspect:module-functions(xs:anyURI("namespaces.xql"))
+))


### PR DESCRIPTION
Support for a computed namespace constructor in eXist dated back to a very early draft of XQuery and was later abandoned. Fixed the grammar to comply with 3.0 and made the implementation match the latest spec. Added a bunch of test cases.
