### PR TITLE
add .odd as an XML file extension

### DIFF
--- a/mime-types.xml.tmpl
+++ b/mime-types.xml.tmpl
@@ -22,7 +22,7 @@
     <!-- Mime types stored as XML -->
     <mime-type name="application/xml" type="xml">
         <description>XML document</description>
-        <extensions>.xml,.xsd,.rng,.mods,.xmp,.xmi,.xconf,.xmap,.xsp,.wsdl,.x3d,.owl,.dbx,.tei,.xces,.ead,.xqx,.xform,.gml,.fo,.nvdl,.sch,.imdi,.cmdi</extensions>
+        <extensions>.xml,.xsd,.rng,.mods,.xmp,.xmi,.xconf,.xmap,.xsp,.wsdl,.x3d,.owl,.dbx,.tei,.xces,.ead,.xqx,.xform,.gml,.fo,.nvdl,.sch,.imdi,.cmdi,.odd</extensions>
     </mime-type>
     <!-- default is 'application/xml' for .xml This required to resolve 'text/xml' -->
     <mime-type name="text/xml" type="xml">


### PR DESCRIPTION
[ODD](http://en.wikipedia.org/wiki/Text_Encoding_Initiative#ODD) is an XML-based vocabulary for defining schemas for Text Encoding Initiative (TEI) projects.  ODD should be treated as XML syntax but until this pull request was treated as a binary format.