### PR TITLE
Improved HTML5 serialiser [reworked: AR]

### DIFF
--- a/src/org/exist/util/serializer/HTML5Writer.java
+++ b/src/org/exist/util/serializer/HTML5Writer.java
@@ -1,92 +1,173 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2014 The eXist-db Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ *  $Id$
+ */
 package org.exist.util.serializer;
 
-import java.io.Writer;
-import javax.xml.transform.TransformerException;
+import org.exist.dom.QName;
 import org.exist.util.hashtable.ObjectHashSet;
 
-public class HTML5Writer extends XHTMLWriter {
+import javax.xml.transform.TransformerException;
+import java.io.IOException;
+import java.io.Writer;
 
-    private final static ObjectHashSet<String> inlineTags = new ObjectHashSet<String>(31);
-    
+/**
+ * HTML5 writer which does not produce well-formed XHTML.
+ *
+ * @author Wolfgang
+ */
+public class HTML5Writer extends XHTML5Writer {
+
+    private final static ObjectHashSet<String> EMPTY_TAGS = new ObjectHashSet<String>(31);
     static {
-    	inlineTags.add("a");
-    	inlineTags.add("abbr");
-    	inlineTags.add("area");
-    	inlineTags.add("audio");
-    	inlineTags.add("b");
-    	inlineTags.add("bdi");
-    	inlineTags.add("bdo");
-    	inlineTags.add("br");
-    	inlineTags.add("button");
-    	inlineTags.add("canvas");
-    	inlineTags.add("cite");
-    	inlineTags.add("code");
-    	inlineTags.add("command");
-    	inlineTags.add("datalist");
-    	inlineTags.add("del");
-    	inlineTags.add("dfn");
-    	inlineTags.add("em");
-    	inlineTags.add("embed");
-    	inlineTags.add("i");
-    	inlineTags.add("img");
-    	inlineTags.add("ins");
-    	inlineTags.add("input");
-    	inlineTags.add("kbd");
-    	inlineTags.add("keygen");
-    	inlineTags.add("label");
-    	inlineTags.add("map");
-    	inlineTags.add("mark");
-    	inlineTags.add("math");
-    	inlineTags.add("meter");
-    	inlineTags.add("object");
-    	inlineTags.add("output");
-    	inlineTags.add("progress");
-    	inlineTags.add("q");
-    	inlineTags.add("ruby");
-    	inlineTags.add("s");
-    	inlineTags.add("samp");
-    	inlineTags.add("select");
-    	inlineTags.add("small");
-    	inlineTags.add("span");
-    	inlineTags.add("strong");
-    	inlineTags.add("sub");
-    	inlineTags.add("sup");
-    	inlineTags.add("svg");
-    	inlineTags.add("textarea");
-    	inlineTags.add("time");
-    	inlineTags.add("tt");
-    	inlineTags.add("u");
-    	inlineTags.add("var");
-    	inlineTags.add("video");
+        EMPTY_TAGS.add("area");
+        EMPTY_TAGS.add("base");
+        EMPTY_TAGS.add("br");
+        EMPTY_TAGS.add("col");
+        EMPTY_TAGS.add("embed");
+        EMPTY_TAGS.add("hr");
+        EMPTY_TAGS.add("img");
+        EMPTY_TAGS.add("input");
+        EMPTY_TAGS.add("keygen");
+        EMPTY_TAGS.add("link");
+        EMPTY_TAGS.add("meta");
+        EMPTY_TAGS.add("param");
+        EMPTY_TAGS.add("source");
+        EMPTY_TAGS.add("track");
+        EMPTY_TAGS.add("wbr");
     }
-    
+
+    private final static ObjectHashSet<String> RAW_TEXT_ELEMENTS = new ObjectHashSet<String>(31);
+    static {
+        RAW_TEXT_ELEMENTS.add("script");
+        RAW_TEXT_ELEMENTS.add("style");
+        RAW_TEXT_ELEMENTS.add("textarea");
+        RAW_TEXT_ELEMENTS.add("title");
+    }
+
     public HTML5Writer() {
-            super();
+        super(EMPTY_TAGS, INLINE_TAGS);
     }
 
-    public HTML5Writer(final Writer writer) {
-            super(writer);
+    public HTML5Writer(Writer writer) {
+        super(writer, EMPTY_TAGS, INLINE_TAGS);
     }
 
     @Override
-    protected void writeDoctype(final String rootElement) throws TransformerException {
-        if(doctypeWritten) {
-            return;
+    public void endElement(QName qname) throws TransformerException {
+        if (!isEmptyTag(qname.getLocalPart())) {
+            super.endElement(qname);
+        } else {
+            closeStartTag(true);
+            endIndent(qname.getNamespaceURI(), qname.getLocalPart());
         }
-
-        documentType(rootElement, null, null);
-        doctypeWritten = true;
     }
 
     @Override
-    protected boolean isInlineTag(final String namespaceURI, final String localName) {
-        return inlineTags.contains(localName);
+    public void endElement(String namespaceURI, String localName, String qname) throws TransformerException {
+        if (!isEmptyTag(localName)) {
+            super.endElement(namespaceURI, localName, qname);
+        } else {
+            closeStartTag(true);
+            endIndent(namespaceURI, localName);
+        }
     }
 
     @Override
-    protected boolean needsEscape(final char ch) {
-        if("script".equals(currentTag)) {
-            return !(ch == '<' || ch == '>' || ch == '&');
+    public void attribute(String qname, String value) throws TransformerException {
+        try {
+            if(!tagIsOpen) {
+                characters(value);
+                return;
+            }
+            final Writer writer = getWriter();
+            writer.write(' ');
+            writer.write(qname);
+            if (!qname.equals(value)) {
+                writer.write("=\"");
+                writeChars(value, true);
+                writer.write('"');
+            }
+        } catch(final IOException ioe) {
+            throw new TransformerException(ioe.getMessage(), ioe);
+        }
+    }
+
+    @Override
+    public void attribute(QName qname, String value) throws TransformerException {
+        try {
+            if(!tagIsOpen) {
+                characters(value);
+                return;
+                // throw new TransformerException("Found an attribute outside an
+                // element");
+            }
+            final Writer writer = getWriter();
+            writer.write(' ');
+            if(qname.getPrefix() != null && qname.getPrefix().length() > 0) {
+                writer.write(qname.getPrefix());
+                writer.write(':');
+            }
+            if (!qname.getLocalPart().equals(value)) {
+                writer.write(qname.getLocalPart());
+                writer.write("=\"");
+                writeChars(value, true);
+                writer.write('"');
+            }
+        } catch(final IOException ioe) {
+            throw new TransformerException(ioe.getMessage(), ioe);
+        }
+    }
+
+    @Override
+    public void namespace(String prefix, String nsURI) throws TransformerException {
+        // no namespaces allowed in HTML5
+    }
+
+    @Override
+    protected void closeStartTag(boolean isEmpty) throws TransformerException {
+        try {
+            if (tagIsOpen) {
+                if (isEmpty) {
+                    if (isEmptyTag(currentTag)) {
+                        getWriter().write(">");
+                    } else {
+                        getWriter().write('>');
+                        getWriter().write("</");
+                        getWriter().write(currentTag);
+                        getWriter().write('>');
+                    }
+                } else {
+                    getWriter().write('>');
+                }
+                tagIsOpen = false;
+            }
+        } catch (final IOException ioe) {
+            throw new TransformerException(ioe.getMessage(), ioe);
+        }
+    }
+
+    @Override
+    protected boolean needsEscape(char ch) {
+        if (RAW_TEXT_ELEMENTS.contains(currentTag)) {
+            return false;
         }
         return super.needsEscape(ch);
     }

--- a/src/org/exist/util/serializer/IndentingXMLWriter.java
+++ b/src/org/exist/util/serializer/IndentingXMLWriter.java
@@ -66,7 +66,7 @@ public class IndentingXMLWriter extends XMLWriter {
             indent();
         }
         super.startElement(namespaceURI, localName, qname);
-        level++;
+        addIndent();
         afterTag = true;
         sameline = true;
     }
@@ -80,7 +80,7 @@ public class IndentingXMLWriter extends XMLWriter {
             indent();
         }
         super.startElement(qname);
-        level++;
+        addIndent();
         afterTag = true;
         sameline = true;
     }
@@ -90,10 +90,7 @@ public class IndentingXMLWriter extends XMLWriter {
      */
     @Override
     public void endElement(final String namespaceURI, final String localName, final String qname) throws TransformerException {
-        level--;
-        if (afterTag && !sameline && !isInlineTag(namespaceURI, localName)){
-            indent();
-        }
+        endIndent(namespaceURI, localName);
         super.endElement(namespaceURI, localName, qname);
         sameline = false;
         afterTag = true;
@@ -104,10 +101,7 @@ public class IndentingXMLWriter extends XMLWriter {
      */
     @Override
     public void endElement(final QName qname) throws TransformerException {
-        level--;
-        if (afterTag && !sameline && !isInlineTag(qname.getNamespaceURI(), qname.getLocalPart())){
-            indent();
-        }
+        endIndent(qname.getNamespaceURI(), qname.getLocalPart());
         super.endElement(qname);
         sameline = false;
         afterTag = true;
@@ -197,6 +191,17 @@ public class IndentingXMLWriter extends XMLWriter {
         super.characters("\n");
         super.characters(indentChars.subSequence(0, spaces));
         sameline = false;
+    }
+
+    protected void addIndent() {
+        level++;
+    }
+
+    protected void endIndent(String namespaceURI, String localName) throws TransformerException {
+        level--;
+        if (afterTag && !sameline && !isInlineTag(namespaceURI, localName)){
+            indent();
+        }
     }
 
     protected static boolean isWhiteSpace(final char ch) {

--- a/src/org/exist/util/serializer/SAXSerializer.java
+++ b/src/org/exist/util/serializer/SAXSerializer.java
@@ -55,16 +55,18 @@ public class SAXSerializer implements ContentHandler, LexicalHandler, Receiver {
     private final static int XHTML_WRITER = 1;
     private final static int TEXT_WRITER = 2;
     private final static int JSON_WRITER = 3;
-    private final static int HTML5_WRITER = 4;
+    private final static int XHTML5_WRITER = 4;
     private final static int MICRO_XML_WRITER = 5;
+    private final static int HTML5_WRITER = 6;
     
     private XMLWriter writers[] = {
         new IndentingXMLWriter(),
         new XHTMLWriter(), 
         new TEXTWriter(),
         new JSONWriter(),
-        new HTML5Writer(),
-        new MicroXmlWriter()
+        new XHTML5Writer(),
+        new MicroXmlWriter(),
+        new HTML5Writer()
     };
 
 
@@ -99,8 +101,10 @@ public class SAXSerializer implements ContentHandler, LexicalHandler, Receiver {
             receiver = writers[TEXT_WRITER];
         } else if ("json".equalsIgnoreCase(method)) {
         	receiver = writers[JSON_WRITER];
+        } else if ("xhtml5".equalsIgnoreCase(method)) {
+        	receiver = writers[XHTML5_WRITER];
         } else if ("html5".equalsIgnoreCase(method)) {
-        	receiver = writers[HTML5_WRITER];
+            receiver = writers[HTML5_WRITER];
         } else if("microxml".equalsIgnoreCase(method)) {
             receiver = writers[MICRO_XML_WRITER];
         } else {

--- a/src/org/exist/util/serializer/TEXTWriter.java
+++ b/src/org/exist/util/serializer/TEXTWriter.java
@@ -196,9 +196,9 @@ public class TEXTWriter extends XMLWriter {
     protected void writeDoctype(final String rootElement) throws TransformerException {
         // empty
     }
-    
-    private void writeChars(final CharSequence s, final boolean inAttribute) throws IOException {
-        
+
+    @Override
+    protected void writeChars(final CharSequence s, final boolean inAttribute) throws IOException {
         final int len = s.length();
         writeCharSeq(s, 0, len);
     }

--- a/src/org/exist/util/serializer/XHTML5Writer.java
+++ b/src/org/exist/util/serializer/XHTML5Writer.java
@@ -1,0 +1,99 @@
+package org.exist.util.serializer;
+
+import java.io.Writer;
+import javax.xml.transform.TransformerException;
+import org.exist.util.hashtable.ObjectHashSet;
+
+/**
+ * A writer which produces well-formed XHTML5.
+ */
+public class XHTML5Writer extends XHTMLWriter {
+
+    protected final static ObjectHashSet<String> XHTML_INLINE_TAGS = new ObjectHashSet<String>(31);
+    
+    static {
+    	XHTML_INLINE_TAGS.add("a");
+    	XHTML_INLINE_TAGS.add("abbr");
+    	XHTML_INLINE_TAGS.add("area");
+    	XHTML_INLINE_TAGS.add("audio");
+    	XHTML_INLINE_TAGS.add("b");
+    	XHTML_INLINE_TAGS.add("bdi");
+    	XHTML_INLINE_TAGS.add("bdo");
+    	XHTML_INLINE_TAGS.add("br");
+    	XHTML_INLINE_TAGS.add("button");
+    	XHTML_INLINE_TAGS.add("canvas");
+    	XHTML_INLINE_TAGS.add("cite");
+    	XHTML_INLINE_TAGS.add("code");
+    	XHTML_INLINE_TAGS.add("command");
+    	XHTML_INLINE_TAGS.add("datalist");
+    	XHTML_INLINE_TAGS.add("del");
+    	XHTML_INLINE_TAGS.add("dfn");
+    	XHTML_INLINE_TAGS.add("em");
+    	XHTML_INLINE_TAGS.add("embed");
+    	XHTML_INLINE_TAGS.add("i");
+    	XHTML_INLINE_TAGS.add("img");
+    	XHTML_INLINE_TAGS.add("ins");
+    	XHTML_INLINE_TAGS.add("input");
+    	XHTML_INLINE_TAGS.add("kbd");
+    	XHTML_INLINE_TAGS.add("keygen");
+    	XHTML_INLINE_TAGS.add("label");
+    	XHTML_INLINE_TAGS.add("map");
+    	XHTML_INLINE_TAGS.add("mark");
+    	XHTML_INLINE_TAGS.add("math");
+    	XHTML_INLINE_TAGS.add("meter");
+    	XHTML_INLINE_TAGS.add("object");
+    	XHTML_INLINE_TAGS.add("output");
+    	XHTML_INLINE_TAGS.add("progress");
+    	XHTML_INLINE_TAGS.add("q");
+    	XHTML_INLINE_TAGS.add("ruby");
+    	XHTML_INLINE_TAGS.add("s");
+    	XHTML_INLINE_TAGS.add("samp");
+    	XHTML_INLINE_TAGS.add("select");
+    	XHTML_INLINE_TAGS.add("small");
+    	XHTML_INLINE_TAGS.add("span");
+    	XHTML_INLINE_TAGS.add("strong");
+    	XHTML_INLINE_TAGS.add("sub");
+    	XHTML_INLINE_TAGS.add("sup");
+    	XHTML_INLINE_TAGS.add("svg");
+    	XHTML_INLINE_TAGS.add("textarea");
+    	XHTML_INLINE_TAGS.add("time");
+    	XHTML_INLINE_TAGS.add("tt");
+    	XHTML_INLINE_TAGS.add("u");
+    	XHTML_INLINE_TAGS.add("var");
+    	XHTML_INLINE_TAGS.add("video");
+    }
+    
+    public XHTML5Writer() {
+        this(EMPTY_TAGS, XHTML_INLINE_TAGS);
+    }
+
+    public XHTML5Writer(final Writer writer) {
+        this(writer, EMPTY_TAGS, XHTML_INLINE_TAGS);
+    }
+
+    public XHTML5Writer(ObjectHashSet<String> emptyTags, ObjectHashSet<String> inlineTags) {
+        super(emptyTags, inlineTags);
+    }
+
+    public XHTML5Writer(Writer writer, ObjectHashSet<String> emptyTags, ObjectHashSet<String> inlineTags) {
+        super(writer, emptyTags, inlineTags);
+    }
+
+    @Override
+    protected void writeDoctype(String rootElement) throws TransformerException {
+        if (doctypeWritten) {
+            return;
+        }
+
+        documentType("html", null, null);
+        doctypeWritten = true;
+    }
+
+    @Override
+    protected boolean needsEscape(final char ch) {
+        if("script".equals(currentTag)) {
+            return !(ch == '<' || ch == '>' || ch == '&');
+        }
+        return super.needsEscape(ch);
+    }
+}

--- a/src/org/exist/util/serializer/XHTML5Writer.java
+++ b/src/org/exist/util/serializer/XHTML5Writer.java
@@ -88,12 +88,4 @@ public class XHTML5Writer extends XHTMLWriter {
         documentType("html", null, null);
         doctypeWritten = true;
     }
-
-    @Override
-    protected boolean needsEscape(final char ch) {
-        if("script".equals(currentTag)) {
-            return !(ch == '<' || ch == '>' || ch == '&');
-        }
-        return super.needsEscape(ch);
-    }
 }

--- a/src/org/exist/util/serializer/XHTMLWriter.java
+++ b/src/org/exist/util/serializer/XHTMLWriter.java
@@ -34,78 +34,92 @@ import org.exist.util.hashtable.ObjectHashSet;
  */
 public class XHTMLWriter extends IndentingXMLWriter {
 
-    private final static ObjectHashSet<String> emptyTags = new ObjectHashSet<String>(31);
-    
+    protected final static ObjectHashSet<String> EMPTY_TAGS = new ObjectHashSet<String>(31);
     static {
-        emptyTags.add("area");
-        emptyTags.add("base");
-        emptyTags.add("br");
-        emptyTags.add("col");
-        emptyTags.add("hr");
-        emptyTags.add("img");
-        emptyTags.add("input");
-        emptyTags.add("link");
-        emptyTags.add("meta");
-        emptyTags.add("basefont");
-        emptyTags.add("frame");
-        emptyTags.add("isindex");
-        emptyTags.add("param");
+        EMPTY_TAGS.add("area");
+        EMPTY_TAGS.add("base");
+        EMPTY_TAGS.add("br");
+        EMPTY_TAGS.add("col");
+        EMPTY_TAGS.add("hr");
+        EMPTY_TAGS.add("img");
+        EMPTY_TAGS.add("input");
+        EMPTY_TAGS.add("link");
+        EMPTY_TAGS.add("meta");
+        EMPTY_TAGS.add("basefont");
+        EMPTY_TAGS.add("frame");
+        EMPTY_TAGS.add("isindex");
+        EMPTY_TAGS.add("param");
     }
     
-    private final static ObjectHashSet<String> inlineTags = new ObjectHashSet<String>(31);
+    protected final static ObjectHashSet<String> INLINE_TAGS = new ObjectHashSet<String>(31);
     
     static {
-    	inlineTags.add("a");
-    	inlineTags.add("abbr");
-    	inlineTags.add("acronym");
-    	inlineTags.add("b");
-    	inlineTags.add("bdo");
-    	inlineTags.add("big");
-    	inlineTags.add("br");
-    	inlineTags.add("button");
-    	inlineTags.add("cite");
-    	inlineTags.add("code");
-    	inlineTags.add("del");
-    	inlineTags.add("dfn");
-    	inlineTags.add("em");
-    	inlineTags.add("i");
-    	inlineTags.add("img");
-    	inlineTags.add("input");
-    	inlineTags.add("kbd");
-    	inlineTags.add("label");
-    	inlineTags.add("q");
-    	inlineTags.add("samp");
-    	inlineTags.add("select");
-    	inlineTags.add("small");
-    	inlineTags.add("span");
-    	inlineTags.add("strong");
-    	inlineTags.add("sub");
-    	inlineTags.add("sup");
-    	inlineTags.add("textarea");
-    	inlineTags.add("tt");
-    	inlineTags.add("var");
-    }
-    
-    private static boolean isEmptyTag(final String tag) {
-        return emptyTags.contains(tag);
+    	INLINE_TAGS.add("a");
+    	INLINE_TAGS.add("abbr");
+    	INLINE_TAGS.add("acronym");
+    	INLINE_TAGS.add("b");
+    	INLINE_TAGS.add("bdo");
+    	INLINE_TAGS.add("big");
+    	INLINE_TAGS.add("br");
+    	INLINE_TAGS.add("button");
+    	INLINE_TAGS.add("cite");
+    	INLINE_TAGS.add("code");
+    	INLINE_TAGS.add("del");
+    	INLINE_TAGS.add("dfn");
+    	INLINE_TAGS.add("em");
+    	INLINE_TAGS.add("i");
+    	INLINE_TAGS.add("img");
+    	INLINE_TAGS.add("input");
+    	INLINE_TAGS.add("kbd");
+    	INLINE_TAGS.add("label");
+    	INLINE_TAGS.add("q");
+    	INLINE_TAGS.add("samp");
+    	INLINE_TAGS.add("select");
+    	INLINE_TAGS.add("small");
+    	INLINE_TAGS.add("span");
+    	INLINE_TAGS.add("strong");
+    	INLINE_TAGS.add("sub");
+    	INLINE_TAGS.add("sup");
+    	INLINE_TAGS.add("textarea");
+    	INLINE_TAGS.add("tt");
+    	INLINE_TAGS.add("var");
     }
     
     protected String currentTag;
-    
+
+    protected ObjectHashSet<String> emptyTags;
+    protected ObjectHashSet<String> inlineTags;
+
     /**
      * 
      */
     public XHTMLWriter() {
+        this(EMPTY_TAGS, INLINE_TAGS);
+    }
+
+    public XHTMLWriter(ObjectHashSet<String> emptyTags, ObjectHashSet<String> inlineTags) {
         super();
+        this.emptyTags = emptyTags;
+        this.inlineTags = inlineTags;
+    }
+
+    public XHTMLWriter(final Writer writer) {
+        this(writer, EMPTY_TAGS, INLINE_TAGS);
     }
 
     /**
      * @param writer
      */
-    public XHTMLWriter(final Writer writer) {
+    public XHTMLWriter(final Writer writer, ObjectHashSet<String> emptyTags, ObjectHashSet<String> inlineTags) {
         super(writer);
+        this.emptyTags = emptyTags;
+        this.inlineTags = inlineTags;
     }
-    
+
+    protected boolean isEmptyTag(final String tag) {
+        return emptyTags.contains(tag);
+    }
+
     boolean haveCollapsedXhtmlPrefix = false;
 
     @Override
@@ -126,7 +140,7 @@ public class XHTMLWriter extends IndentingXMLWriter {
         haveCollapsedXhtmlPrefix = false;
     }
     
-    private QName removeXhtmlPrefix(final QName qname) {
+    protected QName removeXhtmlPrefix(final QName qname) {
         final String prefix = qname.getPrefix();
         final String namespaceURI = qname.getNamespaceURI();
         if(prefix != null && prefix.length() > 0 && namespaceURI != null && namespaceURI.equals(Namespaces.XHTML_NS)) {
@@ -156,7 +170,7 @@ public class XHTMLWriter extends IndentingXMLWriter {
         haveCollapsedXhtmlPrefix = false;
     }
     
-    private String removeXhtmlPrefix(final String namespaceURI, final String qname) {
+    protected String removeXhtmlPrefix(final String namespaceURI, final String qname) {
         
         final int pos = qname.indexOf(':');
         if(pos > 0 && namespaceURI != null && namespaceURI.equals(Namespaces.XHTML_NS)) {

--- a/src/org/exist/util/serializer/XMLWriter.java
+++ b/src/org/exist/util/serializer/XMLWriter.java
@@ -481,7 +481,7 @@ public class XMLWriter {
     	return true;
     }
     
-    private void writeChars(final CharSequence s, final boolean inAttribute) throws IOException {
+    protected void writeChars(final CharSequence s, final boolean inAttribute) throws IOException {
         final boolean[] specialChars = inAttribute ? attrSpecialChars : textSpecialChars;
         char ch = 0;
         final int len = s.length();

--- a/test/src/xquery/serializer.xql
+++ b/test/src/xquery/serializer.xql
@@ -1,0 +1,172 @@
+xquery version "3.0";
+
+(:~
+ : Tests for the XHTML5 and HTML5 serializers.
+ :)
+module namespace st="http://exist-db.org/test/serializer";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+(: HTML5 tests: output is not well-formed XML :)
+
+declare 
+    %test:assertXPath("matches($result, '^&lt;!DOCTYPE html&gt;')")
+function st:html5-doctype() {
+    let $html :=
+        <html>
+            <body></body>
+        </html>
+    return
+        util:serialize($html, "method=html5 indent=no")
+};
+
+declare 
+    %test:assertXPath("matches($result, '.*&lt;link[^&gt;]*[^/]+&gt;')")
+function st:html5-empty-link() {
+    let $html :=
+        <html>
+            <head>
+                <link rel="stylesheet" type="text/css" href="style.css"/>
+            </head>
+            <body></body>
+        </html>
+    return
+        util:serialize($html, "method=html5 indent=no")
+};
+
+declare 
+    %test:assertXPath("matches($result, '.*&lt;img[^&gt;]*[^/]+&gt;')")
+function st:html5-empty-img() {
+    let $html :=
+        <html>
+            <body>
+                <img src="foo.png"></img>
+            </body>
+        </html>
+    return
+        util:serialize($html, "method=html5 indent=no")
+};
+
+declare 
+    %test:assertXPath("matches($result, '.*&lt;script.*&gt;&lt;/script&gt;')")
+function st:html5-non-empty-element() {
+    let $html :=
+        <html>
+            <head>
+                <script type="text/javascript" src="test.js"/>
+            </head>
+            <body></body>
+        </html>
+    return
+        util:serialize($html, "method=html5 indent=no")
+};
+
+declare 
+    %test:assertXPath("matches($result, '1 &lt; 2')")
+function st:html5-script-no-escape() {
+    let $html :=
+        <html>
+            <head>
+                <script type="text/javascript">1 &lt; 2</script>
+            </head>
+            <body></body>
+        </html>
+    return
+        util:serialize($html, "method=html5 indent=no")
+};
+
+declare 
+    %test:assertXPath("matches($result, 'body &gt; p')")
+function st:html5-style-no-escape() {
+    let $html :=
+        <html>
+            <head>
+                <style type="text/css">
+                    body &gt; p {{ color: red; }}
+                </style>
+            </head>
+            <body></body>
+        </html>
+    return
+        util:serialize($html, "method=html5 indent=no")
+};
+
+declare 
+    %test:assertXPath("matches($result, 'checked[^=]')")
+function st:html5-empty-attribute() {
+    let $html :=
+        <html>
+            <body>
+                <input type="checkbox" checked="checked"/>
+            </body>
+        </html>
+    return
+        util:serialize($html, "method=html5 indent=no")
+};
+
+(:  XHTML5 tests :)
+
+(:~
+ : XHTML5 serializer must produce well-formed XML
+ :)
+declare 
+    %test:assertExists
+function st:xhtml5() {
+    let $html :=
+        <html>
+            <head>
+                <script type="text/javascript">1 &lt; 2</script>
+                <style type="text/css">
+                    body &gt; p {{ color: red; }}
+                </style>
+            </head>
+            <body>
+                <img src="foo.png"></img>
+                <input type="checkbox" checked="checked"/>
+            </body>
+        </html>
+    let $str := util:serialize($html, "method=xhtml5 indent=no")
+    return
+        parse-xml($str)
+};
+
+declare 
+    %test:assertXPath("matches($result, '.*&lt;link.*/&gt;')")
+function st:xhtml5-empty-link() {
+    let $html :=
+        <html>
+            <head>
+                <link rel="stylesheet" type="text/css" href="style.css"/>
+            </head>
+            <body></body>
+        </html>
+    return
+        util:serialize($html, "method=xhtml5 indent=no")
+};
+
+declare 
+    %test:assertXPath("matches($result, '.*&lt;img.*/&gt;')")
+function st:xhtml5-empty-img() {
+    let $html :=
+        <html>
+            <body>
+                <img src="foo.png"></img>
+            </body>
+        </html>
+    return
+        util:serialize($html, "method=xhtml5 indent=no")
+};
+
+declare 
+    %test:assertXPath("matches($result, '.*&lt;script.*&gt;&lt;/script&gt;')")
+function st:xhtml5-non-empty-element() {
+    let $html :=
+        <html>
+            <head>
+                <script type="text/javascript" src="test.js"/>
+            </head>
+            <body></body>
+        </html>
+    return
+        util:serialize($html, "method=xhtml5 indent=no")
+};

--- a/test/src/xquery/suite.xql
+++ b/test/src/xquery/suite.xql
@@ -7,5 +7,6 @@ test:suite((
     inspect:module-functions(xs:anyURI("last.xql")),
     inspect:module-functions(xs:anyURI("namespaces.xql")),
     inspect:module-functions(xs:anyURI("positional.xql")),
-    inspect:module-functions(xs:anyURI("count.xql"))
+    inspect:module-functions(xs:anyURI("count.xql")),
+    inspect:module-functions(xs:anyURI("serializer.xql"))
 ))


### PR DESCRIPTION
Improved html5 serialiser which respects the html5 syntax (as expected by most external tools):

* void elements like input, meta or img never have content and must not be closed by an end tag
* script and style are "raw text" elements whose content should not be escaped
* attributes with name=value (like checked="checked") are output as empty attributes without value

The html5 serializer will **not produce well-formed xml**. Use the xhtml5 serializer if you need the output to be well-formed.

Future todo: use the version serialisation property to distinguish between html serialisers.