### PR TITLE
Fix performance of consistency check and export

### DIFF
--- a/extensions/fluent/src/org/exist/fluent/Database.java
+++ b/extensions/fluent/src/org/exist/fluent/Database.java
@@ -190,7 +190,7 @@ public class Database {
 			try {
 				DBBroker broker = pool.enterServiceMode(pool.getSecurityManager().getSystemSubject());
 				try {
-					List<ErrorReport> errors = new ConsistencyCheck(broker, false).checkAll(NULL_PROGRESS_CALLBACK);
+					List<ErrorReport> errors = new ConsistencyCheck(broker, false, false).checkAll(NULL_PROGRESS_CALLBACK);
 					if (errors.isEmpty()) return true;
 					LOG.fatal("database corrupted");
 					for (ErrorReport error : errors) LOG.error(error.toString().replace("\n", " "));

--- a/src/org/exist/backup/ExportGUI.java
+++ b/src/org/exist/backup/ExportGUI.java
@@ -70,6 +70,7 @@ public class ExportGUI extends javax.swing.JFrame
     private javax.swing.JCheckBox    zipBtn;
     private javax.swing.JCheckBox    incrementalBtn;
     private JCheckBox                directAccessBtn;
+    private javax.swing.JCheckBox    scanBtn;
     private javax.swing.JLabel       jLabel1;
     private javax.swing.JLabel       jLabel2;
     private javax.swing.JMenu        jMenu1;
@@ -156,7 +157,8 @@ public class ExportGUI extends javax.swing.JFrame
         jToolBar1       = new javax.swing.JToolBar();
         startBtn        = new javax.swing.JButton();
         exportBtn       = new javax.swing.JButton();
-        incrementalBtn  = new JCheckBox( "Incremental backup" );
+        incrementalBtn  = new JCheckBox( "Incremental" );
+        scanBtn         = new JCheckBox( "Scan docs" );
         directAccessBtn = new JCheckBox( "Direct access" );
         zipBtn			= new JCheckBox("Create ZIP");
         outputDir       = new javax.swing.JTextField();
@@ -246,6 +248,10 @@ public class ExportGUI extends javax.swing.JFrame
         jToolBar1.add( exportBtn );
 
         jToolBar1.add( incrementalBtn );
+        scanBtn.setSelected(true);
+        scanBtn.setToolTipText( "Perform additional checks; scans every XML document" );
+        jToolBar1.add( scanBtn );
+        directAccessBtn.setToolTipText( "Bypass collection index by scanning collection store" );
         jToolBar1.add( directAccessBtn );
         jToolBar1.add( zipBtn );
 
@@ -496,12 +502,14 @@ public class ExportGUI extends javax.swing.JFrame
             
             selected = zipBtn.getSelectedObjects();
             final boolean zip = ( selected != null ) && ( selected[0] != null );
-            
+
             displayMessage( "Starting export ..." );
+            final long start = System.currentTimeMillis();
             final SystemExport sysexport   = new SystemExport( broker, callback, null, directAccess );
             final File         file        = sysexport.export( exportTarget, incremental, zip, errorList );
 
             displayMessage( "Export to " + file.getAbsolutePath() + " completed successfully." );
+            displayMessage( "Export took " + (System.currentTimeMillis() - start) + "ms.");
             progress.setString( "" );
         }
         catch( final EXistException e ) {
@@ -524,9 +532,12 @@ public class ExportGUI extends javax.swing.JFrame
 
         try {
             broker = pool.get( pool.getSecurityManager().getSystemSubject() );
-            final Object[]                                           selected     = directAccessBtn.getSelectedObjects();
-            final boolean                                            directAccess = ( selected != null ) && ( selected[0] != null );
-            final ConsistencyCheck                                   checker      = new ConsistencyCheck( broker, directAccess );
+            Object[] selected     = directAccessBtn.getSelectedObjects();
+            final boolean directAccess = ( selected != null ) && ( selected[0] != null );
+            selected = scanBtn.getSelectedObjects();
+            final boolean scan = ( selected != null ) && ( selected[0] != null );
+
+            final ConsistencyCheck                                   checker      = new ConsistencyCheck( broker, directAccess, scan );
             final org.exist.backup.ConsistencyCheck.ProgressCallback cb           = new ConsistencyCheck.ProgressCallback() {
                 public void startDocument( String path, int current, int count )
                 {

--- a/src/org/exist/storage/ConsistencyCheckTask.java
+++ b/src/org/exist/storage/ConsistencyCheckTask.java
@@ -52,6 +52,7 @@ public class ConsistencyCheckTask implements SystemTask {
     private boolean paused = false;
     private boolean incremental = false;
     private boolean incrementalCheck = false;
+    private boolean checkDocs = false;
     private int maxInc = -1;
 
     private File lastExportedBackup = null;
@@ -64,6 +65,7 @@ public class ConsistencyCheckTask implements SystemTask {
     public final static String INCREMENTAL_PROP_NAME = "incremental";
     public final static String INCREMENTAL_CHECK_PROP_NAME = "incremental-check";
     public final static String MAX_PROP_NAME = "max";
+    public final static String CHECK_DOCS_PROP_NAME = "check-documents";
 
     private final static LoggingCallback logCallback = new LoggingCallback();
     
@@ -104,6 +106,9 @@ public class ConsistencyCheckTask implements SystemTask {
         } catch (final NumberFormatException e) {
             throw new EXistException("Parameter 'max' has to be an integer");
         }
+
+        final String check = properties.getProperty(CHECK_DOCS_PROP_NAME, "no");
+        checkDocs = check.equalsIgnoreCase("YES");
     }
 
     @Override
@@ -134,7 +139,7 @@ public class ConsistencyCheckTask implements SystemTask {
                 report = openLog();
                 final CheckCallback cb = new CheckCallback(report);
 
-                final ConsistencyCheck check = new ConsistencyCheck(broker, false);
+                final ConsistencyCheck check = new ConsistencyCheck(broker, false, checkDocs);
                 agentInstance.changeStatus(brokerPool, new TaskStatus(TaskStatus.Status.RUNNING_CHECK));
                 errors = check.checkAll(cb);
                 


### PR DESCRIPTION
Consistency checks take too long when creating a backup on a large db, sometimes longer than the actual export of the data. In particular, scanning the DOM of every single document is a performance killer.

By default, consistency check will now only test if a document's data can be accessed. Extended checks, which will traverse every document to test for DOM errors, can be enabled via a parameter. To reduce IO, documents are now read in the order they are stored in dom.dbx. This results in higher memory consumption, but makes checks 3 times faster.
