### PR TITLE
Extend org.exist.storage.btree.Repair utility

### DIFF
--- a/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndex.java
+++ b/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndex.java
@@ -28,6 +28,7 @@ import org.exist.indexing.IndexWorker;
 import org.exist.indexing.RawBackupSupport;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.storage.btree.BTree;
 import org.exist.storage.btree.DBException;
 import org.exist.storage.index.BFile;
 import org.exist.util.DatabaseConfigurationException;
@@ -110,6 +111,10 @@ public class NGramIndex extends AbstractIndex implements RawBackupSupport {
 
     public int getN() {
         return gramSize;
+    }
+
+    public BTree getStorage() {
+        return db;
     }
 
     public void backupToArchive(RawDataBackup backup) throws IOException {

--- a/src/org/exist/indexing/AbstractIndex.java
+++ b/src/org/exist/indexing/AbstractIndex.java
@@ -23,6 +23,7 @@ package org.exist.indexing;
 
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.storage.btree.BTree;
 import org.exist.storage.btree.DBException;
 import org.exist.util.DatabaseConfigurationException;
 import org.w3c.dom.Element;
@@ -84,4 +85,8 @@ public abstract class AbstractIndex implements Index {
 
     public abstract boolean checkIndex(DBBroker broker);
 
+    @Override
+    public BTree getStorage() {
+        return null;
+    }
 }

--- a/src/org/exist/indexing/Index.java
+++ b/src/org/exist/indexing/Index.java
@@ -23,6 +23,7 @@ package org.exist.indexing;
 
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.storage.btree.BTree;
 import org.exist.storage.btree.DBException;
 import org.exist.util.DatabaseConfigurationException;
 import org.w3c.dom.Element;
@@ -120,4 +121,12 @@ public interface Index {
      * The definition of "consistency" is left to the user.
      */
     boolean checkIndex(DBBroker broker);
+
+    /**
+     * Returns the underlying btree class for btree-based indexes or null for
+     * other indexes.
+     *
+     * @return the underlying btree or null if not available
+     */
+    BTree getStorage();
 }


### PR DESCRIPTION
Useful if you think that one of the core indexes might be corrupted and you want to quickly rebuild it without reindexing everything. It is fast and uses the same index-rebuild operations as crash recovery.
