### PR TITLE
[performance] ngram index: method for computing string offsets

### DIFF
--- a/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndexWorker.java
+++ b/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndexWorker.java
@@ -578,18 +578,18 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
     }
 
     private void indexText(NodeId nodeId, QName qname, String text) {
-        String[] ngram = tokenize(text);
-        int len = ngram.length;
-        for (int i = 0; i < len; i++) {
-            int offset = text.offsetByCodePoints(0, i);
-            QNameTerm key = new QNameTerm(qname, ngram[i]);
+        final String[] ngram = tokenize(text);
+        final int len = text.length();
+        for (int i = 0, j = 0, cp; i < len; i += Character.charCount(cp), j++) {
+            cp = text.codePointAt(i);
+            final QNameTerm key = new QNameTerm(qname, ngram[j]);
             OccurrenceList list = ngrams.get(key);
             if (list == null) {
                 list = new OccurrenceList();
-                list.add(nodeId, offset);
+                list.add(nodeId, i);
                 ngrams.put(key, list);
             } else {
-                list.add(nodeId, offset);
+                list.add(nodeId, i);
             }
         }
     }

--- a/extensions/indexes/ngram/src/org/exist/xquery/modules/ngram/NGramSearch.java
+++ b/extensions/indexes/ngram/src/org/exist/xquery/modules/ngram/NGramSearch.java
@@ -136,6 +136,7 @@ public class NGramSearch extends Function implements Optimizable {
 
     @Override
     public void setArguments(List<Expression> arguments) throws XPathException {
+        steps.clear();
         Expression path = arguments.get(0);
         steps.add(path);
 


### PR DESCRIPTION
While working on a corpus of Sanskrit texts, we noticed that building an ngram index took minutes on the fastest machine, but several hours on other systems. Profiling showed the method for computing offsets by unicode code points being the main bottleneck. Replacing the code to avoid String.offsetByCodePoints improves indexing performance by at least factor 2, sometimes factor 10 or more.
