### PR TITLE
Support for Regex within Spans in Lucene

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/XMLToQuery.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/XMLToQuery.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.spans.SpanFirstQuery;
 import org.apache.lucene.search.spans.SpanNearQuery;
 import org.apache.lucene.search.spans.SpanQuery;
 import org.apache.lucene.search.spans.SpanTermQuery;
+import org.apache.lucene.search.spans.SpanMultiTermQueryWrapper;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
@@ -190,9 +191,9 @@ public class XMLToQuery {
                         case "first":
                             list.add(getSpanFirst(field, (Element) child, analyzer));
                             break;
-//                      case "regex":
-//                          list.add(getSpanRegex(field, (Element) child, analyzer));
-
+                        case "regex":
+                            list.add(getSpanRegex(field, (Element) child, analyzer));
+                            break;
                         default:
                             throw new XPathException("Unknown query element: " + child.getNodeName());
                     }
@@ -209,10 +210,10 @@ public class XMLToQuery {
     		list.add(new SpanTermQuery(new Term(field, termStr)));
     }
 
-//    private SpanQuery getSpanRegex(String field, Element node, Analyzer analyzer) {
-//    	String regex = getText(node);
-//    	return new SpanRegexQuery(new Term(field, regex));
-//    }
+    private SpanQuery getSpanRegex(String field, Element node, Analyzer analyzer) {
+    	String regex = getText(node);
+    	return new SpanMultiTermQueryWrapper<RegexpQuery>(new RegexpQuery(new Term(field, regex)));
+    }
     
     private SpanQuery getSpanFirst(String field, Element node, Analyzer analyzer) throws XPathException {
     	int slop = getSlop(node);


### PR DESCRIPTION
I recently updated from eXist 2.1 to 2.2 and I came across the problem that Regex queries are no longer supported within Span queries.
Given that the class SpanRegexQuery was deprecated in Lucene 4.0 and is no longer available in exist 2.2, I propose to use the replacement class provided by lucene: SpanMultiTermQueryWrapper<RegexQuery>(new RegexQuery()) to keep supporting the use of Regex within Spans queries.

This has fixed the issue for me, hope you consider ir.
Kind regards.