### PR TITLE
Severe: index failures due to collection cache

### DIFF
--- a/src/org/exist/collections/Collection.java
+++ b/src/org/exist/collections/Collection.java
@@ -624,6 +624,9 @@ public class Collection extends Observable implements Comparable<Collection>, Ca
      */
     @Override
     public boolean allowUnload() {
+        if (getURI().startsWith(CollectionConfigurationManager.ROOT_COLLECTION_CONFIG_URI)) {
+            return false;
+        }
         for(final DocumentImpl doc : documents.values()) {
             if(doc.isLockedForWrite()) {
                 return false;

--- a/src/org/exist/collections/CollectionCache.java
+++ b/src/org/exist/collections/CollectionCache.java
@@ -80,6 +80,7 @@ public class CollectionCache extends LRUCache {
     protected void removeOne(Cacheable item) {
         boolean removed = false;
         SequencedLongHashMap.Entry<Cacheable> next = map.getFirstEntry();
+        int tries = 0;
         do {
             final Cacheable cached = next.getValue();
             if(cached.getKey() != item.getKey()) {
@@ -100,11 +101,15 @@ public class CollectionCache extends LRUCache {
                         lock.release(Lock.READ_LOCK);
                     }
                 }
-            } else {
+            }
+            if (!removed) {
                 next = next.getNext();
-                if(next == null) {
-                    LOG.info("Unable to remove entry");
+                if (next == null && tries < 2) {
                     next = map.getFirstEntry();
+                    tries++;
+                } else {
+                    LOG.info("Unable to remove entry");
+                    removed = true;
                 }
             }
         } while(!removed);


### PR DESCRIPTION
Collections below /db/system/config should never be removed from collection cache. Randomly removing collection configurations from the cache led to index failures once the cache was being filled up. Some collections were still indexed properly, some not.
