### PR TITLE
Cleaned up the XML:DB Local API implementation

### DIFF
--- a/extensions/debuggee/test/org/exist/debugger/DebuggerTest.java
+++ b/extensions/debuggee/test/org/exist/debugger/DebuggerTest.java
@@ -478,7 +478,7 @@ public class DebuggerTest implements ResponseListener {
 	
     private void store(String name,  String data) throws EXistException {
     	Database pool = BrokerPool.getInstance();
-        final TransactionManager = transact = pool.getTransactionManager();
+        final TransactionManager transact = pool.getTransactionManager();
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final Txn transaction = transact.beginTransaction()) {

--- a/src/org/exist/util/function/BiFunctionE.java
+++ b/src/org/exist/util/function/BiFunctionE.java
@@ -1,0 +1,36 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util.function;
+
+/**
+ * Similar to {@link java.util.function.BiFunction} but
+ * permits a single statically know Exception to be thrown
+ *
+ * @param <T> Function parameter 1 type
+ * @param <U> Function parameter 2 type
+ * @param <R> Function return type
+ * @param <E> Function throws exception type
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface BiFunctionE<T, U, R, E extends Throwable> {
+    R apply(final T t, final U u) throws E;
+}

--- a/src/org/exist/util/function/Either.java
+++ b/src/org/exist/util/function/Either.java
@@ -1,0 +1,101 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util.function;
+
+import java.util.NoSuchElementException;
+
+/**
+ * A disjoint union, more basic than but similar to {@link scala.util.Either}
+ *
+ * @param <L> Type of left parameter
+ * @param <R> Type of right parameter
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+public abstract class Either<L, R> {
+    
+    private final boolean isLeft;
+    
+    Either(final boolean isLeft) {
+        this.isLeft = isLeft;
+    }
+    
+    public final boolean isLeft() {
+        return isLeft;
+    }
+
+    public final boolean isRight() {
+        return !isLeft;
+    }
+    
+    public final LeftProjection<L, R> left() {
+        return new LeftProjection(this);
+    }
+    
+    public final RightProjection<L, R> right() {
+        return new RightProjection(this);
+    }
+    
+    public final static class Left<L, R> extends Either<L, R> {
+        final L value;
+        public Left(final L value) {
+            super(true);
+            this.value = value;
+        }
+    }
+    
+    public final static class Right<L, R> extends Either<L, R> {
+        final R value;
+        public Right(final R value) {
+            super(false);
+            this.value = value;
+        }
+    }
+    
+    public final class LeftProjection<L, R> {
+        final Either<L, R> e;
+        private LeftProjection(final Either<L, R> e) {
+            this.e = e;
+        }
+        
+        public final L get() {
+            if(e.isLeft()) {
+                return ((Left<L, R>)e).value;
+            } else {
+                throw new NoSuchElementException("Either.left value on Right");
+            }
+        }
+    }
+    
+    public final class RightProjection<L, R> {
+        final Either<L, R> e;
+        private RightProjection(final Either<L, R> e) {
+            this.e = e;
+        }
+        
+        public final R get() {
+            if(e.isRight()) {
+                return ((Right<L, R>)e).value;
+            } else {
+                throw new NoSuchElementException("Either.right value on Left");
+            }
+        }
+    }
+}

--- a/src/org/exist/util/function/FunctionE.java
+++ b/src/org/exist/util/function/FunctionE.java
@@ -1,0 +1,42 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util.function;
+
+import java.util.Objects;
+
+/**
+ * Similar to {@link java.util.function.Function} but
+ * permits a single statically know Exception to be thrown
+ *
+ * @param <T> Function parameter type
+ * @param <R> Function return type
+ * @param <E> Function throws exception type
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface FunctionE<T, R, E extends Throwable> {
+    R apply(final T t) throws E;
+
+    default <V> FunctionE<T, V, E> andThen(FunctionE<? super R, ? extends V, ? extends E> after) {
+        Objects.requireNonNull(after);
+        return (T t) -> after.apply(apply(t));
+    }
+}

--- a/src/org/exist/util/function/TriFunctionE.java
+++ b/src/org/exist/util/function/TriFunctionE.java
@@ -1,0 +1,37 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util.function;
+
+/**
+ * Similar to {@link java.util.function.BiFunction} but
+ * takes 3 arguments and permits a single statically know Exception to be thrown
+ *
+ * @param <T> Function parameter 1 type
+ * @param <U> Function parameter 2 type
+ * @param <V> Function parameter 3 type
+ * @param <R> Function return type
+ * @param <E> Function throws exception type
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface TriFunctionE<T, U, V, R, E extends Throwable> {
+    R apply(final T t, final U u, final V v) throws E;
+}

--- a/src/org/exist/xmldb/AbstractEXistResource.java
+++ b/src/org/exist/xmldb/AbstractEXistResource.java
@@ -1,144 +1,176 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-06 Wolfgang M. Meier
- *  wolfgang@exist-db.org
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- * 
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.xmldb;
 
-import java.util.Date;
-
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.Permission;
-import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.util.LockException;
-import org.w3c.dom.DocumentType;
-import org.xml.sax.ext.LexicalHandler;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.Txn;
+import org.exist.util.function.FunctionE;
+import org.exist.xmldb.function.LocalXmldbDocumentFunction;
+import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.XMLDBException;
+
+import java.util.Date;
 
 /**
  * Abstract base implementation of interface EXistResource.
  */
-public abstract class AbstractEXistResource implements EXistResource {
-
-	protected Subject user;
-	protected BrokerPool pool;
-	protected LocalCollection parent;
-	protected XmldbURI docId = null;
-	protected String mimeType = null;
+public abstract class AbstractEXistResource extends AbstractLocal implements EXistResource {
+    protected final XmldbURI docId;
+    private String mimeType = null;
     protected boolean isNewResource = false;
+
+    protected Date datecreated = null;
+    protected Date datemodified = null;
     
-	public AbstractEXistResource(Subject user, BrokerPool pool, LocalCollection parent, XmldbURI docId, String mimeType) {
-		this.user = user;
-		this.pool = pool;
-		this.parent = parent;
-		docId = docId.lastSegment();
-		this.docId = docId;
+    public AbstractEXistResource(final Subject user, final BrokerPool pool, final LocalCollection parent, final XmldbURI docId, final String mimeType) {
+        super(user, pool, parent);
+        this.docId = docId.lastSegment();
         this.mimeType = mimeType;
-	}
-	
-	/**
-	 * 
-	 * @param user
-	 * @param pool
-	 * @param parent
-	 * @param docId
-	 * @param mimeType
-	 * 
-	 * @deprecated Use the XmldbURI constructor instead
-	 */
-	public AbstractEXistResource(Subject user, BrokerPool pool, LocalCollection parent, String docId, String mimeType) {
-		this(user, pool, parent, XmldbURI.create(docId), mimeType);
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#getCreationTime()
-	 */
-	public abstract Date getCreationTime() throws XMLDBException;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#getLastModificationTime()
-	 */
-	public abstract Date getLastModificationTime() throws XMLDBException;
-
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#getPermissions()
-	 */
-	public abstract Permission getPermissions() throws XMLDBException;
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#setLexicalHandler(org.xml.sax.ext.LexicalHandler)
-	 */
-	public void setLexicalHandler(LexicalHandler handler) {
-	}
-	
-    public void setMimeType(String mime) {
+    @Override
+    public void setMimeType(final String mime) {
         this.mimeType = mime;
     }
-    
+
+    @Override
     public String getMimeType() throws XMLDBException {
-        return mimeType;
-    }
-    
-	protected DocumentImpl openDocument(DBBroker broker, int lockMode) throws XMLDBException {
-	    DocumentImpl document = null;
-	    org.exist.collections.Collection parentCollection = null;
-	    try {
-	    	parentCollection = parent.getCollectionWithLock(lockMode);
-		    if(parentCollection == null)
-		    	{throw new XMLDBException(ErrorCodes.INVALID_COLLECTION, "Collection " + parent.getPath() + " not found");}
-	        try {
-	        	document = parentCollection.getDocumentWithLock(broker, docId, lockMode);
-	        } catch (final PermissionDeniedException pde) {
-                    throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-	        			"Permission denied for document " + docId + ": " + pde.getMessage());
-                } catch (final LockException e) {
-	        	throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-	        			"Failed to acquire lock on document " + docId);
-	        }
-		    if (document == null) {
-		        throw new XMLDBException(ErrorCodes.INVALID_RESOURCE);
-		    }
-	//	    System.out.println("Opened document " + document.getName() + " mode = " + lockMode);
-		    return document;
-	    } finally {
-	    	if(parentCollection != null)
-	    		{parentCollection.release(lockMode);}
-	    }
-	}
-	
-	protected void closeDocument(DocumentImpl doc, int lockMode) throws XMLDBException {
-		if(doc == null)
-			{return;}
-//		System.out.println("Closed " + doc.getName() + " mode = " + lockMode);
-		doc.getUpdateLock().release(lockMode);
-	}
-
-    public  DocumentType getDocType() throws XMLDBException {
-    	return null;
+        if (isNewResource) {
+            return mimeType;
+        } else {
+            return read((document, broker, transaction) -> document.getMetadata().getMimeType());
         }
+    }
 
-    public void setDocType(DocumentType doctype) throws XMLDBException {
-		
+    @Override
+    public String getId() throws XMLDBException {
+        return docId.toString();
+    }
+
+    @Override
+    public Collection getParentCollection() throws XMLDBException {
+        if (collection == null) {
+            throw new XMLDBException(ErrorCodes.INVALID_COLLECTION, "collection parent is null");
+        }
+        return collection;
+    }
+
+    @Override
+    public Date getCreationTime() throws XMLDBException {
+        return read((document, broker, transaction) -> new Date(document.getMetadata().getCreated()));
+    }
+
+    @Override
+    public Date getLastModificationTime() throws XMLDBException {
+        return read((document, broker, transaction) -> new Date(document.getMetadata().getLastModified()));
+    }
+
+    @Override
+    public long getContentLength() throws XMLDBException {
+        return read((document, broker, transaction) -> document.getContentLength());
+    }
+
+    @Override
+    public Permission getPermissions() throws XMLDBException {
+        return read((document, broker, transaction) -> document.getPermissions());
+    }
+
+    /**
+     * Higher-order-function for performing read-only operations against this resource
+     *
+     * NOTE this read will occur using the database user set on the resource
+     *
+     * @param readOp The read-only operation to execute against the resource
+     * @return The result of the read-only operation
+     */
+    protected <R> R read(final LocalXmldbDocumentFunction<R> readOp) throws XMLDBException {
+        return withDb((broker, transaction) -> this.<R>read(broker, transaction).apply(readOp));
+    }
+
+    /**
+     * Higher-order-function for performing read-only operations against this resource
+     *
+     * @param broker The broker to use for the operation
+     * @param transaction The transaction to use for the operation
+     * @return A function to receive a read-only operation to perform against the resource
+     */
+    public <R> FunctionE<LocalXmldbDocumentFunction<R>, R, XMLDBException> read(final DBBroker broker, final Txn transaction) throws XMLDBException {
+        return with(Lock.READ_LOCK, broker, transaction);
+    }
+
+    /**
+     * Higher-order-function for performing read/write operations against this resource
+     *
+     * NOTE this operation will occur using the database user set on the resource
+     *
+     * @param op The read/write operation to execute against the resource
+     * @return The result of the operation
+     */
+    protected <R> R modify(final LocalXmldbDocumentFunction<R> op) throws XMLDBException {
+        return withDb((broker, transaction) -> this.<R>modify(broker, transaction).apply(op));
+    }
+
+    /**
+     * Higher-order-function for performing read/write operations against this resource
+     *
+     * @param broker The broker to use for the operation
+     * @param transaction The transaction to use for the operation
+     * @return A function to receive an operation to perform against the resource
+     */
+    public <R> FunctionE<LocalXmldbDocumentFunction<R>, R, XMLDBException> modify(final DBBroker broker, final Txn transaction) throws XMLDBException {
+        return writeOp -> this.<R>with(Lock.WRITE_LOCK, broker, transaction).apply((document, broker1, transaction1) -> {
+            final R result = writeOp.apply(document, broker1, transaction1);
+            broker.storeXMLResource(transaction1, document);
+            return result;
+        });
+    }
+
+    /**
+     * Higher-order function for performing lockable operations on this resource
+     *
+     * @param lockMode
+     * @param broker The broker to use for the operation
+     * @param transaction The transaction to use for the operation
+     * @return A function to receive an operation to perform on the locked database resource
+     */
+    private <R> FunctionE<LocalXmldbDocumentFunction<R>, R, XMLDBException> with(final int lockMode, final DBBroker broker, final Txn transaction) throws XMLDBException {
+        return documentOp ->
+                collection.<R>with(lockMode, broker, transaction).apply((collection, broker1, transaction1) -> {
+                    DocumentImpl doc = null;
+                    try {
+                        doc = collection.getDocumentWithLock(broker1, docId, lockMode);
+                        if(doc == null) {
+                            throw new XMLDBException(ErrorCodes.INVALID_RESOURCE);
+                        }
+                        return documentOp.apply(doc, broker1, transaction1);
+                    } finally {
+                        if(doc != null) {
+                            doc.getUpdateLock().release(lockMode);
+                        }
+                    }
+                });
     }
 }

--- a/src/org/exist/xmldb/AbstractLocal.java
+++ b/src/org/exist/xmldb/AbstractLocal.java
@@ -1,0 +1,149 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xmldb;
+
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.Subject;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.Txn;
+import org.exist.util.function.FunctionE;
+import org.exist.xmldb.function.LocalXmldbCollectionFunction;
+import org.exist.xmldb.function.LocalXmldbFunction;
+import org.xmldb.api.base.ErrorCodes;
+import org.xmldb.api.base.XMLDBException;
+
+/**
+ * Base class for Local XMLDB classes
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+public abstract class AbstractLocal {
+    protected final BrokerPool brokerPool;
+    protected final Subject user;
+    protected LocalCollection collection;
+
+    AbstractLocal(final Subject user, final BrokerPool brokerPool, final LocalCollection collection) {
+        this.user = user;
+        this.brokerPool = brokerPool;
+        this.collection = collection;
+    }
+
+    protected XmldbURI resolve(final XmldbURI name) {
+        if (collection != null) {
+            return collection.getPathURI().resolveCollectionPath(name);
+        } else {
+            return name;
+        }
+    }
+
+    /**
+     * Higher-order-function for performing read-only operations against a database collection
+     *
+     * @param collectionUri The uri of the collection to perform read-only operations on
+     * @return A function to receive a read-only operation to perform against the collection
+     */
+    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> read(final XmldbURI collectionUri) throws XMLDBException {
+        return readOp -> withDb((broker, transaction) -> this.<R>read(broker, transaction, collectionUri).apply(readOp));
+    }
+    /**
+     * Higher-order-function for performing read-only operations against a database collection
+     *
+     * @param broker The database broker to use when accessing the collection
+     * @param transaction The transaction to use when accessing the collection
+     * @param collectionUri The uri of the collection to perform read-only operations on
+     * @return A function to receive a read-only operation to perform against the collection
+     */
+    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> read(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws XMLDBException {
+        return this.<R>with(Lock.READ_LOCK, broker, transaction, collectionUri);
+    }
+
+    /**
+     * Higher-order-function for performing read/write operations against a database collection
+     *
+     * @param collectionUri The uri of the collection to perform read/write operations on
+     * @return A function to receive a read/write operation to perform against the collection
+     */
+    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> modify(final XmldbURI collectionUri) throws XMLDBException {
+        return modifyOp -> withDb((broker, transaction) -> this.<R>modify(broker, transaction, collectionUri).apply(modifyOp));
+    }
+
+    /**
+     * Higher-order-function for performing read/write operations against a database collection
+     *
+     * @param broker The database broker to use when accessing the collection
+     * @param transaction The transaction to use when accessing the collection
+     * @param collectionUri The uri of the collection to perform read/write operations on
+     * @return A function to receive a read/write operation to perform against the collection
+     */
+    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> modify(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws XMLDBException {
+        return this.<R>with(Lock.WRITE_LOCK, broker, transaction, collectionUri);
+    }
+
+    /**
+     * Higher-order function for performing lockable operations on a collection
+     *
+     * @param lockMode
+     * @param broker The broker to use for the operation
+     * @param transaction The transaction to use for the operation
+     * @return A function to receive an operation to perform on the locked database collection
+     */
+    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> with(final int lockMode, final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws XMLDBException {
+        return collectionOp -> {
+            org.exist.collections.Collection coll = null;
+            try {
+                coll = broker.openCollection(collectionUri, lockMode);
+                if (coll == null) {
+                    throw new XMLDBException(ErrorCodes.INVALID_COLLECTION, "Collection " + collectionUri.toString() + " not found");
+                }
+
+                final R result = collectionOp.apply(coll, broker, transaction);
+                return result;
+            } catch (final PermissionDeniedException e) {
+                throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, e.getMessage(), e);
+            } finally {
+                if (coll != null) {
+                    coll.release(lockMode);
+                }
+            }
+        };
+    }
+
+    /**
+     * Higher-order-function for performing an XMLDB operation on
+     * the database
+     *
+     * @param dbOperation The operation to perform on the database
+     * @param <R>         The return type of the operation
+     * @throws org.xmldb.api.base.XMLDBException
+     */
+    <R> R withDb(final LocalXmldbFunction<R> dbOperation) throws XMLDBException {
+        try (final DBBroker broker = brokerPool.get(user);
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+            final R result = dbOperation.apply(broker, transaction);
+            transaction.commit();
+            return result;
+        } catch (final EXistException e) {
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+        }
+    }
+}

--- a/src/org/exist/xmldb/AbstractLocalService.java
+++ b/src/org/exist/xmldb/AbstractLocalService.java
@@ -19,40 +19,29 @@
  */
 package org.exist.xmldb;
 
-import java.util.Date;
-
-import org.exist.security.Permission;
-import org.w3c.dom.DocumentType;
-import org.xml.sax.ext.LexicalHandler;
-import org.xmldb.api.base.Resource;
+import org.exist.security.Subject;
+import org.exist.storage.BrokerPool;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.ErrorCodes;
+import org.xmldb.api.base.Service;
 import org.xmldb.api.base.XMLDBException;
 
 /**
- * Defines additional methods implemented by XML and binary 
- * resources.
- * 
- * @author wolf
+ * Base class for Local XMLDB Services
  *
+ * @author Adam Retter <adam.retter@googlemail.com>
  */
-public interface EXistResource extends Resource {
+public abstract class AbstractLocalService extends AbstractLocal implements Service {
 
-    Date getCreationTime() throws XMLDBException;
+    AbstractLocalService(final Subject user, final BrokerPool brokerPool, final LocalCollection collection) {
+        super(user, brokerPool, collection);
+    }
 
-    Date getLastModificationTime() throws XMLDBException;
-
-    Permission getPermissions() throws XMLDBException;
-
-    long getContentLength() throws XMLDBException;
-
-    void setLexicalHandler(LexicalHandler handler);
-    
-    void setMimeType(String mime);
-
-    String getMimeType() throws XMLDBException;
-    
-    DocumentType getDocType() throws XMLDBException;
-    
-    void setDocType(DocumentType doctype) throws XMLDBException;
-    
-    void freeResources() throws XMLDBException;
+    @Override
+    public void setCollection(final Collection collection) throws XMLDBException {
+        if(!(collection instanceof LocalCollection)) {
+            throw new XMLDBException(ErrorCodes.INVALID_COLLECTION, "incompatible collection type: " + collection.getClass().getName());
+        }
+        this.collection = (LocalCollection) collection;
+    }
 }

--- a/src/org/exist/xmldb/CollectionManagementServiceImpl.java
+++ b/src/org/exist/xmldb/CollectionManagementServiceImpl.java
@@ -1,24 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 Wolfgang M. Meier
- *  wolfgang@exist-db.org
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- * 
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.xmldb;
 
@@ -36,64 +33,61 @@ import org.xmldb.api.modules.CollectionManagementService;
  * 
  * @author wolf
  */
-public interface CollectionManagementServiceImpl extends
-        CollectionManagementService {
+public interface CollectionManagementServiceImpl extends CollectionManagementService {
 
 	/**
 	 * @deprecated Use XmldbURI version instead
 	 */
-    public void move(String collection, String destination, String newName)
-    throws XMLDBException;
+    public void move(String collection, String destination, String newName) throws XMLDBException;
     
 	/**
 	 * @deprecated Use XmldbURI version instead
 	 */
-    public void moveResource(String resourcePath, String destinationPath, String newName) 
-    throws XMLDBException;
+    public void moveResource(String resourcePath, String destinationPath, String newName) throws XMLDBException;
      
 	/**
 	 * @deprecated Use XmldbURI version instead
 	 */
-    public void copyResource(String resourcePath, String destinationPath, String newName)
-    throws XMLDBException;
+    public void copyResource(String resourcePath, String destinationPath, String newName) throws XMLDBException;
     
 	/**
 	 * @deprecated Use XmldbURI version instead
 	 */
-    public void copy(String collection, String destination, String newName)
-    throws XMLDBException;
-    
+    public void copy(String collection, String destination, String newName) throws XMLDBException;
+
 	/**
 	 * @deprecated Use XmldbURI version instead
 	 */
-    public Collection createCollection( String collName, Date created) throws XMLDBException;
+    @Deprecated
+    public Collection createCollection(String collName, Date created) throws XMLDBException;
     
-    public void move(XmldbURI collection, XmldbURI destination, XmldbURI newName)
-    throws XMLDBException;
+    public void move(XmldbURI collection, XmldbURI destination, XmldbURI newName) throws XMLDBException;
     
-    public void moveResource(XmldbURI resourcePath, XmldbURI destinationPath, XmldbURI newName) 
-    throws XMLDBException;
+    public void moveResource(XmldbURI resourcePath, XmldbURI destinationPath, XmldbURI newName) throws XMLDBException;
      
-    public void copyResource(XmldbURI resourcePath, XmldbURI destinationPath, XmldbURI newName)
-    throws XMLDBException;
+    public void copyResource(XmldbURI resourcePath, XmldbURI destinationPath, XmldbURI newName) throws XMLDBException;
     
-    public void copy(XmldbURI collection, XmldbURI destination, XmldbURI newName)
-    throws XMLDBException;
+    public void copy(XmldbURI collection, XmldbURI destination, XmldbURI newName) throws XMLDBException;
     
-    public Collection createCollection( XmldbURI collName, Date created) throws XMLDBException;
+    public Collection createCollection(XmldbURI collName, Date created) throws XMLDBException;
     
     /**
      * @deprecated Use XmldbURI version instead
      */
-    public Collection createCollection( String collName) throws XMLDBException;
-    public Collection createCollection( XmldbURI collName) throws XMLDBException;
+    @Deprecated
+    @Override
+    public Collection createCollection(String collName) throws XMLDBException;
+
+    public Collection createCollection(XmldbURI collName) throws XMLDBException;
     
     /**
      * @deprecated Use XmldbURI version instead
      */
-    public void removeCollection( String collName) throws XMLDBException;
-    public void removeCollection( XmldbURI collName) throws XMLDBException;
+    @Override
+    @Deprecated
+    public void removeCollection(String collName) throws XMLDBException;
+
+    public void removeCollection(XmldbURI collName) throws XMLDBException;
     
-    public void runCommand( String[] params) throws XMLDBException;
-    
+    public void runCommand(String[] params) throws XMLDBException;
 }

--- a/src/org/exist/xmldb/ExtendedResource.java
+++ b/src/org/exist/xmldb/ExtendedResource.java
@@ -37,29 +37,29 @@ import org.xmldb.api.base.XMLDBException;
  */
 public interface ExtendedResource
 {
-	/**
-	 * It returns an object representing the content, in the representation
-	 * which needs less memory.
-	 */
-	public Object getExtendedContent()  throws XMLDBException;
-	/**
-	 * It returns an stream to the content, whichever it is its origin
-	 */
-	public InputStream getStreamContent()  throws XMLDBException;
-	/**
-	 * It returns the length of the content, whichever it is its origin
-	 */
-	public long getStreamLength()  throws XMLDBException;
-	
-	/**
-	 * It saves the resource to the local file given as input parameter.
-	 * Do NOT confuse with set content.
-	 */
-	public void getContentIntoAFile(File localfile)  throws XMLDBException;
-	
-	/**
-	 * It saves the resource to the local stream given as input parameter.
-	 * Do NOT confuse with set content.
-	 */
-	public void getContentIntoAStream(OutputStream os)  throws XMLDBException;
+    /**
+     * It returns an object representing the content, in the representation
+     * which needs less memory.
+     */
+    public Object getExtendedContent()  throws XMLDBException;
+    /**
+     * It returns an stream to the content, whichever it is its origin
+     */
+    public InputStream getStreamContent()  throws XMLDBException;
+    /**
+     * It returns the length of the content, whichever it is its origin
+     */
+    public long getStreamLength()  throws XMLDBException;
+
+    /**
+     * It saves the resource to the local file given as input parameter.
+     * Do NOT confuse with set content.
+     */
+    public void getContentIntoAFile(File localfile)  throws XMLDBException;
+
+    /**
+     * It saves the resource to the local stream given as input parameter.
+     * Do NOT confuse with set content.
+     */
+    public void getContentIntoAStream(OutputStream os)  throws XMLDBException;
 }

--- a/src/org/exist/xmldb/LocalBinaryResource.java
+++ b/src/org/exist/xmldb/LocalBinaryResource.java
@@ -1,483 +1,210 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-06 Wolfgang M. Meier
- *  wolfgang@exist-db.org
- *  http://exist.sourceforge.net
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.xmldb;
 
-import org.exist.EXistException;
 import org.exist.dom.persistent.BinaryDocument;
-import org.exist.dom.persistent.DocumentImpl;
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.exist.security.Permission;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
-import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
 import org.exist.util.EXistInputSource;
-import org.exist.util.LockException;
+import org.w3c.dom.DocumentType;
 import org.xml.sax.InputSource;
-import org.xmldb.api.base.Collection;
+import org.xml.sax.ext.LexicalHandler;
 import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.BinaryResource;
 
 import java.io.*;
-import java.util.Date;
-import org.exist.security.PermissionDeniedException;
 
-/**
- * @author wolf
- */
 public class LocalBinaryResource extends AbstractEXistResource implements ExtendedResource, BinaryResource, EXistResource {
 
-	protected InputSource inputSource = null;
-	protected File file = null;
-	protected byte[] rawData = null;
-	private boolean isExternal=false;
-	
-	protected Date datecreated= null;
-	protected Date datemodified= null;
-	
-	/**
-	 * 
-	 */
-	public LocalBinaryResource(Subject user, BrokerPool pool, LocalCollection collection, XmldbURI docId) {
-		super(user, pool, collection, docId, null);
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.xmldb.api.base.Resource#getParentCollection()
-	 */
-	public Collection getParentCollection() throws XMLDBException {
-		return parent;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.xmldb.api.base.Resource#getId()
-	 */
-	public String getId() throws XMLDBException {
-		return docId.toString();
-	}
+    protected InputSource inputSource = null;
+    protected File file = null;
+    protected byte[] rawData = null;
+    private boolean isExternal = false;
 
-	/* (non-Javadoc)
-	 * @see org.xmldb.api.base.Resource#getResourceType()
-	 */
-	public String getResourceType() throws XMLDBException {
-		return "BinaryResource";
-	}
+    public LocalBinaryResource(final Subject user, final BrokerPool brokerPool, final LocalCollection collection, final XmldbURI docId) {
+        super(user, brokerPool, collection, docId, null);
+    }
 
-	public Object getExtendedContent() throws XMLDBException {
-		if(file!=null)
-			{return file;}
-		if(inputSource!=null)
-			{return inputSource;}
+    @Override
+    public String getResourceType() throws XMLDBException {
+        return BinaryResource.RESOURCE_TYPE;
+    }
 
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		BinaryDocument blob = null;
-		InputStream rawDataStream = null;
-		try {
-			broker = pool.get(user);
-			blob = (BinaryDocument)getDocument(broker, Lock.READ_LOCK);
-			if(!blob.getPermissions().validate(user, Permission.READ))
-			    {throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-			    	"Permission denied to read resource");}
-			
-			rawDataStream = broker.getBinaryResource(blob);
-		} catch(final EXistException e) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-				"error while loading binary resource " + getId(), e);
-		} catch(final IOException e) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-				"error while loading binary resource " + getId(), e);
-		} finally {
-			if(blob!=null)
-				{parent.getCollection().releaseDocument(blob, Lock.READ_LOCK);}
-			if(broker!=null)
-				{pool.release(broker);}
-			
-			pool.setSubject(preserveSubject);
-		}
-		
-		return rawDataStream;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.xmldb.api.base.Resource#getContent()
-	 */
-	public Object getContent() throws XMLDBException {
-		final Object res=getExtendedContent();
-		if(res!=null) {
-			if(res instanceof File) {
-				return readFile((File)res);
-			} else if(res instanceof InputSource) {
-				return readFile((InputSource)res);
-			} else if(res instanceof InputStream) {
-				return readFile((InputStream)res);
-			}
-		}
-		
-		return res;
-	}
+    @Override
+    public Object getExtendedContent() throws XMLDBException {
+        if (file != null) {
+            return file;
+        }
+        if (inputSource != null) {
+            return inputSource;
+        }
 
-	/* (non-Javadoc)
-	 * @see org.xmldb.api.base.Resource#setContent(java.lang.Object)
-	 */
-	public void setContent(Object value) throws XMLDBException {
-		if(value instanceof File) {
-			file=(File)value;
-			isExternal=true;
-		} else if(value instanceof InputSource) {
-			inputSource=(InputSource)value;
-			isExternal=true;
-		} else if(value instanceof byte[]) {
-			rawData = (byte[])value;
-			isExternal=true;
-		} else if(value instanceof String) {
-			rawData = ((String)value).getBytes();
-			isExternal=true;
-		} else
-			{throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-				"don't know how to handle value of type " + value.getClass().getName());}
-	}
-	
-	public InputStream getStreamContent() throws XMLDBException {
-		InputStream retval=null;
-		if(file!=null) {
-			try {
-				retval=new FileInputStream(file);
-			} catch(final FileNotFoundException fnfe) {
-				// Cannot fire it :-(
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, fnfe.getMessage(), fnfe);
-			}
-		} else if(inputSource!=null) {
-			retval=inputSource.getByteStream();
-		} else if(rawData!=null) {
-			retval=new ByteArrayInputStream(rawData);
-		} else {
-			final Subject preserveSubject = pool.getSubject();
-			DBBroker broker = null;
-			BinaryDocument blob = null;
-			try {
-				broker = pool.get(user);
-				blob = (BinaryDocument)getDocument(broker, Lock.READ_LOCK);
-				if(!blob.getPermissions().validate(user, Permission.READ))
-				    {throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-				    	"Permission denied to read resource");}
-				
-				retval = broker.getBinaryResource(blob);
-			} catch(final EXistException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-					"error while loading binary resource " + getId(), e);
-			} catch(final IOException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-					"error while loading binary resource " + getId(), e);
-			} finally {
-				if(blob!=null)
-					{parent.getCollection().releaseDocument(blob, Lock.READ_LOCK);}
-				if(broker!=null)
-					{pool.release(broker);}
-				
-				pool.setSubject(preserveSubject);
-			}
-		}
-		
-		return retval;
-	}
-	
-	public void getContentIntoAFile(File tmpfile) throws XMLDBException {
-		try {
-			final FileOutputStream fos=new FileOutputStream(tmpfile);
-			final BufferedOutputStream bos=new BufferedOutputStream(fos);
-			getContentIntoAStream(bos);
-			bos.close();
-			fos.close();
-		} catch(final IOException ioe) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-					"error while loading binary resource " + getId(), ioe);
-		}
-	}
-	
-	public void getContentIntoAStream(OutputStream os) throws XMLDBException {
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		BinaryDocument blob = null;
-		boolean doClose=false;
-		try {
-			broker = pool.get(user);
-			blob = (BinaryDocument)getDocument(broker, Lock.READ_LOCK);
-			if(!blob.getPermissions().validate(user, Permission.READ))
-				{throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-					"Permission denied to read resource");}
-			
-			// Improving the performance a bit for files!
-			if(os instanceof FileOutputStream) {
-				os = new BufferedOutputStream(os,655360);
-				doClose=true;
-			}
-			
-			broker.readBinaryResource(blob, os);
-		} catch(final EXistException e) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-				"error while loading binary resource " + getId(), e);
-		} catch(final IOException ioe) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-					"error while loading binary resource " + getId(), ioe);
-		} finally {
-			if(blob!=null)
-				{parent.getCollection().releaseDocument(blob, Lock.READ_LOCK);}
-			if(broker!=null)
-				{pool.release(broker);}
-			
-			pool.setSubject(preserveSubject);
-			if(doClose) {
-				try {
-					os.close();
-				} catch(final IOException ioe) {
-					// IgnoreIT(R)
-				}
-			}
-		}
-	}
-	
-        @Override
-	public void freeResources()
-	{
-		if(!isExternal && file!=null) {
-			file=null;
-		}
-	}
-	
-	public long getStreamLength() throws XMLDBException {
-		long retval=-1;
-		if(file!=null) {
-			retval=file.length();
-		} else if(inputSource!=null && inputSource instanceof EXistInputSource) {
-			retval=((EXistInputSource)inputSource).getByteStreamLength();
-		} else if(rawData!=null) {
-			retval=rawData.length;
-		} else {
-			final Subject preserveSubject = pool.getSubject();
-			DBBroker broker = null;
-			BinaryDocument blob = null;
-			try {
-				broker = pool.get(user);
-				blob = (BinaryDocument)getDocument(broker, Lock.READ_LOCK);
-				retval=blob.getContentLength();
-			} catch(final EXistException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-					"error while loading binary resource " + getId(), e);
-			} finally {
-				if(blob!=null)
-					{parent.getCollection().releaseDocument(blob, Lock.READ_LOCK);}
-				
-				if(broker!=null)
-					{pool.release(broker);}
-				
-				pool.setSubject(preserveSubject);
-			}
-		}
-		
-		return retval;
-	}
-	
-	private byte[] readFile(File file) throws XMLDBException {
-		try {
-			return readFile(new FileInputStream(file));
-		} catch (final FileNotFoundException e) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-				"file " + file.getAbsolutePath() + " could not be found", e);
-		}
-	}
+        return read((document, broker, transaction) -> broker.getBinaryResource(((BinaryDocument) document)));
+    }
 
