### PR TITLE
[bugfix] Expression state not properly reset throughout function calls

### DIFF
--- a/src/org/exist/xquery/UserDefinedFunction.java
+++ b/src/org/exist/xquery/UserDefinedFunction.java
@@ -48,7 +48,7 @@ public class UserDefinedFunction extends Function implements Cloneable {
     
     private FunctionCall call;
     
-    private boolean reseted = false;
+    private boolean hasBeenReset = false;
 
     private boolean visited = false;
 
@@ -90,7 +90,7 @@ public class UserDefinedFunction extends Function implements Cloneable {
 	 * @see org.exist.xquery.Function#analyze(org.exist.xquery.AnalyzeContextInfo)
 	 */
 	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
-		reseted = false;
+		hasBeenReset = false;
 		
 		if(call != null && !call.isRecursive()) {
 			// Save the local variable stack
@@ -123,6 +123,8 @@ public class UserDefinedFunction extends Function implements Cloneable {
 	public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
 //        context.expressionStart(this);
         context.stackEnter(this);
+        // make sure reset state is called after query has finished
+	    hasBeenReset = false;
         // Save the local variable stack
         final LocalVariable mark = context.markLocalVariables(true);
         if (closureVariables != null)
@@ -207,8 +209,10 @@ public class UserDefinedFunction extends Function implements Cloneable {
 	 * @see org.exist.xquery.PathExpr#resetState()
 	 */
 	public void resetState(boolean postOptimization) {
-		if (reseted) {return;}
-		reseted = true;
+		if (hasBeenReset) {
+            return;
+        }
+		hasBeenReset = true;
 		
 		super.resetState(postOptimization);
         // Question: understand this test. Why not reset even is not in recursion ?


### PR DESCRIPTION
This may result in issues if a query is reused from the pool.
