### PR TITLE
Adding a Lucene ft-index attribute boosting feature.

### DIFF
--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -102,6 +102,15 @@ public class LuceneIndexTest {
         "   von ruhigem Dasein versunken, daß meine Kunst darunter leidet.</p>" +
         "</section>";
 
+    private static String XML8 =
+            "<a>" +
+            "   <b att='att on b1'>AAA on b1</b>" +
+            "   <b att='att on b2' attr='attr on b2'>AAA on b2</b>" +
+            "   <b att='att on b3' attr='attr on b3'>AAA on b3</b>" +
+            "   <c att='att on c1'>AAA on c1</c>" +
+            "   <c>AAA on c2</c>" +
+            "</a>";
+
     private static String COLLECTION_CONFIG1 =
         "<collection xmlns=\"http://exist-db.org/collection-config/1.0\">" +
     	"	<index>" +
@@ -193,6 +202,29 @@ public class LuceneIndexTest {
             "       </lucene>" +
             "   </index>" +
             "</collection>";
+
+     private static String COLLECTION_CONFIG7 =
+            "<collection xmlns=\"http://exist-db.org/collection-config/1.0\">" +
+            "   <index xmlns:tei=\"http://www.tei-c.org/ns/1.0\">" +
+            "       <fulltext default=\"none\" attributes=\"no\">" +
+            "       </fulltext>" +
+            "       <lucene>" +
+            "           <text qname='c'>" +
+            "               <has-attribute qname='att' boost='30'/>" +
+            "           </text>" +
+            "           <text qname='b' boost='5'>" +
+            "               <match-attribute qname='att' value='att on b2' boost='30'/>" + 
+            "               <match-attribute qname='attr' value='attr on b3' boost='5'/>" +
+            "               <has-attribute qname='attr' boost='15'/>" +
+            "           </text>" +
+            "           <text qname='@att'>" +
+            "               <match-sibling-attribute qname='attr' value='attr on b2' boost='2'/>" +
+            "               <has-sibling-attribute qname='attr' boost='2'/>" +
+            "           </text>" +
+            "       </lucene>" +
+            "   </index>" +
+            "</collection>";
+
 
     private static BrokerPool pool;
     private static Collection root;
@@ -359,6 +391,81 @@ public class LuceneIndexTest {
             seq = xquery.execute("/article[ft:query(., 'ignore')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        } finally {
+            pool.release(broker);
+        }
+    }
+
+    @Test
+    public void attributeMatch() {
+        DocumentSet docs
+                = configureAndStore(COLLECTION_CONFIG7, XML8, "test.xml");
+        DBBroker broker = null;
+        TransactionManager transact = null;
+        Txn transaction = null;
+        try {
+            broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            transact = pool.getTransactionManager();
+            transaction = transact.beginTransaction();
+
+            assertNotNull(broker);
+            assertNotNull(transact);
+            assertNotNull(transaction);
+
+            XQuery xquery = broker.getXQueryService();
+            assertNotNull(xquery);
+
+            Sequence seq = xquery.execute("for $a in ft:query((//b|//c), 'AAA') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
+            assertNotNull(seq);
+            assertEquals(5, seq.getItemCount());
+            assertEquals("AAA on b2", seq.itemAt(0).getStringValue());
+            assertEquals("AAA on c1", seq.itemAt(1).getStringValue());
+            assertEquals("AAA on b3", seq.itemAt(2).getStringValue());
+            assertEquals("AAA on b1", seq.itemAt(3).getStringValue());
+            assertEquals("AAA on c2", seq.itemAt(4).getStringValue());
+
+            seq = xquery.execute("for $a in ft:query(//@att, 'att') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
+            assertNotNull(seq);
+            assertEquals(4, seq.getItemCount());
+            assertEquals("att on b2", seq.itemAt(0).getStringValue());
+            assertEquals("att on b3", seq.itemAt(1).getStringValue());
+            assertEquals("att on b1", seq.itemAt(2).getStringValue());
+            assertEquals("att on c1", seq.itemAt(3).getStringValue());
+
+
+            // modify with xupdate and check if boosts are updated accordingly
+            XUpdateProcessor proc = new XUpdateProcessor(broker, docs, AccessContext.TEST);
+            assertNotNull(proc);
+            proc.setBroker(broker);
+            proc.setDocumentSet(docs);
+
+            // remove 'att' attribute from c element: c element gets no boost
+            String xupdate =
+                    XUPDATE_START +
+                    "   <xu:remove select=\"//c[1]/@att\"/>" +
+                    "   <xu:append select=\"//c[2]\"><xu:attribute name=\"att\">att on c2</xu:attribute></xu:append>" +
+                    XUPDATE_END;
+
+            Modification[] modifications = proc.parse(new InputSource(new StringReader(xupdate)));
+            assertNotNull(modifications);
+
+            modifications[0].process(transaction);
+            modifications[1].process(transaction);
+            proc.reset();
+            transact.commit(transaction);
+
+            seq = xquery.execute("for $a in ft:query((//b|//c), 'AAA') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
+            assertNotNull(seq);
+            assertEquals(5, seq.getItemCount());
+            assertEquals("AAA on b2", seq.itemAt(0).getStringValue());
+            assertEquals("AAA on c2", seq.itemAt(1).getStringValue());
+            assertEquals("AAA on b3", seq.itemAt(2).getStringValue());
+            assertEquals("AAA on b1", seq.itemAt(3).getStringValue());
+            assertEquals("AAA on c1", seq.itemAt(4).getStringValue());
+
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/schema/collection.xconf.xsd
+++ b/schema/collection.xconf.xsd
@@ -234,6 +234,10 @@
         <xs:sequence>
             <xs:element ref="inline" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element ref="ignore" minOccurs="0" maxOccurs="unbounded"/>
+	    <xs:element name="match-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
+	    <xs:element name="has-attribute" minOccurs="0" maxOccurs="unbounded" type="hasAttrBoostType"/>
+	    <xs:element name="match-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
+	    <xs:element name="has-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="hasAttrBoostType"/>
         </xs:sequence>
     </xs:group>
 
@@ -251,6 +255,23 @@
         <xs:attribute name="analyzer" use="optional" type="xs:IDREF"/>
         <xs:attribute name="boost" use="optional" type="xs:double"/>
         <xs:attribute name="field" use="optional" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="matchAttrBoostType">
+      <xs:annotation>
+        <xs:documentation>text element children match-attr or match-sibling-attr</xs:documentation>
+      </xs:annotation>
+      <xs:attributeGroup ref="qnameReq"/>
+      <xs:attributeGroup ref="valueReq"/>
+      <xs:attribute name="boost" use="required" type="xs:double"/>
+    </xs:complexType>
+
+    <xs:complexType name="hasAttrBoostType">
+      <xs:annotation>
+        <xs:documentation>text element children has-attr or has-sibling-attr</xs:documentation>
+      </xs:annotation>
+      <xs:attributeGroup ref="qnameReq"/>
+      <xs:attribute name="boost" use="required" type="xs:double"/>
     </xs:complexType>
 
     <xs:complexType name="singleQnameAttrType">

--- a/src/org/exist/dom/ElementImpl.java
+++ b/src/org/exist/dom/ElementImpl.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2001-2007 The eXist team
+ * Copyright (C) 2001-2014 The eXist-db Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
@@ -17,7 +17,6 @@
  * along with this program; if not, write to the Free Software Foundation
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *  
- *  $Id$
  */
 package org.exist.dom;
 
@@ -1545,7 +1544,8 @@ public class ElementImpl extends NamedNode implements Element, ElementAtExist {
             }
             final NodePath path = getPath();
             broker.getIndexController().setDocument(ownerDocument, StreamListener.STORE);
-            final StreamListener listener = broker.getIndexController().getStreamListener();
+            StoredNode reindexRoot = broker.getIndexController().getReindexRoot(this, path, true, true);
+            final StreamListener listener = reindexRoot == null ? broker.getIndexController().getStreamListener() : null;
             if (children == 0) {
                 appendChildren(transaction, nodeId.newChild(), null,
                     new NodeImplRef(this), path, appendList, listener);
@@ -1569,7 +1569,8 @@ public class ElementImpl extends NamedNode implements Element, ElementAtExist {
 
             broker.updateNode(transaction, this, true);
             broker.flush();
-
+            broker.getIndexController().reindex(transaction, reindexRoot,
+                    StreamListener.STORE);
         } catch (final EXistException e) {
             LOG.warn("Exception while inserting node: " + e.getMessage(), e);
         } finally {

--- a/src/org/exist/indexing/IndexController.java
+++ b/src/org/exist/indexing/IndexController.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-07 The eXist Project
+ *  Copyright (C) 2001-2014 The eXist-db Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -17,7 +17,6 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * 
- *  $Id$
  */
 package org.exist.indexing;
 
@@ -54,6 +53,7 @@ public class IndexController {
     protected StreamListener listener = null;    
     protected DocumentImpl currentDoc = null;
     protected int currentMode = StreamListener.UNKNOWN;
+    private boolean isReindexing;
 
     public IndexController(DBBroker broker) {
         this.broker = broker;
@@ -214,11 +214,21 @@ public class IndexController {
     public void reindex(Txn transaction, StoredNode reindexRoot, int mode) {
         if (reindexRoot == null)
             {return;}
+        setReindexing(true);
         reindexRoot = broker.objectWith(new NodeProxy(reindexRoot.getDocument(), reindexRoot.getNodeId()));
         setDocument(reindexRoot.getDocument(), mode);
         getStreamListener();
         IndexUtils.scanNode(broker, transaction, reindexRoot, listener);
         flush();
+        setReindexing(false);
+    }
+
+    public boolean isReindexing() {
+        return isReindexing;
+    }
+
+    protected void setReindexing(final boolean b) {
+        isReindexing = b;
     }
 
     /**


### PR DESCRIPTION
- Adding attribute boosting index configuration elements has-attr, has-sibling-attr, match-attr, match-sibling-attr as Lucene text element children, e g:

``` xml
<text qname="@val">
  <match-sibling-attribute qname="att" value="writtenForm" boost="30"/>
  <match-sibling-attribute qname="att" value="definition" boost="15"/>
</text>
```

to be able to boost LMFish feature attribute/value attributes otherwise use default boost.
- All tests pass.
- Added the attribute boosting text element children to collection.xconf.xsd.