-	private byte[] readFile(InputSource is) throws XMLDBException {
-		return readFile(is.getByteStream());
-	}
+    @Override
+    public Object getContent() throws XMLDBException {
+        final Object res = getExtendedContent();
+        if(res != null) {
+            if(res instanceof File) {
+                    return readFile((File)res);
+            } else if(res instanceof InputSource) {
+                    return readFile((InputSource)res);
+            } else if(res instanceof InputStream) {
+                    return readFile((InputStream)res);
+            }
+        }
 
-	private byte[] readFile(InputStream is) throws XMLDBException {
-		try {
-			final ByteArrayOutputStream bos = new ByteArrayOutputStream(2048);
-			final byte[] temp = new byte[1024];
-			int count = 0;
-			while((count = is.read(temp)) > -1) {
-				bos.write(temp, 0, count);
-			}
-			return bos.toByteArray();
-		} catch (final FileNotFoundException e) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-				"file " + file.getAbsolutePath() + " could not be found", e);
-		} catch (final IOException e) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-				"IO exception while reading file " + file.getAbsolutePath(), e);
-		} finally {
-			try {
-				is.close();
-			} catch (final IOException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-						"IO exception while closing stream of file " + file.getAbsolutePath(), e);
-			}
-		}
-	}
+        return res;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#getCreationTime()
-	 */
-	public Date getCreationTime() throws XMLDBException {
-        if (isNewResource)
-            {throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, "The resource has not yet been stored");}
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		try {
-			broker = pool.get(user);
-			final BinaryDocument blob = (BinaryDocument)getDocument(broker, Lock.NO_LOCK);
-			return new Date(blob.getMetadata().getCreated());
-		} catch (final EXistException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(), e);
-		} finally {
-			pool.release(broker);
-			pool.setSubject(preserveSubject);
-		}
-	}
+    @Override
+    public void setContent(final Object value) throws XMLDBException {
+        if(value instanceof File) {
+            file = (File)value;
+        } else if(value instanceof InputSource) {
+            inputSource = (InputSource)value;
+        } else if(value instanceof byte[]) {
+            rawData = (byte[])value;
+        } else if(value instanceof String) {
+            rawData = ((String)value).getBytes();
+        } else {
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "don't know how to handle value of type " + value.getClass().getName());
+        }
+        isExternal = true;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#getLastModificationTime()
-	 */
-	public Date getLastModificationTime() throws XMLDBException {
-        if (isNewResource)
-            {throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, "The resource has not yet been stored");}
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		try {
-			broker = pool.get(user);
-			final BinaryDocument blob = (BinaryDocument)getDocument(broker, Lock.NO_LOCK);
-			return new Date(blob.getMetadata().getLastModified());
-		} catch (final EXistException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(), e);
-		} finally {
-			pool.release(broker);
-			pool.setSubject(preserveSubject);
-		}
-	}
+    @Override
+    public InputStream getStreamContent() throws XMLDBException {
+        final InputStream retval;
+        if(file != null) {
+            try {
+                retval = new FileInputStream(file);
+            } catch(final FileNotFoundException fnfe) {
+                // Cannot fire it :-(
+                throw new XMLDBException(ErrorCodes.VENDOR_ERROR, fnfe.getMessage(), fnfe);
+            }
+        } else if(inputSource!=null) {
+            retval = inputSource.getByteStream();
+        } else if(rawData!=null) {
+            retval = new ByteArrayInputStream(rawData);
+        } else {
+            retval = read((document, broker, transaction) -> broker.getBinaryResource(((BinaryDocument) document)));
+        }
 
-    /* (non-Javadoc)
-     * @see org.exist.xmldb.AbstractEXistResource#getMimeType()
-     */
-    public String getMimeType() throws XMLDBException {
-        if (isNewResource)
-            {return mimeType;}
-		final Subject preserveSubject = pool.getSubject();
-        DBBroker broker = null;
-        try {
-            broker = pool.get(user);
-            final BinaryDocument blob = (BinaryDocument)getDocument(broker, Lock.NO_LOCK);
-            mimeType = blob.getMetadata().getMimeType();
-            return mimeType;
-        } catch (final EXistException e) {
-            throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(), e);
-        } finally {
-            pool.release(broker);
-			pool.setSubject(preserveSubject);
+        return retval;
+    }
+
+    @Override
+    public void getContentIntoAFile(final File tmpFile) throws XMLDBException {
+        try(final OutputStream bos = new BufferedOutputStream(new FileOutputStream(tmpFile))) {
+            getContentIntoAStream(bos);
+        } catch(final IOException ioe) {
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "error while loading binary resource " + getId(), ioe);
         }
     }
