### PR TITLE
Added json:name attribute for non-XML valid JSON Property Names

### DIFF
--- a/src/org/exist/util/serializer/json/JSONNode.java
+++ b/src/org/exist/util/serializer/json/JSONNode.java
@@ -1,3 +1,24 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2013 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *  
+ *  $Id$
+ */
 package org.exist.util.serializer.json;
 
 import java.io.IOException;
@@ -5,77 +26,77 @@ import java.io.Writer;
 
 public abstract class JSONNode {
 
-	protected final static String ANONYMOUS_OBJECT = "#anonymous";
-	
-	public static enum SerializationType { AS_STRING, AS_ARRAY, AS_LITERAL };
-	
-	public static enum Type { OBJECT_TYPE, VALUE_TYPE, SIMPLE_PROPERTY_TYPE };
-	
-	private Type type;
-	private String name;
-	private SerializationType writeAs = SerializationType.AS_STRING;
-	
-	private JSONNode next = null;
-	private JSONNode nextOfSame = null;
-	 
-	public JSONNode(Type type, String name) {
-		this.type = type;
-		this.name = name;
-	}
-	
-	public abstract void serialize(Writer writer, boolean isRoot) throws IOException;
-	
-	public abstract void serializeContent(Writer writer) throws IOException;
-	
-	public Type getType() {
-		return type;
-	}
-	
-	public boolean isNamed() {
-		return !getName().equals(ANONYMOUS_OBJECT);
-	}
-	
-	public boolean isArray() {
-		return getNextOfSame() != null || getSerializationType() == SerializationType.AS_ARRAY;
-	}
-	
-	public SerializationType getSerializationType() {
-		return writeAs;
-	}
-	
-	public void setSerializationType(SerializationType type) {
-		writeAs = type;
-	}
-	
-	public JSONNode getNextOfSame() {
-		return nextOfSame;
-	}
-	
-	public void setNextOfSame(JSONNode nextOfSame) {
-		if (this.nextOfSame == null)
-			{this.nextOfSame = nextOfSame;}
-		else {
-			JSONNode current = this.nextOfSame;
-			while (current.nextOfSame != null) {
-				current = current.nextOfSame;
-			}
-			current.nextOfSame = nextOfSame;
-		}
-	}
+    protected final static String ANONYMOUS_OBJECT = "#anonymous";
 
-	public void setNext(JSONNode next) {
-		this.next = next;
-	}
-	
-	public JSONNode getNext() {
-		return next;
-	}
-	
-	public String getName() {
-		return name;
-	}
-	
-	public void setName(String name) {
-		this.name = name;
-	}
+    public static enum SerializationType { AS_STRING, AS_ARRAY, AS_LITERAL };
+
+    public static enum Type { OBJECT_TYPE, VALUE_TYPE, SIMPLE_PROPERTY_TYPE };
+
+    private Type type;
+    private String name;
+    private SerializationType writeAs = SerializationType.AS_STRING;
+
+    private JSONNode next = null;
+    private JSONNode nextOfSame = null;
+
+    public JSONNode(final Type type, final String name) {
+        this.type = type;
+        this.name = name;
+    }
+
+    public abstract void serialize(final Writer writer, final boolean isRoot) throws IOException;
+
+    public abstract void serializeContent(final Writer writer) throws IOException;
+
+    public Type getType() {
+        return type;
+    }
+
+    public boolean isNamed() {
+        return !getName().equals(ANONYMOUS_OBJECT);
+    }
+
+    public boolean isArray() {
+        return getNextOfSame() != null || getSerializationType() == SerializationType.AS_ARRAY;
+    }
+
+    public SerializationType getSerializationType() {
+        return writeAs;
+    }
+
+    public void setSerializationType(SerializationType type) {
+        writeAs = type;
+    }
+
+    public JSONNode getNextOfSame() {
+        return nextOfSame;
+    }
+
+    public void setNextOfSame(JSONNode nextOfSame) {
+        if(this.nextOfSame == null) {
+            this.nextOfSame = nextOfSame;
+        } else {
+            JSONNode current = this.nextOfSame;
+            while(current.nextOfSame != null) {
+                current = current.nextOfSame;
+            }
+            current.nextOfSame = nextOfSame;
+        }
+    }
+
+    public void setNext(final JSONNode next) {
+        this.next = next;
+    }
+
+    public JSONNode getNext() {
+        return next;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
 }

--- a/src/org/exist/util/serializer/json/JSONObject.java
+++ b/src/org/exist/util/serializer/json/JSONObject.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2011 The eXist Project
+ * Copyright (C) 2013 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
@@ -24,153 +24,161 @@ package org.exist.util.serializer.json;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import org.apache.log4j.Logger;
 
 public class JSONObject extends JSONNode {
-	
-	protected JSONNode firstChild = null;
-	private boolean asSimpleValue = false;
-	
-	public JSONObject() {
-		super(Type.OBJECT_TYPE, ANONYMOUS_OBJECT);
-	}
-	
-	public JSONObject(String name) {
-		super(Type.OBJECT_TYPE, name);
-	}
-	
-	public JSONObject(String name, boolean asSimpleValue) {
-		super(Type.OBJECT_TYPE, name);
-		this.asSimpleValue = asSimpleValue;
-	}
 
-	public void addObject(JSONNode node) {
-		JSONNode childNode = findChild(node.getName());
-		if (childNode == null) {
-			childNode = getLastChild();
-			if (childNode == null)
-				{firstChild = node;}
-			else
-				{childNode.setNext(node);}
-		} else
-			{childNode.setNextOfSame(node);}
-	}
+    private final static Logger LOG = Logger.getLogger(JSONObject.class);
+    
+    protected JSONNode firstChild = null;
+    private boolean asSimpleValue = false;
+
+    public JSONObject() {
+        super(Type.OBJECT_TYPE, ANONYMOUS_OBJECT);
+    }
+
+    public JSONObject(final String name) {
+        super(Type.OBJECT_TYPE, name);
+    }
+
+    public JSONObject(final String name, final boolean asSimpleValue) {
+        super(Type.OBJECT_TYPE, name);
+        this.asSimpleValue = asSimpleValue;
+    }
+
+    public void addObject(final JSONNode node) {
+        JSONNode childNode = findChild(node.getName());
+        if(childNode == null) {
+            childNode = getLastChild();
+            if(childNode == null) {
+                firstChild = node;
+            } else {
+                childNode.setNext(node);
+            }
+        } else {
+            childNode.setNextOfSame(node);
+        }
+    }
 	
-	public JSONNode findChild(String nameToFind) {
-		JSONNode nextNode = firstChild;
-		while (nextNode != null) {
-			if (nextNode.getName().equals(nameToFind))
-				{return nextNode;}
-			nextNode = nextNode.getNext();
-		}
-		return null;
-	}
+    public JSONNode findChild(final String nameToFind) {
+        JSONNode nextNode = firstChild;
+        while(nextNode != null) {
+            if(nextNode.getName().equals(nameToFind)) {
+                return nextNode;
+            }
+            nextNode = nextNode.getNext();
+        }
+        return null;
+    }
+
+    public JSONNode getLastChild() {
+        JSONNode nextNode = firstChild;
+        JSONNode currentNode = null;
+        while(nextNode != null) {
+            currentNode = nextNode;
+            nextNode = currentNode.getNext();
+        }
+        return currentNode;
+    }
 	
-	public JSONNode getLastChild() {
-		JSONNode nextNode = firstChild;
-		JSONNode currentNode = null;
-		while (nextNode != null) {
-			currentNode = nextNode;
-			nextNode = currentNode.getNext();
-		}
-		return currentNode;
-	}
+    public int getChildCount() {
+        int count = 0;
+        JSONNode nextNode = firstChild;
+        while(nextNode != null) {
+            count++;
+            nextNode = nextNode.getNext();
+        }
+        return count;
+    }
 	
-	public int getChildCount() {
-		int count = 0;
-		JSONNode nextNode = firstChild;
-		while (nextNode != null) {
-			count++;
-			nextNode = nextNode.getNext();
-		}
-		return count;
-	}
-	
-	public void serialize(Writer writer, boolean isRoot) throws IOException {
-		if (!isRoot && isNamed()) {
-			writer.write('"');
-			writer.write(getName());
-			writer.write("\" : ");
-		}
-		if (getNextOfSame() != null || getSerializationType() == SerializationType.AS_ARRAY) {
-			writer.write("[");
-			JSONNode next = this;
-			while (next != null) {
-				next.serializeContent(writer);
-				next = next.getNextOfSame();
-				if (next != null)
-					{writer.write(", ");}
-			}
-			writer.write("]");
-		} else
-			{serializeContent(writer);}
-	}
-	
-	public void serializeContent(Writer writer) throws IOException {
-		if (firstChild == null) {
-                    // an empty node gets a null value, unless its a specified array
-                    if(getSerializationType() != SerializationType.AS_ARRAY) {
-                        writer.write("null");
-                    }
+    public void serialize(final Writer writer, final boolean isRoot) throws IOException {
+        if(!isRoot && isNamed()) {
+            writer.write('"');
+            writer.write(getName());
+            writer.write("\" : ");
+        }
+        
+        if(getNextOfSame() != null || getSerializationType() == SerializationType.AS_ARRAY) {
+            writer.write("[");
+            JSONNode next = this;
+            while(next != null) {
+                next.serializeContent(writer);
+                next = next.getNextOfSame();
+                if (next != null) {
+                    writer.write(", ");
                 }
-		else if (firstChild.getNext() == null && 
-					(
-						firstChild.getType() == Type.VALUE_TYPE ||
-						(firstChild.isArray() && !firstChild.isNamed())
-					)
-				)
-			// if there's only one child and if it is text, it is serialized as simple value
-			{firstChild.serialize(writer, false);}
-		else {
-			// complex object
-			writer.write("{ ");
-			
-			JSONNode next = firstChild;
-			boolean allowText = false;
-			boolean skipMixedContentText = false;
-			while (next != null) {
-				if (next.getType() == Type.VALUE_TYPE) {
-					// if an element has attributes and text content, the text
-					// node is serialized as property "#text". 
-                    // Text in mixed content nodes is ignored though.
-					if (allowText) {
-						writer.write("\"#text\" : ");
-						next.serialize(writer, false);
-						allowText = false;
-					} else {
+            }
+            writer.write("]");
+        } else {
+            serializeContent(writer);
+        }
+    }
+	
+    @Override
+    public void serializeContent(final Writer writer) throws IOException {
+        if(firstChild == null) {
+            // an empty node gets a null value, unless its a specified array
+            if(getSerializationType() != SerializationType.AS_ARRAY) {
+                writer.write("null");
+            }
+        } else if(firstChild.getNext() == null
+                && (firstChild.getType() == Type.VALUE_TYPE || (firstChild.isArray() && !firstChild.isNamed()))) {
+                // if there's only one child and if it is text, it is serialized as simple value
+                firstChild.serialize(writer, false);
+        } else {
+            // complex object
+            writer.write("{ ");
+
+            JSONNode next = firstChild;
+            boolean allowText = false;
+            boolean skipMixedContentText = false;
+            while(next != null) {
+                if(next.getType() == Type.VALUE_TYPE) {
+                    /*
+                     if an element has attributes and text content, the text
+                     node is serialized as property "#text". 
+                     Text in mixed content nodes is ignored though.
+                    */
+                    if(allowText) {
+                        writer.write("\"#text\" : ");
+                        next.serialize(writer, false);
+                        allowText = false;
+                    } else {
                         //writer.write("\"#mixed-content-text\" : ");
                         skipMixedContentText = true;
                     }
-				} else
-					{next.serialize(writer, false);}
-				if (next.getType() == Type.SIMPLE_PROPERTY_TYPE)
-					{allowText = true;}
-				next = next.getNext();
-				if (next != null && !skipMixedContentText && !isMixedContentTextLast(next, allowText)) {
-					writer.write(", ");
+                } else {
+                    next.serialize(writer, false);
                 }
+
+                if(next.getType() == Type.SIMPLE_PROPERTY_TYPE) {
+                    allowText = true;
+                }
+
+                next = next.getNext();
+
+                if(next != null && !skipMixedContentText && !isMixedContentTextLast(next, allowText)) {
+                    writer.write(", ");
+                }
+
                 skipMixedContentText = false;
-			}
-			
-			writer.write(" }");
-		}
-	}
+            }
+            writer.write(" }");
+        }
+    }
  
-   private boolean isMixedContentTextLast(final JSONNode node, final boolean allowText) {
-       if (node.getType() == Type.VALUE_TYPE && !allowText && node.equals(getLastChild()))
-            {return true;}
-        return false;
+    private boolean isMixedContentTextLast(final JSONNode node, final boolean allowText) {
+        return node.getType() == Type.VALUE_TYPE && !allowText && node.equals(getLastChild());
     }
 
-	@Override
-	public String toString() {
-		final StringWriter writer = new StringWriter();
-		try {
-			serialize(writer, false);
-		} catch (final IOException e) {
-			e.printStackTrace();
-		}
-		return writer.toString();
-	}
-	
-	
+    @Override
+    public String toString() {
+        final StringWriter writer = new StringWriter();
+        try {
+            serialize(writer, false);
+        } catch(final IOException e) {
+            LOG.warn(e);
+        }
+        return writer.toString();
+    }
 }

--- a/src/org/exist/util/serializer/json/JSONSimpleProperty.java
+++ b/src/org/exist/util/serializer/json/JSONSimpleProperty.java
@@ -1,3 +1,24 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2013 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *  
+ *  $Id$
+ */
 package org.exist.util.serializer.json;
 
 import java.io.IOException;
@@ -12,33 +33,38 @@ import java.io.Writer;
  */
 public class JSONSimpleProperty extends JSONNode {
 
-	private String value;
+    private final String value;
 
-	public JSONSimpleProperty(String name, String value) {
-		this(name, value, false);
-	}
-
-    public JSONSimpleProperty(String name, String value, boolean isLiteral) {
-        super(Type.SIMPLE_PROPERTY_TYPE, name);
-        this.value = JSONValue.escape(value);
-        if (isLiteral)
-            {setSerializationType(SerializationType.AS_LITERAL);}
+    public JSONSimpleProperty(final String name, final String value) {
+        this(name, value, false);
     }
 
-	@Override
-	public void serialize(Writer writer, boolean isRoot) throws IOException {
-		writer.write('"');
-		writer.write(getName());
-		writer.write("\" : ");
-        if (getSerializationType() != SerializationType.AS_LITERAL)
-            {writer.write('"');}
-		writer.write(value);
-        if (getSerializationType() != SerializationType.AS_LITERAL)
-            {writer.write('"');}
-	}
+    public JSONSimpleProperty(final String name, final String value, final boolean isLiteral) {
+        super(Type.SIMPLE_PROPERTY_TYPE, name);
+        this.value = JSONValue.escape(value);
+        if(isLiteral) {
+            setSerializationType(SerializationType.AS_LITERAL);
+        }
+    }
 
-	@Override
-	public void serializeContent(Writer writer) throws IOException {
-	}
+    @Override
+    public void serialize(final Writer writer, final boolean isRoot) throws IOException {
+        writer.write('"');
+        writer.write(getName());
+        writer.write("\" : ");
+        
+        if(getSerializationType() != SerializationType.AS_LITERAL) {
+            writer.write('"');
+        }
+        
+        writer.write(value);
+        
+        if(getSerializationType() != SerializationType.AS_LITERAL) {
+            writer.write('"');
+        }
+    }
 
+    @Override
+    public void serializeContent(final Writer writer) throws IOException {
+    }
 }

--- a/src/org/exist/util/serializer/json/JSONValue.java
+++ b/src/org/exist/util/serializer/json/JSONValue.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2011-2012 The eXist Project
+ * Copyright (C) 2013 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
@@ -26,82 +26,91 @@ import java.io.Writer;
 
 public class JSONValue extends JSONNode {
 	
-	public final static String NAME_VALUE = "#text";
-	
-	private String content = null;
+    public final static String NAME_VALUE = "#text";
 
-    public JSONValue(String content) {
+    private String content = null;
+
+    public JSONValue(final String content) {
         this(content, true);
     }
 
-	public JSONValue(String content, boolean escape) {
-		super(Type.VALUE_TYPE, NAME_VALUE);
-        if (escape)
-            {this.content =  escape(content);}
-        else
-            {this.content = content;}
-	}
+    public JSONValue(final String content, final boolean escape) {
+        super(Type.VALUE_TYPE, NAME_VALUE);
+        
+        if(escape) {
+            this.content =  escape(content);
+        } else {
+            this.content = content;
+        }
+    }
 
-	public JSONValue() {
-		super(Type.VALUE_TYPE, NAME_VALUE);
-	}
+    public JSONValue() {
+        super(Type.VALUE_TYPE, NAME_VALUE);
+    }
 
-	public void addContent(String str) {
-		if (content == null)
-			{content = str;}
-		else
-			{content += str;}
-	}
-	
-	@Override
-	public void serialize(Writer writer, boolean isRoot) throws IOException {
-		if (getNextOfSame() != null) {
-			writer.write("[");
-			JSONNode next = this;
-			while (next != null) {
-				next.serializeContent(writer);
-				next = next.getNextOfSame();
-				if (next != null)
-					{writer.write(", ");}
-			}
-			writer.write("]");
-		} else
-			{serializeContent(writer);}		
-	}
+    public void addContent(final String str) {
+        if(content == null){
+            content = str;
+        } else {
+            content += str;
+        }
+    }
 
-	@Override
-	public void serializeContent(Writer writer) throws IOException {
-		if (getSerializationType() != SerializationType.AS_LITERAL)
-			{writer.write('"');}
-		writer.write(content);
-		if (getSerializationType() != SerializationType.AS_LITERAL)
-			{writer.write('"');}
-	}
-	
-	protected static String escape(String str) {
-		final StringBuilder builder = new StringBuilder();
-		for (int i = 0; i < str.length(); i++) {
-			final char ch = str.charAt(i);
-			switch (ch) {
-			case '\n':
-				builder.append("\\n");
-				break;
-			case '\r':
-				break;
-			case '\t':
-				builder.append("\\t");
-				break;
-			case '"':
-				builder.append("\\\"");
-				break;
-			case '\\':
-				builder.append("\\\\");
-				break;
-			default:
-				builder.append(ch);
-				break;
-			}
-		}
-		return builder.toString();
-	}
+    @Override
+    public void serialize(final Writer writer, final boolean isRoot) throws IOException {
+        if(getNextOfSame() != null) {
+            writer.write("[");
+            JSONNode next = this;
+            while(next != null) {
+                next.serializeContent(writer);
+                next = next.getNextOfSame();
+                if(next != null) {
+                    writer.write(", ");
+                }
+            }
+            writer.write("]");
+        } else {
+            serializeContent(writer);
+        }		
+    }
+
+    @Override
+    public void serializeContent(final Writer writer) throws IOException {
+        if(getSerializationType() != SerializationType.AS_LITERAL) {
+            writer.write('"');
+        }
+        
+        writer.write(content);
+        
+        if(getSerializationType() != SerializationType.AS_LITERAL) {
+            writer.write('"');
+        }
+    }
+
+    protected static String escape(final String str) {
+        final StringBuilder builder = new StringBuilder();
+        for(int i = 0; i < str.length(); i++) {
+            final char ch = str.charAt(i);
+            switch (ch) {
+                case '\n':
+                    builder.append("\\n");
+                    break;
+                case '\r':
+                    break;
+                case '\t':
+                    builder.append("\\t");
+                    break;
+                case '"':
+                    builder.append("\\\"");
+                    break;
+                case '\\':
+                    builder.append("\\\\");
+                    break;
+                default:
+                    builder.append(ch);
+                    break;
+            }
+        }
+        return builder.toString();
+    }
 }

--- a/src/org/exist/util/serializer/json/JSONWriter.java
+++ b/src/org/exist/util/serializer/json/JSONWriter.java
@@ -50,10 +50,12 @@ public class JSONWriter extends XMLWriter {
     private final static String ARRAY = "array";
     private final static String LITERAL = "literal";
     private final static String VALUE = "value";
+    private final static String NAME = "name";
     
     private final static String JSON_ARRAY = "json:" + ARRAY;
     private final static String JSON_LITERAL = "json:" + LITERAL;
     private final static String JSON_VALUE = "json:" + VALUE;
+    private final static String JSON_NAME = "json:" + NAME;
     
     public final static String JASON_NS = "http://www.json.org";
 	
@@ -183,6 +185,8 @@ public class JSONWriter extends XMLWriter {
             parent.setSerializationType(JSONNode.SerializationType.AS_ARRAY);
         } else if(qname.equals(JSON_LITERAL)) {
             parent.setSerializationType(JSONNode.SerializationType.AS_LITERAL);
+        } else if(qname.equals(JSON_NAME)) {
+            parent.setName(value);
         } else {
             final String name = prefixAttributes ? "@" + qname : qname;
             final JSONSimpleProperty obj = new JSONSimpleProperty(name, value);


### PR DESCRIPTION
Ignoring cleanup, the detail is in commit 9bdeded. Some JSON property names are non-valid XML element names, it was previously impossible to create JSON with such names.

You can now use the json:name attribute to create JSON properties with names which are not valid XML element names. For example if you want to create the JSON:

``` json
{
  "id": 1,
  "name": "my-thing",
  "$ref": "1/extra",
}
```

You can now use:

``` xml
<json:value>
  <id>1</id>
  <name>my-thing</name>
  <ref json:name="$ref">1/extra</ref>
</json:value>
```
