### PR TITLE
Fix slow insert/append

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -202,7 +202,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         return this.mode;
     }
 
-    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf) {
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf) {
         if (node.getNodeType() == Node.ATTRIBUTE_NODE)
             return null;
         if (config == null)

--- a/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndexWorker.java
+++ b/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndexWorker.java
@@ -512,7 +512,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
     }
 
     @Override
-    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf) {
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf) {
         if (node.getNodeType() == Node.ATTRIBUTE_NODE)
             return null;
         IndexSpec indexConf = node.getDocument().getCollection().getIndexConfiguration(broker);

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexWorker.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexWorker.java
@@ -255,7 +255,7 @@ public class RangeIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
     }
 
     @Override
-    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf) {
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf) {
 //        if (node.getNodeType() == Node.ATTRIBUTE_NODE)
 //            return null;
         if (config == null)

--- a/extensions/indexes/sort/src/org/exist/indexing/sort/SortIndexWorker.java
+++ b/extensions/indexes/sort/src/org/exist/indexing/sort/SortIndexWorker.java
@@ -362,8 +362,8 @@ public class SortIndexWorker implements IndexWorker {
         return mode;
     }
 
-    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf) {
-        return node;
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf) {
+        return insert ? null : node;
     }
 
     public StreamListener getListener() {

--- a/extensions/indexes/spatial/src/org/exist/indexing/spatial/AbstractGMLJDBCIndexWorker.java
+++ b/extensions/indexes/spatial/src/org/exist/indexing/spatial/AbstractGMLJDBCIndexWorker.java
@@ -222,7 +222,7 @@ public abstract class AbstractGMLJDBCIndexWorker implements IndexWorker {
         return null;
     }
 
-    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf) {
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf) {
         if (!isDocumentGMLAware)
             //Not concerned
             return null;

--- a/src/org/exist/dom/ElementImpl.java
+++ b/src/org/exist/dom/ElementImpl.java
@@ -475,8 +475,9 @@ public class ElementImpl extends NamedNode implements Element, ElementAtExist {
             StreamListener listener = null;
             //May help getReindexRoot() to make some useful things
             broker.getIndexController().setDocument(ownerDocument);
-            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(this, path);
+            StoredNode reindexRoot = broker.getIndexController().getReindexRoot(this, path, true, true);
             broker.getIndexController().setMode(StreamListener.STORE);
+            // only reindex if reindexRoot is an ancestor of the current node
             if (reindexRoot == null) {
                 listener = broker.getIndexController().getStreamListener();
             }
@@ -1222,7 +1223,7 @@ public class ElementImpl extends NamedNode implements Element, ElementAtExist {
             StreamListener listener = null;
             //May help getReindexRoot() to make some useful things
             broker.getIndexController().setDocument(ownerDocument);
-            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(this, path, true);
+            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(this, path, true, true);
             broker.getIndexController().setMode(StreamListener.STORE);
             if (reindexRoot == null) {
                 listener = broker.getIndexController().getStreamListener();
@@ -1272,7 +1273,8 @@ public class ElementImpl extends NamedNode implements Element, ElementAtExist {
             StreamListener listener = null;
             //May help getReindexRoot() to make some useful things
             broker.getIndexController().setDocument(ownerDocument);
-            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(this, path, true);
+            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(this, path, true, true);
+            System.out.println("Reindex root after insert: " + reindexRoot);
             broker.getIndexController().setMode(StreamListener.STORE);
             if (reindexRoot == null) {
                 listener = broker.getIndexController().getStreamListener();
@@ -1311,7 +1313,7 @@ public class ElementImpl extends NamedNode implements Element, ElementAtExist {
         try {
             broker = ownerDocument.getBrokerPool().get(null);
             broker.getIndexController().setDocument(ownerDocument);
-            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(this, path, true);
+            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(this, path, true, true);
             broker.getIndexController().setMode(StreamListener.REMOVE_SOME_NODES);
             if (reindexRoot == null) {
                 listener = broker.getIndexController().getStreamListener();
@@ -1395,7 +1397,7 @@ public class ElementImpl extends NamedNode implements Element, ElementAtExist {
             //May help getReindexRoot() to make some useful things
             broker.getIndexController().setDocument(ownerDocument);
             //Check if the change affects any ancestor nodes, which then need to be reindexed later
-            StoredNode reindexRoot = broker.getIndexController().getReindexRoot(oldNode, oldPath);
+            StoredNode reindexRoot = broker.getIndexController().getReindexRoot(oldNode, oldPath, false);
             //Remove indexes
             if (reindexRoot == null)
                 {reindexRoot = oldNode;}
@@ -1445,7 +1447,7 @@ public class ElementImpl extends NamedNode implements Element, ElementAtExist {
             //May help getReindexRoot() to make some useful things
             broker = ownerDocument.getBrokerPool().get(null);
             broker.getIndexController().setDocument(ownerDocument);
-            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(oldNode, oldPath);
+            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(oldNode, oldPath, false);
             broker.getIndexController().setMode(StreamListener.REMOVE_SOME_NODES);
             if (reindexRoot == null) {
                 listener = broker.getIndexController().getStreamListener();
@@ -1580,7 +1582,7 @@ public class ElementImpl extends NamedNode implements Element, ElementAtExist {
         try {
             broker = ownerDocument.getBrokerPool().get(null);
             broker.getIndexController().setDocument(ownerDocument);
-            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(oldNode, oldPath);
+            final StoredNode reindexRoot = broker.getIndexController().getReindexRoot(oldNode, oldPath, false);
             broker.getIndexController().setMode(StreamListener.REMOVE_SOME_NODES);
             if (reindexRoot == null) {
                 listener = broker.getIndexController().getStreamListener();

--- a/src/org/exist/fulltext/FTIndexWorker.java
+++ b/src/org/exist/fulltext/FTIndexWorker.java
@@ -126,7 +126,7 @@ public class FTIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         return mode;
     }
 
-    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf) {
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf) {
         if (node.getNodeType() == Node.ATTRIBUTE_NODE)
             {return null;}
         final IndexSpec indexConf = node.getDocument().getCollection().getIndexConfiguration(broker);

--- a/src/org/exist/indexing/IndexController.java
+++ b/src/org/exist/indexing/IndexController.java
@@ -224,36 +224,33 @@ public class IndexController {
     /**
      * When adding or removing nodes to or from the document tree, it might become
      * necessary to re-index some parts of the tree, in particular if indexes are defined
-     * on mixed content nodes. This method will call
-     * {@link IndexWorker#getReindexRoot(org.exist.dom.StoredNode, org.exist.storage.NodePath, boolean)}
-     * on each configured index. It will then return the top-most root.
+     * on mixed content nodes. This method will return the top-most root.
      *
      * @param node the node to be modified.
      * @param path the NodePath of the node
      * @return the top-most root node to be re-indexed
      */
-    public StoredNode getReindexRoot(StoredNode node, NodePath path) {
-        return getReindexRoot(node, path, false);
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert) {
+        return getReindexRoot(node, path, insert, false);
     }
 
     /**
      * When adding or removing nodes to or from the document tree, it might become
      * necessary to re-index some parts of the tree, in particular if indexes are defined
-     * on mixed content nodes. This method will call
-     * {@link IndexWorker#getReindexRoot(org.exist.dom.StoredNode, org.exist.storage.NodePath, boolean)}
-     * on each configured index. It will then return the top-most root.
+     * on mixed content nodes. This method will return the top-most root.
      *
      * @param node the node to be modified.
      * @param path path the NodePath of the node
      * @param includeSelf if set to true, the current node itself will be included in the check
      * @return the top-most root node to be re-indexed
      */
-    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf) {
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf) {
         StoredNode next, top = null;
         for (final IndexWorker indexWorker : indexWorkers.values()) {
-            next = indexWorker.getReindexRoot(node, path, includeSelf);
-            if (next != null && (top == null || top.getNodeId().isDescendantOf(next.getNodeId())))
-                {top = next;}
+            next = indexWorker.getReindexRoot(node, path, insert, includeSelf);
+            if (next != null && (top == null || top.getNodeId().isDescendantOf(next.getNodeId()))) {
+                top = next;
+            }
         }
         if (top != null && top.getNodeId().equals(node.getNodeId()))
             {top = node;}

--- a/src/org/exist/indexing/IndexWorker.java
+++ b/src/org/exist/indexing/IndexWorker.java
@@ -128,16 +128,17 @@ public interface IndexWorker {
     /**
      * When adding or removing nodes to or from the document tree, it might become
      * necessary to re-index some parts of the tree, in particular if indexes are defined
-     * on mixed content nodes. This method will call
-     * {@link IndexWorker#getReindexRoot(org.exist.dom.StoredNode, org.exist.storage.NodePath, boolean)}
-     * on each configured index. It will then return the top-most root.
+     * on mixed content nodes. It will then return the top-most root.
      *
      * @param node the node to be modified.
      * @param path path the NodePath of the node
+     * @param insert true if a node is being inserted or appended. In this case, the method
+     *               will be called with the parent node as first argument. Usually a reindex is
+     *               not required unless the index is defined on the parent node or an ancestor of it.
      * @param includeSelf if set to true, the current node itself will be included in the check
      * @return the top-most root node to be reindexed
      */
-    StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf);
+    StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf);
 
     /**
      * Return a stream listener to index the current document in the current mode.

--- a/src/org/exist/storage/statistics/IndexStatisticsWorker.java
+++ b/src/org/exist/storage/statistics/IndexStatisticsWorker.java
@@ -92,7 +92,7 @@ public class IndexStatisticsWorker implements IndexWorker {
         return mode;
     }
 
-    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf) {
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf) {
         return null;
     }
 

--- a/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
+++ b/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
@@ -364,8 +364,9 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
         return mode;
     }
 
-    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean includeSelf) {
-        return node;
+    public StoredNode getReindexRoot(StoredNode node, NodePath path, boolean insert, boolean includeSelf) {
+        // if a node is inserted, we do not need to reindex the parent
+        return insert ? null : node;
     }
 
     private NativeStructuralStreamListener listener = new NativeStructuralStreamListener();


### PR DESCRIPTION
Fix slow insertion or addition of nodes using update extensions: eXist always reindexed the parent node, which should only be required if an index is defined on the parent or any of its ancestors. This caused a major bottleneck, blocking concurrent operations. Normal inserts should now be really fast.
