### PR TITLE
handle "xmldb:/db/..." URIs

### DIFF
--- a/src/org/exist/protocolhandler/protocols/xmldb/Handler.java
+++ b/src/org/exist/protocolhandler/protocols/xmldb/Handler.java
@@ -72,6 +72,10 @@ public class Handler extends URLStreamHandler {
             LOG.debug("Parsing xmldb:// URL.");
             super.parseURL(url, spec, XMLDB.length(), limit);
             
+        } else if(spec.startsWith(XMLDB+"/")) {
+            LOG.debug("Parsing xmldb:/ URL.");
+            super.parseURL(url, spec, XMLDB.length(), limit);
+
         } else if(spec.matches(PATTERN)) {
             LOG.debug("Parsing URL with custom exist instance");
             final String splits[] = spec.split(":",3);


### PR DESCRIPTION
I have only one explanation why git do diff so dramatic way ... because this file was not touched for long it may be end-of-line chars that changed by git. (in IDE before commit preview show only 4 lines difference)

Change: add lines 75-77

} else if(spec.startsWith(XMLDB+"/")) {
            LOG.debug("Parsing xmldb:/ URL.");
            super.parseURL(url, spec, XMLDB.length(), limit); 
