### PR TITLE
[bugfix] function lookups: ExternalModuleImpl.isReady always returned fa...

### DIFF
--- a/src/org/exist/xquery/ExternalModuleImpl.java
+++ b/src/org/exist/xquery/ExternalModuleImpl.java
@@ -67,7 +67,7 @@ public class ExternalModuleImpl implements ExternalModule {
     }
 
     public boolean isReady() {
-        return false;
+        return isReady;
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
...lse, so a second lookup was done. Costs performance and may lead to NPE in dynamic function lookups.
