### PR TITLE
[bugfix] Strip user information from repo.xml after deployment

### DIFF
--- a/src/org/exist/repo/Deployment.java
+++ b/src/org/exist/repo/Deployment.java
@@ -763,15 +763,16 @@ public class Deployment {
         @Override
         public void startElement(QName qname, AttrList attribs) {
             stack.push(qname.getLocalName());
-            if (!"deployed".equals(qname.getLocalName()))
-                {super.startElement(qname, attribs);}
+            if (!("deployed".equals(qname.getLocalName()) || "permissions".equals(qname.getLocalName()))) {
+                super.startElement(qname, attribs);
+            }
         }
 
         @Override
         public void startElement(String namespaceURI, String localName,
                                  String qName, Attributes attrs) throws SAXException {
             stack.push(localName);
-            if (!"deployed".equals(localName))
+            if (!("deployed".equals(localName) || "permissions".equals(localName)))
                 {super.startElement(namespaceURI, localName, qName, attrs);}
         }
 
@@ -781,8 +782,9 @@ public class Deployment {
             if ("meta".equals(qname.getLocalName())) {
                 addDeployTime();
             }
-            if (!"deployed".equals(qname.getLocalName()))
-                {super.endElement(qname);}
+            if (!("deployed".equals(qname.getLocalName()) || "permissions".equals(qname.getLocalName()))) {
+                super.endElement(qname);
+            }
         }
 
         @Override
@@ -792,8 +794,17 @@ public class Deployment {
             if ("meta".equals(localName)) {
                 addDeployTime();
             }
-            if (!"deployed".equals(localName))
-                {super.endElement(uri, localName, qName);}
+            if (!("deployed".equals(localName) || "permissions".equals(localName))) {
+                super.endElement(uri, localName, qName);
+            }
+        }
+
+        @Override
+        public void attribute(QName qname, String value) throws SAXException {
+            final String current = stack.peek();
+            if (!"permissions".equals(current)) {
+                super.attribute(qname, value);
+            }
         }
 
         @Override


### PR DESCRIPTION
Password is contained in clear text, which poses a security risk if access to the file is not properly restricted. Because the user info is only required during install, we can remove it after deployment.
