### PR TITLE
Updating svn extension library svnkit to version 1.8.8

### DIFF
--- a/extensions/svn/extension.xml
+++ b/extensions/svn/extension.xml
@@ -17,10 +17,11 @@
     <echo>Retrieving 3rd party jar files '${extension.name}'</echo>
     <taskdef name="fetch" classname="nl.ow.dilemma.ant.fetch.FetchTask" classpathref="classpath.core"/>
     <fetch classpathref="classpath.core" dest="${existhome.dir}/${lib.user}" 
-                 url="http://www.svnkit.com/org.tmatesoft.svn_1.3.3.standalone.zip" classname="org.tmatesoft.svn.cli.SVN">
+           url="http://www.svnkit.com/org.tmatesoft.svn_1.8.8.standalone.zip" classname="org.tmatesoft.svn.cli.SVN">
          <patternset>
-            <include name="**/svnkit.jar"/>
-            <include name="**/svnkit-cli.jar"/>
+            <include name="**/svnkit-1.8.8.jar"/>
+            <include name="**/svnkit-cli-1.8.8.jar"/>
+            <include name="**/sequence-library-*.jar"/>
      </patternset>
    </fetch>
  </target>

--- a/extensions/svn/src/org/exist/versioning/svn/internal/wc/SVNMergeDriver.java
+++ b/extensions/svn/src/org/exist/versioning/svn/internal/wc/SVNMergeDriver.java
@@ -1473,9 +1473,9 @@ public abstract class SVNMergeDriver extends SVNBasicClient implements ISVNMerge
             rightURL = myCurrentMergeSource.myURL2;
         }
         
-        SVNConflictVersion leftConflictVersion = new SVNConflictVersion(srcReposRoot, SVNURLUtil.getRelativeURL(srcReposRoot, leftURL), 
+        SVNConflictVersion leftConflictVersion = new SVNConflictVersion(srcReposRoot, SVNURLUtil.getRelativeURL(srcReposRoot, leftURL, false),
                 myCurrentMergeSource.myRevision1, kind);
-        SVNConflictVersion rightConflictVersion = new SVNConflictVersion(srcReposRoot, SVNURLUtil.getRelativeURL(srcReposRoot, rightURL), 
+        SVNConflictVersion rightConflictVersion = new SVNConflictVersion(srcReposRoot, SVNURLUtil.getRelativeURL(srcReposRoot, rightURL, false),
                 myCurrentMergeSource.myRevision2, kind);
         SVNTreeConflictDescription conflictDescription  = new SVNTreeConflictDescription(victim, kind, action, reason, SVNOperation.MERGE, 
                 leftConflictVersion, rightConflictVersion);
@@ -2415,8 +2415,8 @@ public abstract class SVNMergeDriver extends SVNBasicClient implements ISVNMerge
             if (myTarget.equals(child.myPath)) {
                 childRelativePath = "";
             } else {
-                childRelativePath = SVNPathUtil.getRelativePath(myTarget.getAbsolutePath(), 
-                		child.myPath.getAbsolutePath());
+                childRelativePath = SVNPathUtil.getRelativePath(myTarget.getAbsolutePath(),
+                               child.myPath.getAbsolutePath());
             }
             MergePath parent = null;
             SVNURL childURL1 = url1.appendPath(childRelativePath, false);

--- a/extensions/svn/src/org/exist/versioning/svn/internal/wc/SVNPropertiesManager.java
+++ b/extensions/svn/src/org/exist/versioning/svn/internal/wc/SVNPropertiesManager.java
@@ -179,9 +179,13 @@ public class SVNPropertiesManager {
                 }
 
                 public boolean fileIsBinary() throws SVNException {
-                    SVNPropertyValue mimeType = getProperty(access, path, SVNProperty.MIME_TYPE);
+                    SVNPropertyValue mimeType = SVNPropertiesManager.getProperty(access, path, SVNProperty.MIME_TYPE);
                     return mimeType != null && SVNProperty.isBinaryMimeType(mimeType.getString());
                 }
+		public SVNPropertyValue getProperty(String propertyName) throws SVNException {
+		    SVNVersionedProperties wcProps = dir.getWCProperties(entry.getName());
+		    return wcProps.getPropertyValue(propertyName);
+	        }
             });
         }
 

