### PR TITLE
Fix wrapper script MacOSX 

### DIFF
--- a/tools/wrapper/bin/exist.sh.in
+++ b/tools/wrapper/bin/exist.sh.in
@@ -291,7 +291,7 @@ then
     then
         DIST_BITS="32"
     else
-        if [ "X`sysctl -n hw.cpu64bit_capable`" == "X1" ]  
+        if [ "X`/usr/sbin/sysctl -n hw.cpu64bit_capable`" == "X1" ]  
         then
             DIST_BITS="64"
         else


### PR DESCRIPTION
Under MacOSX the wrapper-script is sometimes not able to find the “sysctl” application.

e.g. run “sudo tools\wrapper\bin\exist.sh console” can/will fail
