### PR TITLE
[bugfix] Deadlock when saving XQuery module

### DIFF
--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -2825,20 +2825,8 @@ public class XQueryContext implements BinaryValueManager, Context
 
     private ExternalModule compileOrBorrowModule( String prefix, String namespaceURI, String location, Source source ) throws XPathException
     {
-        ExternalModule module = getBroker().getBrokerPool().getXQueryPool().borrowModule( getBroker(), source, this );
+        final ExternalModule module = compileModule( prefix, namespaceURI, location, source );
 
-        if( module == null ) {
-            module = compileModule( prefix, namespaceURI, location, source );
-        } else {
-
-            for( final Iterator<Module> it = module.getContext().getAllModules(); it.hasNext(); ) {
-                final Module importedModule = it.next();
-
-                if( ( importedModule != null ) && !allModules.containsKey( importedModule.getNamespaceURI() ) ) {
-                    setRootModule( importedModule.getNamespaceURI(), importedModule );
-                }
-            }
-        }
         setModule( module.getNamespaceURI(), module );
         declareModuleVars( module );
         return( module );


### PR DESCRIPTION
Deadlocks occurred when an XQuery module was saved and another thread tried to execute it at the same time. The issue is caused by the restxq trigger trying to check for cached modules while the collection is still locked. Fix: we effectively disabled caching of library modules long ago, so the cache lookup will never find anything. Yet it synchronizes on the query pool. Removing this old code fixes the issue.