### PR TITLE
Package repository: merge repo.xml

### DIFF
--- a/extensions/modules/build.xml
+++ b/extensions/modules/build.xml
@@ -215,7 +215,7 @@
                 <path refid="classpath.core"/>
             </classpath>
 
-        <exclude name="org/exist/xquery/modules/cache/**" unless="${include.module.cache}"/>
+            <exclude name="org/exist/xquery/modules/cache/**" unless="${include.module.cache}"/>
             <exclude name="org/exist/xquery/modules/compression/**" unless="${include.module.compression}"/>
             <exclude name="org/exist/xquery/modules/context/**" unless="${include.module.context}"/>
             <exclude name="org/exist/xquery/modules/counter/**" unless="${include.module.counter}"/>
@@ -241,6 +241,7 @@
             <exclude name="org/exist/xquery/modules/process/**" unless="${include.module.process}"/>
             <exclude name="org/exist/xquery/modules/persistentlogin/**" unless="${include.module.persistentlogin}"/>
         </javac>
+        <copy file="${src}/org/exist/xquery/modules/file/repo.xsl" tofile="${classes}/org/exist/xquery/modules/file/repo.xsl"/>
     </target>
 
     <target name="jar" depends="compile, finish-persistentlogin">

--- a/extensions/modules/src/org/exist/xquery/modules/file/repo.xsl
+++ b/extensions/modules/src/org/exist/xquery/modules/file/repo.xsl
@@ -1,0 +1,38 @@
+<!--
+    Merge repo.xml modified by user with original file. This is necessary because we have to
+    remove sensitive information during upload (default password) and need to restore it
+    when the package is synchronized back to disk.
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:repo="http://exist-db.org/xquery/repo">
+
+    <!-- Set to the original repo.xml which should be merged with the input document -->
+    <xsl:param name="original"/>
+
+    <xsl:template match="repo:permissions">
+        <permissions xmlns="http://exist-db.org/xquery/repo">
+            <!-- If a (new) password has been specified in the input doc, use it.
+                 Preserve the original password otherwise.
+            -->
+            <xsl:attribute name="password">
+                <xsl:choose>
+                    <xsl:when test="@password">
+                        <xsl:value-of select="@password"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="$original//repo:permissions/@password"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
+            <xsl:copy-of select="@*[local-name(.) != 'password']"/>
+        </permissions>
+    </xsl:template>
+
+    <xsl:template match="repo:deployed"/>
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
During synchronize, do not overwrite repo.xml, but merge it with the original one on the file system. This is required because we strip sensitive information (passwords) from the file before upload. This information has to be restored when synching the app back to the file system, otherwise we may end up with wrong permissions.
