### PR TITLE
Tests output cleanup

### DIFF
--- a/build/scripts/extensions-common.xml
+++ b/build/scripts/extensions-common.xml
@@ -312,6 +312,8 @@ to add: -pre-compile steps
       <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="yes" showoutput="${junit.output}"
          maxmemory="${junit.forked.VM.maxmemory}">
 
+        <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
+
         <sysproperty key="jetty.port" value="${jetty.port}" />
         <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl}" />
 

--- a/build/scripts/junit.xml
+++ b/build/scripts/junit.xml
@@ -93,6 +93,10 @@
         <mkdir dir="${junit.reports}/classes"/>
         <mkdir dir="${junit.reports.dat}"/>
         <mkdir dir="${junit.reports.html}"/>
+
+        <!-- create a log4j config for running the tests -->
+        <xslt in="${basedir}/log4j2.xml" out="${basedir}/test/classes/log4j2-test.xml" style="${build.scripts}/log4j2-test.xsl"/>
+
     </target>
 
     <!-- Generate HTML reports -->
@@ -117,6 +121,7 @@
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="yes" showoutput="${junit.output}" 
             maxmemory="${junit.forked.VM.maxmemory}">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- local database, so should not be needed. /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl}" />
@@ -192,6 +197,7 @@
 
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="yes" showoutput="${junit.output}" maxmemory="${junit.forked.VM.maxmemory}">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- fixme! - jetty.port.jetty /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl}" />
@@ -223,6 +229,7 @@
         <echo message="-----------------"/>
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="on" showoutput="${junit.output}" fork="no">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- local database, so should not be needed. /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl}" />
@@ -245,6 +252,7 @@
         <echo message="--------------"/>
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="on" showoutput="${junit.output}" fork="yes" maxmemory="${junit.forked.VM.maxmemory}">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- local database, so should not be needed. /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl}" />
@@ -275,6 +283,7 @@
         </delete>
         <java classname="org.exist.jetty.StandaloneServer">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- fixme! - jetty.port.standalone /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port.standalone}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl.standalone}" />
@@ -294,6 +303,7 @@
         <echo message="--------------------------------"/>
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="yes" showoutput="${junit.output}" maxmemory="${junit.forked.VM.maxmemory}">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- fixme! - jetty.port.standalone /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port.standalone}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl.standalone}" />
@@ -323,6 +333,7 @@
         <echo message="--------------------------------"/>
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="yes" showoutput="${junit.output}" maxmemory="${junit.forked.VM.maxmemory}">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- local database, so should not be needed. /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl}" />
@@ -345,6 +356,7 @@
 
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="yes" showoutput="${junit.output}" maxmemory="${junit.forked.VM.maxmemory}">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- fixme! - jetty.port.jetty /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl}" />
@@ -504,6 +516,7 @@
         <echo message="--------------"/>
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="on" showoutput="${junit.output}" fork="yes" maxmemory="${junit.forked.VM.maxmemory.external}">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- fixme! - jetty.port.jetty /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl}" />
@@ -530,6 +543,7 @@
         <echo message="--------------"/>
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="on" showoutput="${junit.output}" fork="yes" maxmemory="${junit.forked.VM.maxmemory.external}">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 	    <!-- fixme! - jetty.port.jetty /ljo -->
             <sysproperty key="jetty.port" value="${jetty.port}" />
             <sysproperty key="jetty.port.ssl" value="${jetty.port.ssl}" />
@@ -587,6 +601,7 @@
         <echo message="--------------"/>
         <junit haltonfailure="${junit.haltonfailure}" haltonerror="${junit.haltonerror}" printsummary="on" showoutput="${junit.output}" fork="yes" maxmemory="${junit.forked.VM.maxmemory.external}">
             <sysproperty key="exist.home" value="${basedir}" />
+            <sysproperty key="java.util.logging.manager" value="org.apache.logging.log4j.jul.LogManager"/>
 
             <classpath refid="classpath.core"/>
             <classpath refid="classpath.aspectj"/>

--- a/build/scripts/log4j2-test.xsl
+++ b/build/scripts/log4j2-test.xsl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    exclude-result-prefixes="xs"
+    version="1.0">
+    
+    <xsl:output indent="yes" encoding="UTF-8"/>
+    
+    <!-- strip output to STDOUT -->
+    <xsl:template match="Logger[@name = 'org.exist.jetty.JettyStart' or @name = 'org.exist.jetty.StandaloneServer']">
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+            <xsl:apply-templates select="node()[local-name(.) = 'AppenderRef'][@ref != 'STDOUT']"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/extensions/debuggee/src/org/exist/debuggee/DebuggeeJointImpl.java
+++ b/extensions/debuggee/src/org/exist/debuggee/DebuggeeJointImpl.java
@@ -271,7 +271,6 @@ public class DebuggeeJointImpl implements DebuggeeJoint, Status {
 	}
 
 	public void reset() {
-		System.out.println("reset");
 		firstExpression = null;
 		
 		stack = new ArrayList<Expression>();

--- a/extensions/debuggee/test/org/exist/debugger/DebuggerTest.java
+++ b/extensions/debuggee/test/org/exist/debugger/DebuggerTest.java
@@ -87,19 +87,18 @@ public class DebuggerTest implements ResponseListener {
 		try {
 			debugger = DebuggerImpl.getDebugger();
 
-			System.out.println("sending init request");
+			//sending init request
 			// jetty.port.jetty
 			DebuggingSource source = debugger.init("http://127.0.0.1:" + System.getProperty("jetty.port") + "/exist/xquery/fibo.xql");
 
 			assertNotNull("Debugging source can't be NULL.", source);
 			
-			System.out.println("get stack frames");
+			//get stack frames
 			List<Location> stack = source.getStackFrames();
 			assertEquals(1, stack.size());
 			assertEquals(15, stack.get(0).getLineBegin());
 
-			System.out.print("sending step-into");
-			System.out.print(".");
+			//sending step-into
 			source.stepInto(this);
 			
 			try {
@@ -107,22 +106,20 @@ public class DebuggerTest implements ResponseListener {
 			} catch (InterruptedException e) {
 			}
 
-			System.out.println("get stack frames");
+			//"get stack frames
 			stack = source.getStackFrames();
 			assertEquals(1, stack.size());
 			assertEquals(16, stack.get(0).getLineBegin());
 
 			for (int i = 0; i < 9; i++) {
-				System.out.print(".");
 				source.stepInto(this);
 			}
 			try {
 				Thread.sleep(5000); //TODO: query current stage or wait for BREAK status ???
 			} catch (InterruptedException e) {
 			}
-			System.out.println("=");
 			
-			System.out.println("get stack frames");
+			//get stack frames
 			stack = source.getStackFrames();
 			assertEquals(3, stack.size());
 			assertEquals(8, stack.get(0).getLineBegin());
@@ -133,7 +130,7 @@ public class DebuggerTest implements ResponseListener {
 			assertEquals(24, stack.get(2).getLineBegin());
 			assertEquals(42, stack.get(2).getColumnBegin());
 			
-			System.out.println("sending get-variables first time");
+			//sending get-variables first time
 			List<Variable> vars = source.getVariables();
 			
 			assertEquals(2, vars.size());
@@ -145,7 +142,7 @@ public class DebuggerTest implements ResponseListener {
 					assertEquals("default", var.getValue());
 			}
 			
-			System.out.println("sending get-local-variables");
+			//sending get-local-variables
 			vars = source.getLocalVariables();
 			assertEquals(1, vars.size());
 			for (Variable var : vars) {
@@ -153,7 +150,7 @@ public class DebuggerTest implements ResponseListener {
 				assertEquals("1", var.getValue());
 			}
 
-			System.out.println("sending get-glocal-variables");
+			//sending get-glocal-variables
 			vars = source.getGlobalVariables();
 			assertEquals(1, vars.size());
 			for (Variable var : vars) {
@@ -161,14 +158,12 @@ public class DebuggerTest implements ResponseListener {
 				assertEquals("default", var.getValue());
 			}
 
-			System.out.print("sending step-into & waiting stop status");
+			//sending step-into & waiting stop status
 			for (int i = 0; i < 7; i++) {
-				System.out.print(".");
 				source.stepInto();
 			}
-			System.out.print("=");
 
-			System.out.println("sending get-variables second time");
+			//sending get-variables second time
 			vars = source.getVariables();
 			
 			assertEquals(2, vars.size());
@@ -180,13 +175,13 @@ public class DebuggerTest implements ResponseListener {
 					assertEquals("default", var.getValue());
 			}
 
-			System.out.println("sending step-over");
+			//sending step-over
 			source.stepOver(this);
 
-			System.out.println("sending step-out");
+			//sending step-out
 			source.stepOut(this);
 
-			System.out.println("sending run");
+			//sending run
 			source.run(this);
 
 		} catch (IOException e) {
@@ -203,7 +198,6 @@ public class DebuggerTest implements ResponseListener {
 		Debugger debugger = DebuggerImpl.getDebugger();
 		
 		try {
-			System.out.println("sending init request");
 			// jetty.port.jetty
 			DebuggingSource source = debugger.init("http://127.0.0.1:" + System.getProperty("jetty.port") + "/exist/xquery/fibo.xql");
 
@@ -237,7 +231,7 @@ public class DebuggerTest implements ResponseListener {
 		Debugger debugger = DebuggerImpl.getDebugger();
 		
 		try {
-			System.out.println("sending init request");
+			//sending init request
 			// jetty.port.jetty
 			DebuggingSource source = debugger.init("http://127.0.0.1:" + System.getProperty("jetty.port") + "/exist/xquery/fibo.xql");
 
@@ -275,7 +269,7 @@ public class DebuggerTest implements ResponseListener {
 		Debugger debugger = DebuggerImpl.getDebugger();
 		
 		try {
-			System.out.println("sending init request");
+			//sending init request
 			// jetty.port.jetty
 			DebuggingSource source = debugger.init("http://127.0.0.1:" + System.getProperty("jetty.port") + "/exist/xquery/fibo.xql");
 
@@ -319,7 +313,7 @@ public class DebuggerTest implements ResponseListener {
 		Debugger debugger = DebuggerImpl.getDebugger();
 
 		try {
-			System.out.println("sending init request");
+			//sending init request
 			// jetty.port.jetty
 			DebuggingSource source = debugger.init("http://127.0.0.1:" + System.getProperty("jetty.port") + "/exist/xquery/debug-test.xql");
 
@@ -337,7 +331,7 @@ public class DebuggerTest implements ResponseListener {
 
             String res = source.evaluate("$t:XML");
 			assertNotNull(res);
-            System.out.println("$t:XML: " + res);
+            //$t:XML: " + res
             assertEquals("<root><a id=\"a1\"/><b id=\"b1\" type=\"t\"/><c id=\"c1\">text</c><d id=\"d1\"><e>text</e></d></root>", res);
 			breakpoint.remove();
 
@@ -359,7 +353,7 @@ public class DebuggerTest implements ResponseListener {
 		Exception exception = null;
 		
 		try {
-			System.out.println("sending init request");
+			//sending init request
 			// jetty.port.jetty
 			debugger.init("http://127.0.0.1:" + System.getProperty("jetty.port") + "/exist/logo.jpg");
 
@@ -373,7 +367,7 @@ public class DebuggerTest implements ResponseListener {
 		assertEquals(exception.getClass().toString(), "class java.io.IOException");
 
 		try {
-			System.out.println("sending init request");
+			//sending init request
 			// jetty.port.jetty
 			debugger.init("http://127.0.0.1:" + System.getProperty("jetty.port") + "/notExist/fibo.xql");
 
@@ -393,25 +387,21 @@ public class DebuggerTest implements ResponseListener {
 		String url = "http://127.0.0.1:" + System.getProperty("jetty.port") + "/exist/xquery/json-test.xql";
 		for (int i = 0; i < 10; i++) {
 			Debugger debugger = DebuggerImpl.getDebugger();
-
-			System.out.println("init "+i);
 			DebuggingSource debuggerSource = debugger.init(url);
 
-			System.out.println("send stepInto");
+			//send stepInto
 			debuggerSource.stepInto();
 			//Thread.sleep(1000);
 
-			System.out.println("send getStackFrames");
+			//send getStackFrames
 			List<Location> stack = debuggerSource.getStackFrames();
 			assertEquals(1, stack.size());
 			assertEquals(8, stack.get(0).getLineBegin());
 			assertEquals(6, stack.get(0).getColumnBegin());
 
-			System.out.println("send stop");
+			//send stop
 			debuggerSource.stop();
 			//Thread.sleep(1000);
-			
-			System.out.println("stoped");
 
 			DebuggerImpl.shutdownDebugger();
 		} 
@@ -445,25 +435,23 @@ public class DebuggerTest implements ResponseListener {
 		
 		for (int i = 0; i < 10; i++) {
 			Debugger debugger = DebuggerImpl.getDebugger();
-
-			System.out.println("init "+i);
 			DebuggingSource debuggerSource = debugger.init(url);
 
-			System.out.println("send stepInto");
+			//send stepInto
 			debuggerSource.stepInto();
 			//Thread.sleep(1000);
 
-			System.out.println("send getStackFrames");
+			//send getStackFrames
 			List<Location> stack = debuggerSource.getStackFrames();
 			assertEquals(1, stack.size());
 			assertEquals(16, stack.get(0).getLineBegin());
 			assertEquals(18, stack.get(0).getColumnBegin());
 
-			System.out.println("send stop");
+			//send stop
 			debuggerSource.stop();
 			//Thread.sleep(1000);
 			
-			System.out.println("stoped");
+			//stoped
 
 			DebuggerImpl.shutdownDebugger();
 		} 
@@ -485,7 +473,7 @@ public class DebuggerTest implements ResponseListener {
     }
 
 	public void responseEvent(CommandContinuation command, Response response) {
-		System.out.println("getResponse command = "+command);
+		//System.out.println("getResponse command = "+command);
 	}
 	
     private void store(String name,  String data) throws EXistException {

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -254,7 +254,6 @@ public class LuceneIndexTest {
 
     @Test
     public void simpleQueries() {
-        System.out.println("Test simple queries ...");
         DocumentSet docs = configureAndStore(COLLECTION_CONFIG1, XML1, "test.xml");
         DBBroker broker = null;
         try {
@@ -293,7 +292,6 @@ public class LuceneIndexTest {
             seq = xquery.execute("/section[ft:query(head/*, 'just')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
-            System.out.println("Test PASSED.");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -336,7 +334,6 @@ public class LuceneIndexTest {
 
     @Test
     public void inlineAndIgnore() {
-        System.out.println("Test simple queries ...");
         DocumentSet docs = configureAndStore(COLLECTION_CONFIG5, XML5, "test.xml");
         DBBroker broker = null;
         try {
@@ -689,19 +686,16 @@ public class LuceneIndexTest {
 
     @Test
     public void dropSingleDoc() {
-        System.out.println("Test removal of single document ...");
         DocumentSet docs = configureAndStore(COLLECTION_CONFIG1, XML1, "dropDocument.xml");
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
 
-            System.out.println("Removing document dropDocument.xml");
             root.removeXMLResource(transaction, broker, XmldbURI.create("dropDocument.xml"));
             transact.commit(transaction);
 
             checkIndex(docs, broker, null, null, 0);
 
-            System.out.println("Test PASSED.");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -710,7 +704,6 @@ public class LuceneIndexTest {
 
     @Test
     public void dropDocuments() {
-        System.out.println("Test removal of multiple documents ...");
         configureAndStore(COLLECTION_CONFIG1, "samples/shakespeare");
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
@@ -722,7 +715,6 @@ public class LuceneIndexTest {
                 assertNotNull(seq);
                 assertEquals(6, seq.getItemCount());
 
-                System.out.println("Removing document r_and_j.xml");
                 root.removeXMLResource(transaction, broker, XmldbURI.create("r_and_j.xml"));
                 transact.commit(transaction);
 
@@ -732,15 +724,12 @@ public class LuceneIndexTest {
             }
 
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Removing document hamlet.xml");
                 root.removeXMLResource(transaction, broker, XmldbURI.create("hamlet.xml"));
                 transact.commit(transaction);
 
                 Sequence seq = xquery.execute("//LINE[ft:query(., 'bark')]", null, AccessContext.TEST);
                 assertNotNull(seq);
                 assertEquals(1, seq.getItemCount());
-
-                System.out.println("Test PASSED.");
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -750,7 +739,6 @@ public class LuceneIndexTest {
 
     @Test
     public void removeCollection() {
-        System.out.println("Test removal of collection ...");
         DocumentSet docs = configureAndStore(COLLECTION_CONFIG1, "samples/shakespeare");
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -760,10 +748,8 @@ public class LuceneIndexTest {
             assertNotNull(xquery);
             Sequence seq = xquery.execute("//SPEECH[ft:query(LINE, 'love')]", null, AccessContext.TEST);
             assertNotNull(seq);
-            System.out.println("Found: " + seq.getItemCount());
             assertEquals(166, seq.getItemCount());
 
-            System.out.println("Removing collection");
             broker.removeCollection(transaction, root);
 
             root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
@@ -776,7 +762,6 @@ public class LuceneIndexTest {
             
             checkIndex(docs, broker, null, null, 0);
 
-            System.out.println("Test PASSED.");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -929,10 +914,6 @@ public class LuceneIndexTest {
             proc.reset();
 
             Occurrences o[] = checkIndex(docs, broker, new QName[] { new QName("condition") }, null, 2);
-            System.out.println("prices: " + o.length);
-            for (int i = 0; i < o.length; i++) {
-                System.out.println("occurance: " + o[i].getTerm() + ": " + o[i].getOccurrences());
-            }
             checkIndex(docs, broker, new QName[] { new QName("description") }, null, 4);
             checkIndex(docs, broker, new QName[] { new QName("item") }, null, 6);
 
@@ -1265,7 +1246,6 @@ public class LuceneIndexTest {
             for (int j = 0; j < files.length; j++) {
                 MimeType mime = mimeTab.getContentTypeFor(files[j].getName());
                 if(mime != null && mime.isXMLType()) {
-                    System.out.println("Storing document " + files[j].getName());
                     InputSource is = new InputSource(files[j].getAbsolutePath());
                     IndexInfo info =
                             root.validateXMLResource(transaction, broker, XmldbURI.create(files[j].getName()), is);
@@ -1298,11 +1278,6 @@ public class LuceneIndexTest {
         }
         XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
         Occurrences[] occur = index.scanIndex(context, docs, null, hints);
-        if (occur != null && expected != occur.length) {
-            for (int i = 0; i < occur.length; i++) {
-                System.out.println("term: " + occur[i].getTerm());
-            }
-        }
         assertEquals(expected, occur.length);
         return occur;
     }

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneMatchListenerTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneMatchListenerTest.java
@@ -138,7 +138,6 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>some paragraph with <hi>" + MATCH_START + "mixed" +
                     MATCH_END + "</hi> content.</para>", result);
 
@@ -146,7 +145,6 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>another paragraph with <note><hi>" + MATCH_START + "nested" +
                     MATCH_END + "</hi> " + MATCH_START +
                     "inner" + MATCH_END + "</note> " + MATCH_START + "elements" + MATCH_END + ".</para>", result);
@@ -155,7 +153,6 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>a third paragraph with <term>" + MATCH_START + "term" + MATCH_END +
                     "</term>.</para>", result);
 
@@ -163,7 +160,6 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>" + MATCH_START + "double" + MATCH_END + " " +
                     MATCH_START + "match" + MATCH_END + " " + MATCH_START + "double" + MATCH_END + " " +
                     MATCH_START + "match" + MATCH_END + "</para>", result);
@@ -174,7 +170,6 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<hit><para>" + MATCH_START + "double" + MATCH_END + " " +
                     MATCH_START + "match" + MATCH_END + " " + MATCH_START + "double" + MATCH_END + " " +
                     MATCH_START + "match" + MATCH_END + "</para></hit>", result);
@@ -200,14 +195,12 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertXpathEvaluatesTo("1", "count(//exist:match)", result);
 
             seq = xquery.execute("//para[ft:query(., 'nested')]/note", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertXpathEvaluatesTo("1", "count(//hi/exist:match)", result);
         } catch (Exception e) {
             e.printStackTrace();
@@ -231,14 +224,12 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertXpathEvaluatesTo("1", "count(//exist:match)", result);
 
             seq = xquery.execute("//hi[ft:query(., 'nested')]/parent::note", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertXpathEvaluatesTo("1", "count(//hi/exist:match)", result);
         } catch (Exception e) {
             e.printStackTrace();
@@ -262,7 +253,6 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<p>Paragraphs with <s>" + MATCH_START + "mix" + MATCH_END +
                     "</s><s>ed</s> content are <s>danger</s>ous.</p>", result);
 
@@ -270,7 +260,6 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<p>A simple<note>sic</note> paragraph with <hi>highlighted</hi> text <note>and a note</note> to be " +
                     MATCH_START + "ignored" + MATCH_END + ".</p>", result);
 
@@ -278,7 +267,6 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<p>A simple<note>sic</note> paragraph with <hi>" + MATCH_START +
                     "highlighted" + MATCH_END + "</hi> text <note>and a note</note> to be " +
                     "ignored.</p>", result);
@@ -287,14 +275,12 @@ public class LuceneMatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<hi>" + MATCH_START + "highlighted" + MATCH_END + "</hi>", result);
             
             seq = xquery.execute("//head[ft:query(., 'title')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<head>The <b>" + MATCH_START + "title" + MATCH_END + "</b>of it</head>",
                     result);
         } catch (Exception e) {

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
@@ -590,7 +590,7 @@ public class CustomIndexTest extends TestCase {
             }
             serializer.endDocument();
             //TODO : check content
-            System.out.println(out.toString());
+
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
@@ -130,7 +130,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>some paragraph with <hi>" + MATCH_START + "mixed" +
                     MATCH_END + "</hi> content.</para>", result);
 
@@ -138,7 +137,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>some paragraph with <hi>mixed</hi> " + MATCH_START + "content" +
                     MATCH_END + ".</para>", result);
 
@@ -146,7 +144,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>another paragraph with <note><hi>" + MATCH_START + "nested" + MATCH_END +
                     "</hi> inner</note> elements.</para>", result);
 
@@ -154,7 +151,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>some paragraph with <hi>" + MATCH_START + "mixed" + MATCH_END +
                     "</hi> " + MATCH_START + "content" + MATCH_END + ".</para>", result);
         } catch (Exception e) {
@@ -179,7 +175,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<hi>" + MATCH_START + "mixed" + MATCH_END + "</hi>", result);
 
         } catch (Exception e) {
@@ -204,14 +199,12 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<note><hi>" + MATCH_START + "nested" + MATCH_END + "</hi> inner</note>", result);
 
             seq = xquery.execute("//para[ngram:contains(., 'nested')]//hi", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<hi>" + MATCH_START + "nested" + MATCH_END + "</hi>", result);
         } catch (Exception e) {
             e.printStackTrace();
@@ -235,21 +228,18 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>a third paragraph with <term>" + MATCH_START + "term" + MATCH_END + "</term>.</para>", result);
 
             seq = xquery.execute("//term[ngram:contains(., 'term')]/..", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>a third paragraph with <term>" + MATCH_START + "term" + MATCH_END + "</term>.</para>", result);
 
             seq = xquery.execute("//term[ngram:contains(., 'term')]/ancestor::para", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>a third paragraph with <term>" + MATCH_START + "term" + MATCH_END + "</term>.</para>", result);
         } catch (Exception e) {
             e.printStackTrace();
@@ -272,7 +262,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>some paragraph with <hi>" + MATCH_START + "mixed" +
                     MATCH_END + "</hi>" + MATCH_START + " content" + MATCH_END + ".</para>", result);
 
@@ -280,7 +269,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>some paragraph " + MATCH_START + "with " + MATCH_END + "<hi>" +
                     MATCH_START + "mixed" + MATCH_END + "</hi>" + MATCH_START + " content" + MATCH_END +
                 ".</para>", result);
@@ -289,7 +277,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>another paragraph " + MATCH_START + "with " + MATCH_END +
                 "<note><hi>" + MATCH_START + "nested" + MATCH_END + "</hi> inner</note> elements.</para>", result);
 
@@ -297,7 +284,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>another paragraph " + MATCH_START + "with " + MATCH_END +
                 "<note><hi>" + MATCH_START + "nested" + MATCH_END + "</hi>" + MATCH_START + " inner" + MATCH_END +
                 "</note>" + MATCH_START + " elements" + MATCH_END + ".</para>", result);
@@ -322,7 +308,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>another paragraph with <note><hi>" + MATCH_START + "nested" + MATCH_END +
                 "</hi>" + MATCH_START + " inner" + MATCH_END + "</note> elements.</para>", result);
 
@@ -330,7 +315,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>another paragraph with <note><hi>" + MATCH_START + "nested" + MATCH_END +
                 "</hi>" + MATCH_START + " inner" + MATCH_END + "</note> elements.</para>", result);
         } catch (Exception e) {
@@ -355,7 +339,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>" + MATCH_START + "double match" + MATCH_END + " " +
                 MATCH_START + "double match" + MATCH_END + "</para>", result);
 
@@ -363,7 +346,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>" + MATCH_START + "aaa aaa" + MATCH_END
                 + " aaa</para>", result);
 
@@ -371,7 +353,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>aaa " + MATCH_START + "aaa aaa" + MATCH_END + "</para>", result);
 
         } catch (Exception e) {
@@ -397,7 +378,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert
                 .assertEquals("<para>" + MATCH_START + "double match double match" + MATCH_END + "</para>", result);
 
@@ -406,7 +386,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>some " + MATCH_START + "paragraph with " + MATCH_END + "<hi>" + MATCH_START
                 + "mixed" + MATCH_END + "</hi>" + MATCH_START + " content." + MATCH_END
                 + "</para>", result);
@@ -418,7 +397,6 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>another paragra" + MATCH_START + "ph with " + MATCH_END + "<note><hi>"
                 + MATCH_START + "nested" + MATCH_END + "</hi>" + MATCH_START + " inner" + MATCH_END + "</note>"
                 + MATCH_START + " elements." + MATCH_END + "</para>", result);
@@ -429,7 +407,6 @@ public class MatchListenerTest {
             for (int i = 0; i < matches.getLength(); i++)
                 m.append(matches.item(i).getTextContent());
             String match = m.toString();
-            System.out.println("MATCH: " + match);
 
             assertMatches(wildcardQuery, match);
 
@@ -439,11 +416,9 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>Where did all the " + MATCH_START + "*s go?" + MATCH_END + "</para>", result);
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
-            System.out.println("MATCH: " + match);
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = ".est[][?]tes.";
@@ -453,36 +428,30 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>" + MATCH_START + "test]test" + MATCH_END + " " + MATCH_START + "test[test"
                 + MATCH_END + " " + MATCH_START + "test?test" + MATCH_END + "</para>", result);
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
-            System.out.println("MATCH: " + match);
 
             seq = xquery.execute("//para[ngram:wildcard-contains(., '^" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>" + MATCH_START + "test]test" + MATCH_END + " test[test test?test</para>",
                 result);
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
-            System.out.println("MATCH: " + match);
 
             seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "$')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>test]test test[test " + MATCH_START + "test?test" + MATCH_END + "</para>",
                 result);
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
-            System.out.println("MATCH: " + match);
 
             wildcardQuery = "^aaa.aaa$";
             seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
@@ -490,11 +459,9 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>" + MATCH_START + "aaacaaa" + MATCH_END + "</para>", result);
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
-            System.out.println("MATCH: " + match);
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = ".+simple";
@@ -503,11 +470,9 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>" + MATCH_START + "a simple" + MATCH_END + " paragraph</para>", result);
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
-            System.out.println("MATCH: " + match);
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = "a s.?i.?m.?p.?l.?e.?";
@@ -516,11 +481,9 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>" + MATCH_START + "a simple " + MATCH_END + "paragraph</para>", result);
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
-            System.out.println("MATCH: " + match);
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = "a s.?i.?m.?p.?l.?e.?";
@@ -529,11 +492,9 @@ public class MatchListenerTest {
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
-            System.out.println("RESULT: " + result);
             XMLAssert.assertEquals("<para>" + MATCH_START + "a simple " + MATCH_END + "paragraph</para>", result);
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
-            System.out.println("MATCH: " + match);
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = "b.{3,6}c";
@@ -544,10 +505,7 @@ public class MatchListenerTest {
 
             for (int i = 0; i < 2; i++) {
                 result = queryResult2String(broker, seq, i);
-                System.out.println("RESULT: " + result);
-
                 match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
-                System.out.println("MATCH: " + match);
                 assertMatches(wildcardQuery, match);
             }
 
@@ -582,8 +540,6 @@ public class MatchListenerTest {
                 assertNotNull(seq);
                 assertEquals(1, seq.getItemCount());
                 String result = queryResult2String(broker, seq, 0);
-                System.out.println("RESULT: " + result);
-
                 XMLAssert.assertXpathEvaluatesTo(i < 2 ? "2" : "1", "count(//exist:match)", result);
                 XMLAssert.assertXpathExists("//exist:match[text() = '" + strings[i] + "']", result);
             }
@@ -617,8 +573,6 @@ public class MatchListenerTest {
                 assertNotNull(seq);
                 assertEquals(1, seq.getItemCount());
                 String result = queryResult2String(broker, seq, 0);
-                System.out.println("RESULT: " + result);
-
                 XMLAssert.assertXpathEvaluatesTo(i < 2 ? "2" : "1", "count(//exist:match)", result);
                 XMLAssert.assertXpathExists("//exist:match[text() = '" + strings[i] + "']", result);
             }

--- a/extensions/indexes/spatial/test/src/org/exist/indexing/spatial/GMLIndexTest.java
+++ b/extensions/indexes/spatial/test/src/org/exist/indexing/spatial/GMLIndexTest.java
@@ -126,9 +126,7 @@ public class GMLIndexTest extends TestCase {
             assertNotNull(broker);
             GMLHSQLIndexWorker indexWorker = (GMLHSQLIndexWorker)broker.getIndexController().getWorkerByIndexId(AbstractGMLJDBCIndex.ID);
             //Unplugged
-            if (indexWorker == null) {
-                System.out.println("No spatial index found");
-            } else {
+            if (indexWorker != null) {
                 try {
                     Connection conn = null;
                     try {
@@ -145,7 +143,6 @@ public class GMLIndexTest extends TestCase {
                                 //Let be sure we have the right count
                             }
                             int count = rs.getRow();
-                            System.out.println(count + " geometries in the index");
                             ps.close();
                             assertTrue(count > 0);
                         }
@@ -178,10 +175,9 @@ public class GMLIndexTest extends TestCase {
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
             AbstractGMLJDBCIndex index = (AbstractGMLJDBCIndex)pool.getIndexManager().getIndexById(AbstractGMLJDBCIndex.ID);
             //Unplugged
-            if (index == null)
-                System.out.println("No spatial index found");
-            else
+            if (index != null) {
                 assertTrue(index.checkIndex(broker));
+            }
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -235,9 +231,7 @@ public class GMLIndexTest extends TestCase {
             assertNotNull(broker);
             AbstractGMLJDBCIndexWorker indexWorker = (AbstractGMLJDBCIndexWorker)broker.getIndexController().getWorkerByIndexId(AbstractGMLJDBCIndex.ID);
             //Unplugged
-            if (indexWorker == null)
-                System.out.println("No spatial index found");
-            else {
+            if (indexWorker != null) {
                 SAXParserFactory factory = SAXParserFactory.newInstance();
                 factory.setNamespaceAware(true);
                 InputSource src = new InputSource(new StringReader(IN_MEMORY_GML));
@@ -250,8 +244,6 @@ public class GMLIndexTest extends TestCase {
                 
                 Geometry EPSG4326_geometry = indexWorker.transformGeometry(currentGeometry, "osgb:BNG", "EPSG:4326");
                 assertNotNull(EPSG4326_geometry);
-                
-                System.out.println(EPSG4326_geometry);
                 
                 NodeSet ns = indexWorker.search(broker, null, EPSG4326_geometry, SpatialOperator.EQUALS);
                 assertTrue(ns.getLength() > 0);

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/BackupRestoreMDTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/BackupRestoreMDTest.java
@@ -27,13 +27,12 @@ import junit.framework.TestCase;
 import org.exist.EXistException;
 import org.exist.backup.SystemExport;
 import org.exist.backup.SystemImport;
-import org.exist.backup.restore.listener.DefaultRestoreListener;
+import org.exist.backup.restore.listener.LogRestoreListener;
 import org.exist.backup.restore.listener.RestoreListener;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
 import org.exist.collections.IndexInfo;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -81,8 +80,6 @@ public class BackupRestoreMDTest extends TestCase {
 
     //@Test
 	public void test_01() throws Exception {
-    	System.out.println("test_01");
-    	
     	startDB();
     	
     	MetaData md = MetaData.get();
@@ -153,7 +150,7 @@ public class BackupRestoreMDTest extends TestCase {
     	clean();
     	
     	SystemImport restore = new SystemImport(pool);
-		RestoreListener listener = new DefaultRestoreListener();
+		RestoreListener listener = new LogRestoreListener();
 		restore.restore(listener, "admin", "", "", file, "xmldb:exist://");
 
         broker = null;
@@ -239,12 +236,10 @@ public class BackupRestoreMDTest extends TestCase {
             CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(transaction, broker, root, COLLECTION_CONFIG);
 
-            System.out.println("store " + doc1uri);
             IndexInfo info = root.validateXMLResource(transaction, broker, doc1uri.lastSegment(), XML);
             assertNotNull(info);
             root.store(transaction, broker, info, XML, false);
 
-            System.out.println("store " + doc2uri);
             BinaryDocument doc = root.addBinaryResource(transaction, broker, doc2uri.lastSegment(), BINARY.getBytes(), null);
             assertNotNull(doc);
 
@@ -271,11 +266,9 @@ public class BackupRestoreMDTest extends TestCase {
     	clean();
         BrokerPool.stopAll(false);
         pool = null;
-        System.out.println("stoped");
     }
 
     private static void clean() {
-    	System.out.println("CLEANING...");
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final Txn transaction = transact.beginTransaction()) {
@@ -289,6 +282,5 @@ public class BackupRestoreMDTest extends TestCase {
             e.printStackTrace();
             fail(e.getMessage());
         }
-    	System.out.println("CLEANED.");
     }
 }

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/DocumentAsValueTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/DocumentAsValueTest.java
@@ -85,8 +85,6 @@ public class DocumentAsValueTest {
 
     @Test
 	public void test_00() throws Exception {
-    	System.out.println("test");
-    	
     	startDB();
     	
     	MetaData md = MetaData.get();
@@ -149,13 +147,10 @@ public class DocumentAsValueTest {
             CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(txn, broker, root, COLLECTION_CONFIG);
 
-            System.out.println("STORING DOCUMENT....");
             IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
             assertNotNull(info);
-            System.out.println("STORING DOCUMENT....SECOND ROUND....");
             root.store(txn, broker, info, XML1, false);
             assertNotNull(info.getDocument());
-            System.out.println("STORING DOCUMENT....DONE.");
 
             doc1 = info.getDocument();
 
@@ -165,7 +160,6 @@ public class DocumentAsValueTest {
 
             doc2 = info.getDocument();
 
-            System.out.println("store " + doc3uri);
             root.addBinaryResource(txn, broker, doc3uri.lastSegment(), BINARY.getBytes(), null);
 
             txnManager.commit(txn);
@@ -195,16 +189,11 @@ public class DocumentAsValueTest {
         pool = null;
         doc1 = null;
         doc2 = null;
-        System.out.println("stopped");
     }
 
     private static void clean(final DBBroker broker, final Txn txn) throws PermissionDeniedException, IOException, TriggerException {
-    	System.out.println("CLEANING...");
-
         final Collection col = broker.getOrCreateCollection(txn, col1uri);
         assertNotNull(col);
         broker.removeCollection(txn, col);
-
-    	System.out.println("CLEANED.");
     }
 }

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/MatchDocumentsTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/MatchDocumentsTest.java
@@ -119,7 +119,6 @@ public class MatchDocumentsTest {
 	    	assertEquals(1, matching.size());
 	    	assertEquals(doc3uri, matching.get(0).getURI());
 
-        	System.out.println("DELETE...");
             final TransactionManager txnManager = pool.getTransactionManager();
 
 	        try(final Txn txn = txnManager.beginTransaction()) {
@@ -129,7 +128,6 @@ public class MatchDocumentsTest {
 	            e.printStackTrace();
 	            fail(e.getMessage());
 	        }
-	    	System.out.println("DONE.");
 
 	    	matching = md.matchDocuments(KEY2, VALUE1);
 	    	assertEquals(0, matching.size());
@@ -181,7 +179,6 @@ public class MatchDocumentsTest {
 	    	assertEquals(1, matching.size());
 	    	assertEquals(doc3uri, matching.get(0).getURI());
 
-        	System.out.println("MOVE...");
 
             final TransactionManager txnManager = pool.getTransactionManager();
 	        try(final Txn txn = txnManager.beginTransaction()) {
@@ -191,7 +188,6 @@ public class MatchDocumentsTest {
                 e.printStackTrace();
 	            fail(e.getMessage());
 	        }
-	    	System.out.println("DONE.");
 
 	    	matching = md.matchDocuments(KEY2, VALUE1);
 
@@ -231,7 +227,6 @@ public class MatchDocumentsTest {
 	    	assertEquals(1, matching.size());
 	    	assertEquals(doc1uri, matching.get(0).getURI());
 
-	    	System.out.println("RENAMING...");
             Collection col = broker.getCollection(col1uri);
         	assertNotNull(col);
 
@@ -244,7 +239,6 @@ public class MatchDocumentsTest {
                 e.printStackTrace();
 	            fail(e.getMessage());
             }
-	    	System.out.println("DONE.");
 
 	    	matching = md.matchDocuments(KEY2, VALUE1);
 
@@ -281,7 +275,6 @@ public class MatchDocumentsTest {
 	    	assertEquals(1, matching.size());
 	    	assertEquals(doc1uri, matching.get(0).getURI());
 
-	    	System.out.println("MOVING...");
             final TransactionManager txnManager = pool.getTransactionManager();
 	        try(final Txn txn = txnManager.beginTransaction()) {
 	            Collection col2 = broker.getOrCreateCollection(txn, col2uri);
@@ -295,7 +288,6 @@ public class MatchDocumentsTest {
 	            e.printStackTrace();
 	            fail(e.getMessage());
 	        }
-	    	System.out.println("DONE.");
 
 	    	matching = md.matchDocuments(KEY2, VALUE1);
 
@@ -341,7 +333,6 @@ public class MatchDocumentsTest {
             assertEquals(1, matching.size());
             assertEquals(doc1uri, matching.get(0).getURI());
 
-            System.out.println("DELETING...");
 
             final TransactionManager txnManager = pool.getTransactionManager();
             try(final Txn txn = txnManager.beginTransaction()) {
@@ -353,7 +344,6 @@ public class MatchDocumentsTest {
                 e.printStackTrace();
                 fail(e.getMessage());
             }
-            System.out.println("DONE.");
 
             //check the metadata was deleted
             matching = md.matchDocuments(KEY2, VALUE1);
@@ -388,8 +378,6 @@ public class MatchDocumentsTest {
 	    	assertEquals(1, matching.size());
 	    	assertEquals(doc3uri, matching.get(0).getURI());
 
-	    	System.out.println("MOVING...");
-
             final TransactionManager txnManager = pool.getTransactionManager();
             final Txn txn = txnManager.beginTransaction();
 	        try {
@@ -403,7 +391,6 @@ public class MatchDocumentsTest {
 	        } finally {
                 txnManager.close(txn);
             }
-	    	System.out.println("DONE.");
 
 	    	matching = md.matchDocuments(KEY2, VALUE1);
 
@@ -440,8 +427,6 @@ public class MatchDocumentsTest {
 	    	assertEquals(1, matching.size());
 	    	assertEquals(doc3uri, matching.get(0).getURI());
 
-	    	System.out.println("MOVING...");
-
             final TransactionManager txnManager = pool.getTransactionManager();
 	        try(final Txn txn = txnManager.beginTransaction()) {
 	            Collection col2 = broker.getOrCreateCollection(txn, col2uri);
@@ -455,7 +440,6 @@ public class MatchDocumentsTest {
 	            e.printStackTrace();
 	            fail(e.getMessage());
 	        }
-	    	System.out.println("DONE.");
 
 	    	matching = md.matchDocuments(KEY2, VALUE1);
 
@@ -493,8 +477,6 @@ public class MatchDocumentsTest {
 	    	assertEquals(1, matching.size());
 	    	assertEquals(doc3uri, matching.get(0).getURI());
 
-	    	System.out.println("DELETING...");
-
             final TransactionManager txnManager = pool.getTransactionManager();
 
 	        try(final Txn txn = txnManager.beginTransaction()) {
@@ -506,7 +488,6 @@ public class MatchDocumentsTest {
                 e.printStackTrace();
                 fail(e.getMessage());
             }
-	    	System.out.println("DONE.");
 
 	    	matching = md.matchDocuments(KEY2, VALUE1);
 	    	assertEquals(0, matching.size());
@@ -562,12 +543,9 @@ public class MatchDocumentsTest {
     private void shutdown() {
         BrokerPool.stopAll(false);
         pool = null;
-        System.out.println("stopped");
     }
 
     private void clean() {
-    	System.out.println("CLEANING...");
-
         final TransactionManager txnManager = pool.getTransactionManager();
         Collection col1 = null;
         Collection col2 = null;
@@ -596,6 +574,5 @@ public class MatchDocumentsTest {
                 col1.release(Lock.WRITE_LOCK);
             }
         }
-    	System.out.println("CLEANED.");
     }
 }

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/SearchTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/SearchTest.java
@@ -209,13 +209,10 @@ public class SearchTest {
     }
     
 	private static DocumentImpl storeDocument(Txn txn, DBBroker broker, Collection col, XmldbURI uri, String data) throws TriggerException, EXistException, PermissionDeniedException, SAXException, LockException, IOException {
-        System.out.println("STORING DOCUMENT....");
         IndexInfo info = col.validateXMLResource(txn, broker, uri.lastSegment(), data);
         assertNotNull(info);
-        System.out.println("STORING DOCUMENT....SECOND ROUND....");
         col.store(txn, broker, info, data, false);
         assertNotNull(info.getDocument());
-        System.out.println("STORING DOCUMENT....DONE.");
 
         return info.getDocument();
 	}
@@ -250,7 +247,6 @@ public class SearchTest {
             doc1 = storeDocument(txn, broker, root, doc1uri, XML1);
             doc2 = storeDocument(txn, broker, root, doc2uri, XML2);
 
-            System.out.println("store "+doc5uri);
             root.addBinaryResource(txn, broker, doc5uri.lastSegment(), BINARY.getBytes(), null);
 
             txnManager.commit(txn);
@@ -281,12 +277,9 @@ public class SearchTest {
         pool = null;
         doc1 = null;
         doc2 = null;
-        System.out.println("stopped");
     }
 
     private static void clean(final DBBroker broker, final Txn txn) throws PermissionDeniedException, IOException, TriggerException {
-    	System.out.println("CLEANING...");
-
         Collection col = broker.getOrCreateCollection(txn, col1uri);
         assertNotNull(col);
         broker.removeCollection(txn, col);
@@ -298,7 +291,5 @@ public class SearchTest {
         col = broker.getOrCreateCollection(txn, col3uri);
         assertNotNull(col);
         broker.removeCollection(txn, col);
-
-    	System.out.println("CLEANED.");
     }
 }

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/SimpleMDTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/SimpleMDTest.java
@@ -226,8 +226,6 @@ public class SimpleMDTest {
 
     	List<DocumentImpl> ds = md.matchDocuments(KEY1, VALUE1);
     	
-    	System.out.println(" * "+Arrays.toString(ds.toArray()));
-    	
     	assertEquals(1, ds.size());
     	assertEquals(doc1, ds.get(0));
 
@@ -331,7 +329,6 @@ public class SimpleMDTest {
     	//add first key-value
     	docMD.put(KEY1, VALUE1);
 
-    	System.out.println("MOVING...");
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
             Collection col = broker.getCollection(col1uri);
@@ -347,7 +344,6 @@ public class SimpleMDTest {
 	            e.printStackTrace();
 	            fail(e.getMessage());
 	        }
-	    	System.out.println("MOVED.");
 
 	    	docMD = md.getMetas(doc2uri);
 	    	assertNotNull(docMD);
@@ -424,7 +420,6 @@ public class SimpleMDTest {
             Collection col = broker.getCollection(col1uri);
         	assertNotNull(col);
 
-        	System.out.println("MOVING...");
             final TransactionManager txnManager = pool.getTransactionManager();
             try(final Txn txn = txnManager.beginTransaction()) {
 	            
@@ -435,7 +430,6 @@ public class SimpleMDTest {
 	            e.printStackTrace();
 	            fail(e.getMessage());
 	        }
-	    	System.out.println("MOVED.");
 
             Collection moved = broker.getCollection(col3uri);
         	assertNotNull(moved);
@@ -523,7 +517,6 @@ public class SimpleMDTest {
             Collection col = broker.getCollection(col1uri);
         	assertNotNull(col);
 
-        	System.out.println("MOVING...");
             try(final Txn txn = txnManager.beginTransaction()) {
 	            
 	            broker.moveCollection(txn, col, parent, col3uri.lastSegment());
@@ -533,7 +526,6 @@ public class SimpleMDTest {
 	            e.printStackTrace();
 	            fail(e.getMessage());
 	        }
-	    	System.out.println("MOVED.");
 
             Collection moved = broker.getCollection(col3uri);
         	assertNotNull(moved);
@@ -599,7 +591,6 @@ public class SimpleMDTest {
             Collection col = broker.getCollection(col1uri);
         	assertNotNull(col);
 
-        	System.out.println("COPY...");
             final TransactionManager txnManager = pool.getTransactionManager();
             try(final Txn txn = txnManager.beginTransaction()) {
 	            
@@ -610,7 +601,6 @@ public class SimpleMDTest {
 	            e.printStackTrace();
 	            fail(e.getMessage());
 	        }
-	    	System.out.println("DONE.");
 
             Collection moved = broker.getCollection(col3uri);
         	assertNotNull(moved);
@@ -662,7 +652,6 @@ public class SimpleMDTest {
             Collection col = broker.getCollection(col1uri);
         	assertNotNull(col);
 
-        	System.out.println("DELETE...");
             final TransactionManager txnManager = pool.getTransactionManager();
             try(final Txn txn = txnManager.beginTransaction()) {
 	            
@@ -673,7 +662,6 @@ public class SimpleMDTest {
 	            e.printStackTrace();
 	            fail(e.getMessage());
 	        }
-	    	System.out.println("DONE.");
 
             col = broker.getCollection(col1uri);
         	assertNull(col);
@@ -725,7 +713,6 @@ public class SimpleMDTest {
                     final CollectionConfigurationManager mgr = pool.getConfigurationManager();
                     mgr.addConfiguration(txn, broker, root, COLLECTION_CONFIG);
 
-                    System.out.println("store " + doc1uri);
                     final IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
                     assertNotNull(info);
                     root.store(txn, broker, info, XML1, false);
@@ -750,7 +737,6 @@ public class SimpleMDTest {
                     final CollectionConfigurationManager mgr = pool.getConfigurationManager();
                     mgr.addConfiguration(txn, broker, root, COLLECTION_CONFIG);
 
-                    System.out.println("store " + doc1uri);
                     final IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), wrongXML);
                     assertNotNull(info);
                     root.store(txn, broker, info, wrongXML, false);
@@ -782,13 +768,10 @@ public class SimpleMDTest {
 //	}
 	
 	private static DocumentImpl storeDocument(Txn txn, DBBroker broker, Collection col, XmldbURI uri, String data) throws TriggerException, EXistException, PermissionDeniedException, SAXException, LockException, IOException {
-        System.out.println("STORING DOCUMENT....");
         IndexInfo info = col.validateXMLResource(txn, broker, uri.lastSegment(), data);
         assertNotNull(info);
-        System.out.println("STORING DOCUMENT....SECOND ROUND....");
         col.store(txn, broker, info, data, false);
         assertNotNull(info.getDocument());
-        System.out.println("STORING DOCUMENT....DONE.");
 
         return info.getDocument();
 	}
@@ -822,8 +805,6 @@ public class SimpleMDTest {
 
             doc1 = storeDocument(txn, broker, root, doc1uri, XML1);
             doc2 = storeDocument(txn, broker, root, doc2uri, XML2);
-
-            System.out.println("store "+doc5uri);
             root.addBinaryResource(txn, broker, doc5uri.lastSegment(), BINARY.getBytes(), null);
 
             txnManager.commit(txn);
@@ -845,7 +826,6 @@ public class SimpleMDTest {
         pool = null;
         doc1 = null;
         doc2 = null;
-        System.out.println("stopped");
     }
 
     private static void clean() throws EXistException, PermissionDeniedException, IOException, TriggerException {
@@ -858,8 +838,6 @@ public class SimpleMDTest {
     }
 
     private static void clean(final DBBroker broker, final Txn txn) throws PermissionDeniedException, IOException, TriggerException {
-    	System.out.println("CLEANING...");
-
         Collection col = broker.getOrCreateCollection(txn, col1uri);
         assertNotNull(col);
         broker.removeCollection(txn, col);
@@ -871,7 +849,5 @@ public class SimpleMDTest {
         col = broker.getOrCreateCollection(txn, col3uri);
         assertNotNull(col);
         broker.removeCollection(txn, col);
-
-    	System.out.println("CLEANED.");
     }
 }

--- a/extensions/metadata/sleepycat/src/main/java/org/exist/storage/md/MetaDataImpl.java
+++ b/extensions/metadata/sleepycat/src/main/java/org/exist/storage/md/MetaDataImpl.java
@@ -487,7 +487,6 @@ public class MetaDataImpl extends MetaData {
 			docByUUID.put(ms);
 
 			ms = (MetasImpl)getMetas(oldUri);
-			System.out.println(ms);
 		} else {
 			throw new RuntimeException("Metas NULL: " + oldUri + " in moveMetas");
 			//LOG.warn("Metas NULL for document: " + doc.getURI() + " in moveMetas");

--- a/extensions/svn/src/org/exist/versioning/svn/InfoHandler.java
+++ b/extensions/svn/src/org/exist/versioning/svn/InfoHandler.java
@@ -33,7 +33,6 @@ public class InfoHandler implements ISVNInfoHandler {
      * native SVN command line client.
      */
     public void handleInfo(SVNInfo info) {
-        System.out.println("-----------------INFO-----------------");
         System.out.println("Local Path: " + info.getFile().getPath());
         System.out.println("URL: " + info.getURL());
         if (info.isRemote() && info.getRepositoryRootURL() != null) {

--- a/extensions/svn/src/org/exist/versioning/svn/internal/wc/SVNFileUtil.java
+++ b/extensions/svn/src/org/exist/versioning/svn/internal/wc/SVNFileUtil.java
@@ -1086,7 +1086,7 @@ public class SVNFileUtil {
             return ((Resource)file).getOutputStream(append);
 
     		
-		System.out.println(" !!! createFileOutputStream on File = "+file);
+		System.err.println(" !!! createFileOutputStream on File = "+file);
 		Exception e = new Exception();
 		e.printStackTrace();
 		

--- a/extensions/svn/test/src/org/exist/versioning/svn/xquery/XQueryFunctionsTest.java
+++ b/extensions/svn/test/src/org/exist/versioning/svn/xquery/XQueryFunctionsTest.java
@@ -285,7 +285,6 @@ public class XQueryFunctionsTest {
                 System.err.print(results);
                 fail(fails.toString());
             }
-            System.out.println(results);
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/extensions/xUnit/src/main/java/org/exist/xquery/xUnit/xUnit.java
+++ b/extensions/xUnit/src/main/java/org/exist/xquery/xUnit/xUnit.java
@@ -76,7 +76,7 @@ public class xUnit {
 				
 				for (Annotation ann : sig.getAnnotations()) {
 					if ("http://exist-db.org/xquery/xUnit".equals( ann.getName().getNamespaceURI())) {
-						System.out.println(ann.getName().getLocalPart());
+//						System.out.println(ann.getName().getLocalPart());
 						
 						FunctionCall call = new FunctionCall(context, func);
 						call.eval(Sequence.EMPTY_SEQUENCE);

--- a/extensions/xqdoc/test/src/xquery/xqdoc/RunTests.java
+++ b/extensions/xqdoc/test/src/xquery/xqdoc/RunTests.java
@@ -43,7 +43,6 @@ public class RunTests {
 				xqs.declareVariable("doc", file.getName());
 				ResourceSet result = xqs.execute(query);
 				XMLResource resource = (XMLResource) result.getResource(0);
-                System.out.println(resource.getContent());
 				Element root = (Element) resource.getContentAsDOM();
 				NodeList tests = root.getElementsByTagName("test");
 				for (int i = 0; i < tests.getLength(); i++) {

--- a/extensions/xslt/src/org/exist/xslt/TemplatesHandlerImpl.java
+++ b/extensions/xslt/src/org/exist/xslt/TemplatesHandlerImpl.java
@@ -66,7 +66,7 @@ public class TemplatesHandlerImpl extends SAXAdapter implements TemplatesHandler
 			} catch (XPathException e) {
 				LOG.debug(e);
 				e.printStackTrace();
-				System.out.println(e.getDetailMessage()); //TODO: remove 
+				System.err.println(e.getDetailMessage()); //TODO: remove
 			}
 		}
 		return templates;

--- a/extensions/xslt/src/org/exist/xslt/compiler/XSLElement.java
+++ b/extensions/xslt/src/org/exist/xslt/compiler/XSLElement.java
@@ -70,9 +70,6 @@ public class XSLElement implements org.w3c.dom.Element, INode, Names {
 		if (expr != null)
 			return expr;
 		
-		if (getQName() == null) //TODO: remove
-			System.out.println(getQName());
-		
 		Class<XSLPathExpr> clazz = Factory.qns.get(getQName());
 		
 		try {

--- a/extensions/xslt/test/src/org/exist/xslt/XSLTS_case.java
+++ b/extensions/xslt/test/src/org/exist/xslt/XSLTS_case.java
@@ -187,22 +187,22 @@ public class XSLTS_case extends TestCase {
 			tokenCount++;
 			String refToken = refTokenizer.nextToken();
 			if (!resTokenizer.hasMoreTokens()) {
-				System.out.println("expected:");
-				System.out.println(ref);
-				System.out.println("get:");
-				System.out.println(result);
+//				System.out.println("expected:");
+//				System.out.println(ref);
+//				System.out.println("get:");
+//				System.out.println(result);
 				throw new Exception("result should have: "+refToken+", but get EOF (at "+tokenCount+")");
 			}
 			String resToken = resTokenizer.nextToken();
 			if (!refToken.equals(resToken)) {
-				System.out.println(ref);
-				System.out.println(result);
+//				System.out.println(ref);
+//				System.out.println(result);
 				throw new Exception("result should have: "+refToken+", but get "+resToken+" (at "+tokenCount+")");
 			}
 		}
 		if (resTokenizer.hasMoreTokens()) {
 			String resToken = resTokenizer.nextToken();
-			System.out.println(ref);
+//			System.out.println(ref);
 			throw new Exception("result should have nothing, but get "+resToken+" (at "+tokenCount+")");
 		}
 		return true;

--- a/extensions/xslt/test/src/org/exist/xslt/XSLTestCase.java
+++ b/extensions/xslt/test/src/org/exist/xslt/XSLTestCase.java
@@ -99,7 +99,6 @@ public class XSLTestCase {
 						"CollectionManagementService",
 						"1.0");
 				col = mgtService.createCollection(XSLT_COLLECTION);
-				System.out.println("collection created.");
 			}
 			
 			BrokerPool.getInstance().getConfiguration().setProperty(
@@ -370,18 +369,15 @@ public class XSLTestCase {
 			tokenCount++;
 			String refToken = refTokenizer.nextToken();
 			if (!resTokenizer.hasMoreTokens()) {
-				System.out.println(ref);
 				throw new Exception("result should have: "+refToken+", but get EOF (at "+tokenCount+")");
 			}
 			String resToken = resTokenizer.nextToken();
 			if (!refToken.equals(resToken)) {
-				System.out.println(ref);
 				throw new Exception("result should have: "+refToken+", but get "+resToken+" (at "+tokenCount+")");
 			}
 		}
 		if (resTokenizer.hasMoreTokens()) {
 			String resToken = resTokenizer.nextToken();
-			System.out.println(ref);
 			throw new Exception("result should have nothing, but get "+resToken+" (at "+tokenCount+")");
 		}
 		return true;
@@ -410,13 +406,12 @@ public class XSLTestCase {
 			content = null;
 			
 			testInfo = bench.get(testName);
-			
-			System.out.print(testName+": ");
+
 			if (testInfo.containsKey("storeBeforeTest")) {
-				System.out.print("skipping");
-				if (testInfo.containsKey("comment"))
-					System.out.print(" ("+testInfo.get("comment")+")");
-				System.out.println();
+//				System.out.print("skipping");
+//				if (testInfo.containsKey("comment"))
+//					System.out.print(" ("+testInfo.get("comment")+")");
+//				System.out.println();
 				continue;
 			}
 			
@@ -451,21 +446,22 @@ public class XSLTestCase {
 	        } catch (Exception e) {
 //	        	System.out.println("************************************** query ******************************");
 //	        	System.out.println(query);
-	        	System.out.println();
-	        	System.out.println("************************************* content ******************************");
-	        	System.out.println(content);
+//	        	System.out.println();
+//	        	System.out.println("************************************* content ******************************");
+//	        	System.out.println(content);
 				passing = false;
 	            throw new RuntimeException(e);
 	        }
 	        if (passing) {
 	        	end_time = end_time - start_time;
-	        	System.out.println("pass ("+end_time+" ms)");
+//	        	System.out.println("pass ("+end_time+" ms)");
 	        	passed++;
-	        } else
-				System.out.println("faild");
+	        } else {
+				System.err.println("faild");
+            }
 		}
 		
-		System.out.println(" "+passed+" of "+bench.keySet().size());
+//		System.out.println(" "+passed+" of "+bench.keySet().size());
     }
 	
 	//TODO: test <!-- reassembles an xml tree in reverse order -->

--- a/src/org/exist/ant/RestoreTask.java
+++ b/src/org/exist/ant/RestoreTask.java
@@ -27,7 +27,7 @@ import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.DirSet;
 
 import org.exist.backup.Restore;
-import org.exist.backup.restore.listener.DefaultRestoreListener;
+import org.exist.backup.restore.listener.ConsoleRestoreListener;
 import org.exist.backup.restore.listener.RestoreListener;
 
 import java.io.File;
@@ -86,7 +86,7 @@ public class RestoreTask extends AbstractXMLDBTask
                         }
                     } else {
                         final Restore         restore  = new Restore();
-                        final RestoreListener listener = new DefaultRestoreListener();
+                        final RestoreListener listener = new ConsoleRestoreListener();
                         restore.restore( listener, user, password, restorePassword, file, uri );
                     }
 
@@ -113,7 +113,7 @@ public class RestoreTask extends AbstractXMLDBTask
 
                             // TODO subdirectories as sub-collections?
                             final Restore         restore  = new Restore();
-                            final RestoreListener listener = new DefaultRestoreListener();
+                            final RestoreListener listener = new ConsoleRestoreListener();
                             restore.restore( listener, user, password, restorePassword, contentsFile, uri );
                         }
                     }
@@ -131,7 +131,7 @@ public class RestoreTask extends AbstractXMLDBTask
                         }
                     } else {
                         final Restore         restore  = new Restore();
-                        final RestoreListener listener = new DefaultRestoreListener();
+                        final RestoreListener listener = new ConsoleRestoreListener();
                         restore.restore( listener, user, password, restorePassword, zipFile, uri );
                     }
                 }

--- a/src/org/exist/backup/Main.java
+++ b/src/org/exist/backup/Main.java
@@ -59,7 +59,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 
 import javax.xml.parsers.ParserConfigurationException;
-import org.exist.backup.restore.listener.DefaultRestoreListener;
+import org.exist.backup.restore.listener.ConsoleRestoreListener;
 import org.exist.backup.restore.listener.GuiRestoreListener;
 import org.exist.backup.restore.listener.RestoreListener;
 import org.exist.client.ClientFrame;
@@ -330,7 +330,7 @@ public class Main
     private static void restoreWithoutGui(final String username, final String password, final String dbaPassword, final File f,
                                           final String uri, final boolean rebuildRepo) {
         
-        final RestoreListener listener = new DefaultRestoreListener();
+        final RestoreListener listener = new ConsoleRestoreListener();
         final Restore restore = new Restore();
 
         try {

--- a/src/org/exist/backup/SystemExport.java
+++ b/src/org/exist/backup/SystemExport.java
@@ -39,7 +39,6 @@ import org.exist.security.ACLPermission;
 import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.security.internal.AccountImpl;
-import org.exist.stax.EmbeddedXMLStreamReader;
 import org.exist.storage.DBBroker;
 import org.exist.storage.DataBackup;
 import org.exist.storage.NativeBroker;

--- a/src/org/exist/backup/restore/listener/ConsoleRestoreListener.java
+++ b/src/org/exist/backup/restore/listener/ConsoleRestoreListener.java
@@ -25,7 +25,7 @@ package org.exist.backup.restore.listener;
  *
  * @author Adam Retter <adam@exist-db.org>
  */
-public class DefaultRestoreListener extends AbstractRestoreListener {
+public class ConsoleRestoreListener extends AbstractRestoreListener {
      
     @Override
     public void info(String message) {

--- a/src/org/exist/backup/restore/listener/LogRestoreListener.java
+++ b/src/org/exist/backup/restore/listener/LogRestoreListener.java
@@ -1,0 +1,50 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2015 The eXist-db Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *  $Id: Restore.java 15109 2011-08-09 13:03:09Z deliriumsky $
+ */
+package org.exist.backup.restore.listener;
+
+import org.apache.log4j.Logger;
+
+/**
+ *
+ * @author Adam Retter <adam@exist-db.org>
+ */
+public class LogRestoreListener extends AbstractRestoreListener {
+
+    public final static Logger LOG = Logger.getLogger(LogRestoreListener.class );
+
+    @Override
+    public void info(String message) {
+        LOG.info(message);
+    }
+
+    @Override
+    public void warn(String message) {
+        super.warn(message);
+        LOG.warn(message);
+    }
+
+    @Override
+    public void error(String message) {
+        super.error(message);
+        LOG.error(message);
+    }
+}

--- a/src/org/exist/backup/restore/listener/LogRestoreListener.java
+++ b/src/org/exist/backup/restore/listener/LogRestoreListener.java
@@ -21,7 +21,8 @@
  */
 package org.exist.backup.restore.listener;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  *
@@ -29,7 +30,7 @@ import org.apache.log4j.Logger;
  */
 public class LogRestoreListener extends AbstractRestoreListener {
 
-    public final static Logger LOG = Logger.getLogger(LogRestoreListener.class );
+    public final static Logger LOG = LogManager.getLogger(LogRestoreListener.class );
 
     @Override
     public void info(String message) {

--- a/src/org/exist/collections/CollectionConfigurationManager.java
+++ b/src/org/exist/collections/CollectionConfigurationManager.java
@@ -289,7 +289,6 @@ public class CollectionConfigurationManager {
                         final String message = "Failed to read configuration document " + confDoc.getFileURI() + " in " + configCollection.getURI() + ". "
                                 + e.getMessage();
                         LOG.error(message);
-                        System.out.println(message);
                     }
                     
                     latch.write(new Callable<Void>() {

--- a/src/org/exist/config/mapper/CallMathod.java
+++ b/src/org/exist/config/mapper/CallMathod.java
@@ -88,7 +88,6 @@ public class CallMathod {
         	}
         }
 
-        System.out.println("'callMethod' element '"+name+"' method can not be found, skip instance creation.");
 		Configurator.LOG.error("'callMethod' element '"+name+"' method can not be found, skip instance creation.");
 
 		return false;

--- a/src/org/exist/http/Descriptor.java
+++ b/src/org/exist/http/Descriptor.java
@@ -425,25 +425,28 @@ public class Descriptor implements ErrorHandler
     /**
      * @see org.xml.sax.ErrorHandler#error(org.xml.sax.SAXParseException)
      */
+    @Override
     public void error(SAXParseException exception) throws SAXException
     {
-        System.err.println("Error occured while reading descriptor file [line: " + exception.getLineNumber() + "]:" + exception.getMessage());
+        LOG.error("Error occurred while reading descriptor file [line: " + exception.getLineNumber() + "]:" + exception.getMessage(), exception);
     }
     
     /**
      * @see org.xml.sax.ErrorHandler#fatalError(org.xml.sax.SAXParseException)
      */
+    @Override
     public void fatalError(SAXParseException exception) throws SAXException
 	{
-        System.err.println("Error occured while reading descriptor file [line: " + exception.getLineNumber() + "]:" + exception.getMessage());
+        LOG.error("Error occurred while reading descriptor file [line: " + exception.getLineNumber() + "]:" + exception.getMessage(), exception);
     }
     
     /** 
      * @see org.xml.sax.ErrorHandler#warning(org.xml.sax.SAXParseException)
      */
+    @Override
     public void warning(SAXParseException exception) throws SAXException
     {
-        System.err.println("error occured while reading descriptor file [line: " + exception.getLineNumber() + "]:" + exception.getMessage());
+        LOG.error("error occurred while reading descriptor file [line: " + exception.getLineNumber() + "]:" + exception.getMessage(), exception);
     }
 		
 }

--- a/src/org/exist/security/xacml/XACMLSource.java
+++ b/src/org/exist/security/xacml/XACMLSource.java
@@ -26,6 +26,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.exist.source.*;
 import org.exist.xmldb.XmldbURI;
 
@@ -36,6 +38,8 @@ import org.exist.xmldb.XmldbURI;
  */
 public class XACMLSource
 {
+    private final static Logger LOG = LogManager.getLogger(XACMLSource.class);
+
 	private static final String FILE_PROTOCOL = "file";
 	private final String type;
 	private final String key;
@@ -94,7 +98,7 @@ public class XACMLSource
 
 
             final String key = (String) o2;
-            System.out.println("Found CocoonSource with key "+key);
+            LOG.info("Found CocoonSource with key " + key);
 
 			return new XACMLSource(XACMLConstants.COCOON_SOURCE_TYPE, key);
 

--- a/src/org/exist/storage/Signatures.java
+++ b/src/org/exist/storage/Signatures.java
@@ -21,6 +21,8 @@
  */
 package org.exist.storage;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.exist.util.ByteConversion;
 import org.w3c.dom.Node;
 
@@ -39,6 +41,8 @@ import org.w3c.dom.Node;
  *   to store the name of the node (local name for elements and attributes).
  */
 public final class Signatures {
+
+    private final static Logger LOG = LogManager.getLogger(Signatures.class);
 
     public final static int Char = 0x0;
     public final static int Elem = 0x1;
@@ -109,7 +113,7 @@ public final class Signatures {
                 return Node.CDATA_SECTION_NODE;
         }
         //TODO : thorw exception here -pb
-        System.err.println( "Unknown node type : " + type);
+        LOG.error("Unknown node type : " + type);
         return -1;
     }
     

--- a/src/org/exist/storage/btree/BTree.java
+++ b/src/org/exist/storage/btree/BTree.java
@@ -2422,7 +2422,7 @@ public class BTree extends Paged implements Lockable {
             try {
                 System.arraycopy(keys, idx + 1, keys, idx, nKeys - idx - 1);
             } catch (ArrayIndexOutOfBoundsException e) {
-                System.err.println("keys: " + nKeys + " idx: " + idx);
+                LOG.error("keys: " + nKeys + " idx: " + idx);
             }
             pageHeader.setValueCount((short) --nKeys);
             saved = false;

--- a/src/org/exist/storage/dom/DOMFile.java
+++ b/src/org/exist/storage/dom/DOMFile.java
@@ -1473,10 +1473,7 @@ public class DOMFile extends BTree implements Lockable {
                 writer.write(DLNBase.toBitString(data[key.start() + 4 + i]));
             }
         } catch (final Exception e) {
-            LOG.error(e);
-            e.printStackTrace();
-            System.out.println(e.getMessage() + ": doc: " +
-                    Integer.toString(ByteConversion.byteToInt(key.data(), key.start())));
+            LOG.error(e.getMessage() + ": doc: " + Integer.toString(ByteConversion.byteToInt(key.data(), key.start())), e);
         }
     }
 

--- a/src/org/exist/storage/dom/DOMTransaction.java
+++ b/src/org/exist/storage/dom/DOMTransaction.java
@@ -101,7 +101,7 @@ public abstract class DOMTransaction {
             try {
                 lock.acquire( mode );
             } catch( final LockException e ) {
-                System.out.println("Failed to acquire read lock on " + file.getFile().getName());
+                LOG.error("Failed to acquire read lock on " + file.getFile().getName(), e);
                 return null;
             }
             file.setOwnerObject(ownerObject);

--- a/src/org/exist/storage/lock/FileLock.java
+++ b/src/org/exist/storage/lock/FileLock.java
@@ -297,8 +297,7 @@ public class FileLock {
         if (LOG.isInfoEnabled()) {
             LOG.info(message);
         }
-        
-        System.err.println(message);
+
         return message;
     }
 }

--- a/src/org/exist/util/CompressedWhitespace.java
+++ b/src/org/exist/util/CompressedWhitespace.java
@@ -242,10 +242,10 @@ public class CompressedWhitespace implements CharSequence {
         }
     }
 
-    public static void main( String[] args ) {
-        final CharSequence c = compress("\t\n\n\t\t\n      ");
-        System.err.println(c);
-    }
+//    public static void main( String[] args ) {
+//        final CharSequence c = compress("\t\n\n\t\t\n      ");
+//        System.err.println(c);
+//    }
 
 }
 

--- a/src/org/exist/util/Configuration.java
+++ b/src/org/exist/util/Configuration.java
@@ -1676,9 +1676,10 @@ public class Configuration implements ErrorHandler
      *
      * @see     org.xml.sax.ErrorHandler#error(org.xml.sax.SAXParseException)
      */
+    @Override
     public void error( SAXParseException exception ) throws SAXException
     {
-        System.err.println( "error occured while reading configuration file " + "[line: " + exception.getLineNumber() + "]:" + exception.getMessage() );
+        LOG.error( "error occurred while reading configuration file " + "[line: " + exception.getLineNumber() + "]:" + exception.getMessage(), exception );
     }
 
 
@@ -1691,9 +1692,10 @@ public class Configuration implements ErrorHandler
      *
      * @see     org.xml.sax.ErrorHandler#fatalError(org.xml.sax.SAXParseException)
      */
+    @Override
     public void fatalError( SAXParseException exception ) throws SAXException
     {
-        System.err.println( "error occured while reading configuration file " + "[line: " + exception.getLineNumber() + "]:" + exception.getMessage() );
+        LOG.error("error occurred while reading configuration file " + "[line: " + exception.getLineNumber() + "]:" + exception.getMessage(), exception);
     }
 
 
@@ -1706,9 +1708,10 @@ public class Configuration implements ErrorHandler
      *
      * @see     org.xml.sax.ErrorHandler#warning(org.xml.sax.SAXParseException)
      */
+    @Override
     public void warning( SAXParseException exception ) throws SAXException
     {
-        System.err.println( "error occured while reading configuration file " + "[line: " + exception.getLineNumber() + "]:" + exception.getMessage() );
+        LOG.error( "error occurred while reading configuration file " + "[line: " + exception.getLineNumber() + "]:" + exception.getMessage(), exception );
     }
     
 

--- a/src/org/exist/util/MimeTable.java
+++ b/src/org/exist/util/MimeTable.java
@@ -36,6 +36,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.exist.xmldb.XmldbURI;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
@@ -58,7 +60,9 @@ import org.xml.sax.helpers.DefaultHandler;
  * @author wolf
  */
 public class MimeTable {
-    
+
+    private final static Logger LOG = LogManager.getLogger(MimeTable.class);
+
     private static final String FILE_LOAD_FAILED_ERR = "Failed to load mime-type table from ";
     private static final String LOAD_FAILED_ERR = "Failed to load mime-type table from class loader";
     
@@ -214,29 +218,21 @@ public class MimeTable {
         try {
         	loadMimeTypes(stream);
         	this.src=src;
-        } catch (final ParserConfigurationException e) {
-            System.err.println(LOAD_FAILED_ERR);
-        } catch (final SAXException e) {
-            System.err.println(LOAD_FAILED_ERR);
-        } catch (final IOException e) {
-            System.err.println(LOAD_FAILED_ERR);
+        } catch (final ParserConfigurationException | SAXException | IOException e) {
+            LOG.error(LOAD_FAILED_ERR, e);
         }
     	
         if (!loaded) {
             final ClassLoader cl = MimeTable.class.getClassLoader();
             final InputStream is = cl.getResourceAsStream(MIME_TYPES_XML_DEFAULT);
             if (is == null) {
-                System.err.println(LOAD_FAILED_ERR);
+                LOG.error(LOAD_FAILED_ERR);
             }
             try {
                 loadMimeTypes(is);
                 this.src="resource://"+MIME_TYPES_XML_DEFAULT;
-            } catch (final ParserConfigurationException e) {
-                System.err.println(LOAD_FAILED_ERR);
-            } catch (final SAXException e) {
-                System.err.println(LOAD_FAILED_ERR);
-            } catch (final IOException e) {
-                System.err.println(LOAD_FAILED_ERR);
+            } catch (final ParserConfigurationException | SAXException | IOException e) {
+                LOG.error(LOAD_FAILED_ERR, e);
             }
         }
     }
@@ -245,35 +241,25 @@ public class MimeTable {
         boolean loaded = false;
         if (f.canRead()) {
             try {
-                System.out.println("Loading mime table from file " + f.getAbsolutePath());
+                LOG.info("Loading mime table from file " + f.getAbsolutePath());
                 loadMimeTypes(new FileInputStream(f));
                 loaded = true;
                 this.src=f.toURI().toString();
-            } catch (final FileNotFoundException e) {
-                System.err.println(FILE_LOAD_FAILED_ERR + f.getAbsolutePath());
-            } catch (final ParserConfigurationException e) {
-                System.err.println(FILE_LOAD_FAILED_ERR + f.getAbsolutePath());
-            } catch (final SAXException e) {
-                System.err.println(FILE_LOAD_FAILED_ERR + f.getAbsolutePath());
-            } catch (final IOException e) {
-                System.err.println(FILE_LOAD_FAILED_ERR + f.getAbsolutePath());
+            } catch (final ParserConfigurationException | SAXException | IOException e) {
+                LOG.error(FILE_LOAD_FAILED_ERR + f.getAbsolutePath(), e);
             }
         }
         if (!loaded) {
             final ClassLoader cl = MimeTable.class.getClassLoader();
             final InputStream is = cl.getResourceAsStream(MIME_TYPES_XML_DEFAULT);
             if (is == null) {
-                System.err.println(LOAD_FAILED_ERR);
+                LOG.error(LOAD_FAILED_ERR);
             }
             try {
                 loadMimeTypes(is);
                 this.src="resource://"+MIME_TYPES_XML_DEFAULT;
-            } catch (final ParserConfigurationException e) {
-                System.err.println(LOAD_FAILED_ERR);
-            } catch (final SAXException e) {
-                System.err.println(LOAD_FAILED_ERR);
-            } catch (final IOException e) {
-                System.err.println(LOAD_FAILED_ERR);
+            } catch (final ParserConfigurationException | SAXException | IOException e) {
+                LOG.error(LOAD_FAILED_ERR, e);
             }
         }
     }
@@ -351,7 +337,7 @@ public class MimeTable {
             if (MIME_TYPE.equals(qName)) {
                 final String name = attributes.getValue("name");
                 if (name == null || name.length() == 0) {
-                    System.err.println("No name specified for mime-type");
+                    LOG.error("No name specified for mime-type");
                     return;
                 }
                 int type = MimeType.BINARY;

--- a/src/org/exist/util/io/Resource.java
+++ b/src/org/exist/util/io/Resource.java
@@ -34,6 +34,8 @@ import java.util.Properties;
 
 import javax.xml.transform.OutputKeys;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.Collection.CollectionEntry;
@@ -70,6 +72,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  *
  */
 public class Resource extends File {
+
+    private final static Logger LOG = LogManager.getLogger(Resource.class);
 
 	private static final long serialVersionUID = -3450182389919974961L;
 
@@ -814,8 +818,9 @@ public class Resource extends File {
 
     public OutputStream getOutputStream(boolean append) throws IOException {
     	//XXX: code append
-    	if (append)
-    		{System.err.println("BUG: OutputStream in append mode!");}
+    	if (append) {
+            LOG.error("BUG: OutputStream in append mode!");
+        }
     	return getConnection().getOutputStream();
     }
 

--- a/src/org/exist/util/serializer/DOMStreamer.java
+++ b/src/org/exist/util/serializer/DOMStreamer.java
@@ -27,6 +27,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Stack;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.ReferenceNode;
 import org.w3c.dom.Attr;
@@ -49,6 +51,8 @@ import javax.xml.XMLConstants;
  * @author Wolfgang Meier (wolfgang@exist-db.org)
  */
 public class DOMStreamer {
+
+    private final static Logger LOG = LogManager.getLogger(DOMStreamer.class);
 
     private ContentHandler contentHandler = null;
     private LexicalHandler lexicalHandler = null;
@@ -255,7 +259,7 @@ public class DOMStreamer {
             break;
         default :
             //TODO : what kind of default here ? -pb
-            System.out.println("Found node: " + node.getNodeType());
+            LOG.error("Unknown node type: " + node.getNodeType());
             break;
         }
     }

--- a/src/org/exist/validation/XmlLibraryChecker.java
+++ b/src/org/exist/validation/XmlLibraryChecker.java
@@ -149,8 +149,7 @@ public class XmlLibraryChecker {
         if( hasValidClassVersion( "Parser", validParsers, message ) ) {
 			logger.info( message.toString() );
         } else {
-			logger.warn( message.toString() );
-            System.err.println( message.toString() );
+			logger.warn(message.toString());
 			invalidVersionFound	= true;
         }
 
@@ -182,20 +181,18 @@ public class XmlLibraryChecker {
          */
         message = new StringBuilder();
         if( hasValidClassVersion( "Resolver", validResolvers, message ) ) {
-            logger.info( message.toString() );
+            logger.info(message.toString());
         } else {
-            logger.warn( message.toString() );
-            System.err.println( message.toString() );
+            logger.warn(message.toString());
 			invalidVersionFound	= true;
         }
 
 		logger.info( "Using parser " + determineActualParserClass() );
 		logger.info( "Using transformer " + determineActualTransformerClass() );
 		
-		if( invalidVersionFound ) {
-			System.err.println( "Using parser " + determineActualParserClass() );
-			System.err.println( "Using transformer " + determineActualTransformerClass() );
-			System.err.println();
+		if(invalidVersionFound) {
+			logger.warn("Using parser " + determineActualParserClass());
+            logger.warn( "Using transformer " + determineActualTransformerClass() );
 		}
     }
 

--- a/src/org/exist/xmldb/LocalCollection.java
+++ b/src/org/exist/xmldb/LocalCollection.java
@@ -868,7 +868,7 @@ public class LocalCollection extends Observable implements CollectionImpl {
             transact.commit(txn);
             collection.deleteObservers();
         } catch(final Exception e) {
-            LOG.error(e);
+            LOG.error(e.getMessage());
             throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
         } finally {
             brokerPool.setSubject(subject);
@@ -893,7 +893,7 @@ public class LocalCollection extends Observable implements CollectionImpl {
             } catch(final Exception e) {
                 LOG.error("Error while involing NekoHTML parser. (" + e.getMessage()
                     + "). If you want to parse non-wellformed HTML files, put "
-                    + "nekohtml.jar into directory 'lib/optional'.", e);
+                    + "nekohtml.jar into directory 'lib/optional'.");
                 throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "NekoHTML parser error", e);
             }
         }

--- a/src/org/exist/xmldb/LocalIndexQueryService.java
+++ b/src/org/exist/xmldb/LocalIndexQueryService.java
@@ -21,6 +21,8 @@
  */
 package org.exist.xmldb;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.exist.EXistException;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
@@ -44,6 +46,8 @@ import org.xmldb.api.base.XMLDBException;
 import java.net.URISyntaxException;
 
 public class LocalIndexQueryService implements IndexQueryService {
+
+    private final static Logger LOG = LogManager.getLogger(LocalIndexQueryService.class);
 
 	private LocalCollection parent = null;
 	private BrokerPool pool = null;
@@ -125,7 +129,7 @@ public class LocalIndexQueryService implements IndexQueryService {
             final CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(txn, broker, parent.getCollection(), configData);
             transact.commit(txn);
-            System.out.println("Configured '" + parent.getCollection().getURI() + "'");
+            LOG.info("Configured '" + parent.getCollection().getURI() + "'");
         } catch (final CollectionConfigurationException e) {
 			throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
 		} catch (final EXistException e) {

--- a/src/org/exist/xmldb/RemoteResourceSet.java
+++ b/src/org/exist/xmldb/RemoteResourceSet.java
@@ -57,7 +57,7 @@ public class RemoteResourceSet implements ResourceSet {
         try {
             collection.getClient().execute("releaseQueryResult", params);
         } catch (final XmlRpcException e) {
-            System.err.println("Failed to release query result on server: " + e.getMessage());
+            LOG.error("Failed to release query result on server: " + e.getMessage(), e);
         }
         handle = -1;
         hash = -1;

--- a/src/org/exist/xquery/value/AbstractDateTimeValue.java
+++ b/src/org/exist/xquery/value/AbstractDateTimeValue.java
@@ -36,6 +36,8 @@ import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.xerces.util.DatatypeMessageFormatter;
 import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
@@ -47,7 +49,9 @@ import org.exist.xquery.XPathException;
  * @author ljo
  */
 public abstract class AbstractDateTimeValue extends ComputableValue {
-	
+
+    private final static Logger LOG = LogManager.getLogger(AbstractDateTimeValue.class);
+
 	//Provisionally public
 	public final XMLGregorianCalendar calendar;
 	private XMLGregorianCalendar implicitCalendar, canonicalCalendar, trimmedCalendar;
@@ -342,8 +346,8 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
         	try {
         		//TODO : find something that will consume less resources
         		return calendar.compare(TimeUtils.getInstance().newXMLGregorianCalendar(other.getStringValue()));
-        	} catch (final XPathException e) {
-        		System.out.println("Failed to get string value of '" + other + "'");
+            } catch (final XPathException e) {
+        		LOG.error("Failed to get string value of '" + other + "'", e);
         		//Why not ?
         		return Constants.SUPERIOR;
         	}

--- a/test/src/org/exist/TestDataGenerator.java
+++ b/test/src/org/exist/TestDataGenerator.java
@@ -61,7 +61,6 @@ public class TestDataGenerator {
             context.setStaticallyKnownDocuments(docs);
 
             String query = IMPORT + xqueryContent;
-            System.out.println("query: " + query);
 
             CompiledXQuery compiled = service.compile(context, query);
 
@@ -94,7 +93,6 @@ public class TestDataGenerator {
 
     public File[] generate(org.xmldb.api.base.Collection collection, String xqueryContent) throws SAXException {
         String query = IMPORT + xqueryContent;
-        System.out.println("query: " + query);
         try {
             XQueryService service = (XQueryService) collection.getService("XQueryService", "1.0");
             service.declareVariable("filename", "");

--- a/test/src/org/exist/ant/AntUnitTestRunner.java
+++ b/test/src/org/exist/ant/AntUnitTestRunner.java
@@ -72,7 +72,6 @@ public class AntUnitTestRunner {
         // clear instance variables
         service = null;
         root = null;
-    //System.out.println("tearDown PASSED");
     }
 
     @Test

--- a/test/src/org/exist/backup/SystemExportImportTest.java
+++ b/test/src/org/exist/backup/SystemExportImportTest.java
@@ -30,9 +30,7 @@ import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
 import org.exist.EXistException;
-import org.exist.backup.SystemExport;
-import org.exist.backup.SystemImport;
-import org.exist.backup.restore.listener.DefaultRestoreListener;
+import org.exist.backup.restore.listener.LogRestoreListener;
 import org.exist.backup.restore.listener.RestoreListener;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
@@ -45,7 +43,6 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
-import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
 import org.exist.util.Configuration;
@@ -98,7 +95,6 @@ public class SystemExportImportTest {
 
     @Test
 	public void test_01() throws Exception {
-    	System.out.println("test_01");
     	
     	startDB();
     	
@@ -132,7 +128,7 @@ public class SystemExportImportTest {
         }
 
     	SystemImport restore = new SystemImport(pool);
-		RestoreListener listener = new DefaultRestoreListener();
+		RestoreListener listener = new LogRestoreListener();
 		restore.restore(listener, "admin", "", "", file, "xmldb:exist://");
 
         broker = null;
@@ -193,7 +189,6 @@ public class SystemExportImportTest {
              final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             assertNotNull(transaction);
-            System.out.println("Transaction started ...");
 
             Collection root = broker.getOrCreateCollection(transaction, col1uri);
             assertNotNull(root);
@@ -202,22 +197,18 @@ public class SystemExportImportTest {
             CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(transaction, broker, root, COLLECTION_CONFIG);
 
-            System.out.println("store " + doc01uri);
             IndexInfo info = root.validateXMLResource(transaction, broker, doc01uri.lastSegment(), XML1);
             assertNotNull(info);
             root.store(transaction, broker, info, XML1, false);
 
-            System.out.println("store " + doc02uri);
             info = root.validateXMLResource(transaction, broker, doc02uri.lastSegment(), XML2);
             assertNotNull(info);
             root.store(transaction, broker, info, XML2, false);
 
-            System.out.println("store " + doc03uri);
             info = root.validateXMLResource(transaction, broker, doc03uri.lastSegment(), XML3);
             assertNotNull(info);
             root.store(transaction, broker, info, XML3, false);
 
-            System.out.println("store " + doc11uri);
             root.addBinaryResource(transaction, broker, doc11uri.lastSegment(), BINARY.getBytes(), null);
 
             pool.getTransactionManager().commit(transaction);
@@ -239,16 +230,12 @@ public class SystemExportImportTest {
     	clean();
         BrokerPool.stopAll(false);
         pool = null;
-        System.out.println("stoped");
     }
 
     private static void clean() throws PermissionDeniedException, IOException, TriggerException, EXistException {
-    	System.out.println("CLEANING...");
         
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = pool.getTransactionManager().beginTransaction()) {
-
-            System.out.println("Transaction started ...");
 
             Collection root = broker.getOrCreateCollection(transaction, col1uri);
             assertNotNull(root);
@@ -256,7 +243,5 @@ public class SystemExportImportTest {
 
             pool.getTransactionManager().commit(transaction);
         }
-
-    	System.out.println("CLEANED.");
     }
 }

--- a/test/src/org/exist/collections/CollectionRemovalTest.java
+++ b/test/src/org/exist/collections/CollectionRemovalTest.java
@@ -136,7 +136,6 @@ public class CollectionRemovalTest {
             Serializer serializer = broker.getSerializer();
             serializer.reset();
             String xml = serializer.serialize(doc);
-            System.out.println(xml);
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/test/src/org/exist/collections/triggers/SAXTriggerTest.java
+++ b/test/src/org/exist/collections/triggers/SAXTriggerTest.java
@@ -31,11 +31,7 @@ import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Database;
@@ -77,14 +73,6 @@ public class SAXTriggerTest {
     private final static String BASE_URI = "xmldb:exist://";
 
     private final static String testCollection = "/db/triggers";
-    
-    @Rule
-    public TestRule watcher = new TestWatcher() {
-        @Override
-        protected void starting(Description description) {
-            System.out.println("\nStarting test: " + description.getMethodName());
-        }
-    };
 
     @Test
     public void test() throws EXistException {

--- a/test/src/org/exist/collections/triggers/TestTrigger.java
+++ b/test/src/org/exist/collections/triggers/TestTrigger.java
@@ -52,7 +52,6 @@ public class TestTrigger extends SAXTrigger implements DocumentTrigger {
     public void configure(DBBroker broker, org.exist.collections.Collection parent, Map<String, List<?>> parameters) throws TriggerException {
         super.configure(broker, parent, parameters);
         XmldbURI docPath = XmldbURI.create("messages.xml");
-        System.out.println("TestTrigger prepares");
         TransactionManager transactMgr = broker.getBrokerPool().getTransactionManager();
         Txn transaction = transactMgr.beginTransaction();
         try {

--- a/test/src/org/exist/collections/triggers/TriggerConfigTest.java
+++ b/test/src/org/exist/collections/triggers/TriggerConfigTest.java
@@ -105,7 +105,6 @@ public class TriggerConfigTest {
             Resource resource = root.createResource("data.xml", "XMLResource");
             resource.setContent(DOCUMENT_CONTENT);
             root.storeResource(resource);
-            printMessages();
             XQueryService qs = (XQueryService) root.getService("XQueryService", "1.0");
             ResourceSet result = qs.queryResource("messages.xml", "string(//event[last()]/@collection)");
             assertEquals(1, result.getSize());
@@ -179,17 +178,6 @@ public class TriggerConfigTest {
             ResourceSet result = qs.query("if (doc-available('" + testCollection + "/messages.xml')) then doc('" + testCollection + "/messages.xml')/events/event[@id = 'STORE-DOCUMENT']/string(@collection) else ()");
             assertEquals(1, result.getSize());
             assertEquals(testCollection, result.getResource(0).getContent());
-        } catch (XMLDBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
-    }
-
-    private void printMessages() {
-        try {
-            Collection root = DatabaseManager.getCollection(BASE_URI + testCollection, "admin", "");
-            XMLResource messages = (XMLResource) root.getResource("messages.xml");
-            System.out.println(messages.getContent().toString());
         } catch (XMLDBException e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/test/src/org/exist/collections/triggers/TriggerConfigTest.java
+++ b/test/src/org/exist/collections/triggers/TriggerConfigTest.java
@@ -34,14 +34,9 @@ import org.junit.runners.Parameterized;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.*;
 import org.xmldb.api.modules.CollectionManagementService;
-import org.xmldb.api.modules.XMLResource;
 import org.xmldb.api.modules.XQueryService;
 
 import java.util.LinkedList;
-import org.junit.Rule;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 
 /**
  * Test proper configuration of triggers in collection.xconf, in particular if there's
@@ -86,14 +81,6 @@ public class TriggerConfigTest {
     public TriggerConfigTest(String testCollection) {
         this.testCollection = testCollection;
     }
-    
-    @Rule
-    public TestRule watcher = new TestWatcher() {
-        @Override
-        protected void starting(Description description) {
-            System.out.println("\nStarting test: " + description.getMethodName());
-        }
-    };
 
     @Test
     public void storeDocument() {

--- a/test/src/org/exist/collections/triggers/XQueryTriggerTest.java
+++ b/test/src/org/exist/collections/triggers/XQueryTriggerTest.java
@@ -21,7 +21,6 @@ package org.exist.collections.triggers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 import java.net.URISyntaxException;
 
@@ -38,11 +37,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Database;
@@ -253,14 +248,6 @@ public class XQueryTriggerTest {
 
     private final static String documentURI = "[uri/text() = '/db/testXQueryTrigger/test.xml']";
     private final static String binaryURI = "[uri/text() = '/db/testXQueryTrigger/1x1.gif']";
-    
-    @Rule
-    public TestRule watcher = new TestWatcher() {
-        @Override
-        protected void starting(Description description) {
-            System.out.println("\nStarting test: " + description.getMethodName());
-        }
-    };
     
     /** just start the DB and create the test collection */
     @BeforeClass

--- a/test/src/org/exist/deadlocks/GetReleaseBrokerDeadlocks.java
+++ b/test/src/org/exist/deadlocks/GetReleaseBrokerDeadlocks.java
@@ -63,7 +63,6 @@ public class GetReleaseBrokerDeadlocks {
 		        Thread.sleep(1000);
 	        	
 	        } finally {
-		        System.out.println("release broker"+Thread.currentThread());
 	        	db.release(broker);
 	        }
 	        
@@ -86,7 +85,6 @@ public class GetReleaseBrokerDeadlocks {
 	        	Subject subject = db.getSecurityManager().getSystemSubject();
 				try {
 					db.enterServiceMode(subject);
-			        System.out.println("enter servise mode "+Thread.currentThread());
 					
 					//do something
 					Thread.sleep(100);
@@ -116,8 +114,6 @@ public class GetReleaseBrokerDeadlocks {
 	        	thread = new Thread(new GetRelease());
 	        	thread.start();
 		        Thread.sleep(rd.nextInt(250));
-		        
-		        System.out.println(""+i+", "+db.countActiveBrokers());
 		        
 		        if (ex != null) {
 		        	ex.printStackTrace();
@@ -149,12 +145,11 @@ public class GetReleaseBrokerDeadlocks {
 		            if (stackTraces.isEmpty())
 		            	sb.append("No threads.");
 		            
-		            System.out.println(sb.toString());
+//		            System.out.println(sb.toString());
 		        }
 	        }
 	        
 	        while (db.countActiveBrokers() > 0) {
-		        System.out.println(db.countActiveBrokers());
 		        Thread.sleep(100);
 	        }
 	        	
@@ -179,7 +174,6 @@ public class GetReleaseBrokerDeadlocks {
 	        	DBBroker broker = null;
 				try {
 					broker = db.get(subject);
-			        System.out.println("get broker "+Thread.currentThread());
 					
 					//do something
 					Thread.sleep(rd.nextInt(5000));
@@ -194,7 +188,6 @@ public class GetReleaseBrokerDeadlocks {
 					}
 
 				} finally {
-			        System.out.println("releasing broker "+Thread.currentThread());
 					db.release(broker);
 				}
 				

--- a/test/src/org/exist/dom/memtree/DOMIndexerTest.java
+++ b/test/src/org/exist/dom/memtree/DOMIndexerTest.java
@@ -124,7 +124,7 @@ public class DOMIndexerTest {
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
             XQuery xquery = broker.getXQueryService();
             Sequence result = xquery.execute(XQUERY, null, AccessContext.TEST);
-            System.out.println("Found: " + result.getItemCount());
+            int count = result.getItemCount();
             StringWriter out = new StringWriter();
             Properties props = new Properties();
             props.setProperty(OutputKeys.INDENT, "yes");
@@ -135,7 +135,7 @@ public class DOMIndexerTest {
                 next.toSAX(broker, serializer, props);
             }
             serializer.endDocument();
-            System.out.println(out.toString());
+            out.toString();
         } finally {
             pool.release(broker);
         }

--- a/test/src/org/exist/dom/memtree/DOMTest.java
+++ b/test/src/org/exist/dom/memtree/DOMTest.java
@@ -63,7 +63,7 @@ public class DOMTest extends TestCase {
 			StringWriter writer = new StringWriter();
 			DOMSerializer serializer = new DOMSerializer(writer, null);
 			serializer.serialize(node);
-			System.out.println(writer.toString());
+			writer.toString();
     	} catch (Exception e) {
     		fail(e.getMessage()); 
     	}			
@@ -170,21 +170,21 @@ public class DOMTest extends TestCase {
                 }
         }
 
-	public void print(Node node) {
-		while (node != null) {
-			switch (node.getNodeType()) {
-				case Node.ELEMENT_NODE :
-					System.out.println('<' + node.getNodeName() + '>');
-					break;
-				case Node.TEXT_NODE :
-					System.out.println(node.getNodeValue());
-					break;
-				default :
-					System.out.println("unknown node type");
-			}
-			if (node.hasChildNodes())
-				print(node.getFirstChild());
-			node = node.getNextSibling();
-		}
-	}
+//	public void print(Node node) {
+//		while (node != null) {
+//			switch (node.getNodeType()) {
+//				case Node.ELEMENT_NODE :
+//					System.out.println('<' + node.getNodeName() + '>');
+//					break;
+//				case Node.TEXT_NODE :
+//					System.out.println(node.getNodeValue());
+//					break;
+//				default :
+//					System.out.println("unknown node type");
+//			}
+//			if (node.hasChildNodes())
+//				print(node.getFirstChild());
+//			node = node.getNextSibling();
+//		}
+//	}
 }

--- a/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
+++ b/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
@@ -285,7 +285,7 @@ public class BasicNodeSetTest {
         serializer.reset();
         DocumentSet docs = root.allDocs(broker, new DefaultDocumentSet(), true);
 
-        System.out.println("------------ Testing NativeElementIndex.findChildNodesByTagName ---------");
+        //Testing NativeElementIndex.findChildNodesByTagName
         // parent set: 1.1.1; child set: 1.1.1.1, 1.1.1.2, 1.1.1.3, 1.1.2.1, 1.2.1
         ExtNodeSet nestedSet = (ExtNodeSet) executeQuery(broker, "//section[@n = '1.1.1']", 1, null);
         NodeSet children = 
@@ -345,8 +345,6 @@ public class BasicNodeSetTest {
             broker.getStructuralIndex().findDescendantsByTagName(ElementValue.ATTRIBUTE, new QName("n", ""), 
                             Constants.DESCENDANT_ATTRIBUTE_AXIS, docs, nestedSet, -1);
         assertEquals(7, children.getLength());
-
-        System.out.println("------------ PASSED: NativeElementIndex.findChildNodesByTagName ---------");
     }
     
     @Test

--- a/test/src/org/exist/dom/persistent/DocTypeTest.java
+++ b/test/src/org/exist/dom/persistent/DocTypeTest.java
@@ -76,7 +76,6 @@ public class DocTypeTest extends XMLTestCase {
 		try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 			final File existHome = pool.getConfiguration().getExistHome();
 			final File testFile = new File(existHome, "/test/src/org/exist/dom/persistent/test_content.xml");
-			System.out.println("path: " + testFile);
 			assertEquals(true, testFile.canRead());
 			
 			final InputSource is = new FileInputSource(testFile);
@@ -103,7 +102,6 @@ public class DocTypeTest extends XMLTestCase {
 			
 			final String serialized = serializer.serialize(doc);
 
-			System.out.println(serialized);
 			assertTrue("Checking for Public Id in output", serialized.contains("-//OASIS//DTD DITA Reference//EN"));
 
 		} finally {
@@ -133,8 +131,6 @@ public class DocTypeTest extends XMLTestCase {
 
             String serialized = serializer.serialize(doc);
 
-            System.out.println(serialized);
-
             assertTrue("Checking for Public Id in output", serialized.contains("-//OASIS//DTD DITA Topic//EN"));
 
         } finally {
@@ -152,7 +148,6 @@ public class DocTypeTest extends XMLTestCase {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final Txn transaction = transact.beginTransaction()) {
-            System.out.println("NodeTest#setUp ...");
             
             root = broker.getOrCreateCollection(transaction, XmldbURI.create(XmldbURI.ROOT_COLLECTION + "/test"));
             assertNotNull(root);
@@ -164,7 +159,6 @@ public class DocTypeTest extends XMLTestCase {
             root.store(transaction, broker, info, XML, false);
             
             transact.commit(transaction);
-            System.out.println("NodeTest#setUp finished.");
         }
 	}
 	
@@ -186,7 +180,6 @@ public class DocTypeTest extends XMLTestCase {
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final Txn transaction = transact.beginTransaction()) {
-            System.out.println("BasicNodeSetTest#tearDown >>>");
             
             root = broker.getOrCreateCollection(transaction, XmldbURI.create(XmldbURI.ROOT_COLLECTION + "/test"));
             assertNotNull(root);

--- a/test/src/org/exist/dom/persistent/NodeTest.java
+++ b/test/src/org/exist/dom/persistent/NodeTest.java
@@ -53,7 +53,8 @@ public class NodeTest extends XMLTestCase {
             NodeList children = doc.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 IStoredNode node = (IStoredNode) children.item(i);
-                System.out.println(node.getNodeId() + ": " + node.getNodeName());
+                node.getNodeId();
+                node.getNodeName();
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -71,18 +72,18 @@ public class NodeTest extends XMLTestCase {
             doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),Lock.READ_LOCK);
             Element rootNode = doc.getDocumentElement();
             
-            System.out.println("Testing getChildNodes() ...");
+            //Testing getChildNodes()
             NodeList cl = rootNode.getChildNodes();
             assertEquals(((IStoredNode)rootNode).getChildCount(), cl.getLength());
             assertEquals(4, cl.getLength());
         	assertEquals(cl.item(0).getNodeName(), "a");
         	assertEquals(cl.item(1).getNodeName(), "b");
         	
-        	System.out.println("Testing getFirstChild() ...");
+        	//Testing getFirstChild()
         	StoredNode node = (StoredNode) cl.item(1).getFirstChild();
             assertEquals(node.getNodeValue(), "def");
             
-            System.out.println("Testing getChildNodes() ...");
+            //Testing getChildNodes()
             node = (StoredNode) cl.item(0);
             assertEquals(3, node.getChildCount());
             assertEquals(2, node.getAttributes().getLength());
@@ -90,7 +91,7 @@ public class NodeTest extends XMLTestCase {
         	assertEquals(3, cl.getLength());
         	assertEquals(cl.item(2).getNodeValue(), "abc");
         	
-        	System.out.println("Testing getParentNode() ...");
+        	//Testing getParentNode()
         	Node parent = cl.item(0).getParentNode();
         	assertNotNull(parent);
         	assertEquals(parent.getNodeName(), "a");
@@ -111,7 +112,6 @@ public class NodeTest extends XMLTestCase {
     public void testSiblingAxis() {
         DocumentImpl doc = null;
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
-            System.out.println("testSiblingAxis() ...");
             
             doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),Lock.READ_LOCK);
             Element rootNode = doc.getDocumentElement();
@@ -122,26 +122,21 @@ public class NodeTest extends XMLTestCase {
             assertNotNull(sibling);
             assertEquals(sibling.getNodeName(), "b");
             while (sibling != null) {
-                System.out.println(sibling);
                 sibling = sibling.getNextSibling();
             }
             
             NodeList cl = rootNode.getChildNodes();
             sibling = cl.item(2).getFirstChild();
-            System.out.println("Sibling = " + sibling);
             sibling = sibling.getNextSibling();
             // should be null - there's no following sibling
-            System.out.println("Sibling = " + sibling);
             
             int count = 0;
             sibling = cl.item(3);
             while (sibling != null) {
-                System.out.println(sibling);
                 sibling = sibling.getPreviousSibling();
                 count++;
             }
             assertEquals(count, 4);
-            System.out.println("testSiblingAxis(): PASS");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -185,8 +180,7 @@ public class NodeTest extends XMLTestCase {
             
             NamedNodeMap map = first.getAttributes();
             assertEquals(2, map.getLength());
-            for (int i = 0; i < map.getLength(); i++)
-            	System.out.println(map.item(i).getNodeName());
+
             attr = (Attr) map.getNamedItemNS("http://foo.org", "b");
             assertNotNull(attr);
             assertEquals(attr.getLocalName(), "b");
@@ -206,14 +200,13 @@ public class NodeTest extends XMLTestCase {
         DocumentImpl doc = null;
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
             
-            System.out.println("testVisitor() ...");
-            
             doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"));
             StoredNode rootNode = (StoredNode) doc.getDocumentElement();
             NodeVisitor visitor = new NodeVisitor() {
                 @Override
                 public boolean visit(IStoredNode node) {
-                    System.out.println(node.getNodeId() + "\t" + node.getNodeName());
+                    node.getNodeId();
+                    node.getNodeName();
                     return true;
                 };
             };
@@ -235,8 +228,6 @@ public class NodeTest extends XMLTestCase {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final Txn transaction = transact.beginTransaction()) {
-
-            System.out.println("NodeTest#setUp ...");
             
             root = broker.getOrCreateCollection(transaction, XmldbURI.create(XmldbURI.ROOT_COLLECTION + "/test"));
             assertNotNull(root);
@@ -248,7 +239,6 @@ public class NodeTest extends XMLTestCase {
             root.store(transaction, broker, info, XML, false);
             
             transact.commit(transaction);
-            System.out.println("NodeTest#setUp finished.");
         } catch (Exception e) {
 	        fail(e.getMessage()); 	        
         }
@@ -276,8 +266,6 @@ public class NodeTest extends XMLTestCase {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final Txn transaction = transact.beginTransaction()) {
-
-            System.out.println("BasicNodeSetTest#tearDown >>>");
             
             root = broker.getOrCreateCollection(transaction, XmldbURI.create(XmldbURI.ROOT_COLLECTION + "/test"));
             assertNotNull(root);

--- a/test/src/org/exist/http/RESTServiceTest.java
+++ b/test/src/org/exist/http/RESTServiceTest.java
@@ -164,7 +164,6 @@ public class RESTServiceTest {
         //Don't worry about closing the server : the shutdownDB hook will do the job
         if (server == null) {
             server = new JettyStart();
-            System.out.println("Starting standalone server...");
             server.run();
             while (!server.isStarted()) {
                 Thread.sleep(1000);
@@ -174,7 +173,6 @@ public class RESTServiceTest {
 
     @Test
     public void getFailNoSuchDocument() throws IOException {
-        System.out.println("--- try to retrieve missing document, should fail ---");
         String uri = COLLECTION_URI + "/nosuchdocument.xml";
         HttpURLConnection connect = getConnection(uri);
         connect.setRequestMethod("GET");
@@ -187,11 +185,9 @@ public class RESTServiceTest {
     @Test
     public void xqueryGetWithEmptyPath() throws IOException {
         /* store the documents that we need for this test */
-        System.out.println("--- Storing requestwithpath xquery ---");
         doPut(TEST_XQUERY_WITH_PATH_PARAMETER, "requestwithpath.xq", 201);
 
         String path = COLLECTION_URI + "/requestwithpath.xq";
-        System.out.println("--- retrieving "+path+" --- ");
         HttpURLConnection connect = getConnection(path);
         connect.setRequestProperty("Authorization", "Basic " + credentials);
         connect.setRequestMethod("GET");
@@ -199,7 +195,6 @@ public class RESTServiceTest {
         int r = connect.getResponseCode();
         assertEquals("Server returned response code " + r, 200, r);
         String response = readResponse(connect.getInputStream());
-        System.out.println("--- got response:"+response+"\n -- end response");
         String pathInfo = response.substring("pathInfo=".length(), response.indexOf("servletPath=")-2);
         String servletPath = response.substring(response.indexOf("servletPath=") + "servletPath=".length(), response.lastIndexOf("\r\n"));
 
@@ -211,17 +206,14 @@ public class RESTServiceTest {
     @Test
     public void xqueryPOSTWithEmptyPath() throws IOException {
         /* store the documents that we need for this test */
-        System.out.println("--- Storing requestwithpath xquery ---");
         doPut(TEST_XQUERY_WITH_PATH_PARAMETER, "requestwithpath.xq", 201);
 
         String path = COLLECTION_URI + "/requestwithpath.xq";
-        System.out.println("--- posting to "+path+" --- ");
         HttpURLConnection connect = preparePost("boo", path);
         connect.connect();
         int r = connect.getResponseCode();
         assertEquals("Server returned response code " + r, 200, r);
         String response = readResponse(connect.getInputStream());
-        System.out.println("--- got response:"+response+"\n -- end response");
         String pathInfo = response.substring("pathInfo=".length(), response.indexOf("servletPath=")-2);
         String servletPath = response.substring(response.indexOf("servletPath=") + "servletPath=".length(), response.lastIndexOf("\r\n"));
 
@@ -233,11 +225,9 @@ public class RESTServiceTest {
     @Test
     public void xqueryGetWithNonEmptyPath() throws IOException {
         /* store the documents that we need for this test */
-        System.out.println("--- Storing requestwithpath xquery ---");
         doPut(TEST_XQUERY_WITH_PATH_PARAMETER, "requestwithpath.xq", 201);
 
         String path = COLLECTION_URI + "/requestwithpath.xq/some/path";
-        System.out.println("--- retrieving "+path+" --- ");
         HttpURLConnection connect = getConnection(path);
         connect.setRequestProperty("Authorization", "Basic " + credentials);
         connect.setRequestMethod("GET");
@@ -245,7 +235,6 @@ public class RESTServiceTest {
         int r = connect.getResponseCode();
         assertEquals("Server returned response code " + r, 200, r);
         String response = readResponse(connect.getInputStream());
-        System.out.println("--- got response:"+response+"\n -- end response");
         String pathInfo = response.substring("pathInfo=".length(), response.indexOf("servletPath=")-2);
         String servletPath = response.substring(response.indexOf("servletPath=") + "servletPath=".length(), response.lastIndexOf("\r\n"));
 	            
@@ -257,17 +246,14 @@ public class RESTServiceTest {
     @Test
     public void xqueryPOSTWithNonEmptyPath() throws IOException {
         /* store the documents that we need for this test */
-        System.out.println("--- Storing requestwithpath xquery ---");
         doPut(TEST_XQUERY_WITH_PATH_PARAMETER, "requestwithpath.xq", 201);
     		
         String path = COLLECTION_URI + "/requestwithpath.xq/some/path";
-        System.out.println("--- post to "+path+" --- ");
         HttpURLConnection connect = preparePost("boo", path);
         connect.connect();
         int r = connect.getResponseCode();
         assertEquals("Server returned response code " + r, 200, r);
         String response = readResponse(connect.getInputStream());
-        System.out.println("--- got response:"+response+"\n -- end response");
         String pathInfo = response.substring("pathInfo=".length(), response.indexOf("servletPath=")-2);
         String servletPath = response.substring(response.indexOf("servletPath=") + "servletPath=".length(), response.lastIndexOf("\r\n"));
 	            
@@ -290,7 +276,6 @@ public class RESTServiceTest {
         writer.close();
 
         String path = RESOURCE_URI + "/some/path";	// should not be able to get this path
-        System.out.println("--- retrieving "+path+"  should fail --- ");
         HttpURLConnection connect = getConnection(path);
         connect.setRequestMethod("GET");
         connect.connect();
@@ -308,7 +293,6 @@ public class RESTServiceTest {
 
     @Test
     public void putFailAgainstCollection() throws IOException {
-        System.out.println("--- Storing document against collection URI - should fail ---");
         HttpURLConnection connect = getConnection(COLLECTION_URI);
         connect.setRequestProperty("Authorization", "Basic " + credentials);
         connect.setRequestMethod("PUT");
@@ -325,7 +309,6 @@ public class RESTServiceTest {
     
     @Test
     public void putWithCharset() throws IOException {
-        System.out.println("--- Storing document ---");
         HttpURLConnection connect = getConnection(RESOURCE_URI);
         connect.setRequestProperty("Authorization", "Basic " + credentials);
         connect.setRequestMethod("PUT");
@@ -345,7 +328,6 @@ public class RESTServiceTest {
 
     @Test
     public void putFailAndRechallengeAuthorization() throws IOException {
-        System.out.println("--- Authenticate with bad credentials ---");
         HttpURLConnection connect = getConnection(RESOURCE_URI);
         connect.setRequestProperty("Authorization", "Basic " + badCredentials);
         connect.setDoOutput(true);
@@ -354,14 +336,12 @@ public class RESTServiceTest {
         connect.connect();
         int r = connect.getResponseCode();
         assertEquals("Server returned response code " + r, 401, r);
-        System.out.println("--- Get rechallenged for authentication: basic ---");
         String auth = connect.getHeaderField("WWW-Authenticate");         
         assertEquals("WWW-Authenticate = " + auth, "Basic realm=\"exist\"", auth);
     }
 
     @Test
     public void putAgainstXQuery() throws IOException {
-        System.out.println("--- Storing requestwithpath xquery ---");
         doPut(TEST_XQUERY_WITH_PATH_AND_CONTENT, "requestwithcontent.xq", 201);
 
         String path = COLLECTION_URI_REDIRECTED + "/requestwithcontent.xq/a/b/c";
@@ -385,7 +365,6 @@ public class RESTServiceTest {
 
     @Test
     public void deleteAgainstXQuery() throws IOException {
-        System.out.println("--- Storing requestwithpath xquery ---");
         doPut(TEST_XQUERY_WITH_PATH_PARAMETER, "requestwithcontent.xq", 201);
 
         String path = COLLECTION_URI_REDIRECTED + "/requestwithcontent.xq/a/b/c";
@@ -405,7 +384,6 @@ public class RESTServiceTest {
 
     @Test
     public void headAgainstXQuery() throws IOException {
-        System.out.println("--- Storing requestwithpath xquery ---");
         doPut(TEST_XQUERY_WITH_PATH_PARAMETER, "requestwithcontent.xq", 201);
 
         String path = COLLECTION_URI_REDIRECTED + "/requestwithcontent.xq/a/b/c";
@@ -438,7 +416,6 @@ public class RESTServiceTest {
         assertEquals("Server returned response code " + r, 200, r);
 
         String data = readResponse(connect.getInputStream());
-        System.out.println(data);
         int hits = parseResponse(data);
         assertEquals(1, hits);
     }
@@ -449,8 +426,7 @@ public class RESTServiceTest {
         connect.connect();
         int r = connect.getResponseCode();
         assertEquals("Server returned response code " + r, 202, r);
-        System.out.println("--- Get XQuery error code for posted query ---");
-        System.out.println(readResponse(connect.getInputStream()));
+        readResponse(connect.getInputStream());
     }
 
     @Test
@@ -502,7 +478,6 @@ public class RESTServiceTest {
     @Test
     public void requestGetParameterFromModule() throws IOException {
         /* store the documents that we need for this test */
-        System.out.println("--- Storing xquery and module ---");
         doPut(TEST_XQUERY_PARAMETER, "requestparameter.xql", 201);
         doPut(TEST_XQUERY_PARAMETER_MODULE, "requestparametermod.xqm", 201);
 
@@ -510,7 +485,6 @@ public class RESTServiceTest {
         HttpURLConnection connect;
         int iHttpResult;
         for(int i=0; i < 5; i++) {
-            System.out.println("--- Executing stored xquery, iteration=" + i + " ---");
             connect = getConnection(COLLECTION_URI + "/requestparameter.xql?doc=somedoc" + i);
             connect.setRequestProperty("Authorization", "Basic " + credentials);
             connect.setRequestMethod("GET");
@@ -539,7 +513,6 @@ public class RESTServiceTest {
 
     @Test
     public void storedQuery() throws IOException {
-        System.out.println("--- Storing query ---");
         doPut(TEST_MODULE, "module.xq", 201);
         doPut(TEST_XQUERY, "test.xq", 201);
 
@@ -573,7 +546,7 @@ public class RESTServiceTest {
         if(wrap) {
             uri += "&_wrap=yes";
         }
-        System.out.println("--- Calling query: " + uri);
+
         HttpURLConnection connect = getConnection(uri);
         connect.setRequestProperty("Authorization", "Basic " + credentials);
         connect.setRequestMethod("GET");
@@ -582,9 +555,7 @@ public class RESTServiceTest {
         int r = connect.getResponseCode();
         assertEquals("Server returned response code " + r, 200, r);
 
-        dumpHeaders(connect);
         String cached = connect.getHeaderField("X-XQuery-Cached");
-        System.out.println("X-XQuery-Cached: " + cached);
         assertNotNull(cached);
         assertEquals(cacheHeader, Boolean.valueOf(cached).booleanValue());
 
@@ -600,7 +571,6 @@ public class RESTServiceTest {
         }
 
         String response = readResponse(connect.getInputStream());
-        System.out.println('"' + response + '"');
         if (wrap) {
             assertTrue ("Server returned response: " + response, 
                         response.startsWith ("<exist:result "));
@@ -611,7 +581,6 @@ public class RESTServiceTest {
     }
     
     private int uploadData() throws IOException {
-        System.out.println("--- Storing document ---");
         HttpURLConnection connect = getConnection(RESOURCE_URI);
         connect.setRequestProperty("Authorization", "Basic " + credentials);
         connect.setRequestMethod("PUT");
@@ -626,7 +595,6 @@ public class RESTServiceTest {
     }
     
     private void doGet() throws IOException {
-        System.out.println("--- Retrieving document ---");
         HttpURLConnection connect = getConnection(RESOURCE_URI);
         connect.setRequestMethod("GET");
         connect.connect();
@@ -640,7 +608,7 @@ public class RESTServiceTest {
         }
         assertEquals("Server returned content type " + contentType, "application/xml", contentType);
 
-        System.out.println(readResponse(connect.getInputStream()));
+        readResponse(connect.getInputStream());
     }
 
     private HttpURLConnection preparePost(String content, String path) throws IOException {
@@ -688,12 +656,5 @@ public class RESTServiceTest {
     private HttpURLConnection getConnection(String url) throws IOException {
         URL u = new URL(url);
         return (HttpURLConnection) u.openConnection();
-    }
-
-    private void dumpHeaders(HttpURLConnection connect) {
-    	Map<String,List<String>> headers = connect.getHeaderFields();
-    	for (Map.Entry<String,List<String>> entry : headers.entrySet()) {
-    		System.out.println(entry.getKey() + ": " + entry.getValue());
-    	}
     }
 }

--- a/test/src/org/exist/http/RESTTest.java
+++ b/test/src/org/exist/http/RESTTest.java
@@ -21,7 +21,6 @@ public abstract class RESTTest {
         try {
             if(server == null) {
                 server = new JettyStart();
-                System.out.println("Starting standalone server...");
                 server.run();
             }
         } catch(Exception e) {

--- a/test/src/org/exist/numbering/DLNStorageTest.java
+++ b/test/src/org/exist/numbering/DLNStorageTest.java
@@ -61,11 +61,11 @@ public class DLNStorageTest extends TestCase {
                     null, AccessContext.TEST);
             assertEquals(1, seq.getItemCount());
             NodeProxy href = (NodeProxy) seq.itemAt(0);
-            System.out.println(StorageAddress.toString(href));
+            StorageAddress.toString(href);
             assertEquals("1.3.2.1", href.getNodeId().toString());
             // test Attr deserialization
             Attr attr = (Attr) href.getNode();
-            System.out.println(StorageAddress.toString(((NodeHandle)attr)));
+            StorageAddress.toString(((NodeHandle)attr));
             // test Attr fields
             assertEquals(attr.getNodeName(), "href");
             assertEquals(attr.getName(), "href");
@@ -121,7 +121,6 @@ public class DLNStorageTest extends TestCase {
             test.store(transaction, broker, info, TEST_XML, false);
 
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         } catch (Exception e) {
             fail(e.getMessage());
         }

--- a/test/src/org/exist/numbering/DLNTest.java
+++ b/test/src/org/exist/numbering/DLNTest.java
@@ -57,9 +57,6 @@ public class DLNTest extends TestCase {
     private final static int ITEMS_TO_TEST = 10000;
     
     public void testSingleId() {
-        long start = System.currentTimeMillis();
-        
-        System.out.println("------- testSingleId: generating " + ITEMS_TO_TEST + " random ids --------");
         Random rand = new Random();
         TestItem items[] = new TestItem[ITEMS_TO_TEST];
         for (int i = 0; i < ITEMS_TO_TEST; i++) {
@@ -68,32 +65,19 @@ public class DLNTest extends TestCase {
             dln.setLevelId(0, next);
             items[i] = new TestItem(next, dln);
         }
-        System.out.println("------ generation took " + (System.currentTimeMillis() - start));
-        
-        start = System.currentTimeMillis();
-        System.out.println("------ sorting id set ------");
+
         Arrays.sort(items);
-        System.out.println("------ sort took " + (System.currentTimeMillis() - start));
-        
-        System.out.println("------ testing id set ------");
+
         for (int i = 0; i < ITEMS_TO_TEST; i++) {
             assertEquals("Item: " + i, items[i].id, ((DLN)items[i].dln).getLevelId(0));
             if (i + 1 < ITEMS_TO_TEST)
                 assertTrue(items[i].id <= items[i + 1].id);
             if (i > 0)
                 assertTrue(items[i].id >= items[i - 1].id);
-//            System.out.println(items[i].toBitString());
         }
-        System.out.println("------- testSingleId: PASSED --------");
-        Runtime rt = Runtime.getRuntime();
-        System.out.println("Memory: total: " + (rt.totalMemory() / 1024) + 
-                "; free: " + (rt.freeMemory() / 1024));
     }
     
     public void testSort() {
-        long start = System.currentTimeMillis();
-        
-        System.out.println("------- testSort: generating " + ITEMS_TO_TEST + " random ids --------");
         Random rand = new Random();
         DLN items[] = new DLN[ITEMS_TO_TEST];
         for (int i = 0; i < ITEMS_TO_TEST; i++) {
@@ -102,78 +86,53 @@ public class DLNTest extends TestCase {
             dln.setLevelId(0, next);
             items[i] = dln;
         }
-        System.out.println("------ generation took " + (System.currentTimeMillis() - start));
-        
-        start = System.currentTimeMillis();
-        System.out.println("------ sorting id set ------");
         Arrays.sort(items);
-        System.out.println("------ sort took " + (System.currentTimeMillis() - start));
-        
-        System.out.println("------- testSortId: PASSED --------");
-        Runtime rt = Runtime.getRuntime();
-        System.out.println("Memory: total: " + (rt.totalMemory() / 1024) + 
-                "; free: " + (rt.freeMemory() / 1024));
     }
     
     public void testCreate() {
-        System.out.println("------ testCreate ------");
         DLN dln = new DLN();
         for (int i = 1; i < 500000; i++) {
             dln.incrementLevelId();
         }
         assertEquals(500000, dln.getLevelId(0));
-        System.out.println("ID: " + dln.toBitString() + " = " + dln.getLevelId(0));
-        System.out.println("------- testCreate: PASSED --------");
     }
     
     public void testLevelIds() {
-        System.out.println("------ testLevelIds ------");
-        DLN dln = new DLN("1.33.56.2.98.1.27");
-        System.out.println("ID: " + dln.debug());
+        DLN dln = new DLN("1.33.56.2.98.1.27");;
         assertEquals("1.33.56.2.98.1.27", dln.toString());
         
         dln = new DLN("1.56.4.33.30.11.9.40.3.2");
-        System.out.println("ID: " + dln.debug());
         assertEquals("1.56.4.33.30.11.9.40.3.2", dln.toString());
         assertEquals(10, dln.getLevelCount(0));
         
         dln = new DLN("1.8000656.40.3.2");
-        System.out.println("ID: " + dln.debug());
         assertEquals("1.8000656.40.3.2", dln.toString());
         assertEquals(5, dln.getLevelCount(0));
         
         dln = new DLN("1.1");
-        System.out.println("ID: " + dln.debug());
         assertEquals("1.1", dln.toString());
         assertEquals(2, dln.getLevelCount(0));
         dln.incrementLevelId();
-        System.out.println("ID after increment: " + dln.debug());
         assertEquals("1.2", dln.toString());
         assertEquals(2, dln.getLevelCount(0));
-        System.out.println(((DLN)dln.getParentId()).toBitString());
         assertEquals("1", dln.getParentId().toString());
         
         dln = new DLN("1");
-        System.out.println("ID: " + dln.debug());
         assertEquals("1", dln.toString());
         assertEquals(1, dln.getLevelCount(0));
         assertSame(NodeId.DOCUMENT_NODE, dln.getParentId());
         
         dln = new DLN("1.72");
-        System.out.println("ID: " + dln.debug());
         assertEquals("1.72", dln.toString());
         
         dln = new DLN("1.7.3/1.34");
-        System.out.println("ID: " + dln.debug());
         assertEquals("1.7.3/1.34", dln.toString());
         assertEquals(4, dln.getLevelCount(0));
         
         dln = new DLN("1.7.3.1/34");
-        System.out.println("ID: " + dln.debug());
         assertEquals("1.7.3.1/34", dln.toString());
         assertEquals(4, dln.getLevelCount(0));
         dln.incrementLevelId();
-        System.out.println("ID after increment: " + dln.debug());
         assertEquals("1.7.3.1/35", dln.toString());
         assertEquals(4, dln.getLevelCount(0));
         
@@ -182,108 +141,81 @@ public class DLNTest extends TestCase {
         
         dln = new DLN("1/2/3");
         assertEquals(3, dln.getSubLevelCount(dln.lastLevelOffset()));
-        
-        System.out.println("------- testing DLN.incrementLevelId --------");
+
         int[] id0 = new int[] { 1, 33, 56, 2, 98, 1, 27 };
         dln = new DLN();
         for (int i = 0; i < id0.length; i++) {
             if (i > 0)
                 dln.addLevelId(1, false);
             for (int j = 1; j < id0[i]; j++) dln.incrementLevelId();
-            System.out.println("ID: " + dln.debug());
         }
-        System.out.println("ID: " + dln.debug());
         assertEquals("1.33.56.2.98.1.27", dln.toString());
         assertEquals(7, dln.getLevelCount(0));
-        
-        System.out.println("------- testLevelIds: PASSED --------");
     }
     
     public void testRelations() {
-    	System.out.println("------ testLevelRelations ------");
     	DLN root = new DLN("1.3");
     	DLN descendant = new DLN("1.3.1");
-    	
-    	System.out.println("Testing isDescendant: " + descendant + " -> " + root);
+
     	assertTrue(descendant.isDescendantOf(root));
-    	
-    	System.out.println("Testing isChildOf: " + descendant + " -> " + root);
+
     	assertTrue(descendant.isChildOf(root));
-    	
-    	System.out.println("Testing getParentId: " + descendant + " -> " + root);
+
     	assertTrue(root.equals(descendant.getParentId()));
     	
     	descendant = new DLN("1.3.2.5.6");
-    	System.out.println("Testing isDescendantOf: " + descendant + " -> " + root);
     	assertTrue(descendant.isDescendantOf(root));
-    	
-    	System.out.println("Testing isChildOf: " + descendant + " -> " + root);
+
     	assertFalse(descendant.isChildOf(root));
-    	
-    	System.out.println("Testing isDescendantOrSelf: " + descendant + " -> " + root);
+
     	assertTrue(descendant.isDescendantOrSelfOf(root));
     	
     	descendant = new DLN("1.4");
-    	System.out.println("Testing isDescendant: " + descendant + " -> " + root);
     	assertFalse(descendant.isDescendantOf(root));
     	
     	descendant = new DLN("1.3");
-    	System.out.println("Testing isDescendant: " + descendant + " -> " + root);
     	assertFalse(descendant.isDescendantOf(root));
-    	
-    	System.out.println("Testing isDescendantOrSelf: " + descendant + " -> " + root);
+
     	assertTrue(descendant.isDescendantOrSelfOf(root));
     	
     	root = new DLN("1.3.2.5.6");
     	descendant = new DLN("1.3.2.5.6.7777");
-    	System.out.println("Testing isDescendantOf: " + descendant + " -> " + root);
     	assertTrue(descendant.isDescendantOf(root));
-    	
-    	System.out.println("Testing isChildOf: " + descendant + " -> " + root);
+
     	assertTrue(descendant.isChildOf(root));
-    	
-    	System.out.println("Testing getParentId: " + descendant + " -> " + root);
+
     	assertTrue(root.equals(descendant.getParentId()));
     	
     	descendant = new DLN("1.3.2.5.6.7777.1");
-    	System.out.println("Testing isDescendantOf: " + descendant + " -> " + root);
     	assertTrue(descendant.isDescendantOf(root));
-    	
-    	System.out.println("Testing isChildOf: " + descendant + " -> " + root);
+
     	assertFalse(descendant.isChildOf(root));
     	
     	root = new DLN("1.3.1");
     	descendant = new DLN("1.3.2");
-    	System.out.println("Testing isDescendantOf: " + descendant + " -> " + root);
     	assertFalse(descendant.isDescendantOf(root));
     	
     	root = new DLN("1.6.6.66");
     	descendant = new DLN("1.6.6.65.1");
-    	System.out.println("Testing isChildOf: " + descendant + " -> " + root);
     	assertFalse(descendant.isChildOf(root));
     	
     	descendant = new DLN("1.6.6.66");
-    	System.out.println("Testing isChildOf: " + descendant + " -> " + root);
     	assertFalse(descendant.isChildOf(root));
     	
     	root = new DLN("1.3.1/1");
     	descendant = new DLN("1.3.1/1.1");
-    	System.out.println("Testing isChildOf: " + descendant + " -> " + root);
     	assertTrue(descendant.isChildOf(root));
     	
     	descendant = (DLN) root.newChild();
     	assertEquals("1.3.1/1.1", descendant.toString());
     	descendant.incrementLevelId();
     	assertEquals("1.3.1/1.2", descendant.toString());
-    	
-    	System.out.println("Parent of " + descendant + " -> " + descendant.getParentId());
+
     	assertTrue(root.equals(descendant.getParentId()));
     	
     	descendant = new DLN("1.3.1/1.2.2");
-    	System.out.println("Testing isChildOf: " + descendant + " -> " + root);
     	assertFalse(descendant.isChildOf(root));
-    	
-    	System.out.println("Testing isDescendantOf: " + descendant + " -> " + root);
+
     	assertTrue(descendant.isDescendantOf(root));
     	
     	NodeId left = new DLN("1.3.1");
@@ -296,7 +228,6 @@ public class DLNTest extends TestCase {
     	assertTrue(right.compareTo(dln) > 0);
     	assertTrue(left.compareTo(right) < 0);
 
-        System.out.println("Testing isSiblingOf ...");
         DLN id0 = new DLN("1.1.7");
         DLN id1 = new DLN("1.1.6");
         DLN id2 = new DLN("1.1.7.1");
@@ -308,41 +239,31 @@ public class DLNTest extends TestCase {
         assertFalse(id2.isSiblingOf(id0));
         assertTrue(id3.isSiblingOf(id0));
         assertTrue(id0.isSiblingOf(id3));
-        
-        System.out.println("------ testLevelRelations: PASSED ------");
     }
     
     public void testInsertion() {
-        System.out.println("------ testInsertion ------");
         DLN left = new DLN("1.1"); 
         DLN right = (DLN) left.insertNode(null);
         assertEquals("1.2", right.toString());
         
         DLN dln = (DLN) left.insertNode(right);
-        System.out.println(dln);
         assertEquals("1.1/1", dln.toString());
         
         left = dln;
         dln = (DLN) left.insertNode(right);
-        System.out.println(dln);
         assertEquals("1.1/2", dln.toString());
         
         right = dln;
         dln = (DLN) left.insertNode(right);
-        System.out.println(dln);
         assertEquals("1.1/1/1", dln.toString());
         
         right = new DLN("1.1/1");
         left = new DLN("1.1");
         dln = (DLN) left.insertNode(right);
-        System.out.println(dln);
         assertEquals("1.1/0/35", dln.toString());
         
         right = dln;
         dln = (DLN) left.insertNode(right);
-        System.out.println(dln);
         assertEquals("1.1/0/34", dln.toString());
-        
-        System.out.println("------ testInsertion: PASSED ------");
     }
 }

--- a/test/src/org/exist/performance/Group.java
+++ b/test/src/org/exist/performance/Group.java
@@ -79,9 +79,7 @@ public class Group {
         runner.getResults().groupStart(this);
 
         if (setupAction != null) {
-            System.out.println("Running setup ...");
             setupAction.run();
-            System.out.println("Setup done ...");
         }
 
         Stack<Thread> stack = new Stack<Thread>();
@@ -100,9 +98,7 @@ public class Group {
         }
 
         if (tearDownAction != null) {
-            System.out.println("Tearing down ...");
             tearDownAction.run();
-            System.out.println("Done.");
         }
 
         runner.getResults().groupEnd(this);

--- a/test/src/org/exist/performance/actions/DataGenerator.java
+++ b/test/src/org/exist/performance/actions/DataGenerator.java
@@ -111,7 +111,6 @@ public class DataGenerator extends AbstractAction {
         service.declareVariable("filename", "");
         service.declareVariable("count", "0");
         String query = IMPORT + xqueryContent;
-        System.out.println("query: " + query);
         CompiledExpression compiled = service.compile(query);
         try {
             for (int i = 0; i < count; i++) {

--- a/test/src/org/exist/performance/actions/RemoveCollection.java
+++ b/test/src/org/exist/performance/actions/RemoveCollection.java
@@ -37,7 +37,6 @@ public class RemoveCollection extends AbstractAction {
 
     public void configure(Runner runner, Action parent, Element config) throws EXistException {
         super.configure(runner, parent, config);
-        System.out.println(config.getNodeName());
         if (!config.hasAttribute("parent"))
             throw new EXistException(RemoveCollection.class.getName() + " requires an attribute 'parent'");
         parentPath = config.getAttribute("parent");

--- a/test/src/org/exist/security/RestApiSecurityTest.java
+++ b/test/src/org/exist/security/RestApiSecurityTest.java
@@ -167,7 +167,6 @@ public class RestApiSecurityTest extends AbstractApiSecurityTest {
         //Don't worry about closing the server : the shutdownDB hook will do the job
         if (server == null) {
             server = new JettyStart();
-            System.out.println("Starting standalone server...");
             server.run();
             while (!server.isStarted()) {
                 Thread.sleep(1000);

--- a/test/src/org/exist/security/SecurityManagerRoundtripTest.java
+++ b/test/src/org/exist/security/SecurityManagerRoundtripTest.java
@@ -47,7 +47,6 @@ public class SecurityManagerRoundtripTest {
     @Before
     public void startServer() {
         try {
-            System.out.println("Starting standalone server...");
             server = new JettyStart();
             server.run();
         } catch (Exception e) {
@@ -58,7 +57,6 @@ public class SecurityManagerRoundtripTest {
 
     @After
     public void stopServer() {
-        System.out.println("Shutdown standalone server...");
         server.shutdown();
         server = null;
     }

--- a/test/src/org/exist/security/XMLDBSecurityTest.java
+++ b/test/src/org/exist/security/XMLDBSecurityTest.java
@@ -1943,7 +1943,6 @@ public class XMLDBSecurityTest {
     @BeforeClass
     public static void startServer() {
         try {
-            System.out.println("Starting standalone server...");
             server = new JettyStart();
             server.run();
         } catch (Exception e) {
@@ -1954,7 +1953,6 @@ public class XMLDBSecurityTest {
 
     @AfterClass
     public static void stopServer() {
-        System.out.println("Shutdown standalone server...");
         server.shutdown();
         server = null;
     }

--- a/test/src/org/exist/security/XmldbApiSecurityTest.java
+++ b/test/src/org/exist/security/XmldbApiSecurityTest.java
@@ -368,8 +368,7 @@ public class XmldbApiSecurityTest extends AbstractApiSecurityTest {
 //            DatabaseManager.registerDatabase(database);
 //            Collection root = DatabaseManager.getCollection("xmldb:exist:///db", "admin", "");
 //            assertNotNull(root);
-            
-            System.out.println("Starting standalone server...");
+
             server = new JettyStart();
             server.run();
     }
@@ -384,7 +383,6 @@ public class XmldbApiSecurityTest extends AbstractApiSecurityTest {
 //        } catch (XMLDBException e) {
 //            e.printStackTrace();
 //        }
-        System.out.println("Shutdown standalone server...");
         server.shutdown();
         server = null;
     }

--- a/test/src/org/exist/soap/CopyMoveTest.java
+++ b/test/src/org/exist/soap/CopyMoveTest.java
@@ -72,7 +72,6 @@ public class CopyMoveTest extends TestCase {
         assertEquals(2,resources.length);
         assertTrue(resources[0].equals("duplicate") || resources[1].equals("duplicate"));
         String content = query.getResource(a_session,testColl + "/duplicate",true,false);
-        System.out.println(content);
     }
     
     public void testMoveResource() throws RemoteException {

--- a/test/src/org/exist/soap/UsersAndPermissionsTest.java
+++ b/test/src/org/exist/soap/UsersAndPermissionsTest.java
@@ -51,25 +51,14 @@ public class UsersAndPermissionsTest extends TestCase {
         UserDesc desc;
         try {
             desc = admin.getUser(sessionId,testUser);
-            System.out.println("Removing user " + testUser);
             admin.removeUser(sessionId,testUser);
         } catch (RemoteException rex) {
             
         }
         String[] testGroups = {testGroup};
-        System.out.println("==> Creating user " + testUser);
         admin.setUser(sessionId,testUser,testPassword,new Strings(testGroups),testHome);
         desc = admin.getUser(sessionId,testUser);
         assertNotNull(desc);
-        System.out.print("User: " + desc.getName() + " Groups: (");
-        for (int i = 0; i < desc.getGroups().getElements().length; i++) {
-            if (i > 0)
-                System.out.print(",");
-            System.out.print(desc.getGroups().getElements()[i]);
-        }
-        System.out.println(") Home: " + desc.getHome());
-        
-        System.out.println("==> Creating test resource");
         
         // Create a test resource
         admin.removeCollection(sessionId,testColl);
@@ -78,39 +67,28 @@ public class UsersAndPermissionsTest extends TestCase {
         admin.store(sessionId,"<sample/>".getBytes(),"UTF-8",res,true);
         
         Permissions perms = admin.getPermissions(sessionId,res);
-        System.out.println("Owner: " + perms.getOwner() + " Group: " + perms.getGroup() + " Access: " + Integer.toOctalString(perms.getPermissions()));
-        
-        System.out.println("==> Modifying resource permissions");
+
         admin.setPermissions(sessionId,res,testUser,testGroup,0777);
         
         Permissions newperms = admin.getPermissions(sessionId,res);
-        System.out.println("Owner: " + newperms.getOwner() + " Group: " + newperms.getGroup() + " Access: " + Integer.toOctalString(newperms.getPermissions()));
         
         assertEquals(newperms.getOwner(),testUser);
         assertEquals(newperms.getGroup(),testGroup);
         assertEquals(newperms.getPermissions(),0777);
-        
-        System.out.println("==> Restoring resource permissions");
+
         admin.setPermissions(sessionId,res,perms.getOwner(),perms.getGroup(),perms.getPermissions());
-        
-        System.out.println("==> Locking resource");
+
         admin.lockResource(sessionId,res,testUser);
         String lockOwner = admin.hasUserLock(sessionId,res);
-        System.out.println("Lock owner : " + lockOwner);
         assertEquals(lockOwner,testUser);
-        
-        System.out.println("==> Unlocking resource");
+
         admin.unlockResource(sessionId,res);
-        System.out.println("Lock owner : " + admin.hasUserLock(sessionId,res));
         
         perms = admin.getPermissions(sessionId,res);
-        System.out.println("Owner: " + perms.getOwner() + " Group: " + perms.getGroup() + " Access: " + Integer.toOctalString(perms.getPermissions()));
-        
-        System.out.println("==> Removing user " + testUser);
+
         admin.removeUser(sessionId,testUser);
         try {
             desc = admin.getUser(sessionId,testUser);
-            System.out.println("Remove of user " + testUser + " failed");
             assertTrue(false);
         } catch (RemoteException rex) {
             

--- a/test/src/org/exist/soap/XQueryTest.java
+++ b/test/src/org/exist/soap/XQueryTest.java
@@ -44,36 +44,26 @@ public class XQueryTest extends TestCase {
                 "  <fruit name='persimmon'/>" +
                 "  <fruit name='pomegranate'/>" +
                 "</test>";
-        System.out.println("====> Creating test documents");
+
         admin.store(sessionId,data.getBytes(),"UTF-8",testColl + "/docA",true);
         admin.store(sessionId,data1.getBytes(),"UTF-8",testColl + "/docB",true);
-        System.out.println("====> getResource");
+
         String rd = query.getResource(sessionId,testColl + "/docA", true,false);
-        System.out.println(rd);
-        System.out.println("====> listCollection");
+
         Collection coll = query.listCollection(sessionId,testColl);
         String[] colls = coll.getCollections().getElements();
-        if (colls != null)
-            for (int i = 0; i < colls.length; i++) {
-            System.out.println("  collection " + colls[i]);
-            }
         String[] ress = coll.getResources().getElements();
         assertEquals(ress.length,2);
-        if (ress != null)
-            for (int i = 0; i < ress.length; i++) {
-            System.out.println("  resources " + ress[i]);
-            }
-        System.out.println("====> getResourceData");
+
         byte[] rd1 = query.getResourceData(sessionId,testColl + "/docB", true,false,false);
-        System.out.println(new String(rd1));
-        System.out.println("====> performing xquery with retrieve");
+
         String qry = "for $a in collection('" + testColl + "')/test/fruit return $a";
         assertEquals(doXQuery(qry),12);
-        System.out.println("====> performing xquery with retrieveData");
+
         assertEquals(doXQueryB(qry),12);
-        System.out.println("====> performing xquery with retrieveByDocument");
+
         assertEquals(doXQueryC(qry),6);
-        System.out.println("====> performing xquery, expecting 0 hits");
+
         String qry1 = "for $a in collection('" + testColl + "')/test/nuts return $a";
         assertEquals(doXQuery(qry1),0);
         String qry2 = "for $a in collection('" + testColl + "')/test/fruit[@name = 'apple'] return $a";
@@ -85,12 +75,7 @@ public class XQueryTest extends TestCase {
         int noHits = rsp.getHits();
         if (noHits > 0) {
             String[] rsps = query.retrieve(sessionId,1,noHits,true,false,"none");
-            for (int i = 0; i < rsps.length; i++) {
-                System.out.println(rsps[i]);
-            }
             assertEquals(noHits,rsps.length);
-        } else {
-            System.out.println("No hits");
         }
         return noHits;
     }
@@ -100,12 +85,7 @@ public class XQueryTest extends TestCase {
         int noHits = rsp.getHits();
         if (noHits > 0) {
             byte[][] rsps = query.retrieveData(sessionId,1,noHits,true,false,"none").getElements();
-            for (int i = 0; i < rsps.length; i++) {
-                System.out.println(new String(rsps[i]));
-            }
             assertEquals(noHits,rsps.length);
-        } else {
-            System.out.println("No hits");
         }
         return noHits;
     }
@@ -115,13 +95,8 @@ public class XQueryTest extends TestCase {
         int noHits = rsp.getHits();
         if (noHits > 0) {
             String[] rsps = query.retrieveByDocument(sessionId,1,noHits,testColl + "/docA",true,false,"none");
-            for (int i = 0; i < rsps.length; i++) {
-                System.out.println(rsps[i]);
-            }
             noHits = rsps.length;
 //			assertEquals(noHits,rsps.length);
-        } else {
-            System.out.println("No hits");
         }
         return noHits;
     }

--- a/test/src/org/exist/storage/AbstractUpdateTest.java
+++ b/test/src/org/exist/storage/AbstractUpdateTest.java
@@ -55,7 +55,6 @@ public abstract class AbstractUpdateTest {
         BrokerPool pool = null;
         DBBroker broker = null;
         try {
-        	System.out.println("testRead() ...\n");  
         	
         	pool = startDB();
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -68,15 +67,12 @@ public abstract class AbstractUpdateTest {
             doc = broker.getXMLResource(TEST_COLLECTION_URI.append("test2/test.xml"), Lock.READ_LOCK);
             assertNotNull("Document '"+ TEST_COLLECTION_URI.append("test2/test.xml")+"' should not be null", doc);
             data = serializer.serialize(doc);
-            System.out.println(data);
             doc.getUpdateLock().release(Lock.READ_LOCK);
             
             XQuery xquery = broker.getXQueryService();
             Sequence seq = xquery.execute("/products/product[last()]", null, AccessContext.TEST);
-            System.out.println("Found: " + seq.getItemCount());
             for (SequenceIterator i = seq.iterate(); i.hasNext(); ) {
                 Item next = i.nextItem();
-                System.out.println(serializer.serialize((NodeValue) next));
             }
         } catch (Exception e) {            
             fail(e.getMessage());
@@ -100,8 +96,7 @@ public abstract class AbstractUpdateTest {
 	        test.store(transaction, broker, info, TEST_XML, false);
 	
 	        mgr.commit(transaction);	
-	        System.out.println("Transaction commited ...");
-	        
+
 	    } catch (Exception e) {
 	        fail(e.getMessage());
 	    }  

--- a/test/src/org/exist/storage/BFileOverflowTest.java
+++ b/test/src/org/exist/storage/BFileOverflowTest.java
@@ -99,7 +99,6 @@ public class BFileOverflowTest extends TestCase {
             
             Value key = new Value("test".getBytes());
             Value val = collectionsDb.get(key);
-            System.out.println(new String(val.data(), val.start(), val.getLength()));
         } catch (Exception e) {
             fail(e.getMessage());
         } finally {

--- a/test/src/org/exist/storage/BFileRecoverTest.java
+++ b/test/src/org/exist/storage/BFileRecoverTest.java
@@ -77,8 +77,7 @@ public class BFileRecoverTest extends TestCase {
             
             Writer writer = new StringWriter();
             collectionsDb.dump(writer);
-            System.out.println(writer.toString());
-        } catch (Exception e) {            
+        } catch (Exception e) {
             fail(e.getMessage());            
         }
     }
@@ -91,16 +90,11 @@ public class BFileRecoverTest extends TestCase {
             BFile collectionsDb = (BFile)((NativeBroker)broker).getStorage(NativeBroker.COLLECTIONS_DBX_ID);
             Writer writer = new StringWriter();
             collectionsDb.dump(writer);
-            System.out.println(writer.toString());
-            
+
             for (int i = 1; i < 1001; i++) {
                 String key = "test" + i;
                 byte[] data = key.getBytes(UTF_8);
                 Value value = collectionsDb.get(new Value(data));
-                if (value == null)
-                    System.out.println("Key " + key + " not found.");
-                else
-                    System.out.println(new String(value.data(), value.start(), value.getLength(), UTF_8));
             }
         } catch (Exception e) {            
             fail(e.getMessage());            

--- a/test/src/org/exist/storage/BTreeRecoverTest.java
+++ b/test/src/org/exist/storage/BTreeRecoverTest.java
@@ -54,7 +54,7 @@ public class BTreeRecoverTest extends TestCase {
     private int count = 0;
     
     public void testAdd() {
-        System.out.println("Add some random data and force db corruption ...\n");
+        //Add some random data and force db corruption
         
         TransactionManager mgr = pool.getTransactionManager();
         NodeIdFactory idFact = pool.getNodeFactory();
@@ -97,7 +97,6 @@ public class BTreeRecoverTest extends TestCase {
             
             Writer writer = new StringWriter();
             domDb.dump(writer);
-            System.out.println(writer.toString());
         } catch (Exception e) {
         	e.printStackTrace();
             fail(e.getMessage());
@@ -105,7 +104,7 @@ public class BTreeRecoverTest extends TestCase {
     }
     
     public void testGet() {
-        System.out.println("Recover and read the data ...\n");
+        //Recover and read the data
         @SuppressWarnings("unused")
 		TransactionManager mgr = pool.getTransactionManager();
         NodeIdFactory idFact = pool.getNodeFactory();
@@ -118,12 +117,10 @@ public class BTreeRecoverTest extends TestCase {
             
             IndexQuery query = new IndexQuery(IndexQuery.GEQ, new NativeBroker.NodeRef(500, idFact.createInstance(1)));
             domDb.query(query, new IndexCallback());
-            System.out.println("Found: " + count);
             assertEquals(count, 800);
             
             Writer writer = new StringWriter();
             domDb.dump(writer);
-            System.out.println(writer.toString());
         } catch (Exception e) {
         	e.printStackTrace();
             fail(e.getMessage());
@@ -157,7 +154,6 @@ public class BTreeRecoverTest extends TestCase {
         	@SuppressWarnings("unused")
 			final byte[] data = value.data();
 //        	NodeId id = pool.getNodeFactory().createFromData(data[value.start() + 4], data, value.start() + 5);
-//            System.out.println(id + " -> " + pointer);
             count++;
             return false;
         }

--- a/test/src/org/exist/storage/CollectionTest.java
+++ b/test/src/org/exist/storage/CollectionTest.java
@@ -86,23 +86,18 @@ public class CollectionTest {
     public void read() {
         BrokerPool.FORCE_CORRUPTION = false;
         BrokerPool pool = startDB();
-        
-        System.out.println("testRead() ...\n");
-        
+
         DBBroker broker = null;
         try {
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
             BTree btree = ((NativeBroker)broker).getStorage(NativeBroker.COLLECTIONS_DBX_ID);
             Writer writer = new StringWriter();
             btree.dump(writer);
-            System.out.println(writer.toString());
-            
+
             Collection test = broker.getCollection(TEST_COLLECTION_URI.append("test2"));
             assertNotNull(test);
-            System.out.println("Contents of collection " + test.getURI() + ":");
             for (Iterator<DocumentImpl> i = test.iterator(broker); i.hasNext(); ) {
                 DocumentImpl next = i.next();
-                System.out.println("- " + next.getURI());
             }
         } catch (Exception e) {            
             fail(e.getMessage());              

--- a/test/src/org/exist/storage/ConcurrentStoreTest.java
+++ b/test/src/org/exist/storage/ConcurrentStoreTest.java
@@ -85,10 +85,8 @@ public class ConcurrentStoreTest extends TestCase {
             assertNotNull(test);
             test2 = broker.getCollection(TEST_COLLECTION_URI.append("test2"));
             assertNotNull(test2);
-            System.out.println("Contents of collection " + test.getURI() + ":");
             for (Iterator<DocumentImpl> i = test.iterator(broker); i.hasNext(); ) {
                 DocumentImpl next = i.next();
-                System.out.println("- " + next.getURI());
             }
 	    } catch (Exception e) {            
 	        fail(e.getMessage());              
@@ -138,8 +136,6 @@ public class ConcurrentStoreTest extends TestCase {
             final TransactionManager transact = pool.getTransactionManager();
             try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                     final Txn transaction = transact.beginTransaction()) {
-                
-                System.out.println("Transaction started ...");
                 XMLFilenameFilter filter = new XMLFilenameFilter();
                 File files[] = dir.listFiles(filter);
                 
@@ -164,8 +160,7 @@ public class ConcurrentStoreTest extends TestCase {
                 
 //              Don't commit...
                 transact.getJournal().flushToLog(true);
-                System.out.println("Transaction interrupted ...");
-    	    } catch (Exception e) {            
+    	    } catch (Exception e) {
     	        fail(e.getMessage()); 
             }
         }
@@ -179,8 +174,7 @@ public class ConcurrentStoreTest extends TestCase {
                 
                 Iterator<DocumentImpl> i = test.iterator(broker);
                 DocumentImpl doc = i.next();
-                
-                System.out.println("\nREMOVING DOCUMENT\n");
+
                 test.removeXMLResource(transaction, broker, doc.getFileURI());
                 
                 File f = new File(dir + File.separator + "hamlet.xml");

--- a/test/src/org/exist/storage/CopyCollectionTest.java
+++ b/test/src/org/exist/storage/CopyCollectionTest.java
@@ -72,7 +72,6 @@ public class CopyCollectionTest {
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
-            System.out.println("Transaction started ...");
 
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             broker.saveCollection(transaction, root);
@@ -93,8 +92,6 @@ public class CopyCollectionTest {
             broker.copyCollection(transaction, test, dest, XmldbURI.create("test3"));
 
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
-            
 	    } catch (Exception e) {            
 	        fail(e.getMessage());              
         }
@@ -106,7 +103,6 @@ public class CopyCollectionTest {
         DBBroker broker = null;
         
         try {
-        	System.out.println("testRead() ...\n");  
         	pool = startDB();
         	assertNotNull(pool);
         	broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -118,8 +114,7 @@ public class CopyCollectionTest {
             DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("destination/test3/test.xml"), Lock.READ_LOCK);
             assertNotNull("Document should not be null", doc);
             String data = serializer.serialize(doc);
-            System.out.println(data);
-            doc.getUpdateLock().release(Lock.READ_LOCK);                
+            doc.getUpdateLock().release(Lock.READ_LOCK);
 	    } catch (Exception e) {  
 	    	e.printStackTrace();
 	        fail(e.getMessage());              
@@ -139,8 +134,6 @@ public class CopyCollectionTest {
 
             try(final Txn transaction = transact.beginTransaction()) {
 
-                System.out.println("Transaction started ...");
-
                 Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
                 assertNotNull(root);
                 broker.saveCollection(transaction, root);
@@ -157,12 +150,10 @@ public class CopyCollectionTest {
                 test2.store(transaction, broker, info, new InputSource(f.toURI().toASCIIString()), false);
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
             
             final Txn transaction = transact.beginTransaction();
-            System.out.println("Transaction started ...");
-            
+
             Collection dest = broker.getOrCreateCollection(transaction, XmldbURI.ROOT_COLLECTION_URI.append("destination"));
             assertNotNull(dest);
             broker.saveCollection(transaction, dest);            
@@ -170,8 +161,7 @@ public class CopyCollectionTest {
 
 //          Don't commit...
             transact.getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");            
-	    } catch (Exception e) {    
+	    } catch (Exception e) {
 	    	e.printStackTrace();
 	        fail(e.getMessage());              
         }
@@ -183,8 +173,7 @@ public class CopyCollectionTest {
         DBBroker broker = null;
        
         try {
-        	System.out.println("testReadAborted() ...\n");
-        	pool = startDB();
+            pool = startDB();
         	assertNotNull(pool);
         	broker = pool.get(pool.getSecurityManager().getSystemSubject());
         	assertNotNull(broker);
@@ -252,8 +241,6 @@ public class CopyCollectionTest {
 	        assertNotNull(test);
 	        Resource res = test.getResource("test_xmldb.xml");
 	        assertNotNull("Document should not be null", res);
-	        System.out.println(res.getContent());
-	        
 	        org.xmldb.api.base.Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
 	        assertNotNull(root);
 	        CollectionManagementServiceImpl mgr = (CollectionManagementServiceImpl) 

--- a/test/src/org/exist/storage/CopyResourceTest.java
+++ b/test/src/org/exist/storage/CopyResourceTest.java
@@ -73,8 +73,6 @@ public class CopyResourceTest {
 		try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
 
-			System.out.println("Transaction started ...");
-
 			Collection root = broker.getOrCreateCollection(transaction,	XmldbURI.ROOT_COLLECTION_URI.append("test"));
 			assertNotNull(root);
 			broker.saveCollection(transaction, root);
@@ -99,8 +97,7 @@ public class CopyResourceTest {
 			broker.saveCollection(transaction, testCollection);
 
 			transact.commit(transaction);
-			System.out.println("Transaction commited ...");
-	    } catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
 	        fail(e.getMessage()); 	      			
 		}
@@ -112,7 +109,6 @@ public class CopyResourceTest {
 		DBBroker broker = null;
 		
 		try {
-			System.out.println("testRead() ...\n");
 			pool = startDB();
 			assertNotNull(pool);
 			broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -124,7 +120,7 @@ public class CopyResourceTest {
 			assertNotNull("Document should not be null", doc);
 			String data = serializer.serialize(doc);
 			assertNotNull(data);
-			//System.out.println(data);
+
 			doc.getUpdateLock().release(Lock.READ_LOCK);
 	    } catch (Exception e) {            
 	        fail(e.getMessage()); 			
@@ -144,7 +140,6 @@ public class CopyResourceTest {
             IndexInfo info;
 
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 Collection root = broker.getOrCreateCollection(transaction, XmldbURI.ROOT_COLLECTION_URI.append("test"));
                 assertNotNull(root);
@@ -167,19 +162,16 @@ public class CopyResourceTest {
                 subTestCollection.store(transaction, broker, info, new InputSource(f.toURI().toASCIIString()), false);
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
 
 			final Txn transaction = transact.beginTransaction();
-			System.out.println("Transaction started ...");
 
 			broker.copyResource(transaction, info.getDocument(), testCollection, XmldbURI.create("new_test2.xml"));
 			broker.saveCollection(transaction, testCollection);
 			
 //			Don't commit...
 			pool.getTransactionManager().getJournal().flushToLog(true);
-			System.out.println("Transaction interrupted ...");
-	    } catch (Exception e) {            
+	    } catch (Exception e) {
 	        fail(e.getMessage());			
 		}
 	}
@@ -189,7 +181,6 @@ public class CopyResourceTest {
 		BrokerPool pool = null;
 		DBBroker broker = null;		
 		try {
-			System.out.println("testReadAborted() ...\n");
 			pool = startDB();
 			assertNotNull(pool);
 			broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -201,7 +192,7 @@ public class CopyResourceTest {
 			assertNotNull("Document should not be null", doc);
 			String data = serializer.serialize(doc);
 			assertNotNull(data);
-			//System.out.println(data);
+
 			doc.getUpdateLock().release(Lock.READ_LOCK);
 
 			doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test").append(testCollectionName).append("new_test2.xml"), Lock.READ_LOCK);

--- a/test/src/org/exist/storage/DOMFileRecoverTest.java
+++ b/test/src/org/exist/storage/DOMFileRecoverTest.java
@@ -59,7 +59,7 @@ public class DOMFileRecoverTest extends TestCase {
         final NodeIdFactory idFact = pool.getNodeFactory();
 
 		try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
-			System.out.println("Add some random data and force db corruption ...\n");
+			//Add some random data and force db corruption
 
             broker.flush();
             final DOMFile domDb = ((NativeBroker) broker).getDOMFile();
@@ -70,7 +70,6 @@ public class DOMFileRecoverTest extends TestCase {
             long firstToRemove = -1;
 
             try(final Txn txn = mgr.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 // put 1000 values into the btree
                 for (int i = 1; i <= 10000; i++) {
@@ -102,11 +101,9 @@ public class DOMFileRecoverTest extends TestCase {
 
                 domDb.closeDocument();
                 mgr.commit(txn);
-                System.out.println("Transaction commited ...");
             }
             
             try(final Txn txn = mgr.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 // put 1000 new values into the btree
                 for (int i = 1; i <= 1000; i++) {
@@ -119,12 +116,10 @@ public class DOMFileRecoverTest extends TestCase {
 
                 domDb.closeDocument();
                 mgr.commit(txn);
-                System.out.println("Transaction commited ...");
             }
             
             // the following transaction is not committed and will be rolled back during recovery
             try(final Txn txn = mgr.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 for (int i = 1; i <= 200; i++) {
                     domDb.remove(txn, new NativeBroker.NodeRef(500, idFact.createInstance(i)));
@@ -138,11 +133,9 @@ public class DOMFileRecoverTest extends TestCase {
                 mgr.commit(txn);
             }
             mgr.getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");
-            
+
             Writer writer = new StringWriter();
             domDb.dump(writer);
-            System.out.println(writer.toString());
 	    } catch (Exception e) {
 	    	e.printStackTrace();
 	        fail(e.getMessage());               
@@ -153,7 +146,7 @@ public class DOMFileRecoverTest extends TestCase {
         
         DBBroker broker = null;
         try {
-        	System.out.println("Recover and read the data ...\n");        	
+        	//Recover and read the data
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
             assertNotNull(broker);
             TransactionManager mgr = pool.getTransactionManager();
@@ -173,14 +166,11 @@ public class DOMFileRecoverTest extends TestCase {
                 assertNotNull(key);
                 Value value = domDb.get(key);
                 assertNotNull(value);
-                System.out.println(new String(value.data(), value.start(), value.getLength()));
             }
-            System.out.println("Values read: " + count);
             
             Writer writer = new StringWriter();
             domDb.dump(writer);
-            System.out.println(writer.toString());
-	    } catch (Exception e) {            
+	    } catch (Exception e) {
 	        fail(e.getMessage());             
         } finally {
             pool.release(broker);

--- a/test/src/org/exist/storage/DirtyShutdownTest.java
+++ b/test/src/org/exist/storage/DirtyShutdownTest.java
@@ -60,7 +60,6 @@ public class DirtyShutdownTest {
             }
 
             for (int i = 0; i < 50; i++) {
-                System.out.println("Storing " + i + " out of 50...");
                 try(final Txn transaction = transact.beginTransaction()) {
 
                     File f = new File("samples/shakespeare/macbeth.xml");

--- a/test/src/org/exist/storage/LargeValuesTest.java
+++ b/test/src/org/exist/storage/LargeValuesTest.java
@@ -46,8 +46,6 @@ public class LargeValuesTest {
     @Test
     public void storeAndRecover() {
         for (int i = 0; i < 1; i++) {
-            System.out.println("-----------------------------------------------------");
-            System.out.println("Run: " + i);
             storeDocuments();
             restart();
             remove();
@@ -91,7 +89,6 @@ public class LargeValuesTest {
             Collection root;
 
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
                 assertNotNull(root);
@@ -118,7 +115,6 @@ public class LargeValuesTest {
             }
 
             transact.getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");
             file.delete();
         } catch (Exception e) {
             e.printStackTrace();
@@ -134,7 +130,6 @@ public class LargeValuesTest {
         BrokerPool pool = null;
         DBBroker broker = null;
         try {
-        	System.out.println("restart() ...\n");
         	pool = startDB();
         	assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -172,7 +167,6 @@ public class LargeValuesTest {
     }
 
     private void remove() {
-        System.out.println("remove() ...\n");
 
         final BrokerPool pool = startDB();
         final TransactionManager transact = pool.getTransactionManager();

--- a/test/src/org/exist/storage/LowLevelText.java
+++ b/test/src/org/exist/storage/LowLevelText.java
@@ -46,7 +46,6 @@ public class LowLevelText extends TestCase {
 		XQuery xquery = broker.getXQueryService();
 		XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
 		preCompiledXQuery = xquery.compile(context, stringSource);
-		System.out.println("pre-compiled XQuery: " + preCompiledXQuery);
 	}
 
 //	protected void tearDown() {
@@ -102,7 +101,6 @@ public class LowLevelText extends TestCase {
 		CompiledXQuery compiledXQuery = null;
 		try {
 			compiledXQuery = pool.borrowCompiledXQuery(broker, stringSourceArg);
-			System.out.println("compiledXQuery: " + compiledXQuery);
 		} catch (PermissionDeniedException e) {
 			e.printStackTrace();
 		}

--- a/test/src/org/exist/storage/MoveCollectionTest.java
+++ b/test/src/org/exist/storage/MoveCollectionTest.java
@@ -56,8 +56,6 @@ public class MoveCollectionTest extends TestCase {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
 
-            System.out.println("Transaction started ...");
-
             Collection root = broker.getOrCreateCollection(transaction,	TestConstants.TEST_COLLECTION_URI);
             assertNotNull(root);
             broker.saveCollection(transaction, root);
@@ -80,8 +78,7 @@ public class MoveCollectionTest extends TestCase {
             broker.moveCollection(transaction, test, dest, XmldbURI.create("test3"));
 
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
-	    } catch (Exception e) {            
+        } catch (Exception e) {
 	        fail(e.getMessage());              
         }
     }
@@ -91,7 +88,6 @@ public class MoveCollectionTest extends TestCase {
         BrokerPool pool = null;
         DBBroker broker = null;
         try {
-        	System.out.println("testRead() ...\n");
         	pool = startDB();
         	assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -103,7 +99,6 @@ public class MoveCollectionTest extends TestCase {
             assertNotNull("Document should not be null", doc);
             String data = serializer.serialize(doc);
             assertNotNull(data);
-            System.out.println(data);
             doc.getUpdateLock().release(Lock.READ_LOCK);
 	    } catch (Exception e) {            
 	        fail(e.getMessage());              
@@ -123,8 +118,6 @@ public class MoveCollectionTest extends TestCase {
 
             try(final Txn transaction = transact.beginTransaction()) {
 
-                System.out.println("Transaction started ...");
-
                 Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
                 assertNotNull(root);
                 broker.saveCollection(transaction, root);
@@ -142,13 +135,11 @@ public class MoveCollectionTest extends TestCase {
                 test2.store(transaction, broker, info, new InputSource(f.toURI().toASCIIString()), false);
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
             
             final Txn transaction = transact.beginTransaction();
             assertNotNull(transaction);
-            System.out.println("Transaction started ...");
-            
+
             Collection dest = broker.getOrCreateCollection(transaction, TestConstants.DESTINATION_COLLECTION_URI2);
             assertNotNull(dest);
             broker.saveCollection(transaction, dest);            
@@ -156,8 +147,7 @@ public class MoveCollectionTest extends TestCase {
 
 //          Don't commit...
             pool.getTransactionManager().getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");
-	    } catch (Exception e) {            
+	    } catch (Exception e) {
 	        fail(e.getMessage());  
         }
     }
@@ -167,7 +157,6 @@ public class MoveCollectionTest extends TestCase {
         BrokerPool pool = null;
         DBBroker broker = null;
         try {
-        	System.out.println("testRead() ...\n");
         	pool = startDB();
         	assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -236,8 +225,7 @@ public class MoveCollectionTest extends TestCase {
         	Resource res = test.getResource("test_xmldb.xml");
         	assertNotNull(res);
         	assertNotNull("Document should not be null", res);        	
-        	System.out.println(res.getContent());
-	    } catch (Exception e) {            
+	    } catch (Exception e) {
 	        fail(e.getMessage());  	  
 	    }        	
     }

--- a/test/src/org/exist/storage/MoveResourceTest.java
+++ b/test/src/org/exist/storage/MoveResourceTest.java
@@ -66,8 +66,6 @@ public class MoveResourceTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
 
-            System.out.println("Transaction started ...");
-
             final Collection test = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(test);
             broker.saveCollection(transaction, test);
@@ -84,19 +82,16 @@ public class MoveResourceTest {
             assertNotNull(info);
             test2.store(transaction, broker, info, new InputSource(f.toURI().toASCIIString()), false);
 
-            System.out.println("Moving document /db/test2/test.xml to /db/test/new_test.xml ...");
             final DocumentImpl doc = test2.getDocument(broker, TestConstants.TEST_XML_URI);
             assertNotNull(doc);
             broker.moveResource(transaction, doc, test, XmldbURI.create("new_test.xml"));
             broker.saveCollection(transaction, test);
 
             transact.commit(transaction);
-            System.out.println("Transaction committed ...");
         }
     }
 
     private void doRead() throws EXistException, PermissionDeniedException, SAXException, IOException {
-        System.out.println("testRead() ...\n");
 
         BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();
@@ -113,7 +108,6 @@ public class MoveResourceTest {
 
             final TransactionManager transact = pool.getTransactionManager();
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
                 assertNotNull(root);
@@ -121,7 +115,6 @@ public class MoveResourceTest {
                 broker.removeCollection(transaction, root);
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
         }
     }
@@ -142,8 +135,6 @@ public class MoveResourceTest {
 
             try(final Txn transaction = transact.beginTransaction()) {
 
-                System.out.println("Transaction started ...");
-
                 final Collection test2 = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI2);
                 assertNotNull(test2);
                 broker.saveCollection(transaction, test2);
@@ -162,7 +153,6 @@ public class MoveResourceTest {
 
             final Txn transaction = transact.beginTransaction();
 
-            System.out.println("Moving document /db/test2/new_test2.xml to /db/test/new_test2.xml ...");
             final Collection test2 = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI2);
             final DocumentImpl doc = test2.getDocument(broker, XmldbURI.create("new_test2.xml"));
             assertNotNull(doc);
@@ -178,7 +168,6 @@ public class MoveResourceTest {
     }
 
     private void readAborted() throws EXistException, PermissionDeniedException, SAXException, IOException {
-        System.out.println("testRead() ...\n");
 
         BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();
@@ -191,13 +180,11 @@ public class MoveResourceTest {
             assertNotNull("Document should not be null", doc);
             final String data = serializer.serialize(doc);
             assertNotNull(data);
-//	        System.out.println(data);
+
             doc.getUpdateLock().release(Lock.READ_LOCK);
 
             final TransactionManager transact = pool.getTransactionManager();
             try(final Txn transaction = transact.beginTransaction()) {
-
-                System.out.println("Transaction started ...");
 
                 final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
                 assertNotNull(root);
@@ -205,7 +192,6 @@ public class MoveResourceTest {
                 broker.removeCollection(transaction, root);
 
                 transact.commit(transaction);
-                System.out.println("Transaction committed ...");
             }
         }
     }

--- a/test/src/org/exist/storage/RangeIndexUpdateTest.java
+++ b/test/src/org/exist/storage/RangeIndexUpdateTest.java
@@ -164,7 +164,6 @@ public class RangeIndexUpdateTest {
         int found = 0;
         for (int i = 0; i < occurrences.length; i++) {
             ValueOccurrences occurrence = occurrences[i];
-            System.out.println("Found: " + occurrence.getValue());
             if (occurrence.getValue().compareTo(term) == 0)
                 found++;
         }
@@ -183,7 +182,6 @@ public class RangeIndexUpdateTest {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final Txn transaction = transact.beginTransaction()) {
-            System.out.println("Transaction started ...");
 
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(root);
@@ -218,7 +216,6 @@ public class RangeIndexUpdateTest {
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
-            System.out.println("Transaction started ...");
 
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(root);

--- a/test/src/org/exist/storage/RecoverBinaryTest.java
+++ b/test/src/org/exist/storage/RecoverBinaryTest.java
@@ -57,16 +57,13 @@ public class RecoverBinaryTest {
     }
 
     private void store() {
-        System.out.println("store() ...\n");
-
     	BrokerPool.FORCE_CORRUPTION = true;
 
         final TransactionManager transact = pool.getTransactionManager();
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
-            System.out.println("Transaction started ...");
-            
+
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(root);
             broker.saveCollection(transaction, root);
@@ -86,8 +83,6 @@ public class RecoverBinaryTest {
             assertNotNull(doc);
             
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
-            
             // the following transaction will not be committed. It will thus be rolled back by recovery
 //            transaction = transact.beginTransaction();
 //            root.removeBinaryResource(transaction, broker, doc);
@@ -103,7 +98,6 @@ public class RecoverBinaryTest {
         BrokerPool.FORCE_CORRUPTION = false;
         DBBroker broker = null;
         try {
-        	System.out.println("load() ...\n");
         	assertNotNull(pool);
         	broker = pool.get(pool.getSecurityManager().getSystemSubject());
         	assertNotNull(broker);
@@ -115,7 +109,6 @@ public class RecoverBinaryTest {
             is.close();
             String data = new String(bdata);
             assertNotNull(data);
-            //System.out.println(data);
 		} catch (Exception e) {            
 	        fail(e.getMessage());
 	    } finally {

--- a/test/src/org/exist/storage/RecoverBinaryTest2.java
+++ b/test/src/org/exist/storage/RecoverBinaryTest2.java
@@ -68,8 +68,6 @@ public class RecoverBinaryTest2 {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
 
-            System.out.println("Transaction started ...");
-            
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(root);
             broker.saveCollection(transaction, root);
@@ -80,7 +78,6 @@ public class RecoverBinaryTest2 {
             
             storeFiles(broker, transaction, test2);
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());             
@@ -89,7 +86,6 @@ public class RecoverBinaryTest2 {
 
     //@Test
     public void read() {
-        System.out.println("testRead2() ...\n");
 
         BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();
@@ -98,7 +94,6 @@ public class RecoverBinaryTest2 {
             Collection test2 = broker.getCollection(TestConstants.TEST_COLLECTION_URI2);
             for (Iterator<DocumentImpl> i = test2.iterator(broker); i.hasNext(); ) {
                 DocumentImpl doc = i.next();
-                System.out.println(doc.getURI().toString());
             }
             
             BrokerPool.FORCE_CORRUPTION = true;
@@ -106,11 +101,9 @@ public class RecoverBinaryTest2 {
             assertNotNull(transact);
             try(final Txn transaction = transact.beginTransaction()) {
                 assertNotNull(transaction);
-                System.out.println("Transaction started ...");
 
                 storeFiles(broker, transaction, test2);
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
             
         } catch (Exception e) {
@@ -121,7 +114,6 @@ public class RecoverBinaryTest2 {
 
     //@Test
     public void read2() {
-        System.out.println("testRead2() ...\n");
 
         BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();
@@ -131,18 +123,15 @@ public class RecoverBinaryTest2 {
             Collection test2 = broker.getCollection(TestConstants.TEST_COLLECTION_URI2);
             for (Iterator<DocumentImpl> i = test2.iterator(broker); i.hasNext(); ) {
                 DocumentImpl doc = i.next();
-                System.out.println(doc.getURI().toString());
             }
             
             final TransactionManager transact = pool.getTransactionManager();
             assertNotNull(transact);
             try(final Txn transaction = transact.beginTransaction()) {
                 assertNotNull(transaction);
-                System.out.println("Transaction started ...");
                 Collection test1 = broker.getCollection(TestConstants.TEST_COLLECTION_URI);
                 broker.removeCollection(transaction, test1);
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/test/src/org/exist/storage/RecoveryTest.java
+++ b/test/src/org/exist/storage/RecoveryTest.java
@@ -94,7 +94,6 @@ public class RecoveryTest {
             BinaryDocument doc;
 
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
                 assertNotNull(root);
@@ -148,20 +147,17 @@ public class RecoveryTest {
                 test2.removeXMLResource(transaction, broker, XmldbURI.create(files[files.length - 1].getName()));
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
 
             // the following transaction will not be committed. It will thus be rolled back by recovery
             final Txn transaction = transact.beginTransaction();
-            System.out.println("Transaction started ...");
-            
+
             test2.removeXMLResource(transaction, broker, XmldbURI.create(files[0].getName()));            
             test2.removeBinaryResource(transaction, broker, doc);
             
 //          Don't commit...            
             transact.getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");
-            
+
             //DOMFile domDb = ((NativeBroker)broker).getDOMFile();
             //assertNotNull(domDb);
             //Writer writer = new StringWriter();
@@ -174,7 +170,6 @@ public class RecoveryTest {
     }
 
     private void read() {
-        System.out.println("testRead() ...\n");
 
         BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();
@@ -188,14 +183,12 @@ public class RecoveryTest {
             assertNotNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/hamlet.xml' should not be null", doc);
             String data = serializer.serialize(doc);
             assertNotNull(data);
-            //System.out.println(data);
             doc.getUpdateLock().release(Lock.READ_LOCK);
             
             doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test/test2/test_string.xml"), Lock.READ_LOCK);
             assertNotNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/test_string.xml' should not be null", doc);
             data = serializer.serialize(doc);
             assertNotNull(data);
-            //System.out.println(data);
             doc.getUpdateLock().release(Lock.READ_LOCK);
             
             File files[] = dir.listFiles();
@@ -208,11 +201,9 @@ public class RecoveryTest {
             assertNotNull(xquery);
             Sequence seq = xquery.execute("//SPEECH[ft:query(LINE, 'king')]", null, AccessContext.TEST);
             assertNotNull(seq);
-            System.out.println("Found: " + seq.getItemCount());
             for (SequenceIterator i = seq.iterate(); i.hasNext(); ) {
                 Item next = i.nextItem();
                 String value = serializer.serialize((NodeValue) next);
-                //System.out.println(value);
             }
             
             BinaryDocument binDoc = (BinaryDocument) broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(TestConstants.TEST_BINARY_URI), Lock.READ_LOCK);
@@ -222,19 +213,15 @@ public class RecoveryTest {
                 is.read(bdata);
                 data = new String(bdata);
                 assertNotNull(data);
-                System.out.println(data);
             }
             
             DOMFile domDb = ((NativeBroker)broker).getDOMFile();
             assertNotNull(domDb);
             Writer writer = new StringWriter();
             domDb.dump(writer);
-            //System.out.println(writer.toString());
             
             final TransactionManager transact = pool.getTransactionManager();
             try(final Txn transaction = transact.beginTransaction()) {
-
-                System.out.println("Transaction started ...");
 
                 Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
                 assertNotNull(root);
@@ -242,7 +229,6 @@ public class RecoveryTest {
                 broker.removeCollection(transaction, root);
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
 	    } catch (Exception e) {
 	        fail(e.getMessage());

--- a/test/src/org/exist/storage/RecoveryTest2.java
+++ b/test/src/org/exist/storage/RecoveryTest2.java
@@ -71,8 +71,6 @@ public class RecoveryTest2 extends TestCase {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction();) {
 
-            System.out.println("Transaction started ...");
-            
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(root); 
             broker.saveCollection(transaction, root);
@@ -80,14 +78,12 @@ public class RecoveryTest2 extends TestCase {
             Collection test2 = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI2);
             assertNotNull(test2); 
             broker.saveCollection(transaction, test2);
-            
-            System.out.println("Contents of dom.dbx:\n\n");
+
             DOMFile domDb = ((NativeBroker)broker).getDOMFile();
             assertNotNull(domDb); 
             Writer writer = new StringWriter();
             domDb.dump(writer);
-            System.out.println(writer.toString());
-            
+
             File f;
             IndexInfo info;
             
@@ -105,8 +101,7 @@ public class RecoveryTest2 extends TestCase {
             }
             
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
-            
+
 	    } catch (Exception e) {            
 	        fail(e.getMessage());          
         }
@@ -117,7 +112,6 @@ public class RecoveryTest2 extends TestCase {
         BrokerPool pool = null;
         DBBroker broker = null;
         try {
-        	System.out.println("testRead() ...\n");
         	pool = startDB();
         	assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -129,7 +123,6 @@ public class RecoveryTest2 extends TestCase {
             assertNotNull("Document should not be null", doc);
             String data = serializer.serialize(doc);
             assertNotNull(data);
-            System.out.println(data);
             doc.getUpdateLock().release(Lock.READ_LOCK);
 	    } catch (Exception e) {            
 	        fail(e.getMessage()); 

--- a/test/src/org/exist/storage/RecoveryTest3.java
+++ b/test/src/org/exist/storage/RecoveryTest3.java
@@ -68,8 +68,6 @@ public class RecoveryTest3 extends TestCase {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
 
-            System.out.println("Transaction started ...");
-
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(root);
             broker.saveCollection(transaction, root);
@@ -99,7 +97,6 @@ public class RecoveryTest3 extends TestCase {
             }
 
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
 	    } catch (Exception e) {
             e.printStackTrace();
 	        fail(e.getMessage());             
@@ -107,7 +104,6 @@ public class RecoveryTest3 extends TestCase {
     }
     
     public void testRead() {
-        System.out.println("testRead() ...\n");
 
     	BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();
@@ -119,7 +115,6 @@ public class RecoveryTest3 extends TestCase {
             Collection root;
 
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
                 assertNotNull(root);
@@ -127,11 +122,9 @@ public class RecoveryTest3 extends TestCase {
                 broker.removeCollection(transaction, root);
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
             
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
                 assertNotNull(root);
@@ -161,7 +154,6 @@ public class RecoveryTest3 extends TestCase {
                 }
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
 	    } catch (Exception e) {
             e.printStackTrace();
@@ -174,7 +166,6 @@ public class RecoveryTest3 extends TestCase {
         BrokerPool pool = null;
         DBBroker broker = null;
         try {
-        	System.out.println("testRead2() ...\n");
         	pool = startDB();
         	assertNotNull(pool);        
             broker = pool.get(pool.getSecurityManager().getSystemSubject());

--- a/test/src/org/exist/storage/ReindexTest.java
+++ b/test/src/org/exist/storage/ReindexTest.java
@@ -56,7 +56,6 @@ public class ReindexTest {
 
             try(final Txn transaction = transact.beginTransaction()) {
                 assertNotNull(transaction);
-                System.out.println("Transaction started ...");
 
                 Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
                 assertNotNull(root);
@@ -86,7 +85,6 @@ public class ReindexTest {
             broker.reindexCollection(TestConstants.TEST_COLLECTION_URI);
 
             transact.getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -106,15 +104,12 @@ public class ReindexTest {
 
             BrokerPool.FORCE_CORRUPTION = true;
 
-            System.out.println("Transaction started ...");
-
             Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
             assertNotNull(root);
             transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
             broker.removeCollection(transaction, root);
             transact.getJournal().flushToLog(true);
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -129,7 +124,6 @@ public class ReindexTest {
         BrokerPool pool = null;
         DBBroker broker = null;
         try {
-        	System.out.println("testRead2() ...\n");
         	pool = startDB();
         	assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());

--- a/test/src/org/exist/storage/RemoveCollectionTest.java
+++ b/test/src/org/exist/storage/RemoveCollectionTest.java
@@ -93,13 +93,9 @@ public class RemoveCollectionTest {
             final Collection test = storeDocs(broker, transact);
 
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
-
-                System.out.println("Removing collection ...");
                 broker.removeCollection(transaction, test);
 
                 transact.commit(transaction);
-                System.out.println("Transaction interrupted ...");
             }
 	    } catch (Exception e) {  
 	    	e.printStackTrace();
@@ -119,17 +115,13 @@ public class RemoveCollectionTest {
             final Collection test = storeDocs(broker, transact);
 
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
-                System.out.println("Removing documents one by one ...");
                 for (Iterator<DocumentImpl> i = test.iterator(broker); i.hasNext(); ) {
                     DocumentImpl doc = i.next();
                     broker.removeXMLResource(transaction, doc);
                 }
                 broker.saveCollection(transaction, test);
                 transact.commit(transaction);
-
-                System.out.println("Transaction committed ...");
             }
 	    } catch (Exception e) {
 	        fail(e.getMessage());
@@ -147,11 +139,8 @@ public class RemoveCollectionTest {
             final Collection test = storeDocs(broker, transact);
 
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
-                System.out.println("Replacing resources ...");
                 TestDataGenerator generator = new TestDataGenerator("xdb", COUNT);
-                System.out.println("Generating " + COUNT + " files...");
                 File[] files = generator.generate(broker, test, generateXQ);
 
                 int j = 0;
@@ -165,7 +154,6 @@ public class RemoveCollectionTest {
                 }
                 generator.releaseAll();
                 transact.commit(transaction);
-                System.out.println("Transaction committed ...");
             }
 	    } catch (Exception e) {
             e.printStackTrace();
@@ -180,8 +168,6 @@ public class RemoveCollectionTest {
 
         try(final Txn transaction = transact.beginTransaction()) {
 
-            System.out.println("Transaction started ...");
-
             test = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             assertNotNull(test);
             broker.saveCollection(transaction, test);
@@ -195,12 +181,10 @@ public class RemoveCollectionTest {
             assertNotNull(info);
             test.store(transaction, broker, info, is, false);
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         }
 
         try(final Txn transaction = transact.beginTransaction()) {
             TestDataGenerator generator = new TestDataGenerator("xdb", COUNT);
-            System.out.println("Generating " + COUNT + " files...");
             File[] files = generator.generate(broker, test, generateXQ);
             for (int i = 0; i < files.length; i++) {
                 File file = files[i];
@@ -212,7 +196,6 @@ public class RemoveCollectionTest {
             }
             generator.releaseAll();
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         }
         return test;
     }
@@ -224,7 +207,6 @@ public class RemoveCollectionTest {
         assertNotNull(pool);
         DocumentImpl doc = null;
         try {
-        	System.out.println("testRead() ...\n");
         	assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
             if (checkResource) {

--- a/test/src/org/exist/storage/RemoveTest.java
+++ b/test/src/org/exist/storage/RemoveTest.java
@@ -59,8 +59,6 @@ public class RemoveTest extends AbstractUpdateTest {
             
             try(final Txn transaction = mgr.beginTransaction()) {
 
-                System.out.println("Transaction started ...");
-
                 // append some new element to records
                 for (int i = 1; i <= 50; i++) {
                     final String xupdate =
@@ -83,7 +81,6 @@ public class RemoveTest extends AbstractUpdateTest {
                 }
 
                 mgr.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
             
             Serializer serializer = broker.getSerializer();
@@ -92,13 +89,11 @@ public class RemoveTest extends AbstractUpdateTest {
             DocumentImpl doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(TestConstants.TEST_XML_URI), Lock.READ_LOCK);
             assertNotNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/test.xml' should not be null", doc);
             String data = serializer.serialize(doc);
-            System.out.println(data);
             doc.getUpdateLock().release(Lock.READ_LOCK);
             
             // the following transaction will not be committed and thus undone during recovery
             final Txn transaction = mgr.beginTransaction();
-            System.out.println("Transaction started ...");
-            
+
             // remove elements
             for (int i = 1; i <= 25; i++) {
                 final String xupdate =
@@ -115,8 +110,7 @@ public class RemoveTest extends AbstractUpdateTest {
             
 //          Don't commit...            
             pool.getTransactionManager().getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");
-	    } catch (Exception e) {            
+	    } catch (Exception e) {
 	        fail(e.getMessage());  
 	    }
     }

--- a/test/src/org/exist/storage/RenameTest.java
+++ b/test/src/org/exist/storage/RenameTest.java
@@ -54,7 +54,6 @@ public class RenameTest extends AbstractUpdateTest {
             assertNotNull(proc);
             
             try(final Txn transaction = mgr.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 // append some new element to records
                 for (int i = 1; i <= 200; i++) {
@@ -79,16 +78,14 @@ public class RenameTest extends AbstractUpdateTest {
 
                 DOMFile domDb = ((NativeBroker) broker).getDOMFile();
                 assertNotNull(domDb);
-                System.out.println(domDb.debugPages(info.getDocument(), false));
+                domDb.debugPages(info.getDocument(), false);
 
                 mgr.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
             
             // the following transaction will not be committed and thus undone during recovery
             final Txn transaction = mgr.beginTransaction();
-            System.out.println("Transaction started ...");
-            
+
             // rename elements
             final String xupdate =
                 "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
@@ -103,7 +100,6 @@ public class RenameTest extends AbstractUpdateTest {
             
 //          Don't commit...            
             pool.getTransactionManager().getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");
 	    } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/test/src/org/exist/storage/ReplaceTest.java
+++ b/test/src/org/exist/storage/ReplaceTest.java
@@ -54,7 +54,6 @@ public class ReplaceTest extends AbstractUpdateTest {
             assertNotNull(proc);
             
             try(final Txn transaction = mgr.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 String xupdate =
                         "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
@@ -96,16 +95,13 @@ public class ReplaceTest extends AbstractUpdateTest {
 
                 DOMFile domDb = ((NativeBroker) broker).getDOMFile();
                 assertNotNull(domDb);
-                System.out.println(domDb.debugPages(info.getDocument(), false));
+                domDb.debugPages(info.getDocument(), false);
 
                 mgr.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
             
             // the following transaction will not be committed and thus undone during recovery
             final Txn transaction = mgr.beginTransaction();
-            System.out.println("Transaction started...");   
-            
             // replace elements
             for (int i = 1; i <= 100; i++) {
                 final String xupdate =
@@ -127,8 +123,7 @@ public class ReplaceTest extends AbstractUpdateTest {
             
 //          Don't commit...              
             pool.getTransactionManager().getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");
-	    } catch (Exception e) {            
+	    } catch (Exception e) {
 	        fail(e.getMessage());             
         }
     }

--- a/test/src/org/exist/storage/ResourceTest.java
+++ b/test/src/org/exist/storage/ResourceTest.java
@@ -79,8 +79,7 @@ public class ResourceTest {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
-            System.out.println("Transaction started ...");
-            
+
             Collection collection = broker
                     .getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             
@@ -92,14 +91,12 @@ public class ResourceTest {
                     DOCUMENT_NAME_URI , EMPTY_BINARY_FILE.getBytes(), "text/text");
             
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         } catch (Exception e) {
             fail(e.getMessage());
         }
     }
 
     private void read() {
-        System.out.println("testRead() ...\n");
 
         BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();
@@ -110,8 +107,6 @@ public class ResourceTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction();) {
 
-            System.out.println("Transaction started ...");
-            
             XmldbURI docPath = TestConstants.TEST_COLLECTION_URI.append(DOCUMENT_NAME_URI);
             
             BinaryDocument binDoc = (BinaryDocument) broker
@@ -134,7 +129,6 @@ public class ResourceTest {
             broker.saveCollection(transaction, collection);
             
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         } catch (Exception ex){
             fail("Error opening document" + ex);
             
@@ -150,7 +144,6 @@ public class ResourceTest {
 
     @Test
     public void removeCollection() {
-        System.out.println("testRemoveCollection() ...\n");
 
         BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();
@@ -161,8 +154,6 @@ public class ResourceTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
 
-            System.out.println("Transaction started ...");
-            
             XmldbURI docPath = TestConstants.TEST_COLLECTION_URI.append(DOCUMENT_NAME_URI);
             
             BinaryDocument binDoc = (BinaryDocument) broker
@@ -183,7 +174,6 @@ public class ResourceTest {
             broker.removeCollection(transaction, collection);
             
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         } catch (Exception ex){
             fail("Error opening document" + ex);
             

--- a/test/src/org/exist/storage/ShutdownTest.java
+++ b/test/src/org/exist/storage/ShutdownTest.java
@@ -35,8 +35,6 @@ public class ShutdownTest {
 	public void shutdown() {
 		for (int i = 0; i < 2; i++) {
 			storeAndShutdown();
-			
-			System.out.println("-----------------------------------------------------");
 		}
 	}
 	
@@ -48,8 +46,6 @@ public class ShutdownTest {
             Collection test;
 
             try(final Txn transaction = transact.beginTransaction()) {
-
-                System.out.println("Transaction started ...");
 
                 test = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
                 assertNotNull(test);
@@ -87,16 +83,13 @@ public class ShutdownTest {
                 assertEquals(result.getItemCount(), 160);
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
 
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 broker.removeCollection(transaction, test);
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
         } catch (Exception e) {            
             fail(e.getMessage()); 
@@ -104,7 +97,6 @@ public class ShutdownTest {
 		
 		// shut down the database
         shutdownDB();
-        System.out.println("Database stopped.");
         
         // try to remove the database files
 //        try {
@@ -117,7 +109,6 @@ public class ShutdownTest {
 //	        	}
 //	        });
 //	        for (int i = 0; i < files.length; i++) {
-//	        	System.out.println("Removing " + files[i].getAbsolutePath());
 //	    		files[i].delete();;
 //	        }
 //        } catch (Exception e) {

--- a/test/src/org/exist/storage/UpdateAttributeTest.java
+++ b/test/src/org/exist/storage/UpdateAttributeTest.java
@@ -55,8 +55,6 @@ public class UpdateAttributeTest extends AbstractUpdateTest {
             
             try(final Txn transaction = mgr.beginTransaction()) {
 
-                System.out.println("Transaction started ...");
-
                 // append some new element to records
                 for (int i = 1; i <= 200; i++) {
                     final String xupdate =
@@ -79,14 +77,12 @@ public class UpdateAttributeTest extends AbstractUpdateTest {
                 }
 
                 mgr.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
 
             // the following transaction will not be committed and thus undone during recovery
             final Txn transaction = mgr.beginTransaction();
             assertNotNull(transaction);
-            System.out.println("Transaction started ...");
-            
+
             // update attributes
             for (int i = 1; i <= 200; i++) {
                 final String xupdate =
@@ -103,8 +99,7 @@ public class UpdateAttributeTest extends AbstractUpdateTest {
            
             //Don't commit
             pool.getTransactionManager().getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");    
-        } catch (Exception e) {            
+        } catch (Exception e) {
             fail(e.getMessage());             
         }
     }

--- a/test/src/org/exist/storage/UpdateRecoverTest.java
+++ b/test/src/org/exist/storage/UpdateRecoverTest.java
@@ -91,8 +91,6 @@ public class UpdateRecoverTest {
 
             try(final Txn transaction = transact.beginTransaction()) {
 
-                System.out.println("Transaction started ...");
-
                 Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
                 assertNotNull(root);
                 broker.saveCollection(transaction, root);
@@ -108,11 +106,9 @@ public class UpdateRecoverTest {
                 test2.store(transaction, broker, info, TEST_XML, false);
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
             
             try(final Txn transaction = transact.beginTransaction()) {
-                System.out.println("Transaction started ...");
 
                 MutableDocumentSet docs = new DefaultDocumentSet();
                 docs.add(info.getDocument());
@@ -122,7 +118,6 @@ public class UpdateRecoverTest {
                 String xupdate;
                 Modification modifications[];
 
-                System.out.println("Inserting new items  ...");
                 // insert some nodes
                 for (int i = 1; i <= 200; i++) {
                     xupdate =
@@ -143,7 +138,6 @@ public class UpdateRecoverTest {
                     proc.reset();
                 }
 
-                System.out.println("Adding attributes  ...");
                 // add attribute
                 for (int i = 1; i <= 200; i++) {
                     xupdate =
@@ -160,7 +154,6 @@ public class UpdateRecoverTest {
                     proc.reset();
                 }
 
-                System.out.println("Replacing elements  ...");
                 // replace some
                 for (int i = 1; i <= 100; i++) {
                     xupdate =
@@ -177,11 +170,9 @@ public class UpdateRecoverTest {
                     modifications = proc.parse(new InputSource(new StringReader(xupdate)));
                     assertNotNull(modifications);
                     long mods = modifications[0].process(transaction);
-                    System.out.println("Modifications: " + mods);
                     proc.reset();
                 }
 
-                System.out.println("Removing some elements ...");
                 // remove some
                 for (int i = 1; i <= 100; i++) {
                     xupdate =
@@ -196,7 +187,6 @@ public class UpdateRecoverTest {
                     proc.reset();
                 }
 
-                System.out.println("Appending some elements ...");
                 for (int i = 1; i <= 100; i++) {
                     xupdate =
                             "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
@@ -217,7 +207,6 @@ public class UpdateRecoverTest {
                     proc.reset();
                 }
 
-                System.out.println("Renaming elements  ...");
                 // rename element "description" to "descript"
                 xupdate =
                         "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
@@ -230,7 +219,6 @@ public class UpdateRecoverTest {
                 modifications[0].process(transaction);
                 proc.reset();
 
-                System.out.println("Updating attribute values ...");
                 // update attribute values
                 for (int i = 1; i <= 200; i++) {
                     xupdate =
@@ -242,10 +230,9 @@ public class UpdateRecoverTest {
                     modifications = proc.parse(new InputSource(new StringReader(xupdate)));
                     assertNotNull(modifications);
                     long mods = modifications[0].process(transaction);
-                    System.out.println(mods + " records modified.");
                     proc.reset();
                 }
-                System.out.println("Append new element to each item ...");
+
                 // append new element to records
                 for (int i = 1; i <= 200; i++) {
                     xupdate =
@@ -262,7 +249,6 @@ public class UpdateRecoverTest {
                     proc.reset();
                 }
 
-                System.out.println("Updating element content ...");
                 // update element content
                 for (int i = 1; i <= 200; i++) {
                     xupdate =
@@ -274,12 +260,10 @@ public class UpdateRecoverTest {
                     modifications = proc.parse(new InputSource(new StringReader(xupdate)));
                     assertNotNull(modifications);
                     long mods = modifications[0].process(transaction);
-                    System.out.println(mods + " records modified.");
                     proc.reset();
                 }
 
                 transact.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
         } catch (Exception e) {
         	fail(e.getMessage());  
@@ -291,7 +275,6 @@ public class UpdateRecoverTest {
         BrokerPool pool = null;
         DBBroker broker = null;
         try {
-	        System.out.println("testRead() ...\n");
 	        pool = startDB();
 	        assertNotNull(pool);
        	    broker = pool.get(pool.getSecurityManager().getSystemSubject());
@@ -304,7 +287,6 @@ public class UpdateRecoverTest {
             assertNotNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/test.xml' should not be null", doc);
             String data = serializer.serialize(doc);
             assertNotNull(data);
-            System.out.println(data);
             doc.getUpdateLock().release(Lock.READ_LOCK);
         } catch (Exception e) {            
         	fail(e.getMessage());                    
@@ -342,8 +324,7 @@ public class UpdateRecoverTest {
         	assertNotNull(service);
         
         	String xupdate;
-        
-	        System.out.println("Inserting new items  ...");
+
 	        // insert some nodes
 	        for (int i = 1; i <= 200; i++) {
 	            xupdate =
@@ -358,8 +339,7 @@ public class UpdateRecoverTest {
 	                "</xu:modifications>";
 	            service.updateResource("test_xmldb.xml", xupdate);
 	        }
-	        
-	        System.out.println("Adding attributes  ...");
+
 	        // add attribute
 	        for (int i = 1; i <= 200; i++) {
 	          xupdate =
@@ -370,8 +350,7 @@ public class UpdateRecoverTest {
 	              "</xu:modifications>";
 	          service.updateResource("test_xmldb.xml", xupdate);
 	      }
-	        
-	        System.out.println("Replacing elements  ...");
+
 	        // replace some
 	        for (int i = 1; i <= 100; i++) {
 	          xupdate =
@@ -385,8 +364,7 @@ public class UpdateRecoverTest {
 	              "</xu:modifications>";
 	          service.updateResource("test_xmldb.xml", xupdate);
 	      }
-	            
-	        System.out.println("Removing some elements ...");
+
 	        // remove some
 	        for (int i = 1; i <= 100; i++) {
 	            xupdate =
@@ -395,8 +373,7 @@ public class UpdateRecoverTest {
 	                "</xu:modifications>";
 	            service.updateResource("test_xmldb.xml", xupdate);
 	        }
-	        
-	        System.out.println("Appending some elements ...");
+
 	        for (int i = 1; i <= 100; i++) {
 	            xupdate =
 	                "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
@@ -411,16 +388,14 @@ public class UpdateRecoverTest {
 	                "</xu:modifications>";
 	            service.updateResource("test_xmldb.xml", xupdate);
 	        }
-	        
-	        System.out.println("Renaming elements  ...");
+
 	        // rename element "description" to "descript"
 	        xupdate =
 	            "<xu:modifications version=\"1.0\" xmlns:xu=\"http://www.xmldb.org/xupdate\">" +
 	            "   <xu:rename select=\"/products/product/description\">descript</xu:rename>" +
 	            "</xu:modifications>";
 	        service.updateResource("test_xmldb.xml", xupdate);
-	        
-	        System.out.println("Updating attribute values ...");
+
 	        // update attribute values
 	        for (int i = 1; i <= 200; i++) {
 	            xupdate =
@@ -429,7 +404,7 @@ public class UpdateRecoverTest {
 	                "</xu:modifications>";
 	            service.updateResource("test_xmldb.xml", xupdate);
 	        }
-	        System.out.println("Append new element to each item ...");
+
 	        // append new element to records
 	        for (int i = 1; i <= 200; i++) {
 	            xupdate =
@@ -440,8 +415,7 @@ public class UpdateRecoverTest {
 	                "</xu:modifications>";
 	            service.updateResource("test_xmldb.xml", xupdate);
 	        }
-	        
-	        System.out.println("Updating element content ...");
+
 	        // update element content
 	        for (int i = 1; i <= 200; i++) {
 	            xupdate =
@@ -463,8 +437,6 @@ public class UpdateRecoverTest {
         	assertNotNull(test2);
         	Resource res = test2.getResource("test_xmldb.xml");
 	        assertNotNull("Document should not be null", res);
-	        System.out.println(res.getContent());
-	        
 	        org.xmldb.api.base.Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
 	        assertNotNull(root);
 	        CollectionManagementServiceImpl mgr = (CollectionManagementServiceImpl) 

--- a/test/src/org/exist/storage/UpdateTest.java
+++ b/test/src/org/exist/storage/UpdateTest.java
@@ -55,7 +55,6 @@ public class UpdateTest extends AbstractUpdateTest {
 
             try(final Txn transaction = mgr.beginTransaction()) {
                 assertNotNull(transaction);
-                System.out.println("Transaction started ...");
 
                 // append some new element to records
                 for (int i = 1; i <= 200; i++) {
@@ -79,14 +78,12 @@ public class UpdateTest extends AbstractUpdateTest {
                 }
 
                 mgr.commit(transaction);
-                System.out.println("Transaction commited ...");
             }
 
             // the following transaction will not be committed and thus undone during recovery
             final Txn transaction = mgr.beginTransaction();
             assertNotNull(transaction);
-            System.out.println("Transaction started ...");
-            
+
             // update elements
             for (int i = 1; i <= 200; i++) {
                 final String xupdate =
@@ -103,7 +100,6 @@ public class UpdateTest extends AbstractUpdateTest {
             
             //Don't commit
             pool.getTransactionManager().getJournal().flushToLog(true);
-            System.out.println("Transaction interrupted ...");
 
         } catch (Exception e) {
             fail(e.getMessage());

--- a/test/src/org/exist/storage/ValueIndexFactoryTest.java
+++ b/test/src/org/exist/storage/ValueIndexFactoryTest.java
@@ -25,9 +25,9 @@ public class ValueIndexFactoryTest {
         byte[] data2 = encode(1.0);
         long v2 = ByteConversion.byteToLong(data2, 0);
 
-        // print data
-        print(data1);
-        print(data2);
+//        // print data
+//        print(data1);
+//        print(data2);
 
         // -8.6 < 1.0
         assertTrue("v1= " + v1 + " v2 = " + v2, v1 < v2);
@@ -47,9 +47,9 @@ public class ValueIndexFactoryTest {
         byte[] data2 = encode(-1.0);
         long v2 = ByteConversion.byteToLong(data2, 0);
 
-        // print data
-        print(data1);
-        print(data2);
+//        // print data
+//        print(data1);
+//        print(data2);
 
         // -8.6 < 1.0
         assertTrue("v1= " + v1 + " v2 = " + v2, v1 < v2);
@@ -69,9 +69,9 @@ public class ValueIndexFactoryTest {
         byte[] data2 = encode(1.0);
         long v2 = ByteConversion.byteToLong(data2, 0);
 
-        // print data
-        print(data1);
-        print(data2);
+//        // print data
+//        print(data1);
+//        print(data2);
 
         // -8.6 < 1.0
         assertTrue("v1= " + v1 + " v2 = " + v2, v1 > v2);
@@ -91,9 +91,9 @@ public class ValueIndexFactoryTest {
         byte[] data2 = encode(-1.0);
         long v2 = ByteConversion.byteToLong(data2, 0);
 
-        // print data
-        print(data1);
-        print(data2);
+//        // print data
+//        print(data1);
+//        print(data2);
 
         // -8.6 < 1.0
         assertTrue("v1= " + v1 + " v2 = " + v2, v1 > v2);
@@ -121,10 +121,9 @@ public class ValueIndexFactoryTest {
         return data;
     }
 
-    private static void print(byte[] data) {
-        for (int i = 0; i < data.length; i++) {
-            System.out.print(Byte.toString(data[i]) + " ");
-        }
-        System.out.println();
-    }
+//    private static void print(byte[] data) {
+//        for (int i = 0; i < data.length; i++) {
+//            System.out.print(Byte.toString(data[i]) + " ");
+//        }
+//    }
 }

--- a/test/src/org/exist/storage/XIncludeSerializerTest.java
+++ b/test/src/org/exist/storage/XIncludeSerializerTest.java
@@ -159,9 +159,6 @@ public class XIncludeSerializerTest {
 	    
 	    final String responseXML = out.toString();
 
-        System.out.println("response XML:"+ responseXML);
-        System.out.println("control XML" + XML_RESULT);
-
         final Diff myDiff = new Diff(XML_RESULT, responseXML);
         assertTrue("pieces of XML are similar " + myDiff, myDiff.similar());
         assertTrue("but are they identical? " + myDiff, myDiff.identical());
@@ -183,9 +180,6 @@ public class XIncludeSerializerTest {
  	        out.append("\r\n");
  	    }
  	    final String responseXML = out.toString();
-
-        System.out.println("response XML:"+ responseXML);
-        System.out.println("control XML" + XML_RESULT);
 
         final Diff myDiff = new Diff(XML_RESULT, responseXML);
         assertTrue("pieces of XML are similar " + myDiff, myDiff.similar());
@@ -210,9 +204,6 @@ public class XIncludeSerializerTest {
  	    }
  	    final String responseXML = out.toString();
 
-        System.out.println("response XML:"+ responseXML);
-        System.out.println("control XML" + XML_RESULT);
-
         final Diff myDiff = new Diff(XML_RESULT, responseXML);
         assertTrue("pieces of XML are similar " + myDiff, myDiff.similar());
         assertTrue("but are they identical? " + myDiff, myDiff.identical());
@@ -234,9 +225,6 @@ public class XIncludeSerializerTest {
             out.append("\r\n");
         }
         final String responseXML = out.toString();
-
-        System.out.println("response XML:"+ responseXML);
-        System.out.println("control XML" + XML_RESULT_XPOINTER);
 
         final Diff myDiff = new Diff(XML_RESULT_XPOINTER, responseXML);
         assertTrue("pieces of XML are similar " + myDiff, myDiff.similar());
@@ -260,9 +248,6 @@ public class XIncludeSerializerTest {
         }
         final String responseXML = out.toString();
 
-        System.out.println("response XML:"+ responseXML);
-        System.out.println("control XML" + XML_RESULT_XPOINTER);
-
         final Diff myDiff = new Diff(XML_RESULT_XPOINTER, responseXML);
         assertTrue("pieces of XML are similar " + myDiff, myDiff.similar());
         assertTrue("but are they identical? " + myDiff, myDiff.identical());
@@ -285,9 +270,6 @@ public class XIncludeSerializerTest {
         }
         String responseXML = out.toString();
 
-        System.out.println("response XML:"+ responseXML);
-        System.out.println("control XML" + XML_RESULT_FALLBACK1);
-
         final Diff myDiff = new Diff(XML_RESULT_FALLBACK1, responseXML);
         assertTrue("pieces of XML are similar " + myDiff, myDiff.similar());
         assertTrue("but are they identical? " + myDiff, myDiff.identical());
@@ -309,7 +291,6 @@ public class XIncludeSerializerTest {
             out.append("\r\n");
         }
         final String responseXML = out.toString();
-        System.out.println("response XML:"+ responseXML);
     }
 
     //TODO add full url test e.g. http://www.example.org/test.xml for xinclude
@@ -379,11 +360,9 @@ public class XIncludeSerializerTest {
         //Don't worry about closing the server : the shutdownDB hook will do the job
         if (server == null) {
             server = new JettyStart();
-            System.out.println("Starting standalone server...");
             server.run();
         }
 
-        System.out.println("Creating collection " + XINCLUDE_COLLECTION);
         final XmlRpcClient xmlrpc = getClient();
         final Vector<Object> params = new Vector<Object>();
         params.addElement(XINCLUDE_COLLECTION.toString());
@@ -393,7 +372,6 @@ public class XIncludeSerializerTest {
         params.addElement(XINCLUDE_NESTED_COLLECTION.toString());
         xmlrpc.execute("createCollection", params);
 
-        System.out.println("Loading test document data");
         params.clear();
         params.addElement(XML_DATA1);
         params.addElement("/db/xinclude_test/test_simple.xml");

--- a/test/src/org/exist/storage/btree/BTreeTest.java
+++ b/test/src/org/exist/storage/btree/BTreeTest.java
@@ -36,7 +36,6 @@ public class BTreeTest {
 
     @Test
     public void simpleUpdates() {
-        System.out.println("------------------ testStrings: START -------------------------");
         BTree btree = null;
         try {
             btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file, 0.1);
@@ -48,24 +47,24 @@ public class BTreeTest {
                 btree.addValue(value, i);
             }
 
-            System.out.println("Testing IndexQuery.TRUNC_RIGHT");
+            //Testing IndexQuery.TRUNC_RIGHT
             IndexQuery query = new IndexQuery(IndexQuery.TRUNC_RIGHT, new Value(prefixStr));
             btree.query(query, new StringIndexCallback());
             assertEquals(COUNT, count);
             btree.flush();
 
-            System.out.println("Removing index entries ...");
+            //Removing index entries
             btree.remove(query, new StringIndexCallback());
             assertEquals(COUNT, count);
             btree.flush();
 
-            System.out.println("Readding data ...");
+            //Reading data
             for (int i = 1; i <= COUNT; i++) {
                 Value value = new Value(prefixStr + Integer.toString(i));
                 btree.addValue(value, i);
             }
 
-            System.out.println("Testing IndexQuery.TRUNC_RIGHT");
+            //Testing IndexQuery.TRUNC_RIGHT
             btree.query(query, new StringIndexCallback());
             assertEquals(COUNT, count);
             btree.flush();
@@ -85,12 +84,10 @@ public class BTreeTest {
                 } catch (DBException e) {
                 }
         }
-        System.out.println("------------------ testStrings: END -------------------------");
     }
 
     @Test
     public void strings() {
-        System.out.println("------------------ testStrings: START -------------------------");
         BTree btree = null;
         try {
             btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file, 0.1);
@@ -103,43 +100,41 @@ public class BTreeTest {
             }
 
             btree.flush();
-            System.out.println("BTree size: " + file.length());
 
             StringWriter writer = new StringWriter();
             btree.dump(writer);
-            System.out.println(writer.toString());
-            
+
             for (int i = 1; i <= COUNT; i++) {
                 long p = btree.findValue(new Value(prefixStr + Integer.toString(i)));
                 assertEquals(p, i);
             }
 
-            System.out.println("Testing IndexQuery.TRUNC_RIGHT");
+            //Testing IndexQuery.TRUNC_RIGHT
             IndexQuery query = new IndexQuery(IndexQuery.TRUNC_RIGHT, new Value(prefixStr));
             btree.query(query, new StringIndexCallback());
             assertEquals(COUNT, count);
 
-            System.out.println("Testing IndexQuery.TRUNC_RIGHT");
+            //Testing IndexQuery.TRUNC_RIGHT
             query = new IndexQuery(IndexQuery.TRUNC_RIGHT, new Value(prefixStr + "1"));
             btree.query(query, new StringIndexCallback());
             assertEquals(1111, count);
 
-            System.out.println("Testing IndexQuery.NEQ");
+            //Testing IndexQuery.NEQ
             query = new IndexQuery(IndexQuery.NEQ, new Value(prefixStr + "10"));
             btree.query(query, new StringIndexCallback());
             assertEquals(COUNT - 1, count);
 
-            System.out.println("Testing IndexQuery.GT");
+            //Testing IndexQuery.GT
             query = new IndexQuery(IndexQuery.GT, new Value(prefixStr));
             btree.query(query, new StringIndexCallback());
             assertEquals(COUNT, count);
 
-            System.out.println("Testing IndexQuery.GT");
+            //Testing IndexQuery.GT
             query = new IndexQuery(IndexQuery.GT, new Value(prefixStr + "1"));
             btree.query(query, new StringIndexCallback());
             assertEquals(COUNT - 1, count);
 
-            System.out.println("Testing IndexQuery.LT");
+            //Testing IndexQuery.LT
             query = new IndexQuery(IndexQuery.LT, new Value(prefixStr));
             btree.query(query, new StringIndexCallback());
             assertEquals(count, 0);
@@ -159,13 +154,11 @@ public class BTreeTest {
                 } catch (DBException e) {
                 }
         }
-        System.out.println("------------------ testStrings: END -------------------------");
     }
 
     @Test
     public void longStrings() {
         // Test storage of long keys up to half of the page size (4k)
-        System.out.println("------------------ testLongStrings: START -------------------------");
         Random rand = new Random(System.currentTimeMillis());
 
         BTree btree = null;
@@ -194,11 +187,9 @@ public class BTreeTest {
             }
 
             btree.flush();
-            System.out.println("BTree size: " + (file.length() / 1024));
 
             for (Map.Entry<String, Integer> entry: keys.entrySet()) {
                 long p = btree.findValue(new Value(entry.getKey().toString()));
-                //System.out.println("Checking key " + entry.getKey());
                 assertEquals(p, entry.getValue().intValue());
             }
         } catch (DBException e) {
@@ -214,12 +205,10 @@ public class BTreeTest {
                 } catch (DBException e) {
                 }
         }
-        System.out.println("------------------ testLongStrings: END -------------------------");
     }
 
     @Test
     public void stringsTruncated() {
-        System.out.println("------------------ testStringsTruncated: START -------------------------");
         BTree btree = null;
         try {
             btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file, 0.1);
@@ -236,7 +225,7 @@ public class BTreeTest {
 
             btree.flush();
 
-            System.out.println("Testing IndexQuery.TRUNC_RIGHT");
+            //Testing IndexQuery.TRUNC_RIGHT
             prefix = 'A';
             for (int i = 0; i < 24; i++) {
                 IndexQuery query = new IndexQuery(IndexQuery.TRUNC_RIGHT, new Value(Character.toString(prefix)));
@@ -260,12 +249,10 @@ public class BTreeTest {
                 } catch (DBException e) {
                 }
         }
-        System.out.println("------------------ testStringsTruncated: END -------------------------");
     }
 
     @Test
     public void removeStrings() {
-        System.out.println("------------------ testRemoveStrings: START -------------------------");
         BTree btree = null;
         try {
             btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file, 0.1);
@@ -295,7 +282,7 @@ public class BTreeTest {
                 prefix++;
             }
 
-            System.out.println("Testing IndexQuery.TRUNC_RIGHT");
+            //Testing IndexQuery.TRUNC_RIGHT
             IndexQuery query = new IndexQuery(IndexQuery.TRUNC_RIGHT, new Value(Character.toString('D')));
             btree.query(query, new StringIndexCallback());
             assertEquals(0, count);
@@ -315,12 +302,10 @@ public class BTreeTest {
                 } catch (DBException e) {
                 }
         }
-        System.out.println("------------------ testRemoveStrings: END -------------------------");
     }
 
     @Test
     public void numbers() throws TerminatedException {
-        System.out.println("------------------ testNumbers: START -------------------------");
         try {
             BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file, 0.1);
             btree.create((short) -1);
@@ -336,7 +321,7 @@ public class BTreeTest {
                 assertEquals(p, i);
             }
 
-            System.out.println("Testing IndexQuery.GT");
+            //Testing IndexQuery.GT
             IndexQuery query;
             for (int i = 0; i < COUNT; i += 10) {
                 query = new IndexQuery(IndexQuery.GT, new SimpleValue(new DoubleValue(i)));
@@ -344,12 +329,12 @@ public class BTreeTest {
                 assertEquals(COUNT - i, count);
             }
 
-            System.out.println("Testing IndexQuery.GEQ");
+            //Testing IndexQuery.GEQ
             query = new IndexQuery(IndexQuery.GEQ, new SimpleValue(new DoubleValue(COUNT / 2)));
             btree.query(query, new SimpleCallback());
             assertEquals(COUNT / 2 + 1, count);
 
-            System.out.println("Testing IndexQuery.NEQ");
+            //Testing IndexQuery.NEQ
             for (int i = 1; i <= COUNT / 8; i++) {
                 query = new IndexQuery(IndexQuery.NEQ, new SimpleValue(new DoubleValue(i)));
                 btree.query(query, new SimpleCallback());
@@ -367,12 +352,10 @@ public class BTreeTest {
             e.printStackTrace();
             fail(e.getMessage());
         }
-        System.out.println("------------------ testNumbers: END -------------------------");
     }
 
     @Test
     public void numbersWithPrefix() {
-        System.out.println("------------------ testNumbersWithPrefix: START -------------------------");
         try {
             BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file, 0.1);
             btree.create((short) -1);
@@ -388,7 +371,6 @@ public class BTreeTest {
             }
 
             btree.flush();
-            System.out.println("BTree size: " + file.length());
 
             for (int i = 1; i <= COUNT; i++) {
                 long p = btree.findValue(new PrefixValue(99, new DoubleValue(i)));
@@ -396,34 +378,34 @@ public class BTreeTest {
             }
             Value prefix = new PrefixValue(99);
 
-            System.out.println("Testing IndexQuery.TRUNC_RIGHT");
+            //Testing IndexQuery.TRUNC_RIGHT
             IndexQuery query = new IndexQuery(IndexQuery.TRUNC_RIGHT, new PrefixValue(99));
             btree.query(query, new PrefixIndexCallback());
             assertEquals(COUNT, count);
 
-            System.out.println("Testing IndexQuery.GT");
+            //Testing IndexQuery.GT
             for (int i = 0; i < COUNT; i += 10) {
                 query = new IndexQuery(IndexQuery.GT, new PrefixValue(99, new DoubleValue(i)));
                 btree.query(query, prefix, new PrefixIndexCallback());
                 assertEquals(COUNT - i, count);
             }
 
-            System.out.println("Testing IndexQuery.GEQ");
+            //Testing IndexQuery.GEQ
             query = new IndexQuery(IndexQuery.GEQ, new PrefixValue(99, new DoubleValue(COUNT / 2)));
             btree.query(query, prefix, new PrefixIndexCallback());
             assertEquals(COUNT / 2 + 1, count);
 
-            System.out.println("Testing IndexQuery.LT");
+            //Testing IndexQuery.LT
             query = new IndexQuery(IndexQuery.LT, new PrefixValue(99, new DoubleValue(COUNT / 2)));
             btree.query(query, prefix, new PrefixIndexCallback());
             assertEquals(COUNT / 2 - 1, count);
 
-            System.out.println("Testing IndexQuery.LEQ");
+            //Testing IndexQuery.LEQ
             query = new IndexQuery(IndexQuery.LEQ, new PrefixValue(99, new DoubleValue(COUNT / 2)));
             btree.query(query, prefix, new PrefixIndexCallback());
             assertEquals(COUNT / 2, count);
 
-            System.out.println("Testing IndexQuery.NEQ");
+            //Testing IndexQuery.NEQ
             for (int i = 1; i <= COUNT / 8; i++) {
                 count = 0;
                 query = new IndexQuery(IndexQuery.NEQ, new PrefixValue(99, new DoubleValue(i)));
@@ -445,7 +427,6 @@ public class BTreeTest {
             e.printStackTrace();
             fail(e.getMessage());
         }
-        System.out.println("------------------ testNumbersWithPrefix: END -------------------------");
     }
 
     @Before
@@ -498,7 +479,6 @@ public class BTreeTest {
             int prefix = ByteConversion.byteToInt(value.data(), value.start());
             assertEquals(99, prefix);
 //            XMLString key = UTF8.decode(value.data(), value.start() + 4, value.getLength() - 4);
-//            System.out.println(prefix + " : " + key);
             count++;
             return false;
         }
@@ -513,7 +493,6 @@ public class BTreeTest {
         public boolean indexInfo(Value value, long pointer) throws TerminatedException {
             @SuppressWarnings("unused")
 			XMLString key = UTF8.decode(value.data(), value.start(), value.getLength());
-//            System.out.println("\"" + key + "\": " + count);
             count++;
             return false;
         }

--- a/test/src/org/exist/storage/io/VariableByteStreamTest.java
+++ b/test/src/org/exist/storage/io/VariableByteStreamTest.java
@@ -19,7 +19,6 @@ public class VariableByteStreamTest extends TestCase {
 	}
 
 	protected void setUp() {
-		System.out.println("generating " + (SIZE * 3) + " numbers ...");
 		Random rand = new Random(System.currentTimeMillis()); 
 		for(int i = 0; i < SIZE * 3; i++) {
 			values[i++] = rand.nextInt();
@@ -36,7 +35,6 @@ public class VariableByteStreamTest extends TestCase {
 			os.writeShort((short)values[i]);
 		}
 		byte[] data = os.toByteArray();
-		System.out.println("long data length: " + data.length + "; original: " + (SIZE * 8 + SIZE * 2 + SIZE * 4));
 		
 		VariableByteArrayInput is = new VariableByteArrayInput(data);
 		long l;
@@ -75,8 +73,6 @@ public class VariableByteStreamTest extends TestCase {
 		    }
 		    
 		    byte[] data = os.toByteArray();
-		    System.out.println(valuesWritten + " values written");
-			System.out.println("compressed data length: " + data.length + "; original: " + dataLen);
 			
 			int valuesCopied = 0;
 			dataLen = 0;
@@ -95,8 +91,6 @@ public class VariableByteStreamTest extends TestCase {
 			    }
 			}
 			data = os.toByteArray();
-			System.out.println("copied " + valuesCopied + " values; skipped " + (valuesWritten - valuesCopied));
-			System.out.println("compressed data length: " + data.length + "; original: " + dataLen);
 			
 			int valuesRead = 0;
 			is = new VariableByteArrayInput(data);

--- a/test/src/org/exist/storage/lock/DeadlockTest.java
+++ b/test/src/org/exist/storage/lock/DeadlockTest.java
@@ -141,7 +141,6 @@ public class DeadlockTest {
 	
 	public DeadlockTest(int mode) {
 		this.mode = mode;
-		System.out.println("MODE: " + mode);
 	}
 	
 	@BeforeClass
@@ -271,7 +270,6 @@ public class DeadlockTest {
                         transact.commit(transaction);
                     }
 
-                    System.out.println("Generating " + docCount + " files...");
                     final File[] files = generator.generate(broker, coll, generateXQ);
                     for (int j = 0; j < files.length; j++, fileCount++) {
                         try(final Txn transaction = transact.beginTransaction()) {
@@ -341,7 +339,6 @@ public class DeadlockTest {
 			}
 			
 			String query = buf.toString();
-			System.out.println("Query: " + query);
 			try {
 				org.xmldb.api.base.Collection testCollection = DatabaseManager
 						.getCollection("xmldb:exist://" + collection, "admin", null);
@@ -352,7 +349,7 @@ public class DeadlockTest {
 				service.beginProtected();
 				try {
 					ResourceSet result = service.query(query);
-					System.out.println("Result: " + result.getSize());
+                    result.getSize();
 				} finally {
 					service.endProtected();
 				}

--- a/test/src/org/exist/storage/lock/GetXMLResourceNoLockTest.java
+++ b/test/src/org/exist/storage/lock/GetXMLResourceNoLockTest.java
@@ -77,19 +77,12 @@ public class GetXMLResourceNoLockTest {
 
 	@Before
 	public void setup() throws IOException, DatabaseConfigurationException {
-	
-		
-		System.out.println("Stuff before! dddd ");
-		
 		dataDirBackup = TestUtils.moveDataDirToTempAndCreateClean();
 		database = TestUtils.startupDatabase();
 	}
 	
 	@After
 	public void tearDown() throws IOException, DatabaseConfigurationException {
-		
-		System.out.println("Yay after!");
-		
 		TestUtils.stopDatabase(database);
 		TestUtils.moveDataDirBack(dataDirBackup);
 	}
@@ -103,8 +96,6 @@ public class GetXMLResourceNoLockTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
 
-            System.out.println("Transaction started ...");
-            
             Collection collection = broker
                     .getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             
@@ -116,7 +107,6 @@ public class GetXMLResourceNoLockTest {
                     DOCUMENT_NAME_URI , EMPTY_BINARY_FILE.getBytes(), "text/text");
             
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         } catch (Exception e) {
             fail(e.getMessage());
             

--- a/test/src/org/exist/storage/lock/ProtectedModeTest.java
+++ b/test/src/org/exist/storage/lock/ProtectedModeTest.java
@@ -152,7 +152,6 @@ public class ProtectedModeTest {
             TestDataGenerator generator = new TestDataGenerator("xdb", DOCUMENT_COUNT);
             for (int i = 0; i < COLLECTION_COUNT; i++) {
                 Collection currentColl = mgmt.createCollection("test" + i);
-                System.out.println("Generating " + DOCUMENT_COUNT + " files...");
                 File[] files = generator.generate(currentColl, generateXQ);
                 for (int j = 0; j < files.length; j++) {
                     XMLResource resource = (XMLResource) currentColl.createResource("xdb" + j + ".xml", "XMLResource");

--- a/test/src/org/exist/test/EmbeddedExistTester.java
+++ b/test/src/org/exist/test/EmbeddedExistTester.java
@@ -76,7 +76,6 @@ public class EmbeddedExistTester {
     @BeforeClass
     public static void before() {
         try {
-            System.out.println("Starting test..");
             LOG.info("Starting test..");
 
             Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
@@ -108,11 +107,6 @@ public class EmbeddedExistTester {
             LOG.error(ex);
             fail(ex.getMessage());
         }
-    }
-
-    @Before
-    public void before_test(){
-        System.out.println("\n-------------------------------------------------------\n");
     }
 
     protected static Collection createCollection(Collection collection, String collectionName) throws XMLDBException {

--- a/test/src/org/exist/util/DOMSerializerTest.java
+++ b/test/src/org/exist/util/DOMSerializerTest.java
@@ -65,7 +65,6 @@ public class DOMSerializerTest extends TestCase {
 			StringWriter writer = new StringWriter();
 			DOMSerializer serializer = new DOMSerializer(writer, null);
 			serializer.serialize(doc.getDocumentElement());
-			System.out.println(writer.toString());
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/test/src/org/exist/util/XMLStringTest.java
+++ b/test/src/org/exist/util/XMLStringTest.java
@@ -34,7 +34,6 @@ public class XMLStringTest extends TestCase {
 		s.append(ch, 0, ch.length);
 		s = s.normalize(XMLString.SUPPRESS_BOTH);
 		String r = s.toString();
-		System.out.println('"' + r + '"');
 		assertEquals(r, "Hello World");
 	}
 
@@ -44,7 +43,6 @@ public class XMLStringTest extends TestCase {
         s.append(ch, 0, ch.length);
         s = s.normalize(XMLString.NORMALIZE);
         String r = s.toString();
-        System.out.println('"' + r + '"');
         assertEquals(r, "Hello World");
     }
 
@@ -54,7 +52,6 @@ public class XMLStringTest extends TestCase {
 		s.append(ch, 0, ch.length);
 		s = s.normalize(XMLString.SUPPRESS_BOTH);
 		String r = s.substring(6, 5);
-		System.out.println('"' + r + '"');
 		assertEquals(r, "World");
 	}
 
@@ -64,11 +61,9 @@ public class XMLStringTest extends TestCase {
 		s.append(ch, 0, ch.length);
 		s.insert(5, " happy");
 		String r = s.toString();
-		System.out.println('"' + r + '"');
 		assertEquals(r, "Hello happy World");
 		s = s.delete(5, 6);
 		r = s.toString();
-		System.out.println('"' + r + '"');
 		assertEquals(r, "Hello World");
 	}
 }

--- a/test/src/org/exist/util/hashtable/HashtableTest.java
+++ b/test/src/org/exist/util/hashtable/HashtableTest.java
@@ -46,7 +46,6 @@ public class HashtableTest extends TestCase {
 		int keys[] = new int[tabSize];
 		Int2ObjectHashMap<String> table = new Int2ObjectHashMap<String>(tabSize);
 		Random rand = new Random(System.currentTimeMillis());
-		System.out.println("Generating " + tabSize + " random keys...");
 		for(int i = 0; i < tabSize; i++) {
 			do {
 				keys[i] = rand.nextInt(Integer.MAX_VALUE);
@@ -54,12 +53,12 @@ public class HashtableTest extends TestCase {
 			values[i] = new String("a" + keys[i]);
 			table.put(keys[i], values[i]);
 		}
-		System.out.println("Testing get(key) ...");
+
 		for(int i = 0; i < tabSize; i++) {
 			String v = table.get(keys[i]);
 			assertEquals( values[i], v );
 		}
-		System.out.println("Testing remove(key) ...");
+
 		int r;
 		for(int i = 0; i < tabSize / 10; i++) {
 			do {
@@ -80,8 +79,6 @@ public class HashtableTest extends TestCase {
 			@SuppressWarnings("unused")
 			Integer v = (Integer)i.next();
 		}
-		System.out.println(table.size() + " = " + c);
-		System.out.println("maxRehash: " + table.getMaxRehash());
 		assertEquals(table.size(), c);
 	}
 
@@ -90,7 +87,6 @@ public class HashtableTest extends TestCase {
         long values[] = new long[tabSize];
         Object2LongHashMap<String> table = new Object2LongHashMap<String>(tabSize / 4);
 		Random rand = new Random(System.currentTimeMillis());
-		System.out.println("Generating " + tabSize + " random keys...");
 		for(int i = 0; i < tabSize; i++) {
 			do {
 				keys[i] = "/db/" + rand.nextInt(Integer.MAX_VALUE);
@@ -98,12 +94,12 @@ public class HashtableTest extends TestCase {
             values[i] = rand.nextInt(Integer.MAX_VALUE);
             table.put(keys[i], values[i]);
 		}
-        System.out.println("Testing get(key) ...");
+
 		for(int i = 0; i < tabSize; i++) {
 			long k = table.get(keys[i]);
 			assertEquals( values[i], k );
 		}
-        System.out.println("Remove/add keys ...");
+
         for(int i = 0; i < tabSize * 10; i++) {
             int idx0 = rand.nextInt(tabSize);
             table.remove(keys[idx0]);
@@ -112,7 +108,7 @@ public class HashtableTest extends TestCase {
             table.put(keys[idx0], values[idx0]);
             table.put(keys[idx1], values[idx1]);
         }
-        System.out.println("Testing get(key) ...");
+
 		for(int i = 0; i < tabSize; i++) {
 			long k = table.get(keys[i]);
 			assertEquals( values[i], k );
@@ -123,7 +119,7 @@ public class HashtableTest extends TestCase {
 		long keys[] = new long[tabSize];
 		SequencedLongHashMap<String> table = new SequencedLongHashMap<String>(tabSize);
 		Random rand = new Random(System.currentTimeMillis());
-		System.out.println("Generating " + tabSize + " random keys...");
+
 		for(int i = 0; i < tabSize; i++) {
 			do {
 				keys[i] = rand.nextInt(Integer.MAX_VALUE);
@@ -156,7 +152,6 @@ public class HashtableTest extends TestCase {
 			values[k] = null;
 			assertNull(table.get(keys[k]));
 		}
-		System.out.println("Hashtable size: " + table.size());
 		
 		// iterate through the sequence again
 		int k = 0;
@@ -220,9 +215,6 @@ public class HashtableTest extends TestCase {
 		Iterator<Long> iter = table.iterator();
 		assertFalse("Hashtable should be empty", iter.hasNext());
 		assertTrue(table.size() == 0);
-		
-		System.out.println("Hashtable size: " + table.size());
-		System.out.println("maxRehash: " + table.getMaxRehash());
 	}
     
     public void testSequencedMap2() {
@@ -237,11 +229,8 @@ public class HashtableTest extends TestCase {
         int i = 0;
         while(next != null) {
             assertEquals(next.getKey(), expected[i]);
-            System.out.print(next.getKey());
-            System.out.print(' ');
             next = next.getNext();
             i++;
         }
-        System.out.println();
     }
 }

--- a/test/src/org/exist/validation/CollectionConfigurationTest.java
+++ b/test/src/org/exist/validation/CollectionConfigurationTest.java
@@ -70,8 +70,6 @@ public class CollectionConfigurationTest {
                 "DatabaseInstanceManager", "1.0");
         dim.shutdown();
         database = null;
-
-        System.out.println("tearDown PASSED");
     }
 
 
@@ -89,7 +87,6 @@ public class CollectionConfigurationTest {
     }
 
     private void createCollection(String collection) throws XMLDBException {
-        System.out.println("createCollection=" + collection);
         Collection testCollection = cmservice.createCollection(collection);
         assertNotNull(testCollection);
 
@@ -98,7 +95,6 @@ public class CollectionConfigurationTest {
     }
 
     private void storeCollectionXconf(String collection, String document) throws XMLDBException {
-        System.out.println("storeCollectionXconf=" + collection);
         ResourceSet result = xpqservice.query("xmldb:store(\"" + collection + "\", \"collection.xconf\", " + document + ")");
         String r = (String) result.getResource(0).getContent();
         assertEquals("Store xconf", collection + "/collection.xconf", r);
@@ -106,7 +102,6 @@ public class CollectionConfigurationTest {
 
     @SuppressWarnings("unused")
 	private void storeDocument(String collection, String name, String document) throws XMLDBException {
-        System.out.println("storeDocument=" + collection + " " + name);
         ResourceSet result = xpqservice.query("xmldb:store(\"" + collection + "\", \"" + name + "\", " + document + ")");
         String r = (String) result.getResource(0).getContent();
         assertEquals("Store doc", collection + "/" + name, r);

--- a/test/src/org/exist/validation/CollectionConfigurationValidationModeTest.java
+++ b/test/src/org/exist/validation/CollectionConfigurationValidationModeTest.java
@@ -81,24 +81,17 @@ public class CollectionConfigurationValidationModeTest {
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        System.out.println("Clear grammar cache");
         @SuppressWarnings("unused")
 		ResourceSet result = xpqservice.query("validation:clear-grammar-cache()");
     }
 
     @Before
     public void setUp() throws Exception {
-        System.out.println("Clear grammar cache");
         @SuppressWarnings("unused")
 		ResourceSet result = xpqservice.query("validation:clear-grammar-cache()");
     }
 
-    @After
-    public void tearDown() throws Exception {
-    }
-
     private void createCollection(String collection) throws XMLDBException {
-        System.out.println("createCollection=" + collection);
         Collection testCollection = cmservice.createCollection(collection);
         assertNotNull(testCollection);
 
@@ -107,14 +100,12 @@ public class CollectionConfigurationValidationModeTest {
     }
 
     private void storeCollectionXconf(String collection, String document) throws XMLDBException {
-        System.out.println("storeCollectionXconf=" + collection);
         ResourceSet result = xpqservice.query("xmldb:store(\"" + collection + "\", \"collection.xconf\", " + document + ")");
         String r = (String) result.getResource(0).getContent();
         assertEquals("Store xconf", collection + "/collection.xconf", r);
     }
 
     private void storeDocument(String collection, String name, String document) throws XMLDBException {
-        System.out.println("storeDocument=" + collection + " " + name);
         ResourceSet result = xpqservice.query("xmldb:store(\"" + collection + "\", \"" + name + "\", " + document + ")");
         String r = (String) result.getResource(0).getContent();
         assertEquals("Store doc", collection + "/" + name, r);
@@ -167,9 +158,7 @@ public class CollectionConfigurationValidationModeTest {
             fail("should have failed");
         } catch (XMLDBException ex) {
             String msg = ex.getMessage();
-            if (msg.contains("cvc-complex-type.2.4.a: Invalid content was found")) {
-                System.out.println("OK: " + msg);
-            } else {
+            if (!msg.contains("cvc-complex-type.2.4.a: Invalid content was found")) {
                 fail(msg);
             }
         }
@@ -180,9 +169,7 @@ public class CollectionConfigurationValidationModeTest {
             fail("should have failed");
         } catch (XMLDBException ex) {
             String msg = ex.getMessage();
-            if (msg.contains("Cannot find the declaration of element 'schema'.")) {
-                System.out.println("OK: " + msg);
-            } else {
+            if (!msg.contains("Cannot find the declaration of element 'schema'.")) {
                 fail(msg);
             }
         }
@@ -194,9 +181,7 @@ public class CollectionConfigurationValidationModeTest {
             fail("should have failed");
         } catch (XMLDBException ex) {
             String msg = ex.getMessage();
-            if (msg.contains("Cannot find the declaration of element 'asd:schema'.")) {
-                System.out.println("OK: " + msg);
-            } else {
+            if (!msg.contains("Cannot find the declaration of element 'asd:schema'.")) {
                 fail(msg);
             }
         }
@@ -222,9 +207,7 @@ public class CollectionConfigurationValidationModeTest {
             fail("should have failed");
         } catch (XMLDBException ex) {
             String msg = ex.getMessage();
-            if (msg.contains("cvc-complex-type.2.4.a: Invalid content was found")) {
-                System.out.println("OK: " + msg);
-            } else {
+            if (!msg.contains("cvc-complex-type.2.4.a: Invalid content was found")) {
                 fail(msg);
             }
         }
@@ -234,9 +217,7 @@ public class CollectionConfigurationValidationModeTest {
             storeDocument("/db/auto", "anonymous.xml", anonymous);
         } catch (XMLDBException ex) {
             String msg = ex.getMessage();
-            if (msg.contains("Cannot find the declaration of element 'schema'.")) {
-                System.out.println("OK: " + msg);
-            } else {
+            if (!msg.contains("Cannot find the declaration of element 'schema'.")) {
                 fail(msg);
             }
         }

--- a/test/src/org/exist/validation/DatabaseCollectionTest.java
+++ b/test/src/org/exist/validation/DatabaseCollectionTest.java
@@ -56,7 +56,6 @@ public class DatabaseCollectionTest {
     @Before
     public void setUp() {
         try {
-            System.out.println(">>> setUp");
             Class<?> cl = Class.forName(DRIVER);
             Database database = (Database) cl.newInstance();
             database.setProperty("create-database", "true");
@@ -71,7 +70,6 @@ public class DatabaseCollectionTest {
             ums.chmod(Permission.DEFAULT_COLLECTION_PERM);
 
             assertNotNull("Could not connect to database.");
-            System.out.println("<<<\n");
         } catch (Exception e) {
             fail(e.getMessage());
         }

--- a/test/src/org/exist/validation/DtdEntityTest.java
+++ b/test/src/org/exist/validation/DtdEntityTest.java
@@ -43,7 +43,6 @@ public class DtdEntityTest extends EmbeddedExistTester {
             storeResource(col, "docname.xml", input.getBytes());
 
             String result = getXMLResource(col, "docname.xml");
-            System.out.println(result);
             fail("Exception expected");
 
         } catch (XMLDBException ex) {
@@ -68,7 +67,6 @@ public class DtdEntityTest extends EmbeddedExistTester {
             storeResource(col, "docname.xml", input.getBytes());
 
             String result = getXMLResource(col, "docname.xml");
-            System.out.println(result);
             fail("Exception expected, document should be rejected");
 
         } catch (XMLDBException ex) {

--- a/test/src/org/exist/w3c/tests/TestCase.java
+++ b/test/src/org/exist/w3c/tests/TestCase.java
@@ -83,8 +83,6 @@ public abstract class TestCase {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-//		System.out.println("setUpBeforeClass ENTERED");
-
 	    Configuration configuration = new Configuration();
         BrokerPool.configure(1, 10, configuration);
 
@@ -92,19 +90,13 @@ public abstract class TestCase {
         
         broker = db.get(db.getSecurityManager().getSystemSubject());
         Assert.assertNotNull(broker);
-
-//		System.out.println("setUpBeforeClass PASSED");
 	}
 
 	public abstract void loadTS() throws Exception;
 	
 	@AfterClass
 	public static void tearDownAfterClass() throws Exception {
-//      System.out.println("tearDownAfterClass ENTERED");
-
 	    db.release(broker);
-
-//		System.out.println("tearDownAfterClass PASSED");
 	}
 
 	/**
@@ -112,15 +104,12 @@ public abstract class TestCase {
 	 */
 	@Before
 	public void setUp() throws Exception {
-//		System.out.println("setUp ENTERED");
 		if (testCollection == null) {
 			synchronized (db) {
 				if (testCollection == null) {
 					testCollection = broker.getCollection(getCollection());
 					if (testCollection == null) {
-						System.out.println("setUp no TS data");
 						loadTS();
-						System.out.println("setUp checking TS data");
 	                    testCollection = broker.getCollection(getCollection());
 						if (testCollection == null) {
 							Assert.fail("There is no Test Suite data at database");
@@ -129,18 +118,9 @@ public abstract class TestCase {
 				}
 			}
 		}
-//		System.out.println("setUp PASSED");
 	}
 	
 	protected abstract XmldbURI getCollection();
-
-	/**
-	 * @throws java.lang.Exception
-	 */
-	@After
-	public void tearDown() throws Exception {
-		// System.out.println("tearDown PASSED");
-	}
 
 	public Exception catchError(Sequence result) {
 		

--- a/test/src/org/exist/xmldb/BinaryResourceUpdateTest.java
+++ b/test/src/org/exist/xmldb/BinaryResourceUpdateTest.java
@@ -63,7 +63,6 @@ public class BinaryResourceUpdateTest  {
 
             Resource resource = testCollection.getResource("test1.xml");
             assertNotNull(resource);
-            System.out.println("Content:\n" + resource.getContent().toString());
 
             XMLResource xmlResource = (XMLResource) testCollection.createResource("test2.xml", "XMLResource");
             xmlResource.setContent(xmlFile);
@@ -71,7 +70,6 @@ public class BinaryResourceUpdateTest  {
 
             resource = testCollection.getResource("test2.xml");
             assertNotNull(resource);
-            System.out.println("Content:\n" + resource.getContent().toString());
         }
         
     }
@@ -86,7 +84,6 @@ public class BinaryResourceUpdateTest  {
 
             Resource resource = testCollection.getResource("test.xml");
             assertNotNull(resource);
-            System.out.println("Content:\n" + resource.getContent().toString());
 
             XMLResource xmlResource = (XMLResource) testCollection.createResource("test.xml", "XMLResource");
             xmlResource.setContent(xmlFile);
@@ -94,7 +91,7 @@ public class BinaryResourceUpdateTest  {
 
             resource = testCollection.getResource("test.xml");
             assertNotNull(resource);
-            System.out.println("Content:\n" + resource.getContent().toString());
+            
         }
     }
 

--- a/test/src/org/exist/xmldb/CollectionConfigurationTest.java
+++ b/test/src/org/exist/xmldb/CollectionConfigurationTest.java
@@ -1437,7 +1437,6 @@ public class CollectionConfigurationTest {
    private void storeConfiguration(XmldbURI collPath, XmldbURI confName, String confContent) throws XMLDBException {
        Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
        String fullCollPath = ROOT_URI + collPath.toString();
-       System.out.println("Storing configuration '" + confName + "' to '" + collPath + "'" );
        Collection configColl = DatabaseManager.getCollection(fullCollPath, "admin", null);
        if(configColl == null) {
      	   CollectionManagementService cms = (CollectionManagementService)testCollection.getService("CollectionManagementService", "1.0");

--- a/test/src/org/exist/xmldb/ContentAsDOMTest.java
+++ b/test/src/org/exist/xmldb/ContentAsDOMTest.java
@@ -75,10 +75,6 @@ public class ContentAsDOMTest {
         for(long i = 0; i < result.getSize(); i++) {
             XMLResource r = (XMLResource) result.getResource(i);
 
-            System.out.println("Output of getContent():");
-            System.out.println(r.getContent());
-
-            System.out.println("Output of getContentAsDOM():");
             Node node = r.getContentAsDOM();
             Transformer t = TransformerFactory.newInstance().newTransformer();
             t.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/test/src/org/exist/xmldb/CopyMoveTest.java
+++ b/test/src/org/exist/xmldb/CopyMoveTest.java
@@ -29,7 +29,6 @@ public class CopyMoveTest {
         assertEquals(2, testCollection.getResourceCount());
         XMLResource duplicate = (XMLResource) testCollection.getResource("duplicate");
         assertNotNull(duplicate);
-        System.out.println(duplicate.getContent());
     }
 
     @Test

--- a/test/src/org/exist/xmldb/CreateCollectionsTest.java
+++ b/test/src/org/exist/xmldb/CreateCollectionsTest.java
@@ -208,19 +208,15 @@ public class CreateCollectionsTest  {
     }
 
     private XMLResource storeResourceFromFile(File file, Collection testCollection) throws XMLDBException, IOException {
-        System.out.println("storing " + file.getAbsolutePath());
         XMLResource res = (XMLResource) testCollection.createResource(file.getName(), "XMLResource");
         assertNotNull("storeResourceFromFile", res);
         String xml = XMLUtil.readFile(file, "UTF-8");
         res.setContent(xml);
         testCollection.storeResource(res);
-        System.out.println("stored " + file.getAbsolutePath());
         return res;
     }
 
     private byte[] storeBinaryResourceFromFile(File file, Collection testCollection) throws XMLDBException, IOException {
-        System.out.println("storing " + file.getAbsolutePath());
-
         Resource res = (BinaryResource)testCollection.createResource(file.getName(), "BinaryResource");
         assertNotNull("store binary Resource From File", res);
 
@@ -234,7 +230,6 @@ public class CreateCollectionsTest  {
 
         res.setContent(data);
         testCollection.storeResource(res);
-        System.out.println("stored " + file.getAbsolutePath());
         return data;
     }
 
@@ -246,7 +241,6 @@ public class CreateCollectionsTest  {
         assertNotNull(cms);
 
         cms.createCollection("dummy1");
-        printChildren(testCol);
         Collection c1 = testCol.getChildCollection("dummy1");
         assertNotNull(c1);
 
@@ -262,16 +256,7 @@ public class CreateCollectionsTest  {
 
         cms.setCollection(testCol);
         cms.removeCollection("dummy1");
-        printChildren(testCol);
         c1 = testCol.getChildCollection("dummy1");
         assertNull(c1);
-    }
-
-    private static void printChildren(Collection c) throws XMLDBException {
-        System.out.print("Children of " + c.getName() + ":");
-        for (String childCollectionName : c.listChildCollections()) {
-            System.out.print(" " + childCollectionName);
-        }
-        System.out.println();
     }
 }

--- a/test/src/org/exist/xmldb/DOMTest.java
+++ b/test/src/org/exist/xmldb/DOMTest.java
@@ -56,7 +56,6 @@ public class DOMTest {
 	 */
 	public void runTest1() {
 		try {
-			System.out.println("Running test1 ...");
 			Class<?> dbc = Class.forName(driver);
 			Database database = (Database) dbc.newInstance();
 			DatabaseManager.registerDatabase(database);
@@ -90,9 +89,6 @@ public class DOMTest {
 				r = (XMLResource) i.nextResource();
 				String s = (String) r.getContent();
 				Node content = r.getContentAsDOM();
-				System.out.println("Resource: " + r.getId());
-				System.out.println("getContent: " + s);
-				System.out.println("getContentAsDOM: " + content);
 				coll.removeResource(r);
 			}
 
@@ -103,9 +99,7 @@ public class DOMTest {
 					"DatabaseInstanceManager",
 					"1.0");
 			dim.shutdown();
-			System.out.println("test 1: PASSED");
 		} catch (Exception e) {
-			System.err.println("test 1: FAILED");
 			e.printStackTrace();
 		}
 	}
@@ -116,7 +110,6 @@ public class DOMTest {
 	 * */
 	public void runTest2() {
 		try {
-			System.out.println("Running test 2 ...");
 			for (int i = 0; i < 2; i++) {
 				Class<?> dbc = Class.forName(driver);
 				Database database = (Database) dbc.newInstance();
@@ -126,7 +119,6 @@ public class DOMTest {
 					DatabaseManager.getCollection(baseURI, username, password);
 				XMLResource resource = (XMLResource) coll.getResource(name);
 				if (resource == null) {
-					System.out.println("Creating resource!");
 					resource =
 						(XMLResource) coll.createResource(
 							name,
@@ -148,15 +140,10 @@ public class DOMTest {
 							username,
 							password);
 					resource = (XMLResource) coll.getResource(name);
-				} else {
-					System.out.println("Found resource!");
 				}
 
 				String s = (String) resource.getContent();
 				Node content = resource.getContentAsDOM();
-				System.out.println("Resource: " + resource);
-				System.out.println("getContent: " + s);
-				System.out.println("getContentAsDOM: " + content);
 
 				DatabaseManager.deregisterDatabase(database);
 				DatabaseInstanceManager dim =
@@ -180,9 +167,7 @@ public class DOMTest {
 					"1.0");
 			dim.shutdown();
 
-			System.out.println("test 2: PASSED");
 		} catch (Exception e) {
-			System.out.println("test 2: FAILED");
 			e.printStackTrace();
 		}
 	}
@@ -190,7 +175,6 @@ public class DOMTest {
 	/** like test 2 but add attribute and text as well */
 	public void runTest3() {
 		try {
-			System.out.println("Running test 3 ...");
 
 			Class<?> dbc = Class.forName("org.exist.xmldb.DatabaseImpl");
 			Database database = (Database) dbc.newInstance();
@@ -223,8 +207,6 @@ public class DOMTest {
 			resource = (XMLResource) coll.getResource(name);
 			String s = (String) resource.getContent();
 			Node n = resource.getContentAsDOM();
-			System.out.println("getContent: " + s);
-			System.out.println("getContentAsDOM: " + n);
 
 			coll.removeResource(resource);
 
@@ -234,9 +216,7 @@ public class DOMTest {
 					"DatabaseInstanceManager",
 					"1.0");
 			dim.shutdown();
-			System.out.println("test 3 : PASSED");
 		} catch (Exception e) {
-			System.out.println("test 3 : FAILED");
 			e.printStackTrace();
 		}
 	}
@@ -245,7 +225,6 @@ public class DOMTest {
 	public void runTest4(boolean getContentAsDOM) {
 		Database database = null;
 		try {
-			System.out.println("Running test 4 ...");
 
 			Class<?> dbc = Class.forName("org.exist.xmldb.DatabaseImpl");
 			database = (Database) dbc.newInstance();
@@ -290,8 +269,6 @@ public class DOMTest {
 				n = db.parse(bais);
 			}
 
-			System.out.println("getContentAsDOM: " + n.getNodeName());
-
 			Transformer t = TransformerFactory.newInstance().newTransformer();
 			DOMSource source = new DOMSource(n);
 			SAXResult result = new SAXResult(new DOMTest.SAXHandler());
@@ -299,9 +276,7 @@ public class DOMTest {
 
 			coll.removeResource(resource);
 
-			System.out.println("test 4 : PASSED");
 		} catch (Exception e) {
-			System.out.println("test 4 : FAILED");
 			e.printStackTrace();
 		} finally {
 			if (database != null) {
@@ -318,6 +293,7 @@ public class DOMTest {
 							"1.0");
 					dim.shutdown();
 				} catch (Exception e) {
+                    e.printStackTrace();
 				}
 			}
 		}

--- a/test/src/org/exist/xmldb/DOMTestJUnit.java
+++ b/test/src/org/exist/xmldb/DOMTestJUnit.java
@@ -58,11 +58,7 @@ public class DOMTestJUnit extends RemoteDBTest {
 	public void testDOMUpdate() {
 		try {
 			XMLResource index = (XMLResource) rootColl.getResource(name);
-			{
-				System.out.println("Retrieving initial content:");
-				String content = (String) index.getContent();
-				System.out.println(content);
-			}
+            String content = (String) index.getContent();
             Document doc=null;
             Element root=null;
             NodeList nl=null;
@@ -79,10 +75,9 @@ public class DOMTestJUnit extends RemoteDBTest {
                 fail("RemoteXMLResource unable to return a Document either an Element");
             }
 
-            System.out.println("Retrieving root comments and PIs");
             nl = doc.getChildNodes();
             for (int i = 0; i < nl.getLength(); i++) {
-                System.out.println(" * "+nl.item(i).getNodeName());
+                nl.item(i).getNodeName();
             }
 
             
@@ -93,11 +88,9 @@ public class DOMTestJUnit extends RemoteDBTest {
 			root.appendChild(schemaNode);
 			index.setContentAsDOM(doc);
 			rootColl.storeResource(index);
-	
-			System.out.println("Retrieving modified content:");
+
 			index = (XMLResource) rootColl.getResource(name);
-			String content = (String) index.getContent();
-			System.out.println(content);
+			content = (String) index.getContent();
 			n = index.getContentAsDOM();
             if (n instanceof Document) { 
                 doc=(Document)n;
@@ -109,7 +102,7 @@ public class DOMTestJUnit extends RemoteDBTest {
             }
 			nl = root.getChildNodes();
 			for (int i = 0; i < nl.getLength(); i++) {
-				System.out.println(nl.item(i).getNodeName());
+                nl.item(i).getNodeName();
 			}
 		} catch(Exception e) {			
 			fail(e.getMessage());

--- a/test/src/org/exist/xmldb/DTMHandleTest.java
+++ b/test/src/org/exist/xmldb/DTMHandleTest.java
@@ -83,7 +83,6 @@ public class DTMHandleTest extends TestCase {
 					foundFieldText = false;
 					
 					Node field = rootChildren.item(r);
-					System.out.println("Found field node[" + 1 + "]");
 					
 					NodeList fieldChildren = field.getChildNodes();
 					for(int f=0; f < fieldChildren.getLength(); f++)
@@ -102,8 +101,6 @@ public class DTMHandleTest extends TestCase {
 					assertTrue("Failed to read existing field[" + 1 + "]/name/text()", foundFieldText);
 				}
 			}
-			
-			System.out.println("Test succeeded");			
 		}
 		catch (Exception e)
 		{		    

--- a/test/src/org/exist/xmldb/IndexingTest.java
+++ b/test/src/org/exist/xmldb/IndexingTest.java
@@ -96,7 +96,6 @@ public class IndexingTest extends TestCase {
 		startTime = System.currentTimeMillis();
 		
 		try {
-			System.out.println("Running test " + testName + " ...");
 
 			// Tell eXist where conf.xml is :
                         // DWES #### use Configuration.getExistHome()
@@ -125,13 +124,11 @@ public class IndexingTest extends TestCase {
 			resource.setContentAsDOM(doc);
 			printTime();
 			coll.storeResource(resource);
-			System.out.println("TEST> stored Resource " + name );
 			printTime();
 			coll.close();
 
 			coll = DatabaseManager.getCollection(baseURI, username, password);
 			resource = (XMLResource) coll.getResource(name);
-			System.out.println("TEST> retrieved Resource " + name );
 			printTime();
 			
 			Node n;
@@ -146,7 +143,6 @@ public class IndexingTest extends TestCase {
 				n = db.parse(bais);
 			}
 
-			System.out.println("getContentAsDOM: " + n.getNodeName());
 			Element documentElement = null;
 			if ( n instanceof Element ) {
 				documentElement = (Element)n;
@@ -157,8 +153,6 @@ public class IndexingTest extends TestCase {
 			assertions(documentElement);
 			
 			coll.removeResource(resource);
-
-			System.out.println("TEST> " + testName + " : PASSED");
 
 		} finally {
 			printTime();
@@ -189,15 +183,9 @@ public class IndexingTest extends TestCase {
 		int computedElementCount = 
 			documentElement.getElementsByTagName("element").getLength();
 
-		System.out.println(" documentElement.getChildNodes().getLength(): " +
-			computedSiblingCount );
-		System.out.println(" documentElement.getElementsByTagName(\"element\").getLength(): " +
-			computedElementCount );
-
 		assertEquals("siblingCount", effectiveSiblingCount, computedSiblingCount );
 		assertEquals("depth", depth*arity + depth, computedDepth );
 
-		System.out.println("TEST> assertions PASSED");
 		printTime();
 		// dumpCatabaseContent(n);
 	}
@@ -209,8 +197,6 @@ public class IndexingTest extends TestCase {
 		// Add a long fat branch at root's first child :
 		deepBranch = doc.getDocumentElement().getFirstChild();
 		effectiveDepth = addFatBranch( doc, deepBranch, depth, null);
-
-		System.out.println("TEST> populate() done.");
 		return childrenCount;
 		}
 	
@@ -244,7 +230,6 @@ public class IndexingTest extends TestCase {
 				current = current.getNextSibling();
 			}
 		}
-		System.out.println("TEST> " + firstLevelWidth + " first Level elements populated.");
 		return childrenCount;
 	}
 

--- a/test/src/org/exist/xmldb/MultiDBTest.java
+++ b/test/src/org/exist/xmldb/MultiDBTest.java
@@ -102,7 +102,6 @@ public class MultiDBTest extends TestCase {
 	        XQueryService service = (XQueryService)
 	            collection.getService("XQueryService", "1.0");
 	        ResourceSet result = service.query(query);
-	        System.out.println("Found " + result.getSize() + " results.");
 	        for(ResourceIterator i = result.getIterator(); i.hasMoreResources(); ) {
 	            @SuppressWarnings("unused")
 				String content = i.nextResource().getContent().toString();
@@ -116,7 +115,6 @@ public class MultiDBTest extends TestCase {
     protected void setUp() 
        throws Exception
     {
-       System.out.println("Setting up "+INSTANCE_COUNT+" databases...");
        String homeDir = SingleInstanceConfiguration.getPath();
        if (homeDir == null) {
           homeDir = ".";
@@ -132,7 +130,6 @@ public class MultiDBTest extends TestCase {
        for (int i = 0; i < INSTANCE_COUNT; i++) {
           File dir = new File(testDir, "db" + i);
           dir.mkdirs();
-          System.out.println("Storing database test" + i + " in " + dir.getAbsolutePath());
           File conf = new File(dir, "conf.xml");
           FileOutputStream os = new FileOutputStream(conf);
           os.write(CONFIG.getBytes(UTF_8));
@@ -153,7 +150,6 @@ public class MultiDBTest extends TestCase {
         long free = rt.freeMemory() / 1024;
         long total = rt.totalMemory() / 1024;
         for (int i = 0; i < INSTANCE_COUNT; i++) {
-            System.out.println("Shutting down instance test"+i);
             Collection root = DatabaseManager.getCollection("xmldb:test" + i + "://" + XmldbURI.ROOT_COLLECTION, "admin", null);
             CollectionManagementService service = (CollectionManagementService)
                 root.getService("CollectionManagementService", "1.0");
@@ -163,7 +159,5 @@ public class MultiDBTest extends TestCase {
                 root.getService("DatabaseInstanceManager", "1.0");
             mgr.shutdown();
         }
-        System.out.println("Mem total: " + total + "K");
-        System.out.println("Mem free: " + free + "K");
     }
 }

--- a/test/src/org/exist/xmldb/RemoteCollectionTest.java
+++ b/test/src/org/exist/xmldb/RemoteCollectionTest.java
@@ -106,7 +106,6 @@ public class RemoteCollectionTest extends RemoteDBTest {
 	
 	public void testGetNonExistentResource() {
 		try {
-			System.out.println("Retrieving non-existing resource");
 			Collection collection = getCollection();
 			Resource resource = collection.getResource("unknown.xml");
 			assertNull(resource);
@@ -129,7 +128,6 @@ public class RemoteCollectionTest extends RemoteDBTest {
 		    createResources(binaryNames, "BinaryResource");
 	
 		    String[] actualContents = getCollection().listResources();
-		    System.out.println("Resources found: " + actualContents.length);
 		    for (int i = 0; i < actualContents.length; i++) {
 		        xmlNames.remove(actualContents[i]);
 		        binaryNames.remove(actualContents[i]);

--- a/test/src/org/exist/xmldb/RemoteDBTest.java
+++ b/test/src/org/exist/xmldb/RemoteDBTest.java
@@ -51,7 +51,6 @@ public abstract class RemoteDBTest extends TestCase {
 			if (server == null) {
 				server = new JettyStart();
 				if (!server.isStarted()) {
-                    System.out.println("Starting standalone server...");
                     server.run();
                 }
 			}

--- a/test/src/org/exist/xmldb/RemoteQueryTest.java
+++ b/test/src/org/exist/xmldb/RemoteQueryTest.java
@@ -64,8 +64,6 @@ public class RemoteQueryTest extends RemoteDBTest {
 			for (int i = 0; i < result.getSize(); i++) {
 				XMLResource r = (XMLResource) result.getResource(i);
 				Node node = r.getContentAsDOM().getFirstChild();
-				System.out.println(node.getNodeName());
-				System.out.println(r.getContent());
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -92,7 +90,6 @@ public class RemoteQueryTest extends RemoteDBTest {
 			
 			for (int i = 0; i < result.getSize(); i++) {
 				XMLResource r = (XMLResource) result.getResource(i);
-				System.out.println(r.getContent());
 			}
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -154,9 +151,6 @@ public class RemoteQueryTest extends RemoteDBTest {
 			}
 			testCollection = null;
 			xmlrpcCollection = null;
-			
-			System.out.println("tearDown PASSED");
-			
 		} catch (XMLDBException e) {
 			e.printStackTrace();
 			fail(e.getMessage());

--- a/test/src/org/exist/xmldb/ResourceSetTest.java
+++ b/test/src/org/exist/xmldb/ResourceSetTest.java
@@ -53,14 +53,9 @@ public class ResourceSetTest extends TestCase {
 			assertNotNull(testCollection);
 			XPathQueryService service = (XPathQueryService)
 				testCollection.getService("XPathQueryService", "1.0");
-				
-			System.out.println("query1: " + query1);
+
 			ResourceSet result1 = service.query(query1);
-			System.out.println("query1: getSize()=" + result1.getSize());
-			
-			System.out.println("query2: " + query2);
 			ResourceSet result2 = service.query(query2);
-			System.out.println("query2: getSize()=" + result2.getSize());
 			
 			assertEquals( "size of intersection of "+query1+" and "+query2+" yields ",
 			  expected,

--- a/test/src/org/exist/xmldb/ResourceTest.java
+++ b/test/src/org/exist/xmldb/ResourceTest.java
@@ -86,19 +86,14 @@ public class ResourceTest {
         String[] resources = testCollection.listResources();
         assertEquals(resources.length, testCollection.getResourceCount());
 
-        System.out.println("reading " + resources[0]);
         XMLResource doc = (XMLResource) testCollection.getResource(resources[0]);
         assertNotNull(doc);
 
-        System.out.println("testing XMLResource.getContentAsSAX()");
         StringWriter sout = new StringWriter();
         OutputFormat format = new OutputFormat("xml", "ISO-8859-1", true);
         format.setLineWidth(60);
         XMLSerializer xmlout = new XMLSerializer(sout, format);
         doc.getContentAsSAX(xmlout);
-        System.out.println("----------------------------------------");
-        System.out.println(sout.toString());
-        System.out.println("----------------------------------------");
     }
 
     @Test
@@ -117,16 +112,13 @@ public class ResourceTest {
         }
         assertNotNull(elem);
         assertEquals(elem.getNodeName(), "PLAY");
-        System.out.println("Root element: " + elem.getNodeName());
         NodeList children = elem.getChildNodes();
         Node node;
         for(int i = 0; i < children.getLength(); i++) {
             node = children.item(i);
-            System.out.println("Child: " + node.getNodeName());
             assertNotNull(node);
             node = node.getFirstChild();
             while(node != null) {
-                System.out.println("child: " + node.getNodeName());
                 node = node.getNextSibling();
             }
         }

--- a/test/src/org/exist/xmldb/SerializationTest.java
+++ b/test/src/org/exist/xmldb/SerializationTest.java
@@ -54,7 +54,6 @@ public class SerializationTest extends XMLTestCase {
 			ResourceSet result = service.query("declare namespace foo=\"http://foo.com\"; //foo:entry");
 			Resource resource = result.getMembersAsResource();
 			String str = resource.getContent().toString();
-			System.out.println(str);
 			assertXMLEqual(XML_EXPECTED1, str);
 			
 			//TODO : THIS IS BUGGY !
@@ -67,7 +66,6 @@ public class SerializationTest extends XMLTestCase {
 					"</c:Site>");
 			resource = result.getMembersAsResource();
 			str = resource.getContent().toString();
-			System.out.println(str);
 			assertXMLEqual(XML_EXPECTED2, str);
 			
 		} catch (Exception e) {
@@ -126,7 +124,6 @@ public class SerializationTest extends XMLTestCase {
 	        dim.shutdown();
             database = null;
             testCollection = null;
-	        System.out.println("tearDown PASSED");
 		} catch (XMLDBException e) {
 			fail(e.getMessage());
 		}

--- a/test/src/org/exist/xmldb/ShutdownTest.java
+++ b/test/src/org/exist/xmldb/ShutdownTest.java
@@ -73,7 +73,6 @@ public class ShutdownTest extends TestCase {
 	public void testShutdown() {
 		try {
 			for (int i = 0; i < 50; i++) {
-				System.out.println("Starting the database ...");
 				Collection rootCol = DBUtils.setupDB(URI);
 				
 				// after restarting the db, we first try a bunch of queries
@@ -96,14 +95,11 @@ public class ShutdownTest extends TestCase {
 				String xml =
 					"<data now=\"" + System.currentTimeMillis() + "\" count=\"" +
 					i + "\">" + XML + "</data>";
-				System.out.println("Storing resource ...");
 				DBUtils.addXMLResource(testCol, "R1.xml", xml);
-				
-				System.out.println("Storing large file ...");
+
 				File tempFile = DBUtils.generateXMLFile(5000, 7, wordList);
 				DBUtils.addXMLResource(testCol, "R2.xml", tempFile);
-				
-				System.out.println("Shut down the database ...");
+
 				DBUtils.shutdownDB(URI);
 			}
         } catch (Exception e) {            

--- a/test/src/org/exist/xmldb/StorageStressTest.java
+++ b/test/src/org/exist/xmldb/StorageStressTest.java
@@ -62,16 +62,13 @@ public class StorageStressTest extends TestCase {
     public void testStore() {
     	try {
 	        String[] wordList = DBUtils.wordList(collection);
-	        long start = System.currentTimeMillis();
 	        for (int i = 0; i < 30000; i++) {
 	            File f = DBUtils.generateXMLFile(6, 3, wordList, false);
-	            System.out.println("Storing file: " + f.getName() + "; size: " + (f.length() / 1024) + "kB");
 	            Resource res = collection.createResource("test_" + i, "XMLResource");
 	            res.setContent(f);
 	            collection.storeResource(res);
 	            f.delete();
 	        }
-	        System.out.println("Indexing took " + (System.currentTimeMillis() - start));
         } catch (Exception e) {            
             fail(e.getMessage()); 
         }	        
@@ -87,7 +84,6 @@ public class StorageStressTest extends TestCase {
 		try {
 			if (server == null) {
 				server = new JettyStart();
-                System.out.println("Starting standalone server...");
                 server.run();
 			}
         } catch (Exception e) {            

--- a/test/src/org/exist/xmldb/TestEXistXMLSerialize.java
+++ b/test/src/org/exist/xmldb/TestEXistXMLSerialize.java
@@ -114,14 +114,12 @@ public class TestEXistXMLSerialize {
     @Test
     public void serialize1() throws TransformerException, XMLDBException, ParserConfigurationException, SAXException, IOException {
         Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
-        System.out.println("Xerces version: "+org.apache.xerces.impl.Version.getVersion( ));
         XMLResource resource = (XMLResource) testCollection.createResource(null, "XMLResource");
 
         Document doc = javax.xml.parsers.DocumentBuilderFactory.newInstance( ).
                         newDocumentBuilder().parse(testFile);
 
         resource.setContentAsDOM(doc);
-        System.out.println("Storing resource: "+resource.getId( ));
         testCollection.storeResource(resource);
 
         resource = (XMLResource)testCollection.getResource(resource.getId());
@@ -129,34 +127,27 @@ public class TestEXistXMLSerialize {
         Node node = resource.getContentAsDOM( );
         node = node.getOwnerDocument();
 
-        System.out.println("Attempting serialization 1");
+        //Attempting serialization
         DOMSource source = new DOMSource(node);
         ByteArrayOutputStream out = new ByteArrayOutputStream( );
         StreamResult result = new StreamResult(out);
 
         Transformer xformer = TransformerFactory.newInstance().newTransformer();
         xformer.transform(source, result);
-
-        System.out.println("Using javax.xml.transform.Transformer");
-        System.out.println("---------------------");
-        System.out.println(new String(out.toByteArray()));
-        System.out.println("--------------------- ");
     }
 
     @Test
     public void serialize2() throws ParserConfigurationException, SAXException, IOException, XMLDBException {
         Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
-        System.out.println("Xerces version: "+org.apache.xerces.impl.Version.getVersion( ));
         Document doc = javax.xml.parsers.DocumentBuilderFactory.newInstance( ).newDocumentBuilder().parse(testFile);
         XMLResource resource = (XMLResource) testCollection.createResource(null, "XMLResource");
         resource.setContentAsDOM(doc);
-        System.out.println("Storing resource: "+resource.getId( ));
         testCollection.storeResource(resource);
 
         resource = (XMLResource)testCollection.getResource(resource.getId());
         assertNotNull(resource);
         Node node = resource.getContentAsDOM();
-        System.out.println("Attempting serialization using XMLSerializer");
+
         OutputFormat format = new OutputFormat( );
         format.setLineWidth(0);
         format.setIndent(5);
@@ -171,63 +162,46 @@ public class TestEXistXMLSerialize {
         }else{
             fail("Can't serialize node type: "+node);
         }
-        System.out.println("Using org.apache.xml.serialize.XMLSerializer");
-        System.out.println("---------------------");
-        System.out.println(new String(out.toByteArray()));
-        System.out.println("--------------------- ");
     }
 
     @Test
     public void serialize3() throws ParserConfigurationException, SAXException, IOException, XMLDBException, TransformerException {
         Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
-        System.out.println("Xerces version: "+org.apache.xerces.impl.Version.getVersion( ));
         Document doc = javax.xml.parsers.DocumentBuilderFactory.newInstance( ).newDocumentBuilder().parse(testFile);
         XMLResource resource = (XMLResource) testCollection.createResource(null, "XMLResource");
         resource.setContentAsDOM(doc);
-        System.out.println("Storing resource: "+resource.getId( ));
         testCollection.storeResource(resource);
 
         resource = (XMLResource)testCollection.getResource(resource.getId());
         assertNotNull(resource);
         Node node = resource.getContentAsDOM();
-        System.out.println("Attempting serialization using eXist's serializer");
+
         StringWriter writer = new StringWriter();
         Properties outputProperties = new Properties();
         outputProperties.setProperty("indent", "yes");
         DOMSerializer serializer = new DOMSerializer(writer, outputProperties);
         serializer.serialize(node);
-
-        System.out.println("Using org.exist.util.serializer.DOMSerializer");
-        System.out.println("---------------------");
-        System.out.println(writer.toString());
-        System.out.println("---------------------");
     }
 
     @Test
     public void serialize4() throws ParserConfigurationException, SAXException, IOException, XMLDBException {
         Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
-        System.out.println("Xerces version: "+org.apache.xerces.impl.Version.getVersion( ));
+
         Document doc = javax.xml.parsers.DocumentBuilderFactory.newInstance( ).newDocumentBuilder().parse(testFile);
         XMLResource resource = (XMLResource) testCollection.createResource(null, "XMLResource");
         resource.setContentAsDOM(doc);
-        System.out.println("Storing resource: "+resource.getId( ));
+
         testCollection.storeResource(resource);
 
         resource = (XMLResource)testCollection.getResource(resource.getId());
         assertNotNull(resource);
         @SuppressWarnings("unused")
                 Node node = resource.getContentAsDOM();
-        System.out.println("Attempting serialization using eXist's SAX serializer");
         StringWriter writer = new StringWriter();
         Properties outputProperties = new Properties();
         outputProperties.setProperty("indent", "yes");
         SAXSerializer serializer = new SAXSerializer(writer, outputProperties);
         resource.getContentAsSAX(serializer);
-
-        System.out.println("Using org.exist.util.serializer.SAXSerializer");
-        System.out.println("---------------------");
-        System.out.println(writer.toString());
-        System.out.println("---------------------");
     }
 
     @Test
@@ -235,12 +209,11 @@ public class TestEXistXMLSerialize {
         Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
         XMLResource resource = (XMLResource) testCollection.createResource("test.xml", "XMLResource");
         resource.setContent(XML_DATA);
-        System.out.println("Storing resource: "+resource.getId( ));
+
         testCollection.storeResource(resource);
 
         XMLResource style = (XMLResource) testCollection.createResource("test.xsl", "XMLResource");
         style.setContent(XSL_DATA);
-        System.out.println("Storing resource: "+style.getId( ));
         testCollection.storeResource(style);
 
         Properties outputProperties = new Properties();
@@ -250,10 +223,5 @@ public class TestEXistXMLSerialize {
         StringWriter writer = new StringWriter();
         SAXSerializer serializer = new SAXSerializer(writer, outputProperties);
         resource.getContentAsSAX(serializer);
-
-        System.out.println("Using org.exist.util.serializer.SAXSerializer");
-        System.out.println("---------------------");
-        System.out.println(writer.toString());
-        System.out.println("---------------------");
     }
 }

--- a/test/src/org/exist/xmldb/concurrent/ConcurrentQueryTest.java
+++ b/test/src/org/exist/xmldb/concurrent/ConcurrentQueryTest.java
@@ -81,18 +81,4 @@ public class ConcurrentQueryTest extends ConcurrentTestBase {
             fail(e.getMessage()); 
         }				
 	}
-	
-	/* (non-Javadoc)
-     * @see org.exist.xmldb.test.concurrent.ConcurrentTestBase#tearDown()
-     */
-    protected void tearDown() {    	
-        super.tearDown();
-        System.out.println("Avg. query time for " + action0.getQuery() + ": " + action0.avgExecTime());
-        System.out.println("Avg. query time for " + action1.getQuery() + ": " + action1.avgExecTime());
-        System.out.println("Avg. query time for " + action2.getQuery() + ": " + action2.avgExecTime());
-//        System.out.println("Avg. query time for " + action3.getQuery() + ": " + action3.avgExecTime());
-//        System.out.println("Avg. query time for " + action4.getQuery() + ": " + action4.avgExecTime());
-//        System.out.println("Avg. query time for " + action5.getQuery() + ": " + action5.avgExecTime());        
-//        System.out.println("element index: " + NativeElementIndex.getTime());	        
-    }
 }

--- a/test/src/org/exist/xmldb/concurrent/ConcurrentQueryUpdateTest.java
+++ b/test/src/org/exist/xmldb/concurrent/ConcurrentQueryUpdateTest.java
@@ -51,7 +51,7 @@ public class ConcurrentQueryUpdateTest extends ConcurrentTestBase {
 			assertEquals(result.getSize(), 41);
 			for (int i = 0; i < result.getSize(); i++) {
 				XMLResource next = (XMLResource) result.getResource((long)i);
-				System.out.println(next.getContent());
+				next.getContent();
 			}
 			
 			super.tearDown();

--- a/test/src/org/exist/xmldb/concurrent/DBUtils.java
+++ b/test/src/org/exist/xmldb/concurrent/DBUtils.java
@@ -99,8 +99,7 @@ public class DBUtils {
 		File file = File.createTempFile(Thread.currentThread().getName(), ".xml");
 		if(file.exists() && !file.canWrite())
 			throw new IllegalArgumentException("Cannot write to output file " + file.getAbsolutePath());
-		
-		System.out.println("Generating XML file " + file.getAbsolutePath());
+
 		Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
 		
 		XMLGenerator gen = new XMLGenerator(elementCnt, attrCnt, depth, wordList, namespaces);

--- a/test/src/org/exist/xmldb/concurrent/action/AttributeUpdateAction.java
+++ b/test/src/org/exist/xmldb/concurrent/action/AttributeUpdateAction.java
@@ -46,7 +46,6 @@ public class AttributeUpdateAction extends RemoveAppendAction {
 		for (int i = 0; i < 10; i++) {
 			String xupdate = XUPDATE_START + xmlGenerator.generateText(attrSize) + XUPDATE_END;
 			long mods = service.update(xupdate);
-			System.out.println(Thread.currentThread().getName() + ": " + mods + " attributes updated ...");
 		}
 		return false;
 	}

--- a/test/src/org/exist/xmldb/concurrent/action/ComplexUpdateAction.java
+++ b/test/src/org/exist/xmldb/concurrent/action/ComplexUpdateAction.java
@@ -78,7 +78,6 @@ public class ComplexUpdateAction extends Action {
 	public boolean execute() throws Exception {
 		Collection col = DatabaseManager.getCollection(collectionPath, "admin", null);
 		for(int i = 0; i < repeat; i++) {
-			System.out.println("Starting run " + (i + 1));
 			query(col, i); 
 			col.close();
 			
@@ -101,13 +100,9 @@ public class ComplexUpdateAction extends Action {
 		XPathQueryService service = (XPathQueryService)col.getService("XPathQueryService", "1.0");
 		ResourceSet r = service.query("//USER-SESSION-DATA");
 		Assert.assertEquals(1, r.getSize());
-		System.out.println("------------------------------------------------------------------");
 		for(long i = 0; i < r.getSize(); i++) {
 			XMLResource res = (XMLResource)r.getResource(i);
-			System.out.println(res.getContent());
 		}
-		System.out.println("------------------------------------------------------------------");
-		
 		r = service.query("string(//USER-SESSION-DATA[1]/@version)");
 		Assert.assertEquals(1, r.getSize());
 		Assert.assertEquals(repeat, Integer.parseInt(r.getResource(0).getContent().toString()));
@@ -117,14 +112,10 @@ public class ComplexUpdateAction extends Action {
 		XUpdateQueryService service = (XUpdateQueryService)
 		col.getService("XUpdateQueryService", "1.0");
 		long mods = service.updateResource(resourceName, xupdate);
-		System.out.println("Processed " + mods + " modifications.");
 	}
 	
 	@SuppressWarnings("unused")
 	private void displayResource(Collection col) throws XMLDBException {
 		XMLResource res = (XMLResource)col.getResource(resourceName);
-		System.out.println("------------------------------------------------------------------");
-		System.out.println(res.getContent());
-		System.out.println("------------------------------------------------------------------");
 	}
 }

--- a/test/src/org/exist/xmldb/concurrent/action/CreateCollectionAction.java
+++ b/test/src/org/exist/xmldb/concurrent/action/CreateCollectionAction.java
@@ -44,11 +44,7 @@ public class CreateCollectionAction extends Action {
         Collection col = DatabaseManager.getCollection(collectionPath, "admin", null);
         Collection target = DBUtils.addCollection(col, "C" + ++collectionCnt);
         addFiles(target);
-        System.out.println("Resources in collection " + target.getName());
         String resources[] = target.listResources();
-        for (int i = 0; i < resources.length; i++) {
-            System.out.println(resources[i]);
-        }
         
         CollectionManagementServiceImpl mgt = (CollectionManagementServiceImpl)
             col.getService("CollectionManagementService", "1.0");
@@ -57,12 +53,8 @@ public class CreateCollectionAction extends Action {
            mgt.copyResource(target.getName() + '/' + resources[i], 
                    copy.getName(), null);
         }
-        
-        System.out.println("Resources in collection " + copy.getName());
+
         resources = copy.listResources();
-        for (int i = 0; i < resources.length; i++) {
-            System.out.println(resources[i]);
-        }
         return false;
     }
 

--- a/test/src/org/exist/xmldb/concurrent/action/MultiResourcesAction.java
+++ b/test/src/org/exist/xmldb/concurrent/action/MultiResourcesAction.java
@@ -67,11 +67,9 @@ public class MultiResourcesAction extends Action {
         File[] files = d.listFiles();
 		for(int i = 0; i < files.length; i++) {
             if(files[i].isFile()) {
-                System.out.println("Storing " + files[i].getName());
             	DBUtils.addXMLResource(col, files[i].getName(), files[i]);
             }
         }
-		System.out.println("All files stored.");
 	}
 
 }

--- a/test/src/org/exist/xmldb/concurrent/action/RemoveAppendAction.java
+++ b/test/src/org/exist/xmldb/concurrent/action/RemoveAppendAction.java
@@ -60,7 +60,6 @@ public class RemoveAppendAction extends Action {
 	}
 	
 	private void remove(XUpdateQueryService service) throws XMLDBException {
-		System.out.println(Thread.currentThread().getName() + ": removing elements ...");
 		for(int i = 0; i < 10; i++)
 			service.update(REMOVE);
 	}
@@ -72,7 +71,6 @@ public class RemoveAppendAction extends Action {
 		final String updateClose =
 			"</xu:append>" +
 			"</xu:modifications>";
-		System.out.println(Thread.currentThread().getName() + ": inserting elements ...");
 		for (int i = 0; i < 10; i++) {
 			String update = updateOpen + xmlGenerator.generateElement() + updateClose;
 			service.update(update);

--- a/test/src/org/exist/xmldb/concurrent/action/RetrieveResourceAction.java
+++ b/test/src/org/exist/xmldb/concurrent/action/RetrieveResourceAction.java
@@ -41,13 +41,10 @@ public class RetrieveResourceAction extends Action {
 	public boolean execute() throws Exception {
 		Collection col = DatabaseManager.getCollection(collectionPath);
 		XMLResource res = (XMLResource)col.getResource(resourceName);
-		
-//		System.out.println(res.getContent());
+
 		DefaultHandler handler = new DefaultHandler();
 		res.getContentAsSAX(handler);
-		
-		System.out.println(Thread.currentThread()
-				+ " - Retrieved resource: " + resourceName);
+
 		return false;
 	}
 }

--- a/test/src/org/exist/xmldb/concurrent/action/TextUpdateAction.java
+++ b/test/src/org/exist/xmldb/concurrent/action/TextUpdateAction.java
@@ -91,7 +91,6 @@ public class TextUpdateAction extends Action {
 		mods = service.update(update);
 		
 		Assert.assertEquals(1, mods);
-		System.out.println(mods + " nodes updated.");
 		
 		// query for section
 		XPathQueryService query = (XPathQueryService)
@@ -101,7 +100,7 @@ public class TextUpdateAction extends Action {
 		updateText = result.getResource(0).getContent().toString();
 		result = query.query("/article/section/para[. = '" + updateText + "']");
 		Assert.assertEquals(1, result.getSize());
-		System.out.println(result.getResource(0).getContent().toString());
+		result.getResource(0).getContent();
 		
 		mods = service.update(REMOVE);
 		Assert.assertEquals(1, mods);

--- a/test/src/org/exist/xmldb/concurrent/action/ValueAppendAction.java
+++ b/test/src/org/exist/xmldb/concurrent/action/ValueAppendAction.java
@@ -61,7 +61,6 @@ public class ValueAppendAction extends Action {
     }
 
     private void remove(XUpdateQueryService service) throws XMLDBException {
-		System.out.println(Thread.currentThread().getName() + ": removing elements ...");
 		for(int i = 0; i < 10; i++)
 			service.update(REMOVE);
 	}
@@ -73,7 +72,6 @@ public class ValueAppendAction extends Action {
 		final String updateClose =
 			"</xu:append>" +
 			"</xu:modifications>";
-		System.out.println(Thread.currentThread().getName() + ": inserting elements ...");
 		for (int i = 0; i < 10; i++) {
 			String update = updateOpen +
 				"<item id=\"" + i + "\"><name>abcdefg</name>" +

--- a/test/src/org/exist/xmldb/concurrent/action/XQueryAction.java
+++ b/test/src/org/exist/xmldb/concurrent/action/XQueryAction.java
@@ -57,15 +57,11 @@ public class XQueryAction extends Action {
 	    
 		Collection col = DatabaseManager.getCollection(collectionPath);
 		
-		System.out.println(Thread.currentThread().getName() + ": executing query: " + xquery);
-		
 		XPathQueryServiceImpl service = (XPathQueryServiceImpl)
 			col.getService("XPathQueryService", "1.0");
 		
 //		service.beginProtected();
 		ResourceSet result = service.query(xquery);
-
-		System.out.println(Thread.currentThread().getName() + ": found " + result.getSize());
 		
 		DefaultHandler handler = new DefaultHandler();
 		for (int i = 0; i < result.getSize(); i++) {
@@ -76,8 +72,7 @@ public class XQueryAction extends Action {
 		
 		runningTime += (System.currentTimeMillis() - start);
 		called++;
-		
-		System.out.println(Thread.currentThread().getName() + ": XQuery completed.");
+
 		return false;
 	}
 	

--- a/test/src/org/exist/xmlrpc/MoveResourceTest.java
+++ b/test/src/org/exist/xmlrpc/MoveResourceTest.java
@@ -55,8 +55,6 @@ public class MoveResourceTest extends TestCase {
             thread3.join();
         } catch (InterruptedException e) {
         }
-
-        System.out.println("DONE.");
     }
     
     private void createCollection(XmlRpcClient client, XmldbURI collection) throws IOException, XmlRpcException {
@@ -93,14 +91,14 @@ public class MoveResourceTest extends TestCase {
                     XmldbURI sourceResource = sourceColl.append("source.xml");
                     XmldbURI targetResource = targetColl2.append("copied.xml");
 
-                    System.out.println("Creating collections ...");
+                    //Creating collections
                     XmlRpcClient xmlrpc = getClient();
 
                     createCollection(xmlrpc, sourceColl);
                     createCollection(xmlrpc, targetColl1);
                     createCollection(xmlrpc, targetColl2);
 
-                    System.out.println("Storing document ...");
+                    //Storing document
                     Vector<Object> params = new Vector<Object>();
                     params.addElement(readData());
                     params.addElement(sourceResource.toString());
@@ -109,9 +107,7 @@ public class MoveResourceTest extends TestCase {
                     Boolean result = (Boolean)xmlrpc.execute("parse", params);
                     assertTrue(result.booleanValue());
 
-                    System.out.println("Document stored.");
-
-                    System.out.println("Moving resource ...");
+                    //Moving resource
                     params.clear();
                     params.addElement(sourceResource.toString());
                     params.addElement(targetColl2.toString());
@@ -119,7 +115,7 @@ public class MoveResourceTest extends TestCase {
 
                     xmlrpc.execute( "moveResource", params );
 
-                    System.out.println("Retrieving document " + targetResource);
+                    //Retrieving document
                     Hashtable<String, String> options = new Hashtable<String, String>();
                     options.put("indent", "yes");
                     options.put("encoding", "UTF-8");
@@ -132,20 +128,18 @@ public class MoveResourceTest extends TestCase {
 
                     byte[] data = (byte[]) xmlrpc.execute( "getDocument", params );
                     assertTrue(data != null && data.length > 0);
-//                    System.out.println( new String(data, "UTF-8") );
 
                     synchronized (this) {
                         wait(250);
                     }
 
-                    System.out.println("Removing created collections ...");
+                    //Removing created collections
                     params.clear();
                     params.addElement(sourceColl.toString());
                     xmlrpc.execute("removeCollection", params);
 
                     params.setElementAt(targetColl1.toString(), 0);
                     xmlrpc.execute("removeCollection", params);
-                    System.out.println("Collections removed.");
                 } catch (Exception e) {
                     e.printStackTrace();
                     fail(e.getMessage());
@@ -168,7 +162,7 @@ public class MoveResourceTest extends TestCase {
                     int r = connect.getResponseCode();
                     assertEquals("Server returned response code " + r, 200, r);
 
-                    System.out.println(readResponse(connect.getInputStream()));
+                    readResponse(connect.getInputStream());
 
                     synchronized (this) {
                         wait(250);
@@ -221,7 +215,6 @@ public class MoveResourceTest extends TestCase {
 		try {
 			if (server == null) {
 				server = new JettyStart();
-                System.out.println("Starting standalone server...");
                 server.run();
 			}
 	    } catch (Exception e) {

--- a/test/src/org/exist/xmlrpc/QuerySessionTest.java
+++ b/test/src/org/exist/xmlrpc/QuerySessionTest.java
@@ -63,7 +63,6 @@ public class QuerySessionTest {
 
     @Test (expected=XMLDBException.class)
     public void manualRelease() throws XMLDBException {
-        System.out.println("---manualRelease");
         Collection test = DatabaseManager.getCollection(baseURI + "/db/rpctest", "admin", "");
         XQueryService service = (XQueryService) test.getService("XQueryService", "1.0");
         ResourceSet result = service.query("//chapter[@xml:id = 'chapter1']");
@@ -74,18 +73,13 @@ public class QuerySessionTest {
 
         // the result has been cleared already. we should get an exception here
         Resource members = result.getMembersAsResource();
-        System.out.println("members: " + members.getContent().toString());
+        members.getContent();
     }
 
     @Test
     public void runTasks() {
-        System.out.println("---runTasks");
         ExecutorService executor = Executors.newFixedThreadPool(N_THREADS);
         for (int i = 0; i < 1000; i++) {
-            if(i % 10 == 0)
-                System.out.print(".");
-            else
-                System.out.print(".");
             executor.submit(new QueryTask(QUERY));
         }
 
@@ -124,11 +118,7 @@ public class QuerySessionTest {
 	@BeforeClass
     public static void startServer() throws Exception {
         
-        System.out.println("\n\n==================================\n\n");
-        
         server = new JettyStart();
-        System.out.println("Starting standalone server...");
-        System.out.println("Waiting for server to start...");
         server.run();
 
         // initialize XML:DB driver
@@ -160,8 +150,6 @@ public class QuerySessionTest {
 
     @AfterClass
     public static void stopServer() {
-        
-        System.out.println("\n\nStop server...\n");
 
         try {
             Collection root = DatabaseManager.getCollection(baseURI + "/db", "admin", "");

--- a/test/src/org/exist/xmlrpc/XmlRpcTest.java
+++ b/test/src/org/exist/xmlrpc/XmlRpcTest.java
@@ -100,7 +100,6 @@ public class XmlRpcTest {
 	
     @BeforeClass
     public static void setUp() {
-        System.out.println("==================================");
 		//Don't worry about closing the server : the shutdownDB hook will do the job
 		initServer();		
 	}
@@ -134,7 +133,6 @@ public class XmlRpcTest {
 		try {
 			if (server == null) {
 				server = new JettyStart();
-                System.out.println("Starting standalone server...");
                 server.run();
             }
 	    } catch (Exception e) {
@@ -145,16 +143,13 @@ public class XmlRpcTest {
 
 	@Test
 	public void testStoreAndRetrieve() {
-        System.out.println("---testStoreAndRetrieve");
 		try {
-			System.out.println("Creating collection " + TARGET_COLLECTION);
 			XmlRpcClient xmlrpc = getClient();
 			Vector<Object> params = new Vector<Object>();
 			params.addElement(TARGET_COLLECTION.toString());
 			Boolean result = (Boolean)xmlrpc.execute("createCollection", params);
 			Assert.assertTrue(result.booleanValue());
 
-			System.out.println("Storing document " + XML_DATA);
 			params.clear();
 			params.addElement(XML_DATA);
 			params.addElement(TARGET_RESOURCE.toString());
@@ -163,15 +158,12 @@ public class XmlRpcTest {
 			result = (Boolean)xmlrpc.execute("parse", params);
 			Assert.assertTrue(result.booleanValue());
 
-			System.out.println("Documents stored.");
-
             HashMap<String, String> options = new HashMap<String, String>();
             params.clear();
             params.addElement(TARGET_RESOURCE.toString());
             params.addElement(options);
 
 			byte[] data = (byte[]) xmlrpc.execute( "getDocument", params );
-			System.out.println( new String(data, "UTF-8") );
             Assert.assertNotNull(data);
 
             params.clear();
@@ -180,14 +172,12 @@ public class XmlRpcTest {
             params.addElement(0);
 
             data = (byte[]) xmlrpc.execute( "getDocument", params );
-            System.out.println( new String(data, "UTF-8") );
             Assert.assertNotNull(data);
 
             params.clear();
             params.addElement(TARGET_RESOURCE.toString());
             params.addElement(0);
             String sdata = (String) xmlrpc.execute( "getDocumentAsString", params );
-            System.out.println(sdata);
             Assert.assertNotNull(data);
 
             params.clear();
@@ -209,7 +199,6 @@ public class XmlRpcTest {
             }
             data = os.toByteArray();
             Assert.assertTrue(data.length > 0);
-            System.out.println(new String(data, "UTF-8"));
 
             params.clear();
             params.addElement(TARGET_RESOURCE.toString());
@@ -222,16 +211,13 @@ public class XmlRpcTest {
 	}
 
 	private void storeData() {
-        System.out.println("---storeData");
 		try {
-			System.out.println("Creating collection " + TARGET_COLLECTION);
 			XmlRpcClient xmlrpc = getClient();
 			Vector<Object> params = new Vector<Object>();
 			params.addElement(TARGET_COLLECTION.toString());
 			Boolean result = (Boolean)xmlrpc.execute("createCollection", params);
 			Assert.assertTrue(result.booleanValue());
-			
-			System.out.println("Storing document " + XML_DATA);
+
 			params.clear();
 			params.addElement(XML_DATA);
 			params.addElement(TARGET_RESOURCE.toString());
@@ -239,22 +225,19 @@ public class XmlRpcTest {
 			
 			result = (Boolean)xmlrpc.execute("parse", params);
 			Assert.assertTrue(result.booleanValue());
-			
-			System.out.println("Storing resource " + XSL_DATA);
+
 			params.setElementAt(XSL_DATA, 0);
 			params.setElementAt(TARGET_COLLECTION.append("test.xsl").toString(), 1);
 			result = (Boolean)xmlrpc.execute("parse", params);
 			Assert.assertTrue(result.booleanValue());
-			
-			System.out.println("Storing resource " + MODULE_DATA);
+
 			params.setElementAt(MODULE_DATA.getBytes(UTF_8), 0);
 			params.setElementAt(MODULE_RESOURCE.toString(), 1);
 			params.setElementAt(MimeType.XQUERY_TYPE.getName(), 2);
 			params.addElement(Boolean.TRUE);
 			result = (Boolean)xmlrpc.execute("storeBinary", params);
 			Assert.assertTrue(result.booleanValue());
-			
-			System.out.println("Documents stored.");
+
 	    } catch (Exception e) {
             e.printStackTrace();
             Assert.fail(e.getMessage());  
@@ -263,7 +246,6 @@ public class XmlRpcTest {
 
 	@Test
     public void testRemoveCollection() {
-        System.out.println("---testRemoveCollection");
         storeData();
         XmlRpcClient xmlrpc = getClient();
         try {
@@ -285,7 +267,6 @@ public class XmlRpcTest {
 
 	@Test
     public void testRemoveDoc() {
-        System.out.println("---testRemoveDoc");
         storeData();
         XmlRpcClient xmlrpc = getClient();
         try {
@@ -308,9 +289,7 @@ public class XmlRpcTest {
 
 	@Test
 	public void testRetrieveDoc() {
-        System.out.println("---testRetrieveDoc");
         storeData();
-		System.out.println("Retrieving document " + TARGET_RESOURCE);
 		Hashtable<String, String> options = new Hashtable<String, String>();
         options.put("indent", "yes");
         options.put("encoding", "UTF-8");
@@ -325,12 +304,9 @@ public class XmlRpcTest {
 	        // execute the call
 			XmlRpcClient xmlrpc = getClient();
 			byte[] data = (byte[]) xmlrpc.execute( "getDocument", params );
-			System.out.println( new String(data, "UTF-8") );
-			
-			System.out.println("Retrieving document with stylesheet applied");
+
 			options.put("stylesheet", "test.xsl");
 			data = (byte[]) xmlrpc.execute( "getDocument", params );
-			System.out.println( new String(data, "UTF-8") );
 	    } catch (Exception e) {            
 	    	Assert.fail(e.getMessage());  
 	    }			
@@ -338,10 +314,8 @@ public class XmlRpcTest {
 	
 	@Test
 	public void testCharEncoding() {
-        System.out.println("---testCharEncoding");
         storeData();
 		try {
-			System.out.println("Testing charsets returned by query");
 			Vector<Object> params = new Vector<Object>();
 			String query = "distinct-values(//para)";
 			params.addElement(query.getBytes(UTF_8));
@@ -353,10 +327,8 @@ public class XmlRpcTest {
 	        Assert.assertEquals(resources.length, 2);
 	        String value = (String)resources[0];
 	        Assert.assertEquals(value, "\u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF");
-	        System.out.println("Result1: " + value);
 	        value = (String)resources[1];
 	        Assert.assertEquals(value, "\uC5F4\uB2E8\uACC4");
-	        System.out.println("Result2: " + value);
 	    } catch (Exception e) {            
 	    	Assert.fail(e.getMessage());
         }
@@ -364,7 +336,6 @@ public class XmlRpcTest {
 	
 	@Test
 	public void testQuery() {
-        System.out.println("---testQuery");
         storeData();
 		try {
 			Vector<Object> params = new Vector<Object>();
@@ -378,7 +349,6 @@ public class XmlRpcTest {
 	        byte[] result = (byte[]) xmlrpc.execute( "query", params );
 	        Assert.assertNotNull(result);
 	        Assert.assertTrue(result.length > 0);
-	        System.out.println(new String(result, "UTF-8"));
 	    } catch (Exception e) {            
 	    	Assert.fail(e.getMessage());  
 	    }	        
@@ -386,7 +356,6 @@ public class XmlRpcTest {
 	
 	@Test
 	public void testQueryWithStylesheet() {
-        System.out.println("---testQueryWithStylesheet");
         storeData();
 		try {
 			HashMap<String, String> options = new HashMap<String, String>();
@@ -410,7 +379,6 @@ public class XmlRpcTest {
 	        Assert.assertNotNull(item);
 	        Assert.assertTrue(item.length > 0);
 	        String out = new String(item, UTF_8);
-	        System.out.println("Received: " + out);
 	        XMLAssert.assertXMLEqual("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
 	        		"<p>Test: \u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF</p>", out);
 	    } catch (Exception e) {            
@@ -420,7 +388,6 @@ public class XmlRpcTest {
 
     @Test
     public void testCompile() {
-        System.out.println("---testCompile");
         storeData();
 		try {
 			Vector<Object> params = new Vector<Object>();
@@ -428,7 +395,6 @@ public class XmlRpcTest {
 			params.addElement(query.getBytes(UTF_8));
 			params.addElement(new Hashtable<Object, Object>());
 			XmlRpcClient xmlrpc = getClient();
-			System.out.println("Executing query: " + query);
 	        Map stats = (Map) xmlrpc.execute( "compile", params );
 	        Assert.assertNotNull(stats);
             Assert.assertNotNull(stats.get("error"));
@@ -439,7 +405,6 @@ public class XmlRpcTest {
 
     @Test
     public void testAddAccount() {
-        System.out.println("---testAddAccount");
         try {
             String user = "rudi";
             String passwd = "pass";
@@ -468,7 +433,6 @@ public class XmlRpcTest {
 
 	@Test
 	public void testExecuteQuery() {
-        System.out.println("---testExecuteQuery");
         storeData();
 		try {
 			Vector<Object> params = new Vector<Object>();
@@ -476,7 +440,6 @@ public class XmlRpcTest {
 			params.addElement(query.getBytes(UTF_8));
 			params.addElement(new Hashtable<Object, Object>());
 			XmlRpcClient xmlrpc = getClient();
-			System.out.println("Executing query: " + query);
 	        Integer handle = (Integer) xmlrpc.execute( "executeQuery", params );
 	        Assert.assertNotNull(handle);
 	        
@@ -484,21 +447,18 @@ public class XmlRpcTest {
 	        params.addElement(handle);
 	        Integer hits = (Integer) xmlrpc.execute( "getHits", params );
 	        Assert.assertNotNull(hits);
-	        System.out.println("Found: " + hits.intValue());
 	        
 	        Assert.assertEquals(hits.intValue(), 2);	        
         
 	        params.addElement(new Integer(0));
 	        params.addElement(new Hashtable<Object, Object>());
 	        byte[] item = (byte[]) xmlrpc.execute( "retrieve", params );
-	        System.out.println(new String(item, "UTF-8"));
 	        
 	        params.clear();
 	        params.addElement(handle);
 	        params.addElement(Integer.valueOf(1));
 	        params.addElement(new Hashtable<Object, Object>());
 	        item = (byte[]) xmlrpc.execute( "retrieve", params );
-	        System.out.println(new String(item, "UTF-8"));
 	    } catch (Exception e) {            
 	    	Assert.fail(e.getMessage());  
 	    }	        
@@ -506,10 +466,8 @@ public class XmlRpcTest {
 	
 	@Test
 	public void testQueryModuleExternalVar() {
-        System.out.println("---testQueryModuleExternalVar");
         storeData();
 		try {
-			System.out.println("Quering with external variable definied in module ...");
 			Vector<Object> params = new Vector<Object>();
 			params.addElement(QUERY_MODULE_DATA.getBytes(UTF_8));
 			
@@ -533,10 +491,8 @@ public class XmlRpcTest {
 	        Assert.assertEquals(resources.length, 2);
 	        String value = (String) resources[0];
 	        Assert.assertEquals(value, "imported-string-value");
-	        System.out.println("Imported external: " + value);
 	        value = (String) resources[1];
 	        Assert.assertEquals(value, "local-string-value");
-	        System.out.println("Local external: " + value);
 	        
 	    } catch (Exception e) {            
 	    	Assert.fail(e.getMessage());  
@@ -545,16 +501,13 @@ public class XmlRpcTest {
 	
 	@Test
 	public void testCollectionWithAccentsAndSpaces() {
-        System.out.println("---testCollectionWithAccentsAndSpaces");
         storeData();
 		try {
-			System.out.println("Creating collection with accents and spaces in name ...");
 			Vector<Object> params = new Vector<Object>();
 			params.addElement(SPECIAL_COLLECTION.toString());
 			XmlRpcClient xmlrpc = getClient();
 			xmlrpc.execute( "createCollection", params );
-			
-			System.out.println("Storing document " + XML_DATA);
+
 			params.clear();
 			params.addElement(XML_DATA);
 			params.addElement(SPECIAL_RESOURCE.toString());
@@ -572,15 +525,13 @@ public class XmlRpcTest {
 			String targetCollectionName = SPECIAL_COLLECTION.lastSegment().toString();
 			for (int i = 0; i < collections.length; i++) {
 				String childName = (String) collections[i];
-				System.out.println("Child collection: " + childName);
 				if(childName.equals(targetCollectionName)) {
 					foundMatch=true;
 					break;
 				}
 			}
 			Assert.assertTrue("added collection not found", foundMatch);
-			
-			System.out.println("Retrieving document '" + SPECIAL_RESOURCE.toString() + "'");
+
 			HashMap<String, String> options = new HashMap<String, String>();
 	        options.put("indent", "yes");
 	        options.put("encoding", "UTF-8");
@@ -593,7 +544,6 @@ public class XmlRpcTest {
 	        
 	        // execute the call
 			byte[] data = (byte[]) xmlrpc.execute( "getDocument", params );
-			System.out.println( new String(data, "UTF-8") );
 	    } catch (Exception e) {            
 	    	Assert.fail(e.getMessage());  
 	    }			

--- a/test/src/org/exist/xqj/MarshallerTest.java
+++ b/test/src/org/exist/xqj/MarshallerTest.java
@@ -91,7 +91,6 @@ public class MarshallerTest {
             SAXSerializer serializer = new SAXSerializer(writer, new Properties());
             Marshaller.marshall(broker, values, serializer);
             String serialized = writer.toString();
-            System.out.println(serialized);
 
             Sequence seq = Marshaller.demarshall(broker, new StringReader(serialized));
             assertEquals(seq.itemAt(0).getStringValue(), "foo");
@@ -121,7 +120,6 @@ public class MarshallerTest {
             SAXSerializer serializer = new SAXSerializer(writer, new Properties());
             Marshaller.marshall(broker, p, serializer);
             String serialized = writer.toString();
-            System.out.println(serialized);
 
             Sequence seq = Marshaller.demarshall(broker, new StringReader(serialized));
             assertTrue(Type.subTypeOf(seq.getItemType(), Type.NODE));
@@ -131,7 +129,6 @@ public class MarshallerTest {
             serializer.reset();
             serializer.setOutput(writer, new Properties());
             n.toSAX(broker, serializer, new Properties());
-            System.out.println(writer.toString());
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -92,7 +92,6 @@ public class ConstructedNodesRecoveryTest extends TestCase
 	{
 		//create a transaction
 		try(final Txn transaction = transact.beginTransaction()) {
-            System.out.println("Transaction started ...");
 
             //get the test collection
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
@@ -106,7 +105,6 @@ public class ConstructedNodesRecoveryTest extends TestCase
 
             //commit the transaction
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         }
 	}
 	
@@ -114,7 +112,6 @@ public class ConstructedNodesRecoveryTest extends TestCase
 	{
 		//create a transaction
 		try(final Txn transaction = transact.beginTransaction()) {
-            System.out.println("Transaction started ...");
 
             //get the test collection
             Collection root = broker.getOrCreateCollection(transaction, XmldbURI.TEMP_COLLECTION_URI.append(childCollectionName));
@@ -123,7 +120,6 @@ public class ConstructedNodesRecoveryTest extends TestCase
 
             //commit the transaction
             transact.commit(transaction);
-            System.out.println("Transaction commited ...");
         }
 	}
 	
@@ -131,7 +127,6 @@ public class ConstructedNodesRecoveryTest extends TestCase
 	{
 		//create a transaction
         try(final Txn transaction = transact.beginTransaction()) {
-            System.out.println("Transaction started ...");
 
             //get the test collection
             Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
@@ -165,7 +160,6 @@ public class ConstructedNodesRecoveryTest extends TestCase
 	{
 		//create a transaction
         try(final Txn transaction = transact.beginTransaction()) {
-            System.out.println("Transaction started ...");
 
             //get the temp child collection
             Collection tempChildCollection = broker.getOrCreateCollection(transaction, XmldbURI.TEMP_COLLECTION_URI.append(childCollectionName));

--- a/test/src/org/exist/xquery/ConstructedNodesTest.java
+++ b/test/src/org/exist/xquery/ConstructedNodesTest.java
@@ -108,7 +108,6 @@ public class ConstructedNodesTest extends TestCase
 		}
 		catch (XMLDBException e)
 		{
-			System.out.println("testIterateConstructNodes(): " + e);
 			fail(e.getMessage());
 		}
 	}
@@ -152,7 +151,6 @@ public class ConstructedNodesTest extends TestCase
 		}
 		catch (XMLDBException e)
 		{
-			System.out.println("testConstructedNodesSort(): " + e);
 			fail(e.getMessage());
 		}
 	}
@@ -195,7 +193,6 @@ public class ConstructedNodesTest extends TestCase
 		}
 		catch (XMLDBException e)
 		{
-			System.out.println("testConstructedNodesPosition(): " + e);
 			fail(e.getMessage());
 		}
 	}
@@ -234,7 +231,6 @@ public class ConstructedNodesTest extends TestCase
 			service.setProperty(OutputKeys.INDENT, oki);
 			
 		} catch (XMLDBException e) {
-			System.out.println("testConstructedTextNodes(): " + e);
 			fail(e.getMessage());
 		}
 	}

--- a/test/src/org/exist/xquery/ConvertionsTest.java
+++ b/test/src/org/exist/xquery/ConvertionsTest.java
@@ -59,7 +59,6 @@ public class ConvertionsTest extends TestCase {
 			assertEquals( "XQuery: " + query, 3, result.getSize() );
 			
 		} catch (XMLDBException e) {
-			System.out.println("testQName2string(): " + e);
 			fail(e.getMessage());
 		}
 	}
@@ -91,7 +90,6 @@ public class ConvertionsTest extends TestCase {
 			DatabaseInstanceManager dim =
 				(DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
 			dim.shutdown();
-			//System.out.println("tearDown PASSED");
 	    } catch (Exception e) {            
 	        fail(e.getMessage());  
 	    }			

--- a/test/src/org/exist/xquery/DeepEqualTest.java
+++ b/test/src/org/exist/xquery/DeepEqualTest.java
@@ -410,7 +410,6 @@ public class DeepEqualTest extends TestCase {
                         +"let $result2 := ds:result($result1, $v2) "
                         +"return deep-equal($expected, $result2/Value)";
                 for(int i=1; i<20;i++){
-                    System.out.println("nr="+i);
                     assertQuery(true,query);
                }
 

--- a/test/src/org/exist/xquery/DocumentUpdateTest.java
+++ b/test/src/org/exist/xquery/DocumentUpdateTest.java
@@ -31,7 +31,7 @@ public class DocumentUpdateTest extends TestCase {
     		"import module namespace util='http://exist-db.org/xquery/util';\n";
     	
 		try {
-			System.out.println("-- TEST 1: doc() function --");
+			//TEST 1: doc() function
 			String query = imports +
 	    		"declare function local:get-doc($path as xs:string) {\n" + 
 	    		"    if (doc-available($path)) then doc($path) else ()\n" + 
@@ -45,7 +45,7 @@ public class DocumentUpdateTest extends TestCase {
 			String result = execQuery(query);
 			assertEquals(result, "0 false");
 			
-			System.out.println("-- TEST 2: xmldb:document() function --");
+			//TEST 2: xmldb:document()
 			query = imports +
 	    		"declare function local:get-doc($path as xs:string) {\n" + 
 	    		"    if (doc-available($path)) then xmldb:document($path) else ()\n" + 
@@ -58,7 +58,7 @@ public class DocumentUpdateTest extends TestCase {
 			result = execQuery(query);
 			assertEquals(result, "1 true");
 			
-			System.out.println("-- TEST 3: collection() function --");
+			//TEST 3: collection()
 			query = imports +
 				"declare function local:xpath($collection as xs:string) {\n" + 
 	    		"    for $c in collection($collection) return $c//n\n" + 
@@ -71,7 +71,7 @@ public class DocumentUpdateTest extends TestCase {
 			result = execQuery(query);
 			assertEquals(result, "1");
 		
-			System.out.println("-- TEST 4: 'update insert' statement --");
+			//TEST 4: 'update insert' statement
 			query = imports +
 				"declare function local:xpath($collection as xs:string) {\n" + 
 	    		"    collection($collection)\n" + 
@@ -87,7 +87,7 @@ public class DocumentUpdateTest extends TestCase {
 			result = execQuery(query);
 			assertEquals(result, "2");
 
-			System.out.println("-- TEST 5: 'update replace' statement --");
+			//TEST 5: 'update replace' statement
 			query = imports + "let $doc := xdb:store('/db', 'test1.xml', " +
 				"<test> " +
 					"<link href=\"features\"/> " +
@@ -195,7 +195,6 @@ public class DocumentUpdateTest extends TestCase {
 	        dim.shutdown();
             database = null;
             testCollection = null;
-	        System.out.println("tearDown PASSED");
 		} catch (XMLDBException e) {
 			fail(e.getMessage());
 		}

--- a/test/src/org/exist/xquery/DuplicateAttributesTest.java
+++ b/test/src/org/exist/xquery/DuplicateAttributesTest.java
@@ -123,7 +123,7 @@ public class DuplicateAttributesTest {
         String query =
             "<results>{fn:idref(('id1', 'id2'), doc('/db/test/docdtd.xml')/IDS)}</results>";
         ResourceSet result = xqs.query(query);
-        System.out.println(result.getResource(0).getContent());
+        result.getResource(0).getContent();
     }
 
     @BeforeClass

--- a/test/src/org/exist/xquery/EntitiesTest.java
+++ b/test/src/org/exist/xquery/EntitiesTest.java
@@ -58,7 +58,6 @@ public class EntitiesTest extends XMLTestCase {
         try {
             if (server == null) {
                 server = new JettyStart();
-                System.out.println("Starting standalone server...");
                 server.run();
             }
         } catch(Exception e) {
@@ -75,9 +74,6 @@ public class EntitiesTest extends XMLTestCase {
                 dim.shutdown();
             }
             testCollection = null;
-            
-            System.out.println("tearDown PASSED");
-            
         } catch (XMLDBException e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -149,20 +145,6 @@ public class EntitiesTest extends XMLTestCase {
                 "XPathQueryService",
                 "1.0");
         return service;
-    }
-    
-    /**
-     * @param result
-     * @throws XMLDBException
-     */
-    @SuppressWarnings("unused")
-	private void printResult(ResourceSet result) throws XMLDBException {
-        for (ResourceIterator i = result.getIterator();
-        i.hasMoreResources();
-        ) {
-            Resource r = i.nextResource();
-            System.out.println(r.getContent());
-        }
     }
     
     public void testAttributeConstructor() {

--- a/test/src/org/exist/xquery/JavaFunctionsTest.java
+++ b/test/src/org/exist/xquery/JavaFunctionsTest.java
@@ -93,7 +93,6 @@ public class JavaFunctionsTest extends TestCase {
 		DatabaseInstanceManager dim =
 			(DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
 		dim.shutdown();
-		//System.out.println("tearDown PASSED");
 	}
 
 }

--- a/test/src/org/exist/xquery/LexerTest.java
+++ b/test/src/org/exist/xquery/LexerTest.java
@@ -107,7 +107,7 @@ public class LexerTest extends TestCase {
 				}
 	
 				AST ast = xparser.getAST();
-				System.out.println("generated AST: " + ast.toStringTree());
+
 	
 				PathExpr expr = new PathExpr(context);
 				treeParser.xpath(ast, expr);
@@ -118,10 +118,9 @@ public class LexerTest extends TestCase {
 				expr.analyze(new AnalyzeContextInfo());
 				// execute the query
 				Sequence result = expr.eval(null, null);
-	
+
 				// check results
-				System.out.println("----------------------------------");
-				System.out.println("found: " + result.getItemCount());
+				int count = result.getItemCount();
 			} catch (Exception e) {
 	            e.printStackTrace();
 	            fail(e.getMessage());

--- a/test/src/org/exist/xquery/OptimizerTest.java
+++ b/test/src/org/exist/xquery/OptimizerTest.java
@@ -211,7 +211,6 @@ public class OptimizerTest {
 
     private int execute(String query, boolean optimize) {
         try {
-            System.out.println("--- Query: " + query + "; Optimize: " + Boolean.toString(optimize));
             XQueryService service = (XQueryService) testCollection.getService("XQueryService", "1.0");
             if (optimize)
                 query = OPTIMIZE + query;
@@ -219,7 +218,6 @@ public class OptimizerTest {
                 query = NO_OPTIMIZE + query;
             query = NAMESPACES + query;
             ResourceSet result = service.query(query);
-            System.out.println("-- Found: " + result.getSize());
             return (int) result.getSize();
         } catch (XMLDBException e) {
             e.printStackTrace();
@@ -230,14 +228,12 @@ public class OptimizerTest {
 
     private void execute(String query, boolean optimize, String message, int expected) {
         try {
-            System.out.println("--- Query: " + query + "; Optimize: " + Boolean.toString(optimize));
             XQueryService service = (XQueryService) testCollection.getService("XQueryService", "1.0");
             if (optimize)
                 query = NAMESPACES + OPTIMIZE + query;
             else
                 query = NAMESPACES + NO_OPTIMIZE + query;
             ResourceSet result = service.query(query);
-            System.out.println("-- Found: " + result.getSize());
             Assert.assertEquals(message, expected, result.getSize());
         } catch (XMLDBException e) {
             e.printStackTrace();
@@ -279,7 +275,6 @@ public class OptimizerTest {
                 throw new IOException("Unable to read samples directory");
             File[] files = dir.listFiles(new XMLFilenameFilter());
             for (File file : files) {
-                System.out.println("Create resource from "+file.getAbsolutePath());
                 resource = (XMLResource) testCollection.createResource(file.getName(), "XMLResource");
                 resource.setContent(file);
                 testCollection.storeResource(resource);
@@ -303,7 +298,5 @@ public class OptimizerTest {
             Assert.fail(e.getMessage());
         }
         testCollection = null;
-
-		System.out.println("tearDown PASSED");
 	}
 }

--- a/test/src/org/exist/xquery/QueryPoolTest.java
+++ b/test/src/org/exist/xquery/QueryPoolTest.java
@@ -49,7 +49,6 @@ public class QueryPoolTest extends TestCase {
         try {
             XQueryService service = (XQueryService) testCollection.getService("XQueryService", "1.0");
             for (int i = 0; i < 10000; i++) {
-                System.out.println("Inserting node " + i + "...");
                 String query = "update insert <node id='id" + Integer.toHexString(i) + "'>" +
                         "<p>Some longer text <b>content</b> in this node. Some longer text <b>content</b> in this node. " +
                         "Some longer text <b>content</b> in this node. Some longer text <b>content</b> in this node.</p>" +
@@ -67,7 +66,6 @@ public class QueryPoolTest extends TestCase {
         try {
             XMLResource res = (XMLResource) testCollection.getResource("large_list.xml");
             assertNotNull(res);
-            System.out.println(res.getContent());
         } catch (XMLDBException e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/test/src/org/exist/xquery/SAXStorageTest.java
+++ b/test/src/org/exist/xquery/SAXStorageTest.java
@@ -75,12 +75,10 @@ public class SAXStorageTest extends TestCase {
 		ResourceSet result = null;
 		if ( xquery != "") {
 			// xquery = "/*/*[2]";
-			System.out.println("Querying \""+xquery+"\" ..." );
 			long t0 = System.currentTimeMillis();
 			result = service.queryResource( "big.xml", xquery );
 			// assertEquals(1, result.getSize());
 			long t1 = System.currentTimeMillis();
-			System.out.println("Time for query \""+xquery+"\" on "+ mess + ": " + ( t1-t0) + " ms." );
 		}
 		return result;
 	}
@@ -128,8 +126,6 @@ public class SAXStorageTest extends TestCase {
                                 File existDir = existHome==null ? new File(".") : new File(existHome);
 				doc.setContent(new File(existDir,FILE_STORED));
 				coll.storeResource(doc);
-				long t1 = System.currentTimeMillis();
-				System.out.println("Time for storing:  " + ( t1-t0) + " ms." );
 			}
 		} catch (XMLDBException e) {
 			fail(e.getMessage());

--- a/test/src/org/exist/xquery/SpecialNamesTest.java
+++ b/test/src/org/exist/xquery/SpecialNamesTest.java
@@ -58,7 +58,6 @@ public class SpecialNamesTest extends XMLTestCase {
         try {
             if (server == null) {
                 server = new JettyStart();
-                System.out.println("Starting standalone server...");
                 server.run();
             }
         } catch(Exception e) {
@@ -75,9 +74,6 @@ public class SpecialNamesTest extends XMLTestCase {
                 dim.shutdown();
             }
             testCollection = null;
-            
-            System.out.println("tearDown PASSED");
-            
         } catch (XMLDBException e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -149,20 +145,6 @@ public class SpecialNamesTest extends XMLTestCase {
                 "XPathQueryService",
                 "1.0");
         return service;
-    }
-    
-    /**
-     * @param result
-     * @throws XMLDBException
-     */
-    @SuppressWarnings("unused")
-	private void printResult(ResourceSet result) throws XMLDBException {
-        for (ResourceIterator i = result.getIterator();
-        i.hasMoreResources();
-        ) {
-            Resource r = i.nextResource();
-            System.out.println(r.getContent());
-        }
     }
     
     public void testAttributes() {

--- a/test/src/org/exist/xquery/StoredModuleTest.java
+++ b/test/src/org/exist/xquery/StoredModuleTest.java
@@ -150,7 +150,7 @@ public class StoredModuleTest {
         for (int i = 0; i < cols.length; i++) {
             xqService.declareVariable("itg-modules:coll", cols[i]);
             ResourceSet result = xqService.execute(compiledQuery);
-            System.out.println("Result: " + result.getResource(0).getContent());
+            result.getResource(0).getContent();
         }
     }
 

--- a/test/src/org/exist/xquery/TransformTest.java
+++ b/test/src/org/exist/xquery/TransformTest.java
@@ -33,14 +33,12 @@ public class TransformTest extends TestCase {
     		"import module namespace transform='http://exist-db.org/xquery/transform';\n";
     	
 		try {
-			System.out.println("-- transform:transform with relative stylesheet paths");
 			String query = 
 				"import module namespace transform='http://exist-db.org/xquery/transform';\n" +
 				"let $xml := <empty />,\n" +
 				"	$xsl := 'xmldb:exist:///db/"+TEST_COLLECTION_NAME+"/xsl1/1.xsl'\n" +
 				"return transform:transform($xml, $xsl, ())";
 			String result = execQuery(query);
-			System.out.println("RESULT = "+result);
 			assertEquals(result, "<doc>" +
 					"<p>Start Template 1</p>" +
 					"<p>Start Template 2</p>" +
@@ -169,7 +167,6 @@ public class TransformTest extends TestCase {
 	        dim.shutdown();
             database = null;
             testCollection = null;
-	        System.out.println("tearDown PASSED");
 		} catch (XMLDBException e) {
 			fail(e.getMessage());
 		}

--- a/test/src/org/exist/xquery/ValueIndexTest.java
+++ b/test/src/org/exist/xquery/ValueIndexTest.java
@@ -127,7 +127,6 @@ public class ValueIndexTest extends TestCase {
             (DatabaseInstanceManager) testCollection.getService("DatabaseInstanceManager", "1.0");
         dim.shutdown();
         testCollection = null;
-        //System.out.println("tearDown PASSED");
     }
     
 	/**
@@ -151,7 +150,6 @@ public class ValueIndexTest extends TestCase {
             ResourceSet result = queryResource(service, "items.xml", "for $i in //item[stock <= 10] return $i/itemno", 5);
             for (long i = 0; i < result.getSize(); i++) {
                 Resource res = result.getResource(i);
-                System.out.println(res.getContent());
             }
 
             queryResource(service, "items.xml", "//item[stock > 20]", 1);
@@ -405,7 +403,6 @@ public class ValueIndexTest extends TestCase {
 
     public void testIndexScan() {
         try {
-            System.out.println("----- testIndexScan -----");
             configureCollection(CONFIG);
             String queryBody =
                 "declare namespace f=\'http://exist-db.org/xquery/test\';\n" + 
@@ -425,14 +422,14 @@ public class ValueIndexTest extends TestCase {
             String query = queryBody + "u:index-keys(//item/name, \'\', util:function(xs:QName(\'f:term-callback\'), 2), 1000)";
             ResourceSet result = service.query(query);
             for (ResourceIterator i = result.getIterator(); i.hasMoreResources(); ) {
-                System.out.println(i.nextResource().getContent());
+                i.nextResource().getContent();
             }
             assertEquals(7, result.getSize());
 
             query = queryBody + "u:index-keys(//item/stock, 0, util:function(xs:QName(\'f:term-callback\'), 2), 1000)";
             result = service.query(query);
             for (ResourceIterator i = result.getIterator(); i.hasMoreResources(); ) {
-                System.out.println(i.nextResource().getContent());
+                i.nextResource().getContent();
             }
             assertEquals(5, result.getSize());
         } catch (XMLDBException e) {

--- a/test/src/org/exist/xquery/XMLNodeAsXQueryParameterTest.java
+++ b/test/src/org/exist/xquery/XMLNodeAsXQueryParameterTest.java
@@ -124,9 +124,7 @@ public class XMLNodeAsXQueryParameterTest extends TestCase {
 		// issue xpath query
 		try {
 			Node node = root.getFirstChild();
-			if (node != null) {
-				System.out.println("Found '" + node.getNodeName() + "'");
-			} else {
+			if (node == null) {
 				fail("XUpdate:append using w3c dom node failed! Content node was not returned.");
 			}
 		} catch (Exception e) {

--- a/test/src/org/exist/xquery/XPathQueryTest.java
+++ b/test/src/org/exist/xquery/XPathQueryTest.java
@@ -193,7 +193,6 @@ public class XPathQueryTest {
 	private void initServer() {
         if (server == null) {
             server = new JettyStart();
-            System.out.println("Starting standalone server...");
             server.run();
         }
     }
@@ -286,8 +285,6 @@ public class XPathQueryTest {
 
         String query = "/test/item[ @id='1' ]";
         ResourceSet result = service.queryResource(testDocument, query);
-        System.out.println("testAttributes 1: ========");
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize());
 
         XMLResource resource = (XMLResource)result.getResource(0);
@@ -298,8 +295,6 @@ public class XPathQueryTest {
 
         query = "/test/item [ @type='alphanum' ]";
         result = service.queryResource(testDocument, query);
-        System.out.println("testAttributes 2: ========");
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize());
     }
 
@@ -309,23 +304,15 @@ public class XPathQueryTest {
                 storeXMLStringAndGetQueryService("numbers.xml", numbers);
 
         ResourceSet result = service.queryResource("numbers.xml", "/*/item");
-        System.out.println("testStarAxis 1: ========");
-        printResult(result);
         assertEquals("XPath: /*/item", 4, result.getSize());
 
         result = service.queryResource("numbers.xml", "/test/*");
-        System.out.println("testStarAxis  2: ========");
-        printResult(result);
         assertEquals("XPath: /test/*", 4, result.getSize());
 
         result = service.queryResource("numbers.xml", "/test/descendant-or-self::*");
-        System.out.println("testStarAxis  3: ========");
-        printResult(result);
         assertEquals("XPath: /test/descendant-or-self::*", 13, result.getSize());
 
         result = service.queryResource("numbers.xml", "/*/*");
-        System.out.println("testStarAxis 4: ========" );
-        printResult(result);
         //Strange !!! Should be 8
         assertEquals("XPath: /*/*", 4, result.getSize());
     }
@@ -335,57 +322,38 @@ public class XPathQueryTest {
         final XQueryService service =
                 storeXMLStringAndGetQueryService("namespaces.xml", namespaces);
         service.setNamespace("t", "http://www.foo.com");
-        System.out.println("testStarAxisConstraints : ========");
 
         String query = "// t:title/text() [ . != 'aaaa' ]";
         ResourceSet result = service.queryResource( "namespaces.xml", query);
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize() );
-        System.out.println("testStarAxisConstraints : ========");
 
         query = "/t:test/*:section[contains(., 'comment')]";
         result = service.queryResource("namespaces.xml", query);
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize());
-        System.out.println("testStarAxisConstraints : ========");
 
         query = "/t:test/t:*[contains(., 'comment')]";
         result = service.queryResource("namespaces.xml", query);
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize());
-        System.out.println("testStarAxisConstraints : ========");
 
         query = "/t:test/t:section[contains(., 'comment')]";
         result = service.queryResource("namespaces.xml", query);
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize());
-        System.out.println("testStarAxisConstraints : ========");
 
         query = "/t:test/t:section/*[contains(., 'comment')]";
         result = service.queryResource("namespaces.xml", query);
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize());
-        System.out.println("testStarAxisConstraints : ========");
 
         query = "/ * / * [ t:title ]";
         result = service.queryResource( "namespaces.xml", query);
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize() );
-        System.out.println("testStarAxisConstraints : ========");
 
         query = "/ t:test / t:section [ t:title ]";
         result = service.queryResource( "namespaces.xml", query);
-        printResult(result);
-        System.out.println("g) 1 / " +  result.getSize());
         assertEquals("XPath: " + query, 1, result.getSize() );
-        System.out.println("testStarAxisConstraints : ========");
 
         query = "/ t:test / t:section";
         result = service.queryResource( "namespaces.xml", query);
-        printResult(result);
-        System.out.println("h) 1 / " +  result.getSize());
         assertEquals("XPath: " + query, 1, result.getSize() );
-        System.out.println("testStarAxisConstraints : ========");
     }
 
     @Test
@@ -396,14 +364,10 @@ public class XPathQueryTest {
 
         String query =  "/ * [ ./ * / t:title ]";
         ResourceSet result = service.queryResource( "namespaces.xml", query);
-        System.out.println("testStarAxisConstraints2 : ========");
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize());
 
         query =  "/ * [ * / t:title ]";
         result = service.queryResource( "namespaces.xml", query);
-        System.out.println("testStarAxisConstraints2 : ========");
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize());
     }
 
@@ -415,8 +379,6 @@ public class XPathQueryTest {
 
         final String query =  "// * [ . = 'Test Document' ]";
         final ResourceSet result = service.queryResource("namespaces.xml", query);
-        System.out.println("testStarAxisConstraints3 : ========");
-        printResult(result);
         assertEquals("XPath: " + query, 1, result.getSize());
     }
 
@@ -1068,8 +1030,8 @@ public class XPathQueryTest {
         final XQueryService service = getQueryService();
         final ResourceSet rs = service.query(xQuery);
         
-        System.out.println("BUG1460791/1" + rs.getResource(0).getContent().toString() );
-        System.out.println("BUG1460791/2" + rs.getResource(1).getContent().toString() );
+//        System.out.println("BUG1460791/1" + rs.getResource(0).getContent().toString() );
+//        System.out.println("BUG1460791/2" + rs.getResource(1).getContent().toString() );
         
         assertEquals("SFBUG 1460791 nr of results", 2, rs.getSize());
         
@@ -1291,8 +1253,6 @@ public class XPathQueryTest {
     @Test
     public void booleans() throws XMLDBException {
 
-        System.out.println("Testing effective boolean value of expressions ...");
-
         final XQueryService service =
                 storeXMLStringAndGetQueryService("numbers.xml", numbers);
 
@@ -1508,7 +1468,6 @@ public class XPathQueryTest {
         String message = "";
         try {
             service.execute(expr);
-            System.out.println(query);
         } catch (XMLDBException e) {
             e.printStackTrace();
             message = e.getMessage();
@@ -1526,7 +1485,6 @@ public class XPathQueryTest {
 
         message = "";
         try {
-            System.out.println(query);
             service.execute(expr);
         } catch (XMLDBException e) {
             e.printStackTrace();
@@ -1642,7 +1600,6 @@ public class XPathQueryTest {
                 storeXMLStringAndGetQueryService("nested.xml", nested);
 
         final ResourceSet result = service.queryResource("nested.xml", "//c");
-        printResult(result);
         assertEquals(3, result.getSize());
     }
     
@@ -1664,19 +1621,10 @@ public class XPathQueryTest {
 
         //ResourceSet result = service.query("//SPEECH[SPEAKER=$name]");
         ResourceSet result = service2.query( doc, "//item[stock=$name]");
-
-        System.out.println("testStaticVariables 1: ========");
-        printResult(result);
         result = service2.query("$name");
         assertEquals(1, result.getSize());
-
-        System.out.println("testStaticVariables 2: ========");
-        printResult(result);
         result = service2.query( doc, "//item[stock=43]");
         assertEquals(1, result.getSize());
-
-        System.out.println("testStaticVariables 3: ========");
-        printResult(result);
         result = service2.query(doc, "//item");
         assertEquals(4, result.getSize());
 
@@ -1709,7 +1657,6 @@ public class XPathQueryTest {
         } else {
             content = (String)r.getContent();
         }
-        System.out.println(content);
 
         final Pattern p = Pattern.compile(".*(<price>.*){4}", Pattern.DOTALL);
         final Matcher m = p.matcher(content);
@@ -1907,11 +1854,9 @@ public class XPathQueryTest {
 
         ResourceSet result = service.queryResource("xpointer.xml",
                 "/test/.[local-name()='xpointer']");
-        printResult(result);
         assertEquals(1, result.getSize());
 
         result = service.queryResource("xpointer.xml", "/test/xpointer");
-        printResult(result);
         assertEquals(1, result.getSize());
     }
 
@@ -1931,7 +1876,6 @@ public class XPathQueryTest {
         service.setProperty(OutputKeys.INDENT, "no");
         final ResourceSet result = service.query(query);
         assertEquals(1, result.getSize());
-        printResult(result);
         assertXMLEqual("<test><test:name xmlns:test=\"http://test.org\"/><test:name xmlns:test=\"http://test.org\"/></test>", result.getResource(0).getContent().toString());
     }
 
@@ -2024,17 +1968,6 @@ public class XPathQueryTest {
                 "XPathQueryService",
                 "1.0");
         return service;
-    }
-
-    /**
-     * @param result
-     * @throws XMLDBException
-     */
-    private void printResult(final ResourceSet result) throws XMLDBException {
-        for (final ResourceIterator i = result.getIterator(); i.hasMoreResources(); ) {
-            final Resource r = i.nextResource();
-            System.out.println(r.getContent());
-        }
     }
 
     public static void main(final String[] args) {

--- a/test/src/org/exist/xquery/XQueryFunctionsTest.java
+++ b/test/src/org/exist/xquery/XQueryFunctionsTest.java
@@ -101,7 +101,6 @@ public class XQueryFunctionsTest extends TestCase {
 			assertEquals(0,result.getSize());
 
 		} catch (XMLDBException e) {
-			System.out.println("testSum(): " + e);
 			fail(e.getMessage());
 		}
 	}	
@@ -131,7 +130,6 @@ public class XQueryFunctionsTest extends TestCase {
 			assertEquals( "0", r );
 		
 		} catch (XMLDBException e) {
-			System.out.println("testRoundHtE_INTEGER(): "+e);
 			fail(e.getMessage());
 		}
 	}
@@ -160,7 +158,6 @@ public class XQueryFunctionsTest extends TestCase {
 				assertEquals( resultvalues[i], r );
 			}
 		} catch (XMLDBException e) {
-			System.out.println("testRoundHtE_DOUBLE(): "+e);
 			fail(e.getMessage());
 		}
 	}
@@ -190,7 +187,6 @@ public class XQueryFunctionsTest extends TestCase {
 			assertEquals( "true", r );
 			
 		} catch (XMLDBException e) {
-			System.out.println("testTokenize(): " + e);
 			fail(e.getMessage());
 		}
 	}
@@ -206,7 +202,6 @@ public class XQueryFunctionsTest extends TestCase {
 			r 		= (String) result.getResource(0).getContent();
 			assertEquals( "true", r );
 		} catch (XMLDBException e) {
-			System.out.println("testDeepEqual(): " + e);
 			fail(e.getMessage());
 		}
 	}
@@ -229,7 +224,6 @@ public class XQueryFunctionsTest extends TestCase {
 			
 			
 		} catch (XMLDBException e) {
-			System.out.println("testCompare(): " + e);
 			fail(e.getMessage());
 		}
 	}	
@@ -255,7 +249,6 @@ public class XQueryFunctionsTest extends TestCase {
             assertEquals(2, result.getSize());
 		
 		} catch (XMLDBException e) {
-			System.out.println("testDistinctValues(): " + e);
 			fail(e.getMessage());
 		}
 	}	
@@ -279,7 +272,6 @@ public class XQueryFunctionsTest extends TestCase {
 			
 
 		} catch (XMLDBException e) {
-			System.out.println("testSum(): " + e);
 			fail(e.getMessage());
 		}
 	}	
@@ -329,7 +321,6 @@ public class XQueryFunctionsTest extends TestCase {
 
 		} catch (XMLDBException e) {
 			e.printStackTrace();
-			System.out.println("testAvg(): " + e);
 			fail(e.getMessage());
 		}
 	}	
@@ -630,7 +621,6 @@ public class XQueryFunctionsTest extends TestCase {
 	        assertEquals(2, result.getSize());
 	        
 		} catch (XMLDBException e) {
-			System.out.println("testEncodeForURI(): " + e);
 			fail(e.getMessage());
 		}			
 	}
@@ -665,7 +655,6 @@ public class XQueryFunctionsTest extends TestCase {
 			assertEquals(expected, r);
 			
 		} catch (XMLDBException e) {
-			System.out.println("testIRIToURI(): " + e);
 			fail(e.getMessage());
 		}
 	}	
@@ -702,7 +691,6 @@ public class XQueryFunctionsTest extends TestCase {
 	        assertEquals(2, result.getSize());			
 
 		} catch (XMLDBException e) {
-			System.out.println("EscapeHTMLURI(): " + e);
 			fail(e.getMessage());
 		}		
 	}		
@@ -717,7 +705,6 @@ public class XQueryFunctionsTest extends TestCase {
 			r 		= (String) result.getResource(0).getContent();
 			assertEquals( "a", r );
 		} catch (XMLDBException e) {
-			System.out.println("local-name(): " + e);
 			fail(e.getMessage());
 		}
 	}
@@ -733,7 +720,6 @@ public class XQueryFunctionsTest extends TestCase {
 			r 		= (String) result.getResource(0).getContent();
 			assertEquals( "2007-05-02T15:12:52.421+02:00", r );
 		} catch (XMLDBException e) {
-			System.out.println("local-name(): " + e);
 			fail(e.getMessage());
 		}
     }	
@@ -760,7 +746,6 @@ public class XQueryFunctionsTest extends TestCase {
 		    assertEquals("2007-08-23T00:01:02.062+02:00", r);          
         
         } catch (XMLDBException e) {
-            System.out.println("current-dateTime(): " + e);
             fail(e.getMessage());
         }
     }
@@ -1119,7 +1104,6 @@ public class XQueryFunctionsTest extends TestCase {
 		}
 		catch(XMLDBException e)
 		{
-			System.out.println("testBase64Binary: XMLDBException: "+e);
 			fail(e.getMessage());
 		}
 	}
@@ -1150,7 +1134,6 @@ public class XQueryFunctionsTest extends TestCase {
         // clear instance variables
         service = null;
         root = null;
-		//System.out.println("tearDown PASSED");
 	}
 
 }

--- a/test/src/org/exist/xquery/XQueryProcessingInstruction.java
+++ b/test/src/org/exist/xquery/XQueryProcessingInstruction.java
@@ -51,7 +51,6 @@ public class XQueryProcessingInstruction {
         // clear instance variables
         service = null;
         root = null;
-    //System.out.println("tearDown PASSED");
     }
 
     @Test
@@ -75,7 +74,6 @@ public class XQueryProcessingInstruction {
         } catch (SAXException sae) {
                 fail(sae.getMessage());
         } catch (XMLDBException e) {
-            System.out.println("testPI(): " + e);
             fail(e.getMessage());
         }
 

--- a/test/src/org/exist/xquery/XQueryTest.java
+++ b/test/src/org/exist/xquery/XQueryTest.java
@@ -171,8 +171,6 @@ public class XQueryTest extends XMLTestCase {
         dim.shutdown();
         DatabaseManager.deregisterDatabase(database);
         database = null;
-
-        System.out.println("tearDown PASSED");
     }
 
     private Collection getTestCollection() throws XMLDBException {
@@ -189,27 +187,18 @@ public class XQueryTest extends XMLTestCase {
                     storeXMLStringAndGetQueryService(NUMBERS_XML, numbers);
 
             //Non null context sequence
-            System.out.println("testLet 1: ========");
             query = "/test/item[let $id := ./@id return $id]";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             assertEquals("XQuery: " + query, 4, result.getSize());
-
-            System.out.println("testLet 2: ========");
             query = "/test/item[let $id := ./@id return not(/test/set[@id=$id])]";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             assertEquals("XQuery: " + query, 4, result.getSize());
-
-            System.out.println("testLet 3: ========");
             query = "let $test := <test><a> a </a><a>a</a></test> " +
                     "return distinct-values($test/a/normalize-space(.))";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             assertEquals("XQuery: " + query, 1, result.getSize());
 
             //Ordered value sequence
-            System.out.println("testLet 4: ========");
             query = "let $unordset := (for $val in reverse(1 to 100) return " +
                     "<value>{$val}</value>)" +
                     "let $ordset := (for $newval in $unordset " +
@@ -219,7 +208,6 @@ public class XQueryTest extends XMLTestCase {
                     "return $ordset/ancestor::node()";
 
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             assertEquals("XQuery: " + query, 50, result.getSize());
 
             //WARNING : the return order CHANGES !!!!!!!!!!!!!!!!!!
@@ -228,7 +216,6 @@ public class XQueryTest extends XMLTestCase {
             assertXMLEqual("<value>1</value>", ((XMLResource) result.getResource(49)).getContent().toString());
 
         } catch (Exception e) {
-            System.out.println("testLet(): XMLDBException: " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }
@@ -241,51 +228,33 @@ public class XQueryTest extends XMLTestCase {
         try {
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(NUMBERS_XML, numbers);
-
-            System.out.println("testFor 1: ========");
             query = "for $f in /*/item return $f";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             assertEquals("XQuery: " + query, 4, result.getSize());
-
-            System.out.println("testFor 2: ========");
             query = "for $f in /*/item  order by $f ascending  return $f";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, "3", ((Element) resu.getContentAsDOM()).getAttribute("id"));
-
-            System.out.println("testFor 3: ========");
             query = "for $f in /*/item  order by $f descending  return $f";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, "2", ((Element) resu.getContentAsDOM()).getAttribute("id"));
-
-            System.out.println("testFor 4: ========");
             query = "for $f in /*/item  order by xs:double($f/price) descending  return $f";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, "4", ((Element) resu.getContentAsDOM()).getAttribute("id"));
-
-            System.out.println("testFor 5: ========");
             query = "for $f in //item where $f/@id = '3' return $f";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, "3", ((Element) resu.getContentAsDOM()).getAttribute("id"));
 
             //Non null context sequence
-            System.out.println("testFor 6: ========");
             query = "/test/item[for $id in ./@id return $id]";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, 4, result.getSize());
 
             //Ordered value sequence
-            System.out.println("testFor 7: ========");
             query = "let $doc := <doc><value>Z</value><value>Y</value><value>X</value></doc> " +
                     "return " +
                     "let $ordered_values := " +
@@ -295,20 +264,16 @@ public class XQueryTest extends XMLTestCase {
                     "	return $value[. = $ordered_values[position() = 1]]";
 
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, "<value>X</value>", resu.getContent());
 
             //Ordered value sequence
-            System.out.println("testFor 8: ========");
             query = "for $e in (1) order by $e return $e";
             result = service.queryResource(NUMBERS_XML, query);
-            printResult(result);
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, "1", resu.getContent());
 
         } catch (XMLDBException e) {
-            System.out.println("testFor(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -360,39 +325,29 @@ public class XQueryTest extends XMLTestCase {
                     (XPathQueryService) getTestCollection().getService(
                     "XPathQueryService",
                     "1.0");
-
-            System.out.println("testCombiningNodeSequences 1: ========");
             query = "let $a := <a/> \n" +
                     "let $aa := ($a, $a) \n" +
                     "for $b in ($aa intersect $aa \n)" +
                     "return $b";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<a/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testCombiningNodeSequences 2: ========");
             query = "let $a := <a/> \n" +
                     "let $aa := ($a, $a) \n" +
                     "for $b in ($aa union $aa \n)" +
                     "return $b";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<a/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testCombiningNodeSequences 3: ========");
             query = "let $a := <a/> \n" +
                     "let $aa := ($a, $a) \n" +
                     "for $b in ($aa except $aa \n)" +
                     "return $b";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 0, result.getSize());
 
 
         } catch (XMLDBException e) {
-            System.out.println("testCombiningNodeSequences(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -407,69 +362,38 @@ public class XQueryTest extends XMLTestCase {
                     (XPathQueryService) getTestCollection().getService(
                     "XPathQueryService",
                     "1.0");
-
-            System.out.println("testInMemoryNodeSequences 1: ========");
             query = "let $c := (<a/>,<b/>) return <t>text{$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t>text<a/></t>", result.getResource(0).getContent());
-
-            System.out.println("testInMemoryNodeSequences 2: ========");
             query = "let $c := (<a/>,<b/>) return <t><text/>{$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t><text/><a/></t>", result.getResource(0).getContent());
-
-            System.out.println("testInMemoryNodeSequences 3: ========");
             query = "let $c := (<a/>,<b/>) return <t>{\"text\"}{$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t>text<a/></t>", result.getResource(0).getContent());
-
-            System.out.println("testInMemoryNodeSequences 4: ========");
             query = "let $c := (<a/>,\"b\") return <t>text{$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t>text<a/></t>", result.getResource(0).getContent());
-
-            System.out.println("testInMemoryNodeSequences 5: ========");
             query = "let $c := (<a/>,\"b\") return <t><text/>{$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t><text/><a/></t>", result.getResource(0).getContent());
-
-            System.out.println("testInMemoryNodeSequences 6: ========");
             query = "let $c := (<a/>,\"b\") return <t>{\"text\"}{$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t>text<a/></t>", result.getResource(0).getContent());
-
-            System.out.println("testInMemoryNodeSequences 7: ========");
             query = "let $c := (<a/>,<b/>) return <t>{<text/>,$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t>text<a/></t>", result.getResource(0).getContent());
-
-            System.out.println("testInMemoryNodeSequences 8: ========");
             query = "let $c := (<a/>,<b/>) return <t>{\"text\",$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t>text<a/></t>", result.getResource(0).getContent());
-
-            System.out.println("testInMemoryNodeSequences 9: ========");
             query = "let $c := (<a/>,\"b\") return <t>{<text/>,$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t>text<a/></t>", result.getResource(0).getContent());
-
-            System.out.println("testInMemoryNodeSequences 10: ========");
             query = "let $c := (<a/>,\"b\") return <t>{\"text\",$c[1]}</t>";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, "<t>text<a/></t>", result.getResource(0).getContent());
 
         } catch (XMLDBException e) {
-            System.out.println("testInMemoryNodeSequences(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -484,48 +408,33 @@ public class XQueryTest extends XMLTestCase {
         try {
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(NUMBERS_XML, numbers);
-
-            System.out.println("testVariable 1: ========");
             query = "xquery version \"1.0\";\n" + "declare namespace param=\"param\";\n" + "declare variable $param:a {\"a\"};\n" + "declare function param:a() {$param:a};\n" + "let $param:a := \"b\" \n" + "return ($param:a, $param:a)";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 2, result.getSize());
             assertEquals("XQuery: " + query, "b", ((XMLResource) result.getResource(0)).getContent());
             assertEquals("XQuery: " + query, "b", ((XMLResource) result.getResource(1)).getContent());
-
-            System.out.println("testVariable 2: ========");
             query = "xquery version \"1.0\";\n" + "declare namespace param=\"param\";\n" + "declare variable $param:a {\"a\"};\n" + "declare function param:a() {$param:a};\n" + "let $param:a := \"b\" \n" + "return param:a(), param:a()";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 2, result.getSize());
             assertEquals("XQuery: " + query, "a", ((XMLResource) result.getResource(0)).getContent());
             assertEquals("XQuery: " + query, "a", ((XMLResource) result.getResource(1)).getContent());
-
-            System.out.println("testVariable 3: ========");
             query = "declare variable $foo {\"foo1\"};\n" + "let $foo := \"foo2\" \n" + "for $bar in (1 to 1) \n" + "  let $foo := \"foo3\" \n" + "  return $foo";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "foo3", ((XMLResource) result.getResource(0)).getContent());
 
             try {
                 message = "";
-                System.out.println("testVariable 4 ========");
                 query = "xquery version \"1.0\";\n" + "declare variable $a {\"1st instance\"};\n" + "declare variable $a {\"2nd instance\"};\n" + "$a";
                 result = service.query(query);
             } catch (XMLDBException e) {
                 message = e.getMessage();
             }
             assertTrue(message.indexOf("XQST0049") > -1);
-
-            System.out.println("testVariable 5: ========");
             query = "xquery version \"1.0\";\n" + "declare namespace param=\"param\";\n" + "declare function param:f() { $param:a };\n" + "declare variable $param:a {\"a\"};\n" + "param:f()";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "a", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testVariable 6: ========");
             query = "let $a := <root> " +
                     "<b name='1'>" +
                     "  <c name='x'> " +
@@ -542,14 +451,12 @@ public class XQueryTest extends XMLTestCase {
                     "return $b";
             result = service.queryResource(NUMBERS_XML, query);
             assertEquals("XQuery: " + query, 2, result.getSize());
-            printResult(result);
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, "2", ((Element) resu.getContentAsDOM()).getAttribute("name"));
             resu = (XMLResource) result.getResource(1);
             assertEquals("XQuery: " + query, "3", ((Element) resu.getContentAsDOM()).getAttribute("name"));
 
         } catch (XMLDBException e) {
-            System.out.println("testVariable : XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -593,7 +500,6 @@ public class XQueryTest extends XMLTestCase {
             assertXMLEqual("<id id='b' />", ((XMLResource) result.getResource(0)).getContent().toString());
 
         } catch (Exception e) {
-            System.out.println("testVirtualNodesets : XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -626,7 +532,6 @@ public class XQueryTest extends XMLTestCase {
                     ((XMLResource) result.getResource(0)).getContent().toString());
 
         } catch (Exception e) {
-            System.out.println("testWhereClause : XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -640,30 +545,20 @@ public class XQueryTest extends XMLTestCase {
         try {
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(NUMBERS_XML, numbers);
-
-            System.out.println("testTypedVariables 1: ========");
             query = "let $v as element()* := ( <assign/> , <assign/> )\n" + "let $w := <r>{ $v }</r>\n" + "let $x as element()* := $w/assign\n" + "return $x";
             result = service.query(query);
             assertEquals("XQuery: " + query, 2, result.getSize());
             assertEquals("XQuery: " + query, Node.ELEMENT_NODE, ((XMLResource) result.getResource(0)).getContentAsDOM().getNodeType());
             assertEquals("XQuery: " + query, "assign", ((XMLResource) result.getResource(0)).getContentAsDOM().getNodeName());
-
-            System.out.println("testTypedVariables 2: ========");
             query = "let $v as node()* := ()\n" + "return $v";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testTypedVariables 3: ========");
             query = "let $v as item()* := ()\n" + "return $v";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testTypedVariables 4: ========");
             query = "let $v as empty() := ()\n" + "return $v";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testTypedVariables 5: ========");
             query = "let $v as item() := ()\n" + "return $v";
             try {
                 exceptionThrown = false;
@@ -673,16 +568,12 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue("XQuery: " + query, exceptionThrown);
-
-            System.out.println("testTypedVariables 6: ========");
             query = "let $v as item()* := ( <a/> , 1 )\n" + "return $v";
             result = service.query(query);
             assertEquals("XQuery: " + query, 2, result.getSize());
             assertEquals("XQuery: " + query, Node.ELEMENT_NODE, ((XMLResource) result.getResource(0)).getContentAsDOM().getNodeType());
             assertEquals("XQuery: " + query, "a", ((XMLResource) result.getResource(0)).getContentAsDOM().getNodeName());
             assertEquals("XQuery: " + query, "1", ((XMLResource) result.getResource(1)).getContent());
-
-            System.out.println("testTypedVariables 7: ========");
             query = "let $v as node()* := ( <a/> , 1 )\n" + "return $v";
             try {
                 exceptionThrown = false;
@@ -692,8 +583,6 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(exceptionThrown);
-
-            System.out.println("testTypedVariables 8: ========");
             query = "let $v as item()* := ( <a/> , 1 )\n" + "let $w as element()* := $v\n" + "return $w";
             try {
                 exceptionThrown = false;
@@ -704,30 +593,20 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(exceptionThrown);
-
-            System.out.println("testTypedVariables 9: ========");
             query = "declare variable $v as element()* {( <assign/> , <assign/> ) };\n" + "declare variable $w { <r>{ $v }</r> };\n" + "declare variable $x as element()* { $w/assign };\n" + "$x";
             result = service.query(query);
             assertEquals("XQuery: " + query, 2, result.getSize());
             assertEquals("XQuery: " + query, Node.ELEMENT_NODE, ((XMLResource) result.getResource(0)).getContentAsDOM().getNodeType());
             assertEquals("XQuery: " + query, "assign", ((XMLResource) result.getResource(0)).getContentAsDOM().getNodeName());
-
-            System.out.println("testTypedVariables 10: ========");
             query = "declare variable $v as node()* { () };\n" + "$v";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testTypedVariables 11: ========");
             query = "declare variable $v as item()* { () };\n" + "$v";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testTypedVariables 12: ========");
             query = "declare variable $v as empty() { () };\n" + "$v";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testTypedVariables 13: ========");
             query = "declare variable $v as item() { () };\n" + "$v";
             try {
                 exceptionThrown = false;
@@ -737,16 +616,12 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue("XQuery: " + query, exceptionThrown);
-
-            System.out.println("testTypedVariables 14: ========");
             query = "declare variable $v as item()* { ( <a/> , 1 ) }; \n" + "$v";
             result = service.query(query);
             assertEquals("XQuery: " + query, 2, result.getSize());
             assertEquals("XQuery: " + query, Node.ELEMENT_NODE, ((XMLResource) result.getResource(0)).getContentAsDOM().getNodeType());
             assertEquals("XQuery: " + query, "a", ((XMLResource) result.getResource(0)).getContentAsDOM().getNodeName());
             assertEquals("XQuery: " + query, "1", ((XMLResource) result.getResource(1)).getContent());
-
-            System.out.println("testTypedVariables 15: ========");
             query = "declare variable $v as node()* { ( <a/> , 1 ) };\n" + "$v";
             try {
                 exceptionThrown = false;
@@ -756,8 +631,6 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(exceptionThrown);
-
-            System.out.println("testTypedVariables 16: ========");
             query = "declare variable $v as item()* { ( <a/> , 1 ) };\n" + "declare variable $w as element()* { $v };\n" + "$w";
             try {
                 exceptionThrown = false;
@@ -767,8 +640,6 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(exceptionThrown);
-
-            System.out.println("testTypedVariables 15: ========");
             query = "let $v as document-node() :=  doc('" + XmldbURI.ROOT_COLLECTION + "/test/" + NUMBERS_XML + "') \n" + "return $v";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
@@ -777,7 +648,6 @@ public class XQueryTest extends XMLTestCase {
             assertEquals("XQuery: " + query, "test", ((XMLResource) result.getResource(0)).getContentAsDOM().getNodeName());
 
         } catch (XMLDBException e) {
-            System.out.println("testTypedVariables : XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -792,8 +662,6 @@ public class XQueryTest extends XMLTestCase {
         try {
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(NUMBERS_XML, numbers);
-
-            System.out.println("testPrecedence 1: ========");
             query = "xquery version \"1.0\";\n" + "declare namespace blah=\"blah\";\n" + "declare variable $blah:param  {\"value-1\"};\n" + "let $blah:param := \"value-2\"\n" + "(:: FLWOR expressions have a higher precedence than the comma operator ::)\n" + "return $blah:param, $blah:param ";
             result = service.query(query);
             assertEquals("XQuery: " + query, 2, result.getSize());
@@ -801,7 +669,6 @@ public class XQueryTest extends XMLTestCase {
             assertEquals("XQuery: " + query, "value-1", ((XMLResource) result.getResource(1)).getContent());
 
         } catch (XMLDBException e) {
-            System.out.println("testTypedVariables : XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -815,33 +682,24 @@ public class XQueryTest extends XMLTestCase {
         try {
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(NUMBERS_XML, numbers);
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 1: ========");
             query = "let $a := <x>a<!--b-->c</x>/self::comment() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 2: ========");
             query = "let $a := <x>a<!--b-->c</x>/parent::comment() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 3: ========");
             query = "let $a := <x>a<!--b-->c</x>/ancestor::comment() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 4: ========");
             query = "let $a := <x>a<!--b-->c</x>/ancestor-or-self::comment() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
 
 //			This one is intercepted by the parser
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 5: ========");
             query = "let $a := <x>a<!--b-->c</x>/attribute::comment() return <z>{$a}</z>";
             try {
                 exceptionThrown = false;
@@ -853,7 +711,6 @@ public class XQueryTest extends XMLTestCase {
             assertTrue(exceptionThrown);
 
 //			This one is intercepted by the parser
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 6: ========");
             query = "let $a := <x>a<!--b-->c</x>/namespace::comment() return <z>{$a}</z>";
             try {
                 exceptionThrown = false;
@@ -863,75 +720,52 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(exceptionThrown);
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 7: ========");
             query = "let $a := <x>a<!--b-->c</x>/self::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 8: ========");
             query = "let $a := <x>a<!--b-->c</x>/parent::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 9: ========");
             query = "let $a := <x>a<!--b-->c</x>/ancestor::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 10: ========");
             query = "let $a := <x>a<!--b-->c</x>/ancestor-or-self::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 11: ========");
             query = "let $a := <x>a<!--b-->c</x>/child::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 12: ========");
             query = "let $a := <x>a<!--b-->c</x>/descendant::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 13: ========");
             query = "let $a := <x>a<!--b-->c</x>/descendant-or-self::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 14: ========");
             query = "let $a := <x>a<!--b-->c</x>/preceding::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 15: ========");
             query = "let $a := <x>a<!--b-->c</x>/preceding-sibling::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 16: ========");
             query = "let $a := <x>a<!--b-->c</x>/following::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 17: ========");
             query = "let $a := <x>a<!--b-->c</x>/following-sibling::attribute() return <z>{$a}</z>";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<z/>", ((XMLResource) result.getResource(0)).getContent());
 
 //			This one is intercepted by the parser
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 18: ========");
             query = "let $a := <x>a<!--b-->c</x>/namespace::attribute() return <z>{$a}</z>";
             try {
                 exceptionThrown = false;
@@ -945,25 +779,21 @@ public class XQueryTest extends XMLTestCase {
             //TODO : uncomment when PI are OK
 
             /*
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 19: ========" );
             query = "let $a := <x>a<?foo ?>c</x>/self::processing-instruction('foo') return <z>{$a}</z>";
             result = service.query(query);				
             assertEquals( "XQuery: " + query, 1, result.getSize() );
             assertEquals( "XQuery: " + query, "<z/>", ((XMLResource)result.getResource(0)).getContent());
-            
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 20: ========" );
+
             query = "let $a := <x>a<?foo ?>c</x>/parent::processing-instruction('foo') return <z>{$a}</z>";
             result = service.query(query);				
             assertEquals( "XQuery: " + query, 1, result.getSize() );
             assertEquals( "XQuery: " + query, "<z/>", ((XMLResource)result.getResource(0)).getContent());	
-            
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 21: ========" );
+
             query = "let $a := <x>a<?foo ?>c</x>/ancestor::processing-instruction('foo') return <z>{$a}</z>";
             result = service.query(query);				
             assertEquals( "XQuery: " + query, 1, result.getSize() );
             assertEquals( "XQuery: " + query, "<z/>", ((XMLResource)result.getResource(0)).getContent());
-            
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 22: ========" );
+
             query = "let $a := <x>a<?foo ?>c</x>/ancestor-or-self::processing-instruction('foo') return <z>{$a}</z>";
             result = service.query(query);				
             assertEquals( "XQuery: " + query, 1, result.getSize() );
@@ -971,7 +801,6 @@ public class XQueryTest extends XMLTestCase {
              */
 
 //			This one is intercepted by the parser
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 23: ========");
             query = "let $a := <x>a<?foo ?>c</x>/attribute::processing-instruction('foo') return <z>{$a}</z>";
             try {
                 exceptionThrown = false;
@@ -983,7 +812,6 @@ public class XQueryTest extends XMLTestCase {
             assertTrue(exceptionThrown);
 
 //			This one is intercepted by the parser
-            System.out.println("testImprobableAxesAndNodeTestsCombinations 24: ========");
             query = "let $a := <x>a<?foo ?>c</x>/namespace::processing-instruction('foo') return <z>{$a}</z>";
             try {
                 exceptionThrown = false;
@@ -995,7 +823,6 @@ public class XQueryTest extends XMLTestCase {
             assertTrue(exceptionThrown);
 
         } catch (XMLDBException e) {
-            System.out.println("testTypedVariables : XMLDBException: " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }
@@ -1032,8 +859,6 @@ public class XQueryTest extends XMLTestCase {
                     (XPathQueryService) testCollection.getService(
                     "XPathQueryService",
                     "1.0");
-
-            System.out.println("testNamespace 1: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace blah=\"blah\" at \"" + URI + "/test/" + MODULE1_NAME + "\";\n" + "(:: redefine existing prefix ::)\n" + "declare namespace blah=\"bla\";\n" + "$blah:param";
             try {
                 message = "";
@@ -1042,8 +867,6 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(message.indexOf("XQST0033") > -1);
-
-            System.out.println("testNamespace 2: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace blah=\"blah\" at \"" + URI + "/test/" + MODULE1_NAME + "\";\n" + "(:: redefine existing prefix with same URI ::)\n" + "declare namespace blah=\"blah\";\n" + "declare variable $blah:param  {\"value-2\"};\n" + "$blah:param";
             try {
                 message = "";
@@ -1052,8 +875,6 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(message.indexOf("XQST0033") > -1);
-
-            System.out.println("testNamespace 3: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace foo=\"ho\" at \"" + URI + "/test/" + MODULE1_NAME + "\";\n" + "$foo:bar";
             try {
                 message = "";
@@ -1063,8 +884,6 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(message.indexOf("does not match namespace URI") > -1);
-
-            System.out.println("testNamespace 4: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace foo=\"ho\" at \"" + URI + "/test/" + MODULE2_NAME + "\";\n" + "$bar";
             try {
                 message = "";
@@ -1073,8 +892,6 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(message.indexOf("No namespace defined for prefix") > -1);
-
-            System.out.println("testNamespace 5: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace foo=\"blah\" at \"" + URI + "/test/" + MODULE2_NAME + "\";\n" + "$bar";
             try {
                 message = "";
@@ -1083,15 +900,11 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(message.indexOf("No namespace defined for prefix") > -1);
-
-            System.out.println("testNamespace 6: ========");
             query = "declare namespace x = \"http://www.foo.com\"; \n" +
                     "let $a := doc('" + XmldbURI.ROOT_COLLECTION + "/test/" + NAMESPACED_NAME + "') \n" +
                     "return $a//x:edition";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testNamespace 7: ========");
             query = "declare namespace x = \"http://www.foo.com\"; \n" +
                     "declare namespace y = \"http://exist.sourceforge.net/dc-ext\"; \n" +
                     "let $a := doc('" + XmldbURI.ROOT_COLLECTION + "/test/" + NAMESPACED_NAME + "') \n" +
@@ -1100,8 +913,6 @@ public class XQueryTest extends XMLTestCase {
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "<x:edition xmlns:x=\"http://exist.sourceforge.net/dc-ext\">place</x:edition>",
                     ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testNamespace 8: ========");
             query = "<result xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>{//rdf:Description}</result>";
             result = service.query(query);
             assertEquals("XQuery: " + query,
@@ -1114,8 +925,6 @@ public class XQueryTest extends XMLTestCase {
                     "    </rdf:Description>\n" +
                     "</result>",
                     ((XMLResource) result.getResource(0)).getContent());
-
-            System.out.println("testNamespace 9: ========");
             query = "<result xmlns='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>{//Description}</result>";
             result = service.query(query);
             assertEquals("XQuery: " + query,
@@ -1138,8 +947,6 @@ public class XQueryTest extends XMLTestCase {
             the statically known namespaces. This feature provides a way 
             to remove predeclared namespace prefixes such as local.
              */
-
-            System.out.println("testNamespace 9: ========");
             query = "declare option exist:serialize 'indent=no';" +
                     "for $x in <parent4 xmlns=\"http://www.example.com/parent4\"><child4/></parent4> " +
                     "return <new>{$x//*:child4}</new>";
@@ -1148,7 +955,6 @@ public class XQueryTest extends XMLTestCase {
                     ((XMLResource) result.getResource(0)).getContent().toString());
 
         } catch (Exception e) {
-            System.out.println("testNamespace : " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }
@@ -1235,15 +1041,11 @@ public class XQueryTest extends XMLTestCase {
                     (XPathQueryService) testCollection.getService(
                     "XPathQueryService",
                     "1.0");
-
-            System.out.println("testModule 1: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace blah=\"blah\" at \"" + URI + "/test/" + MODULE1_NAME + "\";\n" + "$blah:param";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "value-1", result.getResource(0).getContent());
 
-//            System.out.println("testModule 2: ========");
 //            query = "xquery version \"1.0\";\n" + "import module namespace blah=\"blah\" at \"" + URI + "/test/" + MODULE1_NAME + "\";\n" + "(:: redefine variable ::)\n" + "declare variable $blah:param  {\"value-2\"};\n" + "$blah:param";
 //            try {
 //                message = "";
@@ -1252,15 +1054,10 @@ public class XQueryTest extends XMLTestCase {
 //                message = e.getMessage();
 //            }
 //            assertTrue(message.indexOf("XQST0049") > -1);
-
-            System.out.println("testModule 3: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace blah=\"blah\" at \"" + URI + "/test/" + MODULE1_NAME + "\";\n" + "declare namespace blah2=\"blah\";\n" + "$blah2:param";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "value-1", result.getResource(0).getContent());
-
-            System.out.println("testModule 4: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace blah=\"bla\" at \"" + URI + "/test/" + MODULE1_NAME + "\";\n" + "$blah:param";
             try {
                 message = "";
@@ -1269,18 +1066,14 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(message.indexOf("does not match namespace URI") > -1);
-
-            System.out.println("testModule 5: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace foo=\"foo\" at \"" + URI + "/test/" + FATHER_MODULE_NAME + "\";\n" + "$foo:bar, $foo:bar1, $foo:bar2";
             result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 3, result.getSize());
             assertEquals("XQuery: " + query, "bar", result.getResource(0).getContent());
             assertEquals("XQuery: " + query, "bar1", result.getResource(1).getContent());
             assertEquals("XQuery: " + query, "bar2", result.getResource(2).getContent());
 
 //			Non-heritance check
-            System.out.println("testModule 6: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace foo=\"foo\" at \"" + URI + "/test/" + FATHER_MODULE_NAME + "\";\n" + "declare namespace foo1=\"foo1\"; \n" + "$foo1:bar";
             try {
                 message = "";
@@ -1291,7 +1084,6 @@ public class XQueryTest extends XMLTestCase {
             assertTrue(message.indexOf("XPDY0002") > -1);
 
 //			Non-heritance check
-            System.out.println("testModule 7: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace foo=\"foo\" at \"" + URI + "/test/" + FATHER_MODULE_NAME + "\";\n" + "declare namespace foo2=\"foo2\"; \n" + "$foo2:bar";
             try {
                 message = "";
@@ -1300,8 +1092,6 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(message.indexOf("XPDY0002") > -1);
-
-            System.out.println("testModule 8: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace foo1=\"foo\" at \"" + URI + "/test/" + CHILD1_MODULE_NAME + "\";\n" + "import module namespace foo2=\"foo\" at \"" + URI + "/test/" + CHILD1_MODULE_NAME + "\";\n" + "$foo1:bar";
             try {
                 message = "";
@@ -1311,8 +1101,6 @@ public class XQueryTest extends XMLTestCase {
             }
 //			Should be a XQST0047 error
             assertTrue(message.indexOf("does not match namespace URI") > -1);
-
-            System.out.println("testModule 9: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace foo=\"foo\" at \"" + URI + "/test/" + MODULE3_NAME + "\";\n" + "$bar:bar";
             try {
                 message = "";
@@ -1321,8 +1109,6 @@ public class XQueryTest extends XMLTestCase {
                 message = e.getMessage();
             }
             assertTrue(message.indexOf("No namespace defined for prefix") > -1);
-
-            System.out.println("testModule 10: ========");
             query = "xquery version \"1.0\";\n" + "import module namespace foo=\"foo\" at \"" + URI + "/test/" + MODULE4_NAME + "\";\n" + "foo:bar()";
             try {
                 message = "";
@@ -1330,7 +1116,6 @@ public class XQueryTest extends XMLTestCase {
                 //WARNING !
                 //This result is false ! The external vairable has not been resolved
                 //Furthermore it is not in the module's namespace !
-                printResult(result);
                 assertEquals("XQuery: " + query, 0, result.getSize());
             } catch (XMLDBException e) {
                 message = e.getMessage();
@@ -1339,7 +1124,6 @@ public class XQueryTest extends XMLTestCase {
         //assertTrue(message.indexOf("XQST0048") > -1);
 
         } catch (XMLDBException e) {
-            System.out.println("testModule : XMLDBException: " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }
@@ -1362,7 +1146,7 @@ public class XQueryTest extends XMLTestCase {
                     "</div>";
             ResourceSet result = service.query(query);
             assertEquals(1, result.getSize());
-            System.out.println("testModulesAndNS result: " + result.getResource(0).getContent().toString());
+            result.getResource(0).getContent();
             assertXMLEqual("<div xmlns='http://www.w3.org/1999/xhtml'><a xmlns=\"\" href='#'>Link</a></div>",
                     result.getResource(0).getContent().toString());
 
@@ -1373,7 +1157,7 @@ public class XQueryTest extends XMLTestCase {
                     "</div>";
             result = service.query(query);
             assertEquals(1, result.getSize());
-            System.out.println("testModulesAndNS result: " + result.getResource(0).getContent().toString());
+            result.getResource(0).getContent();
             assertXMLEqual("<div xmlns='http://www.w3.org/1999/xhtml'><a>Link</a></div>",
                     result.getResource(0).getContent().toString());
         } catch (Exception e) {
@@ -1422,21 +1206,15 @@ public class XQueryTest extends XMLTestCase {
             doc.setContent(module6);
             ((EXistResource) doc).setMimeType("application/xquery");
             testCollection.storeResource(doc);
-
-            System.out.println("testGlobalVars 1: ========");
             XQueryService service = (XQueryService) testCollection.getService("XPathQueryService", "1.0");
             String query = "xquery version \"1.0\";\n" + "import module namespace foo=\"foo\" at \"" + URI + "/test/" + MODULE5_NAME + "\";\n" + "$foo:bar";
             ResourceSet result = service.query(query);
             assertEquals(result.getSize(), 1);
             assertEquals(result.getResource(0).getContent(), "bar");
-
-            System.out.println("testGlobalVars 2: ========");
             query = "xquery version \"1.0\";\n" + "declare variable $local:a := 'abc';" + "$local:a";
             result = service.query(query);
             assertEquals(result.getSize(), 1);
             assertEquals(result.getResource(0).getContent(), "abc");
-
-            System.out.println("testGlobalVars 3: ========");
             boolean gotException = false;
             try {
                 query = "xquery version \"1.0\";\n" + "import module namespace foo=\"foo\" at \"" + URI + "/test/" + MODULE6_NAME + "\";\n" + "$foo:bar";
@@ -1446,8 +1224,6 @@ public class XQueryTest extends XMLTestCase {
                 gotException = true;
             }
             assertTrue("Duplicate global variable should generate error", gotException);
-
-            System.out.println("testGlobalVars 4: ========");
             gotException = false;
             try {
                 query = "xquery version \"1.0\";\n" + "declare variable $local:a := 'abc';" + "declare variable $local:a := 'abc';" + "$local:a";
@@ -1473,29 +1249,21 @@ public class XQueryTest extends XMLTestCase {
         try {
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(NUMBERS_XML, numbers);
-
-            System.out.println("testFunctionDoc 1: ========");
             query = "doc('" + XmldbURI.ROOT_COLLECTION + "/test/" + NUMBERS_XML + "')";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             try {
                 Node n = ((XMLResource) result.getResource(0)).getContentAsDOM();
                 DetailedDiff d = new DetailedDiff(compareXML(numbers, n.toString()));
-                System.out.println(d.toString());
                 assertEquals(0, d.getAllDifferences().size());
             //ignore eXist namespace's attributes				
             //assertEquals(1, d.getAllDifferences().size());
             } catch (Exception e) {
-                System.out.println("testFunctionDoc : XMLDBException: " + e);
                 fail(e.getMessage());
             }
-
-            System.out.println("testFunctionDoc 2: ========");
             query = "let $v := ()\n" + "return doc($v)";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testFunctionDoc 3: ========");
             query = "doc('" + XmldbURI.ROOT_COLLECTION + "/test/dummy" + NUMBERS_XML + "')";
             try {
                 exceptionThrown = false;
@@ -1507,26 +1275,19 @@ public class XQueryTest extends XMLTestCase {
             //TODO : to be decided !
             //assertTrue(exceptionThrown);
             assertEquals(0, result.getSize());
-
-            System.out.println("testFunctionDoc 4: ========");
             query = "doc-available('" + XmldbURI.ROOT_COLLECTION + "/test/" + NUMBERS_XML + "')";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "true", result.getResource(0).getContent());
-
-            System.out.println("testFunctionDoc 5: ========");
             query = "let $v := ()\n" + "return doc-available($v)";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "false", result.getResource(0).getContent());
-
-            System.out.println("testFunctionDoc 6: ========");
             query = "doc-available('" + XmldbURI.ROOT_COLLECTION + "/test/dummy" + NUMBERS_XML + "')";
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "false", result.getResource(0).getContent());
 
         } catch (XMLDBException e) {
-            System.out.println("testFunctionDoc : XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -1559,48 +1320,33 @@ public class XQueryTest extends XMLTestCase {
         try {
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(NUMBERS_XML, numbers);
-
-            System.out.println("testFunctionDocExternal 1: ========");
             query = "if (doc-available(\"http://www.w3.org/XML/Core/\")) then doc(\"http://www.w3.org/XML/Core/\") else ()";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
-
-            System.out.println("testFunctionDocExternal 2: ========");
             query = "if (doc-available(\"http://www.w3.org/XML/dummy\")) then doc(\"http://www.w3.org/XML/dummy\") else ()";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testFunctionDocExternal 3: ========");
             query = "doc-available(\"http://www.w3.org/XML/Core/\")";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "true", result.getResource(0).getContent());
-
-            System.out.println("testFunctionDocExternal 4: ========");
             query = "doc-available(\"http://www.google.com/404\")";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "false", result.getResource(0).getContent());
-
-            System.out.println("testFunctionDocExternal 5: ========");
             //A redirected 404
             query = "doc-available(\"http://java.sun.com/404\")";
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "false", result.getResource(0).getContent());
-
-            System.out.println("testFunctionDocExternal 6: ========");
             query = "if (doc-available(\"file:////doesnotexist.xml\")) then doc(\"file:////doesnotexist.xml\") else ()";
             result = service.query(query);
             assertEquals("XQuery: " + query, 0, result.getSize());
-
-            System.out.println("testFunctionDocExternal 7: ========");
             query = "doc-available(\"file:////doesnotexist.xml\")";
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
             assertEquals("XQuery: " + query, "false", result.getResource(0).getContent());
 
         } catch (XMLDBException e) {
-            System.out.println("testFunctionDoc : XMLDBException: " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }
@@ -1616,14 +1362,11 @@ public class XQueryTest extends XMLTestCase {
     }
 
     public void testTextConstructor() {
-        System.out.println("testTextConstructor 1: ========");
-
         String query = "text{ \"a\" }, text{ \"b\" }, text{ \"c\" }, text{ \"d\" }";
 
         try {
             XPathQueryService service = (XPathQueryService) getTestCollection().getService("XPathQueryService", "1.0");
             ResourceSet result = service.query(query);
-            printResult(result);
             assertEquals("XQuery: " + query, 4, result.getSize());
 
             assertEquals("XQuery: " + query, "a", result.getResource(0).getContent().toString());
@@ -1632,21 +1375,16 @@ public class XQueryTest extends XMLTestCase {
             assertEquals("XQuery: " + query, "d", result.getResource(3).getContent().toString());
 
         } catch (XMLDBException e) {
-            System.out.println("testAttributeAxis(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
 
     public void testUserEscalationForInMemoryNodes() {
-        System.out.println("testUserEscalationForInMemoryNodes 1: ========");
-
         String query = "xmldb:login(\"xmldb:exist:///db\", \"guest\", \"guest\"), xmldb:get-current-user(), let $node := <node id=\"1\">value</node>, $null := $node[@id eq '1'] return xmldb:get-current-user()";
 
         try {
             XPathQueryService service = (XPathQueryService) getTestCollection().getService("XPathQueryService", "1.0");
             ResourceSet result = service.query(query);
-            printResult(result);
-
             Resource loggedIn = result.getResource(0);
             Resource currentUser = result.getResource(1);
             Resource currentUserAfterInMemoryOp = result.getResource(2);
@@ -1660,7 +1398,6 @@ public class XQueryTest extends XMLTestCase {
             //check that we are still guest
             assertEquals("After Query, User should still be guest and is: " + currentUserAfterInMemoryOp.getContent().toString(), "guest", currentUserAfterInMemoryOp.getContent().toString());
         } catch (XMLDBException e) {
-            System.out.println("testUserEscalationForInMemoryNodes(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -1683,7 +1420,6 @@ public class XQueryTest extends XMLTestCase {
         String query;
         XMLResource resu;
         try {
-            System.out.println("testAttributeAxis 1: ========");
             @SuppressWarnings("unused")
 			String large = createXMLContentWithLargeString();
             XPathQueryService service =
@@ -1692,11 +1428,9 @@ public class XQueryTest extends XMLTestCase {
             query = "let $node := (<c id=\"OK\">b</c>)/descendant-or-self::*/attribute::id " +
                     "return <a>{$node}</a>";
             result = service.query(query);
-            printResult(result);
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, "OK", ((Element) resu.getContentAsDOM()).getAttribute("id"));
         } catch (XMLDBException e) {
-            System.out.println("testAttributeAxis(): XMLDBException: " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }
@@ -1723,17 +1457,14 @@ public class XQueryTest extends XMLTestCase {
         @SuppressWarnings("unused")
 		XMLResource resu;
         try {
-            System.out.println("testLargeAttributeSimple 1: ========");
             String large = createXMLContentWithLargeString();
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(file_name, xml);
 
             query = "doc('" + file_name + "') / details/metadata[@docid= '" + large + "' ]";
             result = service.queryResource(file_name, query);
-            printResult(result);
             assertEquals("XQuery: " + query, nbElem, result.getSize());
         } catch (XMLDBException e) {
-            System.out.println("testLargeAttributeSimple(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -1752,7 +1483,6 @@ public class XQueryTest extends XMLTestCase {
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, "gaga", resu.getContent().toString());
         } catch (XMLDBException e) {
-            System.out.println("testAttributeAxis(): XMLDBException: " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }
@@ -1791,7 +1521,6 @@ public class XQueryTest extends XMLTestCase {
             resu = (XMLResource) result.getResource(0);
             assertEquals("XQuery: " + query, xml, resu.getContent().toString());
         } catch (XMLDBException e) {
-            System.out.println("testCDATAQuery(): XMLDBException: " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }
@@ -1819,7 +1548,6 @@ public class XQueryTest extends XMLTestCase {
         @SuppressWarnings("unused")
 		XMLResource resu;
         try {
-            System.out.println("testLargeAttributeSimple 1: ========");
             @SuppressWarnings("unused")
 			String large = createXMLContentWithLargeString();
             XPathQueryService service =
@@ -1829,7 +1557,6 @@ public class XQueryTest extends XMLTestCase {
             result = service.queryResource(file_name, query);
             assertEquals("XQuery: " + query, nbElem, result.getSize());
         } catch (XMLDBException e) {
-            System.out.println("testLargeAttributeSimple(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -1840,7 +1567,6 @@ public class XQueryTest extends XMLTestCase {
         @SuppressWarnings("unused")
 		XMLResource resu;
         try {
-            System.out.println("testLargeAttributeSimple 1: ========");
             String large = createXMLContentWithLargeString();
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(file_name, xml);
@@ -1849,7 +1575,6 @@ public class XQueryTest extends XMLTestCase {
             result = service.queryResource(file_name, query);
             assertEquals("XQuery: " + query, nbElem, result.getSize());
         } catch (XMLDBException e) {
-            System.out.println("testLargeAttributeSimple(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -1914,7 +1639,6 @@ public class XQueryTest extends XMLTestCase {
         //assertTrue(message.indexOf("XQDY0025") > -1); 
 
         } catch (XMLDBException e) {
-            System.out.println("testVariable : XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -1932,16 +1656,13 @@ public class XQueryTest extends XMLTestCase {
             xml += elem;
         }
         xml += tail;
-        System.out.println("XML:\n" + xml);
         return large;
     }
 
     public void testRetrieveLargeAttribute() throws XMLDBException {
-        System.out.println("testRetrieveLargeAttribute 1: ========");
         createXMLContentWithLargeString();
         storeXMLStringAndGetQueryService(file_name, xml);
         XMLResource res = (XMLResource) getTestCollection().getResource(file_name);
-        System.out.println("res.getContent(): " + res.getContent());
     }
 
     /** This test is obsolete because testLargeAttributeSimple() reproduces the problem without a file,
@@ -1952,7 +1673,6 @@ public class XQueryTest extends XMLTestCase {
         @SuppressWarnings("unused")
 		XMLResource resu;
         try {
-            System.out.println("testLargeAttributeRealFile 1: ========");
             String large;
             large = "challengesininformationretrievalandlanguagemodelingreportofaworkshopheldatthecenterforintelligentinformationretrievaluniversityofmassachusettsamherstseptember2002-extdocid-howardturtlemarksandersonnorbertfuhralansmeatonjayaslamdragomirradevwesselkraaijellenvoorheesamitsinghaldonnaharmanjaypontejamiecallannicholasbelkinjohnlaffertylizliddyronirosenfeldvictorlavrenkodavidjharperrichschwartzjohnpragerchengxiangzhaijinxixusalimroukosstephenrobertsonandrewmccallumbrucecroftrmanmathasuedumaisdjoerdhiemstraeduardhovyralphweischedelthomashofmannjamesallanchrisbuckleyphilipresnikdavidlewis2003";
             if (attributeXML != null) {
@@ -1969,10 +1689,8 @@ public class XQueryTest extends XMLTestCase {
             // query = "doc('"+ FILE_NAME+"') / details/metadata[ docid= '" + large + "' ]"; // test passes!
 
             result = service.queryResource(FILE_NAME, query);
-            printResult(result);
             assertEquals("XQuery: " + query, 2, result.getSize());
         } catch (XMLDBException e) {
-            System.out.println("testLargeAttributeRealFile(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -1995,12 +1713,9 @@ public class XQueryTest extends XMLTestCase {
         try {
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(NUMBERS_XML, numbers);
-
-            System.out.println("testXUpdateWithAdvancentTextNodes 1: ========");
             result = service.query(query);
             assertEquals("XQuery: " + query, 1, result.getSize());
         } catch (XMLDBException e) {
-            System.out.println("testXUpdateWithAdvancentTextNodes(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -2036,12 +1751,9 @@ public class XQueryTest extends XMLTestCase {
         try {
             XPathQueryService service =
                     storeXMLStringAndGetQueryService(BOWLING_XML, bowling);
-
-            System.out.println("testXUpdateAttributesAndElements 1: ========");
             result = service.query(query);
             assertEquals("XQuery: " + query, 3, result.getSize());
         } catch (XMLDBException e) {
-            System.out.println("testXUpdateAttributesAndElements(): XMLDBException: " + e);
             fail(e.getMessage());
         }
     }
@@ -2105,10 +1817,8 @@ public class XQueryTest extends XMLTestCase {
             for (int i = 0; i < 25; i++) { // repeat a few times
 
                 XPathQueryService service = (XPathQueryService) getTestCollection().getService("XPathQueryService", "1.0");
-                System.out.println("Attempt " + i);
                 ResourceSet result = service.query(query);
                 assertEquals(1, result.getSize());
-                printResult(result);
                 assertEquals(expectedresult, result.getResource(0).getContent().toString());
             }
 
@@ -2218,7 +1928,6 @@ public class XQueryTest extends XMLTestCase {
             ResourceSet result = service.query(query);
             assertXMLEqual("<row>titolo giulio</row>", result.getResource(0).getContent().toString());
         } catch (Exception e) {
-            System.out.println("testEnclosedExpressions(): " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }
@@ -3519,7 +3228,7 @@ public class XQueryTest extends XMLTestCase {
             	result = service.query(query);
             } catch (Exception e) {
             	//SENR0001 : OK
-            	System.out.println(e.getMessage());
+            	e.printStackTrace();
             }
             query = "declare option exist:serialize 'method=text'; \n"
             	+ "//@* \n";
@@ -3564,18 +3273,6 @@ public class XQueryTest extends XMLTestCase {
         XPathQueryService service = (XPathQueryService) testCollection.getService(
                 "XPathQueryService", "1.0");
         return service;
-    }
-
-    /**
-     * @param result
-     * @throws XMLDBException
-     */
-    private void printResult(ResourceSet result) throws XMLDBException {
-        for (ResourceIterator i = result.getIterator();
-                i.hasMoreResources();) {
-            Resource r = i.nextResource();
-            System.out.println(r.getContent());
-        }
     }
 
     public static void main(String[] args) {

--- a/test/src/org/exist/xquery/XQueryUpdateTest.java
+++ b/test/src/org/exist/xquery/XQueryUpdateTest.java
@@ -47,7 +47,6 @@ public class XQueryUpdateTest extends TestCase {
 	public void testAppend() {
         DBBroker broker = null;
         try {
-        	System.out.println("testAppend() ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
             XQuery xquery = broker.getXQueryService();
@@ -71,14 +70,13 @@ public class XQueryUpdateTest extends TestCase {
             assertEquals(seq.getItemCount(), 1);
             
             Serializer serializer = broker.getSerializer();
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+            serializer.serialize((NodeValue) seq.itemAt(0));
             
             seq = xquery.execute("//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
             
             seq = xquery.execute("//product[price > 0.0]", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
-            System.out.println("testAppend: PASS");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -91,7 +89,6 @@ public class XQueryUpdateTest extends TestCase {
 		testAppend();
         DBBroker broker = null;
         try {
-        	System.out.println("testAppendAttributes() ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
             XQuery xquery = broker.getXQueryService();
@@ -111,7 +108,7 @@ public class XQueryUpdateTest extends TestCase {
             assertEquals(seq.getItemCount(), 1);
 
             Serializer serializer = broker.getSerializer();
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+            serializer.serialize((NodeValue) seq.itemAt(0));
 
             seq = xquery.execute("//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
@@ -122,14 +119,12 @@ public class XQueryUpdateTest extends TestCase {
             store(broker, "attribs.xml", "<test attr1='aaa' attr2='bbb'>ccc</test>");
             query = "update insert attribute attr1 { 'eee' } into /test";
 
-            System.out.println("testing duplicate attribute ...");
+            //testing duplicate attribute ...
             xquery.execute(query, null, AccessContext.TEST);
 
             seq = xquery.execute("xmldb:document('" + TEST_COLLECTION + "/attribs.xml')/test[@attr1 = 'eee']", null, AccessContext.TEST);
             assertEquals(1, seq.getItemCount());
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
-
-            System.out.println("testAppendAttributes: PASS");
+            serializer.serialize((NodeValue) seq.itemAt(0));
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -141,7 +136,6 @@ public class XQueryUpdateTest extends TestCase {
     public void testInsertBefore() {
         DBBroker broker = null;
         try {
-            System.out.println("testInsertBefore() ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
             String query =
@@ -176,14 +170,13 @@ public class XQueryUpdateTest extends TestCase {
             assertEquals(seq.getItemCount(), 1);
 
             Serializer serializer = broker.getSerializer();
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+            serializer.serialize((NodeValue) seq.itemAt(0));
 
             seq = xquery.execute("//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND + 1, seq.getItemCount());
 
             seq = xquery.execute("//product[price > 0.0]", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
-            System.out.println("testInsertBefore: PASS");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -195,7 +188,6 @@ public class XQueryUpdateTest extends TestCase {
     public void testInsertAfter() {
         DBBroker broker = null;
         try {
-            System.out.println("testInsertAfter() ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
             String query =
@@ -230,14 +222,13 @@ public class XQueryUpdateTest extends TestCase {
             assertEquals(seq.getItemCount(), 1);
 
             Serializer serializer = broker.getSerializer();
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+            serializer.serialize((NodeValue) seq.itemAt(0));
 
             seq = xquery.execute("//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND + 1, seq.getItemCount());
 
             seq = xquery.execute("//product[price > 0.0]", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
-            System.out.println("testInsertAfter: PASS");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -250,7 +241,6 @@ public class XQueryUpdateTest extends TestCase {
     	testAppend();
         DBBroker broker = null;
         try {
-            System.out.println("testUpdate() ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
             
             XQuery xquery = broker.getXQueryService();
@@ -266,17 +256,17 @@ public class XQueryUpdateTest extends TestCase {
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
 
             Serializer serializer = broker.getSerializer();
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+            serializer.serialize((NodeValue) seq.itemAt(0));
 
             for (int i = 1; i <= ITEMS_TO_APPEND; i++) {
                 seq = xquery.execute("//product[description &= 'Description" + i + "']", null, AccessContext.TEST);
                 assertEquals(1, seq.getItemCount());
-                System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+                serializer.serialize((NodeValue) seq.itemAt(0));
             }
             seq = xquery.execute("//product[description &= 'Updated']", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
 
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+            serializer.serialize((NodeValue) seq.itemAt(0));
             
             query =
             	"declare option exist:output-size-limit '-1';\n" +
@@ -290,7 +280,7 @@ public class XQueryUpdateTest extends TestCase {
             seq = xquery.execute("//product[stock &= '401']", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+            serializer.serialize((NodeValue) seq.itemAt(0));
             
             query =
             	"declare option exist:output-size-limit '-1';\n" +
@@ -305,7 +295,7 @@ public class XQueryUpdateTest extends TestCase {
             seq = xquery.execute("//product[@num = 3]", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
             
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+            serializer.serialize((NodeValue) seq.itemAt(0));
             
             query =
             	"declare option exist:output-size-limit '-1';\n" +
@@ -319,8 +309,6 @@ public class XQueryUpdateTest extends TestCase {
             
             seq = xquery.execute("//product/stock/external[. = 1]", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
-            
-            System.out.println("testUpdate: PASS");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -346,7 +334,6 @@ public class XQueryUpdateTest extends TestCase {
         	seq = xquery.execute("//product", null, AccessContext.TEST);
         	assertEquals(seq.getItemCount(), 0);
 
-        	System.out.println("testRemove: PASS");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -359,7 +346,6 @@ public class XQueryUpdateTest extends TestCase {
     	testAppend();
         DBBroker broker = null;
         try {
-            System.out.println("testUpdate() ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
             XQuery xquery = broker.getXQueryService();
@@ -380,7 +366,6 @@ public class XQueryUpdateTest extends TestCase {
             seq = xquery.execute("//product/@count", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
 
-            System.out.println("testUpdate: PASS");
         } catch (Exception e) {
         	e.printStackTrace();
             fail(e.getMessage());
@@ -393,7 +378,6 @@ public class XQueryUpdateTest extends TestCase {
     	testAppend();
         DBBroker broker = null;
         try {
-            System.out.println("testReplace() ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
             XQuery xquery = broker.getXQueryService();
@@ -421,8 +405,6 @@ public class XQueryUpdateTest extends TestCase {
 
             seq = xquery.execute("//product[starts-with(desc, 'A new')]", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
-
-            System.out.println("testUpdate: PASS");
         } catch (Exception e) {
         	e.printStackTrace();
             fail(e.getMessage());
@@ -434,7 +416,6 @@ public class XQueryUpdateTest extends TestCase {
     public void testAttrUpdate() {
         DBBroker broker = null;
         try {
-            System.out.println("testAttrUpdate() ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
             store(broker, "test.xml", UPDATE_XML);
 
@@ -449,8 +430,6 @@ public class XQueryUpdateTest extends TestCase {
             XQuery xquery = broker.getXQueryService();
             @SuppressWarnings("unused")
 			Sequence result = xquery.execute(query, null, AccessContext.TEST);
-
-            System.out.println("testAttrUpdate(): PASSED\n");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -462,7 +441,6 @@ public class XQueryUpdateTest extends TestCase {
     public void testAppendCDATA() {
         DBBroker broker = null;
         try {
-        	System.out.println("testAppendCDATA() ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
             XQuery xquery = broker.getXQueryService();
@@ -483,12 +461,10 @@ public class XQueryUpdateTest extends TestCase {
             assertEquals(seq.getItemCount(), 1);
 
             Serializer serializer = broker.getSerializer();
-            System.out.println(serializer.serialize((NodeValue) seq.itemAt(0)));
+            serializer.serialize((NodeValue) seq.itemAt(0));
 
             seq = xquery.execute("//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
-
-            System.out.println("testAppendCDATA: PASS");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -500,7 +476,6 @@ public class XQueryUpdateTest extends TestCase {
     public void bugtestInsertAttribDoc_1730726() {
         DBBroker broker = null;
         try {
-            System.out.println(this.getName()+" ...\n");
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
             String query =
@@ -513,8 +488,6 @@ public class XQueryUpdateTest extends TestCase {
             XQuery xquery = broker.getXQueryService();
             @SuppressWarnings("unused")
 			Sequence result = xquery.execute(query, null, AccessContext.TEST);
-
-            System.out.println(this.getName()+"(): PASSED\n");
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -543,7 +516,6 @@ public class XQueryUpdateTest extends TestCase {
         Collection root;
         final TransactionManager mgr = pool.getTransactionManager();
         try(final Txn transaction = mgr.beginTransaction()) {
-            System.out.println("Transaction started ...");
 
             root = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
             broker.saveCollection(transaction, root);

--- a/test/src/org/exist/xquery/functions/fn/DocTest.java
+++ b/test/src/org/exist/xquery/functions/fn/DocTest.java
@@ -138,7 +138,6 @@ public class DocTest {
             n = res.getContentAsDOM();
             assertEquals("x", n.getLocalName());
         } catch (XMLDBException e) {
-            System.out.println("testEval(): " + e);
             fail(e.getMessage());
         }
     }
@@ -153,7 +152,7 @@ public class DocTest {
 		// jetty.port.jetty
 		PostMethod method = new PostMethod("http://localhost:" + System.getProperty("jetty.port") + "/exist/rest/test/text.xq");
 
-    	System.out.println( client.executeMethod(method) );
+    	client.executeMethod(method);
 
     }
 }

--- a/test/src/org/exist/xquery/functions/util/Base64FunctionsTest.java
+++ b/test/src/org/exist/xquery/functions/util/Base64FunctionsTest.java
@@ -92,7 +92,6 @@ public class Base64FunctionsTest
             assertEquals( "VGhpcyBpcyBhIHRlc3Qh", r );
         }
         catch( XMLDBException e ) {
-            System.out.println( "testBase64Encode(): " + e );
             fail( e.getMessage() );
         }
 
@@ -111,7 +110,6 @@ public class Base64FunctionsTest
             assertEquals( "This is a test!", r );		
         }
         catch( XMLDBException e ) {
-            System.out.println( "testBase64Decode(): " + e );
             fail( e.getMessage() );
         }
 
@@ -130,7 +128,6 @@ public class Base64FunctionsTest
             assertEquals( "This is a test!", r );
         }
         catch( XMLDBException e ) {
-            System.out.println( "testBase64EncodeDecode(): " + e );
             fail( e.getMessage() );
         }
 

--- a/test/src/org/exist/xquery/functions/util/BaseConverterTest.java
+++ b/test/src/org/exist/xquery/functions/util/BaseConverterTest.java
@@ -84,7 +84,6 @@ public class BaseConverterTest {
             assertEquals("493", r);
 
         } catch (XMLDBException e) {
-            System.out.println("testBaseConverterOctalToInt(): " + e);
             fail(e.getMessage());
         }
 
@@ -102,7 +101,6 @@ public class BaseConverterTest {
             assertEquals("a", r);
 
         } catch (XMLDBException e) {
-            System.out.println("testBaseConverterIntToHex(): " + e);
             fail(e.getMessage());
         }
 
@@ -120,7 +118,6 @@ public class BaseConverterTest {
             assertEquals("100", r);
 
         } catch (XMLDBException e) {
-            System.out.println("testBaseConverterIntToBinary(): " + e);
             fail(e.getMessage());
         }
 

--- a/test/src/org/exist/xquery/functions/util/CounterTest.java
+++ b/test/src/org/exist/xquery/functions/util/CounterTest.java
@@ -74,7 +74,6 @@ public class CounterTest {
             r = (String) result.getResource(0).getContent();
             assertEquals("true", r);
         } catch (XMLDBException e) {
-            System.out.println("testCreateAndDestroyCounter(): " + e.getMessage());
             fail(e.getMessage());
         }
     }
@@ -99,7 +98,6 @@ public class CounterTest {
             r = (String) result.getResource(0).getContent();
             assertEquals("true", r);
         } catch (XMLDBException e) {
-            System.out.println("testCreateAndDestroyCounter(): " + e.getMessage());
             fail(e.getMessage());
         }
     }
@@ -145,7 +143,7 @@ public class CounterTest {
 	        	for (int i=0; i<200; i++) {
 	        		query = IMPORT +"counter:next-value('jasper2')";
 	                result = service.query(query);
-	                System.out.println("Thread "+getId()+": Counter value:"+result.getResource(0).getContent());
+	                result.getResource(0).getContent();
 	        	}
         	} catch (XMLDBException e) {
         			e.printStackTrace();

--- a/test/src/org/exist/xquery/functions/util/EvalTest.java
+++ b/test/src/org/exist/xquery/functions/util/EvalTest.java
@@ -72,7 +72,6 @@ public class EvalTest {
         // clear instance variables
         service = null;
         root = null;
-    //System.out.println("tearDown PASSED");
     }
 
     @Test
@@ -89,7 +88,6 @@ public class EvalTest {
             assertEquals("1", r);
 
         } catch (XMLDBException e) {
-            System.out.println("testEval(): " + e);
             fail(e.getMessage());
         }
 
@@ -108,7 +106,6 @@ public class EvalTest {
             assertEquals(n.getLocalName(), "hello");
             assertEquals("world", n.getFirstChild().getNodeValue());
         } catch (XMLDBException e) {
-            System.out.println("testEval(): " + e);
             fail(e.getMessage());
         }
     }
@@ -126,7 +123,6 @@ public class EvalTest {
             assertEquals("1", r);
 
         } catch (XMLDBException e) {
-            System.out.println("testEval(): " + e);
             fail(e.getMessage());
         }
 
@@ -147,7 +143,6 @@ public class EvalTest {
             assertEquals("3", r);
 
         } catch (XMLDBException e) {
-            System.out.println("testEvalInline(): " + e);
             fail(e.getMessage());
         }
 
@@ -171,7 +166,6 @@ public class EvalTest {
             assertEquals("true", r);
 
         } catch (XMLDBException e) {
-            System.out.println("testEvalWithContextVariable(): " + e);
             fail(e.getMessage());
         }
 
@@ -197,7 +191,6 @@ public class EvalTest {
 
 
         } catch (XMLDBException e) {
-            System.out.println("testEvalSupplyingContext(): " + e);
             fail(e.getMessage());
         }
 
@@ -224,7 +217,6 @@ public class EvalTest {
 
 
         } catch (XMLDBException e) {
-            System.out.println("testEvalSupplyingContextAndVariable(): " + e);
             fail(e.getMessage());
         }
 

--- a/test/src/org/exist/xquery/functions/util/ExpandTest.java
+++ b/test/src/org/exist/xquery/functions/util/ExpandTest.java
@@ -101,7 +101,6 @@ public class ExpandTest {
             assertEquals(expected, r);
 
         } catch (XMLDBException e) {
-            System.out.println("testEval(): " + e);
             fail(e.getMessage());
         }
     }

--- a/test/src/org/exist/xquery/functions/util/SerializeTest.java
+++ b/test/src/org/exist/xquery/functions/util/SerializeTest.java
@@ -77,7 +77,6 @@ public class SerializeTest {
         } catch (SAXException sae) {
                 fail(sae.getMessage());
         } catch (XMLDBException e) {
-            System.out.println("testSerialize(): " + e);
             fail(e.getMessage());
         }
 
@@ -101,7 +100,6 @@ public class SerializeTest {
         } catch (SAXException sae) {
                 fail(sae.getMessage());
         } catch (XMLDBException e) {
-            System.out.println("testSerialize2(): " + e);
             fail(e.getMessage());
         }
 
@@ -121,7 +119,6 @@ public class SerializeTest {
             assertEquals(r,"test");
 
         } catch (XMLDBException e) {
-            System.out.println("testSerializeText(): " + e);
             fail(e.getMessage());
         }
 
@@ -146,7 +143,6 @@ public class SerializeTest {
         } catch (SAXException sae) {
                 fail(sae.getMessage());
         } catch (XMLDBException e) {
-            System.out.println("testSerializeIndent(): " + e);
             fail(e.getMessage());
         }
 
@@ -168,7 +164,6 @@ public class SerializeTest {
 
            result = service.query(query);
            r = (String) result.getResource(0).getContent();
-           System.out.println(r);
            assertXpathEvaluatesTo("2.0","/test//@version",r);
 
         } catch (IOException ioe) {
@@ -176,7 +171,6 @@ public class SerializeTest {
         } catch (SAXException sae) {
                 fail(sae.getMessage());
         } catch (XMLDBException e) {
-            System.out.println("testSerializeXincludes(): " + e);
             e.printStackTrace();
             fail(e.getMessage());
         }

--- a/test/src/org/exist/xquery/functions/validate/AdditionalJingXsdRngTest.java
+++ b/test/src/org/exist/xquery/functions/validate/AdditionalJingXsdRngTest.java
@@ -110,7 +110,6 @@ public class AdditionalJingXsdRngTest extends EmbeddedExistTester {
             assertEquals("false", r);
 
         } catch (XMLDBException e) {
-            System.out.println("testValidateXSDwithJing_invalid(): " + e);
             fail(e.getMessage());
         }
 
@@ -225,7 +224,6 @@ public class AdditionalJingXsdRngTest extends EmbeddedExistTester {
     public void repeatTests() {
         for (int i = 0; i < 1000; i++) {
             try {
-                System.out.println("nr=" + i);
                 testValidateRNGwithJing();
                 testValidateRNGwithJing_invalid();
                 testValidateXSDwithJing();

--- a/test/src/org/exist/xquery/functions/validate/JaxpDtdCatalogTest.java
+++ b/test/src/org/exist/xquery/functions/validate/JaxpDtdCatalogTest.java
@@ -91,7 +91,6 @@ public class JaxpDtdCatalogTest extends EmbeddedExistTester {
         try {
             results = executeQuery("validation:clear-grammar-cache()");
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
         } catch (Exception e) {
             LOG.error(e);

--- a/test/src/org/exist/xquery/functions/validate/JaxpParseTest.java
+++ b/test/src/org/exist/xquery/functions/validate/JaxpParseTest.java
@@ -78,7 +78,6 @@ public class JaxpParseTest extends EmbeddedExistTester {
         try {
             results = executeQuery("validation:clear-grammar-cache()");
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
         } catch (Exception e) {
             LOG.error(e);
@@ -104,9 +103,6 @@ public class JaxpParseTest extends EmbeddedExistTester {
                 "    <color>red</color>\n" +
                 "    <shoesize country=\"nl\">43</shoesize>\n" +
                 "</ns1:root>";
-
-        System.out.println("Expected:" + expected);
-        System.out.println("Result:" + result);
 
         try {
             XMLAssert.assertXMLEqual(expected, result);

--- a/test/src/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
+++ b/test/src/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
@@ -91,7 +91,6 @@ public class JaxpXsdCatalogTest extends EmbeddedExistTester {
         try {
             results = executeQuery("validation:clear-grammar-cache()");
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
         } catch (Exception e) {
             LOG.error(e);

--- a/test/src/org/exist/xquery/functions/validate/JaxvTest.java
+++ b/test/src/org/exist/xquery/functions/validate/JaxvTest.java
@@ -104,7 +104,6 @@ public class JaxvTest extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("valid", "//status/text()", r);
 
@@ -127,7 +126,6 @@ public class JaxvTest extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("invalid", "//status/text()", r);
 
@@ -148,7 +146,6 @@ public class JaxvTest extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("valid", "//status/text()", r);
 
@@ -169,7 +166,6 @@ public class JaxvTest extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("invalid", "//status/text()", r);
 

--- a/test/src/org/exist/xquery/functions/validate/JingSchematronTest.java
+++ b/test/src/org/exist/xquery/functions/validate/JingSchematronTest.java
@@ -101,7 +101,6 @@ public class JingSchematronTest extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertEquals("true", r);
 

--- a/test/src/org/exist/xquery/functions/validate/ParseDtdTestNOK.java
+++ b/test/src/org/exist/xquery/functions/validate/ParseDtdTestNOK.java
@@ -88,7 +88,6 @@ public class ParseDtdTestNOK extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("valid", "//status/text()", r);
 
@@ -109,7 +108,6 @@ public class ParseDtdTestNOK extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("invalid", "//status/text()", r);
 
@@ -132,7 +130,6 @@ public class ParseDtdTestNOK extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("valid", "//status/text()", r);
 
@@ -154,7 +151,6 @@ public class ParseDtdTestNOK extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("invalid", "//status/text()", r);
 

--- a/test/src/org/exist/xquery/functions/validate/ParseXsdTestNOK.java
+++ b/test/src/org/exist/xquery/functions/validate/ParseXsdTestNOK.java
@@ -82,7 +82,6 @@ public class ParseXsdTestNOK extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("valid", "//status/text()", r);
 
@@ -103,7 +102,6 @@ public class ParseXsdTestNOK extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("invalid", "//status/text()", r);
 
@@ -124,7 +122,6 @@ public class ParseXsdTestNOK extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("valid", "//status/text()", r);
 
@@ -145,7 +142,6 @@ public class ParseXsdTestNOK extends EmbeddedExistTester {
             assertEquals(1, results.getSize());
 
             String r = (String) results.getResource(0).getContent();
-            System.out.println(r);
 
             assertXpathEvaluatesTo("invalid", "//status/text()", r);
 

--- a/test/src/org/exist/xquery/functions/xquery3/SwitchTest.java
+++ b/test/src/org/exist/xquery/functions/xquery3/SwitchTest.java
@@ -50,11 +50,6 @@ public class SwitchTest extends EmbeddedExistTester {
     public static void tearDownClass() throws Exception {
     }
 
-    @Before
-    public void setUp() {
-        System.out.println("***********************");
-    }
-
     @After
     public void tearDown() {
     }

--- a/test/src/org/exist/xquery/functions/xquery3/TryCatchTest.java
+++ b/test/src/org/exist/xquery/functions/xquery3/TryCatchTest.java
@@ -35,11 +35,6 @@ public class TryCatchTest extends EmbeddedExistTester {
     public static void tearDownClass() throws Exception {
     }
 
-    @Before
-    public void setUp() {
-        System.out.println("***********************");
-    }
-
     @After
     public void tearDown() {
     }

--- a/test/src/org/exist/xquery/update/AbstractTestUpdate.java
+++ b/test/src/org/exist/xquery/update/AbstractTestUpdate.java
@@ -56,7 +56,6 @@ public abstract class AbstractTestUpdate {
     private void initServer() {
         if (server == null) {
             server = new JettyStart();
-            System.out.println("Starting standalone server...");
             server.run();
         }
     }

--- a/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
+++ b/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
@@ -141,7 +141,6 @@ public class QT3TS_To_junit {
     }
 
     private void loadDirectory(Txn txn, File folder, Collection col) throws Exception {
-    	//System.out.println("******* loadDirectory "+folder.getName());
     	if (!(folder.exists() && folder.canRead()))
     		return;
     	
@@ -162,8 +161,6 @@ public class QT3TS_To_junit {
     }
 
     private void loadFile(Txn txn, File file, Collection col) throws Exception {
-    	//System.out.println("******* loadFile "+file.getName());
-    	
     	if (file.getName().endsWith(".html") 
     			|| file.getName().endsWith(".xsd")
     			|| file.getName().equals("badxml.xml")
@@ -203,7 +200,6 @@ public class QT3TS_To_junit {
                 is.close();
             }
         }
-    	//System.out.println(file);
     }
 
     private MimeTable mtable = null;
@@ -290,8 +286,6 @@ public class QT3TS_To_junit {
         	"    private String file = \""+file+"\";\n\n");
 
         for (NodeProxy p : results.toNodeSet()) {
-//        	System.out.println(p);
-
         	Node testSet = p.getNode();
         	NamedNodeMap attrs = testSet.getAttributes();
         	

--- a/test/src/org/exist/xquery/xqts/QT3TS_case.java
+++ b/test/src/org/exist/xquery/xqts/QT3TS_case.java
@@ -578,7 +578,6 @@ public class QT3TS_case extends TestCase {
         SAXSerializer serializer = new SAXSerializer(writer, properties);
         item.toSAX(broker, serializer, properties);
         String serialized = writer.toString();
-        // System.out.println(serialized);
         return serialized;
     }
 

--- a/test/src/org/exist/xquery/xqts/XQTS_To_junit.java
+++ b/test/src/org/exist/xquery/xqts/XQTS_To_junit.java
@@ -126,7 +126,6 @@ public class XQTS_To_junit {
     }
 
     private void loadDirectory(File folder, Collection col) throws Exception {
-//        System.out.println("******* loadDirectory "+folder.getName());
         if (!(folder.exists() && folder.canRead()))
             return;
         
@@ -150,8 +149,6 @@ public class XQTS_To_junit {
     }
 
     private void loadFile(File file, Collection col) throws Exception {
-//        System.out.println("******* loadFile "+file.getName());
-        
         if (file.getName().endsWith(".html") 
                 || file.getName().endsWith(".xsd")
 //                || file.getName().equals("")
@@ -183,7 +180,6 @@ public class XQTS_To_junit {
             System.out.println("fail to load file "+file.getName());
             e.printStackTrace();
         }
-        //System.out.println(file);
     }
 
     private MimeTable mtable = null;

--- a/test/src/org/exist/xupdate/CompareDocuments.java
+++ b/test/src/org/exist/xupdate/CompareDocuments.java
@@ -85,7 +85,7 @@ public class CompareDocuments {
                     System.out.print("@");
                 default:
             }
-            System.out.print(node1 + "[" + node1.getChildNodes().getLength() + "] <==> "); 
+            System.out.print(node1 + "[" + node1.getChildNodes().getLength() + "] <==> ");
             switch (node2.getNodeType()) {
                 case Node.ATTRIBUTE_NODE:
                     System.out.print("@");

--- a/test/src/org/exist/xupdate/RemoveAppendTest.java
+++ b/test/src/org/exist/xupdate/RemoveAppendTest.java
@@ -83,7 +83,7 @@ public class RemoveAppendTest extends TestCase {
 //            
 //            ResourceSet result = query.query("/test/item[@id='" + which + "']");
 //            assertEquals(result.getSize(), 1);
-//            System.out.println(result.getResource(0).getContent());
+//            result.getResource(0).getContent();
 //        }
 //    }
     
@@ -97,7 +97,6 @@ public class RemoveAppendTest extends TestCase {
             
             ResourceSet result = query.query("/test/item[@id='" + i + "']");
             assertEquals(result.getSize(), 1);
-            System.out.println(result.getResource(0).getContent());
         }
         
         for (int i = 100; i > 10; i--) {
@@ -109,7 +108,6 @@ public class RemoveAppendTest extends TestCase {
             assertEquals(mods, 1);
             
             ResourceSet result = query.query("/test/item/e0");
-            System.out.println(result.getResource(0).getContent());
         }
     }
     

--- a/test/src/org/exist/xupdate/StressTest.java
+++ b/test/src/org/exist/xupdate/StressTest.java
@@ -89,20 +89,16 @@ public class StressTest extends TestCase {
                 "</xupdate:modifications>";
             
             long mods = service.updateResource("test.xml", xupdate);
-            System.out.println("Inserted " + tag + ": " + mods + " ; parent = " + parent);
             assertEquals(mods, 1);
             
             tagsWritten[i] = tag;
             String query = "//" + tagsWritten[rand.nextInt(i + 1)];
             ResourceSet result = xquery.query(query);
             assertEquals(result.getSize(), 1);
-            
-            System.out.println(result.getResource(0).getContent());
         }
         
         XMLResource res = (XMLResource) testCol.getResource("test.xml");
         assertNotNull(res);
-        System.out.println(res.getContent());
     }
     
     private void removeTags() throws Exception {
@@ -116,7 +112,6 @@ public class StressTest extends TestCase {
             
             @SuppressWarnings("unused")
 			long mods = service.updateResource("test.xml", xupdate);
-            System.out.println("Removed: " + tags[i]);
             
             i += rand.nextInt(3);
         }
@@ -130,12 +125,9 @@ public class StressTest extends TestCase {
         for (int i = 0; i < result.getSize(); i++) {
             Resource r = result.getResource(i);
             String tag = r.getContent().toString();
-            System.out.println("Retrieving " + tag);
             
             ResourceSet result2 = xquery.query("//" + tag);
             assertEquals(result2.getSize(), 1);
-            
-            System.out.println(result2.getResource(0).getContent());
         }
     }
     
@@ -151,8 +143,6 @@ public class StressTest extends TestCase {
         
         testCol = DBUtils.addCollection(rootCol, "test");
         assertNotNull(testCol);
-        
-        System.out.println("Generating " + RUNS + " tags ...");
         
         tags = new String[RUNS];
         for (int i = 0; i < RUNS; i++) {

--- a/test/src/org/exist/xupdate/XUpdateTest.java
+++ b/test/src/org/exist/xupdate/XUpdateTest.java
@@ -82,8 +82,6 @@ public class XUpdateTest {
                         Account guest = ums.getAccount("guest");
                         ums.chown(guest, guest.getPrimaryGroup());
                         ums.chmod(Permission.DEFAULT_COLLECTION_PERM);
-
-                        System.out.println("collection created.");
                     }
             } catch (Exception e) {
                     e.printStackTrace();
@@ -106,7 +104,6 @@ public class XUpdateTest {
 		removeWhiteSpace(referenceXML);
         
 		//compare
-		System.out.println("\n");
         new CompareDocuments().compare(referenceXML, xupdateResult);
         
 		removeDocument();
@@ -124,13 +121,11 @@ public class XUpdateTest {
 			System.err.println("can't read file " + sourceFile);
 		document.setContent(f);
 		col.storeResource(document);
-		System.out.println("document stored.");
 	}
 
 	public void removeDocument() throws Exception {
 		Resource document = col.getResource(XUPDATE_FILE);
 		col.removeResource(document);
-		System.out.println("document removed.");
 	}
 
 	private Document updateDocument(String updateFile) throws Exception {
@@ -138,14 +133,12 @@ public class XUpdateTest {
 			(XUpdateQueryService) col.getService("XUpdateQueryService", "1.0");
 
 		// Read XUpdate-Modifcations
-		System.out.println("update file: " + updateFile);
 		File file = new File(updateFile);
 		BufferedReader br = new BufferedReader(new FileReader(file));
 		char[] characters = new char[new Long(file.length()).intValue()];
 		br.read(characters, 0, Long.valueOf(file.length()).intValue());
 		br.close();
 		String xUpdateModifications = new String(characters);
-		System.out.println("modifications: " + xUpdateModifications);
 		//
 
 		service.update(xUpdateModifications);
@@ -154,8 +147,6 @@ public class XUpdateTest {
 		//col.setProperty("encoding", "UTF-8");
 		XMLResource ret = (XMLResource) col.getResource(XUPDATE_FILE);
 		String xmlString = ((String) ret.getContent());
-		System.out.println("Result:");
-		System.out.println(xmlString);
 
 		// convert xml string to dom
 		// todo: make it nicer


### PR DESCRIPTION
This pull-request addresses the output issues of the test-suite and eXist onto stdout. Working in co-operation with log4j2, all log output (including SLF4j and JUL) is correctly captured to `$EXIST_HOME/webapp/WEB-INF/tests` even when running the test suite. Main features include:

* Reducing calls to `System.out.println`. Replaced with LOG statements where appropriate or otherwise removed.

* Redirecting JUL output from code running under Ant's JUnit task

* Dynamically generating a log4j2 configuration that is suitable for testing

* Refactored the output of the XQuery/XML tests when run from JUnit to improve the visibility of test results.

* Also... allows the test-suite to run correctly in Travis-CI.

As a result the output of the the test suite has been reduced from 22MB to >200KB, instead all significant output from eXist is correctly captured in its log files. There will be a follow-up pull-request to allow access to the eXist log files from Travis-CI when the test suite reports a failure.

