### PR TITLE
Ignore null password for user account

### DIFF
--- a/src/org/exist/security/AbstractRealm.java
+++ b/src/org/exist/security/AbstractRealm.java
@@ -430,7 +430,12 @@ public abstract class AbstractRealm implements Realm, Configurable {
             }
         }
 
-        updatingAccount.setPassword(account.getPassword());
+        final String passwd = account.getPassword();
+        if (passwd != null) {
+            // if password is empty, ignore it to keep the old one
+            // assumes that empty passwords should never be allowed
+            updatingAccount.setPassword(account.getPassword());
+        }
         updatingAccount.setUserMask(account.getUserMask());
         
         //update the metadata


### PR DESCRIPTION
Setting a null password will corrupt the user's account. null should mean: do not change, keep old.
