### PR TITLE
This patch allows to build eXist on Windows 7.

### DIFF
--- a/build/scripts/installer.xml
+++ b/build/scripts/installer.xml
@@ -115,8 +115,9 @@
         <delete file="installer/install.xml" failonerror="false"/>
         <xslt basedir="installer" in="installer/install.xml.tmpl"
             out="installer/install.xml"
-            style="install.xsl" classpathref="classpath.core" 
+            style="installer/install.xsl" classpathref="classpath.core" 
             processor="trax">
+            <factory name="net.sf.saxon.TransformerFactoryImpl"/>
             <classpath>
                 <fileset dir="lib/endorsed">
                     <include name="saxon*.jar"/>
@@ -129,7 +130,7 @@
     </target>
     
     <target name="process-xar">
-        <propertyregex property="app.name" regexp="^.*/([^/]+).xar$"
+        <propertyregex property="app.name" regexp="^.*\${file.separator}([^\${file.separator}]+).xar$"
             input="${app}" select="\1"/>
         <echo message="Processing application package: ${app.name}"/>
         <unjar dest="${apps.dir}" src="${app}">


### PR DESCRIPTION
New request replacing previous one using a single commit.

All 3 commits steps were due to a git flow feature finish done before git flow feature publish.

Last commit comment was
-  Opened related issue https://github.com/eXist-db/exist/issues/385

Warning suppression:
The obsolete usage of xslt style location has been updated.
The new location is relative to the project. The subdirectory
installer has been inserted before the install.xsl style.

Failing building:
The Saxon factory has been added to force Saxon usage and acces to the tokenize function.

Failing building:
The processing of xar are failing due to Linux dependent usage of file separators