-    
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#getMode()
-	 */
-	public Permission getPermissions() throws XMLDBException {
-        if (isNewResource)
-            {throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, "The resource has not yet been stored");}
-		final Subject preserveSubject = pool.getSubject();
-	    DBBroker broker = null;
-	    try {
-	        broker = pool.get(user);
-		    final DocumentImpl document = getDocument(broker, Lock.NO_LOCK);
-			return document != null ? document.getPermissions() : null;
-	    } catch (final EXistException e) {
-            throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e.getMessage(), e);
-        } finally {
-	        pool.release(broker);
-			pool.setSubject(preserveSubject);
-	    }
-	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#getContentLength()
-	 */
-	public long getContentLength() throws XMLDBException {
-        if (isNewResource)
-            {throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, "The resource has not yet been stored");}
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		try {
-			broker = pool.get(user);
-			final DocumentImpl document = getDocument(broker, Lock.NO_LOCK);
-			return document.getContentLength();
-		} catch (final EXistException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(),
-					e);
-		} finally {
-			pool.release(broker);
-			pool.setSubject(preserveSubject);
-		}
-	}
-	
-	protected DocumentImpl getDocument(DBBroker broker, int lock) throws XMLDBException {
-	    DocumentImpl document = null;
-	    if(lock != Lock.NO_LOCK) {
-                try {
-                    document = parent.getCollection().getDocumentWithLock(broker, docId, lock);
-                } catch (final PermissionDeniedException e) {
-                    throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-                            "Permission denied for document " + docId + ": " + e.getMessage());
-                } catch (final LockException e) {
-                    throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-                            "Failed to acquire lock on document " + docId);
+    @Override
+    public void getContentIntoAStream(final OutputStream os) throws XMLDBException {
+        read((document, broker, transaction) -> {
+            if(os instanceof FileOutputStream) {
+                try(final OutputStream bos = new BufferedOutputStream(os, 655360)) {
+                    broker.readBinaryResource((BinaryDocument) document, bos);
                 }
             } else {
-                try { 
-                    document = parent.getCollection().getDocument(broker, docId);
-                } catch (final PermissionDeniedException e) {
-                    throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, "Permission denied for document " + docId + ": " + e.getMessage());
-                }
+                broker.readBinaryResource((BinaryDocument) document, os);
             }
-	    
-            if (document == null) {
-	        throw new XMLDBException(ErrorCodes.INVALID_RESOURCE);
-            }
-	    
-            if (document.getResourceType() != DocumentImpl.BINARY_FILE) {
-	        throw new XMLDBException(ErrorCodes.WRONG_CONTENT_TYPE, "Document " + docId + 
-	                " is not a binary resource");
-            }
-            
-	    return document;
-	}
+            return null;
+        });
+    }
 	
-	protected DocumentImpl openDocument(DBBroker broker, int lockMode) throws XMLDBException {
-	    final DocumentImpl document = super.openDocument(broker, lockMode);
-	    if (document.getResourceType() != DocumentImpl.BINARY_FILE) {
-	    	closeDocument(document, lockMode);
-	        throw new XMLDBException(ErrorCodes.WRONG_CONTENT_TYPE, "Document " + docId + 
-	                " is not a binary resource");
-	    }
-	    return document;
-	}
+    @Override
+    public void freeResources() {
+        if(!isExternal && file != null) {
+            file = null;
+        }
+    }
+
+    @Override
+    public long getStreamLength() throws XMLDBException {
+        final long retval;
+
+        if(file != null) {
+            retval = file.length();
+        } else if(inputSource != null && inputSource instanceof EXistInputSource) {
+            retval = ((EXistInputSource)inputSource).getByteStreamLength();
+        } else if(rawData != null) {
+            retval = rawData.length;
+        } else {
+            retval = getContentLength();
+        }
+		
+        return retval;
+    }
+	
+    private byte[] readFile(final File file) throws XMLDBException {
+        try {
+            return readFile(new FileInputStream(file));
+        } catch (final FileNotFoundException e) {
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "file " + file.getAbsolutePath() + " could not be found", e);
+        }
+    }
+
+    private byte[] readFile(final InputSource is) throws XMLDBException {
+        return readFile(is.getByteStream());
+    }
+
+    private byte[] readFile(final InputStream is) throws XMLDBException {
+        try(final ByteArrayOutputStream bos = new ByteArrayOutputStream(2048)) {
+            final byte[] temp = new byte[1024];
+            int count = 0;
+            while((count = is.read(temp)) > -1) {
+                    bos.write(temp, 0, count);
+            }
+            return bos.toByteArray();
+        } catch (final FileNotFoundException e) {
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "file " + file.getAbsolutePath() + " could not be found", e);
+        } catch (final IOException e) {
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "IO exception while reading file " + file.getAbsolutePath(), e);
+        } finally {
+            try {
+                is.close();
+            } catch (final IOException e) {
+                throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "IO exception while closing stream of file " + file.getAbsolutePath(), e);
+            }
+        }
+    }
+
+    @Override
+    public DocumentType getDocType() throws XMLDBException {
+        return null;
+    }
+
+    @Override
+    public void setDocType(final DocumentType doctype) throws XMLDBException {
+    }
+
+    @Override
+    public void setLexicalHandler(final LexicalHandler handler) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/org/exist/xmldb/LocalResourceSet.java
+++ b/src/org/exist/xmldb/LocalResourceSet.java
@@ -1,41 +1,35 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2001-2007 The eXist Project
+ * Copyright (C) 2001-2015 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *  
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
- *  $Id$
  */
 package org.exist.xmldb;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Iterator;
-import java.util.Properties;
-import java.util.Vector;
+import java.util.*;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import org.exist.EXistException;
 import org.exist.Namespaces;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.persistent.SortedNodeSet;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
-import org.exist.storage.DBBroker;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.serializer.SerializerPool;
@@ -57,248 +51,197 @@ import org.xmldb.api.base.ResourceIterator;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 
-public class LocalResourceSet implements ResourceSet {
+public class LocalResourceSet extends AbstractLocal implements ResourceSet {
 
-        protected final static Logger LOG = LogManager.getLogger(LocalResourceSet.class);
+        private final static Logger LOG = LogManager.getLogger(LocalResourceSet.class);
 
-	protected BrokerPool brokerPool;
-	protected LocalCollection collection;
-	protected Vector<Object> resources = new Vector<Object>();
-	protected Properties outputProperties;
-	private Subject user;
+    private final List resources = new ArrayList();
+    private final Properties outputProperties;
 
-	@SuppressWarnings("unused")
-	private LocalResourceSet() {}
-	
-	public LocalResourceSet(
-		Subject user,
-		BrokerPool pool,
-		LocalCollection col,
-		Properties properties,
-		Sequence val,
-		String sortExpr)
-		throws XMLDBException {
-		if(col == null)
-			{throw new NullPointerException("Collection cannot be null");}
-		this.user = user;
-		this.brokerPool = pool;
-		this.outputProperties = properties;
-		this.collection = col;
-		if(val.isEmpty())
-			{return;}
-		if(Type.subTypeOf(val.getItemType(), Type.NODE) && sortExpr != null) {
-			SortedNodeSet sorted = new SortedNodeSet(brokerPool, user, sortExpr, collection.getAccessContext());
-			try {
-				sorted.addAll(val);
-			} catch (final XPathException e) {
-				throw new XMLDBException(ErrorCodes.INVALID_RESOURCE,
-					e.getMessage(), e);
-			}
-			val = sorted;
-		}
-		Item item;
-		try {
-			for(final SequenceIterator i = val.iterate(); i.hasNext(); ) {
-				item = i.nextItem();
-				resources.add(item);
-			}
-		} catch (final XPathException e) {
-			throw new XMLDBException(ErrorCodes.INVALID_RESOURCE,
-					e.getMessage(), e);
-		}
-	}
+    public LocalResourceSet(final Subject user, final BrokerPool pool, final LocalCollection col, final Properties properties, final Sequence val, final String sortExpr) throws XMLDBException {
+        super(user, pool, col);
+        this.outputProperties = properties;
 
-    @Override
-	public void addResource(Resource resource) throws XMLDBException {
-		resources.add(resource);
-	}
-
-    @Override
-	public void clear() throws XMLDBException {
-
-            //cleanup any binary values
-            for(final Object resource : resources) {
-                if(resource instanceof BinaryValue) {
-                    try {
-                        ((BinaryValue) resource).close();
-                    } catch(final IOException ioe) {
-                        LOG.warn("Unable to cleanup BinaryValue: " + resource.hashCode(), ioe);
-                    }
-                }
-            }
-
-                resources.clear();
-	}
-
-	public ResourceIterator getIterator() throws XMLDBException {
-		return new NewResourceIterator();
-	}
-
-	public ResourceIterator getIterator(long start) throws XMLDBException {
-		return new NewResourceIterator(start);
-	}
-
-	public Resource getMembersAsResource() throws XMLDBException {
-        final SAXSerializer handler = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
-		final StringWriter writer = new StringWriter();
-		handler.setOutput(writer, outputProperties);
-		
-		DBBroker broker = null;
-		try {
-			broker = brokerPool.get(user);
-			// configure the serializer
-			final Serializer serializer = broker.getSerializer();
-			serializer.reset();
-			collection.properties.setProperty(Serializer.GENERATE_DOC_EVENTS, "false");
-			serializer.setProperties(outputProperties);
-			serializer.setUser(user);
-			serializer.setSAXHandlers(handler, handler);
-
-			//	serialize results
-			handler.startDocument();
-			handler.startPrefixMapping("exist", Namespaces.EXIST_NS);
-			final AttributesImpl attribs = new AttributesImpl();
-			attribs.addAttribute(
-				"",
-				"hitCount",
-				"hitCount",
-				"CDATA",
-				Integer.toString(resources.size()));
-			handler.startElement(
-					Namespaces.EXIST_NS,
-						"result",
-						"exist:result",
-						attribs);
-			Item current;
-			char[] value;
-			for(final Iterator<Object> i = resources.iterator(); i.hasNext(); ) {
-				current = (Item)i.next();
-				if(Type.subTypeOf(current.getType(), Type.NODE)) {
-					((NodeValue)current).toSAX(broker, handler, outputProperties);
-				} else {
-					value = current.toString().toCharArray();
-					handler.characters(value, 0, value.length);
-				}
-			}
-			handler.endElement(Namespaces.EXIST_NS, "result", "exist:result");
-			handler.endPrefixMapping("exist");
-			handler.endDocument();
-		} catch (final EXistException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, "serialization error", e);
-		} catch (final SAXException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, "serialization error", e);
-		} finally {
-			brokerPool.release(broker);
-		}
-		final Resource res = new LocalXMLResource(user, brokerPool, collection, XmldbURI.EMPTY_URI);
-		res.setContent(writer.toString());
-        SerializerPool.getInstance().returnObject(handler);
-		return res;
-	}
-
-	public Resource getResource(long pos) throws XMLDBException {
-		if (pos < 0 || pos >= resources.size())
-			{return null;}
-		final Object r = resources.get((int) pos);
-		LocalXMLResource res = null;
-		if (r instanceof NodeProxy) {
-			final NodeProxy p = (NodeProxy) r;
-			// the resource might belong to a different collection
-			// than the one by which this resource set has been
-			// generated: adjust if necessary.
-			LocalCollection coll = collection;
-			if (p.getOwnerDocument().getCollection() == null
-				|| coll.getCollection().getId() != p.getOwnerDocument().getCollection().getId()) {
-				coll = new LocalCollection(user, brokerPool, null, p.getOwnerDocument().getCollection().getURI(), coll.getAccessContext());
-				coll.properties = outputProperties;
-			}
-			res = new LocalXMLResource(user, brokerPool, coll, p);
-		} else if (r instanceof Node) {
-			res = new LocalXMLResource(user, brokerPool, collection, XmldbURI.EMPTY_URI);
-			res.setContentAsDOM((Node)r);
-		} else if (r instanceof AtomicValue) {
-			res = new LocalXMLResource(user, brokerPool, collection, XmldbURI.EMPTY_URI);
-			res.setContent(r);
-		} else if (r instanceof Resource)
-			{return (Resource) r;}
-		res.setProperties(outputProperties);
-		return res;
-	}
-
-    public Sequence toSequence() {
-        if (resources.size() == 0)
-            {return Sequence.EMPTY_SEQUENCE;}
-        if (resources.size() == 1)
-            {return ((Item) resources.get(0)).toSequence();}
-        final ValueSequence s = new ValueSequence();
-        for (int i = 0; i < resources.size(); i++) {
-            final Item item = (Item) resources.get(i);
-            s.add(item);
+        if(val.isEmpty()) {
+            return;
         }
-        return s;
+
+        final Sequence seq;
+        if(Type.subTypeOf(val.getItemType(), Type.NODE) && sortExpr != null) {
+            final SortedNodeSet sorted = new SortedNodeSet(brokerPool, user, sortExpr, collection.getAccessContext());
+            try {
+                    sorted.addAll(val);
+            } catch (final XPathException e) {
+                    throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e.getMessage(), e);
+            }
+            seq = sorted;
+        } else {
+            seq = val;
+        }
+
+        try {
+            for(final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
+                final Item item = i.nextItem();
+                resources.add(item);
+            }
+        } catch (final XPathException e) {
+            throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e.getMessage(), e);
+        }
     }
 
-	/**
-	 *  Gets the size attribute of the LocalResourceSet object
-	 *
-	 *@return                     The size value
-	 *@exception  XMLDBException  Description of the Exception
-	 */
-	public long getSize() throws XMLDBException {
-		return resources.size();
-	}
+    @Override
+    public void addResource(final Resource resource) throws XMLDBException {
+        resources.add(resource);
+    }
 
-	/**
-	 *  Description of the Method
-	 *
-	 *@param  pos                 Description of the Parameter
-	 *@exception  XMLDBException  Description of the Exception
-	 */
-	public void removeResource(long pos) throws XMLDBException {
-		resources.removeElementAt((int) pos);
-	}
+    @Override
+    public void clear() throws XMLDBException {
+        //cleanup any binary values
+        resources.stream().filter((resource) -> (resource instanceof BinaryValue)).forEach((resource) -> {
+            try {
+                ((BinaryValue) resource).close();
+            } catch(final IOException ioe) {
+                LOG.warn("Unable to cleanup BinaryValue: " + resource.hashCode(), ioe);
+            }
+        });
 
-	/**
-	 *  Description of the Class
-	 *
-	 *@author     wolf
-	 *@created    3. Juni 2002
-	 */
-	class NewResourceIterator implements ResourceIterator {
+        resources.clear();
+    }
 
-		long pos = 0;
+    @Override
+    public ResourceIterator getIterator() throws XMLDBException {
+        return new NewResourceIterator();
+    }
 
-		/**  Constructor for the NewResourceIterator object */
-		public NewResourceIterator() {
-		}
+    public ResourceIterator getIterator(final long start) throws XMLDBException {
+        return new NewResourceIterator(start);
+    }
 
-		/**
-		 *  Constructor for the NewResourceIterator object
-		 *
-		 *@param  start  Description of the Parameter
-		 */
-		public NewResourceIterator(long start) {
-			pos = start;
-		}
+    @Override
+    public Resource getMembersAsResource() throws XMLDBException {
+        final SAXSerializer handler = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
+        final StringWriter writer = new StringWriter();
+        handler.setOutput(writer, outputProperties);
+		
+        return this.<Resource>withDb((broker, transaction) -> {
+            try {
+                // configure the serializer
+                final Serializer serializer = broker.getSerializer();
+                serializer.reset();
+                collection.setProperty(Serializer.GENERATE_DOC_EVENTS, "false");
+                serializer.setProperties(outputProperties);
+                serializer.setUser(user);
+                serializer.setSAXHandlers(handler, handler);
 
-		/**
-		 *  Description of the Method
-		 *
-		 *@return                     Description of the Return Value
-		 *@exception  XMLDBException  Description of the Exception
-		 */
-		public boolean hasMoreResources() throws XMLDBException {
-			return pos < getSize();
-		}
+                //	serialize results
+                handler.startDocument();
+                handler.startPrefixMapping("exist", Namespaces.EXIST_NS);
+                final AttributesImpl attribs = new AttributesImpl();
+                attribs.addAttribute("", "hitCount", "hitCount", "CDATA", Integer.toString(resources.size()));
+                handler.startElement(Namespaces.EXIST_NS, "result", "exist:result", attribs);
+                Item current;
+                char[] value;
+                for (final Iterator<Object> i = resources.iterator(); i.hasNext(); ) {
+                    current = (Item) i.next();
+                    if (Type.subTypeOf(current.getType(), Type.NODE)) {
+                        ((NodeValue) current).toSAX(broker, handler, outputProperties);
+                    } else {
+                        value = current.toString().toCharArray();
+                        handler.characters(value, 0, value.length);
+                    }
+                }
+                handler.endElement(Namespaces.EXIST_NS, "result", "exist:result");
+                handler.endPrefixMapping("exist");
+                handler.endDocument();
 
-		/**
-		 *  Description of the Method
-		 *
-		 *@return                     Description of the Return Value
-		 *@exception  XMLDBException  Description of the Exception
-		 */
-		public Resource nextResource() throws XMLDBException {
-			return getResource(pos++);
-		}
-	}
+                final Resource res = new LocalXMLResource(user, brokerPool, collection, XmldbURI.EMPTY_URI);
+                res.setContent(writer.toString());
+                SerializerPool.getInstance().returnObject(handler);
+                return res;
+            }  catch (final SAXException e) {
+                throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, "serialization error", e);
+            }
+        });
+    }
+
+    @Override
+    public Resource getResource(final long pos) throws XMLDBException {
+        if (pos < 0 || pos >= resources.size()) {
+            return null;
+        }
+
+        final Object r = resources.get((int) pos);
+
+        LocalXMLResource res = null;
+        if (r instanceof NodeProxy) {
+            final NodeProxy p = (NodeProxy) r;
+            // the resource might belong to a different collection
+            // than the one by which this resource set has been
+            // generated: adjust if necessary.
+            LocalCollection coll = collection;
+            if (p.getOwnerDocument().getCollection() == null || !coll.getPathURI().toCollectionPathURI().equals(p.getOwnerDocument().getCollection().getURI())) {
+                    coll = new LocalCollection(user, brokerPool, null, p.getOwnerDocument().getCollection().getURI(), coll.getAccessContext());
+                    coll.setProperties(outputProperties);
+            }
+            res = new LocalXMLResource(user, brokerPool, coll, p);
+        } else if (r instanceof Node) {
+            res = new LocalXMLResource(user, brokerPool, collection, XmldbURI.EMPTY_URI);
+            res.setContentAsDOM((Node) r);
+        } else if (r instanceof AtomicValue) {
+            res = new LocalXMLResource(user, brokerPool, collection, XmldbURI.EMPTY_URI);
+            res.setContent(r);
+        } else if (r instanceof Resource) {
+            return (Resource)r;
+        }
+
+        res.setProperties(outputProperties);
+
+        return res;
+    }
+
+    public Sequence toSequence() {
+        if (resources.isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        } else if (resources.size() == 1) {
+            return ((Item) resources.get(0)).toSequence();
+        } else {
+            final ValueSequence s = new ValueSequence();
+            for (Object resource : resources) {
+                final Item item = (Item) resource;
+                s.add(item);
+            }
+            return s;
+        }
+    }
+
+    @Override
+    public long getSize() throws XMLDBException {
+        return resources.size();
+    }
+
+    @Override
+    public void removeResource(final long pos) throws XMLDBException {
+        resources.remove(pos);
+    }
+
+    class NewResourceIterator implements ResourceIterator {
+        long pos = 0;
+
+        public NewResourceIterator() {
+        }
+
+        public NewResourceIterator(final long start) {
+            pos = start;
+        }
+
+        @Override
+        public boolean hasMoreResources() throws XMLDBException {
+            return pos < getSize();
+        }
+
+        @Override
+        public Resource nextResource() throws XMLDBException {
+            return getResource(pos++);
+        }
+    }
 }

--- a/src/org/exist/xmldb/LocalUserManagementService.java
+++ b/src/org/exist/xmldb/LocalUserManagementService.java
@@ -1,12 +1,28 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.exist.xmldb;
 
-import java.io.IOException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
-import org.exist.EXistException;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.ACLPermission;
 import org.exist.security.Group;
@@ -19,12 +35,10 @@ import org.exist.security.SecurityManager;
 import org.exist.security.internal.aider.ACEAider;
 import org.exist.security.internal.aider.UserAider;
 import org.exist.storage.BrokerPool;
-import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
-import org.exist.storage.txn.TransactionManager;
-import org.exist.storage.txn.Txn;
-import org.exist.util.LockException;
-import org.exist.util.SyntaxException;
+import org.exist.util.function.FunctionE;
+import org.exist.xmldb.function.LocalXmldbCollectionFunction;
+import org.exist.xmldb.function.LocalXmldbDocumentFunction;
+import org.exist.xmldb.function.LocalXmldbFunction;
 import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.Resource;
@@ -39,17 +53,10 @@ import org.xmldb.api.base.XMLDBException;
  * @author Modified by {Marco.Tampucci, Massimo.Martinelli} @isti.cnr.it
  * @author Adam Retter <adam@exist-db.org>
  */
