### PR TITLE
Automatic Resource Management

### DIFF
--- a/extensions/debuggee/test/org/exist/debugger/DebuggerTest.java
+++ b/extensions/debuggee/test/org/exist/debugger/DebuggerTest.java
@@ -489,18 +489,11 @@ public class DebuggerTest implements ResponseListener {
 	}
 	
     private void store(String name,  String data) throws EXistException {
-    	Database pool = BrokerPool.getInstance();;
-    	
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            transaction = transact.beginTransaction();
-            assertNotNull(transaction);
+    	Database pool = BrokerPool.getInstance();
+        final TransactionManager = transact = pool.getTransactionManager();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn transaction = transact.beginTransaction()) {
 
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
     		broker.saveCollection(transaction, root);
@@ -510,12 +503,8 @@ public class DebuggerTest implements ResponseListener {
 
             transact.commit(transaction);
         } catch (Exception e) {
-            if (transact != null)
-                transact.abort(transaction);
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            pool.release(broker);
         }
     }
 

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
@@ -20,6 +20,7 @@
 package org.exist.indexing.ngram;
 
 import junit.framework.TestCase;
+import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationManager;
 import org.exist.collections.IndexInfo;
@@ -35,6 +36,7 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
 import org.exist.util.Configuration;
 import org.exist.util.ConfigurationHelper;
