### PR TITLE
[bugfix] Module load path for XQuery module was overwritten

### DIFF
--- a/src/org/exist/xquery/ModuleContext.java
+++ b/src/org/exist/xquery/ModuleContext.java
@@ -87,7 +87,7 @@ public class ModuleContext extends XQueryContext {
 		parentContext.setModulesChanged();
 	}
 	
-	public void setParentContext(XQueryContext parentContext) {
+	private void setParentContext(XQueryContext parentContext) {
         this.parentContext = parentContext;
         //XXX: raise error on null!
         if (parentContext != null) {
@@ -142,9 +142,6 @@ public class ModuleContext extends XQueryContext {
             modules.remove(namespaceURI);   // unbind the module
         } else {
             modules.put(namespaceURI, module);
-            if (!module.isInternalModule() && module.isReady()) {
-                ((ModuleContext) ((ExternalModule) module).getContext()).setParentContext(parentContext);
-            }
         }
         setRootModule(namespaceURI, module);
     }

--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -1542,10 +1542,6 @@ public class XQueryContext implements BinaryValueManager, Context
             modules.remove( namespaceURI ); // unbind the module
         } else {
             modules.put( namespaceURI, module );
-
-            if( !module.isInternalModule() && module.isReady() ) {
-                ( (ModuleContext)( (ExternalModule)module ).getContext() ).setParentContext( this );
-            }
         }
         setRootModule( namespaceURI, module );
     }


### PR DESCRIPTION
Module load path was overwritten if the same module was imported into multiple other modules referenced from the same main module.
