### PR TITLE
[performance] Removing collection with many docs/subcollections results ...

### DIFF
--- a/src/org/exist/collections/Collection.java
+++ b/src/org/exist/collections/Collection.java
@@ -1006,6 +1006,9 @@ public class Collection extends Observable implements Comparable<Collection>, Ca
      */
     public void read(final DBBroker broker, final VariableByteInput istream) throws IOException, PermissionDeniedException {
         collectionId = istream.readInt();
+        if (collectionId < 0) {
+            throw new PermissionDeniedException("Internal error reading collection: invalid collection id");
+        }
         final int collLen = istream.readInt();
         subCollections = new ObjectHashSet<XmldbURI>(collLen == 0 ? 19 : collLen); //TODO what is this number 19?
         for (int i = 0; i < collLen; i++) {


### PR DESCRIPTION
...in huge recovery log, because the list of freed collection/doc IDs is updated continuously and written to disk. Solution: keep list of unused collection/doc IDs in memory only to reduce IO. The downside is that those lists will get lost if the db is restarted, so some spare IDs might not be reused. This trade off seems acceptable though. Having some gaps in the assigned IDs is ok.
