### PR TITLE
[bugfix] new range index: wrong type returned by scan through index conf

### DIFF
--- a/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
@@ -123,7 +123,7 @@ public class ComplexRangeIndexConfigElement extends RangeIndexConfigElement {
         if (field != null) {
             return field.getType();
         }
-        return Type.STRING;
+        return Type.ITEM;
     }
 
     @Override


### PR DESCRIPTION
Do not automatically assume string if no type is given, but continue scanning configurations.
