### PR TITLE
Module inspection: throw XPathException to detect issues

### DIFF
--- a/src/org/exist/xquery/functions/inspect/ModuleFunctions.java
+++ b/src/org/exist/xquery/functions/inspect/ModuleFunctions.java
@@ -60,15 +60,20 @@ public class ModuleFunctions extends BasicFunction {
             Module module = null;
 
             try {
-            if (isCalledAs("module-functions-by-uri"))
-                {module = tempContext.importModule(args[0].getStringValue(), null, null);}
-            else
-                {module = tempContext.importModule(null, null, args[0].getStringValue());}
+                if (isCalledAs("module-functions-by-uri")) {
+                    module = tempContext.importModule(args[0].getStringValue(), null, null);
+                } else {
+                    module = tempContext.importModule(null, null, args[0].getStringValue());
+                }
             } catch (final Exception e) {
                 LOG.debug("Failed to import module: " + args[0].getStringValue() + ": " + e.getMessage(), e);
+                throw new XPathException(this, e.getMessage());
             }
-            if (module == null)
-                {return Sequence.EMPTY_SEQUENCE;}
+            
+            if (module == null) {
+                return Sequence.EMPTY_SEQUENCE;
+            }
+            
             addFunctionRefsFromModule(tempContext, list, module);
         } else {
             addFunctionRefsFromContext(list);


### PR DESCRIPTION
When inspection of module fails (e.g. syntax error), throw exception to report issue to user;

https://github.com/eXist-db/exist/issues/511

in old situation issues are swallowed, not visible, as a result development time is lost and failing tests are missed.