### PR TITLE
[bugfix] Wrong timeout check: login tokens timed out immedately.

### DIFF
--- a/extensions/modules/src/org/exist/xquery/modules/persistentlogin/PersistentLogin.java
+++ b/extensions/modules/src/org/exist/xquery/modules/persistentlogin/PersistentLogin.java
@@ -199,7 +199,7 @@ public class PersistentLogin {
             long now = System.currentTimeMillis();
             for (Iterator<Map.Entry<String, Long>> i = invalidatedTokens.entrySet().iterator(); i.hasNext(); ) {
                 Map.Entry<String, Long> entry = i.next();
-                if (entry.getValue() > now) {
+                if (entry.getValue() < now) {
                     i.remove();
                 }
             }


### PR DESCRIPTION
They should remain valid for a few seconds or the user gets logged out too quickly if requests come in with a delay.
