### PR TITLE
[bugfix] Handle conflicting user ids when restoring a backup

### DIFF
--- a/src/org/exist/security/SecurityManager.java
+++ b/src/org/exist/security/SecurityManager.java
@@ -100,6 +100,10 @@ public interface SecurityManager extends Configurable {
    public Subject getGuestSubject();
    public Group getDBAGroup();
 
+    public int getNextAccountId();
+
+    public int getNextGroupId();
+
    public List<Account> getGroupMembers(String groupName);
 
    @Deprecated //use realm's method

--- a/src/org/exist/security/internal/SecurityManagerImpl.java
+++ b/src/org/exist/security/internal/SecurityManagerImpl.java
@@ -501,14 +501,14 @@ public class SecurityManagerImpl implements SecurityManager {
         return pool;
     }
 
-    private synchronized int getNextGroupId() {
+    public synchronized int getNextGroupId() {
         if(lastGroupId + 1 == MAX_GROUP_ID) {
             throw new RuntimeException("System has no more group-ids available");            
         }
         return ++lastGroupId;
     }
 
-    private synchronized int getNextAccountId() {
+    public synchronized int getNextAccountId() {
         if(lastUserId +1 == MAX_USER_ID) {
             throw new RuntimeException("System has no more user-ids available");
         }


### PR DESCRIPTION
1. avoid lost user ids: if an account in the backup has the same name as an existing user, but a different user id: update the account but keep the old user id. Not doing so led to corrupted resources/collections: resources still referenced the old, deleted user id, but they could neither be viewed nor removed.
2. avoid duplicate users: if an account in the backup uses a different name, but the same id as an existing user: assign a new id to the user account before restoring it.