--- a/extensions/svn/src/org/exist/versioning/svn/internal/wc/SVNTreeConflictUtil.java
+++ b/extensions/svn/src/org/exist/versioning/svn/internal/wc/SVNTreeConflictUtil.java
@@ -163,16 +163,16 @@ public class SVNTreeConflictUtil {
             sourceLeftVersion = sourceLeftVersion == null ? nullVersion : sourceLeftVersion;
             prependVersionInfo(conflictSkel, sourceLeftVersion);
 
-            conflictSkel.addChild(SVNSkel.createAtom(conflict.getConflictReason().toString()));
-            conflictSkel.addChild(SVNSkel.createAtom(conflict.getConflictAction().toString()));
-            conflictSkel.addChild(SVNSkel.createAtom(conflict.getOperation().toString()));
+            conflictSkel.appendChild(SVNSkel.createAtom(conflict.getConflictReason().toString()));
+            conflictSkel.appendChild(SVNSkel.createAtom(conflict.getConflictAction().toString()));
+            conflictSkel.appendChild(SVNSkel.createAtom(conflict.getOperation().toString()));
 
             if (conflict.getNodeKind() != SVNNodeKind.DIR && conflict.getNodeKind() != SVNNodeKind.FILE) {
                 SVNErrorMessage error = SVNErrorMessage.create(SVNErrorCode.WC_CORRUPT, 
                         "Invalid \'node_kind\' field in tree conflict description");
                 SVNErrorManager.error(error, SVNLogType.WC);
             }
-            conflictSkel.addChild(SVNSkel.createAtom(getNodeKindString(conflict.getNodeKind())));
+            conflictSkel.appendChild(SVNSkel.createAtom(getNodeKindString(conflict.getNodeKind())));
 
             String path = conflict.getPath().getName();
             if (path.length() == 0) {
@@ -180,15 +180,15 @@ public class SVNTreeConflictUtil {
                         "Empty path basename in tree conflict description");
                 SVNErrorManager.error(error, SVNLogType.WC);
             }
-            conflictSkel.addChild(SVNSkel.createAtom(path));
-            conflictSkel.addChild(SVNSkel.createAtom("conflict"));
+            conflictSkel.appendChild(SVNSkel.createAtom(path));
+            conflictSkel.appendChild(SVNSkel.createAtom("conflict"));
 
             if (!isValidConflict(conflictSkel)) {
                 SVNErrorMessage error = SVNErrorMessage.create(SVNErrorCode.WC_CORRUPT, 
                         "Failed to create valid conflict description skel: ''{0}''", skel.toString());
                 SVNErrorManager.error(error, SVNLogType.WC);
             }
-            skel.addChild(conflictSkel);
+            skel.appendChild(conflictSkel);
         }
         return skel.unparse();
     }
