### PR TITLE
[bugfix] collection completion in CLI client

### DIFF
--- a/src/org/exist/client/InteractiveClient.java
+++ b/src/org/exist/client/InteractiveClient.java
@@ -2769,7 +2769,7 @@ public class InteractiveClient {
                     }
                 }
             }
-            return p + 1;
+            return p;
         }
     }
     


### PR DESCRIPTION
Tab-completion in the CLI client does not double the first character of the completed collection name any more.

This behavior was just annoying:

# ./bin/client.sh -s -P xxxxx
exist:/db>cd a[TAB]
exist:/db>cd aapps
