### PR TITLE
Merge crash recovery branch

### DIFF
--- a/src/org/exist/BTreeTest.java
+++ b/src/org/exist/BTreeTest.java
@@ -1,0 +1,136 @@
+package org.exist;
+
+import org.exist.storage.BrokerPool;
+import org.exist.storage.btree.BTree;
+import org.exist.storage.btree.BTreeCallback;
+import org.exist.storage.btree.DBException;
+import org.exist.storage.btree.Value;
+import org.exist.util.Configuration;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.UTF8;
+import org.exist.util.XMLString;
+import org.exist.xquery.TerminatedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+public class BTreeTest {
+
+    private File file;
+
+    private BrokerPool pool = null;
+
+    public BTreeTest() {
+        file = new File(System.getProperty("exist.home", ".") + "/test/test.dbx");
+        try {
+            Configuration config = new Configuration();
+
+            BrokerPool.configure(1, 5, config);
+            pool = BrokerPool.getInstance();
+        } catch (DatabaseConfigurationException e) {
+            e.printStackTrace();
+        } catch (EXistException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void shutdown() {
+        pool.shutdown(false);
+    }
+
+    public void create(int count) throws DBException, IOException {
+        file.delete();
+        BTree btree = null;
+        try {
+            btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file, 0.1);
+            btree.create((short) -1);
+
+            String prefixStr = "KEY";
+            for (int i = 1; i <= count; i++) {
+                Value value = new Value(prefixStr + Integer.toString(i));
+                btree.addValue(value, i);
+            }
+            btree.flush();
+
+            OutputStreamWriter writer = new OutputStreamWriter(System.out);
+            btree.dump(writer);
+            writer.flush();
+        } finally {
+            if (btree != null) {
+                btree.close();
+            }
+        }
+    }
+
+    public void rebuild() throws DBException, IOException, TerminatedException {
+        BTree btree = null;
+        try {
+            System.out.println("Loading btree ...");
+            btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file, 0.1);
+            btree.open((short)-1);
+
+            System.out.println("Rebuilding ...");
+            btree.rebuild();
+
+            OutputStreamWriter writer = new OutputStreamWriter(System.out);
+            btree.dump(writer);
+            writer.flush();
+        } finally {
+            if (btree != null) {
+                btree.close();
+            }
+        }
+    }
+
+    public void read(int count) throws DBException, IOException, TerminatedException {
+        BTree btree = null;
+        try {
+            System.out.println("Loading btree ...");
+            btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file, 0.1);
+            btree.open((short)-1);
+
+            String prefixStr = "KEY";
+            for (int i = 1; i <= count; i++) {
+                Value value = new Value(prefixStr + Integer.toString(i));
+                long r = btree.findValue(value);
+                if (r == -1) {
+                    System.out.println("Key not found: " + i);
+                }
+            }
+        } finally {
+            if (btree != null) {
+                btree.close();
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        int count = Integer.parseInt(args[0]);
+        String command = args.length == 2 ? args[1] : null;
+
+        BTreeTest test = new BTreeTest();
+
+        try {
+            if (command == null) {
+                test.create(count);
+                test.rebuild();
+                test.read(count);
+            } else if ("read".equals(command)) {
+                test.read(count);
+            } else if ("create".equals(command)) {
+                test.create(count);
+            } else if ("rebuild".equals(command)) {
+                test.rebuild();
+            }
+        } catch (DBException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (TerminatedException e) {
+            e.printStackTrace();
+        } finally {
+            test.shutdown();
+        }
+    }
+}

--- a/src/org/exist/config/Configurable.java
+++ b/src/org/exist/config/Configurable.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2008-2012 The eXist Project
+ *  Copyright (C) 2008-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/Configuration.java
+++ b/src/org/exist/config/Configuration.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2011 The eXist Project
+ *  Copyright (C) 2010-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or
@@ -167,4 +167,9 @@ public interface Configuration {
     public void save(DBBroker broker) throws PermissionDeniedException, ConfigurationException;
 
     public boolean equals(Object obj, String uniqField);
+    
+    /**
+     * Free up memory allocated for cache.
+     */
+    public void clearCache();
 }

--- a/src/org/exist/config/ConfigurationDocumentTrigger.java
+++ b/src/org/exist/config/ConfigurationDocumentTrigger.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2012 The eXist Project
+ *  Copyright (C) 2010-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/ConfigurationException.java
+++ b/src/org/exist/config/ConfigurationException.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2012 The eXist Project
+ *  Copyright (C) 2010-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/Proxy.java
+++ b/src/org/exist/config/Proxy.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2008-2012 The eXist Project
+ * Copyright (C) 2008-2013 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/ProxyDocument.java
+++ b/src/org/exist/config/ProxyDocument.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2008-2012 The eXist Project
+ * Copyright (C) 2008-2013 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/ProxyElement.java
+++ b/src/org/exist/config/ProxyElement.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2008-2012 The eXist Project
+ * Copyright (C) 2008-2013 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/ProxyNode.java
+++ b/src/org/exist/config/ProxyNode.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2008-2012 The eXist Project
+ * Copyright (C) 2008-2013 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/Reference.java
+++ b/src/org/exist/config/Reference.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2012 The eXist Project
+ *  Copyright (C) 2010-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/ReferenceImpl.java
+++ b/src/org/exist/config/ReferenceImpl.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2012 The eXist Project
+ *  Copyright (C) 2010-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/annotation/ConfigurationClass.java
+++ b/src/org/exist/config/annotation/ConfigurationClass.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2008-2012 The eXist Project
+ *  Copyright (C) 2008-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/annotation/ConfigurationFieldAsAttribute.java
+++ b/src/org/exist/config/annotation/ConfigurationFieldAsAttribute.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2008-2012 The eXist Project
+ *  Copyright (C) 2008-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/annotation/ConfigurationFieldAsElement.java
+++ b/src/org/exist/config/annotation/ConfigurationFieldAsElement.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2012 The eXist Project
+ *  Copyright (C) 2010-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/annotation/ConfigurationFieldClassMask.java
+++ b/src/org/exist/config/annotation/ConfigurationFieldClassMask.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2011-2012 The eXist Project
+ *  Copyright (C) 2011-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/annotation/ConfigurationFieldSettings.java
+++ b/src/org/exist/config/annotation/ConfigurationFieldSettings.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2012 The eXist Project
+ *  Copyright (C) 2010-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/annotation/ConfigurationReferenceBy.java
+++ b/src/org/exist/config/annotation/ConfigurationReferenceBy.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2012 The eXist Project
+ *  Copyright (C) 2010-2013 The eXist Project
  *  http://exist-db.org
  *  
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/annotation/NewClass.java
+++ b/src/org/exist/config/annotation/NewClass.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2011-2012 The eXist Project
+ *  Copyright (C) 2011-2013 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/mapper/CallMathod.java
+++ b/src/org/exist/config/mapper/CallMathod.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2011 The eXist Project
+ *  Copyright (C) 2011-2013 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/config/mapper/Constructor.java
+++ b/src/org/exist/config/mapper/Constructor.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2011 The eXist Project
+ *  Copyright (C) 2011-2013 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or

--- a/src/org/exist/storage/BrokerPool.java
+++ b/src/org/exist/storage/BrokerPool.java
@@ -955,6 +955,7 @@ public class BrokerPool implements Database {
         					//XXX: don't do if READONLY mode
         					if(recovered) {
         						if(!exportOnly) {
+                                    reportStatus("Reindexing database files...");
         							try {
         								broker.repair();
         							} catch (final PermissionDeniedException e) {

--- a/src/org/exist/storage/CreateBinaryLoggable.java
+++ b/src/org/exist/storage/CreateBinaryLoggable.java
@@ -33,14 +33,12 @@ public class CreateBinaryLoggable extends AbstractLoggable {
    public CreateBinaryLoggable(DBBroker broker,Txn txn,File original)
    {
       super(NativeBroker.LOG_CREATE_BINARY,txn.getId());
-      LOG.debug("CreateBinaryLoggable created");
       this.broker = broker;
       this.original = original;
    }
    
    public CreateBinaryLoggable(DBBroker broker,long transactionId) {
       super(NativeBroker.LOG_CREATE_BINARY,transactionId);
-      LOG.debug("CreateBinaryLoggable created");
       this.broker = broker;
    }
    

--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -479,7 +479,19 @@ public abstract class DBBroker extends Observable {
     public abstract void reindexCollection(XmldbURI collectionName)
         throws PermissionDeniedException;
 
+    /**
+     * Repair indexes. Should delete all secondary indexes and rebuild them.
+     * This method will be called after the recovery run has completed.
+     *
+     * @throws PermissionDeniedException
+     */
     public abstract void repair() throws PermissionDeniedException;
+
+    /**
+     * Repair core indexes (dom, collections ...). This method is called immediately
+     * after recovery and before {@link #repair()}.
+     */
+    public abstract void repairPrimary();
 
     /**
      * Saves the specified collection to storage. Collections are usually cached

--- a/src/org/exist/storage/btree/InsertValueLoggable.java
+++ b/src/org/exist/storage/btree/InsertValueLoggable.java
@@ -96,6 +96,6 @@ public class InsertValueLoggable extends BTAbstractLoggable {
     }
     
 	public String dump() {
-		return super.dump() + " - insert btree key on page: " + pageNum;
+		return super.dump() + " - insert btree key on page: " + pageNum + ": " + Paged.hexDump(key.data());
 	}
 }

--- a/src/org/exist/storage/btree/Paged.java
+++ b/src/org/exist/storage/btree/Paged.java
@@ -1138,12 +1138,10 @@ public abstract class Paged {
 
     public static String hexDump(byte[] data) {
         final StringBuilder buf = new StringBuilder();
-        buf.append("\r\n");
         int columns = 0;
         for (int i = 0; i < data.length; i++, columns++) {
             byteToHex(buf, data[i]);
             if(columns == 16) {
-                buf.append("\r\n");
                 columns = 0;
             } else {
                 buf.append(' ');

--- a/src/org/exist/storage/btree/Repair.java
+++ b/src/org/exist/storage/btree/Repair.java
@@ -1,0 +1,106 @@
+package org.exist.storage.btree;
+
+import org.exist.EXistException;
+import org.exist.indexing.StructuralIndex;
+import org.exist.security.internal.SubjectImpl;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.NativeBroker;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.structural.NativeStructuralIndex;
+import org.exist.storage.structural.NativeStructuralIndexWorker;
+import org.exist.storage.sync.Sync;
+import org.exist.util.Configuration;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.xquery.TerminatedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+/**
+ *
+ */
+public class Repair {
+
+    private static final String[] INDEXES = {
+            "collections", "dom", "structure"
+    };
+
+    private BrokerPool pool;
+
+    public Repair() {
+        startDB();
+    }
+
+    public void repair(String id) {
+        DBBroker broker = null;
+        try {
+            broker = pool.get(pool.getSecurityManager().getSystemSubject());
+
+            BTree btree = null;
+            if ("collections".equals(id)) {
+                btree = ((NativeBroker)broker).getStorage(NativeBroker.COLLECTIONS_DBX_ID);
+            } else if ("dom".equals(id)) {
+                btree = ((NativeBroker)broker).getStorage(NativeBroker.DOM_DBX_ID);
+            } else if ("range".equals(id)) {
+                btree = ((NativeBroker)broker).getStorage(NativeBroker.VALUES_DBX_ID);
+            } else if ("structure".equals(id)) {
+                NativeStructuralIndexWorker index = (NativeStructuralIndexWorker)
+                        broker.getIndexController().getWorkerByIndexName(StructuralIndex.STRUCTURAL_INDEX_ID);
+                btree = index.getStorage();
+            }
+            if (btree == null) {
+                System.console().printf("Unkown index: %s", id);
+                return;
+            }
+            final Lock lock = btree.getLock();
+            try {
+                lock.acquire(Lock.WRITE_LOCK);
+
+//                btree.scanSequential();
+                System.console().printf("Rebuilding %15s ...", btree.getFile().getName());
+                btree.rebuild();
+                System.out.println("Done");
+            } finally {
+                lock.release(Lock.WRITE_LOCK);
+            }
+
+        } catch (Exception e) {
+            System.console().printf("An exception occurred during repair: %s\n", e.getMessage());
+            e.printStackTrace();
+        } finally {
+            pool.release(broker);
+        }
+    }
+
+    private void startDB() {
+        try {
+            Configuration config = new Configuration();
+
+            BrokerPool.configure(1, 5, config);
+            pool = BrokerPool.getInstance();
+        } catch (DatabaseConfigurationException e) {
+            e.printStackTrace();
+        } catch (EXistException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void shutdown() {
+        pool.shutdown(false);
+    }
+
+    public static void main(String[] args) {
+        Repair repair = new Repair();
+
+        if (args.length == 0) {
+            for (String index : INDEXES) {
+                repair.repair(index);
+            }
+        } else {
+            repair.repair(args[0]);
+        }
+        repair.shutdown();
+    }
+}

--- a/src/org/exist/storage/dom/DOMFile.java
+++ b/src/org/exist/storage/dom/DOMFile.java
@@ -2134,12 +2134,8 @@ public class DOMFile extends BTree implements Lockable {
         return null;
     }
 
-    /**
-     * Get the active Lock object for this file.
-     * 
-     * @see org.exist.util.Lockable#getLock()
-     */
-    public final Lock getLock() {
+    @Override
+    public Lock getLock() {
         return lock;
     }
 

--- a/src/org/exist/storage/index/BFile.java
+++ b/src/org/exist/storage/index/BFile.java
@@ -184,6 +184,7 @@ public class BFile extends BTree {
      * 
      * @return Lock
      */
+    @Override
     public Lock getLock() {
         return lock;
     }

--- a/src/org/exist/storage/index/BTreeStore.java
+++ b/src/org/exist/storage/index/BTreeStore.java
@@ -30,6 +30,7 @@ public class BTreeStore extends BTree {
         setSplitFactor(0.7);
     }
 
+    @Override
     public Lock getLock() {
         return lock;
     }

--- a/src/org/exist/storage/recovery/RecoveryManager.java
+++ b/src/org/exist/storage/recovery/RecoveryManager.java
@@ -115,7 +115,7 @@ public class RecoveryManager {
 	                try {
 						final ProgressBar progress = new ProgressBar("Scanning journal ", last.length());
 	        			while ((next = reader.nextEntry()) != null) {
-	//                        LOG.debug(next.dump());
+//	                        LOG.debug(next.dump());
 							progress.set(Lsn.getOffset(next.getLsn()));
 							if (next.getLogType() == LogEntryTypes.TXN_START) {
 				                // new transaction starts: add it to the transactions table
@@ -173,11 +173,16 @@ public class RecoveryManager {
                 // Re-applying them on a second start up attempt would definitely damage the db, so we better
                 // delete them before user tries to launch again.
                 cleanDirectory(files);
+                if (recoveryRun) {
+                    broker.repairPrimary();
+                    broker.sync(Sync.MAJOR_SYNC);
+                }
             }
 		}
         logManager.setCurrentFileNum(lastNum);
 		logManager.switchFiles();
         logManager.clearBackupFiles();
+
         return recoveryRun;
 	}
 

--- a/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
+++ b/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
@@ -5,6 +5,7 @@ import org.exist.dom.*;
 import org.exist.indexing.*;
 import org.exist.numbering.NodeId;
 import org.exist.storage.*;
+import org.exist.storage.btree.BTree;
 import org.exist.storage.btree.BTreeCallback;
 import org.exist.storage.btree.IndexQuery;
 import org.exist.storage.btree.Value;
@@ -509,6 +510,10 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
     @Override
     public QueryRewriter getQueryRewriter(XQueryContext context) {
         return null;
+    }
+
+    public BTree getStorage() {
+        return index.btree;
     }
 
     private void addNode(QName qname, NodeProxy proxy) {


### PR DESCRIPTION
Simplify crash recovery to make it more robust: instead of tracking every small change to the core btrees, we can rebuild the inner b+-tree pages by scanning through leaf pages after a crash. Benefit: during normal operations, only modifications to leaf pages have to be recorded in the transaction log, resulting in smaller log files. During recovery, less operations have to be redone/rolled back, which greatly reduces the risk of conflicts. When rebuilding the btrees we can better handle inconsistencies.

The recovery branch has been tested since two months by several users and has been quite reliable. We've been able to recover from most crash situations (sudden death, deadlocks) which were fatal using the old code.
