### PR TITLE
[bugfix] Wrong dependency leads to incorrect query result

### DIFF
--- a/src/org/exist/xquery/LocationStep.java
+++ b/src/org/exist/xquery/LocationStep.java
@@ -124,7 +124,7 @@ public class LocationStep extends Step {
 
 		// self axis has an obvious dependency on the context item
 		// likewise we depend on the context item if this is a single path step (outside a predicate)
-		if (!this.inPredicate && (this.axis == Constants.SELF_AXIS || (parent != null && parent.getSubExpressionCount() == 1)))
+		if (!this.inPredicate && (this.axis == Constants.SELF_AXIS || (parent != null && parent.getSubExpression(0) == this)))
 			{deps = deps | Dependency.CONTEXT_ITEM;}
 
 		// TODO : normally, we should call this one...

--- a/src/org/exist/xquery/LocationStep.java
+++ b/src/org/exist/xquery/LocationStep.java
@@ -123,11 +123,8 @@ public class LocationStep extends Step {
 		int deps = Dependency.CONTEXT_SET;
 
 		// self axis has an obvious dependency on the context item
-		// TODO : I guess every other axis too... so we might consider using
-		// Constants.UNKNOWN_AXIS here
-		// BUT
-		// in a predicate, the expression can't depend on... itself
-		if (!this.inPredicate && this.axis == Constants.SELF_AXIS)
+		// likewise we depend on the context item if this is a single path step (outside a predicate)
+		if (!this.inPredicate && (this.axis == Constants.SELF_AXIS || (parent != null && parent.getSubExpressionCount() == 1)))
 			{deps = deps | Dependency.CONTEXT_ITEM;}
 
 		// TODO : normally, we should call this one...

--- a/test/src/xquery/selfAxis.xml
+++ b/test/src/xquery/selfAxis.xml
@@ -15,6 +15,9 @@
         <store collection="/db/coll" name="test.xml">
             <test>test</test>
         </store>
+        <store collection="/db/coll" name="test2.xml">
+            <p>Hello <q>world!</q></p>
+        </store>
     </setup>
     <tearDown>
         <remove-collection collection="/db/coll"/>
@@ -202,5 +205,19 @@
         return
             $x/y[following-sibling::element()[1]/self::*] ]]></code>
         <expected><y/></expected>
+    </test>
+    <test output="text">
+        <task>If expression with boolean "or" used with bang operator</task>
+        <code>
+        let $doc := collection('/db/coll')/p
+        return
+            $doc/node() ! (
+                if (ancestor::p or ancestor::x) then
+                    "P"
+                else
+                    .
+            )
+        </code>
+        <expected>P P</expected>
     </test>
 </TestSet>


### PR DESCRIPTION
Wrong dependency leads to incorrect query result in combination with boolean operator: a unrooted path expression depends on the context item. Difficult to reproduce, but the issue does show up when using the bang operator (see test).