### PR TITLE
Dist script not producing usable dist

### DIFF
--- a/build/scripts/dist.xml
+++ b/build/scripts/dist.xml
@@ -312,6 +312,17 @@
                 <include name="wrapper"/>
             </fileset>
         </chmod>
+        
+        <!-- Re-sign jar files that get re-built when this script gets invoked -->
+        <signjar alias="exist" storepass="secret" keystore="key.store">
+            <fileset dir="${dist.dir}">
+                <include name="exist*.jar"/>
+                <include name="start.jar"/>
+                <include name="exist-optional.jar"/>
+                <include name="examples.jar"/>
+                <include name="lib/extensions/exist-modules.jar"/>
+            </fileset>
+        </signjar>
     </target>
     
     <!-- ================================================================== -->

--- a/build/scripts/dist.xml
+++ b/build/scripts/dist.xml
@@ -197,7 +197,14 @@
         <touch file="${dist.dir}/log/.DO_NOT_DELETE"/>
 
         <filter token="database" value="native"/>
-
+        <mkdir dir="${dist.dir}/autodeploy"/>
+        <mkdir dir="${dist.dir}/lib/test"/>
+        <copy todir="${dist.dir}/autodeploy">
+            <fileset dir="./autodeploy">
+                <exclude name="**/*~"/>
+                <include name="*.xar"/>
+            </fileset>
+        </copy>
         <copy todir="${dist.dir}/" filtering="true">
             <fileset dir=".">
                 <include name="LICENSE"/>


### PR DESCRIPTION
Running build dist produces a distribution with no autodeploy directory, and unsigned jars that netx won't run.
Adjusted dist.xml build script to copy autodeploy dir to dist, and signjar stanza to re-sign the jars that get re-compiled when the dist script is called.