### PR TITLE
Fix lucene analyzer configuration

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/AnalyzerConfig.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/AnalyzerConfig.java
@@ -238,7 +238,7 @@ public class AnalyzerConfig {
 
     private static CharArraySet getConstructorParameterCharArraySetValues(Element param) {
         final Set<String> set = getConstructorParameterSetValues(param);
-        return CharArraySet.copy(Version.LUCENE_44, set);
+        return CharArraySet.copy(LuceneIndex.LUCENE_VERSION_IN_USE, set);
     }
 
     private static class KeyTypedValue {

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndex.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndex.java
@@ -32,7 +32,7 @@ import org.apache.lucene.util.Version;
 
 public class LuceneIndex extends AbstractIndex implements RawBackupSupport {
     
-    public final static Version LUCENE_VERSION_IN_USE = Version.LUCENE_43;
+    public final static Version LUCENE_VERSION_IN_USE = Version.LUCENE_44;
 
     private static final Logger LOG = Logger.getLogger(LuceneIndexWorker.class);
 


### PR DESCRIPTION
[bugfix] Lucene index configuration: constructor of default analyzers now expect stopword lists to be provided in a CharArraySet instead of a Set, e.g.:

``` xml
<analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer">
    <param name="stopwords" type="org.apache.lucene.analysis.util.CharArraySet"/>
</analyzer>
```
