### PR TITLE
Fix for Ant Extract task: use original file extensions

### DIFF
--- a/src/org/exist/ant/XMLDBExtractTask.java
+++ b/src/org/exist/ant/XMLDBExtractTask.java
@@ -370,13 +370,14 @@ public class XMLDBExtractTask extends AbstractXMLDBTask
     }
 
 
+    // not used anymore
     public void setType( String type )
     {
         this.type = type;
 
-        if( !"xml".equalsIgnoreCase( type ) & !"binary".equalsIgnoreCase( type ) ) {
-            throw( new BuildException( "non-xml or non-binary resource types are not supported currently" ) );
-        }
+        //if( !"xml".equalsIgnoreCase( type ) & !"binary".equalsIgnoreCase( type ) ) {
+        //    throw( new BuildException( "non-xml or non-binary resource types are not supported currently" ) );
+        //}
     }
 
 


### PR DESCRIPTION
Files were forced to have a .xml or .binary filename extension without no good reason.

if there is a good reason... please write a comment!

github issue  https://github.com/eXist-db/exist/issues/304
