### PR TITLE
CHanges for preparing replication/messaging extension

### DIFF
--- a/src/org/exist/storage/BrokerPool.java
+++ b/src/org/exist/storage/BrokerPool.java
@@ -1547,7 +1547,7 @@ public class BrokerPool implements Database {
 						}
 					}
 				});
-                LOG.error(sb.toString());
+                LOG.debug(sb.toString());
 				throw new RuntimeException(sb.toString());
 			}
 			return broker;

--- a/src/org/exist/xquery/Profiler.java
+++ b/src/org/exist/xquery/Profiler.java
@@ -144,6 +144,7 @@ public class Profiler {
             final Boolean globalProp = (Boolean) broker.getConfiguration().getProperty(CONFIG_PROPERTY_TRACELOG);
             return logEnabled || (globalProp != null && globalProp.booleanValue());
         } catch (Throwable t) {
+            log.debug("Ignored exception: " + t.getMessage());
             return logEnabled;
         }
     }


### PR DESCRIPTION
Unfortunately #getActiveBroker() can throw a RunTimeException ; this is a blocker for the replication/messaging extension.

This change handles the situation gracefully, log messages are written (debug level to prevent flooding)
