### PR TITLE
Register eXists URL Stream Handler just once

### DIFF
--- a/conf.xml.tmpl
+++ b/conf.xml.tmpl
@@ -164,6 +164,12 @@
         -->
         <startup>
             <triggers>
+
+		<!--
+		    Trigger for registering eXists XML:DB URL handler with Java
+		-->
+		<trigger class="org.exist.protocolhandler.URLStreamHandlerStartupTrigger"/>
+
                 <!-- 
                     EXQuery RESTXQ trigger to load the RESTXQ Registry at startup time 
                 -->

--- a/src/org/exist/protocolhandler/URLStreamHandlerStartupTrigger.java
+++ b/src/org/exist/protocolhandler/URLStreamHandlerStartupTrigger.java
@@ -1,0 +1,75 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2015 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.protocolhandler;
+
+import org.apache.log4j.Logger;
+import org.exist.storage.DBBroker;
+import org.exist.storage.StartupTrigger;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Startup Trigger to register eXists URL Stream Handler
+ *
+ * @author Adam Retter <adam@exist-db.org>
+ * @author Dannes Wessels
+ */
+public class URLStreamHandlerStartupTrigger implements StartupTrigger {
+
+    private final static Logger LOG = Logger.getLogger(URLStreamHandlerStartupTrigger.class);
+
+    public final static String JAVA_PROTOCOL_HANDLER_PKGS="java.protocol.handler.pkgs";
+    public final static String EXIST_PROTOCOL_HANDLER="org.exist.protocolhandler.protocols";
+
+    @Override
+    public void execute(final DBBroker sysBroker, final Map<String, List<? extends Object>> params) {
+        registerStreamHandlerFactory();
+    }
+
+    private void registerStreamHandlerFactory() {
+        try {
+            URL.setURLStreamHandlerFactory(new eXistURLStreamHandlerFactory());
+            LOG.info("Successfully registered eXistURLStreamHandlerFactory.");
+        } catch (final Error ex) {
+            LOG.warn("The JVM has already an URLStreamHandlerFactory registered, skipping...");
+
+            String currentSystemProperty = System.getProperty(JAVA_PROTOCOL_HANDLER_PKGS);
+
+            if(currentSystemProperty == null) {
+                // Nothing setup yet
+                LOG.info("Setting " + JAVA_PROTOCOL_HANDLER_PKGS + " to "
+                        + EXIST_PROTOCOL_HANDLER);
+                System.setProperty( JAVA_PROTOCOL_HANDLER_PKGS, EXIST_PROTOCOL_HANDLER );
+            } else {
+                // java.protocol.handler.pkgs is already setup, preserving settings
+                if(currentSystemProperty.indexOf(EXIST_PROTOCOL_HANDLER) == -1) {
+                    // eXist handler is not setup yet
+                    currentSystemProperty = currentSystemProperty + "|" + EXIST_PROTOCOL_HANDLER;
+                    LOG.info("Setting " + JAVA_PROTOCOL_HANDLER_PKGS + " to " + currentSystemProperty);
+                    System.setProperty(JAVA_PROTOCOL_HANDLER_PKGS, currentSystemProperty);
+                } else {
+                    LOG.info("System property " + JAVA_PROTOCOL_HANDLER_PKGS + " has not been updated.");
+                }
+            }
+        }
+    }
+}

--- a/src/org/exist/protocolhandler/eXistURLStreamHandlerFactory.java
+++ b/src/org/exist/protocolhandler/eXistURLStreamHandlerFactory.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-07 The eXist Project
+ *  Copyright (C) 2001-2015 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -19,10 +19,8 @@
  *
  *  $Id: eXistURLStreamHandlerFactory.java 189 2007-03-30 15:02:18Z dizzzz $
  */
-
 package org.exist.protocolhandler;
 
-import java.net.URL;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 
@@ -38,64 +36,28 @@ import org.exist.protocolhandler.protocols.xmldb.Handler;
  * @author Dannes Wessels
  */
 public class eXistURLStreamHandlerFactory implements URLStreamHandlerFactory {
-    
+
     private final static Logger LOG = Logger.getLogger(eXistURLStreamHandlerFactory.class);
-    
-    public final static String JAVA_PROTOCOL_HANDLER_PKGS="java.protocol.handler.pkgs";
-    public final static String EXIST_PROTOCOL_HANDLER="org.exist.protocolhandler.protocols";
-    
-    public static void init(){
-        
-        boolean initOK=false;
-        try {
-            URL.setURLStreamHandlerFactory(new eXistURLStreamHandlerFactory());
-            initOK=true;
-            LOG.info("Succesfully registered eXistURLStreamHandlerFactory.");
-        } catch (final Error ex){
-            LOG.warn("The JVM has already an URLStreamHandlerFactory registered, skipping...");
-        }
-        
-        if(!initOK){
-            String currentSystemProperty = System.getProperty(JAVA_PROTOCOL_HANDLER_PKGS);
-            
-            if(currentSystemProperty==null){
-                // Nothing setup yet
-                LOG.info("Setting " + JAVA_PROTOCOL_HANDLER_PKGS + " to "
-                    + EXIST_PROTOCOL_HANDLER);
-                System.setProperty( JAVA_PROTOCOL_HANDLER_PKGS, EXIST_PROTOCOL_HANDLER );
-                
-            } else {
-                // java.protocol.handler.pkgs is already setup, preserving settings
-                if(currentSystemProperty.indexOf(EXIST_PROTOCOL_HANDLER)==-1){
-                    // eXist handler is not setup yet
-                    currentSystemProperty=currentSystemProperty+"|"+EXIST_PROTOCOL_HANDLER;
-                    LOG.info("Setting " + JAVA_PROTOCOL_HANDLER_PKGS + " to " + currentSystemProperty);
-                    System.setProperty( JAVA_PROTOCOL_HANDLER_PKGS, currentSystemProperty );
-                } else {
-                    LOG.info( "System property " + JAVA_PROTOCOL_HANDLER_PKGS + " has not been updated."); 
-                }
-            }
-        }
-    }
-    
+    private final static URLStreamHandler handler = new Handler();
+
     /**
      *  Create Custom URL streamhandler for the <B>xmldb</B> protocol.
      *
      * @param protocol Protocol
      * @return Custom Xmldb stream handler.
      */
-    public URLStreamHandler createURLStreamHandler(String protocol) {
-        
-        URLStreamHandler handler=null;
-        
-        if("xmldb".equals(protocol)){
-            LOG.debug(protocol);
-            handler=new Handler();
+    public URLStreamHandler createURLStreamHandler(final String protocol) {
+        if("xmldb".equals(protocol)) {
+
+            if(LOG.isDebugEnabled()) {
+                LOG.debug(protocol);
+            }
+
+            return handler;
         } else {
             //LOG.error("Protocol should be xmldb, not "+protocol);
+            return null;
         }
-        
-        return handler;
     }
     
 }

--- a/src/org/exist/util/Configuration.java
+++ b/src/org/exist/util/Configuration.java
@@ -1453,10 +1453,6 @@ public class Configuration implements ErrorHandler
 
     private void configureValidation( String dbHome, Document doc, Element validation ) throws DatabaseConfigurationException
     {
-        // Register custom protocol URL
-        // TODO DWES move to different location?
-        eXistURLStreamHandlerFactory.init();
-
         // Determine validation mode
         final String mode = getConfigAttributeValue( validation, XMLReaderObjectFactory.VALIDATION_MODE_ATTRIBUTE );
 


### PR DESCRIPTION
This ensures that the URL Stream Handler is just registered once within the JVM. In particular, this stops a whole bunch of junk log output when running the test suite.