### PR TITLE
[bugfix] Set the lexical handler so that Comments etc are not lost

### DIFF
--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
@@ -270,6 +270,7 @@ public class RestXqServiceImpl extends AbstractRestXqService {
             builder.startDocument();
             final DocumentBuilderReceiver receiver = new DocumentBuilderReceiver(builder, true);
             reader.setContentHandler(receiver);
+            reader.setProperty("http://xml.org/sax/properties/lexical-handler", receiver);
             reader.parse(src);
             builder.endDocument();
             final Document doc = receiver.getDocument();


### PR DESCRIPTION
Fix to RESTXQ to ensure that the lexical handler is set when parsing XML from the body of a PUT or POST request.
