### PR TITLE
[ignore] ant jars now have version numbers: change bootstrap class path ...

### DIFF
--- a/src/org/exist/start/start.config
+++ b/src/org/exist/start/start.config
@@ -91,7 +91,7 @@ extensions/security/oauth/lib/*                    always
 extensions/webdav/lib/*                            always
 extensions/xprocxq/main/lib/*                      always
 extensions/xqdoc/lib/*                             always
-tools/ant/lib/ant.jar                              always
+tools/ant/lib/ant-%latest%.jar                     always
 tools/ant/lib/xmlunit-%latest%.jar                 mode == other
 tools/ant/lib/xmlunit-%latest%.jar                 mode == client
 tools/ant/lib/xmlunit-%latest%.jar                 mode == jetty


### PR DESCRIPTION
...accordingly.
