### PR TITLE
[severe] Crash recovery fix

### DIFF
--- a/src/org/exist/storage/index/BFile.java
+++ b/src/org/exist/storage/index/BFile.java
@@ -575,6 +575,10 @@ public class BFile extends BTree {
     }
 
     private SinglePage getSinglePage(long pos) throws IOException {
+        return getSinglePage(pos, false);
+    }
+
+    private SinglePage getSinglePage(long pos, boolean initialize) throws IOException {
         final SinglePage wp = (SinglePage) dataCache.get(pos);
         if (wp == null) {
             final Page page = getPage(pos);
@@ -583,7 +587,7 @@ public class BFile extends BTree {
                 return null;
             }
             final byte[] data = page.read();
-            return new SinglePage(page, data, false);
+            return new SinglePage(page, data, initialize);
         }
         return wp;
     }
@@ -1037,7 +1041,7 @@ public class BFile extends BTree {
 
     protected void undoStoreValue(StoreValueLoggable loggable) {
         try {
-            final SinglePage page = (SinglePage) getDataPage(loggable.page);
+            final SinglePage page = (SinglePage) getDataPage(loggable.page, true);
             removeValueHelper(null, loggable.tid, page);
         } catch (final IOException e) {
             LOG.warn("An IOException occurred during redo: " + e.getMessage(), e);
@@ -1085,11 +1089,11 @@ public class BFile extends BTree {
 
     protected void undoRemoveValue(RemoveValueLoggable loggable) {
         try {
-            final SinglePage page = getSinglePage(loggable.page);
+            final SinglePage page = getSinglePage(loggable.page, true);
             final FixedByteArray data = new FixedByteArray(loggable.oldData);
             storeValueHelper(null, loggable.tid, data, page);
         } catch (final IOException e) {
-            LOG.warn("An IOException occurred during redo: " + e.getMessage(), e);
+            LOG.warn("An IOException occurred during undo: " + e.getMessage(), e);
         }
     }
     
@@ -2615,6 +2619,11 @@ public class BFile extends BTree {
 
         @Override
         public void setOffset(short tid, int offset) {
+            if (offsets == null) {
+                LOG.warn("page: " + page.getPageNum() + " file: " + getFile().getName() + " status: " +
+                    getPageHeader().getStatus());
+                throw new RuntimeException("page offsets not initialized");
+            }
             offsets[tid] = (short)offset;
         }
         


### PR DESCRIPTION
NullPointerException while rolling back a transaction causes recovery to abort. Some pages were not properly initialized, thus causing the exceptions.