-public class LocalUserManagementService implements EXistUserManagementService {
-    
-    private LocalCollection collection;
+public class LocalUserManagementService extends AbstractLocalService implements EXistUserManagementService {
 
-    private final BrokerPool pool;
-    private final Subject user;
-
-    public LocalUserManagementService(Subject user, BrokerPool pool, LocalCollection collection) {
-        this.pool = pool;
-        this.collection = collection;
-        this.user = user;
+    public LocalUserManagementService(final Subject user, final BrokerPool pool, final LocalCollection collection) {
+        super(user, pool, collection);
     }
     
     @Override
@@ -64,934 +71,467 @@ public class LocalUserManagementService implements EXistUserManagementService {
 
     @Override
     public void addAccount(final Account u) throws XMLDBException {
-		
-        final SecurityManager manager = pool.getSecurityManager();
-        
-        if(!manager.hasAdminPrivileges(user)) {
-            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, " you are not allowed to change this user");
-        }
-        
-        if(manager.hasAccount(u.getName())) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "user " + u.getName() + " exists");
-        }
-        
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException {
-                    manager.addAccount(u);
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, e.getMessage(), e);
-        }
+        onlyAsAdmin(user).apply(manager -> {
+            if (manager.hasAccount(u.getName())) {
+                throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "user " + u.getName() + " already exists");
+            } else {
+                return (broker, transaction) -> manager.addAccount(u);
+            }
+        });
     }
 
     @Override
     public void addGroup(final Group group) throws XMLDBException {
-        final SecurityManager manager = pool.getSecurityManager();
-		
-        if(!manager.hasAdminPrivileges(user)) {
-            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, " you are not allowed to add role");
-        }
-
-        if(manager.hasGroup(group.getName())) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "group '" + group.getName() + "' exists");
-        }
-		
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException {
-                    manager.addGroup(group);
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, e.getMessage(), e);
-        }
+        onlyAsAdmin(user).apply(manager -> {
+            if (manager.hasGroup(group.getName())) {
+                throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "group '" + group.getName() + "' already exists");
+            } else {
+                return (broker, transaction) -> manager.addGroup(group);
+            }
+        });
     }
 
     @Override
     public void setUserPrimaryGroup(final String username, final String groupName) throws XMLDBException {
-        final SecurityManager manager = pool.getSecurityManager();
-		
-        if(!manager.hasGroup(groupName)) {
-            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, "Group '" + groupName + "' does not exist!");
-        }
-        
-        if(!manager.hasAdminPrivileges(user)) {
-            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, "Not allowed to modify user");
-        }
-		
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException {
+        onlyAsAdmin(user).apply(manager -> {
+            if (!manager.hasGroup(groupName)) {
+                throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, "Group '" + groupName + "' does not exist!");
+            } else {
+                return (broker, transaction) -> {
                     final Account account = manager.getAccount(username);
                     final Group group = manager.getGroup(groupName);
                     account.setPrimaryGroup(group);
-                    manager.updateAccount(account);
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, e.getMessage(), e);
-        }
+                    return manager.updateAccount(account);
+                };
+            }
+        });
     }
     
     @Override
     public void setPermissions(final Resource resource, final Permission perm) throws XMLDBException {
-        
-        try {
-             executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyResource(broker, resource, new DatabaseItemModifier<DocumentImpl, Void>() {
-                        @Override
-                        public Void modify(DocumentImpl document) throws PermissionDeniedException, LockException {
-                            document.setPermissions(perm);
-                            return null;
-                        }
-                    });
-                }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Resource '" + resource.getId() + "'", e);
-        }
+        modify(resource).apply((document, broker, transaction) -> {
+            document.setPermissions(perm);
+            return null;
+        });
     }
 
     @Override
     public void setPermissions(final Collection child, final Permission perm) throws XMLDBException {
-	
         final XmldbURI childUri = XmldbURI.create(child.getName());
-        
-        try {
-             executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyCollection(broker, childUri, new DatabaseItemModifier<org.exist.collections.Collection, Void>() {
-                        @Override
-                        public Void modify(org.exist.collections.Collection collection) throws PermissionDeniedException, LockException {
-                            collection.setPermissions(perm);
-                            return null;
-                        }
-                    });
-                }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Collection '" + childUri.toString() + "'", e);
-        }
+        updateCollection(childUri).apply((collection, broker, transaction) -> {
+            collection.setPermissions(perm);
+            return null;
+        });
     }
     
     @Override
-    public void setPermissions(Collection child, final String owner, final String group, final int mode, final List<ACEAider> aces) throws XMLDBException {
-            
+    public void setPermissions(final Collection child, final String owner, final String group, final int mode, final List<ACEAider> aces) throws XMLDBException {
         final XmldbURI childUri = XmldbURI.create(child.getName());
-        
-        try {
-             executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyCollection(broker, childUri, new DatabaseItemModifier<org.exist.collections.Collection, Void>() {
-                        @Override
-                        public Void modify(org.exist.collections.Collection collection) throws PermissionDeniedException, LockException {
-                            final Permission permission = collection.getPermissionsNoLock();
-                            permission.setOwner(owner);
-                            permission.setGroup(group);
-                            permission.setMode(mode);
-                            if(permission instanceof ACLPermission) {
-                                final ACLPermission aclPermission = (ACLPermission)permission;
-                                aclPermission.clear();
-                                for(final ACEAider ace : aces) {
-                                    aclPermission.addACE(ace.getAccessType(), ace.getTarget(), ace.getWho(), ace.getMode());
-                                }
-                            }
-                            return null;
-                        }
-                    });
+        updateCollection(childUri).apply((collection, broker, transaction) -> {
+            final Permission permission = collection.getPermissionsNoLock();
+            permission.setOwner(owner);
+            permission.setGroup(group);
+            permission.setMode(mode);
+            if (permission instanceof ACLPermission) {
+                final ACLPermission aclPermission = (ACLPermission) permission;
+                aclPermission.clear();
+                for (final ACEAider ace : aces) {
+                    aclPermission.addACE(ace.getAccessType(), ace.getTarget(), ace.getWho(), ace.getMode());
                 }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Collection '" + childUri.toString() + "'", e);
-        }
+            }
+            return null;
+        });
     }
         
     @Override
     public void setPermissions(final Resource resource, final String owner, final String group, final int mode, final List<ACEAider> aces) throws XMLDBException {
-            
-        try {
-             executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyResource(broker, resource, new DatabaseItemModifier<DocumentImpl, Void>() {
-                        @Override
-                        public Void modify(DocumentImpl document) throws PermissionDeniedException, LockException {
-                            final Permission permission = document.getPermissions();
-                            permission.setOwner(owner);
-                            permission.setGroup(group);
-                            permission.setMode(mode);
-                            if(permission instanceof ACLPermission) {
-                                final ACLPermission aclPermission = (ACLPermission)permission;
-                                aclPermission.clear();
-                                for(final ACEAider ace : aces) {
-                                    aclPermission.addACE(ace.getAccessType(), ace.getTarget(), ace.getWho(), ace.getMode());
-                                }
-                            }
-                            return null;
-                        }
-                    });
+        modify(resource).apply((document, broker, transaction) -> {
+            final Permission permission = document.getPermissions();
+            permission.setOwner(owner);
+            permission.setGroup(group);
+            permission.setMode(mode);
+            if (permission instanceof ACLPermission) {
+                final ACLPermission aclPermission = (ACLPermission) permission;
+                aclPermission.clear();
+                for (final ACEAider ace : aces) {
+                    aclPermission.addACE(ace.getAccessType(), ace.getTarget(), ace.getWho(), ace.getMode());
                 }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Resource '" + resource.getId() + "'", e);
-        }
+            }
+            return null;
+        });
     }
-
 
     @Override
     public void chmod(final String modeStr) throws XMLDBException {
-        
         final XmldbURI collUri = collection.getPathURI();
-        
-        try {
-             executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                   return modifyCollection(broker, collUri, new DatabaseItemModifier<org.exist.collections.Collection, Void>() {
-                        @Override
-                        public Void modify(org.exist.collections.Collection collection) throws PermissionDeniedException, SyntaxException, LockException {
-                            collection.setPermissions(modeStr);
-                            return null;
-                        }
-                    });
-                }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Collection '" + collUri.toString() + "'", e);
-        }
+        updateCollection(collUri).apply((collection, broker, transaction) -> {
+            collection.setPermissions(modeStr);
+            return null;
+        });
     }
 
     @Override
     public void chmod(final Resource resource, final int mode) throws XMLDBException {
-        try {
-             executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyResource(broker, resource, new DatabaseItemModifier<DocumentImpl, Void>() {
-                        @Override
-                        public Void modify(DocumentImpl document) throws PermissionDeniedException, LockException {
-                            document.getPermissions().setMode(mode);
-                            return null;
-                        }
-                    });
-                }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Resource '" + resource.getId() + "'", e);
-        }
+        modify(resource).apply((document, broker, transaction) -> {
+            document.getPermissions().setMode(mode);
+            return null;
+        });
     }
 
     @Override
     public void chmod(final int mode) throws XMLDBException {
         final XmldbURI collUri = collection.getPathURI();
-        
-        try {
-             executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyCollection(broker, collUri, new DatabaseItemModifier<org.exist.collections.Collection, Void>() {
-                        @Override
-                        public Void modify(org.exist.collections.Collection collection) throws PermissionDeniedException, SyntaxException, LockException {
-                            collection.setPermissions(mode);
-                            return null;
-                        }
-                    });
-                }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Collection '" + collUri.toString() + "'", e);
-        }
+        updateCollection(collUri).apply((collection, broker, transaction) -> {
+            collection.setPermissions(mode);
+            return null;
+        });
     }
 
     @Override
     public void chmod(final Resource resource, final String modeStr) throws XMLDBException {
-        try {
-             executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyResource(broker, resource, new DatabaseItemModifier<DocumentImpl, Void>() {
-                        @Override
-                        public Void modify(DocumentImpl document) throws SyntaxException, PermissionDeniedException, LockException {
-                            document.getPermissions().setMode(modeStr);
-                            return null;
-                        }
-                    });
-                }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Resource '" + resource.getId() + "'", e);
-        }
+        modify(resource).apply((document, broker, transaction) -> {
+            document.getPermissions().setMode(modeStr);
+            return null;
+        });
     }
 
     @Override
     public void chgrp(final String group) throws XMLDBException {
         final XmldbURI collUri = collection.getPathURI();
-
-        try {
-            executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyCollection(broker, collUri, new DatabaseItemModifier<org.exist.collections.Collection, Void>() {
-                        @Override
-                        public Void modify(org.exist.collections.Collection collection) throws PermissionDeniedException, SyntaxException, LockException {
-                            final Permission permission = collection.getPermissionsNoLock();
-                            permission.setGroup(group);
-                            return null;
-                        }
-                    });
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Collection '" + collUri.toString() + "'", e);
-        }
+        updateCollection(collUri).apply((collection, broker, transaction) -> {
+            final Permission permission = collection.getPermissionsNoLock();
+            permission.setGroup(group);
+            return null;
+        });
     }
 
     @Override
     public void chown(final Account u) throws XMLDBException {
         final XmldbURI collUri = collection.getPathURI();
-
-        try {
-            executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyCollection(broker, collUri, new DatabaseItemModifier<org.exist.collections.Collection, Void>() {
-                        @Override
-                        public Void modify(org.exist.collections.Collection collection) throws PermissionDeniedException, SyntaxException, LockException {
-                            final Permission permission = collection.getPermissionsNoLock();
-                            permission.setOwner(u);
-                            return null;
-                        }
-                    });
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Collection '" + collUri.toString() + "'", e);
-        }
+        updateCollection(collUri).apply((collection, broker, transaction) -> {
+            final Permission permission = collection.getPermissionsNoLock();
+            permission.setOwner(u);
+            return null;
+        });
     }
 
     @Override
     public void chown(final Account u, final String group) throws XMLDBException {
         final XmldbURI collUri = collection.getPathURI();
-        
-        try {
-             executeWithBroker(new BrokerOperation<Void>() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyCollection(broker, collUri, new DatabaseItemModifier<org.exist.collections.Collection, Void>() {
-                        @Override
-                        public Void modify(org.exist.collections.Collection collection) throws PermissionDeniedException, SyntaxException, LockException {
-                            final Permission permission = collection.getPermissionsNoLock();
-                            permission.setOwner(u);
-                            permission.setGroup(group);
-                            return null;
-                        }
-                    });
-                }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Collection '" + collUri.toString() + "'", e);
-        }
+        updateCollection(collUri).apply((collection, broker, transaction) -> {
+            final Permission permission = collection.getPermissionsNoLock();
+            permission.setOwner(u);
+            permission.setGroup(group);
+            return null;
+        });
     }
 
     @Override
     public void chgrp(final Resource resource, final String group) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyResource(broker, resource, new DatabaseItemModifier<DocumentImpl, Void>() {
-                        @Override
-                        public Void modify(DocumentImpl document) throws PermissionDeniedException, LockException {
-                            document.getPermissions().setGroup(group);
-                            return null;
-                        }
-                    });
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Resource '" + resource.getId() + "'", e);
-        }
-
+        modify(resource).apply((document, broker, transaction) -> {
+            document.getPermissions().setGroup(group);
+            return null;
+        });
     }
 
     @Override
     public void chown(final Resource resource, final Account u) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyResource(broker, resource, new DatabaseItemModifier<DocumentImpl, Void>() {
-                        @Override
-                        public Void modify(DocumentImpl document) throws PermissionDeniedException, LockException {
-                            document.getPermissions().setOwner(u);
-                            return null;
-                        }
-                    });
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Resource '" + resource.getId() + "'", e);
-        }
-
+        modify(resource).apply((document, broker, transaction) -> {
+            document.getPermissions().setOwner(u);
+            return null;
+        });
     }
 
     @Override
     public void chown(final Resource resource, final Account u, final String group) throws XMLDBException {
-	try {
-             executeWithBroker(new BrokerOperation() {
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyResource(broker, resource, new DatabaseItemModifier<DocumentImpl, Void>() {
-                        @Override
-                        public Void modify(DocumentImpl document) throws PermissionDeniedException, LockException {
-                            document.getPermissions().setOwner(u);
-                            document.getPermissions().setGroup(group);
-                            return null;
-                        }
-                    });
-                }
-             });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Failed to modify permission on Resource '" + resource.getId() + "'", e);
-        }	
-
+        modify(resource).apply((document, broker, transaction) -> {
+            document.getPermissions().setOwner(u);
+            document.getPermissions().setGroup(group);
+            return null;
+        });
     }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.UserManagementService#hasUserLock(org.xmldb.api.base.Resource)
-	 */
     @Override
