### PR TITLE
Add missing entity-resolver to collection.xconf validation stance

### DIFF
--- a/schema/collection.xconf.xsd
+++ b/schema/collection.xconf.xsd
@@ -260,6 +260,9 @@
         <xs:annotation>
             <xs:documentation>Per collection validation-switch configuration</xs:documentation>
         </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="entity-resolver" minOccurs="0"/>
+        </xs:sequence>
         <xs:attribute name="mode" use="required" type="modeType"/>
     </xs:complexType>
     
@@ -270,6 +273,23 @@
             <xs:enumeration value="yes"/>
         </xs:restriction>
     </xs:simpleType>
+    
+    <xs:element name="entity-resolver" type="entityResolverType"/>
+    
+    <xs:complexType name="entityResolverType">
+        <xs:annotation>
+            <xs:documentation>Reference of a catalogue with grammar links</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="catalog"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:element name="catalog" type="catalogType"/>
+    
+    <xs:complexType name="catalogType">
+        <xs:attribute name="uri" use="required" type="xs:string"/>
+    </xs:complexType>
     
     <!-- we are hiding attributes in attributeGroup to manage their
         namespaces as described here: http://docstore.mik.ua/orelly/xml/schema/ch10_04.htm -->


### PR DESCRIPTION
This allows one entity-resolver, which must contain one catalog with an URI that must be a string.

I do not claim any copyright in such a small contribution. I declare this public domain. If you can use it, I will be happy.
