### PR TITLE
AdminPasswd setting in Headless install

### DIFF
--- a/installer/install.xml.tmpl
+++ b/installer/install.xml.tmpl
@@ -51,6 +51,7 @@
         <variable name="JDKPathPanel.minVersion" value="1.6"/>
         <variable name="dataDir" value="webapp/WEB-INF/data"/>
         <variable name="ShowCreateDirectoryMessage" value="false"/>
+        <variable name="adminPasswd" value="adminPasswd"/>
     </variables>
     
     <!-- Determine suggested data directory -->

--- a/options.xml
+++ b/options.xml
@@ -1,0 +1,5 @@
+INSTALL_PATH=/tmp/exist-2.1dev
+dataDir=/tmp/data-2.1dev
+adminPasswd=myAdminPasswd
+MAX_MEMORY=1024
+cacheSize=128

--- a/src/org/exist/installer/Setup.java
+++ b/src/org/exist/installer/Setup.java
@@ -174,7 +174,7 @@ public class Setup {
                         (UserManagementService) root.getService("UserManagementService", "1.0");
                 final Account admin = service.getAccount("admin");
                 admin.setPassword(adminPass);
-                System.out.println("Setting admin user password...");
+                System.out.println("Setting admin user password...["+adminPass+"]");
                 service.updateAccount(admin);
                 root = DatabaseManager.getCollection(URI, "admin", adminPass);
             }


### PR DESCRIPTION
Headless install lacks variable to set adminpass
$ java -jar eXist-db-setup-2.1-rev.jar -options options.xml
with options.xml does not set adminPasswd
Adding adminPasswd variable in install.xml.tmpl corrects this.
Change in Setup.java is just for verification.
