### PR TITLE
[bugfix] Fix memory leak in lucene-based query functions

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/Query.java
@@ -305,5 +305,13 @@ public class Query extends Function implements Optimizable {
             throw new XPathException(this, "Error while parsing options to ft:query: " + e.getMessage(), e);
         }
     }
+
+    @Override
+    public void resetState(boolean postOptimization) {
+        super.resetState(postOptimization);
+        if (!postOptimization) {
+            preselectResult = null;
+        }
+    }
 }
 

--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/QueryField.java
@@ -153,5 +153,13 @@ public class QueryField extends Query implements Optimizable {
         }
         return result;
     }
+
+    @Override
+    public void resetState(boolean postOptimization) {
+        super.resetState(postOptimization);
+        if (!postOptimization) {
+            preselectResult = null;
+        }
+    }
 }
 

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/FieldLookup.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/FieldLookup.java
@@ -332,4 +332,13 @@ public class FieldLookup extends Function implements Optimizable {
     public int returnsType() {
         return Type.NODE;
     }
+
+    @Override
+    public void resetState(boolean postOptimization) {
+        super.resetState(postOptimization);
+        fallback.resetState(postOptimization);
+        if (!postOptimization) {
+            preselectResult = null;
+        }
+    }
 }

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/Lookup.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/Lookup.java
@@ -301,6 +301,15 @@ public class Lookup extends Function implements Optimizable {
     }
 
     @Override
+    public void resetState(boolean postOptimization) {
+        super.resetState(postOptimization);
+        fallback.resetState(postOptimization);
+        if (!postOptimization) {
+            preselectResult = null;
+        }
+    }
+
+    @Override
     public boolean canOptimize(Sequence contextSequence) {
         return contextQName != null;
     }


### PR DESCRIPTION
preselectResult needs to be cleared in resetState.