-    public String hasUserLock(final Resource res) throws XMLDBException {
-        try {
-            return executeWithBroker(new BrokerOperation<String>(){
-                @Override
-                public String withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return readResource(broker, res, new DatabaseItemReader<DocumentImpl, String>(){
-                        @Override
-                        public String read(DocumentImpl document) {
-                            final Account lockOwner = document.getUserLock();
-                            return lockOwner == null ? null : lockOwner.getName();
-                        }
-                    });
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+    public String hasUserLock(final Resource resource) throws XMLDBException {
+        return withDb((broker, transaction) -> ((AbstractEXistResource)resource).<String>read(broker, transaction).apply((document, broker1, transaction1) -> {
+            final Account lockOwner = document.getUserLock();
+            return lockOwner == null ? null : lockOwner.getName();
+        }));
     }
 	
     @Override
     public void lockResource(final Resource resource, final Account u) throws XMLDBException {
-        
-        final String resourceId = resource.getId();
-        
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyResource(broker, resource, new DatabaseItemModifier<DocumentImpl, Void>(){
-                        @Override
-                        public Void modify(DocumentImpl document) throws PermissionDeniedException, SyntaxException, LockException {
-                            if(!document.getPermissions().validate(user, Permission.WRITE)) {
-                                throw new PermissionDeniedException("User is not allowed to lock resource " + resourceId);
-                            }
+        modify(resource).apply((document, broker, transaction) -> {
+            final String resourceId = resource.getId();
+            if (!document.getPermissions().validate(user, Permission.WRITE)) {
+                throw new PermissionDeniedException("User is not allowed to lock resource " + resourceId);
+            }
 
-                            final SecurityManager manager = broker.getBrokerPool().getSecurityManager();
-                            if(!(user.equals(u) || manager.hasAdminPrivileges(user))) {
-                                throw new PermissionDeniedException("User " + user.getName() + " is not allowed to lock resource '" + resourceId + "' for user " + u.getName());
-                            }
+            final SecurityManager manager = broker.getBrokerPool().getSecurityManager();
+            if (!(user.equals(u) || manager.hasAdminPrivileges(user))) {
+                throw new PermissionDeniedException("User " + user.getName() + " is not allowed to lock resource '" + resourceId + "' for user " + u.getName());
+            }
 
-                            final Account lockOwner = document.getUserLock();
+            final Account lockOwner = document.getUserLock();
 
-                            if(lockOwner != null) {
-                                if(lockOwner.equals(u)) {
-                                    return null;
-                                } else if(!manager.hasAdminPrivileges(user)) {
-                                    throw new PermissionDeniedException("Resource '" + resourceId + "' is already locked by user " + lockOwner.getName());
-                                }
-                            }
-
-                            document.setUserLock(u);
-
-                            return null;
-                        }
-                    });
+            if (lockOwner != null) {
+                if (lockOwner.equals(u)) {
+                    return null;
+                } else if (!manager.hasAdminPrivileges(user)) {
+                    throw new PermissionDeniedException("Resource '" + resourceId + "' is already locked by user " + lockOwner.getName());
                 }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Unable to lock resource '" + resourceId + "': " + e.getMessage(), e);
-        }
+            }
+
+            document.setUserLock(u);
+
+            return null;
+        });
     }
 	
     @Override
     public void unlockResource(final Resource resource) throws XMLDBException {
-        
-        final String resourceId = resource.getId();
-        
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return modifyResource(broker, resource, new DatabaseItemModifier<DocumentImpl, Void>(){
-                        @Override
-                        public Void modify(DocumentImpl document) throws PermissionDeniedException, SyntaxException, LockException {
-                            if(!document.getPermissions().validate(user, Permission.WRITE)) {
-				throw new PermissionDeniedException("User is not allowed to lock resource '" + resourceId + "'");
-                            }
-			
-                            
-                            final Account lockOwner = document.getUserLock();
-			
-                            final SecurityManager manager = broker.getBrokerPool().getSecurityManager();
-                            if(lockOwner != null && !(lockOwner.equals(user) || manager.hasAdminPrivileges(user))) {
-                                throw new PermissionDeniedException("Resource '" + resourceId + "' is already locked by user " + lockOwner.getName());
-                            }
-                            
-                            document.setUserLock(null);
-                            
-                            return null;
-                        }
-                    });
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Unable to unlock resource '" + resourceId + "': " + e.getMessage(), e);
-        }    
+        modify(resource).apply((document, broker, transaction) -> {
+            final String resourceId = resource.getId();
+            if (!document.getPermissions().validate(user, Permission.WRITE)) {
+                throw new PermissionDeniedException("User is not allowed to lock resource '" + resourceId + "'");
+            }
+
+            final Account lockOwner = document.getUserLock();
+
+            final SecurityManager manager = broker.getBrokerPool().getSecurityManager();
+            if (lockOwner != null && !(lockOwner.equals(user) || manager.hasAdminPrivileges(user))) {
+                throw new PermissionDeniedException("Resource '" + resourceId + "' is already locked by user " + lockOwner.getName());
+            }
+
+            document.setUserLock(null);
+
+            return null;
+        });
     }
 
     @Override
-    public Permission getPermissions(Collection coll) throws XMLDBException {
+    public Permission getPermissions(final Collection coll) throws XMLDBException {
         if(coll instanceof LocalCollection) {
-            return ((LocalCollection) coll).getCollection().getPermissionsNoLock();
+            return this.<Permission>read(((LocalCollection) coll).getPathURI()).apply((collection, broker, transaction) -> collection.getPermissionsNoLock());
         }
         return null;
     }
 
     @Override
     public Permission getSubCollectionPermissions(final Collection parent, final String name) throws XMLDBException {
-        try {
-            return executeWithBroker(new BrokerOperation<Permission>(){
-                @Override
-                public Permission withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    if(parent instanceof LocalCollection) {
-                        return ((LocalCollection) parent).getCollection().getSubCollectionEntry(broker, name).getPermissions();
-                    }
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e);
-        }    
+        if(parent instanceof LocalCollection) {
+            return this.<Permission>read(((LocalCollection) parent).getPathURI()).apply((collection, broker, transaction) -> collection.getSubCollectionEntry(broker, name).getPermissions());
+        } else {
+            return null;
+        }
     }
 
     @Override
     public Permission getSubResourcePermissions(final Collection parent, final String name) throws XMLDBException {
-        try {
-            return executeWithBroker(new BrokerOperation<Permission>(){
-                @Override
-                public Permission withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    if(parent instanceof LocalCollection) {
-                        return ((LocalCollection) parent).getCollection().getResourceEntry(broker, name).getPermissions();
-                    }
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e);
+        if(parent instanceof LocalCollection) {
+            return this.<Permission>read(((LocalCollection) parent).getPathURI()).apply((collection, broker, transaction) -> collection.getResourceEntry(broker, name).getPermissions());
+        } else {
+            return null;
         }
     }
 
     @Override
     public Date getSubCollectionCreationTime(final Collection parent, final String name) throws XMLDBException {
-        try {
-            return executeWithBroker(new BrokerOperation<Date>(){
-                @Override
-                public Date withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    if(parent instanceof LocalCollection) {
-                        return new Date(((LocalCollection) parent).getCollection().getSubCollectionEntry(broker, name).getCreated());
-                    }
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e);
+        if(parent instanceof LocalCollection) {
+            return this.<Date>read(((LocalCollection) parent).getPathURI()).apply((collection, broker, transaction) -> new Date(collection.getSubCollectionEntry(broker, name).getCreated()));
+        } else {
+            return null;
         }
     }
-    
-    
-    
 
     @Override
     public Permission getPermissions(final Resource resource) throws XMLDBException {
-        
-        try {
-            return executeWithBroker(new BrokerOperation<Permission>() {
-                @Override
-                public Permission withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return readResource(broker, resource, new DatabaseItemReader<DocumentImpl, Permission>(){
-                        @Override
-                        public Permission read(DocumentImpl document) {
-                            return document.getPermissions();
-                        }
-                    });
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        return withDb((broker, transaction) -> ((AbstractEXistResource)resource).<Permission>read(broker, transaction).apply((document, broker1, transaction1) -> document.getPermissions()));
     }
 
     @Override
     public Permission[] listResourcePermissions() throws XMLDBException {
-        
         final XmldbURI collectionUri = collection.getPathURI();
-        try {
-            return executeWithBroker(new BrokerOperation<Permission[]>() {
-                @Override
-                public Permission[] withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return readCollection(broker, collectionUri, new DatabaseItemReader<org.exist.collections.Collection, Permission[]>(){
-                        @Override
-                        public Permission[] read(org.exist.collections.Collection collection) throws PermissionDeniedException {
-                            if(!collection.getPermissionsNoLock().validate(user, Permission.READ)) {
-                                    return new Permission[0];
-                            }
-                            
-                            final Permission perms[] = new Permission[collection.getDocumentCount(broker)];                            
-                            final Iterator<DocumentImpl> itDocument = collection.iterator(broker);
-                            int i = 0;
-                            while(itDocument.hasNext()) {
-                                final DocumentImpl document = itDocument.next();
-                                perms[i++] = document.getPermissions();
-                            }
+        return this.<Permission[]>read(collectionUri).apply((collection, broker, transaction) -> {
+            if(!collection.getPermissionsNoLock().validate(user, Permission.READ)) {
+                return new Permission[0];
+            }
 
-                            return perms;
-                        }
-                    });
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }   
+            final Permission perms[] = new Permission[collection.getDocumentCount(broker)];
+            final Iterator<DocumentImpl> itDocument = collection.iterator(broker);
+            int i = 0;
+            while(itDocument.hasNext()) {
+                final DocumentImpl document = itDocument.next();
+                perms[i++] = document.getPermissions();
+            }
+
+            return perms;
+        });
     }
 
     @Override
     public Permission[] listCollectionPermissions() throws XMLDBException {
-        
         final XmldbURI collectionUri = collection.getPathURI();
-        try {
-            return executeWithBroker(new BrokerOperation<Permission[]>() {
-                @Override
-                public Permission[] withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    return readCollection(broker, collectionUri, new DatabaseItemReader<org.exist.collections.Collection, Permission[]>(){
-                        @Override
-                        public Permission[] read(org.exist.collections.Collection collection) throws XMLDBException, PermissionDeniedException {
-                            if(!collection.getPermissionsNoLock().validate(user, Permission.READ)) {
-				return new Permission[0];
-                            }
-                            
-                            final Permission perms[] = new Permission[collection.getChildCollectionCount(broker)];
-                            final Iterator<XmldbURI> itChildCollectionUri = collection.collectionIterator(broker);
-                            int i = 0;
-                            while(itChildCollectionUri.hasNext()) {
-                                final XmldbURI childCollectionUri = collectionUri.append(itChildCollectionUri.next());
-                                Permission childPermission = readCollection(broker, childCollectionUri, new DatabaseItemReader<org.exist.collections.Collection, Permission>(){
-                                    @Override
-                                    public Permission read(org.exist.collections.Collection childCollection) {
-                                        return childCollection.getPermissionsNoLock();
-                                    }
-                                });
-                                perms[i++] = childPermission;
-                            }
-                            
-			return perms;
-                        }
-                    });
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }   	
+        return this.<Permission[]>read(collectionUri).apply((collection, broker, transaction) -> {
+            if(!collection.getPermissionsNoLock().validate(user, Permission.READ)) {
+                return new Permission[0];
+            }
+
+            final Permission perms[] = new Permission[collection.getChildCollectionCount(broker)];
+            final Iterator<XmldbURI> itChildCollectionUri = collection.collectionIterator(broker);
+            int i = 0;
+            while(itChildCollectionUri.hasNext()) {
+                final XmldbURI childCollectionUri = collectionUri.append(itChildCollectionUri.next());
+                final Permission childPermission = this.<Permission>read(broker, transaction, childCollectionUri).apply((childCollection, broker1, transaction1) -> childCollection.getPermissionsNoLock());
+                perms[i++] = childPermission;
+            }
+
+            return perms;
+        });
     }
 
     @Override
     public Account getAccount(final String name) throws XMLDBException {
-        
-        try {
-            return executeWithBroker(new BrokerOperation<Account>(){
-
-                @Override
-                public Account withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    return sm.getAccount(name);
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        return withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            return sm.getAccount(name);
+        });
     }
 
     @Override
     public Account[] getAccounts() throws XMLDBException {
-        try {
-            return executeWithBroker(new BrokerOperation<Account[]>(){
-
-                @Override
-                public Account[] withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    final java.util.Collection<Account> users = sm.getUsers();
-                    return users.toArray(new Account[users.size()]);
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        return withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            final java.util.Collection<Account> users = sm.getUsers();
+            return users.toArray(new Account[users.size()]);
+        });
     }
 
     @Override
     public Group getGroup(final String name) throws XMLDBException {
-        try {
-            return executeWithBroker(new BrokerOperation<Group>(){
-
-                @Override
-                public Group withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    return sm.getGroup(name);
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        return withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            return sm.getGroup(name);
+        });
     }
 
     @Override
     public String[] getGroups() throws XMLDBException {
-        try {
-            return executeWithBroker(new BrokerOperation<String[]>(){
-
-                @Override
-                public String[] withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    final java.util.Collection<Group> groups = sm.getGroups();
-                    final String[] groupNames = new String[groups.size()];
-                    int i = 0;
-                    for (final Group group : groups) {
-                        groupNames[i++] = group.getName();
-                    }
-                    return groupNames;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        return withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            final java.util.Collection<Group> groups = sm.getGroups();
+            final String[] groupNames = new String[groups.size()];
+            int i = 0;
+            for (final Group group : groups) {
+                groupNames[i++] = group.getName();
+            }
+            return groupNames;
+        });
     }
 
     @Override
     public void removeAccount(final Account u) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-
-                @Override
-                public Void withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    if(!sm.hasAdminPrivileges(user))
-                    	{throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, "you are not allowed to remove users");}
-	        
-                    sm.deleteAccount(u);
-                    
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        onlyAsAdmin(user).apply(manager -> (broker, transaction) -> {
+            manager.deleteAccount(u);
+            return null;
+        });
     }
 
     @Override
     public void removeGroup(final Group group) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-	        
-                    sm.deleteGroup(group.getName());
-                    
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            sm.deleteGroup(group.getName());
+            return null;
+        });
     }
-
-    @Override
-    public void setCollection(Collection collection) throws XMLDBException {
-        this.collection = (LocalCollection) collection;
-    }
-
-    
 
     @Override
     public void updateAccount(final Account u) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-
-                @Override
-                public Void withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-	        
-                    sm.updateAccount(u);
-                    
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            sm.updateAccount(u);
+            return null;
+        });
     }
     
     @Override
     public void updateGroup(final Group g) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-	        
-                    sm.updateGroup(g);
-                    
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            sm.updateGroup(g);
+            return null;
+        });
     }
 
     @Override
     public String[] getGroupMembers(final String groupName) throws XMLDBException {
-        try {
-            final List<String> groupMembers = executeWithBroker(new BrokerOperation<List<String>>(){
-                @Override
-                public List<String> withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    
-                    return sm.findAllGroupMembers(groupName);
-                }
-            });
-            
-            return groupMembers.toArray(new String[groupMembers.size()]);
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        final List<String> groupMembers = withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            return sm.findAllGroupMembers(groupName);
+        });
+        return groupMembers.toArray(new String[groupMembers.size()]);
     }
     
     @Override
     public void addAccountToGroup(final String accountName, final String groupName) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    final Account account = sm.getAccount(accountName);
-                    account.addGroup(groupName);
-                    sm.updateAccount(account);
-                    
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            final Account account = sm.getAccount(accountName);
+            account.addGroup(groupName);
+            sm.updateAccount(account);
+            return null;
+        });
     }
     
     @Override
     public void addGroupManager(final String manager, final String groupName) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    
-                    final Account account = sm.getAccount(manager);
-                    final Group group = sm.getGroup(groupName);
-                    group.addManager(account);
-                    sm.updateGroup(group);
-                    
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            final Account account = sm.getAccount(manager);
+            final Group group = sm.getGroup(groupName);
+            group.addManager(account);
+            sm.updateGroup(group);
+            return null;
+        });
     }
     
     @Override
     public void removeGroupManager(final String groupName, final String manager) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    
-                    final Group group = sm.getGroup(groupName);
-                    final Account account = sm.getAccount(manager);
-                    group.removeManager(account);
-                    sm.updateGroup(group);
-                    
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            final Group group = sm.getGroup(groupName);
+            final Account account = sm.getAccount(manager);
+            group.removeManager(account);
+            sm.updateGroup(group);
+            return null;
+        });
     }
 	
     @Override
-    public void addUserGroup(Account user) throws XMLDBException {	
+    public void addUserGroup(final Account user) throws XMLDBException {
+        throw new UnsupportedOperationException();
     }
 	
     @Override
     public void removeGroupMember(final String group, final String member) throws XMLDBException {
-        try {
-            executeWithBroker(new BrokerOperation<Void>(){
-                @Override
-                public Void withBroker(final DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-                    final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    
-                    final Account account = sm.getAccount(member);
-                    account.remGroup(group);
-                    sm.updateAccount(account);
-
-                    return null;
-                }
-            });
-        } catch(final Exception e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        }
+        withDb((broker, transaction) -> {
+            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
+            final Account account = sm.getAccount(member);
+            account.remGroup(group);
+            sm.updateAccount(account);
+            return null;
+        });
     }
 
     @Override
-    public void addUser(User user) throws XMLDBException {
+    public void addUser(final User user) throws XMLDBException {
         final Account account = new UserAider(user.getName());
         addAccount(account);
     }
 
     @Override
-    public void updateUser(User user) throws XMLDBException {
+    public void updateUser(final User user) throws XMLDBException {
         final Account account = new UserAider(user.getName());
         account.setPassword(user.getPassword());
         //TODO: groups
@@ -999,7 +539,7 @@ public class LocalUserManagementService implements EXistUserManagementService {
     }
 
     @Override
-    public User getUser(String name) throws XMLDBException {
+    public User getUser(final String name) throws XMLDBException {
         return getAccount(name);
     }
 
@@ -1010,139 +550,59 @@ public class LocalUserManagementService implements EXistUserManagementService {
     }
 
     @Override
-    public void removeUser(User user) throws XMLDBException {
+    public void removeUser(final User user) throws XMLDBException {
         // TODO Auto-generated method stub	
     }
 
     @Override
-    public void lockResource(Resource res, User u) throws XMLDBException {
+    public void lockResource(final Resource res, final User u) throws XMLDBException {
         final Account account = new UserAider(u.getName());
         lockResource(res, account);
     }
         
     @Override
-    public String getProperty(String property) throws XMLDBException {
+    public String getProperty(final String property) throws XMLDBException {
         return null;
     }
     
     @Override
-    public void setProperty(String property, String value) throws XMLDBException {
+    public void setProperty(final String property, final String value) throws XMLDBException {
     }
 
-    private interface BrokerOperation<R> {
-        public R withBroker(DBBroker broker) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException;
+    /**
+     * Executes a LocalXmldbFunction only if the supplied user is an Admin user
+     *
+     * @param user A user to be tested as an admin user
+     */
+    private <R> FunctionE<FunctionE<SecurityManager, LocalXmldbFunction<R>, XMLDBException>, R, XMLDBException> onlyAsAdmin(final Subject user) throws XMLDBException {
+        final SecurityManager manager = brokerPool.getSecurityManager();
+        if (!manager.hasAdminPrivileges(user)) {
+            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, " This operation is restricted to Admin users");
+        } else {
+            return op -> op.andThen(this::withDb).apply(manager);
+        }
     }
 
-    private <R> R executeWithBroker(BrokerOperation<R> brokerOperation) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-    	final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		try {
-		    broker = pool.get(user);
-		    
-		    return brokerOperation.withBroker(broker);
-		    
-		} finally {
-		    if(broker != null) 
-		        {pool.release(broker);}
-		    
-		    if(preserveSubject != null)
-		    	{pool.setSubject(preserveSubject);}
-		}
+    /**
+     * Higher-order-function for performing read/write operations against a database
+     * resource
+     *
+     * @param resource The resource to perform read/write operations on
+     */
+    private <R> FunctionE<LocalXmldbDocumentFunction<R>, R, XMLDBException> modify(final Resource resource) throws XMLDBException {
+        return modifyOp -> withDb((broker, transaction) -> (((AbstractEXistResource)resource).<R>modify(broker, transaction).apply(modifyOp)));
     }
     
-    private <R> R readResource(DBBroker broker, Resource resource, DatabaseItemReader<DocumentImpl, R> reader) throws XMLDBException, PermissionDeniedException {
-        
-        DocumentImpl document = null;    
-        try {
-            document = ((AbstractEXistResource) resource).openDocument(broker, Lock.READ_LOCK);
-                
-            return reader.read(document);
-                
-        } finally {
-            if(document != null) {
-                ((AbstractEXistResource) resource).closeDocument(document, Lock.READ_LOCK);
-            }
-        }
-    }
-    
-    private <R> R readCollection(DBBroker broker, XmldbURI collectionURI, DatabaseItemReader<org.exist.collections.Collection, R> reader) throws XMLDBException, PermissionDeniedException {
-        org.exist.collections.Collection coll = null;
-        
-        try {
-            coll = broker.openCollection(collectionURI, Lock.READ_LOCK);
-            if(coll == null) {
-                throw new XMLDBException(ErrorCodes.INVALID_COLLECTION, "Collection " + collectionURI.toString() + " not found");
-            }
-            
-            return reader.read(coll);
-            
-        } finally {
-            if(coll != null) {
-                coll.release(Lock.READ_LOCK);
-            }
-        }
-    }
-    
-    private <R> R modifyResource(DBBroker broker, Resource resource, DatabaseItemModifier<DocumentImpl, R> modifier) throws XMLDBException, LockException, PermissionDeniedException, EXistException, SyntaxException {
-        final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-        
-        DocumentImpl document = null;
-        try(final Txn transaction = transact.beginTransaction()) {
-            document = ((AbstractEXistResource) resource).openDocument(broker, Lock.WRITE_LOCK);
-            final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-            if(!document.getPermissions().validate(user, Permission.WRITE) && !sm.hasAdminPrivileges(user)) {
-                throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, "you are not the owner of this resource; owner = " + document.getPermissions().getOwner());
-            }
-            
-            final R result = modifier.modify(document);
-            
-            broker.storeXMLResource(transaction, document);
-            transact.commit(transaction);
-            
+    /**
+     * Higher-order-function for updating a collection and its metadata
+     *
+     * @param collectionUri The collection to perform read/write operations on
+     */
+    private <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> updateCollection(final XmldbURI collectionUri) throws XMLDBException {
+        return updateOp -> this.<R>modify(collectionUri).apply((collection, broker1, transaction1) -> {
+            final R result = updateOp.apply(collection, broker1, transaction1);
+            broker1.saveCollection(transaction1, collection);
             return result;
-
-        } catch(final EXistException | XMLDBException | SyntaxException | PermissionDeniedException | LockException e) {
-            throw e;
-        } finally {
-            if(document != null) {
-                ((AbstractEXistResource)resource).closeDocument(document, Lock.WRITE_LOCK);
-            }
-        }
-    }
-    
-    private <R> R modifyCollection(DBBroker broker, XmldbURI collectionURI, DatabaseItemModifier<org.exist.collections.Collection, R> modifier) throws XMLDBException, LockException, PermissionDeniedException, IOException, EXistException, TriggerException, SyntaxException {
-        final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
-        
-        org.exist.collections.Collection coll = null;
-        
-        try(final Txn transaction = transact.beginTransaction()) {
-            coll = broker.openCollection(collectionURI, Lock.WRITE_LOCK);
-            if(coll == null) {
-                throw new XMLDBException(ErrorCodes.INVALID_COLLECTION, "Collection " + collectionURI.toString() + " not found");
-            }
-            
-            final R result = modifier.modify(coll);
-            
-            broker.saveCollection(transaction, coll);
-            transact.commit(transaction);
-            broker.flush();
-            
-            return result;
-            
-        } catch(final EXistException | SyntaxException | TriggerException | IOException | PermissionDeniedException | LockException | XMLDBException e) {
-            throw e;
-        } finally {
-            if(coll != null) {
-                coll.release(Lock.WRITE_LOCK);
-            }
-        }
-    }
-    
-    private interface DatabaseItemModifier<T, R> {
-        public R modify(T databaseItem) throws PermissionDeniedException, SyntaxException, LockException;
-    }
-    
-    private interface DatabaseItemReader<T, R> {
-        public R read(T databaseItem) throws PermissionDeniedException, XMLDBException;
+        });
     }
 }

--- a/src/org/exist/xmldb/LocalXMLResource.java
+++ b/src/org/exist/xmldb/LocalXMLResource.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2003-2007 The eXist Project
+ * Copyright (C) 2001-2015 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
@@ -16,27 +16,17 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
- *  $Id$
  */
 package org.exist.xmldb;
 
-import org.exist.EXistException;
-import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.persistent.XMLUtil;
 import org.exist.dom.memtree.AttrImpl;
 import org.exist.dom.memtree.NodeImpl;
 import org.exist.numbering.NodeId;
-import org.exist.security.Permission;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
-import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
 import org.exist.storage.serializers.Serializer;
-import org.exist.storage.txn.TransactionManager;
-import org.exist.storage.txn.Txn;
-import org.exist.util.LockException;
 import org.exist.util.MimeType;
 import org.exist.util.serializer.DOMSerializer;
 import org.exist.util.serializer.DOMStreamer;
@@ -51,7 +41,6 @@ import org.w3c.dom.DocumentType;
 import org.w3c.dom.Node;
 import org.xml.sax.*;
 import org.xml.sax.ext.LexicalHandler;
-import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.XMLResource;
@@ -60,9 +49,7 @@ import javax.xml.transform.TransformerException;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Date;
 import java.util.Properties;
-import org.exist.security.PermissionDeniedException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -71,534 +58,312 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class LocalXMLResource extends AbstractEXistResource implements XMLResource {
 
-	//protected DocumentImpl document = null;
-	protected NodeProxy proxy = null;
-	
-	protected Properties outputProperties = null;
-	protected LexicalHandler lexicalHandler = null;
-	
-	// those are the different types of content this resource
-	// may have to deal with
-	protected String content = null;
-	protected File file = null;
-	protected InputSource inputSource = null;
-	protected Node root = null;
-	protected AtomicValue value = null;
-	
-	protected Date datecreated= null;
-	protected Date datemodified= null;
+    private NodeProxy proxy = null;
 
-	public LocalXMLResource(Subject user, BrokerPool pool, LocalCollection parent,
-			XmldbURI did) throws XMLDBException {
-		super(user, pool, parent, did, MimeType.XML_TYPE.getName());
-	}
+    private Properties outputProperties = null;
+    private LexicalHandler lexicalHandler = null;
 
-	public LocalXMLResource(Subject user, BrokerPool pool, LocalCollection parent,
-			NodeProxy p) throws XMLDBException {
-		this(user, pool, parent, p.getOwnerDocument().getFileURI());
-		this.proxy = p;
-	}
+    // those are the different types of content this resource
+    // may have to deal with
+    protected String content = null;
+    protected File file = null;
+    protected InputSource inputSource = null;
+    protected Node root = null;
+    protected AtomicValue value = null;
 
-	public Object getContent() throws XMLDBException {
-		if (content != null) {            
-			return content;
+    public LocalXMLResource(final Subject user, final BrokerPool brokerPool, final LocalCollection parent, final XmldbURI did) throws XMLDBException {
+        super(user, brokerPool, parent, did, MimeType.XML_TYPE.getName());
+    }
+
+    public LocalXMLResource(final Subject user, final BrokerPool brokerPool, final LocalCollection parent, final NodeProxy p) throws XMLDBException {
+        this(user, brokerPool, parent, p.getOwnerDocument().getFileURI());
+        this.proxy = p;
+    }
+
+    @Override
+    public String getDocumentId() throws XMLDBException {
+        return docId.toString();
+    }
+
+    @Override
+    public String getResourceType() throws XMLDBException {
+        return XMLResource.RESOURCE_TYPE;
+    }
+
+    @Override
+    public Object getContent() throws XMLDBException {
+        if (content != null) {            
+            return content;
         }
 
-		// Case 1: content is an external DOM node
-		else if (root != null && !(root instanceof NodeValue)) {
+        // Case 1: content is an external DOM node
+        else if (root != null && !(root instanceof NodeValue)) {
             final StringWriter writer = new StringWriter();
-			final DOMSerializer serializer = new DOMSerializer(writer, getProperties());
-			try {
-				serializer.serialize(root);
-				content = writer.toString();
-			} catch (final TransformerException e) {
-				throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e
-						.getMessage(), e);
-			}
-			return content;
+            final DOMSerializer serializer = new DOMSerializer(writer, getProperties());
+            try {
+                    serializer.serialize(root);
+                    content = writer.toString();
+            } catch (final TransformerException e) {
+                    throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e.getMessage(), e);
+            }
+            return content;
 
-			// Case 2: content is an atomic value
-		} else if (value != null) {
-			try {
+        // Case 2: content is an atomic value
+        } else if (value != null) {
+            try {
                 if (Type.subTypeOf(value.getType(),Type.STRING)) {
                     return ((StringValue)value).getStringValue(true);
-                }
-                else {
-				return value.getStringValue();
-                }
-
-
-
-			} catch (final XPathException e) {
-				throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e
-						.getMessage(), e);
-			}
-
-			// Case 3: content is a file
-		} else if (file != null) {
-			try {
-				content = XMLUtil.readFile(file);
-				return content;
-			} catch (final IOException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-						"error while reading resource contents", e);
-			}
-
-			// Case 4: content is an input source
-		} else if (inputSource != null) {
-			try {
-				content = XMLUtil.readFile(inputSource);
-				return content;
-			} catch (final IOException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-						"error while reading resource contents", e);
-			}
-
-			// Case 5: content is a document or internal node
-		} else {
-		    DocumentImpl document = null;
-			final Subject preserveSubject = pool.getSubject();
-			DBBroker broker = null;
-			try {
-				broker = pool.get(user);
-				final Serializer serializer = broker.getSerializer();
-				serializer.setUser(user);
-				serializer.setProperties(getProperties());
-				if (root != null) {
-					content = serializer.serialize((NodeValue) root);
-                    
-                } else if (proxy != null) {
-                    content = serializer.serialize(proxy);
-                    
                 } else {
-				    document = openDocument(broker, Lock.READ_LOCK);
-					if (!document.getPermissions().validate(user,
-							Permission.READ))
-						{throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-								"permission denied to read resource");}
-					content = serializer.serialize(document);
+                    return value.getStringValue();
                 }
-				return content;
-			} catch (final SAXException saxe) {
-				saxe.printStackTrace();
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, saxe
-						.getMessage(), saxe);
-			} catch (final EXistException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e
-						.getMessage(), e);
-			} catch (final Exception e) {
-				e.printStackTrace();
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e
-						.getMessage(), e);
-			} finally {
-			    closeDocument(document, Lock.READ_LOCK);
-				pool.release(broker);
-				pool.setSubject(preserveSubject);
-			}
-		}
-	}
-
-	public Node getContentAsDOM() throws XMLDBException {
-		if (root != null) {
-            if(root instanceof NodeImpl) {
-        		final Subject preserveSubject = pool.getSubject();
-    			DBBroker broker = null;
-    			try {
-    				broker = pool.get(user);
-    				
-    				((NodeImpl)root).expand();
-    			} catch (final EXistException e) {
-    				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-    			} finally {
-    				pool.release(broker);
-    				pool.setSubject(preserveSubject);
-    			}
+            } catch (final XPathException e) {
+                throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e.getMessage(), e);
             }
-			return root;
-        } else if (value != null) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-					"cannot return an atomic value as DOM node");
-		} else {
-		    DocumentImpl document = null;
-			final Subject preserveSubject = pool.getSubject();
-			DBBroker broker = null;
-			try {
-				broker = pool.get(user);
-				document = getDocument(broker, Lock.READ_LOCK);
-				if (!document.getPermissions().validate(user, Permission.READ))
-					{throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-							"permission denied to read resource");}
-				if (proxy != null)
-					{return document.getNode(proxy);}
-                // <frederic.glorieux@ajlsm.com> return a full to get root PI and comments 
-                return document;
-			} catch (final EXistException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e
-						.getMessage(), e);
-			} finally {
-			    parent.getCollection().releaseDocument(document, Lock.READ_LOCK);
-				pool.release(broker);
-				pool.setSubject(preserveSubject);
-			}
-		}
-	}
 
