### PR TITLE
Simplify the RESTXQ caching model to prevent leakage of tmp files.

### DIFF
--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServlet.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServlet.java
@@ -36,13 +36,11 @@ import org.exist.EXistException;
 import org.exist.extensions.exquery.restxq.impl.adapters.HttpServletRequestAdapter;
 import org.exist.extensions.exquery.restxq.impl.adapters.HttpServletResponseAdapter;
 import org.exist.http.servlets.AbstractExistHttpServlet;
-import org.exist.http.servlets.BasicAuthenticator;
 import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.storage.DBBroker;
 import org.exist.util.Configuration;
 import org.exist.util.io.FilterInputStreamCacheFactory.FilterInputStreamCacheConfiguration;
-import org.exquery.http.HttpRequest;
 import org.exquery.restxq.RestXqService;
 import org.exquery.restxq.RestXqServiceException;
 import org.exquery.restxq.RestXqServiceRegistry;
@@ -77,12 +75,13 @@ public class RestXqServlet extends AbstractExistHttpServlet {
         }
         
         DBBroker broker = null;
+        HttpServletRequestAdapter requestAdapter = null;
         try {
             broker = getPool().get(user);
 
             final Configuration configuration = broker.getConfiguration();
             
-            final HttpRequest requestAdapter = new HttpServletRequestAdapter(
+            requestAdapter = new HttpServletRequestAdapter(
                 request,
                 new FilterInputStreamCacheConfiguration(){
                     @Override
@@ -124,6 +123,9 @@ public class RestXqServlet extends AbstractExistHttpServlet {
                 throw new ServletException(rqse.getMessage(), rqse);
             }
         } finally {
+            if(requestAdapter != null) {
+                requestAdapter.release();
+            }
             if(broker != null) {
                 getPool().release(broker);
             }

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/adapters/HttpServletRequestAdapter.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/adapters/HttpServletRequestAdapter.java
@@ -33,6 +33,7 @@ import java.io.Reader;
 import java.util.*;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.io.input.CloseShieldInputStream;
 import org.exist.util.io.CachingFilterInputStream;
 import org.exist.util.io.FilterInputStreamCache;
 import org.exist.util.io.FilterInputStreamCacheFactory;
@@ -122,8 +123,8 @@ public class HttpServletRequestAdapter implements HttpRequest {
         } else {
             is.reset();
         }
-        
-        return is;
+
+        return new CloseShieldInputStream(is);
     }
 
     @Override
@@ -274,5 +275,11 @@ public class HttpServletRequestAdapter implements HttpRequest {
         }
         
         return fields;
+    }
+
+    public void release() throws IOException {
+        if (is != null) {
+            is.close();
+        }
     }
 }


### PR DESCRIPTION
Fix a tmp file leakage into the RESTXQ code for PUTs and POSTs.

The HttpServletRequestAdapter was presuming that consumers would know how to release the cached input stream properly - never a good idea. It ought to own it's own resources and have them released as part of it's lifecycle. That way no-one can use it incorrectly! :)
