### PR TITLE
always disallow empty password for ldap connections

### DIFF
--- a/extensions/security/ldap/src/org/exist/security/realm/ldap/LdapContextFactory.java
+++ b/extensions/security/ldap/src/org/exist/security/realm/ldap/LdapContextFactory.java
@@ -29,6 +29,7 @@ import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.exist.config.Configurable;
 import org.exist.config.Configuration;
@@ -100,7 +101,7 @@ public class LdapContextFactory implements Configurable {
             throw new IllegalStateException("An LDAP URL must be specified of the form ldap://<hostname>:<port>");
         }
 
-        if(password != null && "".equals(password.trim())) {
+        if(StringUtils.isBlank(password)) {
             throw new IllegalStateException("Password for LDAP authentication may not be empty.");
         }
 


### PR DESCRIPTION
some servers may not immediately complain on the initialisation of the LDAPContext if the password is empty
