### PR TITLE
Avoid implicit conversion of unicode \x160 as  numerical entity &#160;

### DIFF
--- a/src/org/exist/util/serializer/XMLWriter.java
+++ b/src/org/exist/util/serializer/XMLWriter.java
@@ -496,7 +496,7 @@ public class XMLWriter {
                     } else {
                         i++;
                     }
-                } else if(!charSet.inCharacterSet(ch) || ch == 160) {
+                } else if(!charSet.inCharacterSet(ch)) {
                                 break;
                 } else {
                     i++;
@@ -531,10 +531,6 @@ public class XMLWriter {
                         break;
                     case '"':
                         writer.write("&#34;");
-                        break;
-                    // non-breaking space:
-                    case 160:
-                        writer.write("&#160;");
                         break;
                     default:
                         writeCharacterReference(ch);


### PR DESCRIPTION
In the serialized result, unicode character \x160 are converted as  numerical entity &amp; # 1 6 0 ;

Even if this is equivalent, on an XML point of view, implicit and unexpected conversions
are source of problems.

See issue (https://github.com/eXist-db/exist/issues/187)