+import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.Occurrences;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.xmldb.XmldbURI;
@@ -96,13 +98,9 @@ public class CustomIndexTest extends TestCase {
      * correctly updated.
      */
     public void testXUpdateRemove() {
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            transact = pool.getTransactionManager();
-            transaction = transact.beginTransaction();
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn transaction = transact.beginTransaction()) {
             
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
@@ -176,24 +174,15 @@ public class CustomIndexTest extends TestCase {
             
             transact.commit(transaction);
         } catch (Exception e) {
-            transact.abort(transaction);
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            if (pool != null) {
-                pool.release(broker);
-            }
         }
     }
 
     public void testXUpdateInsert() {
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            transact = pool.getTransactionManager();
-            transaction = transact.beginTransaction();
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn transaction = transact.beginTransaction()) {
 
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
@@ -303,22 +292,15 @@ public class CustomIndexTest extends TestCase {
 
             transact.commit(transaction);
         } catch (Exception e) {
-            transact.abort(transaction);
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            if (pool != null) {
-                pool.release(broker);
-            }
         }
     }
 
     public void testXUpdateUpdate() {
-        DBBroker broker = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            TransactionManager transact = pool.getTransactionManager();
-            Txn transaction = transact.beginTransaction();
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn transaction = transact.beginTransaction()) {
 
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
@@ -374,19 +356,13 @@ public class CustomIndexTest extends TestCase {
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            if (pool != null) {
-                pool.release(broker);
-            }
         }
     }
 
     public void testXUpdateReplace() {
-        DBBroker broker = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            TransactionManager transact = pool.getTransactionManager();
-            Txn transaction = transact.beginTransaction();
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn transaction = transact.beginTransaction()) {
 
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
@@ -434,19 +410,13 @@ public class CustomIndexTest extends TestCase {
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            if (pool != null) {
-                pool.release(broker);
-            }
         }
     }
 
     public void testXUpdateRename() {
-        DBBroker broker = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            TransactionManager transact = pool.getTransactionManager();
-            Txn transaction = transact.beginTransaction();
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn transaction = transact.beginTransaction()) {
 
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
@@ -476,19 +446,13 @@ public class CustomIndexTest extends TestCase {
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            if (pool != null) {
-                pool.release(broker);
-            }
         }
     }
  
     public void testReindex() {
-        DBBroker broker = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            TransactionManager transact = pool.getTransactionManager();
-            Txn transaction = transact.beginTransaction();
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn transaction = transact.beginTransaction()) {
 
             //Doh ! This reindexes *all* the collections for *every* index
             broker.reindexCollection(XmldbURI.xmldbUriFor("/db"));
@@ -514,17 +478,13 @@ public class CustomIndexTest extends TestCase {
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            pool.release(broker);
         }
     }
 
     public void testDropIndex() {
-        DBBroker broker = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            TransactionManager transact = pool.getTransactionManager();
-            Txn transaction = transact.beginTransaction();
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn transaction = transact.beginTransaction()) {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
@@ -550,16 +510,11 @@ public class CustomIndexTest extends TestCase {
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            pool.release(broker);
         }
     }
 
     public void testQuery() {
-        DBBroker broker = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
@@ -581,16 +536,11 @@ public class CustomIndexTest extends TestCase {
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            pool.release(broker);
         }
     }
 
     public void testIndexKeys() {
-        DBBroker broker = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
             
@@ -645,8 +595,6 @@ public class CustomIndexTest extends TestCase {
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            pool.release(broker);
         }
     }
 
@@ -664,24 +612,16 @@ public class CustomIndexTest extends TestCase {
         assertEquals(count, found);        
     }
 
-    protected void setUp() {
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-        try {
-            File confFile = ConfigurationHelper.lookup("conf.xml");
-            System.out.printf("conf: " + confFile.getAbsolutePath());
-            Configuration config = new Configuration(confFile.getAbsolutePath());
-            BrokerPool.configure(1, 5, config);
-            pool = BrokerPool.getInstance();
-        	assertNotNull(pool);
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            transaction = transact.beginTransaction();
-            assertNotNull(transaction);
-            System.out.println("Transaction started ...");
+    protected void setUp() throws EXistException, DatabaseConfigurationException {
+        final File confFile = ConfigurationHelper.lookup("conf.xml");
+        System.out.printf("conf: " + confFile.getAbsolutePath());
+        final Configuration config = new Configuration(confFile.getAbsolutePath());
+        BrokerPool.configure(1, 5, config);
+        pool = BrokerPool.getInstance();
+
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
 
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(root);
@@ -707,29 +647,16 @@ public class CustomIndexTest extends TestCase {
             transact.commit(transaction);
         } catch (Exception e) {
             e.printStackTrace();
-            transact.abort(transaction);
             fail(e.getMessage());
-        } finally {
-            if (pool != null)
-                pool.release(broker);
         }
     }
 
-    protected void tearDown() {
-        BrokerPool pool = null;
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-        try {
-            pool = BrokerPool.getInstance();
-            assertNotNull(pool);
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            transaction = transact.beginTransaction();
-            assertNotNull(transaction);
-            System.out.println("Transaction started ...");
+    protected void tearDown() throws EXistException {
+        final BrokerPool pool = BrokerPool.getInstance();
+
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
 
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(root);
@@ -742,11 +669,8 @@ public class CustomIndexTest extends TestCase {
             
             transact.commit(transaction);
         } catch (Exception e) {
-        	transact.abort(transaction);
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            if (pool != null) pool.release(broker);
         }
         BrokerPool.stopAll(false);
     }

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/SimpleMDTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/SimpleMDTest.java
@@ -40,6 +40,7 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
 import org.exist.util.Configuration;
 import org.exist.util.ConfigurationHelper;
+import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.junit.Test;
@@ -247,11 +248,8 @@ public class SimpleMDTest {
     	assertNotNull(md);
     	
     	String docUUID = null;
-    	
-        DBBroker broker = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection col = broker.getCollection(col1uri);
         	assertNotNull(col);
@@ -265,13 +263,8 @@ public class SimpleMDTest {
 	    	docMD.put(KEY1, VALUE1);
 	    	docMD.put(KEY2, VALUE2);
 	    	
-	        TransactionManager txnManager = null;
-	        Txn txn = null;
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
+	        final TransactionManager txnManager = pool.getTransactionManager();
+	        try(final Txn txn = txnManager.beginTransaction()) {
 
 		    	IndexInfo info = col.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
 	            assertNotNull(info);
@@ -282,12 +275,9 @@ public class SimpleMDTest {
 
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 	        
-        } finally {
-        	pool.release(broker);
         }
 	        
         shutdown();
@@ -295,24 +285,15 @@ public class SimpleMDTest {
 
     	md = MetaData.get();
     	assertNotNull(md);
-    	
-    	try {
-	    	
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection root = broker.getCollection(col1uri);
         	assertNotNull(root);
 
-	        TransactionManager txnManager = null;
-	        Txn txn = null;
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
+	        final TransactionManager txnManager = pool.getTransactionManager();
+            try(final Txn txn = txnManager.beginTransaction()) {
 
-            
 		    	IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
 	            assertNotNull(info);
 	            root.store(txn, broker, info, XML1, false);
@@ -321,7 +302,6 @@ public class SimpleMDTest {
 	            
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 
@@ -330,8 +310,6 @@ public class SimpleMDTest {
 	    	
 	    	assertNotSame(docUUID, docMD.getUUID());
 
-        } finally {
-        	pool.release(broker);
         }
 
     	cleanup();
@@ -354,28 +332,19 @@ public class SimpleMDTest {
     	docMD.put(KEY1, VALUE1);
 
     	System.out.println("MOVING...");
-    	DBBroker broker = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection col = broker.getCollection(col1uri);
         	assertNotNull(col);
 
-        	TransactionManager txnManager = null;
-	        Txn txn = null;
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
+        	final TransactionManager txnManager = pool.getTransactionManager();
+            try(final Txn txn = txnManager.beginTransaction()) {
             
 	            broker.moveResource(txn, doc1, col, doc2uri.lastSegment());
 
 	            txnManager.commit(txn);
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 	    	System.out.println("MOVED.");
@@ -385,9 +354,7 @@ public class SimpleMDTest {
 	    	
 	    	assertEquals(uuid, docMD.getUUID());
 
-        } finally {
-    		pool.release(broker);
-    	}
+        }
         
 
     	cleanup();
@@ -409,28 +376,17 @@ public class SimpleMDTest {
     	//add first key-value
     	docMD.put(KEY1, VALUE1);
 
-    	DBBroker broker = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection col = broker.getCollection(col2uri);
         	assertNotNull(col);
 
-        	TransactionManager txnManager = null;
-	        Txn txn = null;
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
-            
+        	final TransactionManager txnManager = pool.getTransactionManager();
+	        try(final Txn txn = txnManager.beginTransaction()) {
 	            broker.moveResource(txn, doc1, col, doc3uri.lastSegment());
-
 	            txnManager.commit(txn);
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 
@@ -439,10 +395,7 @@ public class SimpleMDTest {
 	    	
 	    	assertEquals(uuid, docMD.getUUID());
 
-        } finally {
-    		pool.release(broker);
-    	}
-        
+        }
 
     	cleanup();
 	}
@@ -463,10 +416,7 @@ public class SimpleMDTest {
     	//add first key-value
     	docMD.put(KEY1, VALUE1);
 
-    	DBBroker broker = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection parent = broker.getCollection(col3uri.removeLastSegment());
         	assertNotNull(parent);
@@ -475,20 +425,14 @@ public class SimpleMDTest {
         	assertNotNull(col);
 
         	System.out.println("MOVING...");
-        	TransactionManager txnManager = null;
-	        Txn txn = null;
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
+            final TransactionManager txnManager = pool.getTransactionManager();
+            try(final Txn txn = txnManager.beginTransaction()) {
 	            
 	            broker.moveCollection(txn, col, parent, col3uri.lastSegment());
             
 	            txnManager.commit(txn);
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 	    	System.out.println("MOVED.");
@@ -503,14 +447,7 @@ public class SimpleMDTest {
 	    	assertEquals(VALUE1, docMD.get(KEY1).getValue());
 
 	    	Collection nCol = null;
-	    	txnManager = null;
-	        txn = null;
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
-	            
+            try(final Txn txn = txnManager.beginTransaction()) {
 	            nCol = broker.getOrCreateCollection(txn, col1uri);
 	            assertNotNull(nCol);
 	            broker.saveCollection(txn, nCol);
@@ -518,7 +455,6 @@ public class SimpleMDTest {
 	            txnManager.commit(txn);
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 
@@ -529,9 +465,7 @@ public class SimpleMDTest {
 	    	assertNotNull(doc);
 	    	assertEquals(doc4uri.toString(), doc.getURI().toString());
 	    	
-        } finally {
-    		pool.release(broker);
-    	}
+        }
 
     	cleanup();
 	}
@@ -544,17 +478,9 @@ public class SimpleMDTest {
         Collection test2;
         DocumentImpl doc3;
 
-    	DBBroker broker = null;
-        TransactionManager txnManager = null;
-        Txn txn = null;
-        try {
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            
-            txnManager = pool.getTransactionManager();
-            assertNotNull(txnManager);
-            txn = txnManager.beginTransaction();
-            assertNotNull(txn);
+        final TransactionManager txnManager = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn txn = txnManager.beginTransaction()) {
             
             test2 = broker.getOrCreateCollection(txn, col2uri);
             assertNotNull(test2);
@@ -566,11 +492,7 @@ public class SimpleMDTest {
             txnManager.commit(txn);
         } catch (Exception e) {
             e.printStackTrace();
-            txnManager.abort(txn);
             fail(e.getMessage());
-        } finally {
-            if (pool != null)
-                pool.release(broker);
         }
 
     	MetaData md = MetaData.get();
@@ -593,9 +515,7 @@ public class SimpleMDTest {
     	//add first key-value
     	docMD.put(KEY2, VALUE2);
 
-    	try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection parent = broker.getCollection(col3uri.removeLastSegment());
         	assertNotNull(parent);
@@ -604,18 +524,13 @@ public class SimpleMDTest {
         	assertNotNull(col);
 
         	System.out.println("MOVING...");
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
+            try(final Txn txn = txnManager.beginTransaction()) {
 	            
 	            broker.moveCollection(txn, col, parent, col3uri.lastSegment());
             
 	            txnManager.commit(txn);
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 	    	System.out.println("MOVED.");
@@ -636,13 +551,7 @@ public class SimpleMDTest {
 	    	assertEquals(VALUE2, docMD.get(KEY2).getValue());
 
 	    	Collection nCol = null;
-	    	txnManager = null;
-	        txn = null;
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
+            try(final Txn txn = txnManager.beginTransaction()) {
 	            
 	            nCol = broker.getOrCreateCollection(txn, col1uri);
 	            assertNotNull(nCol);
@@ -651,7 +560,6 @@ public class SimpleMDTest {
 	            txnManager.commit(txn);
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 
@@ -662,9 +570,7 @@ public class SimpleMDTest {
 	    	assertNotNull(doc);
 	    	assertEquals(doc4uri.toString(), doc.getURI().toString());
 	    	
-        } finally {
-    		pool.release(broker);
-    	}
+        }
 
     	cleanup();
 	}
@@ -685,10 +591,7 @@ public class SimpleMDTest {
     	//add first key-value
     	docMD.put(KEY1, VALUE1);
 
-    	DBBroker broker = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection parent = broker.getCollection(col3uri.removeLastSegment());
         	assertNotNull(parent);
@@ -697,20 +600,14 @@ public class SimpleMDTest {
         	assertNotNull(col);
 
         	System.out.println("COPY...");
-        	TransactionManager txnManager = null;
-	        Txn txn = null;
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
+            final TransactionManager txnManager = pool.getTransactionManager();
+            try(final Txn txn = txnManager.beginTransaction()) {
 	            
 	            broker.copyCollection(txn, col, parent, col3uri.lastSegment());
             
 	            txnManager.commit(txn);
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 	    	System.out.println("DONE.");
@@ -731,10 +628,7 @@ public class SimpleMDTest {
 	    	assertNotNull(doc);
 	    	assertEquals(doc1uri.toString(), doc.getURI().toString());
 	    	
-        } finally {
-    		pool.release(broker);
-    	}
-        
+        }
 
     	cleanup();
 	}
@@ -760,10 +654,7 @@ public class SimpleMDTest {
     	//add first key-value
     	docMD.put(KEY1, VALUE1);
 
-    	DBBroker broker = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection parent = broker.getCollection(col3uri.removeLastSegment());
         	assertNotNull(parent);
@@ -772,20 +663,14 @@ public class SimpleMDTest {
         	assertNotNull(col);
 
         	System.out.println("DELETE...");
-        	TransactionManager txnManager = null;
-	        Txn txn = null;
-	        try {
-	            txnManager = pool.getTransactionManager();
-	            assertNotNull(txnManager);
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
+            final TransactionManager txnManager = pool.getTransactionManager();
+            try(final Txn txn = txnManager.beginTransaction()) {
 	            
 	            broker.removeCollection(txn, col);
             
 	            txnManager.commit(txn);
 	        } catch (Exception e) {
 	            e.printStackTrace();
-	            txnManager.abort(txn);
 	            fail(e.getMessage());
 	        }
 	    	System.out.println("DONE.");
@@ -808,103 +693,84 @@ public class SimpleMDTest {
 	    	doc = md.getDocument(uuid2);
 	    	assertNull(doc);
 
-        } finally {
-    		pool.release(broker);
-    	}
-        
+        }
 
     	cleanup();
 	}
 
 	@Test
 	public void test_08() throws Exception {
-    	
-        DBBroker broker = null;
-        TransactionManager txnManager = null;
-        Txn txn = null;
+
         try {
-            File confFile = ConfigurationHelper.lookup("conf.xml");
-            Configuration config = new Configuration(confFile.getAbsolutePath());
+            final File confFile = ConfigurationHelper.lookup("conf.xml");
+            final Configuration config = new Configuration(confFile.getAbsolutePath());
             BrokerPool.configure(1, 5, config);
             pool = BrokerPool.getInstance();
-        	assertNotNull(pool);
         	pool.getPluginsManager().addPlugin("org.exist.storage.md.Plugin");
 
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
 
-        	MetaData md = MetaData.get();
-        	assertNotNull(md);
+            try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-            txnManager = pool.getTransactionManager();
-            assertNotNull(txnManager);
-            
-            Collection root = null;
-            
-            try {
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
-	            System.out.println("Transaction started ...");
-	
-	            root = broker.getOrCreateCollection(txn, col1uri);
-	            assertNotNull(root);
-	            broker.saveCollection(txn, root);
-	
-	            CollectionConfigurationManager mgr = pool.getConfigurationManager();
-	            mgr.addConfiguration(txn, broker, root, COLLECTION_CONFIG);
-	
-	            System.out.println("store "+doc1uri);
-	            IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
-	            assertNotNull(info);
-	            root.store(txn, broker, info, XML1, false);
-	
-	            txnManager.commit(txn);
-	        } catch (Exception e) {
-	            e.printStackTrace();
-	            txnManager.abort(txn);
-	            fail(e.getMessage());
-	        }
-            
-	    	Metas docMD = md.getMetas(doc1uri);
-	    	assertNotNull(docMD);
-	    	
-	    	String uuid = docMD.getUUID();
+                final MetaData md = MetaData.get();
+                assertNotNull(md);
 
-            try {
-	            txn = txnManager.beginTransaction();
-	            assertNotNull(txn);
-	            System.out.println("Transaction started ...");
-	
-	            root = broker.getOrCreateCollection(txn, col1uri);
-	            assertNotNull(root);
-	            broker.saveCollection(txn, root);
-	
-	            CollectionConfigurationManager mgr = pool.getConfigurationManager();
-	            mgr.addConfiguration(txn, broker, root, COLLECTION_CONFIG);
-	
-	            System.out.println("store "+doc1uri);
-	            IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), wrongXML);
-	            assertNotNull(info);
-	            root.store(txn, broker, info, wrongXML, false);
-	
-	            txnManager.commit(txn);
-	        } catch (Exception e) {
-	            //e.printStackTrace();
-	            txnManager.abort(txn);
-	            //fail(e.getMessage());
-	        }
-            
-	    	docMD = md.getMetas(doc1uri);
-	    	assertNotNull(docMD);
-	    	
-	    	assertEquals(uuid, docMD.getUUID());
+                final TransactionManager txnManager = pool.getTransactionManager();
+
+                try(final Txn txn = txnManager.beginTransaction()) {
+
+                    final Collection root = broker.getOrCreateCollection(txn, col1uri);
+                    assertNotNull(root);
+                    broker.saveCollection(txn, root);
+
+                    final CollectionConfigurationManager mgr = pool.getConfigurationManager();
+                    mgr.addConfiguration(txn, broker, root, COLLECTION_CONFIG);
+
+                    System.out.println("store " + doc1uri);
+                    final IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
+                    assertNotNull(info);
+                    root.store(txn, broker, info, XML1, false);
+
+                    txnManager.commit(txn);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    fail(e.getMessage());
+                }
+
+                Metas docMD = md.getMetas(doc1uri);
+                assertNotNull(docMD);
+
+                final String uuid = docMD.getUUID();
+
+                try(final Txn txn = txnManager.beginTransaction()) {
+
+                    final Collection root = broker.getOrCreateCollection(txn, col1uri);
+                    assertNotNull(root);
+                    broker.saveCollection(txn, root);
+
+                    final CollectionConfigurationManager mgr = pool.getConfigurationManager();
+                    mgr.addConfiguration(txn, broker, root, COLLECTION_CONFIG);
+
+                    System.out.println("store " + doc1uri);
+                    final IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), wrongXML);
+                    assertNotNull(info);
+                    root.store(txn, broker, info, wrongXML, false);
+
+                    txnManager.commit(txn);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    //txnManager.abort(txn);
+                    //fail(e.getMessage());
+                }
+
+                docMD = md.getMetas(doc1uri);
+                assertNotNull(docMD);
+
+                assertEquals(uuid, docMD.getUUID());
+            }
             
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            if (pool != null)
-                pool.release(broker);
         }
 	}
 
@@ -928,29 +794,20 @@ public class SimpleMDTest {
 	}
 
 	//@BeforeClass
-    public static void startDB() {
-        DBBroker broker = null;
-        TransactionManager txnManager = null;
-        Txn txn = null;
-        try {
-            File confFile = ConfigurationHelper.lookup("conf.xml");
-            Configuration config = new Configuration(confFile.getAbsolutePath());
-            BrokerPool.configure(1, 5, config);
-            pool = BrokerPool.getInstance();
-        	assertNotNull(pool);
-        	pool.getPluginsManager().addPlugin("org.exist.storage.md.MDStorageManager");
+    public static void startDB() throws DatabaseConfigurationException, EXistException {
+        final File confFile = ConfigurationHelper.lookup("conf.xml");
+        final Configuration config = new Configuration(confFile.getAbsolutePath());
+        BrokerPool.configure(1, 5, config);
+        pool = BrokerPool.getInstance();
+        assertNotNull(pool);
+        pool.getPluginsManager().addPlugin("org.exist.storage.md.MDStorageManager");
+
+        final TransactionManager txnManager = pool.getTransactionManager();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn txn = txnManager.beginTransaction()) {
             
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            
-            clean();
-            
-            txnManager = pool.getTransactionManager();
-            assertNotNull(txnManager);
-            txn = txnManager.beginTransaction();
-            assertNotNull(txn);
-            
-            System.out.println("Transaction started ...");
+            clean(broker, txn);
 
             Collection root = broker.getOrCreateCollection(txn, col1uri);
             assertNotNull(root);
@@ -972,17 +829,13 @@ public class SimpleMDTest {
             txnManager.commit(txn);
         } catch (Exception e) {
             e.printStackTrace();
-            txnManager.abort(txn);
             fail(e.getMessage());
-        } finally {
-            if (pool != null)
-                pool.release(broker);
         }
     }
 
     //@AfterClass
-    public static void cleanup() {
-    	clean();
+    public static void cleanup() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        clean();
     	shutdown();
     }
 
@@ -995,41 +848,30 @@ public class SimpleMDTest {
         System.out.println("stopped");
     }
 
-    private static void clean() {
-    	System.out.println("CLEANING...");
-    	
-        DBBroker broker = null;
-        TransactionManager txnManager = null;
-        Txn txn = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            txnManager = pool.getTransactionManager();
-            assertNotNull(txnManager);
-            txn = txnManager.beginTransaction();
-            assertNotNull(txn);
-            System.out.println("Transaction started ...");
+    private static void clean() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final TransactionManager txnManager = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn txn = txnManager.beginTransaction()) {
+            clean(broker, txn);
+            txn.commit();
+        }
+    }
 
-            Collection col = broker.getOrCreateCollection(txn, col1uri);
-            assertNotNull(col);
-        	broker.removeCollection(txn, col);
+    private static void clean(final DBBroker broker, final Txn txn) throws PermissionDeniedException, IOException, TriggerException {
+    	System.out.println("CLEANING...");
+
+        Collection col = broker.getOrCreateCollection(txn, col1uri);
+        assertNotNull(col);
+        broker.removeCollection(txn, col);
 
 //            col = broker.getOrCreateCollection(txn, col2uri);
 //            assertNotNull(col);
 //        	broker.removeCollection(txn, col);
 
-            col = broker.getOrCreateCollection(txn, col3uri);
-            assertNotNull(col);
-        	broker.removeCollection(txn, col);
+        col = broker.getOrCreateCollection(txn, col3uri);
+        assertNotNull(col);
+        broker.removeCollection(txn, col);
 
-        	txnManager.commit(txn);
-        } catch (Exception e) {
-        	txnManager.abort(txn);
-            e.printStackTrace();
-            fail(e.getMessage());
-        } finally {
-            if (pool != null) pool.release(broker);
-        }
     	System.out.println("CLEANED.");
     }
 }

--- a/extensions/svn/src/org/exist/versioning/svn/old/ExportEditor.java
+++ b/extensions/svn/src/org/exist/versioning/svn/old/ExportEditor.java
@@ -443,10 +443,12 @@ public class ExportEditor implements ISVNEditor {
 		try {
 			transact.commit(transaction);
 		} catch (TransactionException e) {
-			SVNErrorMessage err = SVNErrorMessage.create(SVNErrorCode.IO_ERROR,
-					"error: failed on transaction's commit.");
-			throw new SVNException(err);
-		}
+            SVNErrorMessage err = SVNErrorMessage.create(SVNErrorCode.IO_ERROR,
+                    "error: failed on transaction's commit.");
+            throw new SVNException(err);
+        } finally {
+            transact.close(transaction);
+        }
 
 		return null;
 	}

--- a/src/org/exist/Transaction.java
+++ b/src/org/exist/Transaction.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2014 The eXist Project
+ *  Copyright (C) 2001-2015 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -22,12 +22,44 @@ package org.exist;
 import org.exist.storage.txn.TransactionException;
 
 /**
- * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
+ * Represents an atomic Transaction on the database
  *
+ * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
+ * @author <a href="mailto:adam.retter@googlemail.com">Adam Retter</a>
  */
 public interface Transaction extends AutoCloseable {
-    
+
+    /**
+     * @Deprecated use org.exist.Transaction#commit() instead
+     */
+    @Deprecated
     public void success() throws TransactionException;
     
+    /**
+     * Performs an atomic commit of the transaction
+     *
+     * @throws org.exist.storage.txn.TransactionException if an error occurred
+     *   during writing any part of the transaction
+     */
+    public void commit() throws TransactionException;
+
+    /**
+     * @Deprecated use org.exist.Transaction#abort() instead
+     */
+    @Deprecated
     public void failure();
+
+    /**
+     * Performs an atomic abort of the transaction
+     */
+    public void abort();
+
+    /**
+     * Closes the transaction
+     *
+     * If the transaction has not been committed then
+     * it will be auto-aborted.
+     */
+    @Override
+    public void close();
 }

--- a/src/org/exist/atom/modules/AtomProtocol.java
+++ b/src/org/exist/atom/modules/AtomProtocol.java
@@ -21,12 +21,7 @@
  */
 package org.exist.atom.modules;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -164,8 +159,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 			if ("feed".equals(root.getLocalName())) {
 				DocumentImpl feedDoc = null;
 				final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-				final Txn transaction = transact.beginTransaction();
-				try {
+				try(final Txn transaction = transact.beginTransaction();) {
 					if (collection != null) {
 						feedDoc = collection.getDocument(broker, FEED_DOCUMENT_URI);
 						if (feedDoc != null) {
@@ -218,19 +212,13 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					response.setHeader("Location", request.getModuleBase() + request.getPath());
 
 				} catch (final IOException ex) {
-					transact.abort(transaction);
 					throw new EXistException("IO error: " + ex.getMessage(), ex);
 				} catch (final TriggerException ex) {
-					transact.abort(transaction);
 					throw new EXistException("Trigger failed: " + ex.getMessage(), ex);
-				} catch (final SAXException ex) {
-					transact.abort(transaction);
+                } catch (final SAXException ex) {
 					throw new EXistException("SAX error: " + ex.getMessage(), ex);
 				} catch (final LockException ex) {
-					transact.abort(transaction);
-					throw new EXistException("Cannot acquire write lock.", ex);
-				} finally {
-                    transact.close(transaction);
+                    throw new EXistException("Cannot acquire write lock.", ex);
                 }
 			} else if ("entry".equals(root.getLocalName())) {
 
@@ -248,71 +236,71 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 							"Permission denied to update feed " + collection.getURI());}
 
 				final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-				final Txn transaction = transact.beginTransaction();
-				final String uuid = UUIDGenerator.getUUID();
-				final String id = "urn:uuid:" + uuid;
-				final Element publishedE = DOM.replaceTextElement(root,
-						Atom.NAMESPACE_STRING, "published", currentDateTime, true, true);
-				DOM.replaceTextElement(root, Atom.NAMESPACE_STRING, "updated", currentDateTime, true, true);
-				DOM.replaceTextElement(root, Atom.NAMESPACE_STRING, "id", id, true, true);
+				try(final Txn transaction = transact.beginTransaction()) {
+                    final String uuid = UUIDGenerator.getUUID();
+                    final String id = "urn:uuid:" + uuid;
+                    final Element publishedE = DOM.replaceTextElement(root,
+                            Atom.NAMESPACE_STRING, "published", currentDateTime, true, true);
+                    DOM.replaceTextElement(root, Atom.NAMESPACE_STRING, "updated", currentDateTime, true, true);
+                    DOM.replaceTextElement(root, Atom.NAMESPACE_STRING, "id", id, true, true);
 
-				Element editLink = findLink(root, "edit");
-				final Element editLinkSrc = findLink(root, "edit-media");
-				if (editLink != null || editLinkSrc != null) {
-					throw new BadRequestException(
-							"An edit link relation cannot be specified in the entry.");
-				}
-				editLink = doc.createElementNS(Atom.NAMESPACE_STRING, "link");
-				editLink.setAttribute("rel", "edit");
-				editLink.setAttribute("type", Atom.MIME_TYPE);
-				editLink.setAttribute("href", "?id=" + id);
-				final Node next = publishedE.getNextSibling();
-				if (next == null) {
-					root.appendChild(editLink);
-				} else {
-					root.insertBefore(editLink, next);
-				}
+                    Element editLink = findLink(root, "edit");
+                    final Element editLinkSrc = findLink(root, "edit-media");
+                    if (editLink != null || editLinkSrc != null) {
+                        throw new BadRequestException(
+                                "An edit link relation cannot be specified in the entry.");
+                    }
+                    editLink = doc.createElementNS(Atom.NAMESPACE_STRING, "link");
+                    editLink.setAttribute("rel", "edit");
+                    editLink.setAttribute("type", Atom.MIME_TYPE);
+                    editLink.setAttribute("href", "?id=" + id);
+                    final Node next = publishedE.getNextSibling();
+                    if (next == null) {
+                        root.appendChild(editLink);
+                    } else {
+                        root.insertBefore(editLink, next);
+                    }
 
-				try {
-					// get the feed
-					LOG.debug("Acquiring lock on feed document...");
-					final ElementImpl feedRoot = (ElementImpl) feedDoc.getDocumentElement();
+                    try {
+                        // get the feed
+                        LOG.debug("Acquiring lock on feed document...");
+                        final ElementImpl feedRoot = (ElementImpl) feedDoc.getDocumentElement();
 
-					// Lock the feed
-					feedDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+                        // Lock the feed
+                        feedDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
 
-					// Append the entry
-					collection = broker.getOrCreateCollection(transaction, pathUri.append(ENTRY_COLLECTION_URI));
-					setPermissions(broker, root, collection);
-					broker.saveCollection(transaction, collection);
-					final XmldbURI entryURI = entryURI(uuid);
-					final DocumentImpl entryDoc = collection.getDocument(broker, entryURI);
-					if (entryDoc != null) {
-						throw new PermissionDeniedException("Entry with " + id
-								+ " already exists.");
-					}
-					final IndexInfo info = collection.validateXMLResource(transaction, broker, entryURI, doc);
-					setPermissions(broker, root, info.getDocument());
-					// TODO : We should probably unlock the collection here
-					collection.store(transaction, broker, info, doc, false);
+                        // Append the entry
+                        collection = broker.getOrCreateCollection(transaction, pathUri.append(ENTRY_COLLECTION_URI));
+                        setPermissions(broker, root, collection);
+                        broker.saveCollection(transaction, collection);
+                        final XmldbURI entryURI = entryURI(uuid);
+                        final DocumentImpl entryDoc = collection.getDocument(broker, entryURI);
+                        if (entryDoc != null) {
+                            throw new PermissionDeniedException("Entry with " + id
+                                    + " already exists.");
+                        }
+                        final IndexInfo info = collection.validateXMLResource(transaction, broker, entryURI, doc);
+                        setPermissions(broker, root, info.getDocument());
+                        // TODO : We should probably unlock the collection here
+                        collection.store(transaction, broker, info, doc, false);
 
-					// Update the updated element
-					DOMDB.replaceTextElement(transaction, feedRoot,
-							Atom.NAMESPACE_STRING, "updated", currentDateTime,
-							true);
+                        // Update the updated element
+                        DOMDB.replaceTextElement(transaction, feedRoot,
+                                Atom.NAMESPACE_STRING, "updated", currentDateTime,
+                                true);
 
-					// Store the changes
-					LOG.debug("Storing change...");
-					broker.storeXMLResource(transaction, feedDoc);
-					transact.commit(transaction);
+                        // Store the changes
+                        LOG.debug("Storing change...");
+                        broker.storeXMLResource(transaction, feedDoc);
+                        transact.commit(transaction);
 
-					LOG.debug("Done!");
+                        LOG.debug("Done!");
 
-					//XXX: response outside of try-block
-					response.setStatusCode(201);
-					response.setHeader("Location", request.getModuleBase()
-							+ request.getPath() + "?id=" + id);
-					getEntryById(broker, request.getPath(), id, response);
+                        //XXX: response outside of try-block
+                        response.setStatusCode(201);
+                        response.setHeader("Location", request.getModuleBase()
+                                + request.getPath() + "?id=" + id);
+                        getEntryById(broker, request.getPath(), id, response);
 					/*
 					 * response.setContentType(Atom.MIME_TYPE+"; charset="+charset
 					 * ); OutputStreamWriter w = new
@@ -322,31 +310,28 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					 * identity.transform(new DOMSource(doc),new
 					 * StreamResult(w)); w.flush(); w.close();
 					 */
-				} catch (final IOException ex) {
-					transact.abort(transaction);
-					throw new EXistException("IO error: " + ex.getMessage(), ex);
-				} catch (final TriggerException ex) {
-					transact.abort(transaction);
-					throw new EXistException("Trigger failed: "
-							+ ex.getMessage(), ex);
-				} catch (final SAXException ex) {
-					transact.abort(transaction);
-					throw new EXistException("SAX error: " + ex.getMessage(),
-							ex);
-				} catch (final LockException ex) {
-					transact.abort(transaction);
-					throw new EXistException("Cannot acquire write lock.", ex);
+                    } catch (final IOException ex) {
+                        throw new EXistException("IO error: " + ex.getMessage(), ex);
+                    } catch (final TriggerException ex) {
+                        throw new EXistException("Trigger failed: "
+                                + ex.getMessage(), ex);
+                    } catch (final SAXException ex) {
+                        throw new EXistException("SAX error: " + ex.getMessage(),
+                                ex);
+                    } catch (final LockException ex) {
+                        throw new EXistException("Cannot acquire write lock.", ex);
 					/*
 					 * } catch (IOException ex) { throw new
 					 * EXistException("Internal error while serializing result."
 					 * ,ex); } catch (TransformerException ex) { throw new
 					 * EXistException("Serialization error.",ex);
 					 */
-				} finally {
-                    transact.close(transaction);
-					if (feedDoc != null)
-						{feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);}
-				}
+                    } finally {
+                        if (feedDoc != null) {
+                            feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                        }
+                    }
+                }
 			} else {
 				throw new BadRequestException(
 						"Unexpected element: {http://www.w3.org/2005/Atom}" + root.getLocalName());
@@ -379,8 +364,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 			}
 
 			final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-			final Txn transaction = transact.beginTransaction();
-			try {
+			try(final Txn transaction = transact.beginTransaction()) {
 				final XmldbURI docUri = XmldbURI.create(filename);
 				if (collection.getDocument(broker, docUri) != null) {
 					transact.abort(transaction);
@@ -390,24 +374,23 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 				final File tempFile = storeInTemporaryFile(request.getInputStream(), request.getContentLength());
 
 				if (mime.isXMLType()) {
-					InputStream is = new FileInputStream(tempFile);
-					
-					final IndexInfo info = collection.validateXMLResource(
-							transaction, broker, docUri, 
-							new InputSource(new InputStreamReader(is, charset)));
-					
-					is.close();
+                    final IndexInfo info;
+                    try(final Reader reader = new InputStreamReader(new FileInputStream(tempFile), charset)) {
+
+                        info = collection.validateXMLResource(
+                                transaction, broker, docUri,
+                                new InputSource(reader));
+                    }
+
 					info.getDocument().getMetadata().setMimeType(contentType);
-					is = new FileInputStream(tempFile);
-					
-					collection.store(transaction, broker, info, 
-							new InputSource(new InputStreamReader(is, charset)), false);
-					
-					is.close();
+
+					try(final Reader reader = new InputStreamReader(new FileInputStream(tempFile), charset)) {
+                        collection.store(transaction, broker, info, new InputSource(reader), false);
+                    }
 				} else {
-					final FileInputStream is = new FileInputStream(tempFile);
-					collection.addBinaryResource(transaction, broker, docUri, is, contentType, tempFile.length());
-					is.close();
+					try(final FileInputStream is = new FileInputStream(tempFile)) {
+                        collection.addBinaryResource(transaction, broker, docUri, is, contentType, tempFile.length());
+                    }
 				}
 
 				try {
@@ -458,44 +441,35 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					w.close();
 
 				} catch (final ParserConfigurationException ex) {
-					transact.abort(transaction);
 					throw new EXistException("DOM implementation is misconfigured.", ex);
-				} catch (final TransformerException ex) {
+                } catch (final TransformerException ex) {
 					throw new EXistException("Serialization error.", ex);
 				} catch (final LockException ex) {
-					transact.abort(transaction);
 					throw new EXistException("Cannot acquire write lock.", ex);
 				} finally {
-                    transact.close(transaction);
-					if (feedDoc != null)
-						{feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);}
+					if (feedDoc != null) {
+                        feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                    }
 				}
 
 			} catch (final IOException ex) {
-				transact.abort(transaction);
 				throw new EXistException("I/O error while handling temporary files.", ex);
 			} catch (final SAXParseException e) {
-				transact.abort(transaction);
 				throw new BadRequestException("Parsing exception at "
 						+ e.getLineNumber() + "/" + e.getColumnNumber() + ": "
 						+ e.toString());
 			} catch (final TriggerException e) {
-				transact.abort(transaction);
 				throw new PermissionDeniedException(e.getMessage());
 			} catch (SAXException e) {
-				transact.abort(transaction);
 				Exception o = e.getException();
-				if (o == null)
-					{o = e;}
-				
+				if (o == null) {
+                    o = e;
+                }
 				throw new BadRequestException("Parsing exception: " + o.getMessage());
 			
 			} catch (final LockException e) {
-				transact.abort(transaction);
 				throw new PermissionDeniedException(e.getMessage());
-			} finally {
-                transact.close(transaction);
-            }
+			}
 		}
 	}
 
@@ -586,8 +560,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 									+ collection.getURI());}
 
 				final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-				final Txn transaction = transact.beginTransaction();
-				try {
+				try(final Txn transaction = transact.beginTransaction()) {
 					feedDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
 					final ElementImpl feedRoot = (ElementImpl) feedDoc.getDocumentElement();
 
@@ -600,15 +573,13 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					response.setStatusCode(204);
 
 				} catch (final LockException ex) {
-					transact.abort(transaction);
 					throw new EXistException("Cannot acquire write lock.", ex);
 				} catch (final RuntimeException ex) {
-					transact.abort(transaction);
 					throw ex;
 				} finally {
-                    transact.close(transaction);
-					if (feedDoc != null)
-						{feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);}
+					if (feedDoc != null) {
+                        feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                    }
 				}
 
 			} else if ("entry".equals(root.getLocalName())) {
@@ -624,9 +595,8 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 				DocumentImpl feedDoc = null;
 				DocumentImpl entryDoc = null;
 				final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-				final Txn transaction = transact.beginTransaction();
 
-				try {
+				try(final Txn transaction = transact.beginTransaction()) {
 					// Get the feed
 					LOG.debug("Acquiring lock on feed document...");
 					feedDoc = collection.getDocument(broker, FEED_DOCUMENT_URI);
@@ -679,7 +649,6 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					 * StreamResult(w)); w.flush(); w.close();
 					 */
 				} catch (final LockException ex) {
-					transact.abort(transaction);
 					throw new EXistException("Cannot acquire write lock.", ex);
 					/*
 					 * } catch (IOException ex) { throw new EXistException(
@@ -688,12 +657,13 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					 * EXistException("Serialization error.",ex);
 					 */
 				} finally {
-                    transact.close(transaction);
-					if (feedDoc != null)
-						{feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);}
+					if (feedDoc != null) {
+                        feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                    }
 
-					if (entryDoc != null)
-						{entryDoc.getUpdateLock().release(Lock.WRITE_LOCK);}
+					if (entryDoc != null) {
+                        entryDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                    }
 				}
 
 			} else {
@@ -704,8 +674,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 
 		} else {
 			final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-			final Txn transaction = transact.beginTransaction();
-			try {
+			try(final Txn transaction = transact.beginTransaction()) {
 				final XmldbURI docUri = pathUri.lastSegment();
 				final XmldbURI collUri = pathUri.removeLastSegment();
 
@@ -732,22 +701,19 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 						request.getContentLength());
 
 				if (mime.isXMLType()) {
-					InputStream is = new FileInputStream(tempFile);
-					
-					final IndexInfo info = collection.validateXMLResource(
-							transaction, broker, docUri, 
-							new InputSource(new InputStreamReader(is, charset)));
-					
-					is.close();
+                    final IndexInfo info;
+					try(final Reader reader = new InputStreamReader(new FileInputStream(tempFile), charset)) {
+                        info = collection.validateXMLResource(
+                                transaction, broker, docUri,
+                                new InputSource(reader));
+                    }
 					
 					info.getDocument().getMetadata().setMimeType(contentType);
-					
-					is = new FileInputStream(tempFile);
-					
-					collection.store(transaction, broker, info, 
-						new InputSource(new InputStreamReader(is, charset)), false);
-					
-					is.close();
+
+                    try(final Reader reader = new InputStreamReader(new FileInputStream(tempFile), charset)) {
+                        collection.store(transaction, broker, info,
+                                new InputSource(reader), false);
+                    }
 				} else {
 					final FileInputStream is = new FileInputStream(tempFile);
 					collection.addBinaryResource(transaction, broker, docUri,
@@ -761,30 +727,22 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 				response.setStatusCode(200);
 
 			} catch (final IOException ex) {
-				transact.abort(transaction);
 				throw new EXistException("I/O error while handling temporary files.", ex);
 			} catch (final SAXParseException e) {
-				transact.abort(transaction);
 				throw new BadRequestException("Parsing exception at "
 						+ e.getLineNumber() + "/" + e.getColumnNumber() + ": "
 						+ e.toString());
 			} catch (final TriggerException e) {
-				transact.abort(transaction);
 				throw new PermissionDeniedException(e.getMessage());
 			} catch (SAXException e) {
-				transact.abort(transaction);
-				
 				Exception o = e.getException();
-				if (o == null)
-					{o = e;}
-				
+				if (o == null) {
+                    o = e;
+                }
 				throw new BadRequestException("Parsing exception: " + o.getMessage());
 			} catch (final LockException e) {
-				transact.abort(transaction);
 				throw new PermissionDeniedException(e.getMessage());
-			} finally {
-                transact.close(transaction);
-            }
+			}
 		}
 	}
 
@@ -804,13 +762,10 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 		if (id == null) {
 			// delete collection
 			final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-			final Txn transaction = transact.beginTransaction();
-			try {
+			try(final Txn transaction = transact.beginTransaction()) {
 				broker.removeCollection(transaction, collection);
 				transact.commit(transaction);
 				response.setStatusCode(204);
-			} finally {
-				transact.close(transaction);
 			}
 			return;
 		}
@@ -818,9 +773,8 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 		LOG.info("Deleting entry " + id + " in collection " + request.getPath());
 		DocumentImpl feedDoc = null;
 		final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-		final Txn transaction = transact.beginTransaction();
 		final String currentDateTime = DateFormatter.toXSDDateTime(new Date());
-		try {
+		try(final Txn transaction = transact.beginTransaction()) {
 			// Get the feed
 			// LOG.info("Acquiring lock on feed document...");
 			feedDoc = collection.getDocument(broker, FEED_DOCUMENT_URI);
@@ -875,14 +829,11 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 			response.setStatusCode(204);
 
 		} catch (final TriggerException ex) {
-			transact.abort(transaction);
 			throw new EXistException("Cannot delete media resource " + srcUri,
 					ex);
 		} catch (final LockException ex) {
-			transact.abort(transaction);
 			throw new EXistException("Cannot acquire write lock.", ex);
 		} finally {
-            transact.close(transaction);
 			if (feedDoc != null) {
 				feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
 			}

--- a/src/org/exist/collections/CollectionConfigurationManager.java
+++ b/src/org/exist/collections/CollectionConfigurationManager.java
@@ -460,8 +460,7 @@ public class CollectionConfigurationManager {
         + "</collection>";
 
         final TransactionManager transact = broker.getDatabase().getTransactionManager();
-        final Txn txn = transact.beginTransaction();
-        try {
+        try(final Txn txn = transact.beginTransaction()) {
             Collection collection = null;
             try {
                 collection = broker.openCollection(XmldbURI.ROOT_COLLECTION_URI, Lock.READ_LOCK);
@@ -488,10 +487,7 @@ public class CollectionConfigurationManager {
             transact.commit(txn);
             LOG.info("Configured '" + collection.getURI() + "'");
         } catch (final CollectionConfigurationException e) {
-            transact.abort(txn);
             throw new EXistException(e.getMessage());
-        } finally {
-            transact.close(txn);
         }
     }
 

--- a/src/org/exist/collections/triggers/XQueryStartupTrigger.java
+++ b/src/org/exist/collections/triggers/XQueryStartupTrigger.java
@@ -306,10 +306,8 @@ public class XQueryStartupTrigger implements StartupTrigger {
 
         LOG.info(String.format("Creating %s", AUTOSTART_COLLECTION));
 
-        TransactionManager txnManager = broker.getBrokerPool().getTransactionManager();
-        Txn txn = txnManager.beginTransaction();
-
-        try {
+        final TransactionManager txnManager = broker.getBrokerPool().getTransactionManager();
+        try(final Txn txn = txnManager.beginTransaction()) {
             XmldbURI newCollection = XmldbURI.create(AUTOSTART_COLLECTION, true);
 
             // Create collection
@@ -332,10 +330,6 @@ public class XQueryStartupTrigger implements StartupTrigger {
 
         } catch (Throwable ex) {
             LOG.error(ex);
-            txnManager.abort(txn);
-
-        } finally {
-            txnManager.close(txn);
         }
     }
 

--- a/src/org/exist/security/AbstractRealm.java
+++ b/src/org/exist/security/AbstractRealm.java
@@ -91,9 +91,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
         final XmldbURI realmCollectionURL = SecurityManager.SECURITY_COLLECTION_URI.append(getId());
         
         final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-        final Txn txn = transact.beginTransaction();
-        
-        try {    
+        try(final Txn txn = transact.beginTransaction()) {
             collectionRealm = Utils.getOrCreateCollection(broker, txn, realmCollectionURL);
 
             collectionAccounts = Utils.getOrCreateCollection(broker, txn, realmCollectionURL.append("accounts"));
@@ -104,20 +102,8 @@ public abstract class AbstractRealm implements Realm, Configurable {
 
             transact.commit(txn);
             
-        } catch(final PermissionDeniedException pde) {
-            transact.abort(txn);
-            throw new EXistException(pde);
-        } catch(final IOException ioe) {
-            transact.abort(txn);
-            throw new EXistException(ioe);
-        } catch(final LockException le) {
-            transact.abort(txn);
-            throw new EXistException(le);
-        } catch(final TriggerException te) {
-            transact.abort(txn);
-            throw new EXistException(te);
-        } finally {
-            transact.close(txn);
+        } catch(final PermissionDeniedException | IOException | TriggerException | LockException e) {
+            throw new EXistException(e);
         }
     }
     

--- a/src/org/exist/security/internal/RealmImpl.java
+++ b/src/org/exist/security/internal/RealmImpl.java
@@ -204,19 +204,13 @@ public class RealmImpl extends AbstractRealm {
                     remove_account.setCollection(broker, collectionRemovedAccounts, XmldbURI.create(UUIDGenerator.getUUID()+".xml"));
 
                     final TransactionManager transaction = getDatabase().getTransactionManager();
-                    Txn txn = null;
-                    try {
-                        txn = transaction.beginTransaction();
-
+                    try(final Txn txn = transaction.beginTransaction()) {
                         collectionAccounts.removeXMLResource(txn, broker, XmldbURI.create( remove_account.getName() + ".xml"));
 
                         transaction.commit(txn);
                     } catch(final Exception e) {
-                        transaction.abort(txn);
                         e.printStackTrace();
                         LOG.debug("loading configuration failed: " + e.getMessage());
-                    } finally {
-                        transaction.close(txn);
                     }
 
                     getSecurityManager().addUser(remove_account.getId(), remove_account);
@@ -252,18 +246,13 @@ public class RealmImpl extends AbstractRealm {
                 remove_group.setCollection(broker, collectionRemovedGroups, XmldbURI.create(UUIDGenerator.getUUID() + ".xml"));
 		
                 final TransactionManager transaction = getDatabase().getTransactionManager();
-                Txn txn = null;
-                try {
-                    txn = transaction.beginTransaction();
+                try(final Txn txn = transaction.beginTransaction()) {
 
                     collectionGroups.removeXMLResource(txn, broker, XmldbURI.create(remove_group.getName() + ".xml" ));
 
                     transaction.commit(txn);
                 } catch (final Exception e) {
-                    transaction.abort(txn);
                     LOG.debug(e);
-                } finally {
-                    transaction.close(txn);
                 }
 
                 getSecurityManager().addGroup(remove_group.getId(), (Group)remove_group);

--- a/src/org/exist/security/xacml/XACMLUtil.java
+++ b/src/org/exist/security/xacml/XACMLUtil.java
@@ -239,35 +239,15 @@ public class XACMLUtil implements UpdateListener
 		if(policyCollection == null)
 		{
 			final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-			final Txn txn = transact.beginTransaction();
-			try
-			{
+			try(final Txn txn = transact.beginTransaction()) {
 				policyCollection = broker.getOrCreateCollection(txn, XACMLConstants.POLICY_COLLECTION_URI);
 				broker.saveCollection(txn, policyCollection);
 				transact.commit(txn);
 			}
-			catch (final IOException e) {
-				transact.abort(txn);
+			catch (final IOException | EXistException | PermissionDeniedException | TriggerException e) {
 				LOG.error("Error creating policy collection", e);
 				return null;
-			
-			} catch (final EXistException e) {
-				transact.abort(txn);
-				LOG.error("Error creating policy collection", e);
-				return null;
-			
-			} catch (final PermissionDeniedException e) {
-				transact.abort(txn);
-				LOG.error("Error creating policy collection", e);
-				return null;
-			
-			} catch (final TriggerException e) {
-				transact.abort(txn);
-				LOG.error("Error creating policy collection", e);
-				return null;
-			} finally {
-                transact.close(txn);
-            }
+			}
         }
 		
 		return policyCollection;
@@ -604,23 +584,16 @@ public class XACMLUtil implements UpdateListener
 			{return;}
 		
 		final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-		final Txn txn = transact.beginTransaction();
-		try
-		{
+		try(final Txn txn = transact.beginTransaction()) {
 			final IndexInfo info = collection.validateXMLResource(txn, broker, docName, content);
 			//TODO : unlock the collection here ?
 			collection.store(txn, broker, info, content, false);
 			transact.commit(txn);
-		}
-		catch(final Exception e)
-		{
-			transact.abort(txn);
+		} catch(final Exception e) {
 			if(e instanceof EXistException)
 				{throw (EXistException)e;}
 			throw new EXistException("Error storing policy '" + docPath + "'", e);
-		} finally {
-            transact.close(txn);
-        }
+		}
     }
 
 	/** Reads an <code>InputStream</code> into a string.

--- a/src/org/exist/storage/BrokerPool.java
+++ b/src/org/exist/storage/BrokerPool.java
@@ -1118,8 +1118,7 @@ public class BrokerPool implements Database {
         Collection collection = sysBroker.getCollection(sysCollectionUri);
         if(collection == null) {
             final TransactionManager transact = getTransactionManager();
-            final Txn txn = transact.beginTransaction();
-            try {
+            try(final Txn txn = transact.beginTransaction()) {
                 collection = sysBroker.getOrCreateCollection(txn, sysCollectionUri);
                 if(collection == null) {
                     throw new IOException("Could not create system collection: " + sysCollectionUri);
@@ -1129,13 +1128,10 @@ public class BrokerPool implements Database {
 
                 transact.commit(txn);
             } catch(final Exception e) {
-                transact.abort(txn);
                 e.printStackTrace();
                 final String msg = "Initialisation of system collections failed: " + e.getMessage();
                 LOG.error(msg, e);
                 throw new EXistException(msg, e);
-            } finally {
-                transact.close(txn);
             }
         }
     }

--- a/src/org/exist/storage/txn/TransactionManager.java
+++ b/src/org/exist/storage/txn/TransactionManager.java
@@ -235,7 +235,9 @@ public class TransactionManager {
             return;
         }
         if (txn.getState() == Txn.State.STARTED) {
-            LOG.warn("Transaction was not committed or aborted!", new Throwable());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Transaction was not committed or aborted, auto aborting!");
+            }
             abort(txn);
         }
     }

--- a/src/org/exist/storage/txn/TransactionManager.java
+++ b/src/org/exist/storage/txn/TransactionManager.java
@@ -268,18 +268,23 @@ public class TransactionManager {
      * 
      * @throws TransactionException
      */
-	public void checkpoint(boolean switchFiles) throws TransactionException {
-        if (!enabled)
-            {return;}
+    public void checkpoint(boolean switchFiles) throws TransactionException {
+        if (!enabled) {
+            return;
+        }
         
-		final long txnId = nextTxnId++;
-		journal.checkpoint(txnId, switchFiles);
-	}
+	final long txnId = nextTxnId++;
+	journal.checkpoint(txnId, switchFiles);
+    }
 	
-	public Journal getJournal() {
-		return journal;
-	}
-    
+    public Journal getJournal() {
+	return journal;
+    }
+
+    /**
+     * @Deprecated This mixes concerns and should not be here.
+     */
+    @Deprecated
     public void reindex(DBBroker broker) {
     	final Subject currentUser = broker.getSubject();
     	

--- a/src/org/exist/storage/txn/Txn.java
+++ b/src/org/exist/storage/txn/Txn.java
@@ -1,23 +1,21 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
+ *  Copyright (C) 2001-2015 The eXist Project
  *  http://exist-db.org
- *  
+ *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
  *  as published by the Free Software Foundation; either version 2
  *  of the License, or (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.storage.txn;
 
@@ -128,12 +126,24 @@ public class Txn implements Transaction {
     public void setOriginId(String id) {
         originId = id;
     }
-    
+ 
+    @Override
     public void success() throws TransactionException {
+        commit();
+    }
+
+    @Override
+    public void commit() throws TransactionException {
         tm.commit(this);
     }
-    
+
+    @Override
     public void failure() {
+        abort();
+    }
+ 
+    @Override
+    public void abort() {
         tm.abort(this);
     }
 
@@ -142,3 +152,4 @@ public class Txn implements Transaction {
         tm.close(this);
     }
 }
+

--- a/src/org/exist/xmldb/LocalCollectionManagementService.java
+++ b/src/org/exist/xmldb/LocalCollectionManagementService.java
@@ -99,10 +99,8 @@ public class LocalCollectionManagementService implements CollectionManagementSer
 
     	final Subject preserveSubject = brokerPool.getSubject();
 		final TransactionManager transact = brokerPool.getTransactionManager();
-        final Txn transaction = transact.beginTransaction();
-        DBBroker broker = null;
-        try {
-            broker = brokerPool.get(user);
+        try(final DBBroker broker = brokerPool.get(user);
+            final Txn transaction = transact.beginTransaction()) {
             final org.exist.collections.Collection coll =
                 broker.getOrCreateCollection( transaction, collName );
             if (created != null)
@@ -110,24 +108,18 @@ public class LocalCollectionManagementService implements CollectionManagementSer
             broker.saveCollection(transaction, coll);
             transact.commit(transaction);
         } catch ( final EXistException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to create collection " + collName, e);
         } catch ( final IOException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to create collection " + collName, e);
         } catch ( final PermissionDeniedException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                 "not allowed to create collection", e );
         } catch (final TriggerException e) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                 "not allowed to create collection", e );
 		} finally {
-            transact.close(transaction);
-            brokerPool.release( broker );
             brokerPool.setSubject(preserveSubject);
         }
         return new LocalCollection( user, brokerPool, parent, collName, accessCtx );
@@ -179,11 +171,9 @@ public class LocalCollectionManagementService implements CollectionManagementSer
 
     	final Subject preserveSubject = brokerPool.getSubject();
     	final TransactionManager transact = brokerPool.getTransactionManager();
-        final Txn transaction = transact.beginTransaction();
-        DBBroker broker = null;
         org.exist.collections.Collection collection = null;
-        try {
-            broker = brokerPool.get(user);
+        try(final DBBroker broker = brokerPool.get(user);
+            final Txn transaction = transact.beginTransaction()) {
             collection = broker.openCollection(collName, Lock.WRITE_LOCK);
             if(collection == null) {
                 transact.abort(transaction);
@@ -194,27 +184,21 @@ public class LocalCollectionManagementService implements CollectionManagementSer
             broker.removeCollection(transaction, collection);
             transact.commit(transaction);
         } catch ( final EXistException e ) {
-            transact.abort(transaction);
         	e.printStackTrace();
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to remove collection " + collName, e );
         } catch ( final IOException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to remove collection " + collName, e );
         } catch ( final PermissionDeniedException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                 e.getMessage(), e );
         } catch (final TriggerException e) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to remove collection " + collName, e );
 		} finally {
         	if(collection != null)
         		{collection.release(Lock.WRITE_LOCK);}
-            transact.close(transaction);
-            brokerPool.release( broker );
             brokerPool.setSubject(preserveSubject);
         }
     }
@@ -242,12 +226,10 @@ public class LocalCollectionManagementService implements CollectionManagementSer
 
     	final Subject preserveSubject = brokerPool.getSubject();
         final TransactionManager transact = brokerPool.getTransactionManager();
-        final Txn transaction = transact.beginTransaction();
-        DBBroker broker = null;
         org.exist.collections.Collection collection = null;
         org.exist.collections.Collection destination = null;
-        try {
-            broker = brokerPool.get(user);
+        try(final DBBroker broker = brokerPool.get(user);
+            final Txn transaction = transact.beginTransaction()) {
             collection = broker.openCollection(collectionPath, Lock.WRITE_LOCK);
             if(collection == null) {
                 transact.abort(transaction);
@@ -263,24 +245,19 @@ public class LocalCollectionManagementService implements CollectionManagementSer
             broker.moveCollection(transaction, collection, destination, newName);
             transact.commit(transaction);
         } catch ( final EXistException e ) {
-            transact.abort(transaction);
         	e.printStackTrace();
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move collection " + collectionPath, e );
         } catch ( final IOException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move collection " + collectionPath, e );
         } catch ( final PermissionDeniedException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                 e.getMessage(), e );
         } catch (final LockException e) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                     e.getMessage(), e );
         } catch (final TriggerException e) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move collection " + collectionPath, e );
 		} finally {
@@ -288,8 +265,6 @@ public class LocalCollectionManagementService implements CollectionManagementSer
         		{destination.release(Lock.WRITE_LOCK);}
         	if(collection != null)
         		{collection.release(Lock.WRITE_LOCK);}
-            transact.close(transaction);
-            brokerPool.release( broker );
             brokerPool.setSubject(preserveSubject);
         }
     }
@@ -316,12 +291,10 @@ public class LocalCollectionManagementService implements CollectionManagementSer
 
     	final Subject preserveSubject = brokerPool.getSubject();
         final TransactionManager transact = brokerPool.getTransactionManager();
-        final Txn transaction = transact.beginTransaction();
-        DBBroker broker = null;
         org.exist.collections.Collection destination = null;
         org.exist.collections.Collection source = null;
-        try {
-            broker = brokerPool.get(user);
+        try(final DBBroker broker = brokerPool.get(user);
+            final Txn transaction = transact.beginTransaction()) {
      		source = broker.openCollection(resourcePath.removeLastSegment(), Lock.WRITE_LOCK);
     		if(source == null) {
                 transact.abort(transaction);
@@ -343,24 +316,19 @@ public class LocalCollectionManagementService implements CollectionManagementSer
             broker.moveResource(transaction, doc, destination, newName);
             transact.commit(transaction);
         } catch ( final EXistException e ) {
-            transact.abort(transaction);
         	e.printStackTrace();
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move resource " + resourcePath, e );
         } catch ( final IOException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move resource " + resourcePath, e );
         } catch ( final PermissionDeniedException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                 e.getMessage(), e );
         } catch (final LockException e) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                     e.getMessage(), e );
         } catch (final TriggerException e) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move resource " + resourcePath, e );
 		} finally {
@@ -368,8 +336,6 @@ public class LocalCollectionManagementService implements CollectionManagementSer
         		{source.release(Lock.WRITE_LOCK);}
         	if(destination != null)
         		{destination.release(Lock.WRITE_LOCK);}
-            transact.close(transaction);
-            brokerPool.release( broker );
             brokerPool.setSubject(preserveSubject);
         }
     }
@@ -396,12 +362,10 @@ public class LocalCollectionManagementService implements CollectionManagementSer
 
     	final Subject preserveSubject = brokerPool.getSubject();
         final TransactionManager transact = brokerPool.getTransactionManager();
-        final Txn transaction = transact.beginTransaction();
-        DBBroker broker = null;
         org.exist.collections.Collection collection = null;
         org.exist.collections.Collection destination = null;
-        try {
-            broker = brokerPool.get(user);
+        try(final DBBroker broker = brokerPool.get(user);
+            final Txn transaction = transact.beginTransaction()) {
             collection = broker.openCollection(collectionPath, Lock.READ_LOCK);
             if(collection == null) {
                 transact.abort(transaction);
@@ -418,33 +382,26 @@ public class LocalCollectionManagementService implements CollectionManagementSer
             broker.copyCollection(transaction, collection, destination, newName);
             transact.commit(transaction);
         } catch ( final EXistException e ) {
-            transact.abort(transaction);
         	e.printStackTrace();
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move collection " + collectionPath, e );
         } catch ( final IOException e ) {
-            transact.abort(transaction);
         	e.printStackTrace();
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move collection " + collectionPath, e );
         } catch ( final PermissionDeniedException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                 e.getMessage(), e );
         } catch (final LockException e) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                     e.getMessage(), e );
         } catch (final TriggerException e) {
-            transact.abort(transaction);
         	e.printStackTrace();
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move collection " + collectionPath, e );
 		} finally {
         	if(collection != null) {collection.release(Lock.READ_LOCK);}
         	if(destination != null) {destination.release(Lock.WRITE_LOCK);}
-            transact.close(transaction);
-            brokerPool.release( broker );
             brokerPool.setSubject(preserveSubject);
         }
     }
@@ -473,12 +430,10 @@ public class LocalCollectionManagementService implements CollectionManagementSer
 
     	final Subject preserveSubject = brokerPool.getSubject();
     	final TransactionManager transact = brokerPool.getTransactionManager();
-        final Txn transaction = transact.beginTransaction();
-        DBBroker broker = null;
         org.exist.collections.Collection destination = null;
         org.exist.collections.Collection source = null;
-        try {
-            broker = brokerPool.get(user);
+        try(final DBBroker broker = brokerPool.get(user);
+            final Txn transaction = transact.beginTransaction()) {
      		source = broker.openCollection(resourcePath.removeLastSegment(), Lock.WRITE_LOCK);
     		if(source == null) {
                 transact.abort(transaction);
@@ -500,23 +455,18 @@ public class LocalCollectionManagementService implements CollectionManagementSer
             broker.copyResource(transaction, doc, destination, newName);
             transact.commit(transaction);
         } catch ( final EXistException e ) {
-            transact.abort(transaction);
         	e.printStackTrace();
             throw new XMLDBException( ErrorCodes.VENDOR_ERROR,
                 "failed to move resource " + resourcePath, e );
         } catch ( final PermissionDeniedException e ) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                 e.getMessage(), e );
         } catch (final LockException e) {
-            transact.abort(transaction);
             throw new XMLDBException( ErrorCodes.PERMISSION_DENIED,
                     e.getMessage(), e );
         } finally {
         	if(source != null) {source.release(Lock.WRITE_LOCK);}
         	if(destination != null) {destination.release(Lock.WRITE_LOCK);}
-            transact.close(transaction);
-            brokerPool.release( broker );
             brokerPool.setSubject(preserveSubject);
         }
     }

--- a/src/org/exist/xmldb/LocalIndexQueryService.java
+++ b/src/org/exist/xmldb/LocalIndexQueryService.java
@@ -119,24 +119,18 @@ public class LocalIndexQueryService implements IndexQueryService {
     @Override
 	public void configureCollection(String configData) throws XMLDBException {
     	final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
         final TransactionManager transact = pool.getTransactionManager();
-        final Txn txn = transact.beginTransaction();
-        try {
-            broker = pool.get(user);
+        try(final DBBroker broker = pool.get(user); 
+                final Txn txn = transact.beginTransaction()) {
             final CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(txn, broker, parent.getCollection(), configData);
             transact.commit(txn);
             System.out.println("Configured '" + parent.getCollection().getURI() + "'");
         } catch (final CollectionConfigurationException e) {
-            transact.abort(txn);
 			throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
 		} catch (final EXistException e) {
-            transact.abort(txn);
 			throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
 		} finally {
-            transact.close(txn);
-            pool.release(broker);
 			pool.setSubject(preserveSubject);
         }
 	}

--- a/src/org/exist/xmldb/LocalXMLResource.java
+++ b/src/org/exist/xmldb/LocalXMLResource.java
@@ -573,12 +573,10 @@ public class LocalXMLResource extends AbstractEXistResource implements XMLResour
 	
 	public void setDocType(DocumentType doctype) throws XMLDBException {
 		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
 		DocumentImpl document = null;
 		 final TransactionManager transact = pool.getTransactionManager();
-	        final Txn transaction = transact.beginTransaction();
-		try {
-			broker = pool.get(user);
+        try(final DBBroker broker = pool.get(user);
+            final Txn transaction = transact.beginTransaction()) {
 			document = openDocument(broker, Lock.WRITE_LOCK);
            	
 			if (document == null) {
@@ -596,13 +594,10 @@ public class LocalXMLResource extends AbstractEXistResource implements XMLResour
 
 
 		} catch (final EXistException e) {
-            transact.abort(transaction);
 			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(),
 					e);
 		} finally {
-            transact.close(transaction);
 			closeDocument(document, Lock.WRITE_LOCK);
-			pool.release(broker);
 			pool.setSubject(preserveSubject);
 		}
 }

--- a/test/src/org/exist/backup/SystemExportImportTest.java
+++ b/test/src/org/exist/backup/SystemExportImportTest.java
@@ -24,17 +24,21 @@ package org.exist.backup;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Properties;
 
 import javax.xml.transform.OutputKeys;
 
+import org.exist.EXistException;
 import org.exist.backup.SystemExport;
 import org.exist.backup.SystemImport;
 import org.exist.backup.restore.listener.DefaultRestoreListener;
 import org.exist.backup.restore.listener.RestoreListener;
 import org.exist.collections.Collection;
+import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
 import org.exist.collections.IndexInfo;
+import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -46,11 +50,14 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
 import org.exist.util.Configuration;
 import org.exist.util.ConfigurationHelper;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Database;
+import org.xmldb.api.base.XMLDBException;
 
 /**
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
@@ -173,23 +180,18 @@ public class SystemExportImportTest {
 	}
     
 	//@BeforeClass
-    public static void startDB() {
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-        try {
-            File confFile = ConfigurationHelper.lookup("conf.xml");
-            Configuration config = new Configuration(confFile.getAbsolutePath());
-            BrokerPool.configure(1, 5, config);
-            pool = BrokerPool.getInstance();
-        	assertNotNull(pool);
-        	pool.getPluginsManager().addPlugin("org.exist.storage.md.Plugin");
+    public static void startDB() throws DatabaseConfigurationException, EXistException, PermissionDeniedException, IOException, SAXException, CollectionConfigurationException, LockException, ClassNotFoundException, InstantiationException, XMLDBException, IllegalAccessException {
 
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            transaction = transact.beginTransaction();
+        File confFile = ConfigurationHelper.lookup("conf.xml");
+        Configuration config = new Configuration(confFile.getAbsolutePath());
+        BrokerPool.configure(1, 5, config);
+        pool = BrokerPool.getInstance();
+        assertNotNull(pool);
+        pool.getPluginsManager().addPlugin("org.exist.storage.md.Plugin");
+
+        try (final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
             assertNotNull(transaction);
             System.out.println("Transaction started ...");
 
@@ -200,83 +202,61 @@ public class SystemExportImportTest {
             CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(transaction, broker, root, COLLECTION_CONFIG);
 
-            System.out.println("store "+doc01uri);
+            System.out.println("store " + doc01uri);
             IndexInfo info = root.validateXMLResource(transaction, broker, doc01uri.lastSegment(), XML1);
             assertNotNull(info);
             root.store(transaction, broker, info, XML1, false);
 
-            System.out.println("store "+doc02uri);
+            System.out.println("store " + doc02uri);
             info = root.validateXMLResource(transaction, broker, doc02uri.lastSegment(), XML2);
             assertNotNull(info);
             root.store(transaction, broker, info, XML2, false);
 
-            System.out.println("store "+doc03uri);
+            System.out.println("store " + doc03uri);
             info = root.validateXMLResource(transaction, broker, doc03uri.lastSegment(), XML3);
             assertNotNull(info);
             root.store(transaction, broker, info, XML3, false);
 
-            System.out.println("store "+doc11uri);
+            System.out.println("store " + doc11uri);
             root.addBinaryResource(transaction, broker, doc11uri.lastSegment(), BINARY.getBytes(), null);
 
-            transact.commit(transaction);
-        } catch (Exception e) {
-            e.printStackTrace();
-            transact.abort(transaction);
-            fail(e.getMessage());
-        } finally {
-            if (pool != null)
-                pool.release(broker);
+            pool.getTransactionManager().commit(transaction);
         }
 
         rundb();
     }
 
 
-    private static void rundb() {
-		try {
-			Class cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-			Database database = (Database) cl.newInstance();
-			database.setProperty("create-database", "true");
-			DatabaseManager.registerDatabase(database);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+    private static void rundb() throws ClassNotFoundException, XMLDBException, IllegalAccessException, InstantiationException {
+        Class cl = Class.forName("org.exist.xmldb.DatabaseImpl");
+        Database database = (Database) cl.newInstance();
+        database.setProperty("create-database", "true");
+        DatabaseManager.registerDatabase(database);
     }
     
     //@AfterClass
-    public static void cleanup() {
+    public static void cleanup() throws PermissionDeniedException, IOException, TriggerException, EXistException {
     	clean();
         BrokerPool.stopAll(false);
         pool = null;
         System.out.println("stoped");
     }
 
-    private static void clean() {
+    private static void clean() throws PermissionDeniedException, IOException, TriggerException, EXistException {
     	System.out.println("CLEANING...");
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            transaction = transact.beginTransaction();
-            assertNotNull(transaction);
+        
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
             System.out.println("Transaction started ...");
 
             Collection root = broker.getOrCreateCollection(transaction, col1uri);
             assertNotNull(root);
             broker.removeCollection(transaction, root);
 
-            transact.commit(transaction);
-        } catch (Exception e) {
-        	transact.abort(transaction);
-            e.printStackTrace();
-            fail(e.getMessage());
-        } finally {
-            if (pool != null) pool.release(broker);
+            pool.getTransactionManager().commit(transaction);
         }
+
     	System.out.println("CLEANED.");
     }
 }

--- a/test/src/org/exist/config/TwoDatabasesTest.java
+++ b/test/src/org/exist/config/TwoDatabasesTest.java
@@ -133,19 +133,20 @@ public class TwoDatabasesTest extends TestCase
       throws Exception
    {
       System.out.println("Putting documents.");
-      DBBroker broker1 = pool1.get(user1);
-      Txn transaction1 = pool1.getTransactionManager().beginTransaction();
-      Collection top1 = storeBin(broker1,transaction1,"1");
-      pool1.getTransactionManager().commit(transaction1);
-      top1.release(Lock.READ_LOCK);
-      pool1.release(broker1);
+
+      try(final DBBroker broker1 = pool1.get(user1);
+            final Txn transaction1 = pool1.getTransactionManager().beginTransaction()) {
+          Collection top1 = storeBin(broker1, transaction1, "1");
+          pool1.getTransactionManager().commit(transaction1);
+          top1.release(Lock.READ_LOCK);
+      }
       
-      DBBroker broker2 = pool2.get(user1);
-      Txn transaction2 = pool2.getTransactionManager().beginTransaction();
-      Collection top2 = storeBin(broker2,transaction2,"2");
-      pool2.getTransactionManager().commit(transaction2);
-      top2.release(Lock.READ_LOCK);
-      pool2.release(broker2);
+      try(final DBBroker broker2 = pool2.get(user1);
+            final Txn transaction2 = pool2.getTransactionManager().beginTransaction()) {
+          Collection top2 = storeBin(broker2, transaction2, "2");
+          pool2.getTransactionManager().commit(transaction2);
+          top2.release(Lock.READ_LOCK);
+      }
    }
    
    public void get()

--- a/test/src/org/exist/dom/memtree/DOMIndexerTest.java
+++ b/test/src/org/exist/dom/memtree/DOMIndexerTest.java
@@ -97,16 +97,12 @@ public class DOMIndexerTest {
 
     @Test
     public void store() throws PermissionDeniedException, IOException, EXistException, SAXException, LockException, AuthenticationException {
-    	BrokerPool pool = null;
-    	DBBroker broker = null;
-        TransactionManager txnMgr = null;
-        Txn txn = null;
-    	try {
-            pool = BrokerPool.getInstance();
-            txnMgr = pool.getTransactionManager();
-            txn = txnMgr.beginTransaction();
-            Subject admin = pool.getSecurityManager().authenticate("admin", "");
-            broker = pool.get(admin);
+    	final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager txnMgr = pool.getTransactionManager();
+
+    	try(final DBBroker broker = pool.get(pool.getSecurityManager().authenticate("admin", ""));
+                final Txn txn = txnMgr.beginTransaction()) {
+
             Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
             IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, XML);
             //TODO : unlock the collection here ?
@@ -116,13 +112,6 @@ public class DOMIndexerTest {
             broker.flush();
             broker.saveCollection(txn, collection);
             txnMgr.commit(txn);
-        } finally {
-            if(txn != null) {
-                txn.close();
-            }
-            if (pool != null) {
-                pool.release(broker);
-            }
         }
     }
 

--- a/test/src/org/exist/numbering/DLNStorageTest.java
+++ b/test/src/org/exist/numbering/DLNStorageTest.java
@@ -106,14 +106,9 @@ public class DLNStorageTest extends TestCase {
         }
 
         BrokerPool pool = BrokerPool.getInstance();
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;       
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            transact = pool.getTransactionManager();
-            transaction = transact.beginTransaction();
-            System.out.println("Transaction started ...");
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+            final Txn transaction = transact.beginTransaction()) {
 
             Collection test = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
             broker.saveCollection(transaction, test);
@@ -128,10 +123,7 @@ public class DLNStorageTest extends TestCase {
             transact.commit(transaction);
             System.out.println("Transaction commited ...");
         } catch (Exception e) {
-        	transact.abort(transaction);
             fail(e.getMessage());
-        } finally {
-            pool.release(broker);
         }
     }
 

--- a/test/src/org/exist/storage/AbstractUpdateTest.java
+++ b/test/src/org/exist/storage/AbstractUpdateTest.java
@@ -87,11 +87,7 @@ public abstract class AbstractUpdateTest {
 
     protected IndexInfo init(DBBroker broker, TransactionManager mgr) {
     	IndexInfo info = null;
-    	Txn transaction = null;
-    	try {
-    		
-    		transaction = mgr.beginTransaction();        
-        	System.out.println("Transaction started ...");
+    	try(final Txn transaction = mgr.beginTransaction()) {
 	        
 	        Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
 	        broker.saveCollection(transaction, root);
@@ -107,7 +103,6 @@ public abstract class AbstractUpdateTest {
 	        System.out.println("Transaction commited ...");
 	        
 	    } catch (Exception e) {
-	    	mgr.abort(transaction);
 	        fail(e.getMessage());
 	    }  
 	    return info;

--- a/test/src/org/exist/storage/AppendTest.java
+++ b/test/src/org/exist/storage/AppendTest.java
@@ -40,53 +40,49 @@ public class AppendTest extends AbstractUpdateTest {
     @Test
     public void update() {
         BrokerPool.FORCE_CORRUPTION = true;
-        BrokerPool pool = null;       
-        DBBroker broker = null;
+
+        final BrokerPool pool = startDB();
+        final TransactionManager mgr = pool.getTransactionManager();
         
-        try {
-        	pool = startDB();
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            
-            TransactionManager mgr = pool.getTransactionManager();
-            
-            IndexInfo info = init(broker, mgr);
-            MutableDocumentSet docs = new DefaultDocumentSet();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
+
+            final IndexInfo info = init(broker, mgr);
+            final MutableDocumentSet docs = new DefaultDocumentSet();
             docs.add(info.getDocument());
-            XUpdateProcessor proc = new XUpdateProcessor(broker, docs, AccessContext.TEST);
-            
-            Txn transaction = mgr.beginTransaction();
-            
-            String xupdate;
-            Modification modifications[];
-            
-            // append some new element to records
-            for (int i = 1; i <= 50; i++) {
-                xupdate =
-                    "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
-                    "   <xu:append select=\"/products\">" +
-                    "       <product>" +
-                    "           <xu:attribute name=\"id\"><xu:value-of select=\"count(/products/product) + 1\"/></xu:attribute>" +
-                    "           <description>Product " + i + "</description>" +
-                    "           <price>" + (i * 2.5) + "</price>" +
-                    "           <stock>" + (i * 10) + "</stock>" +
-                    "       </product>" +
-                    "   </xu:append>" +
-                    "</xu:modifications>";
-                proc.setBroker(broker);
-                proc.setDocumentSet(docs);
-                modifications = proc.parse(new InputSource(new StringReader(xupdate)));
-                modifications[0].process(transaction);
-                proc.reset();
+            final XUpdateProcessor proc = new XUpdateProcessor(broker, docs, AccessContext.TEST);
+
+            try(final Txn transaction = mgr.beginTransaction()) {
+
+                // append some new element to records
+                for (int i = 1; i <= 50; i++) {
+                    final String xupdate =
+                            "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
+                                    "   <xu:append select=\"/products\">" +
+                                    "       <product>" +
+                                    "           <xu:attribute name=\"id\"><xu:value-of select=\"count(/products/product) + 1\"/></xu:attribute>" +
+                                    "           <description>Product " + i + "</description>" +
+                                    "           <price>" + (i * 2.5) + "</price>" +
+                                    "           <stock>" + (i * 10) + "</stock>" +
+                                    "       </product>" +
+                                    "   </xu:append>" +
+                                    "</xu:modifications>";
+                    proc.setBroker(broker);
+                    proc.setDocumentSet(docs);
+                    final Modification modifications[] = proc.parse(new InputSource(new StringReader(xupdate)));
+                    modifications[0].process(transaction);
+                    proc.reset();
+                }
+
+                mgr.commit(transaction);
             }
-            
-            mgr.commit(transaction);
-            
+
+
             // the following transaction will not be committed and thus undone during recovery
-            transaction = mgr.beginTransaction();
+            final Txn transaction = mgr.beginTransaction();
             
             // append new element
             for (int i = 1; i <= 50; i++) {
-                xupdate =
+                final String xupdate =
                     "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
                     "   <xu:append select=\"/products/product[" + i + "]\">" +
                     "       <date><xu:value-of select=\"current-dateTime()\"/></date>" +
@@ -94,15 +90,13 @@ public class AppendTest extends AbstractUpdateTest {
                     "</xu:modifications>";
                 proc.setBroker(broker);
                 proc.setDocumentSet(docs);
-                modifications = proc.parse(new InputSource(new StringReader(xupdate)));
+                final Modification modifications[] = proc.parse(new InputSource(new StringReader(xupdate)));
                 modifications[0].process(transaction);
                 proc.reset();
             }
             pool.getTransactionManager().getJournal().flushToLog(true);
         } catch (Exception e) {            
             fail(e.getMessage());            
-        } finally {
-            if (pool != null) pool.release(broker);
         }
     }
 

--- a/test/src/org/exist/storage/CollectionTest.java
+++ b/test/src/org/exist/storage/CollectionTest.java
@@ -67,16 +67,10 @@ public class CollectionTest {
     private void store() {
         BrokerPool.FORCE_CORRUPTION = true;
         BrokerPool pool = startDB();
-        DBBroker broker = null;
-        Txn transaction = null;
-        TransactionManager transact = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());            
-            transact = pool.getTransactionManager();
-            
-            transaction = transact.beginTransaction();            
-            System.out.println("Transaction started ...");
-            
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
+
             Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
             broker.saveCollection(transaction, root);
             
@@ -84,12 +78,8 @@ public class CollectionTest {
             broker.saveCollection(transaction, test);
             
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         } catch (Exception e) {
-        	transact.abort(transaction);
             fail(e.getMessage());              
-        } finally {
-            pool.release(broker);
         }
     }
     

--- a/test/src/org/exist/storage/ConcurrentStoreTest.java
+++ b/test/src/org/exist/storage/ConcurrentStoreTest.java
@@ -98,13 +98,9 @@ public class ConcurrentStoreTest extends TestCase {
     }
     
     protected void setupCollections() {
-        DBBroker broker = null;
-        TransactionManager transact = pool.getTransactionManager();
-        Txn transaction = transact.beginTransaction();
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            
-            System.out.println("Transaction started ...");
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction();) {
             
             Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
             broker.saveCollection(transaction, root);
@@ -117,16 +113,13 @@ public class ConcurrentStoreTest extends TestCase {
             
             transact.commit(transaction);
         } catch (Exception e) {
-            transact.abort(transaction);            
             fail(e.getMessage());
-        } finally {
-            pool.release(broker);
         }
     }
     
     protected BrokerPool startDB() {
         try {
-            Configuration config = new Configuration();
+            final Configuration config = new Configuration();
             BrokerPool.configure(1, 5, config);
             return BrokerPool.getInstance();
         } catch (Exception e) {            
@@ -142,12 +135,9 @@ public class ConcurrentStoreTest extends TestCase {
     class StoreThread1 extends Thread {
         
         public void run() {
-            DBBroker broker = null;
-            try {
-                broker = pool.get(pool.getSecurityManager().getSystemSubject());
-                
-                TransactionManager transact = pool.getTransactionManager();
-                Txn transaction = transact.beginTransaction();
+            final TransactionManager transact = pool.getTransactionManager();
+            try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                    final Txn transaction = transact.beginTransaction()) {
                 
                 System.out.println("Transaction started ...");
                 XMLFilenameFilter filter = new XMLFilenameFilter();
@@ -177,22 +167,15 @@ public class ConcurrentStoreTest extends TestCase {
                 System.out.println("Transaction interrupted ...");
     	    } catch (Exception e) {            
     	        fail(e.getMessage()); 
-            } finally {
-                pool.release(broker);
             }
         }
     }
     
     class StoreThread2 extends Thread {
         public void run() {
-            DBBroker broker = null;
-            try {
-                broker = pool.get(pool.getSecurityManager().getSystemSubject());
-                
-                TransactionManager transact = pool.getTransactionManager();
-                Txn transaction = transact.beginTransaction();
-                
-                System.out.println("Transaction started ...");
+            final TransactionManager transact = pool.getTransactionManager();
+            try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                    final Txn transaction = transact.beginTransaction()) {
                 
                 Iterator<DocumentImpl> i = test.iterator(broker);
                 DocumentImpl doc = i.next();
@@ -212,8 +195,6 @@ public class ConcurrentStoreTest extends TestCase {
             } catch (Exception e) {
                 e.printStackTrace();
                 fail(e.getMessage());
-            } finally {
-                pool.release(broker);
             }
         }
     }

--- a/test/src/org/exist/storage/MoveResourceTest.java
+++ b/test/src/org/exist/storage/MoveResourceTest.java
@@ -22,16 +22,20 @@
 package org.exist.storage;
 
 import java.io.File;
+import java.io.IOException;
 
+import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
+import org.exist.security.PermissionDeniedException;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
 import org.exist.util.Configuration;
+import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xmldb.CollectionManagementServiceImpl;
 import org.junit.After;
@@ -39,6 +43,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Database;
 import org.xmldb.api.base.Resource;
@@ -47,100 +52,79 @@ import org.xmldb.api.base.XMLDBException;
 public class MoveResourceTest {
 
     @Test
-    public void store() {
+    public void store() throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
         doStore();
         tearDown();
         doRead();
     }
 
-	private void doStore() {
-		BrokerPool.FORCE_CORRUPTION = true;
-		BrokerPool pool = null;
-		DBBroker broker = null;
-		try {
-			pool = startDB();
-			assertNotNull(pool);
-			broker = pool.get(pool.getSecurityManager().getSystemSubject());
-			assertNotNull(broker);
-			TransactionManager transact = pool.getTransactionManager();
-			assertNotNull(transact);
-			Txn transaction = transact.beginTransaction();
-			assertNotNull(transaction);
-			System.out.println("Transaction started ...");
+    private void doStore() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
+        BrokerPool.FORCE_CORRUPTION = true;
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
 
-			Collection root = broker.getOrCreateCollection(transaction,	TestConstants.TEST_COLLECTION_URI);
-			assertNotNull(root);
-			broker.saveCollection(transaction, root);
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
 
-			Collection test2 = broker.getOrCreateCollection(transaction,TestConstants.TEST_COLLECTION_URI2);
-			assertNotNull(test2);
-			broker.saveCollection(transaction, test2);
-
-            String existHome = System.getProperty("exist.home");
-            File existDir = existHome==null ? new File(".") : new File(existHome);
-			File f = new File(existDir,"samples/shakespeare/r_and_j.xml");
-			assertNotNull(f);
-			IndexInfo info = test2.validateXMLResource(transaction, broker, TestConstants.TEST_XML_URI, new InputSource(f.toURI().toASCIIString()));
-			assertNotNull(info);
-			test2.store(transaction, broker, info, new InputSource(f.toURI().toASCIIString()), false);
-
-            System.out.println("Moving document test.xml to new_test.xml ...");
-			broker.moveResource(transaction, info.getDocument(), root, XmldbURI.create("new_test.xml"));
-			broker.saveCollection(transaction, root);
-
-			transact.commit(transaction);
-			System.out.println("Transaction commited ...");
-		} catch (Exception e) {
-            e.printStackTrace();
-	        fail(e.getMessage());
-		} finally {
-			pool.release(broker);
-		}
-	}
-
-	private void doRead() {
-	    BrokerPool.FORCE_CORRUPTION = false;
-	    BrokerPool pool = null;
-	    DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-	    try {
-	    	System.out.println("testRead() ...\n");
-	    	pool = startDB();
-	    	assertNotNull(pool);
-	        broker = pool.get(pool.getSecurityManager().getSystemSubject());
-	        assertNotNull(broker);
-	        Serializer serializer = broker.getSerializer();
-	        serializer.reset();
-
-	        DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test/new_test.xml"), Lock.READ_LOCK);
-	        assertNotNull("Document should not be null", doc);
-	        String data = serializer.serialize(doc);
-	        assertNotNull(data);
-//	        System.out.println(data);
-	        doc.getUpdateLock().release(Lock.READ_LOCK);
-
-            transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            transaction = transact.beginTransaction();
-            assertNotNull(transaction);
             System.out.println("Transaction started ...");
 
-            Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
-            assertNotNull(root);
-            transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
-            broker.removeCollection(transaction, root);
+            final Collection test = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
+            assertNotNull(test);
+            broker.saveCollection(transaction, test);
+
+            final Collection test2 = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI2);
+            assertNotNull(test2);
+            broker.saveCollection(transaction, test2);
+
+            final String existHome = System.getProperty("exist.home");
+            final File existDir = existHome==null ? new File(".") : new File(existHome);
+            final File f = new File(existDir,"samples/shakespeare/r_and_j.xml");
+
+            final IndexInfo info = test2.validateXMLResource(transaction, broker, TestConstants.TEST_XML_URI, new InputSource(f.toURI().toASCIIString()));
+            assertNotNull(info);
+            test2.store(transaction, broker, info, new InputSource(f.toURI().toASCIIString()), false);
+
+            System.out.println("Moving document /db/test2/test.xml to /db/test/new_test.xml ...");
+            final DocumentImpl doc = test2.getDocument(broker, TestConstants.TEST_XML_URI);
+            assertNotNull(doc);
+            broker.moveResource(transaction, doc, test, XmldbURI.create("new_test.xml"));
+            broker.saveCollection(transaction, test);
 
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
-	    } catch (Exception e) {
-            transact.abort(transaction);
-            e.printStackTrace();
-	        fail(e.getMessage());
-	    } finally {
-	        pool.release(broker);
-	    }
-	}
+            System.out.println("Transaction committed ...");
+        }
+    }
+
+    private void doRead() throws EXistException, PermissionDeniedException, SAXException, IOException {
+        System.out.println("testRead() ...\n");
+
+        BrokerPool.FORCE_CORRUPTION = false;
+        final BrokerPool pool = startDB();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
+            final Serializer serializer = broker.getSerializer();
+            serializer.reset();
+
+            final DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test/new_test.xml"), Lock.READ_LOCK);
+            assertNotNull("Document should not be null", doc);
+            final String data = serializer.serialize(doc);
+            assertNotNull(data);
+            doc.getUpdateLock().release(Lock.READ_LOCK);
+
+            final TransactionManager transact = pool.getTransactionManager();
+            try(final Txn transaction = transact.beginTransaction()) {
+                System.out.println("Transaction started ...");
+
+                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
+                assertNotNull(root);
+                transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
+                broker.removeCollection(transaction, root);
+
+                transact.commit(transaction);
+                System.out.println("Transaction commited ...");
+            }
+        }
+    }
 
     @Test
     public void aborted() throws Exception {
@@ -149,93 +133,82 @@ public class MoveResourceTest {
         readAborted();
     }
 
-	private void storeAborted() throws Exception {
-		BrokerPool.FORCE_CORRUPTION = true;
-		BrokerPool pool = startDB();
+    private void storeAborted() throws Exception {
+        BrokerPool.FORCE_CORRUPTION = true;
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
 
-		DBBroker broker = null;
-		try {
-			broker = pool.get(pool.getSecurityManager().getSystemSubject());
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-			TransactionManager transact = pool.getTransactionManager();
-			Txn transaction = transact.beginTransaction();
+            try(final Txn transaction = transact.beginTransaction()) {
 
-			System.out.println("Transaction started ...");
+                System.out.println("Transaction started ...");
 
-			Collection root = broker.getOrCreateCollection(transaction,	TestConstants.TEST_COLLECTION_URI);
-			assertNotNull(root);
-			broker.saveCollection(transaction, root);
+                final Collection test2 = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI2);
+                assertNotNull(test2);
+                broker.saveCollection(transaction, test2);
 
-			Collection test2 = broker.getOrCreateCollection(transaction,TestConstants.TEST_COLLECTION_URI2);
-			assertNotNull(test2);
-			broker.saveCollection(transaction, test2);
+                final String existHome = System.getProperty("exist.home");
+                final File existDir = existHome == null ? new File(".") : new File(existHome);
+                final File f = new File(existDir, "samples/shakespeare/r_and_j.xml");
 
-            String existHome = System.getProperty("exist.home");
-            File existDir = existHome==null ? new File(".") : new File(existHome);
-			File f = new File(existDir,"samples/shakespeare/r_and_j.xml");
-			assertNotNull(f);
-            IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create("new_test2.xml"),
-					new InputSource(f.toURI().toASCIIString()));
-			test2.store(transaction, broker, info, new InputSource(f.toURI()
-					.toASCIIString()), false);
+                final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create("new_test2.xml"),
+                        new InputSource(f.toURI().toASCIIString()));
+                test2.store(transaction, broker, info, new InputSource(f.toURI()
+                        .toASCIIString()), false);
 
-			transact.commit(transaction);
+                transact.commit(transaction);
+            }
 
-			transaction = transact.beginTransaction();
+            final Txn transaction = transact.beginTransaction();
 
-			broker.moveResource(transaction, info.getDocument(), root,
-					XmldbURI.create("new_test2.xml"));
-			broker.saveCollection(transaction, root);
+            System.out.println("Moving document /db/test2/new_test2.xml to /db/test/new_test2.xml ...");
+            final Collection test2 = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI2);
+            final DocumentImpl doc = test2.getDocument(broker, XmldbURI.create("new_test2.xml"));
+            assertNotNull(doc);
+            final Collection test = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
+            broker.moveResource(transaction, doc, test, XmldbURI.create("new_test2.xml"));
 
-			pool.getTransactionManager().getJournal().flushToLog(true);
-		} finally {
-			pool.release(broker);
-		}
-	}
+            broker.saveCollection(transaction, test);
 
-    private void readAborted() {
-	    BrokerPool.FORCE_CORRUPTION = false;
-	    BrokerPool pool = null;
-	    DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-	    try {
-	    	System.out.println("testRead() ...\n");
-	    	pool = startDB();
-	    	assertNotNull(pool);
-	        broker = pool.get(pool.getSecurityManager().getSystemSubject());
-	        assertNotNull(broker);
-	        Serializer serializer = broker.getSerializer();
-	        serializer.reset();
+            //NOTE: do not commit the transaction
 
-	        DocumentImpl doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append("new_test2.xml"), Lock.READ_LOCK);
-	        assertNotNull("Document should not be null", doc);
-	        String data = serializer.serialize(doc);
-	        assertNotNull(data);
+            pool.getTransactionManager().getJournal().flushToLog(true);
+        }
+    }
+
+    private void readAborted() throws EXistException, PermissionDeniedException, SAXException, IOException {
+        System.out.println("testRead() ...\n");
+
+        BrokerPool.FORCE_CORRUPTION = false;
+        final BrokerPool pool = startDB();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
+            final Serializer serializer = broker.getSerializer();
+            serializer.reset();
+
+            final DocumentImpl doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append("new_test2.xml"), Lock.READ_LOCK);
+            assertNotNull("Document should not be null", doc);
+            final String data = serializer.serialize(doc);
+            assertNotNull(data);
 //	        System.out.println(data);
-	        doc.getUpdateLock().release(Lock.READ_LOCK);
+            doc.getUpdateLock().release(Lock.READ_LOCK);
 
-            transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            transaction = transact.beginTransaction();
-            assertNotNull(transaction);
-            System.out.println("Transaction started ...");
+            final TransactionManager transact = pool.getTransactionManager();
+            try(final Txn transaction = transact.beginTransaction()) {
 
-            Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
-            assertNotNull(root);
-            transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
-            broker.removeCollection(transaction, root);
+                System.out.println("Transaction started ...");
 
-            transact.commit(transaction);
-            System.out.println("Transaction commited ...");
-	    } catch (Exception e) {
-            transact.abort(transaction);
-            e.printStackTrace();
-	        fail(e.getMessage());
-	    } finally {
-	        pool.release(broker);
-	    }
-	}
+                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
+                assertNotNull(root);
+                transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
+                broker.removeCollection(transaction, root);
+
+                transact.commit(transaction);
+                System.out.println("Transaction committed ...");
+            }
+        }
+    }
 
     @Test
     public void xmldbStore() throws XMLDBException {
@@ -244,70 +217,73 @@ public class MoveResourceTest {
         doXmldbRead();
     }
 
-	private void doXmldbStore() throws XMLDBException {
-		BrokerPool.FORCE_CORRUPTION = true;
-	    @SuppressWarnings("unused")
-		BrokerPool pool = startDB();
+    private void doXmldbStore() throws XMLDBException {
+        BrokerPool.FORCE_CORRUPTION = true;
+        @SuppressWarnings("unused")
+        final BrokerPool pool = startDB();
 
-	    org.xmldb.api.base.Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-	    CollectionManagementServiceImpl mgr = (CollectionManagementServiceImpl)
-	    	root.getService("CollectionManagementService", "1.0");
-	    org.xmldb.api.base.Collection test = root.getChildCollection("test");
-	    if (test == null)
-	    	test = mgr.createCollection("test");
-	    org.xmldb.api.base.Collection test2 = test.getChildCollection("test2");
-	    if (test2 == null)
-	    	test2 = mgr.createCollection("test2");
+        final org.xmldb.api.base.Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
+        final CollectionManagementServiceImpl mgr = (CollectionManagementServiceImpl)
+                root.getService("CollectionManagementService", "1.0");
 
-	    String existHome = System.getProperty("exist.home");
-        File existDir = existHome==null ? new File(".") : new File(existHome);
-        File f = new File(existDir,"samples/shakespeare/r_and_j.xml");
-        assertNotNull(f);
-	    Resource res = test2.createResource("test3.xml", "XMLResource");
-	    res.setContent(f);
-	    test2.storeResource(res);
+        org.xmldb.api.base.Collection test = root.getChildCollection("test");
+        if (test == null) {
+            test = mgr.createCollection("test");
+        }
 
-	    mgr.moveResource(XmldbURI.create(XmldbURI.ROOT_COLLECTION +  "/test2/test3.xml"),
+        org.xmldb.api.base.Collection test2 = test.getChildCollection("test2");
+        if (test2 == null) {
+            test2 = mgr.createCollection("test2");
+        }
+
+        final String existHome = System.getProperty("exist.home");
+        final File existDir = existHome==null ? new File(".") : new File(existHome);
+        final File f = new File(existDir,"samples/shakespeare/r_and_j.xml");
+
+        final Resource res = test2.createResource("test3.xml", "XMLResource");
+        res.setContent(f);
+        test2.storeResource(res);
+
+        mgr.moveResource(XmldbURI.create(XmldbURI.ROOT_COLLECTION +  "/test2/test3.xml"),
                 TestConstants.TEST_COLLECTION_URI, XmldbURI.create("new_test3.xml"));
-	}
+    }
 
-	private void doXmldbRead() throws XMLDBException {
-		BrokerPool.FORCE_CORRUPTION = false;
-	    @SuppressWarnings("unused")
-		BrokerPool pool = startDB();
+    private void doXmldbRead() throws XMLDBException {
+        BrokerPool.FORCE_CORRUPTION = false;
+        @SuppressWarnings("unused")
+        final BrokerPool pool = startDB();
 
-	    org.xmldb.api.base.Collection test = DatabaseManager.getCollection(XmldbURI.LOCAL_DB +  "/test", "admin", "");
-	    Resource res = test.getResource("new_test3.xml");
-	    assertNotNull("Document should not be null", res);
-	    System.out.println(res.getContent());
+        final org.xmldb.api.base.Collection test = DatabaseManager.getCollection(XmldbURI.LOCAL_DB +  "/test", "admin", "");
+        final Resource res = test.getResource("new_test3.xml");
+        assertNotNull("Document should not be null", res);
 
-        org.xmldb.api.base.Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-	    CollectionManagementServiceImpl mgr = (CollectionManagementServiceImpl)
-	    	root.getService("CollectionManagementService", "1.0");
+        final org.xmldb.api.base.Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
+        final CollectionManagementServiceImpl mgr = (CollectionManagementServiceImpl)
+                root.getService("CollectionManagementService", "1.0");
         mgr.removeCollection(XmldbURI.create("test"));
         mgr.removeCollection(XmldbURI.create("test2"));
     }
-	
-	protected BrokerPool startDB() {
-		try {
-			Configuration config = new Configuration();
-			BrokerPool.configure(1, 5, config);
-			
-			// initialize driver
-			Database database = (Database) Class.forName("org.exist.xmldb.DatabaseImpl").newInstance();
-			database.setProperty("create-database", "true");
-			DatabaseManager.registerDatabase(database);
 
-			return BrokerPool.getInstance();
-		} catch (Exception e) {
+    protected BrokerPool startDB() {
+        try {
+            final Configuration config = new Configuration();
+            BrokerPool.configure(1, 5, config);
+
+            // initialize driver
+            final Database database = (Database) Class.forName("org.exist.xmldb.DatabaseImpl").newInstance();
+            database.setProperty("create-database", "true");
+            DatabaseManager.registerDatabase(database);
+
+            return BrokerPool.getInstance();
+        } catch (Exception e) {
             e.printStackTrace();
-			fail(e.getMessage());
-		}
-		return null;
-	}
+            fail(e.getMessage());
+        }
+        return null;
+    }
 
     @After
-	public void tearDown() {
-		BrokerPool.stopAll(false);
-	}
+    public void tearDown() {
+        BrokerPool.stopAll(false);
+    }
 }

--- a/test/src/org/exist/storage/RecoverBinaryTest.java
+++ b/test/src/org/exist/storage/RecoverBinaryTest.java
@@ -57,17 +57,14 @@ public class RecoverBinaryTest {
     }
 
     private void store() {
+        System.out.println("store() ...\n");
+
     	BrokerPool.FORCE_CORRUPTION = true;
-        DBBroker broker = null;
-        try {
-            System.out.println("store() ...\n");
-        	assertNotNull(pool);
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            TransactionManager transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            Txn transaction = transact.beginTransaction();
-            assertNotNull(transaction);
+
+        final TransactionManager transact = pool.getTransactionManager();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
             System.out.println("Transaction started ...");
             
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
@@ -99,8 +96,6 @@ public class RecoverBinaryTest {
             transact.getJournal().flushToLog(true);
 		} catch (Exception e) {            
 	        fail(e.getMessage());             
-        } finally {
-            if (pool != null) pool.release(broker);
         }
     }
     

--- a/test/src/org/exist/storage/RecoverBinaryTest2.java
+++ b/test/src/org/exist/storage/RecoverBinaryTest2.java
@@ -62,17 +62,12 @@ public class RecoverBinaryTest2 {
     //@Test
     public void store() {
         BrokerPool.FORCE_CORRUPTION = true;
-        BrokerPool pool = null;        
-        DBBroker broker = null;
-        try {
-            pool = startDB();
-            assertNotNull(pool);
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);            
-            TransactionManager transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            Txn transaction = transact.beginTransaction();
-            assertNotNull(transaction);            
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
+
             System.out.println("Transaction started ...");
             
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
@@ -89,23 +84,17 @@ public class RecoverBinaryTest2 {
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());             
-        } finally {
-            pool.release(broker);
         }
     }
 
     //@Test
     public void read() {
-        BrokerPool.FORCE_CORRUPTION = false;
-        BrokerPool pool = null;
-        DBBroker broker = null;
-        try {
-            System.out.println("testRead2() ...\n");
-            pool = startDB();
-            assertNotNull(pool);        
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+        System.out.println("testRead2() ...\n");
 
+        BrokerPool.FORCE_CORRUPTION = false;
+        final BrokerPool pool = startDB();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
             Collection test2 = broker.getCollection(TestConstants.TEST_COLLECTION_URI2);
             for (Iterator<DocumentImpl> i = test2.iterator(broker); i.hasNext(); ) {
                 DocumentImpl doc = i.next();
@@ -113,36 +102,31 @@ public class RecoverBinaryTest2 {
             }
             
             BrokerPool.FORCE_CORRUPTION = true;
-            TransactionManager transact = pool.getTransactionManager();
+            final TransactionManager transact = pool.getTransactionManager();
             assertNotNull(transact);
-            Txn transaction = transact.beginTransaction();
-            assertNotNull(transaction);            
-            System.out.println("Transaction started ...");
-            
-            storeFiles(broker, transaction, test2);
-            transact.commit(transaction);
-            System.out.println("Transaction commited ...");
+            try(final Txn transaction = transact.beginTransaction()) {
+                assertNotNull(transaction);
+                System.out.println("Transaction started ...");
+
+                storeFiles(broker, transaction, test2);
+                transact.commit(transaction);
+                System.out.println("Transaction commited ...");
+            }
             
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());              
-        } finally {
-            if (pool != null)
-                pool.release(broker);
         }
     }
 
     //@Test
     public void read2() {
+        System.out.println("testRead2() ...\n");
+
         BrokerPool.FORCE_CORRUPTION = false;
-        BrokerPool pool = null;
-        DBBroker broker = null;
-        try {
-            System.out.println("testRead2() ...\n");
-            pool = startDB();
-            assertNotNull(pool);        
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
+        final BrokerPool pool = startDB();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection test2 = broker.getCollection(TestConstants.TEST_COLLECTION_URI2);
             for (Iterator<DocumentImpl> i = test2.iterator(broker); i.hasNext(); ) {
@@ -150,21 +134,19 @@ public class RecoverBinaryTest2 {
                 System.out.println(doc.getURI().toString());
             }
             
-            TransactionManager transact = pool.getTransactionManager();
+            final TransactionManager transact = pool.getTransactionManager();
             assertNotNull(transact);
-            Txn transaction = transact.beginTransaction();
-            assertNotNull(transaction);
-            System.out.println("Transaction started ...");
-            Collection test1 = broker.getCollection(TestConstants.TEST_COLLECTION_URI);
-            broker.removeCollection(transaction, test1);
-            transact.commit(transaction);
-            System.out.println("Transaction commited ...");
+            try(final Txn transaction = transact.beginTransaction()) {
+                assertNotNull(transaction);
+                System.out.println("Transaction started ...");
+                Collection test1 = broker.getCollection(TestConstants.TEST_COLLECTION_URI);
+                broker.removeCollection(transaction, test1);
+                transact.commit(transaction);
+                System.out.println("Transaction commited ...");
+            }
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());              
-        } finally {
-            if (pool != null)
-                pool.release(broker);
         }
     }
     

--- a/test/src/org/exist/storage/RecoveryTest2.java
+++ b/test/src/org/exist/storage/RecoveryTest2.java
@@ -65,17 +65,12 @@ public class RecoveryTest2 extends TestCase {
     
     public void testStore() {
         BrokerPool.FORCE_CORRUPTION = true;
-        BrokerPool pool = null;        
-        DBBroker broker = null;
-        try {
-        	pool = startDB();
-        	assertNotNull(pool);
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);            
-            TransactionManager transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            Txn transaction = transact.beginTransaction();
-            assertNotNull(transaction);            
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction();) {
+
             System.out.println("Transaction started ...");
             
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
@@ -114,8 +109,6 @@ public class RecoveryTest2 extends TestCase {
             
 	    } catch (Exception e) {            
 	        fail(e.getMessage());          
-        } finally {
-        	if (pool != null) pool.release(broker);
         }
     }
     

--- a/test/src/org/exist/storage/RemoveRootCollectionTest.java
+++ b/test/src/org/exist/storage/RemoveRootCollectionTest.java
@@ -20,27 +20,30 @@ public class RemoveRootCollectionTest {
 	Collection root;
 	
 	@Test public void removeEmptyRootCollection() throws Exception {
-		Txn transaction = transact.beginTransaction();
-		broker.removeCollection(transaction, root);
-		transact.commit(transaction);
+		try(final Txn transaction = transact.beginTransaction()) {
+            broker.removeCollection(transaction, root);
+            transact.commit(transaction);
+        }
 		assertEquals(0, root.getChildCollectionCount(broker));
 		assertEquals(0, root.getDocumentCount(broker));
 	}
 
 	@Test public void removeRootCollectionWithChildCollection() throws Exception {
 		addChildToRoot();
-		Txn transaction = transact.beginTransaction();
-		broker.removeCollection(transaction, root);
-		transact.commit(transaction);
+		try(final Txn transaction = transact.beginTransaction()) {
+            broker.removeCollection(transaction, root);
+            transact.commit(transaction);
+        }
 		assertEquals(0, root.getChildCollectionCount(broker));
 		assertEquals(0, root.getDocumentCount(broker));
 	}
 
 	@Ignore @Test public void removeRootCollectionWithDocument() throws Exception {
 		addDocumentToRoot();
-		Txn transaction = transact.beginTransaction();
-		broker.removeCollection(transaction, root);
-		transact.commit(transaction);
+		try(final Txn transaction = transact.beginTransaction()) {
+            broker.removeCollection(transaction, root);
+            transact.commit(transaction);
+        }
 		assertEquals(0, root.getChildCollectionCount(broker));
 		assertEquals(0, root.getDocumentCount(broker));
 	}
@@ -61,19 +64,21 @@ public class RemoveRootCollectionTest {
 	}
 	
 	private void addDocumentToRoot() throws Exception {
-		Txn transaction = transact.beginTransaction();
-		InputSource is = new InputSource(new File("samples/shakespeare/hamlet.xml").toURI().toASCIIString());
-		assertNotNull(is);
-		IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("hamlet.xml"), is);
-		assertNotNull(info);
-		root.store(transaction, broker, info, is, false);
-		transact.commit(transaction);
+		try(final Txn transaction = transact.beginTransaction()) {
+            final InputSource is = new InputSource(new File("samples/shakespeare/hamlet.xml").toURI().toASCIIString());
+            assertNotNull(is);
+            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("hamlet.xml"), is);
+            assertNotNull(info);
+            root.store(transaction, broker, info, is, false);
+            transact.commit(transaction);
+        }
 	}
 	
 	private void addChildToRoot() throws Exception {
-		Txn transaction = transact.beginTransaction();
-		Collection child = broker.getOrCreateCollection(transaction, XmldbURI.ROOT_COLLECTION_URI.append("child"));
-		broker.saveCollection(transaction, child);
-		transact.commit(transaction);
+		try(final Txn transaction = transact.beginTransaction()) {
+            final Collection child = broker.getOrCreateCollection(transaction, XmldbURI.ROOT_COLLECTION_URI.append("child"));
+            broker.saveCollection(transaction, child);
+            transact.commit(transaction);
+        }
 	}
 }

--- a/test/src/org/exist/storage/RenameTest.java
+++ b/test/src/org/exist/storage/RenameTest.java
@@ -42,16 +42,10 @@ public class RenameTest extends AbstractUpdateTest {
     @Test
     public void update() {
         BrokerPool.FORCE_CORRUPTION = true;
-        BrokerPool pool = null;        
-        DBBroker broker = null;
-        try {
-        	pool = startDB();
-        	assertNotNull(pool);
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);            
-            TransactionManager mgr = pool.getTransactionManager();
-            assertNotNull(mgr);
-            
+        final BrokerPool pool = startDB();
+        final TransactionManager mgr = pool.getTransactionManager();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
             IndexInfo info = init(broker, mgr);
             assertNotNull(info);
             MutableDocumentSet docs = new DefaultDocumentSet();
@@ -59,54 +53,50 @@ public class RenameTest extends AbstractUpdateTest {
             XUpdateProcessor proc = new XUpdateProcessor(broker, docs, AccessContext.TEST);
             assertNotNull(proc);
             
-            Txn transaction = mgr.beginTransaction();
-            assertNotNull(transaction);
-            System.out.println("Transaction started ...");
-            
-            String xupdate;
-            Modification modifications[];
-            
-            // append some new element to records
-            for (int i = 1; i <= 200; i++) {
-                xupdate =
-                    "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
-                    "   <xu:append select=\"/products\">" +
-                    "       <product>" +
-                    "           <xu:attribute name=\"id\"><xu:value-of select=\"count(/products/product) + 1\"/></xu:attribute>" +
-                    "           <description>Product " + i + "</description>" +
-                    "           <price>" + (i * 2.5) + "</price>" +
-                    "           <stock>" + (i * 10) + "</stock>" +
-                    "       </product>" +
-                    "   </xu:append>" +
-                    "</xu:modifications>";
-                proc.setBroker(broker);
-                proc.setDocumentSet(docs);
-                modifications = proc.parse(new InputSource(new StringReader(xupdate)));
-                assertNotNull(modifications);
-                modifications[0].process(transaction);
-                proc.reset();
+            try(final Txn transaction = mgr.beginTransaction()) {
+                System.out.println("Transaction started ...");
+
+                // append some new element to records
+                for (int i = 1; i <= 200; i++) {
+                    final String xupdate =
+                            "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
+                                    "   <xu:append select=\"/products\">" +
+                                    "       <product>" +
+                                    "           <xu:attribute name=\"id\"><xu:value-of select=\"count(/products/product) + 1\"/></xu:attribute>" +
+                                    "           <description>Product " + i + "</description>" +
+                                    "           <price>" + (i * 2.5) + "</price>" +
+                                    "           <stock>" + (i * 10) + "</stock>" +
+                                    "       </product>" +
+                                    "   </xu:append>" +
+                                    "</xu:modifications>";
+                    proc.setBroker(broker);
+                    proc.setDocumentSet(docs);
+                    final Modification modifications[] = proc.parse(new InputSource(new StringReader(xupdate)));
+                    assertNotNull(modifications);
+                    modifications[0].process(transaction);
+                    proc.reset();
+                }
+
+                DOMFile domDb = ((NativeBroker) broker).getDOMFile();
+                assertNotNull(domDb);
+                System.out.println(domDb.debugPages(info.getDocument(), false));
+
+                mgr.commit(transaction);
+                System.out.println("Transaction commited ...");
             }
             
-            DOMFile domDb = ((NativeBroker) broker).getDOMFile();
-            assertNotNull(domDb);
-            System.out.println(domDb.debugPages(info.getDocument(), false));
-            
-            mgr.commit(transaction);
-            System.out.println("Transaction commited ...");
-            
             // the following transaction will not be committed and thus undone during recovery
-            transaction = mgr.beginTransaction();
-            assertNotNull(transaction);
+            final Txn transaction = mgr.beginTransaction();
             System.out.println("Transaction started ...");
             
             // rename elements
-            xupdate =
+            final String xupdate =
                 "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
                 "   <xu:rename select=\"/products/product/description\">descript</xu:rename>" +
                 "</xu:modifications>";
             proc.setBroker(broker);
             proc.setDocumentSet(docs);
-            modifications = proc.parse(new InputSource(new StringReader(xupdate)));
+            final Modification modifications[] = proc.parse(new InputSource(new StringReader(xupdate)));
             assertNotNull(modifications);
             modifications[0].process(transaction);
             proc.reset();
@@ -114,11 +104,9 @@ public class RenameTest extends AbstractUpdateTest {
 //          Don't commit...            
             pool.getTransactionManager().getJournal().flushToLog(true);
             System.out.println("Transaction interrupted ...");
-	    } catch (Exception e) {     
-	    	e.printStackTrace();
-	        fail(e.getMessage());               
-        } finally {
-            pool.release(broker);
+	    } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
         }
     }
 

--- a/test/src/org/exist/storage/ResourceTest.java
+++ b/test/src/org/exist/storage/ResourceTest.java
@@ -74,13 +74,11 @@ public class ResourceTest {
 
     private void store() {
         BrokerPool.FORCE_CORRUPTION = true;
-        BrokerPool pool = startDB();
-        DBBroker broker = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            TransactionManager transact = pool.getTransactionManager();
-            
-            Txn transaction = transact.beginTransaction();
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
             System.out.println("Transaction started ...");
             
             Collection collection = broker
@@ -97,28 +95,21 @@ public class ResourceTest {
             System.out.println("Transaction commited ...");
         } catch (Exception e) {
             fail(e.getMessage());
-            
-        } finally {
-            pool.release(broker);
         }
     }
 
     private void read() {
-        BrokerPool.FORCE_CORRUPTION = false;
-        BrokerPool pool = startDB();
-        
         System.out.println("testRead() ...\n");
-        
-        DBBroker broker = null;
-        
+
+        BrokerPool.FORCE_CORRUPTION = false;
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
         
         byte[] data = null;
         
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            
-            TransactionManager transact = pool.getTransactionManager();            
-            Txn transaction = transact.beginTransaction();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction();) {
+
             System.out.println("Transaction started ...");
             
             XmldbURI docPath = TestConstants.TEST_COLLECTION_URI.append(DOCUMENT_NAME_URI);
@@ -130,10 +121,10 @@ public class ResourceTest {
             if(binDoc == null){
                 fail("Binary document '" + docPath + " does not exist.");
             } else {
-               InputStream is = broker.getBinaryResource(binDoc);
-               data = new byte[(int)broker.getBinaryResourceSize(binDoc)];
-               is.read(data);
-               is.close();
+               try(final InputStream is = broker.getBinaryResource(binDoc)) {
+                   data = new byte[(int) broker.getBinaryResourceSize(binDoc)];
+                   is.read(data);
+               }
                 binDoc.getUpdateLock().release(Lock.READ_LOCK);
             }
             
@@ -147,10 +138,6 @@ public class ResourceTest {
         } catch (Exception ex){
             fail("Error opening document" + ex);
             
-        } finally {
-            if(pool!=null){
-                pool.release(broker);
-            }
         }
         
         assertEquals(0, data.length);
@@ -163,21 +150,17 @@ public class ResourceTest {
 
     @Test
     public void removeCollection() {
-    	BrokerPool.FORCE_CORRUPTION = false;
-        BrokerPool pool = startDB();
-        
         System.out.println("testRemoveCollection() ...\n");
-        
-        DBBroker broker = null;
-        
-        
+
+        BrokerPool.FORCE_CORRUPTION = false;
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
+
         byte[] data = null;
         
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            
-            TransactionManager transact = pool.getTransactionManager();            
-            Txn transaction = transact.beginTransaction();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
+
             System.out.println("Transaction started ...");
             
             XmldbURI docPath = TestConstants.TEST_COLLECTION_URI.append(DOCUMENT_NAME_URI);
@@ -189,10 +172,10 @@ public class ResourceTest {
             if(binDoc == null){
                 fail("Binary document '" + docPath + " does not exist.");
             } else {
-               InputStream is = broker.getBinaryResource(binDoc);
-               data = new byte[(int)broker.getBinaryResourceSize(binDoc)];
-               is.read(data);
-               is.close();
+                try(InputStream is = broker.getBinaryResource(binDoc)) {
+                    data = new byte[(int) broker.getBinaryResourceSize(binDoc)];
+                    is.read(data);
+                }
                 binDoc.getUpdateLock().release(Lock.READ_LOCK);
             }
             
@@ -204,10 +187,6 @@ public class ResourceTest {
         } catch (Exception ex){
             fail("Error opening document" + ex);
             
-        } finally {
-            if(pool!=null){
-                pool.release(broker);
-            }
         }
         
         assertEquals(0, data.length);

--- a/test/src/org/exist/storage/StoreBinaryTest.java
+++ b/test/src/org/exist/storage/StoreBinaryTest.java
@@ -122,19 +122,13 @@ public class StoreBinaryTest {
     }
 
     private BinaryDocument storeBinary(String name,  String data, String mimeType) throws EXistException {
-    	BinaryDocument binaryDoc = null;
-        Database pool = BrokerPool.getInstance();;
 
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn transaction = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            assertNotNull(broker);
-            transact = pool.getTransactionManager();
-            assertNotNull(transact);
-            transaction = transact.beginTransaction();
-            assertNotNull(transaction);
+        final Database pool = BrokerPool.getInstance();;
+        final TransactionManager transact = pool.getTransactionManager();
+
+        BinaryDocument binaryDoc = null;
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
 
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
     		broker.saveCollection(transaction, root);
@@ -142,16 +136,10 @@ public class StoreBinaryTest {
 
             binaryDoc = root.addBinaryResource(transaction, broker, XmldbURI.create(name), data.getBytes(), mimeType);
 
-            if(transact != null) {
-                transact.commit(transaction);
-            }
+            transact.commit(transaction);
         } catch (Exception e) {
-            if (transact != null)
-                transact.abort(transaction);
             e.printStackTrace();
             fail(e.getMessage());
-        } finally {
-            pool.release(broker);
         }
 
         return binaryDoc;

--- a/test/src/org/exist/storage/UpdateAttributeTest.java
+++ b/test/src/org/exist/storage/UpdateAttributeTest.java
@@ -42,16 +42,10 @@ public class UpdateAttributeTest extends AbstractUpdateTest {
     @Test
     public void update() {
         BrokerPool.FORCE_CORRUPTION = true;
-        BrokerPool pool = null;        
-        DBBroker broker = null;
-        try {
-        	pool = startDB();
-        	assertNotNull(pool);
-        	broker = pool.get(pool.getSecurityManager().getSystemSubject());
-        	assertNotNull(broker);            
-            TransactionManager mgr = pool.getTransactionManager();
-            assertNotNull(mgr); 
-            
+        final BrokerPool pool = startDB();
+        final TransactionManager mgr = pool.getTransactionManager();
+
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
             IndexInfo info = init(broker, mgr);
             assertNotNull(info);
             MutableDocumentSet docs = new DefaultDocumentSet();
@@ -59,51 +53,49 @@ public class UpdateAttributeTest extends AbstractUpdateTest {
             XUpdateProcessor proc = new XUpdateProcessor(broker, docs, AccessContext.TEST);
             assertNotNull(proc);
             
-            Txn transaction = mgr.beginTransaction();
-            assertNotNull(transaction);
-            System.out.println("Transaction started ...");
-            
-            String xupdate;
-            Modification modifications[];
-            
-            // append some new element to records
-            for (int i = 1; i <= 200; i++) {
-                xupdate =
-                    "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
-                    "   <xu:append select=\"/products\">" +
-                    "       <product>" +
-                    "           <xu:attribute name=\"id\"><xu:value-of select=\"count(/products/product) + 1\"/></xu:attribute>" +
-                    "           <description>Product " + i + "</description>" +
-                    "           <price>" + (i * 2.5) + "</price>" +
-                    "           <stock>" + (i * 10) + "</stock>" +
-                    "       </product>" +
-                    "   </xu:append>" +
-                    "</xu:modifications>";
-                proc.setBroker(broker);
-                proc.setDocumentSet(docs);
-                modifications = proc.parse(new InputSource(new StringReader(xupdate)));
-                assertNotNull(modifications);
-                modifications[0].process(transaction);
-                proc.reset();
+            try(final Txn transaction = mgr.beginTransaction()) {
+
+                System.out.println("Transaction started ...");
+
+                // append some new element to records
+                for (int i = 1; i <= 200; i++) {
+                    final String xupdate =
+                            "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
+                                    "   <xu:append select=\"/products\">" +
+                                    "       <product>" +
+                                    "           <xu:attribute name=\"id\"><xu:value-of select=\"count(/products/product) + 1\"/></xu:attribute>" +
+                                    "           <description>Product " + i + "</description>" +
+                                    "           <price>" + (i * 2.5) + "</price>" +
+                                    "           <stock>" + (i * 10) + "</stock>" +
+                                    "       </product>" +
+                                    "   </xu:append>" +
+                                    "</xu:modifications>";
+                    proc.setBroker(broker);
+                    proc.setDocumentSet(docs);
+                    final Modification modifications[] = proc.parse(new InputSource(new StringReader(xupdate)));
+                    assertNotNull(modifications);
+                    modifications[0].process(transaction);
+                    proc.reset();
+                }
+
+                mgr.commit(transaction);
+                System.out.println("Transaction commited ...");
             }
-            
-            mgr.commit(transaction);
-            System.out.println("Transaction commited ...");
-            
+
             // the following transaction will not be committed and thus undone during recovery
-            transaction = mgr.beginTransaction();
+            final Txn transaction = mgr.beginTransaction();
             assertNotNull(transaction);
             System.out.println("Transaction started ...");
             
             // update attributes
             for (int i = 1; i <= 200; i++) {
-                xupdate =
+                final String xupdate =
                     "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
                     "   <xu:update select=\"/products/product[" + i + "]/@id\">" + i + "u</xu:update>" +
                     "</xu:modifications>";
                 proc.setBroker(broker);
                 proc.setDocumentSet(docs);
-                modifications = proc.parse(new InputSource(new StringReader(xupdate)));
+                final Modification modifications[] = proc.parse(new InputSource(new StringReader(xupdate)));
                 assertNotNull(modifications);
                 modifications[0].process(transaction);
                 proc.reset();
@@ -114,8 +106,6 @@ public class UpdateAttributeTest extends AbstractUpdateTest {
             System.out.println("Transaction interrupted ...");    
         } catch (Exception e) {            
             fail(e.getMessage());             
-        } finally {
-            pool.release(broker);
         }
     }
 }

--- a/test/src/org/exist/storage/lock/GetXMLResourceNoLockTest.java
+++ b/test/src/org/exist/storage/lock/GetXMLResourceNoLockTest.java
@@ -97,13 +97,12 @@ public class GetXMLResourceNoLockTest {
 
     private void storeTestResource() throws EXistException {
         
-        BrokerPool pool = BrokerPool.getInstance();
-        DBBroker broker = null;
-        try {
-            broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            TransactionManager transact = pool.getTransactionManager();
-            
-            Txn transaction = transact.beginTransaction();
+        final BrokerPool pool = BrokerPool.getInstance();
+
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
+                final Txn transaction = transact.beginTransaction()) {
+
             System.out.println("Transaction started ...");
             
             Collection collection = broker
@@ -121,8 +120,6 @@ public class GetXMLResourceNoLockTest {
         } catch (Exception e) {
             fail(e.getMessage());
             
-        } finally {
-            pool.release(broker);
         }
     }
 }

--- a/test/src/org/exist/validation/DatabaseInsertResources_NoValidation_Test.java
+++ b/test/src/org/exist/validation/DatabaseInsertResources_NoValidation_Test.java
@@ -125,17 +125,11 @@ public class DatabaseInsertResources_NoValidation_Test {
 
     private static void createTestCollections() throws Exception {
 
-        BrokerPool pool = BrokerPool.getInstance();
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn txn = null;
-        try {
-            Subject admin = pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD);
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
 
-            broker = pool.get(admin);
-
-            transact = pool.getTransactionManager();
-            txn = transact.beginTransaction();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD));
+                final Txn txn = transact.beginTransaction()) {
 
             /** create nessecary collections if they dont exist */
             Collection testCollection = broker.getOrCreateCollection(txn, XmldbURI.create(VALIDATION_HOME_COLLECTION_URI));
@@ -155,48 +149,22 @@ public class DatabaseInsertResources_NoValidation_Test {
             broker.saveCollection(txn, col);
 
             transact.commit(txn);
-
-        } catch (Exception e) {
-            if(transact != null && txn != null) {
-                transact.abort(txn);
-            }
-            throw e;
-        } finally {
-            if(broker != null) {
-                pool.release(broker);
-            }
         }
     }
 
     private static void removeTestCollections() throws Exception {
 
-        BrokerPool pool = BrokerPool.getInstance();
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn txn = null;
-        try {
-            Subject admin = pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD);
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
 
-            broker = pool.get(admin);
-
-            transact = pool.getTransactionManager();
-            txn = transact.beginTransaction();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD));
+            final Txn txn = transact.beginTransaction()) {
 
             /** create nessecary collections if they dont exist */
             Collection testCollection = broker.getOrCreateCollection(txn, XmldbURI.create(VALIDATION_HOME_COLLECTION_URI));
             broker.removeCollection(txn, testCollection);
 
             transact.commit(txn);
-
-        } catch (Exception e) {
-            if(transact != null && txn != null) {
-                transact.abort(txn);
-            }
-            throw e;
-        } finally {
-            if(broker != null) {
-                pool.release(broker);
-            }
         }
     }
 }

--- a/test/src/org/exist/validation/DatabaseInsertResources_WithValidation_Test.java
+++ b/test/src/org/exist/validation/DatabaseInsertResources_WithValidation_Test.java
@@ -128,17 +128,11 @@ public class DatabaseInsertResources_WithValidation_Test {
 
     private static void createTestCollections() throws Exception {
 
-        BrokerPool pool = BrokerPool.getInstance();
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn txn = null;
-        try {
-            Subject admin = pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD);
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
 
-            broker = pool.get(admin);
-
-            transact = pool.getTransactionManager();
-            txn = transact.beginTransaction();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD));
+            final Txn txn = transact.beginTransaction()) {
 
 
             /** create nessecary collections if they dont exist */
@@ -151,47 +145,21 @@ public class DatabaseInsertResources_WithValidation_Test {
             broker.saveCollection(txn, col);
 
             transact.commit(txn);
-
-        } catch (Exception e) {
-            if(transact != null && txn != null) {
-                transact.abort(txn);
-            }
-            throw e;
-        } finally {
-            if(broker != null) {
-                pool.release(broker);
-            }
         }
     }
 
     private static void removeTestCollections() throws Exception {
 
-        BrokerPool pool = BrokerPool.getInstance();
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn txn = null;
-        try {
-            Subject admin = pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD);
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
 
-            broker = pool.get(admin);
-
-            transact = pool.getTransactionManager();
-            txn = transact.beginTransaction();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD));
+            final Txn txn = transact.beginTransaction()) {
 
             Collection testCollection = broker.getOrCreateCollection(txn, XmldbURI.create(VALIDATION_HOME_COLLECTION_URI));
             broker.removeCollection(txn, testCollection);
 
             transact.commit(txn);
-
-        } catch (Exception e) {
-            if(transact != null && txn != null) {
-                transact.abort(txn);
-            }
-            throw e;
-        } finally {
-            if(broker != null) {
-                pool.release(broker);
-            }
         }
     }
 }

--- a/test/src/org/exist/validation/ValidationFunctions_DTD_Test.java
+++ b/test/src/org/exist/validation/ValidationFunctions_DTD_Test.java
@@ -197,17 +197,11 @@ public class ValidationFunctions_DTD_Test {
 
     private static void createTestCollections() throws Exception {
 
-        BrokerPool pool = BrokerPool.getInstance();
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn txn = null;
-        try {
-            Subject admin = pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD);
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
 
-            broker = pool.get(admin);
-
-            transact = pool.getTransactionManager();
-            txn = transact.beginTransaction();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD));
+            final Txn txn = transact.beginTransaction()) {
 
             /** create nessecary collections if they dont exist */
             org.exist.collections.Collection testCollection = broker.getOrCreateCollection(txn, XmldbURI.create(VALIDATION_HOME_COLLECTION_URI));
@@ -227,31 +221,16 @@ public class ValidationFunctions_DTD_Test {
             broker.saveCollection(txn, col);
 
             transact.commit(txn);
-
-        } catch (Exception e) {
-            if(transact != null && txn != null) {
-                transact.abort(txn);
-            }
-            throw e;
-        } finally {
-            if(broker != null) {
-                pool.release(broker);
-            }
         }
     }
 
     private static void createTestDocuments() throws Exception {
 
-        BrokerPool pool = BrokerPool.getInstance();
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn txn = null;
-        try {
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
 
-            broker = pool.get(pool.getSecurityManager().getGuestSubject());
-
-            transact = pool.getTransactionManager();
-            txn = transact.beginTransaction();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().getGuestSubject());
+            final Txn txn = transact.beginTransaction()) {
 
             /** create necessary documents  */
 
@@ -279,15 +258,6 @@ public class ValidationFunctions_DTD_Test {
             config.setProperty(XMLReaderObjectFactory.PROPERTY_VALIDATION_MODE, "yes");
 
             transact.commit(txn);
-        } catch (Exception e) {
-            if(transact != null && txn != null) {
-                transact.abort(txn);
-            }
-            throw e;
-        } finally {
-            if(broker != null) {
-                pool.release(broker);
-            }
         }
     }
 
@@ -304,31 +274,16 @@ public class ValidationFunctions_DTD_Test {
 
     private static void removeTestCollections() throws Exception {
 
-        BrokerPool pool = BrokerPool.getInstance();
-        DBBroker broker = null;
-        TransactionManager transact = null;
-        Txn txn = null;
-        try {
-            Subject admin = pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD);
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
 
-            broker = pool.get(admin);
-
-            transact = pool.getTransactionManager();
-            txn = transact.beginTransaction();
+        try(final DBBroker broker = pool.get(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD));
+            final Txn txn = transact.beginTransaction()) {
 
             org.exist.collections.Collection testCollection = broker.getOrCreateCollection(txn, XmldbURI.create(VALIDATION_HOME_COLLECTION_URI));
             broker.removeCollection(txn, testCollection);
 
             transact.commit(txn);
-        } catch (Exception e) {
-            if(transact != null && txn != null) {
-                transact.abort(txn);
-            }
-            throw e;
-        } finally {
-            if(broker != null) {
-                pool.release(broker);
-            }
         }
     }
     /*

--- a/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -91,89 +91,89 @@ public class ConstructedNodesRecoveryTest extends TestCase
 	private void storeTestDocument(DBBroker broker, TransactionManager transact, String documentName) throws Exception
 	{
 		//create a transaction
-		Txn transaction = transact.beginTransaction();
-        assertNotNull(transaction);            
-        System.out.println("Transaction started ...");
-		
-		//get the test collection
-        Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
-        assertNotNull(root);
-        broker.saveCollection(transaction, root);
-		
-		//store test document
-        IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(documentName), testDocument);
-        assertNotNull(info);
-        root.store(transaction, broker, info, new InputSource(new StringReader(testDocument)), false);
-        
-        //commit the transaction
-        transact.commit(transaction);
-        System.out.println("Transaction commited ...");
+		try(final Txn transaction = transact.beginTransaction()) {
+            System.out.println("Transaction started ...");
+
+            //get the test collection
+            Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
+            assertNotNull(root);
+            broker.saveCollection(transaction, root);
+
+            //store test document
+            IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(documentName), testDocument);
+            assertNotNull(info);
+            root.store(transaction, broker, info, new InputSource(new StringReader(testDocument)), false);
+
+            //commit the transaction
+            transact.commit(transaction);
+            System.out.println("Transaction commited ...");
+        }
 	}
 	
 	private void createTempChildCollection(DBBroker broker, TransactionManager transact, String childCollectionName) throws Exception
 	{
 		//create a transaction
-		Txn transaction = transact.beginTransaction();
-        assertNotNull(transaction);            
-        System.out.println("Transaction started ...");
-		
-		//get the test collection
-        Collection root = broker.getOrCreateCollection(transaction, XmldbURI.TEMP_COLLECTION_URI.append(childCollectionName));
-        assertNotNull(root);
-        broker.saveCollection(transaction, root);
-		        
-        //commit the transaction
-        transact.commit(transaction);
-        System.out.println("Transaction commited ...");
+		try(final Txn transaction = transact.beginTransaction()) {
+            System.out.println("Transaction started ...");
+
+            //get the test collection
+            Collection root = broker.getOrCreateCollection(transaction, XmldbURI.TEMP_COLLECTION_URI.append(childCollectionName));
+            assertNotNull(root);
+            broker.saveCollection(transaction, root);
+
+            //commit the transaction
+            transact.commit(transaction);
+            System.out.println("Transaction commited ...");
+        }
 	}
 	
 	private void testDocumentIsValid(DBBroker broker, TransactionManager transact, String documentName) throws Exception
 	{
 		//create a transaction
-		Txn transaction = transact.beginTransaction();
-        assertNotNull(transaction);            
-        System.out.println("Transaction started ...");
-		
-		//get the test collection
-        Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
-        assertNotNull(root);
-        broker.saveCollection(transaction, root);
-        
-        //get the test document
-        DocumentImpl doc = root.getDocumentWithLock(broker, XmldbURI.create(documentName), Lock.READ_LOCK);
-        
-        Serializer serializer = broker.getSerializer();
-        serializer.reset();
-        SAXSerializer sax = null;
-        StringWriter writer = new StringWriter();
-        sax = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
-        Properties outputProperties = new Properties();
-        outputProperties.setProperty(OutputKeys.INDENT, "no");
-        outputProperties.setProperty(OutputKeys.ENCODING, "UTF-8");
-        sax.setOutput(writer, outputProperties);
-        serializer.setProperties(outputProperties);
-        serializer.setSAXHandlers(sax, sax);
-        serializer.toSAX(doc);
-        SerializerPool.getInstance().returnObject(sax);
-        
-        assertEquals(testDocument, writer.toString());
-        
-        transact.commit(transaction);
+        try(final Txn transaction = transact.beginTransaction()) {
+            System.out.println("Transaction started ...");
+
+            //get the test collection
+            Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
+            assertNotNull(root);
+            broker.saveCollection(transaction, root);
+
+            //get the test document
+            DocumentImpl doc = root.getDocumentWithLock(broker, XmldbURI.create(documentName), Lock.READ_LOCK);
+
+            Serializer serializer = broker.getSerializer();
+            serializer.reset();
+            SAXSerializer sax = null;
+            StringWriter writer = new StringWriter();
+            sax = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
+            Properties outputProperties = new Properties();
+            outputProperties.setProperty(OutputKeys.INDENT, "no");
+            outputProperties.setProperty(OutputKeys.ENCODING, "UTF-8");
+            sax.setOutput(writer, outputProperties);
+            serializer.setProperties(outputProperties);
+            serializer.setSAXHandlers(sax, sax);
+            serializer.toSAX(doc);
+            SerializerPool.getInstance().returnObject(sax);
+
+            assertEquals(testDocument, writer.toString());
+
+            transact.commit(transaction);
+        }
 	}
 	
 	private void testTempChildCollectionExists(DBBroker broker, TransactionManager transact, String childCollectionName) throws Exception
 	{
 		//create a transaction
-		Txn transaction = transact.beginTransaction();
-        assertNotNull(transaction);            
-        System.out.println("Transaction started ...");
-		
-		//get the temp child collection
-        Collection tempChildCollection = broker.getOrCreateCollection(transaction, XmldbURI.TEMP_COLLECTION_URI.append(childCollectionName));
-        assertNotNull(tempChildCollection);
-        broker.saveCollection(transaction, tempChildCollection);
-        
-        transact.commit(transaction);
+        try(final Txn transaction = transact.beginTransaction()) {
+            System.out.println("Transaction started ...");
+
+            //get the temp child collection
+            Collection tempChildCollection = broker.getOrCreateCollection(transaction, XmldbURI.TEMP_COLLECTION_URI.append(childCollectionName));
+            assertNotNull(tempChildCollection);
+            broker.saveCollection(transaction, tempChildCollection);
+
+            transact.commit(transaction);
+        }
 	}
 	
 	/**

--- a/test/src/org/exist/xquery/LexerTest.java
+++ b/test/src/org/exist/xquery/LexerTest.java
@@ -75,17 +75,13 @@ public class LexerTest extends TestCase {
 			e1.printStackTrace();
 			fail(e1.getMessage());
 		}
-		DBBroker broker = null;
-		TransactionManager transact = null;
-		Txn transaction = null;
-		try {
-			broker = pool.get(pool.getSecurityManager().getSystemSubject());
-			try {
+
+		final TransactionManager transact = pool.getTransactionManager();
+		try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
+
+			try(final Txn transaction = transact.beginTransaction()) {
 				// parse the xml source
-				transact = pool.getTransactionManager();
-	            assertNotNull(transact);
-	            transaction = transact.beginTransaction();
-	            assertNotNull(transaction);
+
 	            Collection collection = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
 	            broker.saveCollection(transaction, collection);
 	
@@ -94,7 +90,6 @@ public class LexerTest extends TestCase {
 	            collection.store(transaction, broker, info, xml, false);
 	            transact.commit(transaction);
 			} catch (Exception e) {
-				transact.abort(transaction);
 	            e.printStackTrace();
 	            fail(e.getMessage());
 			}
@@ -134,8 +129,6 @@ public class LexerTest extends TestCase {
 		} catch (EXistException e) {
             e.printStackTrace();
             fail(e.getMessage());
-		} finally {
-			pool.release(broker);
 		}
 		if (localDb)
 			try {

--- a/test/src/org/exist/xquery/XQueryUpdateTest.java
+++ b/test/src/org/exist/xquery/XQueryUpdateTest.java
@@ -539,27 +539,23 @@ public class XQueryUpdateTest extends TestCase {
         }
     }
 
-	private void store(DBBroker broker, String docName, String data) throws PermissionDeniedException, EXistException, TriggerException, SAXException, LockException, TransactionException {
-		TransactionManager mgr = pool.getTransactionManager();
-		Txn transaction = mgr.beginTransaction();        
-		System.out.println("Transaction started ...");
-		
-		try {
-			Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
-			broker.saveCollection(transaction, root);
-			
-			IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(docName), data);
-			//TODO : unlock the collection here ?
-			root.store(transaction, broker, info, data, false);
-	   
-			mgr.commit(transaction);
-			
-			DocumentImpl doc = root.getDocument(broker, XmldbURI.create(docName));
-		    broker.getSerializer().serialize(doc);
-		} catch (IOException e) {
-			mgr.abort(transaction);
-			fail();
-		}
+	private void store(DBBroker broker, String docName, String data) throws PermissionDeniedException, EXistException, SAXException, LockException, IOException {
+        Collection root;
+        final TransactionManager mgr = pool.getTransactionManager();
+        try(final Txn transaction = mgr.beginTransaction()) {
+            System.out.println("Transaction started ...");
+
+            root = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
+            broker.saveCollection(transaction, root);
+
+            IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(docName), data);
+            //TODO : unlock the collection here ?
+            root.store(transaction, broker, info, data, false);
+
+            mgr.commit(transaction);
+        }
+        DocumentImpl doc = root.getDocument(broker, XmldbURI.create(docName));
+        broker.getSerializer().serialize(doc);
 	}
     
     protected BrokerPool startDB() {

--- a/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
+++ b/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
@@ -92,15 +92,11 @@ public class QT3TS_To_junit {
 		Assert.assertNotNull(broker);
 
         TransactionManager txnMgr = db.getTransactionManager();
-        Txn txn = null;
-        try {
-            txn = txnMgr.beginTransaction();
+        try(final Txn txn = txnMgr.beginTransaction()) {
             collection = broker.getOrCreateCollection(txn, QT3TS_case.QT3_URI);
             Assert.assertNotNull(collection);
             broker.saveCollection(txn, collection);
             txnMgr.commit(txn);
-        } finally {
-            txn.close();
         }
     }
 
@@ -121,9 +117,8 @@ public class QT3TS_To_junit {
 
 
         final TransactionManager txnMgr = broker.getBrokerPool().getTransactionManager();
-        Txn txn = null;
-        try {
-            txn = txnMgr.beginTransaction();
+        try(final Txn txn = txnMgr.beginTransaction()) {
+
 
             for(File file : files) {
                 if(file.isDirectory()) {
@@ -142,10 +137,6 @@ public class QT3TS_To_junit {
             }
 
             txnMgr.commit(txn);
-        } finally {
-            if(txn != null) {
-                txn.close();
-            }
         }
     }
 


### PR DESCRIPTION
By using Java 7s `try-with-with-resources` functionality for `Txn` and `DBBroker` we can ensure that a transaction is always automatically closed and that a broker is always automatically returned to the broker pool.

For example, consider a common access pattern in eXist:
```java
DBBroker broker = null;
TransactionManager transact = null;
Txn transaction = null;
try {
  broker = pool.get(pool.getSecurityManager().getSystemSubject());
  transact = pool.getTransactionManager();
  transaction = transact.beginTransaction();

  //various db access here

  transact.commit(transaction);
} catch(Exception e) {
  if(transact != null) {
    transact.abort(transaction);
    throw e;
  }
} finally {
  if(transact != null) {
    transact.abort(transaction);
  }
  if(broker != null) {
    pool.release(broker);
  }
}
```

Instead, through adopting `try-with-resources` we can use the much simpler and safer pattern:
```java
final TransactionManager transact = pool.getTransactionManager();
try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
    final Txn transaction = transact.beginTransaction()) {

  //various db access here

  transact.commit(transaction);
}
```