@@ -248,18 +248,18 @@ public class SVNTreeConflictUtil {
     private static SVNSkel prependVersionInfo(SVNSkel parent, SVNConflictVersion versionInfo) throws SVNException {
         parent = parent == null ? SVNSkel.createEmptyList() : parent;
         SVNSkel skel = SVNSkel.createEmptyList();
-        skel.addChild(SVNSkel.createAtom(getNodeKindString(versionInfo.getKind())));
+        skel.appendChild(SVNSkel.createAtom(getNodeKindString(versionInfo.getKind())));
         String path = versionInfo.getPath() == null ? "" : versionInfo.getPath();
-        skel.addChild(SVNSkel.createAtom(path));
-        skel.addChild(SVNSkel.createAtom(String.valueOf(versionInfo.getPegRevision())));
+        skel.appendChild(SVNSkel.createAtom(path));
+        skel.appendChild(SVNSkel.createAtom(String.valueOf(versionInfo.getPegRevision())));
         String repoURLString = versionInfo.getRepositoryRoot() == null ? "" : versionInfo.getRepositoryRoot().toString();
-        skel.addChild(SVNSkel.createAtom(repoURLString));
-        skel.addChild(SVNSkel.createAtom("version"));
+        skel.appendChild(SVNSkel.createAtom(repoURLString));
+        skel.appendChild(SVNSkel.createAtom("version"));
         if (!isValidVersionInfo(skel)) {
             SVNErrorMessage error = SVNErrorMessage.create(SVNErrorCode.WC_CORRUPT, "Failed to create valid conflict version skel: ''{0}''", skel.toString());
             SVNErrorManager.error(error, SVNLogType.WC);
         }
-        parent.addChild(skel);
+        parent.appendChild(skel);
         return parent;
     }
 

--- a/extensions/svn/src/org/exist/versioning/svn/internal/wc/admin/SVNTranslator.java
+++ b/extensions/svn/src/org/exist/versioning/svn/internal/wc/admin/SVNTranslator.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.IllegalCharsetNameException;
 import java.util.Collections;
 import java.util.Date;
@@ -458,11 +459,11 @@ public class SVNTranslator {
             return new SVNTranslatorOutputStream(out, eol, repair, keywords, expand);
         }
         if (expand) {
-            out = new SVNCharsetOutputStream(out, UTF8_CHARSET, Charset.forName(charset));
+            out = new SVNCharsetOutputStream(out, UTF8_CHARSET, Charset.forName(charset), CodingErrorAction.IGNORE, CodingErrorAction.IGNORE);
             return new SVNTranslatorOutputStream(out, eol, repair, keywords, expand);
         }
         out = new SVNTranslatorOutputStream(out, eol, repair, keywords, expand);
-        return new SVNCharsetOutputStream(out, Charset.forName(charset), UTF8_CHARSET);
+        return new SVNCharsetOutputStream(out, Charset.forName(charset), UTF8_CHARSET, CodingErrorAction.IGNORE, CodingErrorAction.IGNORE);
     }
 
     public static InputStream getTranslatingInputStream(InputStream in, String charset, byte[] eol, boolean repair, Map keywords, boolean expand) {
@@ -471,9 +472,9 @@ public class SVNTranslator {
         }
         if (expand) {
             in = new SVNTranslatorInputStream(in, eol, repair, keywords, expand);
-            return new SVNCharsetInputStream(in, UTF8_CHARSET, Charset.forName(charset));
+            return new SVNCharsetInputStream(in, UTF8_CHARSET, Charset.forName(charset), CodingErrorAction.IGNORE, CodingErrorAction.IGNORE);
         }
-        in = new SVNCharsetInputStream(in, Charset.forName(charset), UTF8_CHARSET);
+        in = new SVNCharsetInputStream(in, Charset.forName(charset), UTF8_CHARSET, CodingErrorAction.IGNORE, CodingErrorAction.IGNORE);
         return new SVNTranslatorInputStream(in, eol, repair, keywords, expand);
     }
 

--- a/extensions/svn/src/org/exist/versioning/svn/old/ExportEditor.java
+++ b/extensions/svn/src/org/exist/versioning/svn/old/ExportEditor.java
@@ -278,6 +278,8 @@ public class ExportEditor implements ISVNEditor {
 			// }
 			String charset = SVNTranslator.getCharset(fileProperties
 					.getStringValue(SVNProperty.CHARSET),
+								  fileProperties
+					.getStringValue(SVNProperty.MIME_TYPE),
 					currentFile.getPath(), options);
 			byte[] eolBytes = null;
 			if (SVNProperty.EOL_STYLE_NATIVE.equals(fileProperties

--- a/extensions/svn/src/org/exist/versioning/svn/wc/SVNWCClient.java
+++ b/extensions/svn/src/org/exist/versioning/svn/wc/SVNWCClient.java
@@ -848,6 +848,12 @@ public class SVNWCClient extends SVNBasicClient {
                     String mimeType = props.getStringValue(SVNProperty.MIME_TYPE);
                     isBinary = Boolean.valueOf(SVNProperty.isBinaryMimeType(mimeType));
                 }
+
+		public SVNPropertyValue getProperty(String propertyName) throws SVNException {
+		    SVNProperties props = new SVNProperties();
+		    repos.getFile("", baseRev, props, null);
+		    return SVNPropertyValue.create(props.getStringValue(propertyName));
+		}
             });
         }
 


### PR DESCRIPTION
Updating svn extension library svnkit to version 1.8.8 to support jdk7u75+ and jdk8u31+. Please remove your current EXIST_HOME/lib/user/{svnkit,svnkit-cli}.jar to update on build.