### PR TITLE
enhancement for in wrapper script in real-world deployments

### DIFF
--- a/tools/wrapper/bin/exist.sh.in
+++ b/tools/wrapper/bin/exist.sh.in
@@ -656,7 +656,7 @@ checkUser() {
         then
             /sbin/runuser - $RUN_AS_USER -c "\"$REALPATH\" $ADDITIONAL_PARA"
         else
-            su - $RUN_AS_USER -c "\"$REALPATH\" $ADDITIONAL_PARA"
+            su - s /bin/sh $RUN_AS_USER -c "\"$REALPATH\" $ADDITIONAL_PARA"
         fi
         RUN_AS_USER_EXITCODE=$?
         # Now that we are the original user again, we may need to clean up the lock file.


### PR DESCRIPTION
Deploying eXist-db on a server usually involves setting up a special user that is the owner of the process. I found that if that user does not have a valid shell (/bin/false or /usr/sbin/nologin is not uncommon for daemon accounts), the wrapper script for starting the database fails (when using RUN_AS_USER).

This is a trivial patch that fixes the problem.