### PR TITLE
avoid conflicts between transaction's binary operations

### DIFF
--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Observer;
 import java.util.Stack;
 import java.util.StringTokenizer;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -2067,6 +2068,15 @@ public class NativeBroker extends DBBroker {
             throws IOException {
        if (transaction!=null) {
           dir = new File(dir,"txn."+transaction.getId());
+          if (create && !dir.exists()) {
+             if (!dir.mkdir()) {
+                throw new IOException("Cannot make transaction filesystem directory: "+dir);
+             }
+          }
+          
+          //XXX: replace by transaction operation id/number from Txn
+          //add unique id for operation in transaction
+          dir = new File(dir,"oper."+UUID.randomUUID().toString());
           if (create && !dir.exists()) {
              if (!dir.mkdir()) {
                 throw new IOException("Cannot make transaction filesystem directory: "+dir);


### PR DESCRIPTION
add unique part to transaction log folder to avoid conflicts between transaction's binary operations
