### PR TITLE
[performance] Cleanup method: Sequence.destroy ...

### DIFF
--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -2576,16 +2576,13 @@ public class XQueryContext implements BinaryValueManager, Context
      */
     public void popLocalVariables(LocalVariable var, Sequence resultSeq)
     {
-        final LocalVariable end = contextStack.isEmpty() ? null : contextStack.peek();
-
-        for( LocalVariable old = lastVar; old != null; old = old.before ) {
-
-            if( old == end ) {
-                break;
+        // clear all variables registered after var. they should be out of scope.
+        LocalVariable outOfScope = lastVar;
+        while (outOfScope != var) {
+            if (!outOfScope.isClosureVar()) {
+                outOfScope.destroy(this, resultSeq);
             }
-            // reset variable unless it is a closure variable (inherited from context)
-            if (!old.isClosureVar())
-                {old.destroy(this, resultSeq);}
+            outOfScope = outOfScope.before;
         }
         if( var != null ) {
             var.after = null;

--- a/src/org/exist/xquery/value/Item.java
+++ b/src/org/exist/xquery/value/Item.java
@@ -27,6 +27,7 @@ import org.exist.memtree.DocumentBuilderReceiver;
 import org.exist.numbering.NodeId;
 import org.exist.storage.DBBroker;
 import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
@@ -57,7 +58,12 @@ public interface Item {
 	 *  
 	 */
 	public Sequence toSequence();
-	
+
+    /**
+     * Clean up any resources used by the items in this sequence.
+     */
+    void destroy(XQueryContext context, Sequence contextSequence);
+
 	/**
 	 * Convert this item into an atomic value, whose type corresponds to
 	 * the specified target type. requiredType should be one of the type

--- a/src/org/exist/xquery/value/ValueSequence.java
+++ b/src/org/exist/xquery/value/ValueSequence.java
@@ -354,7 +354,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     @Override
     public void destroy(XQueryContext context, Sequence contextSequence) {
         for (int i = 0; i <= size; i++) {
-            ((Sequence)values[i]).destroy(context, contextSequence);
+            values[i].destroy(context, contextSequence);
         }
     }
 
@@ -365,6 +365,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         }
         return false;
     }
+
     public void sortInDocumentOrder() {
         if (size == UNSET_SIZE)
             {return;}


### PR DESCRIPTION
...is called much too often inside FLWOR execution. Causes massive performance loss in complex FLWOR constructs. Only call it once when a variable actually runs out of scope.