-	public void getContentAsSAX(ContentHandler handler) throws XMLDBException {
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		// case 1: content is an external DOM node
-		if (root != null && !(root instanceof NodeValue)) {
-			try {
-				final String option = parent.properties.getProperty(
-						Serializer.GENERATE_DOC_EVENTS, "false");
-                final DOMStreamer streamer = (DOMStreamer) SerializerPool.getInstance().borrowObject(DOMStreamer.class);
-				streamer.setContentHandler(handler);
-				streamer.setLexicalHandler(lexicalHandler);
-				streamer.serialize(root, option.equalsIgnoreCase("true"));
-				SerializerPool.getInstance().returnObject(streamer);
-			} catch (final Exception e) {
-				throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e
-						.getMessage(), e);
-			}
-			
-		// case 2: content is an atomic value
-		} else if (value != null) {
-			try {
-				broker = pool.get(user);
-				value.toSAX(broker, handler, getProperties());
-			} catch (final EXistException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e
-						.getMessage(), e);
-			} catch (final SAXException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e
-						.getMessage(), e);
-			} finally {
-				pool.release(broker);
-				pool.setSubject(preserveSubject);
-			}
-			
-		// case 3: content is an internal node or a document
-		} else {
-			try {
-				broker = pool.get(user);
-				final Serializer serializer = broker.getSerializer();
-				serializer.setUser(user);
-				serializer.setProperties(getProperties());
-				serializer.setSAXHandlers(handler, lexicalHandler);
-				if (root != null) {
-					serializer.toSAX((NodeValue) root);
-                    
-                } else if (proxy != null) {
-                    serializer.toSAX(proxy);
-                    
-                } else {
-					DocumentImpl document = null;
-					try {
-						document = openDocument(broker, Lock.READ_LOCK);
-						if (!document.getPermissions().validate(user,
-								Permission.READ))
-							{throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-							"permission denied to read resource");}
-						serializer.toSAX(document);
-					} finally {
-					    closeDocument(document, Lock.READ_LOCK);
-					}
-				}
-			} catch (final EXistException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e
-						.getMessage(), e);
-			} catch (final SAXException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e
-						.getMessage(), e);
-			} finally {
-				pool.release(broker);
-				pool.setSubject(preserveSubject);
-			}
-		}
-	}
+        // Case 3: content is a file
+        } else if (file != null) {
+            try {
+                content = XMLUtil.readFile(file);
+                return content;
+            } catch (final IOException e) {
+                throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "error while reading resource contents", e);
+            }
 
-	//TODO: use xmldbURI?
-	public String getDocumentId() throws XMLDBException {
-		return docId.toString();
-	}
+        // Case 4: content is an input source
+        } else if (inputSource != null) {
+            try {
+                content = XMLUtil.readFile(inputSource);
+                return content;
+            } catch (final IOException e) {
+                throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "error while reading resource contents", e);
+            }
 
-	//TODO: use xmldbURI?
-	public String getId() throws XMLDBException {
-		return docId.toString();
-	}
-
-	public Collection getParentCollection() throws XMLDBException {
-		if (parent == null)
-			{throw new XMLDBException(ErrorCodes.VENDOR_ERROR,
-					"collection parent is null");}
-		return parent;
-	}
-
-	public String getResourceType() throws XMLDBException {
-		return "XMLResource";
-	}
-
-	public Date getCreationTime() throws XMLDBException {
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		try {
-			broker = pool.get(user);
-			final DocumentImpl document = getDocument(broker, Lock.NO_LOCK);
-			return new Date(document.getMetadata().getCreated());
-		} catch (final EXistException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(),
-					e);
-		} finally {
-			pool.release(broker);
-			pool.setSubject(preserveSubject);
-		}
-	}
-
-	public Date getLastModificationTime() throws XMLDBException {
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		try {
-			broker = pool.get(user);
-			final DocumentImpl document = getDocument(broker, Lock.NO_LOCK);
-			return new Date(document.getMetadata().getLastModified());
-		} catch (final EXistException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(),
-					e);
-		} finally {
-			pool.release(broker);
-			pool.setSubject(preserveSubject);
-		}
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#getContentLength()
-	 */
-	public long getContentLength() throws XMLDBException {
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		try {
-			broker = pool.get(user);
-			final DocumentImpl document = getDocument(broker, Lock.NO_LOCK);
-			return document.getContentLength();
-		} catch (final EXistException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(),
-					e);
-		} finally {
-			pool.release(broker);
-			pool.setSubject(preserveSubject);
-		}
-	}
-
-	/**
-	 * Sets the content for this resource. If value is of type File, it is
-	 * directly passed to the parser when Collection.storeResource is called.
-	 * Otherwise the method tries to convert the value to String.
-	 * 
-	 * Passing a File object should be preferred if the document is large. The
-	 * file's content will not be loaded into memory but directly passed to a
-	 * SAX parser.
-	 * 
-	 * @param obj
-	 *                   the content value to set for the resource.
-	 * @exception XMLDBException
-	 *                         with expected error codes. <br /><code>ErrorCodes.VENDOR_ERROR</code>
-	 *                         for any vendor specific errors that occur. <br />
-	 */
-	public void setContent(Object obj) throws XMLDBException {
-		content = null;
-		file = null;
-		value = null;
-		inputSource = null;
-		root = null;
-		if (obj instanceof File)
-			{file = (File) obj;}
-
-		else if (obj instanceof AtomicValue)
-			{value = (AtomicValue) obj;}
-
-		else if (obj instanceof InputSource)
-			{inputSource=(InputSource) obj;}
-
-        else if (obj instanceof byte[]){
-            content = new String((byte[])obj, UTF_8);
-
+        // Case 5: content is a document or internal node
         } else {
-			content = obj.toString();
-		}
-	}
+            content = withDb((broker, transaction) -> {
+                final Serializer serializer = broker.getSerializer();
+                serializer.setUser(user);
 
-	public void setContentAsDOM(Node root) throws XMLDBException {
-		if (root instanceof AttrImpl)
-			{throw new XMLDBException(ErrorCodes.WRONG_CONTENT_TYPE,
-					"SENR0001: can not serialize a standalone attribute");}
-		content = null;
-		file = null;
-		value = null;
-		inputSource = null;
-		this.root = root;
-	}
+                try {
+                    serializer.setProperties(getProperties());
 
-	public ContentHandler setContentAsSAX() throws XMLDBException {
-		file = null;
-		value = null;
-		inputSource = null;
-		root = null;
-		return new InternalXMLSerializer();
-	}
-        
-        @Override
-        public void freeResources() throws XMLDBException {
-            //dO nothing
-            //TODO consider unifying close() code into freeResources()
+                    if (root != null) {
+                        return serializer.serialize((NodeValue) root);
+                    } else if (proxy != null) {
+                        return serializer.serialize(proxy);
+                    } else {
+                        return this.<String>read(broker, transaction).apply((document, broker1, transaction1) -> {
+                            try {
+                                return serializer.serialize(document);
+                            } catch (final SAXException e) {
+                                throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+                            }
+                        });
+                    }
+                } catch (final SAXException e) {
+                    throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+                }
+            });
+            return content;
+        }
+    }
+
+    @Override
+    public Node getContentAsDOM() throws XMLDBException {
+        if (root != null) {
+            if(root instanceof NodeImpl) {
+                withDb((broker, transaction) -> {
+                    ((NodeImpl)root).expand();
+                    return null;
+                });
+            }
+            return root;
+        } else if (value != null) {
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "cannot return an atomic value as DOM node");
+        } else {
+            return read((document, broker, transaction) -> {
+                if (proxy != null) {
+                    return document.getNode(proxy);
+                } else {
+                    // <frederic.glorieux@ajlsm.com> return a full to get root PI and comments
+                    return document;
+                }
+            });
+        }
+    }
+
+    @Override
+    public void getContentAsSAX(final ContentHandler handler) throws XMLDBException {
+
+        // case 1: content is an external DOM node
+        if (root != null && !(root instanceof NodeValue)) {
+            try {
+                final String option = collection.getProperty(Serializer.GENERATE_DOC_EVENTS, "false");
+                final DOMStreamer streamer = (DOMStreamer) SerializerPool.getInstance().borrowObject(DOMStreamer.class);
+                streamer.setContentHandler(handler);
+                streamer.setLexicalHandler(lexicalHandler);
+                streamer.serialize(root, option.equalsIgnoreCase("true"));
+                SerializerPool.getInstance().returnObject(streamer);
+            } catch (final Exception e) {
+                throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e.getMessage(), e);
+            }
+        } else {
+            withDb((broker, transaction) -> {
+                try {
+                    // case 2: content is an atomic value
+                    if (value != null) {
+                        value.toSAX(broker, handler, getProperties());
+
+                    // case 3: content is an internal node or a document
+                    } else {
+                        final Serializer serializer = broker.getSerializer();
+                        serializer.setUser(user);
+                        serializer.setProperties(getProperties());
+                        serializer.setSAXHandlers(handler, lexicalHandler);
+                        if (root != null) {
+                            serializer.toSAX((NodeValue) root);
+
+                        } else if (proxy != null) {
+                            serializer.toSAX(proxy);
+
+                        } else {
+                            read(broker, transaction).apply((document, broker1, transaction1) -> {
+                                try {
+                                    serializer.toSAX(document);
+                                    return null;
+                                } catch(final SAXException e) {
+                                    throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+                                }
+                            });
+                        }
+                    }
+                    return null;
+                } catch(final SAXException e) {
+                    throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+                }
+            });
+        }
+    }
+
+    /**
+     * Sets the content for this resource. If value is of type File, it is
+     * directly passed to the parser when Collection.storeResource is called.
+     * Otherwise the method tries to convert the value to String.
+     * 
+     * Passing a File object should be preferred if the document is large. The
+     * file's content will not be loaded into memory but directly passed to a
+     * SAX parser.
+     * 
+     * @param obj the content value to set for the resource.
+     * @exception XMLDBException with expected error codes. <br />
+     *     <code>ErrorCodes.VENDOR_ERROR</code> for any vendor specific errors
+     *     that occur. <br />
+     */
+    @Override
+    public void setContent(final Object obj) throws XMLDBException {
+        content = null;
+        file = null;
+        value = null;
+        inputSource = null;
+        root = null;
+
+        if (obj instanceof File) {
+            file = (File) obj;
+        } else if (obj instanceof AtomicValue) {
+            value = (AtomicValue) obj;
+        } else if (obj instanceof InputSource) {
+            inputSource=(InputSource) obj;
+        } else if (obj instanceof byte[]) {
+            content = new String((byte[])obj, UTF_8);
+        } else {
+            content = obj.toString();
+        }
+    }
+
+    @Override
+    public void setContentAsDOM(final Node root) throws XMLDBException {
+        if (root instanceof AttrImpl) {
+            throw new XMLDBException(ErrorCodes.WRONG_CONTENT_TYPE, "SENR0001: can not serialize a standalone attribute");
         }
 
-	private class InternalXMLSerializer extends SAXSerializer {
+        content = null;
+        file = null;
+        value = null;
+        inputSource = null;
+        this.root = root;
+    }
 
-		public InternalXMLSerializer() {
-			super(new StringWriter(), null);
-		}
+    @Override
+    public ContentHandler setContentAsSAX() throws XMLDBException {
+        file = null;
+        value = null;
+        inputSource = null;
+        root = null;
+        return new InternalXMLSerializer();
+    }
+        
+    @Override
+    public void freeResources() throws XMLDBException {
+        //dO nothing
+        //TODO consider unifying close() code into freeResources()
+    }
 
-		/**
-		 * @see org.xml.sax.DocumentHandler#endDocument()
-		 */
-		public void endDocument() throws SAXException {
-			super.endDocument();
-			content = getWriter().toString();
-		}
-	}
+    @Override
+    public boolean getSAXFeature(final String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+        return false;
+    }
 
-	public boolean getSAXFeature(String arg0) throws SAXNotRecognizedException,
-			SAXNotSupportedException {
-		return false;
-	}
-
-	public void setSAXFeature(String arg0, boolean arg1)
-			throws SAXNotRecognizedException, SAXNotSupportedException {
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.exist.xmldb.EXistResource#getMode()
-	 */
-	public Permission getPermissions() throws XMLDBException {
-		final Subject preserveSubject = pool.getSubject();
-	    DBBroker broker = null;
-	    try {
-	        broker = pool.get(user);
-		    final DocumentImpl document = getDocument(broker, Lock.NO_LOCK);
-			return document != null ? document.getPermissions() : null;
-	    } catch (final EXistException e) {
-            throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e.getMessage(), e);
-        } finally {
-	        pool.release(broker);
-			pool.setSubject(preserveSubject);
-	    }
-	}
+    @Override
+    public void setSAXFeature(final String name, final boolean value) throws SAXNotRecognizedException, SAXNotSupportedException {
+    }
 	
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.EXistResource#setLexicalHandler(org.xml.sax.ext.LexicalHandler)
-	 */
-	public void setLexicalHandler(LexicalHandler handler) {
-		lexicalHandler = handler;
-	}
-	
-	protected void setProperties(Properties properties) {
-		this.outputProperties = properties;
-	}
-	
-	private Properties getProperties() {
-		return outputProperties == null ? parent.properties : outputProperties;
-	}
+    @Override
+    public void setLexicalHandler(final LexicalHandler lexicalHandler) {
+        this.lexicalHandler = lexicalHandler;
+    }
 
