### PR TITLE
Correct path in standalone mode "xmldb:exist:///db/apps"

### DIFF
--- a/tools/jetty/etc/standalone/WEB-INF/controller-config.xml
+++ b/tools/jetty/etc/standalone/WEB-INF/controller-config.xml
@@ -30,5 +30,5 @@
         ++ by the REST servlet.
     -->
     <root pattern="/db.*" path="xmldb:exist:///db"/>
-    <root pattern=".*" path="xmldb:exist:///db/www"/>
+    <root pattern=".*" path="xmldb:exist:///db/apps"/>
 </configuration>


### PR DESCRIPTION
Launch ./exist-dev/bin/server.sh open http://localhost:8088/ see
"Document /db/www/ not found"
Was OK in 2.0 :
https://github.com/eXist-db/exist/blob/eXist-2.0.x/tools/jetty/etc/standalone/WEB-INF/controller-config.xml
