### PR TITLE
Handle UnsupportedOperationException for certain lucene field queries to avoid resource drainage

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneMatchListener.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneMatchListener.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2008-2012 The eXist-db Project
+ * Copyright (C) 2008-2013 The eXist-db Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
@@ -326,6 +326,8 @@ public class LuceneMatchListener extends AbstractMatchListener {
                         LuceneUtil.extractTerms(query, termMap, reader, false);
                     } catch (IOException e) {
                         LOG.warn("Error while highlighting lucene query matches: " + e.getMessage(), e);
+                    } catch (UnsupportedOperationException uoe) {
+                        LOG.warn("Error while highlighting lucene query matches: " + uoe.getMessage(), uoe);
                     } finally {
                         index.releaseReader(reader);
                     }

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
@@ -105,8 +105,9 @@ public class LuceneUtil {
      * @param query
      * @param terms
      * @throws IOException in case of an error
+     * @throws UnsupportedOperationException in case of an error
      */
-    public static void extractTerms(Query query, Map<Object, Query> terms, IndexReader reader, boolean includeFields) throws IOException {
+    public static void extractTerms(Query query, Map<Object, Query> terms, IndexReader reader, boolean includeFields) throws IOException, UnsupportedOperationException {
         if (query instanceof BooleanQuery)
             extractTermsFromBoolean((BooleanQuery)query, terms, reader, includeFields);
         else if (query instanceof TermQuery)


### PR DESCRIPTION
Handle and report UnsupportedOperationExceptions to log for certain lucene field queries instead of just muffle the exception with potentially severe resource drainage as a consequence.
