### PR TITLE
[bugfix] Prevent concurrency issue in XQueryURLRewrite

### DIFF
--- a/src/org/exist/http/urlrewrite/ControllerForward.java
+++ b/src/org/exist/http/urlrewrite/ControllerForward.java
@@ -54,6 +54,11 @@ public class ControllerForward extends URLRewrite {
         this.target = config.getAttribute("path");
     }
 
+    public ControllerForward(ControllerForward other) {
+        super(other);
+        this.serverName = other.serverName;
+    }
+
     @Override
     public void doRewrite(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
     }
@@ -95,4 +100,9 @@ public class ControllerForward extends URLRewrite {
 	public String getServerName() {
 		return serverName;
 	}
+
+    @Override
+    protected URLRewrite copy() {
+        return new ControllerForward(this);
+    }
 }

--- a/src/org/exist/http/urlrewrite/Forward.java
+++ b/src/org/exist/http/urlrewrite/Forward.java
@@ -37,6 +37,10 @@ public abstract class Forward extends URLRewrite {
         super(config, uri);
     }
 
+    protected Forward(URLRewrite other) {
+        super(other);
+    }
+
     @Override
     public void doRewrite(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         final RequestDispatcher dispatcher = getRequestDispatcher(request);

--- a/src/org/exist/http/urlrewrite/ModuleCall.java
+++ b/src/org/exist/http/urlrewrite/ModuleCall.java
@@ -77,6 +77,11 @@ public class ModuleCall extends URLRewrite {
         }
     }
 
+    protected ModuleCall(ModuleCall other) {
+        super(other);
+        this.call = other.call;
+    }
+
     @Override
     public void doRewrite(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
@@ -88,5 +93,10 @@ public class ModuleCall extends URLRewrite {
         } catch (final XPathException e) {
             throw new ServletException("Called function threw exception: " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    protected URLRewrite copy() {
+        return new ModuleCall(this);
     }
 }

--- a/src/org/exist/http/urlrewrite/PassThrough.java
+++ b/src/org/exist/http/urlrewrite/PassThrough.java
@@ -43,9 +43,19 @@ public class PassThrough extends Forward {
         this.target = request.getRequestURI().substring(request.getContextPath().length());
     }
 
+    public PassThrough(PassThrough other) {
+        super(other);
+        this.servletConfig = other.servletConfig;
+    }
+
 	@Override
 	protected RequestDispatcher getRequestDispatcher(HttpServletRequest request) {
 		// always forward to the servlet engine's default servlet
         return servletConfig.getServletContext().getNamedDispatcher("default");
 	}
+
+    @Override
+    protected URLRewrite copy() {
+        return new PassThrough(this);
+    }
 }

--- a/src/org/exist/http/urlrewrite/PathForward.java
+++ b/src/org/exist/http/urlrewrite/PathForward.java
@@ -49,7 +49,12 @@ public class PathForward extends Forward {
         }
     }
 
-    
+    protected PathForward(PathForward other) {
+        super(other);
+        this.filterConfig = other.filterConfig;
+        this.servletName = other.servletName;
+    }
+
     @Override
 	protected void setAbsolutePath(RequestWrapper request) {
 		request.setPaths(target, servletName);
@@ -64,5 +69,10 @@ public class PathForward extends Forward {
             {return request.getRequestDispatcher(target);}
         else
             {return filterConfig.getServletContext().getRequestDispatcher(target);}
+    }
+
+    @Override
+    protected URLRewrite copy() {
+        return new PathForward(this);
     }
 }

--- a/src/org/exist/http/urlrewrite/Redirect.java
+++ b/src/org/exist/http/urlrewrite/Redirect.java
@@ -43,9 +43,18 @@ public class Redirect extends URLRewrite {
             {setTarget(URLRewrite.normalizePath(redirectTo));}
     }
 
+    public Redirect(Redirect other) {
+        super(other);
+    }
+
     @Override
     public void doRewrite(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         setHeaders(new HttpResponseWrapper(response));
         response.sendRedirect(target);
+    }
+
+    @Override
+    protected URLRewrite copy() {
+        return new Redirect(this);
     }
 }

