### PR TITLE
Bugfix try/catch

### DIFF
--- a/src/org/exist/xquery/TryCatchExpression.java
+++ b/src/org/exist/xquery/TryCatchExpression.java
@@ -363,10 +363,9 @@ public class TryCatchExpression extends AbstractExpression {
     // err:code	xs:QName	
     // The error code
     private void addErrCode(final QName errorCodeQname) throws XPathException {
-        final String code = errorCodeQname.getStringValue();
         final LocalVariable err_code = new LocalVariable(QN_CODE);
         err_code.setSequenceType(new SequenceType(Type.QNAME, Cardinality.EXACTLY_ONE));
-        err_code.setValue(new StringValue(code));
+        err_code.setValue(new QNameValue(context, errorCodeQname));
         context.declareVariableBinding(err_code);
     }
     

--- a/src/org/exist/xquery/TryCatchExpression.java
+++ b/src/org/exist/xquery/TryCatchExpression.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ import org.exist.xquery.value.StringValue;
 import org.exist.xquery.value.*;
 
 /**
- * XQuery 1.1+ try {...} catch{...} expression.
+ * XQuery 3.0 try {...} catch{...} expression.
  * 
  * @author Adam Retter <adam@exist-db.org>
  * @author Leif-Jöran Olsson <ljo@exist-db.org>
@@ -47,7 +48,7 @@ import org.exist.xquery.value.*;
  */
 public class TryCatchExpression extends AbstractExpression {
 
-    protected static final Logger LOG = Logger.getLogger(TryCatchExpression.class);
+    private static final Logger LOG = Logger.getLogger(TryCatchExpression.class);
 
     private static final QName QN_CODE = new QName("code", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
     private static final QName QN_DESCRIPTION = new QName("description", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
@@ -57,8 +58,11 @@ public class TryCatchExpression extends AbstractExpression {
     private static final QName QN_COLUMN_NUM = new QName("column-number", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
     private static final QName QN_ADDITIONAL = new QName("additional", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
 
+    private static final QName QN_XQUERY_STACK_TRACE = new QName("xquery-stack-trace", Namespaces.EXIST_XQUERY_XPATH_ERROR_NS, Namespaces.EXIST_XQUERY_XPATH_ERROR_PREFIX);
+    private static final QName QN_JAVA_STACK_TRACE = new QName("java-stack-trace", Namespaces.EXIST_XQUERY_XPATH_ERROR_NS, Namespaces.EXIST_XQUERY_XPATH_ERROR_PREFIX);
+
     private final Expression tryTargetExpr;
-    private final List<CatchClause> catchClauses = new ArrayList<CatchClause>();
+    private final List<CatchClause> catchClauses = new ArrayList<>();
 
     /**
      *  Constructor.
@@ -66,7 +70,7 @@ public class TryCatchExpression extends AbstractExpression {
      * @param context   Xquery context
      * @param tryTargetExpr Expression to be evaluated
      */
-    public TryCatchExpression(XQueryContext context, Expression tryTargetExpr) {
+    public TryCatchExpression(final XQueryContext context, final Expression tryTargetExpr) {
         super(context);
         this.tryTargetExpr = tryTargetExpr;
     }
@@ -80,9 +84,6 @@ public class TryCatchExpression extends AbstractExpression {
         catchClauses.add( new CatchClause(catchErrorList, catchVars, catchExpr) );
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#getDependencies()
-     */
     @Override
     public int getDependencies() {
         return Dependency.CONTEXT_SET | Dependency.CONTEXT_ITEM;
@@ -96,38 +97,28 @@ public class TryCatchExpression extends AbstractExpression {
         return catchClauses;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#getCardinality()
-     */
     @Override
     public int getCardinality() {
         return Cardinality.ZERO_OR_MORE;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#analyze(org.exist.xquery.Expression)
-     */
     @Override
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         contextInfo.setFlags(contextInfo.getFlags() & (~IN_PREDICATE));
         contextInfo.setParent(this);
         tryTargetExpr.analyze(contextInfo);
-        for (CatchClause catchClause : catchClauses) {
+        for (final CatchClause catchClause : catchClauses) {
             catchClause.getCatchExpr().analyze(contextInfo);
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#eval(org.exist.dom.persistent.DocumentSet, org.exist.xquery.value.Sequence, org.exist.xquery.value.Item)
-     */
     @Override
-    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
-
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
 
         context.expressionStart(this);
 
         if(getContext().getXQueryVersion()<30){
-            throw new XPathException(this, ErrorCodes.EXXQDY0003, "The try-catch expression is supported for xquery version \"3.0\" and later.");
+            throw new XPathException(this, ErrorCodes.EXXQDY0003, "The try-catch expression is only available in xquery version \"3.0\" and later.");
         }
 
         try {
@@ -137,22 +128,23 @@ public class TryCatchExpression extends AbstractExpression {
 
         } catch (final Throwable throwable) { 
 
-            ErrorCode errorCode = null;
-            XPathException xpe = null;
+            final ErrorCode errorCode;
 
             // fn:error throws an XPathException
             if(throwable instanceof XPathException){
                 // Get errorcode from nicely thrown xpathexception
-                xpe = (XPathException)throwable;
-                errorCode = xpe.getErrorCode();
+                final XPathException xpe = (XPathException)throwable;
 
-                // if no errorcode is found, reconstruct by parsing the error text.
-                if (errorCode == null) {
-                    errorCode = extractErrorCode(xpe);
-                } else if (errorCode == ErrorCodes.ERROR) {
+                if(xpe.getErrorCode() != null) {
+                    if(xpe.getErrorCode() == ErrorCodes.ERROR) {
+                        errorCode = extractErrorCode(xpe);
+                    } else {
+                        errorCode = xpe.getErrorCode();
+                    }
+                } else {
+                    // if no errorcode is found, reconstruct by parsing the error text.
                     errorCode = extractErrorCode(xpe);
                 }
-
             } else {
                 // Get errorcode from all other errors and exceptions
                 errorCode = new JavaErrorCode(throwable);
@@ -194,14 +186,14 @@ public class TryCatchExpression extends AbstractExpression {
                         try {  
                             // Add std errors
                             addErrCode(errorCodeQname);                          
-                            addErrDescription(xpe, errorCode);
-                            addErrValue(xpe); 
-                            addErrModule(xpe); 
-                            addErrLineNumber(xpe); 
-                            addErrColumnNumber(xpe); 
-                            addErrAdditional(xpe); 
-                            addFunctionTrace(xpe);
-                            addJavaTrace(xpe);
+                            addErrDescription(throwable, errorCode);
+                            addErrValue(throwable);
+                            addErrModule(throwable);
+                            addErrLineNumber(throwable);
+                            addErrColumnNumber(throwable);
+                            addErrAdditional(throwable);
+                            addFunctionTrace(throwable);
+                            addJavaTrace(throwable);
 
                             // Evaluate catch expression
                             catchResultSeq = ((Expression) catchClause.getCatchExpr()).eval(contextSequence, contextItem);
@@ -216,7 +208,7 @@ public class TryCatchExpression extends AbstractExpression {
                     }
                 } // for catch clauses
 
-                // If an error hasn't been catched, throw new one
+                // If an error hasn't been caught, throw new one
                 if (!errorMatched) {
                     LOG.error(throwable);
                     throw new XPathException(throwable);
@@ -240,7 +232,7 @@ public class TryCatchExpression extends AbstractExpression {
     // can reference it without raising an error. The purpose of this 
     // variable is to allow implementations to provide any additional 
     // information that might be useful.
-    private void addErrAdditional(final XPathException xpe) throws XPathException {
+    private void addErrAdditional(final Throwable t) throws XPathException {
         final LocalVariable err_additional = new LocalVariable(QN_ADDITIONAL);
         err_additional.setSequenceType(new SequenceType(Type.ITEM, Cardinality.ZERO_OR_ONE));
         err_additional.setValue(Sequence.EMPTY_SEQUENCE);
@@ -252,13 +244,13 @@ public class TryCatchExpression extends AbstractExpression {
     // The column number within the stylesheet module of the instruction 
     // where the error occurred, or an empty sequence if the information 
     // is not available. The value may be approximate.
-    private void addErrColumnNumber(final XPathException xpe) throws XPathException {
+    private void addErrColumnNumber(final Throwable t) throws XPathException {
         final LocalVariable err_column_nr = new LocalVariable(QN_COLUMN_NUM);
         err_column_nr.setSequenceType(new SequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE));
 
         final Sequence colNum;
-        if (xpe != null) {
-            colNum = new IntegerValue(xpe.getColumn());
+        if (t != null && t instanceof XPathException) {
+            colNum = new IntegerValue(((XPathException)t).getColumn());
         } else {
             colNum = Sequence.EMPTY_SEQUENCE;
         }
@@ -271,13 +263,13 @@ public class TryCatchExpression extends AbstractExpression {
     // The line number within the stylesheet module of the instruction 
     // where the error occurred, or an empty sequence if the information 
     // is not available. The value may be approximate.
-    private void addErrLineNumber(final XPathException xpe) throws XPathException {
+    private void addErrLineNumber(final Throwable t) throws XPathException {
         final LocalVariable err_line_nr = new LocalVariable(QN_LINE_NUM);
         err_line_nr.setSequenceType(new SequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE));
 
         final Sequence lineNum;
-        if (xpe != null) {
-            lineNum = new IntegerValue(xpe.getLine());
+        if (t != null && t instanceof XPathException) {
+            lineNum = new IntegerValue(((XPathException)t).getLine());
         } else {
             lineNum = Sequence.EMPTY_SEQUENCE;
         }
@@ -290,13 +282,13 @@ public class TryCatchExpression extends AbstractExpression {
     // The URI (or system ID) of the module containing the expression 
     // where the error occurred, or an empty sequence if the information 
     // is not available.
-    private void addErrModule(final XPathException xpe) throws XPathException {
+    private void addErrModule(final Throwable t) throws XPathException {
         final LocalVariable err_module = new LocalVariable(QN_MODULE);
         err_module.setSequenceType(new SequenceType(Type.STRING, Cardinality.ZERO_OR_ONE));
 
         final Sequence module;
-        if (xpe != null && xpe.getXACMLSource() != null) {
-            module = new StringValue(xpe.getXACMLSource().getKey());
+        if (t != null && t instanceof XPathException && ((XPathException)t).getXACMLSource() != null) {
+            module = new StringValue(((XPathException)t).getXACMLSource().getKey());
         } else {
             module = Sequence.EMPTY_SEQUENCE;
         }
@@ -309,21 +301,25 @@ public class TryCatchExpression extends AbstractExpression {
     // Value associated with the error. For an error raised by calling 
     // the error function, this is the value of the third  argument 
     // (if supplied).
-    private void addErrValue(final XPathException xpe) throws XPathException {
+    private void addErrValue(final Throwable t) throws XPathException {
         final LocalVariable err_value = new LocalVariable(QN_VALUE);
         err_value.setSequenceType(new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE));
 
         final Sequence errorValue;
-        if (xpe != null) {
+        if (t != null) {
             // Get error value from exception
-            if(xpe.getErrorVal() != null) {
-                errorValue = xpe.getErrorVal();
+            if(t instanceof XPathException && ((XPathException)t).getErrorVal() != null) {
+                errorValue = ((XPathException)t).getErrorVal();
             } else {
                 errorValue = Sequence.EMPTY_SEQUENCE;
             }
         } else {
             // fill data from throwable object
-            errorValue = new StringValue(getStackTrace(xpe));
+            try {
+                errorValue = new StringValue(getStackTrace(t));
+            } catch(final IOException ioe) {
+                throw new XPathException(ioe);
+            }
         }
         err_value.setValue(errorValue);
 
@@ -334,10 +330,14 @@ public class TryCatchExpression extends AbstractExpression {
     // A description of the error condition; an empty sequence if no 
     // description is available (for example, if the error function 
     // was called with one argument).
-    private void addErrDescription(final XPathException xpe, final ErrorCode errorCode) throws XPathException {
+    private void addErrDescription(final Throwable t, final ErrorCode errorCode) throws XPathException {
         String description = errorCode.getDescription();
-        if (description == null && xpe != null) {
-            description = xpe.getDetailMessage();
+        if (description == null && t != null) {
+            if(t instanceof XPathException) {
+                description = ((XPathException) t).getDetailMessage();
+            } else {
+                description = t.getMessage();
+            }
         }
 
         final LocalVariable err_description = new LocalVariable(QN_DESCRIPTION);
@@ -358,12 +358,27 @@ public class TryCatchExpression extends AbstractExpression {
         err_code.setValue(new QNameValue(context, errorCodeQname));
         context.declareVariableBinding(err_code);
     }
-    
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("try {");
+        dumper.startIndent();
+        tryTargetExpr.dump(dumper);
+        dumper.endIndent();
+        for (final CatchClause catchClause : catchClauses) {
+            final Expression catchExpr = (Expression) catchClause.getCatchExpr();
+            dumper.nl().display("} catch (expr) {");
+            dumper.startIndent();
+            catchExpr.dump(dumper);
+            dumper.nl().display("}");
+            dumper.endIndent();
+        }
+    }
 
     /**
      *  Extract and construct errorcode from error text.
      */
-    private ErrorCode extractErrorCode(XPathException xpe)  {
+    private ErrorCode extractErrorCode(final XPathException xpe)  {
 
         // Get message from string
         final String message = xpe.getMessage();
@@ -390,25 +405,6 @@ public class TryCatchExpression extends AbstractExpression {
 
         // Fallback, create java error
         return new ErrorCodes.JavaErrorCode(retVal);
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#dump(org.exist.xquery.util.ExpressionDumper)
-     */
-    @Override
-    public void dump(ExpressionDumper dumper) {
-        dumper.display("try {");
-        dumper.startIndent();
-        tryTargetExpr.dump(dumper);
-        dumper.endIndent();
-        for (final CatchClause catchClause : catchClauses) {
-            final Expression catchExpr = (Expression) catchClause.getCatchExpr();
-            dumper.nl().display("} catch (expr) {");
-            dumper.startIndent();
-            catchExpr.dump(dumper);
-            dumper.nl().display("}");
-            dumper.endIndent();
-        }
     }
 
     @Override
@@ -438,7 +434,7 @@ public class TryCatchExpression extends AbstractExpression {
      * @see org.exist.xquery.AbstractExpression#resetState()
      */
     @Override
-    public void resetState(boolean postOptimization) {
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
         tryTargetExpr.resetState(postOptimization);
         for (final CatchClause catchClause : catchClauses) {
@@ -448,7 +444,7 @@ public class TryCatchExpression extends AbstractExpression {
     }
 
     @Override
-    public void accept(ExpressionVisitor visitor) {
+    public void accept(final ExpressionVisitor visitor) {
         visitor.visitTryCatch(this);
     }
 
@@ -458,7 +454,7 @@ public class TryCatchExpression extends AbstractExpression {
      * 
      * @return TRUE is qname is in list, or list contains '*', else FALSE,
      */
-    private boolean isErrorInList(QName error, List<String> errors) {
+    private boolean isErrorInList(final QName error, final List<String> errors) {
 
         final String qError = error.getStringValue();
         for (final String lError : errors) {
@@ -473,7 +469,7 @@ public class TryCatchExpression extends AbstractExpression {
         return false;
     }
 
-    private String[] extractLocalName(String errorText)
+    private String[] extractLocalName(final String errorText)
             throws IllegalArgumentException {
         final int p = errorText.indexOf(':');
         if (p == Constants.STRING_NOT_FOUND) {
@@ -486,82 +482,74 @@ public class TryCatchExpression extends AbstractExpression {
     /**
      * Write stacktrace to String. 
      */
-    private String getStackTrace(Throwable t){
-		if (t == null)
-			{return null;}
-        final StringWriter sw = new StringWriter();
-        final PrintWriter pw = new PrintWriter(sw);
+    private String getStackTrace(final Throwable t ) throws IOException {
+		if (t == null) {
+            return null;
+        }
 
-        t.printStackTrace(pw);
-        pw.flush();
-        return sw.toString();
+        try(final StringWriter sw = new StringWriter();
+            final PrintWriter pw = new PrintWriter(sw)) {
 
+            t.printStackTrace(pw);
+            pw.flush();
+            return sw.toString();
+        }
     }
 
-    private void addFunctionTrace(XPathException xpe) throws XPathException {
-        
-        final QName q_value = new QName("xquery-stack-trace", Namespaces.EXIST_XQUERY_XPATH_ERROR_NS, Namespaces.EXIST_XQUERY_XPATH_ERROR_PREFIX);
-        final LocalVariable localVar = new LocalVariable( q_value);
-        localVar.setSequenceType(new SequenceType(Type.QNAME, Cardinality.ZERO_OR_MORE));
-       
-	    if (xpe == null) {
-			localVar.setValue(Sequence.EMPTY_SEQUENCE);
-		} else { 
-			final List<XPathException.FunctionStackElement> callStack = xpe.getCallStack();
-			if(callStack==null){
-				localVar.setValue(Sequence.EMPTY_SEQUENCE);
-				
+    private void addFunctionTrace(final Throwable t) throws XPathException {
+        final LocalVariable localVar = new LocalVariable(QN_XQUERY_STACK_TRACE);
+        localVar.setSequenceType(new SequenceType(Type.STRING, Cardinality.ZERO_OR_MORE));
+
+        final Sequence trace;
+		if(t != null && t instanceof XPathException) {
+			final List<XPathException.FunctionStackElement> callStack = ((XPathException)t).getCallStack();
+			if(callStack == null){
+				trace = Sequence.EMPTY_SEQUENCE;
 			} else {
 				final Sequence result = new ValueSequence();
 				for(final XPathException.FunctionStackElement elt : callStack){
 					result.add(new StringValue("at " + elt.toString()) );
 				}
-				localVar.setValue(result);  
+				trace = result;
 			}
+        } else {
+            trace = Sequence.EMPTY_SEQUENCE;
         }
+        localVar.setValue(trace);
+
         context.declareVariableBinding(localVar);
     }
     
     
-    private void addJavaTrace(Throwable xpe) throws XPathException  {
-        
-        final QName q_value = new QName("java-stack-trace", Namespaces.EXIST_XQUERY_XPATH_ERROR_NS, Namespaces.EXIST_XQUERY_XPATH_ERROR_PREFIX);
-        final LocalVariable localVar = new LocalVariable( q_value);
+    private void addJavaTrace(final Throwable t) throws XPathException  {
+        final LocalVariable localVar = new LocalVariable(QN_JAVA_STACK_TRACE);
         localVar.setSequenceType(new SequenceType(Type.QNAME, Cardinality.ZERO_OR_MORE));
 
-		if (xpe == null) {
-			localVar.setValue(Sequence.EMPTY_SEQUENCE);
+        final Sequence trace;
+		if (t != null && t.getStackTrace() != null) {
+            final Sequence result = new ValueSequence();
+            addJavaTrace(t, result);
+            trace = result;
 		} else {
-			final StackTraceElement[] elements = xpe.getStackTrace();     
-			if (elements == null) {
-				localVar.setValue(Sequence.EMPTY_SEQUENCE);
-				
-			} else {
-				final Sequence result = new ValueSequence();
-				addJavaTrace(xpe,result);
-				localVar.setValue(result);                    
-			}
+            trace = Sequence.EMPTY_SEQUENCE;
         }
+        localVar.setValue(trace);
+
         context.declareVariableBinding(localVar);
     }
     
     // Local recursive function
-    private void addJavaTrace(Throwable xpe, Sequence result) throws XPathException {
-
-		if (xpe == null)
-			{return;}
-        final StackTraceElement[] elements = xpe.getStackTrace();
-
-        result.add(new StringValue("Caused by: " + xpe.toString()));
+    private void addJavaTrace(final Throwable t, final Sequence result) throws XPathException {
+        final StackTraceElement[] elements = t.getStackTrace();
+        result.add(new StringValue("Caused by: " + t.toString()));
         for (final StackTraceElement elt : elements) {
             result.add(new StringValue("at " + elt.toString()));
         }
 
-        final Throwable cause = xpe.getCause();
+        final Throwable cause = t.getCause();
         if (cause != null) {
             addJavaTrace(cause, result);
         }
-
     }
 
 

--- a/src/org/exist/xquery/TryCatchExpression.java
+++ b/src/org/exist/xquery/TryCatchExpression.java
@@ -49,6 +49,14 @@ public class TryCatchExpression extends AbstractExpression {
 
     protected static final Logger LOG = Logger.getLogger(TryCatchExpression.class);
 
+    private static final QName QN_CODE = new QName("code", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
+    private static final QName QN_DESCRIPTION = new QName("description", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
+    private static final QName QN_VALUE = new QName("value", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
+    private static final QName QN_MODULE = new QName("module", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
+    private static final QName QN_LINE_NUM = new QName("line-number", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
+    private static final QName QN_COLUMN_NUM = new QName("column-number", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
+    private static final QName QN_ADDITIONAL = new QName("additional", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
+
     private final Expression tryTargetExpr;
     private final List<CatchClause> catchClauses = new ArrayList<CatchClause>();
 
@@ -234,9 +242,7 @@ public class TryCatchExpression extends AbstractExpression {
     // information that might be useful.
     private void addErrAdditional(XPathException xpe) throws XPathException {
         final String additional = null;
-        
-        final QName q_additional = new QName("additional", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
-        final LocalVariable err_additional = new LocalVariable( q_additional);
+        final LocalVariable err_additional = new LocalVariable(QN_ADDITIONAL);
         err_additional.setSequenceType(new SequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE));
         if(additional == null){
             err_additional.setValue(Sequence.EMPTY_SEQUENCE);
@@ -251,14 +257,12 @@ public class TryCatchExpression extends AbstractExpression {
     // where the error occurred, or an empty sequence if the information 
     // is not available. The value may be approximate.
     private void addErrColumnNumber(XPathException xpe) throws XPathException {
-
         Integer column_nr = null ; 
         if (xpe != null) {
             column_nr=xpe.getColumn();
-        } 
-        
-        final QName q_column_nr = new QName("column-number", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
-        final LocalVariable err_column_nr = new LocalVariable( q_column_nr);
+        }
+
+        final LocalVariable err_column_nr = new LocalVariable(QN_COLUMN_NUM);
         err_column_nr.setSequenceType(new SequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE));
         if(column_nr == null){
             err_column_nr.setValue(Sequence.EMPTY_SEQUENCE);
@@ -277,10 +281,9 @@ public class TryCatchExpression extends AbstractExpression {
         Integer line_nr = null ; 
         if (xpe != null) {
             line_nr=xpe.getLine();
-        } 
-        
-        final QName q_line_nr = new QName("line-number", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
-        final LocalVariable err_line_nr = new LocalVariable( q_line_nr);
+        }
+
+        final LocalVariable err_line_nr = new LocalVariable(QN_LINE_NUM);
         err_line_nr.setSequenceType(new SequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE));
         if(line_nr == null){
             err_line_nr.setValue(Sequence.EMPTY_SEQUENCE);
@@ -295,7 +298,6 @@ public class TryCatchExpression extends AbstractExpression {
     // where the error occurred, or an empty sequence if the information 
     // is not available.
     private void addErrModule(XPathException xpe) throws XPathException {
-      
         String module = null ; // to be defined where to get
         if (xpe != null) {
             final XACMLSource src = xpe.getXACMLSource();
@@ -304,8 +306,8 @@ public class TryCatchExpression extends AbstractExpression {
             }
         } 
         
-        final QName q_module = new QName("module", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
-        final LocalVariable err_module = new LocalVariable( q_module);
+
+        final LocalVariable err_module = new LocalVariable(QN_MODULE);
         err_module.setSequenceType(new SequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE));
         if(module == null){
             err_module.setValue(Sequence.EMPTY_SEQUENCE);
@@ -320,9 +322,7 @@ public class TryCatchExpression extends AbstractExpression {
     // the error function, this is the value of the third  argument 
     // (if supplied).
     private void addErrValue(XPathException xpe) throws XPathException {
-
-        final QName q_value = new QName("value", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
-        final LocalVariable err_value = new LocalVariable( q_value);
+        final LocalVariable err_value = new LocalVariable(QN_VALUE);
         err_value.setSequenceType(new SequenceType(Type.QNAME, Cardinality.ZERO_OR_MORE));                           
         
         if (xpe != null) {
@@ -346,13 +346,11 @@ public class TryCatchExpression extends AbstractExpression {
     // description is available (for example, if the error function 
     // was called with one argument).
     private void addErrDescription(XPathException xpe, ErrorCode errorCode) throws XPathException {
-
         String description = errorCode.getDescription();
         if (description == null && xpe != null)
             {description = xpe.getDetailMessage();}
-        
-        final QName q_description = new QName("description", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
-        final LocalVariable err_description = new LocalVariable( q_description);
+
+        final LocalVariable err_description = new LocalVariable(QN_DESCRIPTION);
         err_description.setSequenceType(new SequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE));
         if(description == null){
             err_description.setValue(Sequence.EMPTY_SEQUENCE);
@@ -364,12 +362,9 @@ public class TryCatchExpression extends AbstractExpression {
 
     // err:code	xs:QName	
     // The error code
-    private void addErrCode(QName errorCodeQname) throws XPathException {
-
+    private void addErrCode(final QName errorCodeQname) throws XPathException {
         final String code = errorCodeQname.getStringValue();
-        
-        final QName q_code = new QName("code", Namespaces.W3C_XQUERY_XPATH_ERROR_NS, Namespaces.W3C_XQUERY_XPATH_ERROR_PREFIX);
-        final LocalVariable err_code = new LocalVariable( q_code);
+        final LocalVariable err_code = new LocalVariable(QN_CODE);
         err_code.setSequenceType(new SequenceType(Type.QNAME, Cardinality.EXACTLY_ONE));
         err_code.setValue(new StringValue(code));
         context.declareVariableBinding(err_code);

--- a/test/src/xquery/xquery3/xq3_trycatch.xml
+++ b/test/src/xquery/xquery3/xq3_trycatch.xml
@@ -209,24 +209,8 @@ catch err:FORG0001 | err:XPTY0004 {
         </code>
         <expected>0</expected>
     </test>
+
 <!--
-    <test output="text">
-        <task>This try/catch expression shows how to bind variables to
-        the error code, error description, and error value. Since the
-        CatchErrorList is a wildcard, it catches any error:
-        </task>
-        <code><![CDATA[
-try {
-    fn:error(fn:QName('http://www.w3.org/2005/xqt-errors', 'err:FOER0000'))
-}
-catch * ($errcode, $errdesc, $errval) {
-    $errcode, $errdesc
-}
-]]>
-        </code>
-        <expected>err:FOER0000</expected>
-    </test>
- 
     <test output="text">
         <task>Errors raised by using the result of a try/catch expression
         are not caught, since they are outside the scope of the try expression.

--- a/test/src/xquery/xquery3/xq3_trycatch.xml
+++ b/test/src/xquery/xquery3/xq3_trycatch.xml
@@ -325,5 +325,29 @@ catch * {
         </code>
         <expected>err:FOER0000  module:  String ( 4 , 5 )</expected>
     </test>
-    
+
+<test output="text">
+    <task>Check that the $err:code is the correct QName</task>
+    <code><![CDATA[
+xquery version '3.0';
+try {
+    let $xq := "
+	    let $x as xs:string := 1
+	    return $x
+    " return
+	    util:eval($xq)
+}
+catch * {
+    <code>
+        <ns>{namespace-uri-from-QName($err:code)}</ns>
+        <local-name>{local-name-from-QName($err:code)}</local-name>
+    </code>
+}
+]]>
+    </code>
+    <expected>
+        <code><ns>http://www.w3.org/2005/xqt-errors/</ns><local-name>XPTY0004</local-name></code>
+    </expected>
+</test>
+
 </TestSet>


### PR DESCRIPTION
There were several XDM typing issues with the `$err` variables bound within the `catch` expression of a *try/catch* block. In particular the `xs:QName` for `$err:code` was incorrectly processed as an `xs:string` resulting in lost namespace information.