### PR TITLE
[performance] Fix performance of simple range index lookup.

### DIFF
--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexWorker.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexWorker.java
@@ -503,7 +503,14 @@ public class RangeIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                     query = toQuery(field, qname, keys[0], operator, docs);
                 }
 
-                resultSet = doQuery(contextId, docs, contextSet, axis, searcher, qname, query, null);
+                if (contextSet != null && contextSet.hasOne() && contextSet.getItemType() != Type.DOCUMENT) {
+                    NodesFilter filter = new NodesFilter(contextSet);
+                    filter.init(searcher.getIndexReader());
+                    FilteredQuery filtered = new FilteredQuery(query, filter, FilteredQuery.LEAP_FROG_FILTER_FIRST_STRATEGY);
+                    resultSet = doQuery(contextId, docs, contextSet, axis, searcher, null, filtered, null);
+                } else {
+                    resultSet = doQuery(contextId, docs, contextSet, axis, searcher, null, query, null);
+                }
             }
         } finally {
             index.releaseSearcher(searcher);

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/Lookup.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/Lookup.java
@@ -255,7 +255,7 @@ public class Lookup extends Function implements Optimizable {
         final RangeIndex.Operator operator = getOperator();
 
         try {
-            preselectResult = index.query(getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null, qnames, keys, operator, NodeSet.DESCENDANT);
+            preselectResult = index.query(getExpressionId(), docs, contextSequence.toNodeSet(), qnames, keys, operator, NodeSet.DESCENDANT);
         } catch (IOException e) {
             throw new XPathException(this, "Error while querying full text index: " + e.getMessage(), e);
         }

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeIndexModule.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeIndexModule.java
@@ -56,7 +56,8 @@ public class RangeIndexModule extends AbstractInternalModule {
         new FunctionDef(FieldLookup.signatures[8], FieldLookup.class),
         new FunctionDef(FieldLookup.signatures[9], FieldLookup.class),
         new FunctionDef(Optimize.signature, Optimize.class),
-        new FunctionDef(IndexKeys.signatures[0], IndexKeys.class)
+        new FunctionDef(IndexKeys.signatures[0], IndexKeys.class),
+        new FunctionDef(IndexKeys.signatures[1], IndexKeys.class)
     };
 
     public final static Map<String, RangeIndex.Operator> OPERATOR_MAP = new HashMap<String, RangeIndex.Operator>();


### PR DESCRIPTION
If there's only one context node: always restrict lookup using filter. Same approach as for field lookups.
