### PR TITLE
When RESTXQ detects a security error, it should not fail with a 500.

### DIFF
--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServlet.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServlet.java
@@ -117,7 +117,7 @@ public class RestXqServlet extends AbstractExistHttpServlet {
             throw new ServletException(ee.getMessage(), ee);
         } catch(RestXqServiceException rqse) {
             if (rqse.getCause() instanceof PermissionDeniedException) {
-                new BasicAuthenticator(null).sendChallenge(request, response);
+                getAuthenticator().sendChallenge(request, response);
             } else {
                 //TODO should probably be caught higher up and returned as a HTTP Response? maybe need two different types of exception to differentiate critical vs processing exception
                 getLog().error(rqse.getMessage(), rqse);


### PR DESCRIPTION
Instead initiate a basic auth handshake (401), so that the
user can retry the request with the correct level or authorisation.
