### PR TITLE
Fix recovery failures

### DIFF
--- a/src/org/exist/storage/index/BFile.java
+++ b/src/org/exist/storage/index/BFile.java
@@ -2531,7 +2531,8 @@ public class BFile extends BTree {
             ph = (BFilePageHeader) page.getPageHeader();
             if(initialize) {
                 offsets = new short[ph.nextTID];
-                readOffsets();
+                if (ph.getStatus() != MULTI_PAGE)
+                    readOffsets();
             }
         }
 


### PR DESCRIPTION
[bugfix] Critical issue: recovery often failed with ArrayIndexOutOfBounds on large collections due to incorrect initialization of storage pages.
