### PR TITLE
Remove helper text from client 

### DIFF
--- a/src/org/exist/client/InteractiveClient.java
+++ b/src/org/exist/client/InteractiveClient.java
@@ -252,9 +252,6 @@ public class InteractiveClient {
         messageln("rmcol collection     remove collection");
         messageln("set [key=value]      set property. Calling set without ");
         messageln("                     argument shows current settings.");
-        messageln("validate [document]  validate xml document with system xml catalog.");
-        messageln("validate [document] [grammar]  validate xml document with ");
-        messageln("                     specified grammar document.");
         messageln(EOL + "--- search commands ---");
         messageln("find xpath-expr      execute the given XPath expression.");
         messageln("show [position]      display query result value at position.");


### PR DESCRIPTION
 I was convinced the text was removed ages ago. see exist-open http://exist.markmail.org/thread/ena7vtayc52bw24l