-	protected DocumentImpl getDocument(DBBroker broker, int lock) throws XMLDBException {
-	    DocumentImpl document = null;
-            try {
-                if(lock != Lock.NO_LOCK) {
-                    document = parent.getCollection().getDocumentWithLock(broker, docId, lock);
-                 } else {
-                    document = parent.getCollection().getDocument(broker, docId);
-                }
-            } catch (final LockException e) {
-                throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-                        "Failed to acquire lock on document " + docId);
-            } catch (final PermissionDeniedException pde) {
-                throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-                        "Permission denied on document " + docId);
-            }
-	   
-	    if (document == null) {
-	        throw new XMLDBException(ErrorCodes.INVALID_RESOURCE);
-	    }
-	    return document;
-	}
-	
-	public NodeProxy getNode() throws XMLDBException {
-	    if(proxy != null)
-	        {return proxy;}
-		final Subject preserveSubject = pool.getSubject();
-	    DBBroker broker = null;
-	    try {
-	        broker = pool.get(user);
-	        final DocumentImpl document = getDocument(broker, Lock.NO_LOCK);
-	        // this XMLResource represents a document
-			return new NodeProxy(document, NodeId.DOCUMENT_NODE);
-	    } catch (final EXistException e) {
-            throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, e.getMessage(), e);
-        } finally {
-	        pool.release(broker);
-			pool.setSubject(preserveSubject);
-	    }
-	}
+    protected void setProperties(final Properties properties) {
+        this.outputProperties = properties;
+    }
 
+    private Properties getProperties() {
+        return outputProperties == null ? collection.getProperties(): outputProperties;
+    }
+
+    public NodeProxy getNode() throws XMLDBException {
+        if(proxy != null) {
+            return proxy;
+        } else {
+            return read((document, broker, transaction) -> new NodeProxy(document, NodeId.DOCUMENT_NODE));
+        }
+    }
+
+    @Override
 	public  DocumentType getDocType() throws XMLDBException {
-		final Subject preserveSubject = pool.getSubject();
-		DBBroker broker = null;
-		try {
-			broker = pool.get(user);
-			final DocumentImpl document = getDocument(broker, Lock.NO_LOCK);
-			if (!document.getPermissions().validate(user, Permission.READ))
-				{throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-						"permission denied to read resource");}
+        return read((document, broker, transaction) -> document.getDoctype());
+    }
 
-			return  document.getDoctype();			
-		} catch (final EXistException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(),
-					e);
-		} finally {
-			pool.release(broker);
-			pool.setSubject(preserveSubject);
-		}
-}
-	
-	public void setDocType(DocumentType doctype) throws XMLDBException {
-		final Subject preserveSubject = pool.getSubject();
-		DocumentImpl document = null;
-		 final TransactionManager transact = pool.getTransactionManager();
-        try(final DBBroker broker = pool.get(user);
-            final Txn transaction = transact.beginTransaction()) {
-			document = openDocument(broker, Lock.WRITE_LOCK);
-           	
-			if (document == null) {
-                throw new EXistException("Resource "
-                        + docId + " not found");
+    @Override
+    public void setDocType(final DocumentType doctype) throws XMLDBException {
+        modify((document, broker, transaction) -> {
+            if (document == null) {
+                throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, "Resource " + docId + " not found");
             }
-			
-			if (!document.getPermissions().validate(user, Permission.WRITE))
-				{throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, 
-						"User is not allowed to lock resource " + document.getFileURI());}
-			
-			document.setDocumentType(doctype);
-         	broker.storeXMLResource(transaction, document);
-            transact.commit(transaction);
 
+            document.setDocumentType(doctype);
+            return null;
+        });
+    }
+        
+    private class InternalXMLSerializer extends SAXSerializer {
+        public InternalXMLSerializer() {
+            super(new StringWriter(), null);
+        }
 
-		} catch (final EXistException e) {
-			throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(),
-					e);
-		} finally {
-			closeDocument(document, Lock.WRITE_LOCK);
-			pool.setSubject(preserveSubject);
-		}
-}
+        @Override
+        public void endDocument() throws SAXException {
+            super.endDocument();
+            content = getWriter().toString();
+        }
+    }
 }

--- a/src/org/exist/xmldb/LocalXPathQueryService.java
+++ b/src/org/exist/xmldb/LocalXPathQueryService.java
@@ -1,24 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-06 Wolfgang M. Meier
- *  wolfgang@exist-db.org
- *  http://exist.sourceforge.net
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.xmldb;
 
@@ -38,19 +35,21 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.XQueryPool;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.lock.LockedDocumentMap;
+import org.exist.storage.txn.Txn;
 import org.exist.util.LockException;
+import org.exist.xmldb.function.LocalXmldbFunction;
 import org.exist.xquery.value.AnyURIValue;
 import org.exist.xquery.value.Sequence;
 import org.w3c.dom.Node;
 import org.xmldb.api.base.*;
 import org.xmldb.api.modules.XMLResource;
 
-import java.io.IOException;
 import java.io.Writer;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
+
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentImpl;
@@ -59,457 +58,405 @@ import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.persistent.NodeSet;
 import org.exist.security.Permission;
+import org.exist.util.function.Either;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.XQueryContext;
 