--- a/src/org/exist/http/urlrewrite/RewriteConfig.java
+++ b/src/org/exist/http/urlrewrite/RewriteConfig.java
@@ -125,7 +125,7 @@ public class RewriteConfig {
     public synchronized URLRewrite lookup(HttpServletRequest request) throws ServletException {
         final String path = request.getRequestURI().substring(request.getContextPath().length());
         
-        return lookup(path, request.getServerName(), false);
+        return lookup(path, request.getServerName(), false, null);
     }
 
     /**
@@ -137,7 +137,7 @@ public class RewriteConfig {
      * @return the URLRewrite instance for the mapping or null if none was found
      * @throws ServletException
      */
-    public synchronized URLRewrite lookup(String path, String serverName, boolean staticMapping) throws ServletException {
+    public synchronized URLRewrite lookup(String path, String serverName, boolean staticMapping, URLRewrite copyFrom) throws ServletException {
         final int p = path.lastIndexOf(';');
         if(p != Constants.STRING_NOT_FOUND)
             {path = path.substring(0, p);}
@@ -145,8 +145,11 @@ public class RewriteConfig {
             final Mapping m = mappings.get(i);
             final String matchedString = m.match(path);
             if (matchedString != null) {
-                final URLRewrite action = m.action;
-                
+                final URLRewrite action = m.action.copy();
+                if (copyFrom != null) {
+                    action.copyFrom(copyFrom);
+                }
+
                 /*
                  * If the URLRewrite is a ControllerForward, then test to see if there is a condition
                  * on the server name.  If there is a condition on the server name and the names do not

--- a/src/org/exist/http/urlrewrite/URLRewrite.java
+++ b/src/org/exist/http/urlrewrite/URLRewrite.java
@@ -84,6 +84,13 @@ public abstract class URLRewrite {
         }
     }
 
+    protected URLRewrite(URLRewrite other) {
+        this.uri = other.uri;
+        this.target = other.target;
+        this.prefix = other.prefix;
+        this.method = other.method;
+    }
+
     protected void updateRequest(XQueryURLRewrite.RequestWrapper request) {
         if (prefix != null)
             {request.removePathPrefix(prefix);}
@@ -128,10 +135,21 @@ public abstract class URLRewrite {
     }
 
     protected void copyFrom(URLRewrite other) {
-        this.headers = other.headers;
-        this.parameters = other.parameters;
-        this.attributes = other.attributes;
+        if (other.headers != null) {
+            this.headers = new HashMap<String, String>(other.headers);
+        }
+        if (other.attributes != null) {
+            this.attributes = new HashMap<String, String>(other.attributes);
+        }
+        if (other.parameters != null) {
+            this.parameters = new HashMap<String, List<String>>();
+            for (Map.Entry<String, List<String>> entry: other.parameters.entrySet()) {
+                this.parameters.put(entry.getKey(), new ArrayList<String>(entry.getValue()));
+            }
+        }
     }
+
+    protected abstract URLRewrite copy();
 
     private void setHeader(String key, String value) {
         if(headers == null) {

--- a/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -549,7 +549,7 @@ public class XQueryURLRewrite extends HttpServlet {
     protected void doRewrite(URLRewrite action, RequestWrapper request, HttpServletResponse response) throws IOException, ServletException {
         if (action.getTarget() != null && !(action instanceof Redirect)) {
             final String uri = action.resolve(request);
-            URLRewrite staticRewrite = rewriteConfig.lookup(uri, request.getServerName(), true);
+            URLRewrite staticRewrite = rewriteConfig.lookup(uri, request.getServerName(), true, action);
 
             if (staticRewrite != null) {
                 staticRewrite.copyFrom(action);

--- a/test/src/org/exist/http/urlrewrite/URLRewriteTest.java
+++ b/test/src/org/exist/http/urlrewrite/URLRewriteTest.java
@@ -86,6 +86,10 @@ public class URLRewriteTest {
             super(config, uri);
         }
 
+        public TestableURLRewrite(TestableURLRewrite other) {
+            super(other);
+        }
+
         public Map<String, List<String>> getParameters() {
             return parameters;
         }
@@ -95,5 +99,9 @@ public class URLRewriteTest {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
+        @Override
+        protected URLRewrite copy() {
+            return new TestableURLRewrite(this);
+        }
     }
 }


### PR DESCRIPTION
Static rewrite actions may be modified by several threads, causing ConcurrentModificationExceptions.
