### PR TITLE
[bugfix] - new rangeindex: 

### DIFF
--- a/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
@@ -63,6 +63,16 @@ public class ComplexRangeIndexConfigElement extends RangeIndexConfigElement {
     }
 
     @Override
+    public boolean isCaseSensitive(String fieldName) {
+        for (RangeIndexConfigField field: fields.values()) {
+            if(fieldName != null && fieldName.equals(field.getName())) {
+                return field.isCaseSensitive();
+            }
+        }
+        return caseSensitive;
+    }
+
+    @Override
     public boolean match(NodePath other) {
         if (isQNameIndex)
             return other.getLastComponent().equalsSimple(path.getLastComponent());

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfig.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfig.java
@@ -121,12 +121,12 @@ public class RangeIndexConfig {
         if (qname != null) {
             RangeIndexConfigElement idxConf = paths.get(qname);
             if (idxConf != null) {
-                caseSensitive = idxConf.isCaseSensitive();
+                caseSensitive = idxConf.isCaseSensitive(fieldName);
             }
         } else {
             for (RangeIndexConfigElement idxConf: paths.values()) {
                 if (idxConf.isComplex()) {
-                    caseSensitive = idxConf.isCaseSensitive();
+                    caseSensitive = idxConf.isCaseSensitive(fieldName);
                     if (!caseSensitive) {
                         break;
                     }

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigElement.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigElement.java
@@ -232,7 +232,7 @@ public class RangeIndexConfigElement {
         return analyzer;
     }
 
-    public boolean isCaseSensitive() {
+    public boolean isCaseSensitive(String fieldName) {
         return caseSensitive;
     }
 


### PR DESCRIPTION
transform search string to lowercase if configuration says case='no'. 

New range index case="no" only works with lowercase search terms, this corrects it to caseinsensitive