-public class LocalXPathQueryService implements XPathQueryServiceImpl, XQueryService {
+public class LocalXPathQueryService extends AbstractLocalService implements XPathQueryServiceImpl, XQueryService {
 
 	private final static Logger LOG = LogManager.getLogger(LocalXPathQueryService.class);
 
-	protected BrokerPool brokerPool;
-	protected LocalCollection collection;
-	protected Subject user;
-	protected TreeMap<String, String> namespaceDecls = new TreeMap<String, String>();
-	protected TreeMap<String, Object> variableDecls = new TreeMap<String, Object>();
-	protected boolean xpathCompatible = true;
-	protected String moduleLoadPath = null;
-	protected Properties properties = null;
-	protected boolean lockDocuments = false;
-	protected LockedDocumentMap lockedDocuments = null;
-	protected DBBroker reservedBroker = null;
+    private final TreeMap<String, String> namespaceDecls = new TreeMap<>();
+    private final TreeMap<String, Object> variableDecls = new TreeMap<>();
+    private boolean xpathCompatible = true;
+    private String moduleLoadPath = null;
+    private final  Properties properties;
+    private boolean lockDocuments = false;
+    private LockedDocumentMap lockedDocuments = null;
+    private DBBroker reservedBroker = null;
 
-    protected AccessContext accessCtx;
+    private final AccessContext accessCtx;
 	
-	@SuppressWarnings("unused")
-	private LocalXPathQueryService() {}
-	
-	public LocalXPathQueryService(
-		Subject user,
-		BrokerPool pool,
-		LocalCollection collection,
-		AccessContext accessCtx) {
-		if(accessCtx == null)
-			{throw new NullAccessContextException();}
-		this.accessCtx = accessCtx;
-		this.user = user;
-		this.collection = collection;
-		this.brokerPool = pool;
-		this.properties = new Properties(collection.properties);
-	}
+    public LocalXPathQueryService(final Subject user, final BrokerPool pool, final LocalCollection collection, final AccessContext accessCtx) {
+        super(user, pool, collection);
 
-	public void clearNamespaces() throws XMLDBException {
-		namespaceDecls.clear();
-	}
+        if(accessCtx == null) {
+            throw new NullAccessContextException();
+        }
 
-	public String getName() throws XMLDBException {
-		return "XPathQueryService";
-	}
+        this.accessCtx = accessCtx;
+        this.properties = new Properties(collection.getProperties());
+    }
 
-	public String getNamespace(String prefix) throws XMLDBException {
-		return namespaceDecls.get(prefix);
-	}
-	
-	public String getProperty(String property) throws XMLDBException {
-		return properties.getProperty(property);
-	}
+    @Override
+    public String getName() throws XMLDBException {
+        return "XPathQueryService";
+    }
 
-	public String getVersion() throws XMLDBException {
-		return "1.0";
-	}
+    @Override
+    public String getVersion() throws XMLDBException {
+        return "1.0";
+    }
 
-	public ResourceSet query(String query) throws XMLDBException {
-		return query(query, null);
-	}
+    @Override
+    public void clearNamespaces() throws XMLDBException {
+        namespaceDecls.clear();
+    }
 
-	public ResourceSet query(XMLResource res, String query) throws XMLDBException {
-		return query(res, query, null);
-	}
+    @Override
+    public String getNamespace(final String prefix) throws XMLDBException {
+        return namespaceDecls.get(prefix);
+    }
 
-	public ResourceSet query(String query, String sortBy) throws XMLDBException {
-		final XmldbURI[] docs = new XmldbURI[] { XmldbURI.create(collection.getName()) };
-		return doQuery(query, docs, null, sortBy);
-	}
+    @Override
+    public String getProperty(final String property) throws XMLDBException {
+        return properties.getProperty(property);
+    }
 
-	public ResourceSet query(XMLResource res, String query, String sortBy)
-		throws XMLDBException {
-		final Node n = ((LocalXMLResource) res).root;
-		if (n != null && n instanceof org.exist.dom.memtree.NodeImpl) {
-			
-			final XmldbURI[] docs = new XmldbURI[] { XmldbURI.create(res.getParentCollection().getName()) };
-			return doQuery(query, docs, (org.exist.dom.memtree.NodeImpl)n, sortBy);
-		}
-		final NodeProxy node = ((LocalXMLResource) res).getNode();
-		if (node == null) {
-			// resource is a document
+    @Override
+    public ResourceSet query(final String query) throws XMLDBException {
+        return query(query, null);
+    }
+
+    @Override
+    public ResourceSet query(final XMLResource res, final String query) throws XMLDBException {
+        return query(res, query, null);
+    }
+
+    @Override
+    public ResourceSet query(final String query, final String sortBy) throws XMLDBException {
+        final XmldbURI[] docs = new XmldbURI[] { XmldbURI.create(collection.getName()) };
+        return doQuery(query, docs, null, sortBy);
+    }
+
+    @Override
+    public ResourceSet query(final XMLResource res, final String query, final String sortBy) throws XMLDBException {
+        final Node n = ((LocalXMLResource) res).root;
+        if (n != null && n instanceof org.exist.dom.memtree.NodeImpl) {
+            final XmldbURI[] docs = new XmldbURI[] { XmldbURI.create(res.getParentCollection().getName()) };
+            return doQuery(query, docs, (org.exist.dom.memtree.NodeImpl)n, sortBy);
+        }
+        final NodeProxy node = ((LocalXMLResource) res).getNode();
+        if (node == null) {
+            // resource is a document
             //TODO : use dedicated function in XmldbURI
-			final XmldbURI[] docs = new XmldbURI[] { XmldbURI.create(res.getParentCollection().getName()).append(res.getDocumentId()) };
-			return doQuery(query, docs, null, sortBy);
-		} else {
-			final NodeSet set = new ExtArrayNodeSet(1);
-			set.add(node);
-			final XmldbURI[] docs = new XmldbURI[] { node.getOwnerDocument().getURI() };
-			return doQuery(query, docs, set, sortBy);
-		}
-	}
-	
-	public ResourceSet execute(CompiledExpression expression) throws XMLDBException {
-		return execute(null, null, expression, null);
-	}
-	
-	public ResourceSet execute(XMLResource res, CompiledExpression expression)
-			throws XMLDBException {
-		final NodeProxy node = ((LocalXMLResource) res).getNode();
-		if (node == null) {
-			// resource is a document
-			final XmldbURI[] docs = new XmldbURI[] { XmldbURI.create(res.getParentCollection().getName()).append(res.getDocumentId()) };
-			return execute(docs, null, expression, null);
-		} else {
-			final NodeSet set = new ExtArrayNodeSet(1);
-			set.add(node);
-			final XmldbURI[] docs = new XmldbURI[] { node.getOwnerDocument().getURI() };
-			return execute(docs, set, expression, null);
-		}
-	}
-	
-	public ResourceSet execute(Source source) 
-		throws XMLDBException {
-			final long start = System.currentTimeMillis();
-	    	final Subject preserveSubject = brokerPool.getSubject();
-			DBBroker broker = null;
-			Sequence result;
-			try {
-				broker = brokerPool.get(user);
-//				DocumentSet docs = collection.getCollection().allDocs(broker, new DocumentSet(), true, true);
-				final XmldbURI[] docs = new XmldbURI[] { XmldbURI.create(collection.getName()) };
+            final XmldbURI[] docs = new XmldbURI[] { XmldbURI.create(res.getParentCollection().getName()).append(res.getDocumentId()) };
+            return doQuery(query, docs, null, sortBy);
+        } else {
+            final NodeSet set = new ExtArrayNodeSet(1);
+            set.add(node);
+            final XmldbURI[] docs = new XmldbURI[] { node.getOwnerDocument().getURI() };
+            return doQuery(query, docs, set, sortBy);
+        }
+    }
 
-				final XQuery xquery = broker.getXQueryService();
-				final XQueryPool pool = xquery.getXQueryPool();
-				XQueryContext context;
-				CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
-				if(compiled == null)
-				    {context = xquery.newContext(accessCtx);}
-				else
-				    {context = compiled.getContext();}
-				//context.setBackwardsCompatibility(xpathCompatible);
-				context.setStaticallyKnownDocuments(docs);
+    private ResourceSet doQuery(final String query, final XmldbURI[] docs, final Sequence contextSet, final String sortExpr) throws XMLDBException {
+        return withDb((broker, transaction) -> {
+            final Either<XPathException, CompiledExpression> maybeExpr = compileAndCheck(broker, transaction, query);
+            if(maybeExpr.isLeft()) {
+                final XPathException e = maybeExpr.left().get();
+                throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+            } else {
+                return execute(broker, transaction, docs, contextSet, maybeExpr.right().get(), sortExpr);
+            }
+        });
+    }
 
-				if (variableDecls.containsKey(Debuggee.PREFIX+":session")) {
-					context.declareVariable(Debuggee.SESSION, variableDecls.get(Debuggee.PREFIX+":session"));
-					variableDecls.remove(Debuggee.PREFIX+":session");
-				}
+    @Override
+    public ResourceSet execute(final CompiledExpression expression) throws XMLDBException {
+    return withDb((broker, transaction) ->
+        execute(broker, transaction, null, null, expression, null));
+    }
 
-				setupContext(source, context);
-				
-				if(compiled == null)
-				    {compiled = xquery.compile(context, source);}
-				try {
-				    result = xquery.execute(compiled, null, properties);
-				} finally {
-				    pool.returnCompiledXQuery(source, compiled);
-				}
-			} catch (final EXistException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-			} catch (final XPathException e) {
-				throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-			} catch (final IOException e) {
-			    throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-            } catch (final PermissionDeniedException e) {
-			    throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-			} finally {
-				brokerPool.release(broker);
-	            brokerPool.setSubject(preserveSubject);
-			}
-			LOG.debug("query took " + (System.currentTimeMillis() - start) + " ms.");
-			if(result != null)
-				{return new LocalResourceSet(user, brokerPool, collection, properties, result, null);}
-			else
-				{return null;}
-		}
+    @Override
+    public ResourceSet execute(final XMLResource res, final CompiledExpression expression) throws XMLDBException {
+        return withDb((broker, transaction) -> {
+            final NodeProxy node = ((LocalXMLResource) res).getNode();
+            if (node == null) {
+                // resource is a document
+                final XmldbURI[] docs = new XmldbURI[]{XmldbURI.create(res.getParentCollection().getName()).append(res.getDocumentId())};
+                return execute(broker, transaction, docs, null, expression, null);
+            } else {
+                final NodeSet set = new ExtArrayNodeSet(1);
+                set.add(node);
+                final XmldbURI[] docs = new XmldbURI[]{node.getOwnerDocument().getURI()};
+                return execute(broker, transaction, docs, set, expression, null);
+            }
+        });
+    }
+
+    private ResourceSet execute(final DBBroker broker, final Txn transaction, XmldbURI[] docs, final Sequence contextSet, final CompiledExpression expression, final String sortExpr) throws XMLDBException {
+        final long start = System.currentTimeMillis();
+        final CompiledXQuery expr = (CompiledXQuery)expression;
+        Sequence result;
+        final XQueryContext context = expr.getContext();
+        try {
+            context.setStaticallyKnownDocuments(docs);
+            if (lockedDocuments != null) {
+                context.setProtectedDocs(lockedDocuments);
+            }
+            setupContext(null, context);
+
+            final XQuery xquery = broker.getXQueryService();
+            result = xquery.execute(expr, contextSet, properties);
+        } catch (final Exception e) {
+            // need to catch all runtime exceptions here to be able to release locked documents
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+        }
+        LOG.debug("query took " + (System.currentTimeMillis() - start) + " ms.");
+        if(result != null) {
+            return new LocalResourceSet(user, brokerPool, collection, properties, result, sortExpr);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public ResourceSet execute(final Source source) throws XMLDBException {
+        return execute((broker, transaction) -> source);
+    }
 	
     @Override
     public ResourceSet executeStoredQuery(final String uri) throws XMLDBException {
-        final Subject preserveSubject = brokerPool.getSubject();
-        DBBroker broker = null;
-        final Sequence result;
-        try {
-            broker = brokerPool.get(user);
+        return execute((broker, transaction) -> {
             final DocumentImpl resource = broker.getResource(new XmldbURI(uri), Permission.READ | Permission.EXECUTE);
-            if(resource == null) {
+            if (resource == null) {
                 throw new XMLDBException(ErrorCodes.INVALID_URI, "No stored XQuery exists at: " + uri);
             }
-            final Source xquerySource = new DBSource(broker, (BinaryDocument)resource, false);
-            return execute(xquerySource);
-        } catch(final EXistException ee) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, ee.getMessage(), ee);
-        } catch(final PermissionDeniedException pde) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, pde.getMessage(), pde);
-        } finally {
-            if(broker != null) {
-                brokerPool.release(broker);
-            }
-            brokerPool.setSubject(preserveSubject);
-        }
+            return new DBSource(broker, (BinaryDocument) resource, false);
+        });
     }
-        
-	public CompiledExpression compile(String query) throws XMLDBException {
-		try {
-			return compileAndCheck(query);
-		} catch (final XPathException e) {
-			throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-		}
-	}
 
-    public CompiledExpression compileAndCheck(String query) throws XMLDBException, XPathException {
-    	final Subject preserveSubject = brokerPool.getSubject();
-        DBBroker broker = null;
-        try {
+    private ResourceSet execute(final LocalXmldbFunction<Source> sourceOp) throws XMLDBException {
+        return withDb((broker, transaction) -> {
+
             final long start = System.currentTimeMillis();
-            broker = brokerPool.get(user);
+
+            final Source source = sourceOp.apply(broker, transaction);
+
+            final XmldbURI[] docs = new XmldbURI[]{XmldbURI.create(collection.getName())};
+
             final XQuery xquery = broker.getXQueryService();
-            final XQueryContext context = xquery.newContext(accessCtx);
-            setupContext(null, context);
-            final CompiledXQuery expr = xquery.compile(context, query);
-//            checkPragmas(context);
-            LOG.debug("compilation took "  +  (System.currentTimeMillis() - start));
-            return expr;
-        } catch (final EXistException e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        } catch (final IllegalArgumentException e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-        } catch (final PermissionDeniedException e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-		} finally {
-            brokerPool.release(broker);
-            brokerPool.setSubject(preserveSubject);
+            final XQueryPool pool = xquery.getXQueryPool();
+
+            XQueryContext context;
+            CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
+            if (compiled == null) {
+                context = xquery.newContext(accessCtx);
+            } else {
+                context = compiled.getContext();
+            }
+
+            context.setStaticallyKnownDocuments(docs);
+
+            if (variableDecls.containsKey(Debuggee.PREFIX + ":session")) {
+                context.declareVariable(Debuggee.SESSION, variableDecls.get(Debuggee.PREFIX + ":session"));
+                variableDecls.remove(Debuggee.PREFIX + ":session");
+            }
+
+            setupContext(source, context);
+
+            if (compiled == null) {
+                compiled = xquery.compile(context, source);
+            }
+
+            try {
+                final Sequence result = xquery.execute(compiled, null, properties);
+                if(LOG.isDebugEnabled()) {
+                    LOG.debug("query took " + (System.currentTimeMillis() - start) + " ms.");
+                }
+                return result != null ? new LocalResourceSet(user, brokerPool, collection, properties, result, null) : null;
+            } finally {
+                pool.returnCompiledXQuery(source, compiled);
+            }
+        });
+    }
+
+    @Override
+    public CompiledExpression compile(final String query) throws XMLDBException {
+        return withDb((broker, transaction) -> {
+            final Either<XPathException, CompiledExpression> maybeExpr = compileAndCheck(broker, transaction, query);
+            if(maybeExpr.isLeft()) {
+                final XPathException e = maybeExpr.left().get();
+                throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+            } else {
+                return maybeExpr.right().get();
+            }
+        });
+    }
+
+    @Override
+    public CompiledExpression compileAndCheck(final String query) throws XMLDBException, XPathException {
+    	final Either<XPathException, CompiledExpression> result = withDb((broker, transaction) -> compileAndCheck(broker, transaction, query));
+        if(result.isLeft()) {
+            throw result.left().get();
+        } else {
+            return result.right().get();
         }
     }
-    
-    public ResourceSet queryResource(String resource, String query)
-    	throws XMLDBException {
+
+    private Either<XPathException, CompiledExpression> compileAndCheck(final DBBroker broker, final Txn transaction, final String query) throws XMLDBException {
+        final long start = System.currentTimeMillis();
+        final XQuery xquery = broker.getXQueryService();
+        final XQueryContext context = xquery.newContext(accessCtx);
+
+        try {
+            setupContext(null, context);
+            final CompiledExpression expr = xquery.compile(context, query);
+            if(LOG.isDebugEnabled()) {
+                LOG.debug("compilation took " + (System.currentTimeMillis() - start));
+            }
+            return new Either.Right(expr);
+        } catch (final PermissionDeniedException e) {
+            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, e.getMessage(), e);
+        } catch(final IllegalArgumentException e) {
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+        } catch(final XPathException e) {
+            return new Either.Left(e);
+        }
+    }
+
+    @Override
+    public ResourceSet queryResource(final String resource, final String query) throws XMLDBException {
     	final LocalXMLResource res = (LocalXMLResource) collection.getResource(resource);
-    	if (res == null)
-    		{throw new XMLDBException(
-    			ErrorCodes.INVALID_RESOURCE,
-    			"resource '" + resource + "' not found");}
+    	if (res == null) {
+            throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, "resource '" + resource + "' not found");
+        }
         final XmldbURI[] docs = new XmldbURI[] { XmldbURI.create(res.getParentCollection().getName()).append(res.getDocumentId()) };
     	return doQuery(query, docs, null, null);
     }
-	
-	protected void setupContext(Source source, XQueryContext context) throws XMLDBException, XPathException {
-	    try {
-	    	context.setBaseURI(new AnyURIValue(properties.getProperty("base-uri", collection.getPath())));
-	    } catch(final XPathException e) {
-	    	throw new XMLDBException(ErrorCodes.INVALID_URI,"Invalid base uri",e);
-	    }
-		if(moduleLoadPath != null)
-			{context.setModuleLoadPath(moduleLoadPath);}
-		else if (source != null) {
-//	        context.setModuleLoadPath(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + collection.getPath());
 
-	        String modulePath = null;
-		    if (source instanceof DBSource) {
-		        modulePath = ((DBSource) source).getDocumentPath().removeLastSegment().toString();
-            
-		    } else if (source instanceof FileSource) {
+    protected void setupContext(final Source source, final XQueryContext context) throws XMLDBException, XPathException {
+        try {
+            context.setBaseURI(new AnyURIValue(properties.getProperty("base-uri", collection.getPath())));
+        } catch(final XPathException e) {
+            throw new XMLDBException(ErrorCodes.INVALID_URI,"Invalid base uri",e);
+        }
+
+        if(moduleLoadPath != null) {
+            context.setModuleLoadPath(moduleLoadPath);
+        } else if (source != null) {
+            String modulePath = null;
+            if (source instanceof DBSource) {
+                modulePath = ((DBSource) source).getDocumentPath().removeLastSegment().toString();
+            } else if (source instanceof FileSource) {
                 modulePath = ((FileSource) source).getFile().getParent();
-                
             }
-		    
-		    if (modulePath != null)
-		        {context.setModuleLoadPath(modulePath);}
-		}
-		    
 
-		// declare namespace/prefix mappings
-		for (final Map.Entry<String, String> entry : namespaceDecls.entrySet()) {
-			context.declareNamespace(
-				entry.getKey(),
-				entry.getValue());
-		}
-		// declare static variables
-		for (final Map.Entry<String, Object> entry : variableDecls.entrySet()) {
-			context.declareVariable(entry.getKey(), entry.getValue());
-		}
-		//context.setBackwardsCompatibility(xpathCompatible);
-	}
-	
-	/**
-	 * Check if the XQuery contains pragmas that define serialization settings.
-	 * If yes, copy the corresponding settings to the current set of output properties.
-	 *
-	 * @param context
-	 */
-//	private void checkPragmas(XQueryContext context) throws XPathException {
-//		Option pragma = context.getOption(Option.SERIALIZE_QNAME);
-//		if(pragma == null)
-//			return;
-//		String[] contents = pragma.tokenizeContents();
-//		for(int i = 0; i < contents.length; i++) {
-//			String[] pair = Option.parseKeyValuePair(contents[i]);
-//			if(pair == null)
-//				throw new XPathException("Unknown parameter found in " + pragma.getQName().getStringValue() +
-//						": '" + contents[i] + "'");
-//			LOG.debug("Setting serialization property from pragma: " + pair[0] + " = " + pair[1]);
-//			properties.setProperty(pair[0], pair[1]);
-//		}
-//	}
+            if (modulePath != null) {
+                context.setModuleLoadPath(modulePath);
+            }
+        }
 
-	private ResourceSet doQuery(
-		String query,
-		XmldbURI[] docs,
-		Sequence contextSet,
-		String sortExpr)
-		throws XMLDBException {
-		final CompiledExpression expr = compile(query);
-		return execute(docs, contextSet, expr, sortExpr);
-	}
+        // declare namespace/prefix mappings
+        for (final Map.Entry<String, String> entry : namespaceDecls.entrySet()) {
+            context.declareNamespace(entry.getKey(), entry.getValue());
+        }
 
-	/**
-	 * Execute all following queries in a protected environment.
-	 * Protected means: it is guaranteed that documents referenced by the
-	 * query or the result set are not modified by other threads
-	 * until {@link #endProtected} is called.
-	 */
-	public void beginProtected() throws XMLDBException {
-//	    lockDocuments = true;
-//		if (reservedBroker != null)
-            // if a previous broker was not properly released, do it now (just to be sure)
-//            brokerPool.release(reservedBroker);
-		try {
-	        boolean deadlockCaught;
+        // declare static variables
+        for (final Map.Entry<String, Object> entry : variableDecls.entrySet()) {
+            context.declareVariable(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * Execute all following queries in a protected environment.
+     * Protected means: it is guaranteed that documents referenced by the
+     * query or the result set are not modified by other threads
+     * until {@link #endProtected} is called.
+     */
+    @Override
+    public void beginProtected() throws XMLDBException {
+        try {
+            boolean deadlockCaught;
             do {
                 reservedBroker = brokerPool.get(user);
                 deadlockCaught = false;
-	        	MutableDocumentSet docs = null;
-	            try {
-	                final org.exist.collections.Collection coll = collection.getCollection();
-	                lockedDocuments = new LockedDocumentMap();
-	                docs = new DefaultDocumentSet();
-	                coll.allDocs(reservedBroker, docs, true, lockedDocuments, Lock.WRITE_LOCK);
-	            } catch (final LockException e) {
-	                LOG.debug("Deadlock detected. Starting over again. Docs: " + docs.getDocumentCount() + "; locked: " +
-                    lockedDocuments.size());
-					lockedDocuments.unlock();
+                MutableDocumentSet docs = null;
+                try {
+                    final org.exist.collections.Collection coll = reservedBroker.getCollection(collection.getPathURI());
+                    lockedDocuments = new LockedDocumentMap();
+                    docs = new DefaultDocumentSet();
+                    coll.allDocs(reservedBroker, docs, true, lockedDocuments, Lock.WRITE_LOCK);
+                } catch (final LockException e) {
+                    LOG.debug("Deadlock detected. Starting over again. Docs: " + docs.getDocumentCount() + "; locked: " +
+                            lockedDocuments.size());
+                    lockedDocuments.unlock();
                     brokerPool.release(reservedBroker);
                     deadlockCaught = true;
-                    } catch (final PermissionDeniedException e) {
-                        throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
-                        "Permission denied on document");
-	            }
+                } catch (final PermissionDeniedException e) {
+                    throw new XMLDBException(ErrorCodes.PERMISSION_DENIED,
+                            "Permission denied on document");
+                }
             } while (deadlockCaught);
         } catch (final EXistException e) {
             brokerPool.release(reservedBroker);
             throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage());
-		}
+        }
     }
 	
-	/**
-	 * Close the protected environment. All locks held
-	 * by the current thread are released. The result set
-	 * is no longer guaranteed to be stable.
-	 */
-	public void endProtected() {
-	    lockDocuments = false;
-	    if(lockedDocuments != null) {
-	        lockedDocuments.unlock();
-	    }
-	    lockedDocuments = null;
+    /**
+     * Close the protected environment. All locks held
+     * by the current thread are released. The result set
+     * is no longer guaranteed to be stable.
+     */
+    @Override
+    public void endProtected() {
+        lockDocuments = false;
+        if(lockedDocuments != null) {
+            lockedDocuments.unlock();
+        }
+        lockedDocuments = null;
 
-        if (reservedBroker != null)
-            {brokerPool.release(reservedBroker);}
+        if (reservedBroker != null) {
+            brokerPool.release(reservedBroker);
+        }
         reservedBroker = null;
     }
-	
-	public void removeNamespace(String ns) throws XMLDBException {
-		for (final Iterator<String> i = namespaceDecls.values().iterator(); i.hasNext();) {
-			if (i.next().equals(ns)) {
-				i.remove();
-			}
-		}
-	}
 
-    private ResourceSet execute(XmldbURI[] docs, 
-		Sequence contextSet, CompiledExpression expression, String sortExpr) 
-    throws XMLDBException {
-    	final long start = System.currentTimeMillis();
-        final CompiledXQuery expr = (CompiledXQuery)expression;
-    	final Subject preserveSubject = brokerPool.getSubject();
-    	DBBroker broker = null;
-    	Sequence result;
-    	final XQueryContext context = expr.getContext();
-        try {
-    		broker = brokerPool.get(user);
-
-    		//context.setBackwardsCompatibility(xpathCompatible);
-    		context.setStaticallyKnownDocuments(docs);
-            if (lockedDocuments != null)
-                {context.setProtectedDocs(lockedDocuments);}
-            setupContext(null, context);
-//    		checkPragmas(context);
-    		    
-    		final XQuery xquery = broker.getXQueryService();
-    		result = xquery.execute(expr, contextSet, properties);
-    	} catch (final EXistException e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-    	} catch (final XPathException e) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-    	} catch (final Exception e) {
-    	    // need to catch all runtime exceptions here to be able to release locked documents
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
-    	} finally {
-//            if (keepLocks)
-//                reservedBroker = broker;
-//            else
-                brokerPool.release(broker);
-                brokerPool.setSubject(preserveSubject);
-    	}
-    	LOG.debug("query took " + (System.currentTimeMillis() - start) + " ms.");
-    	if(result != null)
-    		{return new LocalResourceSet(user, brokerPool, collection, properties, result, sortExpr);}
-    	else
-    		{return null;}
+    @Override
+    public void removeNamespace(final String ns) throws XMLDBException {
+        for (final Iterator<String> i = namespaceDecls.values().iterator(); i.hasNext();) {
+            if (i.next().equals(ns)) {
+                i.remove();
+            }
+        }
     }
-    
-	public void setCollection(Collection col) throws XMLDBException {
-	}
 
-	public void setNamespace(String prefix, String namespace) throws XMLDBException {
-		namespaceDecls.put(prefix, namespace);
-	}
+    @Override
+    public void setCollection(final Collection col) throws XMLDBException {
+    }
 
-	public void setProperty(String property, String value) throws XMLDBException {
-		properties.setProperty(property, value);
-	}
+    @Override
+    public void setNamespace(final String prefix, final String namespace) throws XMLDBException {
+        namespaceDecls.put(prefix, namespace);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.XPathQueryServiceImpl#declareVariable(java.lang.String, java.lang.Object)
-	 */
-	public void declareVariable(String qname, Object initialValue)
-		throws XMLDBException {
-		variableDecls.put(qname, initialValue);
-	}
+    @Override
+    public void setProperty(final String property, final String value) throws XMLDBException {
+        properties.setProperty(property, value);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.XQueryService#setXPathCompatibility(boolean)
-	 */
-	public void setXPathCompatibility(boolean backwardsCompatible) {
-		this.xpathCompatible = backwardsCompatible;
-	}
+    @Override
+    public void declareVariable(final String qname, final Object initialValue) throws XMLDBException {
+        variableDecls.put(qname, initialValue);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.XQueryService#setModuleLoadPath(java.lang.String)
-	 */
-	public void setModuleLoadPath(String path) {
-		moduleLoadPath = path;		
-	}
+    @Override
+    public void setXPathCompatibility(final boolean backwardsCompatible) {
+        this.xpathCompatible = backwardsCompatible;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xmldb.XQueryService#dump(org.exist.xmldb.CompiledExpression, java.io.Writer)
-	 */
-	public void dump(CompiledExpression expression, Writer writer) throws XMLDBException {
-	    final CompiledXQuery expr = (CompiledXQuery)expression;
-	    expr.dump(writer);
-	}
+    @Override
+    public void setModuleLoadPath(final String path) {
+        moduleLoadPath = path;		
+    }
+
+    @Override
+    public void dump(final CompiledExpression expression, final Writer writer) throws XMLDBException {
+        final CompiledXQuery expr = (CompiledXQuery)expression;
+        expr.dump(writer);
+    }
 }

--- a/src/org/exist/xmldb/function/LocalXmldbCollectionFunction.java
+++ b/src/org/exist/xmldb/function/LocalXmldbCollectionFunction.java
@@ -1,0 +1,66 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xmldb.function;
+
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.util.LockException;
+import org.exist.util.SyntaxException;
+import org.exist.util.function.TriFunctionE;
+import org.xmldb.api.base.ErrorCodes;
+import org.xmldb.api.base.XMLDBException;
+
+import java.io.IOException;
+
+/**
+ * Specialisation of FunctionE which deals with
+ * local XMLDB operations; Predominantly converts exceptions
+ * from the database into XMLDBException types
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface LocalXmldbCollectionFunction<R> extends TriFunctionE<Collection, DBBroker, Txn, R, XMLDBException> {
+
+    @Override
+    default R apply(final org.exist.collections.Collection collection, final DBBroker broker, final Txn transaction) throws XMLDBException {
+        try {
+            return applyXmldb(collection, broker, transaction);
+        } catch(final PermissionDeniedException e) {
+            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, e.getMessage(), e);
+        } catch(final LockException e) {
+            throw new XMLDBException(ErrorCodes.COLLECTION_CLOSED, e.getMessage(), e);
+        } catch(final TriggerException | IOException | SyntaxException e) {
+            throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Signature for lambda function which takes a collection
+     *
+     * @param collection The database collection
+     * @param broker The database broker for the XMLDB function
+     * @param transaction The transaction for the XMLDB function
+     */
+    R applyXmldb(org.exist.collections.Collection collection, final DBBroker broker, final Txn transaction) throws XMLDBException, PermissionDeniedException, LockException, TriggerException, IOException, SyntaxException;
+}

--- a/src/org/exist/xmldb/function/LocalXmldbDocumentFunction.java
+++ b/src/org/exist/xmldb/function/LocalXmldbDocumentFunction.java
@@ -1,0 +1,63 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xmldb.function;
+
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.util.LockException;
+import org.exist.util.SyntaxException;
+import org.exist.util.function.TriFunctionE;
+import org.xmldb.api.base.ErrorCodes;
+import org.xmldb.api.base.XMLDBException;
+
+import java.io.IOException;
+
+/**
+ * Specialisation of FunctionE which deals with
+ * local XMLDB operations; Predominantly converts exceptions
+ * from the database into XMLDBException types
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface LocalXmldbDocumentFunction<R> extends TriFunctionE<DocumentImpl, DBBroker, Txn, R, XMLDBException> {
+
+    @Override
+    default R apply(final DocumentImpl document, final DBBroker broker, final Txn transaction) throws XMLDBException {
+        try {
+            return applyXmldb(document, broker, transaction);
+        } catch(final PermissionDeniedException e) {
+            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, e.getMessage(), e);
+        } catch(final LockException e) {
+            throw new XMLDBException(ErrorCodes.COLLECTION_CLOSED, e.getMessage(), e);
+        } catch(final IOException | SyntaxException e) {
+            throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Signature for lambda function which takes a document
+     *
+     * @param document The database collection
+     */
+    R applyXmldb(final DocumentImpl document, final DBBroker broker, final Txn transaction) throws XMLDBException, PermissionDeniedException, LockException, IOException, SyntaxException;
+}

--- a/src/org/exist/xmldb/function/LocalXmldbFunction.java
+++ b/src/org/exist/xmldb/function/LocalXmldbFunction.java
@@ -1,0 +1,63 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xmldb.function;
+
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.util.function.BiFunctionE;
+import org.exist.xquery.XPathException;
+import org.xmldb.api.base.ErrorCodes;
+import org.xmldb.api.base.XMLDBException;
+
+import java.io.IOException;
+
+/**
+ * Specialisation of BiFunctionE which deals with
+ * local XMLDB operations; Predominantly converts exceptions
+ * from the database into XMLDBException types
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface LocalXmldbFunction<R> extends BiFunctionE<DBBroker, Txn, R, XMLDBException> {
+
+    @Override
+    default R apply(final DBBroker broker, final Txn transaction) throws XMLDBException {
+        try {
+            return applyXmldb(broker, transaction);
+        } catch(final PermissionDeniedException e) {
+            throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, e.getMessage(), e);
+        } catch(final IOException e) {
+            throw new XMLDBException(ErrorCodes.UNKNOWN_ERROR, e.getMessage(), e);
+        } catch(final XPathException | EXistException e) {
+            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Signature for lambda function which takes a broker and transaction
+     *
+     * @param broker The database broker for the XMLDB function
+     * @param transaction The transaction for the XMLDB function
+     */
+    R applyXmldb(final DBBroker broker, final Txn transaction) throws XMLDBException, PermissionDeniedException, IOException, XPathException, EXistException;
+}

--- a/test/src/org/exist/xquery/JavaFunctionsTest.java
+++ b/test/src/org/exist/xquery/JavaFunctionsTest.java
@@ -16,7 +16,8 @@ import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.XPathQueryService;
 
-/** Tests for various standart XQuery functions
+/**
+ * Tests for various standard XQuery functions
  * @author jens
  */
 public class JavaFunctionsTest extends TestCase {
@@ -62,6 +63,7 @@ public class JavaFunctionsTest extends TestCase {
 	/*
 	 * @see TestCase#setUp()
 	 */
+        @Override
 	protected void setUp() throws Exception {
 		// initialize driver
 		Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
@@ -88,6 +90,7 @@ public class JavaFunctionsTest extends TestCase {
 	/*
 	 * @see TestCase#tearDown()
 	 */
+        @Override
 	protected void tearDown() throws Exception {
 		DatabaseManager.deregisterDatabase(database);
 		DatabaseInstanceManager dim =


### PR DESCRIPTION
This is a refactor of the server-side implementation of the XML:DB Local API. Through the use of Java 8 lambda expressions we the following advantages:

1) A huge reduction in code, including the removal of duplicated code.

2) Correct use of `Broker`/`Txn`/`Lock`. The lambda expressions ensure that when we take a resource we always return it.

3) Correct User security. The lambda expressions ensure that the correct cached XML:DB user credentials are applied to the correct operation.

4) Consistent exception handling. For example, we handle `PermissionDeniedException` in one place and that always leads to a `ErrorCodes.PERMISSION_DENIED` for the `XMLDBException`.

I plan to shortly also apply similar mechanisms to the XML:DB Remote API.