### PR TITLE
[ignore] Keep sending signals to java wrapper while jetty is starting up

### DIFF
--- a/src/org/exist/jetty/JettyStart.java
+++ b/src/org/exist/jetty/JettyStart.java
@@ -73,6 +73,7 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
         start.run(args, null);
     }
 
+    public final static String SIGNAL_STARTING = "jetty starting";
     public final static String SIGNAL_STARTED = "jetty started";
     public final static String SIGNAL_ERROR = "error";
 
@@ -190,6 +191,7 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
             
             server.setStopAtShutdown(true);
             server.addLifeCycleListener(this);
+
             BrokerPool.getInstance().registerShutdownListener(new ShutdownListenerImpl(server));
             server.start();
 
@@ -409,12 +411,16 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
 
     public synchronized void lifeCycleStarting(LifeCycle lifeCycle) {
         logger.info("Jetty server starting...");
+        setChanged();
+        notifyObservers(SIGNAL_STARTING);
         status = STATUS_STARTING;
         notifyAll();
     }
 
     public synchronized void lifeCycleStarted(LifeCycle lifeCycle) {
         logger.info("Jetty server started.");
+        setChanged();
+        notifyObservers(SIGNAL_STARTED);
         status = STATUS_STARTED;
         notifyAll();
     }

--- a/tools/wrapper/src/org/exist/wrapper/Main.java
+++ b/tools/wrapper/src/org/exist/wrapper/Main.java
@@ -40,7 +40,7 @@ import org.tanukisoftware.wrapper.WrapperManager;
 public class Main implements WrapperListener, Observer {
     
     public static final int WAIT_HINT_STOP = 60000;
-    public static final int WAIT_HINT_UPDATE = 6000;
+    public static final int WAIT_HINT_UPDATE = 10000;
 
 	private Class<?> klazz;
 	private Object app;


### PR DESCRIPTION
Wrapper sometimes killed eXist too early on some system. Send it some extra signals.
