### PR TITLE
Fixing the version feature on splash-screen

### DIFF
--- a/src/org/exist/launcher/SplashScreen.java
+++ b/src/org/exist/launcher/SplashScreen.java
@@ -91,7 +91,7 @@ public class SplashScreen extends JFrame implements Observer {
         getContentPane().add(statusLabel, BorderLayout.SOUTH);
         // show it
         setSize(new Dimension(icon.getIconWidth() + 40, icon.getIconHeight() + 50));
-        //pack();
+        pack();
         this.setLocationRelativeTo(null);
         setVisible(true);
     }


### PR DESCRIPTION
As @zwobit points out. The pack() call makes the version info show up in splash screen for all oracle java se builds. Uncomments it.
