### PR TITLE
Cleaned up the XML-RPC API implementation

### DIFF
--- a/log4j2.xml
+++ b/log4j2.xml
@@ -37,6 +37,14 @@
             <DefaultRolloverStrategy max="${rollover.max}"/>
             <PatternLayout pattern="${exist.file.pattern}"/>
         </RollingRandomAccessFile>
+
+        <RollingRandomAccessFile name="exist.xmlrpc" filePattern="${logs}/xmlrpc.${rollover.file.pattern}.log.gz" fileName="${logs}/xmlrpc.log">
+            <Policies>
+                <SizeBasedTriggeringPolicy size="${rollover.max.size}"/>
+            </Policies>
+            <DefaultRolloverStrategy max="${rollover.max}"/>
+            <PatternLayout pattern="${exist.file.pattern}"/>
+        </RollingRandomAccessFile>
         
         <RollingRandomAccessFile name="exist.urlrewrite" filePattern="${logs}/urlrewrite.${rollover.file.pattern}.log.gz" fileName="${logs}/urlrewrite.log">
             <Policies>
@@ -149,12 +157,16 @@
             <AppenderRef ref="exist.xacml"/>
         </Logger>
         
-        <Logger name="org.exist.xmldb" additivity="false" level="debug">
+        <Logger name="org.exist.xmldb" additivity="false" level="info">
             <AppenderRef ref="exist.xmldb"/>
         </Logger>
         
-        <Logger name="org.exist.xmlrpc" additivity="false" level="debug">
-            <AppenderRef ref="exist.core"/>
+        <Logger name="org.exist.xmlrpc" additivity="false" level="info">
+            <AppenderRef ref="exist.xmlrpc"/>
+        </Logger>
+
+        <Logger name="org.apache.xmlrpc" additivity="false" level="info">
+            <AppenderRef ref="exist.xmlrpc"/>
         </Logger>
         
         <Logger name="org.exist.http.urlrewrite" additivity="false" level="info">
@@ -164,9 +176,8 @@
         
         <Logger name="org.exist.extensions.exquery.restxq" additivity="false" level="info">
             <AppenderRef ref="exist.restxq"/>
-        </Logger>    
-        
-        <!-- Logging 3rd party libraries -->
+        </Logger>
+
         <Logger name="org.eclipse.jetty" additivity="false" level="info">
             <AppenderRef ref="exist.core"/>
         </Logger>
@@ -175,7 +186,7 @@
             <AppenderRef ref="exist.core"/>
         </Logger>
         
-        <Logger name="net.sf.ehcache" additivity="false" level="debug">
+        <Logger name="net.sf.ehcache" additivity="false" level="info">
             <AppenderRef ref="exist.ehcache"/>
         </Logger>
         

--- a/samples/src/org/exist/examples/xmlrpc/Retrieve.java
+++ b/samples/src/org/exist/examples/xmlrpc/Retrieve.java
@@ -21,60 +21,59 @@
  */
 package org.exist.examples.xmlrpc;
 
-import java.util.Vector;
-import java.util.HashMap;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.xmlrpc.client.XmlRpcClient;
 import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
 import org.exist.util.SSLHelper;
 
 /**
- *  Retrieve a document from the database using XMLRPC.
+ * Retrieve a document from the database using XMLRPC.
  *
  * Execute bin\run.bat org.exist.examples.xmlrpc.Retrieve <remotedoc>
  *
- *  @author     Wolfgang Meier <meier@ifs.tu-darmstadt.de>
- *  created    August 1, 2002
+ * @author Wolfgang Meier <meier@ifs.tu-darmstadt.de>
+ * created August 1, 2002
  */
 public class Retrieve {
 
-    protected final static String uri = "http://localhost:8080/exist/xmlrpc";
+    private final static String uri = "http://localhost:8080/exist/xmlrpc";
 
-    protected static void usage() {
-        System.out.println( "usage: org.exist.examples.xmlrpc.Retrieve path-to-document" );
-        System.exit( 0 );
+    private static void usage() {
+        System.out.println("usage: org.exist.examples.xmlrpc.Retrieve path-to-document");
+        System.exit(0);
     }
 
-    public static void main( String args[] ) throws Exception {
-        if ( args.length < 1 ) {
+    public static void main(final String args[]) throws Exception {
+        if (args.length < 1) {
             usage();
         }
-        
+
         // Initialize HTTPS connection to accept selfsigned certificates
         // and the Hostname is not validated 
         SSLHelper.initialize();
-        
-        
-        XmlRpcClient client = new XmlRpcClient();
-        XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+
+        final XmlRpcClient client = new XmlRpcClient();
+        final XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
         config.setServerURL(new URL(uri));
         config.setBasicUserName("guest");
         config.setBasicPassword("guest");
         client.setConfig(config);
 
-        HashMap<String, String> options = new HashMap<String, String>();
+        final Map<String, String> options = new HashMap<>();
         options.put("indent", "yes");
         options.put("encoding", "UTF-8");
         options.put("expand-xincludes", "yes");
         options.put("process-xsl-pi", "no");
-        
-        Vector<Object> params = new Vector<Object>();
-        params.addElement( args[0] ); 
-        params.addElement( options );
-        String xml = (String)
-            client.execute( "getDocumentAsString", params );
-        System.out.println( xml );
+
+        final List<Object> params = new ArrayList<>();
+        params.add(args[0]);
+        params.add(options);
+        final String xml = (String) client.execute("getDocumentAsString", params);
+        System.out.println(xml);
     }
 }
-

--- a/samples/src/org/exist/examples/xmlrpc/Retrieve.java
+++ b/samples/src/org/exist/examples/xmlrpc/Retrieve.java
@@ -1,23 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-07 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- * $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.examples.xmlrpc;
 

--- a/samples/src/org/exist/examples/xmlrpc/RetrieveChunked.java
+++ b/samples/src/org/exist/examples/xmlrpc/RetrieveChunked.java
@@ -1,23 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-07 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- * $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.examples.xmlrpc;
 

--- a/samples/src/org/exist/examples/xmlrpc/RetrieveChunked.java
+++ b/samples/src/org/exist/examples/xmlrpc/RetrieveChunked.java
@@ -19,7 +19,6 @@
  *
  * $Id$
  */
-
 package org.exist.examples.xmlrpc;
 
 import org.apache.xmlrpc.XmlRpcException;
@@ -29,90 +28,83 @@ import org.exist.xmldb.XmldbURI;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Vector;
+import java.util.List;
+import java.util.Map;
 
 /**
- *  Example code for demonstrating XMLRPC methods getDocumentData
- * and getNextChunk. Please run 'admin-examples setup' first, this will
- * download the required macbeth.xml document.
+ * Example code for demonstrating XMLRPC methods getDocumentData and
+ * getNextChunk. Please run 'admin-examples setup' first, this will download the
+ * required macbeth.xml document.
  *
  * @author Dannes Wessels
  */
 public class RetrieveChunked {
-    
+
     /**
      * @param args ignored command line arguments
      */
-    public static void main(String[] args) {
-        
+    public static void main(final String[] args) {
+
         // Download file using xmldb url
-        String xmldbUri = "xmldb:exist://localhost:8080/exist/xmlrpc/db/shakespeare/plays/macbeth.xml";
-        XmldbURI uri = XmldbURI.create(xmldbUri);
-        
+        final String xmldbUri = "xmldb:exist://localhost:8080/exist/xmlrpc/db/shakespeare/plays/macbeth.xml";
+        final XmldbURI uri = XmldbURI.create(xmldbUri);
+
         // Construct url for xmlrpc, without collections / document
-        String url = "http://" + uri.getAuthority() + uri.getContext();
-        String path =uri.getCollectionPath();
-        
+        final String url = "http://" + uri.getAuthority() + uri.getContext();
+        final String path = uri.getCollectionPath();
+
         // TODO file is hardcoded
-        String filename="macbeth.xml";
-        
+        final String filename = "macbeth.xml";
+
         try {
             // Setup xmlrpc client
-            XmlRpcClient client = new XmlRpcClient();
-            XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+            final XmlRpcClient client = new XmlRpcClient();
+            final XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
             config.setServerURL(new URL(url));
             config.setBasicUserName("guest");
             config.setBasicPassword("guest");
             client.setConfig(config);
 
             // Setup xml serializer
-            Hashtable<String, String> options = new Hashtable<String, String>();
+            final Map<String, String> options = new HashMap<>();
             options.put("indent", "no");
             options.put("encoding", "UTF-8");
-            
+
             // Setup xmlrpc parameters
-            Vector<Object> params = new Vector<Object>();
-            params.addElement( path );
-            params.addElement( options );
-            
+            final List<Object> params = new ArrayList<>();
+            params.add(path);
+            params.add(options);
+
             // Setup output stream
-            FileOutputStream fos = new FileOutputStream(filename);
-            
-            // Shoot first method write data
-            HashMap<?,?> ht = (HashMap<?,?>) client.execute("getDocumentData", params);
-            int offset = ((Integer)ht.get("offset")).intValue();
-            byte[]data= (byte[]) ht.get("data");
-            String handle = (String) ht.get("handle");
-            fos.write(data);
-            
-            // When there is more data to download
-            while(offset!=0){
-                // Clean and re-setup xmlrpc parameters
-                params.clear();
-                params.addElement(handle);
-                params.addElement(new Integer(offset));
-                
-                // Get and write next chunk
-                ht = (HashMap<?,?>) client.execute("getNextChunk", params);
-                data= (byte[]) ht.get("data");
-                offset = ((Integer)ht.get("offset")).intValue();
+            try(final FileOutputStream fos = new FileOutputStream(filename)) {
+
+                // Shoot first method write data
+                Map ht = (Map) client.execute("getDocumentData", params);
+                int offset = (int) ht.get("offset");
+                byte[] data = (byte[]) ht.get("data");
+                final String handle = (String) ht.get("handle");
                 fos.write(data);
+
+                // When there is more data to download
+                while (offset != 0) {
+                    // Clean and re-setup xmlrpc parameters
+                    params.clear();
+                    params.add(handle);
+                    params.add(offset);
+
+                    // Get and write next chunk
+                    ht = (Map) client.execute("getNextChunk", params);
+                    data = (byte[]) ht.get("data");
+                    offset = (int) ht.get("offset");
+                    fos.write(data);
+                }
             }
-            
-            // Finish transport
-            fos.close();
-            
-        } catch (MalformedURLException ex) {
-            ex.printStackTrace();
-        } catch (XmlRpcException ex) {
-            ex.printStackTrace();
-        } catch (IOException ex) {
+
+        } catch (final XmlRpcException | IOException ex) {
             ex.printStackTrace();
         }
     }
-    
 }

--- a/samples/src/org/exist/examples/xmlrpc/Store.java
+++ b/samples/src/org/exist/examples/xmlrpc/Store.java
@@ -1,23 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-07 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- * $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.examples.xmlrpc;
 

--- a/samples/src/org/exist/examples/xmlrpc/Store.java
+++ b/samples/src/org/exist/examples/xmlrpc/Store.java
@@ -24,7 +24,8 @@ package org.exist.examples.xmlrpc;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.net.URL;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.xmlrpc.client.XmlRpcClient;
 import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
@@ -32,50 +33,55 @@ import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
 /**
  * Store a document to the database using XML-RPC.
  *
- * Execute bin\run.bat org.exist.examples.xmlrpc.Store <localfilename> <remotedocname>
+ * Execute bin\run.bat org.exist.examples.xmlrpc.Store <localfilename>
+ * <remotedocname>
  */
 public class Store {
 
-	protected final static String uri = "http://localhost:8080/exist/xmlrpc";
+    private final static String uri = "http://localhost:8080/exist/xmlrpc";
 
-	protected static void usage() {
-		System.out.println("usage: org.exist.examples.xmlrpc.Store xmlFile [docName]");
-		System.exit(0);
-	}
+    protected static void usage() {
+        System.out.println("usage: org.exist.examples.xmlrpc.Store xmlFile [docName]");
+        System.exit(0);
+    }
 
-	public static void main(String args[]) throws Exception {
-		if(args.length < 1)
-			usage();
-		String docName = (args.length == 2) ? args[1] : args[0];
+    public static void main(final String args[]) throws Exception {
+        if (args.length < 1) {
+            usage();
+        }
+        
+        final String docName = (args.length == 2) ? args[1] : args[0];
 
-        XmlRpcClient client = new XmlRpcClient();
-        XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+        final XmlRpcClient client = new XmlRpcClient();
+        final XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
         config.setServerURL(new URL(uri));
         config.setBasicUserName("admin");
         config.setBasicPassword("");
         client.setConfig(config);
 
-		// read the file into a string
-		BufferedReader f = new BufferedReader(new FileReader(args[0]));
-		String line;
-		StringBuffer xml = new StringBuffer();
-		while((line = f.readLine()) != null)
-			xml.append(line);
-		f.close();
+        // read the file into a string
+        final StringBuilder xml = new StringBuilder();
+        try (final BufferedReader f = new BufferedReader(new FileReader(args[0]))) {
+            String line;
+            while ((line = f.readLine()) != null) {
+                xml.append(line);
+            }
+        }
 
-		// set parameters for XML-RPC call
-		Vector<Object> params = new Vector<Object>();
-		params.addElement(xml.toString());
-		params.addElement(docName);
-		params.addElement(new Integer(0));
+        // set parameters for XML-RPC call
+        final List<Object> params = new ArrayList<>();
+        params.add(xml.toString());
+        params.add(docName);
+        params.add(0);
 
-		// execute the call
-		Boolean result = (Boolean)client.execute("parse", params);
+        // execute the call
+        final Boolean result = (Boolean) client.execute("parse", params);
 
-		// check result
-		if(result.booleanValue())
-			System.out.println("document stored.");
-		else
-			System.out.println("could not store document.");
-	}
+        // check result
+        if (result) {
+            System.out.println("document stored.");
+        } else {
+            System.out.println("could not store document.");
+        }
+    }
 }

--- a/samples/src/org/exist/examples/xmlrpc/StoreChunked.java
+++ b/samples/src/org/exist/examples/xmlrpc/StoreChunked.java
@@ -22,12 +22,11 @@
 package org.exist.examples.xmlrpc;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.xmlrpc.XmlRpcException;
 import org.apache.xmlrpc.client.XmlRpcClient;
@@ -35,78 +34,68 @@ import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
 import org.exist.xmldb.XmldbURI;
 
 /**
- *  Example code for demonstrating XMLRPC methods upload and parseLocal.
- * 
- * Execute: bin\run.bat org.exist.examples.xmlrpc.StoreChunked 
+ * Example code for demonstrating XMLRPC methods upload and parseLocal.
+ *
+ * Execute: bin\run.bat org.exist.examples.xmlrpc.StoreChunked
  *
  * @author dizzzz
  */
 public class StoreChunked {
-    
-    
-    public static void main(String args[])  {
-        
+
+    public static void main(final String args[]) {
+
         // Upload file to this uri:
-        String xmldbUri = "xmldb:exist://guest:guest@localhost:8080/exist/xmlrpc/db/admin2.png";
-        XmldbURI uri = XmldbURI.create(xmldbUri);
-        
+        final String xmldbUri = "xmldb:exist://guest:guest@localhost:8080/exist/xmlrpc/db/admin2.png";
+        final XmldbURI uri = XmldbURI.create(xmldbUri);
+
         // Construct url for xmlrpc, without collections / document
         // username/password yet hardcoded, need to update XmldbUri fir this
-        String url = "http://guest:guest@" + uri.getAuthority() + uri.getContext();
-        String path =uri.getCollectionPath();
-        
+        final String url = "http://guest:guest@" + uri.getAuthority() + uri.getContext();
+        final String path = uri.getCollectionPath();
+
         // TODO: Filename hardcoded
-        String filename="webapp/resources/admin2.png";
-        try {
-            InputStream fis = new FileInputStream(filename);
-            
+        final String filename = "webapp/resources/admin2.png";
+        try(final InputStream fis = new FileInputStream(filename)) {
             // Setup xmlrpc client
-            XmlRpcClient client = new XmlRpcClient();
-            XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+            final XmlRpcClient client = new XmlRpcClient();
+            final XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
             config.setServerURL(new URL(url));
             config.setBasicUserName("guest");
             config.setBasicPassword("guest");
             client.setConfig(config);
 
             // Initialize xmlrpc parameters
-            Vector<Object> params = new Vector<Object>();
-            String handle=null;
-            
+            final List<Object> params = new ArrayList<>();
+            String handle = null;
+
             // Copy data from inputstream to database
-            byte[] buf = new byte[4096];
-            int len;
+            final byte[] buf = new byte[4096];
+            int len = -1;
             while ((len = fis.read(buf)) > 0) {
                 params.clear();
-                if(handle!=null){
-                    params.addElement(handle);
+                if (handle != null) {
+                    params.add(handle);
                 }
-                params.addElement(buf);
-                params.addElement(new Integer(len));
-                handle = (String)client.execute("upload", params);
+                params.add(buf);
+                params.add(len);
+                handle = (String) client.execute("upload", params);
             }
-            fis.close();
-            
+
             // All data transported, parse data on server
             params.clear();
-            params.addElement(handle);
-            params.addElement(path);
-            params.addElement(new Boolean(true));
-            params.addElement("image/png");
-            Boolean result =(Boolean)client.execute("parseLocal", params); // exceptions
-            
+            params.add(handle);
+            params.add(path);
+            params.add(true);
+            params.add("image/png");
+            final Boolean result = (Boolean) client.execute("parseLocal", params); // exceptions
+
             // Check result
-            if(result.booleanValue())
+            if (result) {
                 System.out.println("document stored.");
-            else
+            } else {
                 System.out.println("could not store document.");
-            
-        } catch (FileNotFoundException ex) {
-            ex.printStackTrace();
-        } catch (MalformedURLException ex) {
-            ex.printStackTrace();
-        } catch (IOException ex) {
-            ex.printStackTrace();
-        } catch (XmlRpcException ex) {
+            }
+        } catch (final XmlRpcException | IOException ex) {
             ex.printStackTrace();
         }
     }

--- a/samples/src/org/exist/examples/xmlrpc/StoreChunked.java
+++ b/samples/src/org/exist/examples/xmlrpc/StoreChunked.java
@@ -1,23 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-06 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- * $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.examples.xmlrpc;
 

--- a/src/org/exist/protocolhandler/xmlrpc/XmlrpcDownload.java
+++ b/src/org/exist/protocolhandler/xmlrpc/XmlrpcDownload.java
@@ -1,25 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-07 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- * $Id: XmlrpcDownload.java 223 2007-04-21 22:13:05Z dizzzz $
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-
 package org.exist.protocolhandler.xmlrpc;
 
 import java.io.IOException;

--- a/src/org/exist/util/VirtualTempFile.java
+++ b/src/org/exist/util/VirtualTempFile.java
@@ -42,7 +42,12 @@ import org.apache.commons.io.output.ByteArrayOutputStream;;
  * 
  * @author jmfernandez
  *
+ * @deprecated Using this class should be avoided as it publishes an API that
+ * makes using it correctly without leaking resources very difficult. It is very
+ * likely that most uses of this class do not correctly cleanup the resources
+ * they obtain. It needs to be rewritten...
  */
+@Deprecated
 public class VirtualTempFile
 	extends OutputStream
 {

--- a/src/org/exist/util/function/BiFunction2E.java
+++ b/src/org/exist/util/function/BiFunction2E.java
@@ -1,0 +1,37 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util.function;
+
+/**
+ * Similar to {@link org.exist.util.function.BiFunctionE} but
+ * permits two statically know Exceptions to be thrown
+ *
+ * @param <T> Function parameter 1 type
+ * @param <U> Function parameter 2 type
+ * @param <R> Function return type
+ * @param <E1> Function throws exception type
+ * @param <E2> Function throws exception type
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface BiFunction2E<T, U, R, E1 extends Throwable, E2 extends Throwable> {
+    R apply(final T t, final U u) throws E1, E2;
+}

--- a/src/org/exist/util/function/Function2E.java
+++ b/src/org/exist/util/function/Function2E.java
@@ -1,0 +1,43 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util.function;
+
+import java.util.Objects;
+
+/**
+ * Similar to {@link org.exist.util.function.FunctionE} but
+ * permits two statically know Exceptions to be thrown
+ *
+ * @param <T> Function parameter type
+ * @param <R> Function return type
+ * @param <E1> Function throws exception type
+ * @param <E2> Function throws exception type
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface Function2E<T, R, E1 extends Throwable, E2 extends Throwable> {
+    R apply(final T t) throws E1, E2;
+
+    default <V> Function2E<T, V, E1, E2> andThen(Function2E<? super R, ? extends V, ? extends E1, ? extends E2> after) {
+        Objects.requireNonNull(after);
+        return (T t) -> after.apply(apply(t));
+    }
+}

--- a/src/org/exist/util/function/Function3E.java
+++ b/src/org/exist/util/function/Function3E.java
@@ -1,0 +1,44 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util.function;
+
+import java.util.Objects;
+
+/**
+ * Similar to {@link FunctionE} but
+ * permits three statically know Exceptions to be thrown
+ *
+ * @param <T> Function parameter type
+ * @param <R> Function return type
+ * @param <E1> Function throws exception type
+ * @param <E2> Function throws exception type
+ * @param <E3> Function throws exception type
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface Function3E<T, R, E1 extends Throwable, E2 extends Throwable, E3 extends Throwable> {
+    R apply(final T t) throws E1, E2, E3;
+
+    default <V> Function3E<T, V, E1, E2, E3> andThen(Function3E<? super R, ? extends V, ? extends E1, ? extends E2, ? extends E3> after) {
+        Objects.requireNonNull(after);
+        return (T t) -> after.apply(apply(t));
+    }
+}

--- a/src/org/exist/util/function/TriFunction2E.java
+++ b/src/org/exist/util/function/TriFunction2E.java
@@ -1,0 +1,38 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util.function;
+
+/**
+ * Similar to {@link org.exist.util.function.TriFunctionE} but
+ * permits two single statically know Exceptions to be thrown
+ *
+ * @param <T> Function parameter 1 type
+ * @param <U> Function parameter 2 type
+ * @param <V> Function parameter 3 type
+ * @param <R> Function return type
+ * @param <E1> Function throws exception type
+ * @param <E2> Function throws exception type
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface TriFunction2E<T, U, V, R, E1 extends Throwable, E2 extends Throwable> {
+    R apply(final T t, final U u, final V v) throws E1, E2;
+}

--- a/src/org/exist/xmldb/MapResourceSet.java
+++ b/src/org/exist/xmldb/MapResourceSet.java
@@ -38,8 +38,8 @@ import org.xmldb.api.base.XMLDBException;
  *
  * @author Jean-Marc Vanel (2 April 2003)
  */
-public class MapResourceSet implements ResourceSet {
-
+public class MapResourceSet implements ResourceSet 
+{
     private final Map<String, Resource> resources;
     private final List<Resource> resourcesVector = new ArrayList<>();
 
@@ -56,7 +56,7 @@ public class MapResourceSet implements ResourceSet {
         }
     }
 
-    public MapResourceSet(final ResourceSet rs) throws XMLDBException {
+    public MapResourceSet(ResourceSet rs) throws XMLDBException {
         this.resources = new HashMap<>();
         for (int i = 0; i < rs.getSize(); i++) {
             final Resource res = rs.getResource(i);

--- a/src/org/exist/xmldb/RemoteResourceIterator.java
+++ b/src/org/exist/xmldb/RemoteResourceIterator.java
@@ -35,17 +35,17 @@ import org.xmldb.api.modules.XMLResource;
 public class RemoteResourceIterator implements ResourceIterator {
 
     private final RemoteCollection collection;
-    private final List resources;
+    private final List<Object> resources;
     private final int indentXML;
     private final String encoding;
     private int pos = 0;
 
-    public RemoteResourceIterator(final RemoteCollection collection, final List resources, final int indentXML, final String encoding) {
+    public RemoteResourceIterator(final RemoteCollection collection, final List<Object> resources, final int indentXML, final String encoding) {
         this.collection = collection;
         this.resources = resources;
         this.indentXML = indentXML;
         this.encoding = encoding;
-    }
+	}
 
     public int getLength() {
         return resources.size();
@@ -79,7 +79,7 @@ public class RemoteResourceIterator implements ResourceIterator {
             params.add(indentXML);
             params.add(encoding);
             try {
-                final byte[] data = (byte[]) collection.getClient().execute("retrieve", params);
+                final byte[] data = (byte[])collection.getClient().execute("retrieve", params);
                 final XMLResource res = new RemoteXMLResource(collection, XmldbURI.xmldbUriFor(doc), Optional.of(doc + "_" + s_id));
                 res.setContent(new String(data, encoding));
                 return res;

--- a/src/org/exist/xmldb/RemoteXUpdateQueryService.java
+++ b/src/org/exist/xmldb/RemoteXUpdateQueryService.java
@@ -86,6 +86,7 @@ public class RemoteXUpdateQueryService implements XUpdateQueryService {
         }
     }
 
+
     @Override
     public void setCollection(final Collection collection) throws XMLDBException {
         parent = (RemoteCollection) collection;

--- a/src/org/exist/xmldb/ResourceSetHelper.java
+++ b/src/org/exist/xmldb/ResourceSetHelper.java
@@ -1,22 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2005,  Wolfgang M. Meier (meier@ifs.tu-darmstadt.de)
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This library is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Library General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Library General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- *  $Id:
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.xmldb;
 

--- a/src/org/exist/xmldb/ResourceSetHelper.java
+++ b/src/org/exist/xmldb/ResourceSetHelper.java
@@ -34,28 +34,29 @@ import org.xmldb.api.base.XMLDBException;
  *
  */
 public class ResourceSetHelper {
-	public static ResourceSet intersection(ResourceSet s1, ResourceSet s2) throws XMLDBException {
-		final Map<String, Resource> m1 = new MapResourceSet(s1).getResourcesMap();
-		final Map<String, Resource> m2 = new MapResourceSet(s2).getResourcesMap();
-		final Set<String> set1 = m1.keySet();
-		final Set<String> set2 = m2.keySet();
-		set1.retainAll(set2);
-		final Map<String, Resource> m = new HashMap<String, Resource>();
-		final Iterator<String> iter = set1.iterator();
-		while ( iter.hasNext() ) {
-          final String key = iter.next();
-          final Resource resource = m1.get(key);
-          m.put(key, resource);
-		}
-		final MapResourceSet res = new MapResourceSet(m); 
-		/*
-		VectorResourceSet res = new VectorResourceSet(); 
-		Collection c1 = new VectorResourceSet(s1).getResources();
-		res.getResources().addAll( c1 );
-		Collection c2 = new VectorResourceSet(s2).getResources();
-		res.getResources().retainAll(c2);
-	 return res;
-	 */
-	 return res;
-	}
+
+    public static ResourceSet intersection(final ResourceSet s1, final ResourceSet s2) throws XMLDBException {
+        final Map<String, Resource> m1 = new MapResourceSet(s1).getResourcesMap();
+        final Map<String, Resource> m2 = new MapResourceSet(s2).getResourcesMap();
+        final Set<String> set1 = m1.keySet();
+        final Set<String> set2 = m2.keySet();
+        set1.retainAll(set2);
+        final Map<String, Resource> m = new HashMap<>();
+        final Iterator<String> iter = set1.iterator();
+        while (iter.hasNext()) {
+            final String key = iter.next();
+            final Resource resource = m1.get(key);
+            m.put(key, resource);
+        }
+        final MapResourceSet res = new MapResourceSet(m);
+        /*
+         VectorResourceSet res = new VectorResourceSet(); 
+         Collection c1 = new VectorResourceSet(s1).getResources();
+         res.getResources().addAll( c1 );
+         Collection c2 = new VectorResourceSet(s2).getResources();
+         res.getResources().retainAll(c2);
+         return res;
+         */
+        return res;
+    }
 }

--- a/src/org/exist/xmlrpc/AbstractCachedResult.java
+++ b/src/org/exist/xmlrpc/AbstractCachedResult.java
@@ -1,3 +1,22 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.exist.xmlrpc;
 
 /**

--- a/src/org/exist/xmlrpc/AbstractCachedResult.java
+++ b/src/org/exist/xmlrpc/AbstractCachedResult.java
@@ -3,72 +3,73 @@ package org.exist.xmlrpc;
 /**
  * Simple abstract container for serialized resources or results of a query.
  * Used to cache them that may be retrieved by chunks later by the client.
- * 
+ *
  * @author wolf
  * @author jmfernandez
  */
 public abstract class AbstractCachedResult {
-	
-	protected long queryTime = 0;
-	protected long creationTimestamp = 0; 
-	protected long timestamp = 0; 
-	
-	public AbstractCachedResult() {
-		this(0);
-	}
-	
-	public AbstractCachedResult(long queryTime) {
-		this.queryTime = queryTime;
-		touch();
-		this.creationTimestamp = this.timestamp;
-	}
-	
-	/**
-	 * @return Returns the queryTime.
-	 */
-	public long getQueryTime() {
-		return queryTime;
-	}
-	
-	/**
-	 * @return Returns the timestamp.
-	 */
-	public long getTimestamp() {
-		return timestamp;
-	}
 
-	/**
-	 * This method can be used to explicitly update the
-	 * last time the cached result has been used
-	 */
-	public void touch() {
-		timestamp = System.currentTimeMillis();
-	}
-	
-	/**
-	 * @return Returns the timestamp.
-	 */
-	public long getCreationTimestamp() {
-		return creationTimestamp;
-	}
-	
-	/**
-	 * This abstract method must be used
-	 * to free internal variables.
-	 */
-	public abstract void free();
-	
-	/**
-	 * This abstract method returns the cached result
-	 * or null
-	 * @return The object which is being cached
-	 */
-	public abstract Object getResult();
-	
-	protected void finalize()
-		throws Throwable
-	{
-		// Calling free to reclaim pinned resources
-		free();
-	}
+    protected long queryTime = 0;
+    protected long creationTimestamp = 0;
+    protected long timestamp = 0;
+
+    public AbstractCachedResult() {
+        this(0);
+    }
+
+    public AbstractCachedResult(final long queryTime) {
+        this.queryTime = queryTime;
+        touch();
+        this.creationTimestamp = this.timestamp;
+    }
+
+    /**
+     * @return Returns the queryTime.
+     */
+    public long getQueryTime() {
+        return queryTime;
+    }
+
+    /**
+     * @return Returns the timestamp.
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * This method can be used to explicitly update the
+     * last time the cached result has been used
+     */
+    public void touch() {
+        timestamp = System.currentTimeMillis();
+    }
+
+    /**
+     * @return Returns the timestamp.
+     */
+    public long getCreationTimestamp() {
+        return creationTimestamp;
+    }
+
+    /**
+     * This abstract method must be used
+     * to free internal variables.
+     */
+    public abstract void free();
+
+    /**
+     * This abstract method returns the cached result
+     * or null
+     *
+     * @return The object which is being cached
+     */
+    public abstract Object getResult();
+
+    @Override
+    protected void finalize()
+            throws Throwable {
+        // Calling free to reclaim pinned resources
+        free();
+    }
 }

--- a/src/org/exist/xmlrpc/QueryResult.java
+++ b/src/org/exist/xmlrpc/QueryResult.java
@@ -1,10 +1,12 @@
 package org.exist.xmlrpc;
 
 import java.io.IOException;
+
 import org.exist.xquery.XPathException;
 import org.exist.xquery.value.Sequence;
 
 import java.util.Properties;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.xquery.value.BinaryValue;
@@ -12,29 +14,29 @@ import org.exist.xquery.value.BinaryValue;
 /**
  * Simple container for the results of a query. Used to cache
  * query results that may be retrieved later by the client.
- * 
+ *
  * @author wolf
  * @author jmfernandez
  */
 public class QueryResult extends AbstractCachedResult {
 
-    protected final static Logger LOG = LogManager.getLogger(QueryResult.class);
+    private final static Logger LOG = LogManager.getLogger(QueryResult.class);
     protected Sequence result;
     protected Properties serialization = null;
     // set upon failure
     protected XPathException exception = null;
 
-    public QueryResult(Sequence result, Properties outputProperties) {
+    public QueryResult(final Sequence result, final Properties outputProperties) {
         this(result, outputProperties, 0);
     }
 
-    public QueryResult(Sequence result, Properties outputProperties, long queryTime) {
+    public QueryResult(final Sequence result, final Properties outputProperties, final long queryTime) {
         super(queryTime);
         this.serialization = outputProperties;
         this.result = result;
     }
 
-    public QueryResult(XPathException e) {
+    public QueryResult(final XPathException e) {
         exception = e;
     }
 
@@ -56,13 +58,13 @@ public class QueryResult extends AbstractCachedResult {
 
     @Override
     public void free() {
-        if(result != null) {
+        if (result != null) {
 
             //cleanup any binary values
-            if(result instanceof BinaryValue) {
+            if (result instanceof BinaryValue) {
                 try {
                     ((BinaryValue) result).close();
-                } catch(final IOException ioe) {
+                } catch (final IOException ioe) {
                     LOG.warn("Unable to cleanup BinaryValue: " + result.hashCode(), ioe);
                 }
             }

--- a/src/org/exist/xmlrpc/QueryResult.java
+++ b/src/org/exist/xmlrpc/QueryResult.java
@@ -1,3 +1,22 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.exist.xmlrpc;
 
 import java.io.IOException;

--- a/src/org/exist/xmlrpc/QueryResultCache.java
+++ b/src/org/exist/xmlrpc/QueryResultCache.java
@@ -14,8 +14,8 @@ public class QueryResultCache {
     public final static int TIMEOUT = 180000;
 
     private static final int INITIAL_SIZE = 254;
-    
-    public AbstractCachedResult[] results;
+
+    private AbstractCachedResult[] results;
 
     private static final Logger LOG = LogManager.getLogger(QueryResultCache.class);
 
@@ -23,7 +23,7 @@ public class QueryResultCache {
         results = new AbstractCachedResult[INITIAL_SIZE];
     }
 
-    public int add(AbstractCachedResult qr) {
+    public int add(final AbstractCachedResult qr) {
         for (int i = 0; i < results.length; i++) {
             if (results[i] == null) {
                 results[i] = qr;
@@ -31,7 +31,7 @@ public class QueryResultCache {
             }
         }
         // no empty bucket. need to resize.
-        AbstractCachedResult[] temp = new AbstractCachedResult[(results.length * 3) / 2];
+        final AbstractCachedResult[] temp = new AbstractCachedResult[(results.length * 3) / 2];
         System.arraycopy(results, 0, temp, 0, results.length);
         final int pos = results.length;
         temp[pos] = qr;
@@ -39,43 +39,42 @@ public class QueryResultCache {
         return pos;
     }
 
-    public AbstractCachedResult get(int pos) {
-        if (pos < 0 || pos >= results.length)
-            {return null;}
+    public AbstractCachedResult get(final int pos) {
+        if (pos < 0 || pos >= results.length) {
+            return null;
+        }
         return results[pos];
     }
-    
-    public QueryResult getResult(int pos) {
-    	final AbstractCachedResult acr = get(pos);
-    	
-    	return (acr!=null && acr instanceof QueryResult)?(QueryResult)acr:null;
+
+    public QueryResult getResult(final int pos) {
+        final AbstractCachedResult acr = get(pos);
+        return (acr != null && acr instanceof QueryResult) ? (QueryResult) acr : null;
     }
-    
-    public SerializedResult getSerializedResult(int pos) {
-    	final AbstractCachedResult acr = get(pos);
-    	
-    	return (acr!=null && acr instanceof SerializedResult)?(SerializedResult)acr:null;
+
+    public SerializedResult getSerializedResult(final int pos) {
+        final AbstractCachedResult acr = get(pos);
+        return (acr != null && acr instanceof SerializedResult) ? (SerializedResult) acr : null;
     }
-    
-    public void remove(int pos) {
+
+    public void remove(final int pos) {
         if (pos > -1 && pos < results.length) {
-        	// Perhaps we should not free resources here
-        	// but an explicit remove implies you want
-        	// to free resources
-        	
-        	if (results[pos] != null) { // Prevent NPE
-        		results[pos].free();
-        		results[pos] = null;
-        	}
+            // Perhaps we should not free resources here
+            // but an explicit remove implies you want
+            // to free resources
+
+            if (results[pos] != null) { // Prevent NPE
+                results[pos].free();
+                results[pos] = null;
+            }
         }
     }
 
-    public void remove(int pos, int hash) {
+    public void remove(final int pos, final int hash) {
         if (pos > -1 && pos < results.length && (results[pos] != null && results[pos].hashCode() == hash)) {
-        	// Perhaps we should not free resources here
-        	// but an explicit remove implies you want
-        	// to free resources
-        	results[pos].free();
+            // Perhaps we should not free resources here
+            // but an explicit remove implies you want
+            // to free resources
+            results[pos].free();
             results[pos] = null;
         }
     }
@@ -83,11 +82,12 @@ public class QueryResultCache {
     public void checkTimestamps() {
         final long now = System.currentTimeMillis();
         for (int i = 0; i < results.length; i++) {
-        	final AbstractCachedResult result = results[i];
+            final AbstractCachedResult result = results[i];
             if (result != null) {
                 if (now - result.getTimestamp() > TIMEOUT) {
-                    if (LOG.isDebugEnabled())
-                        {LOG.debug("Removing result set " + new Date(result.getTimestamp()).toString());}
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Removing result set " + new Date(result.getTimestamp()).toString());
+                    }
                     // Here we should not free resources, because they could be still in use
                     // by other threads, so leave the work to the garbage collector
                     results[i] = null;

--- a/src/org/exist/xmlrpc/QueryResultCache.java
+++ b/src/org/exist/xmlrpc/QueryResultCache.java
@@ -1,3 +1,22 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.exist.xmlrpc;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/org/exist/xmlrpc/RpcAPI.java
+++ b/src/org/exist/xmlrpc/RpcAPI.java
@@ -1,23 +1,21 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2001-2010 The eXist Project
+ * Copyright (C) 2001-2015 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *  
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
- *  $Id$
  */
 package org.exist.xmlrpc;
 

--- a/src/org/exist/xmlrpc/RpcAPI.java
+++ b/src/org/exist/xmlrpc/RpcAPI.java
@@ -366,7 +366,7 @@ public interface RpcAPI {
     public Map<String, Object> retrieveAllFirstChunk(int resultId, Map<String, Object> parameters)
             throws EXistException, PermissionDeniedException;
 
-    Map<String, Object> compile(byte[] xquery, Map<String, Object> parameters) throws Exception;
+    Map<String, Object> compile(byte[] xquery, Map<String, Object> parameters)  throws EXistException, PermissionDeniedException;
 
     Map<String, Object> queryP(byte[] xpath, Map<String, Object> parameters)
             throws EXistException, PermissionDeniedException;
@@ -897,5 +897,5 @@ public interface RpcAPI {
 
     public Map<String, Object> getSubResourcePermissions(String parentPath, String name) throws EXistException, PermissionDeniedException, URISyntaxException;
 
-    public boolean setTriggersEnabled(String path, String value) throws PermissionDeniedException;
+    public boolean setTriggersEnabled(String path, String value) throws EXistException, PermissionDeniedException;
 }

--- a/src/org/exist/xmlrpc/RpcAPI.java
+++ b/src/org/exist/xmlrpc/RpcAPI.java
@@ -71,7 +71,7 @@ public interface RpcAPI {
      * Shut down the database after the specified delay (in milliseconds).
      *
      * @param delay The delay in milliseconds
-     * @return true if the shutdown succeeded, false otherwise
+     * @return true if the shutdown was scheduled, false otherwise
      * @throws PermissionDeniedException
      * @Deprecated {@see org.exist.xmlrpc.RpcAPI#shutdown(long)
      */

--- a/src/org/exist/xmlrpc/RpcAPI.java
+++ b/src/org/exist/xmlrpc/RpcAPI.java
@@ -20,13 +20,12 @@
  *  $Id$
  */
 package org.exist.xmlrpc;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import org.exist.EXistException;
 import org.exist.security.PermissionDeniedException;
@@ -37,754 +36,744 @@ import org.exist.xquery.XPathException;
 import org.xml.sax.SAXException;
 
 /**
- *  Defines the methods callable through the XMLRPC interface.
+ * Defines the methods callable through the XMLRPC interface.
  *
- * @author     Wolfgang Meier <wolfgang@exist-db.org>
+ * @author Wolfgang Meier <wolfgang@exist-db.org>
  * modified by {Marco.Tampucci, Massimo.Martinelli} @isti.cnr.it
  */
 public interface RpcAPI {
 
-	public final static String SORT_EXPR = "sort-expr";
-	public final static String NAMESPACES = "namespaces";
-	public final static String VARIABLES = "variables";
-	public final static String BASE_URI = "base-uri";
-	public final static String STATIC_DOCUMENTS = "static-documents";
+    public final static String SORT_EXPR = "sort-expr";
+    public final static String NAMESPACES = "namespaces";
+    public final static String VARIABLES = "variables";
+    public final static String BASE_URI = "base-uri";
+    public final static String STATIC_DOCUMENTS = "static-documents";
     public final static String PROTECTED_MODE = "protected";
     public static final String ERROR = "error";
-	public static final String LINE = "line";
-	public static final String COLUMN = "column";
+    public static final String LINE = "line";
+    public static final String COLUMN = "column";
     public static final String MODULE_LOAD_PATH = "module-load-path";
 
     /**
-	 * Return the database version.
-	 * 
-	 * @return database version
-	 */
+     * Return the database version.
+     *
+     * @return database version
+     */
     public String getVersion();
 
-	/**
-	 * Shut down the database immediately.
-	 * 
-	 * @return true if the shutdown succeeded, false otherwise
-	 */
-	public boolean shutdown() throws PermissionDeniedException;
-
-	/**
-	 * Shut down the database after the specified delay (in milliseconds).
-	 * 
-	 * @return true if the shutdown succeeded, false otherwise
-	 * @throws PermissionDeniedException
-	 */
-	public boolean shutdown(String delay) throws PermissionDeniedException;
-	
-	/**
-	 * Shut down the database after the specified delay (in milliseconds).
-	 * 
-	 * @return true if the shutdown succeeded, false otherwise
-	 * @throws PermissionDeniedException
-	 */
-	public boolean shutdown(long delay) throws PermissionDeniedException;
-	
-	public boolean sync();
-	
-	/**
-	 * Returns true if XACML is enabled for the current database instance
-	 * @return if XACML is enabled
-	 */
-	public boolean isXACMLEnabled();
-
-	/**
-	 *  Retrieve document by name. XML content is indented if prettyPrint is set
-	 *  to >=0. Use supplied encoding for output. 
-	 * 
-	 *  This method is provided to retrieve a document with encodings other than UTF-8. Since the data is
-	 *  handled as binary data, character encodings are preserved. byte[]-values
-	 *  are automatically BASE64-encoded by the XMLRPC library.
-	 *
-	 *@param  name                           the document's name.
-	 *@param  prettyPrint                    pretty print XML if >0.
-	 *@param  encoding                       character encoding to use.
-	 *@return   Document data as binary array.
-	 */
-	byte[] getDocument(String name, String encoding, int prettyPrint)
-		throws EXistException, PermissionDeniedException;
-
-	/**
-	 *  Retrieve document by name. XML content is indented if prettyPrint is set
-	 *  to >=0. Use supplied encoding for output and apply the specified stylesheet. 
-	 * 
-	 *  This method is provided to retrieve a document with encodings other than UTF-8. Since the data is
-	 *  handled as binary data, character encodings are preserved. byte[]-values
-	 *  are automatically BASE64-encoded by the XMLRPC library.
-	 *
-	 *@param  name                           the document's name.
-	 *@param  prettyPrint                    pretty print XML if >0.
-	 *@param  encoding                       character encoding to use.
-	 *@return                                The document value
-	 */
-	byte[] getDocument(String name, String encoding, int prettyPrint, String stylesheet)
-		throws EXistException, PermissionDeniedException;
-	
-     /**
-	 * Retrieve document by name.  All optional output parameters are passed as key/value pairs
-	 * int the hashtable <code>parameters</code>.
-	 * 
-	 * Valid keys may either be taken from {@link javax.xml.transform.OutputKeys} or 
-	 * {@link org.exist.storage.serializers.EXistOutputKeys}. For example, the encoding is identified by
-	 * the value of key {@link javax.xml.transform.OutputKeys#ENCODING}.
-	 *
-	 *@param  name                           the document's name.
-	 *@param  parameters                      HashMap of parameters.
-	 *@return                                The document value
-	 */		
-	byte[] getDocument(String name, HashMap<String, Object> parameters)
-			throws EXistException, PermissionDeniedException;	
-		
-
-	String getDocumentAsString(String name, int prettyPrint)
-			throws EXistException, PermissionDeniedException;
-			
-	String getDocumentAsString(String name, int prettyPrint, String stylesheet)
-		throws EXistException, PermissionDeniedException;
-	
-	String getDocumentAsString(String name, HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException;
-	
-	/**
-	 * Retrieve the specified document, but limit the number of bytes transmitted
-	 * to avoid memory shortage on the server.
-	 * 
-	 * @param name
-	 * @param parameters
-	 * @throws EXistException
-	 * @throws PermissionDeniedException
-	 */
-	HashMap<String, Object> getDocumentData(String name, HashMap<String, Object> parameters)
-	throws EXistException, PermissionDeniedException;
-	
-	HashMap<String, Object> getNextChunk(String handle, int offset)
-    throws EXistException, PermissionDeniedException;
-	
-	HashMap<String, Object> getNextExtendedChunk(String handle, String offset)
-    throws EXistException, PermissionDeniedException;
-	
-	byte[] getBinaryResource(String name)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	/**
-	 *  Does the document identified by <code>name</code> exist in the
-	 *  repository?
-	 *
-	 *@param  name                           Description of the Parameter
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	boolean hasDocument(String name) throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	/**
-	 *  Does the Collection identified by <code>name</code> exist in the
-	 *  repository?
-	 *
-	 *@param  name                           Description of the Parameter
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	boolean hasCollection(String name) throws EXistException, PermissionDeniedException, URISyntaxException;
-
-        Vector<String> getCollectionListing(final String collection)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
-        
-	/**
-	 *  Get a list of all documents contained in the database.
-	 *
-	 *@return  list of document paths
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	Vector<String> getDocumentListing() throws EXistException, PermissionDeniedException;
-
-	/**
-	 *  Get a list of all documents contained in the collection.
-	 *
-	 *@param  collection                     the collection to use.
-	 *@return                                list of document paths
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	Vector<String> getDocumentListing(String collection)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	HashMap<String, List<Object>> listDocumentPermissions(String name)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	HashMap<XmldbURI, List<Object>> listCollectionPermissions(String name)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
-
-        /**
-         * Determines whether a Collection exists in the database
-         * and whether the user may open the collection
-         * 
-         * @param collectionUri The URI of the collection of interest
-         * 
-         * @return true if the collection exists and the user can open it, false if the collection does not exist
-         * @throws PermissionDeniedException If the user does not have permission to open the collection
-         */
-        boolean existsAndCanOpenCollection(final String collectionUri) throws EXistException, PermissionDeniedException;
-        
-	/**
-	 *  Describe a collection: returns a struct with the  following fields:
-	 *  
-	 * <pre>
-	 *	name				The name of the collection
-	 *	
-	 *	owner				The name of the user owning the collection.
-	 *	
-	 *	group				The group owning the collection.
-	 *	
-	 *	permissions	The permissions that apply to this collection (int value)
-	 *	
-	 *	created			The creation date of this collection (long value)
-	 *	
-	 *	collections		An array containing the names of all subcollections.
-	 *	
-	 *	documents		An array containing a struct for each document in the collection.
-	 *	</pre>
-	 *
-	 *	Each of the elements in the "documents" array is another struct containing the properties
-	 *	of the document:
-	 *
-	 *	<pre>
-	 *	name				The full path of the document.
-	 *	
-	 *	owner				The name of the user owning the document.
-	 *	
-	 *	group				The group owning the document.
-	 *	
-	 *	permissions	The permissions that apply to this document (int)
-	 *	
-	 *	type					Type of the resource: either "XMLResource" or "BinaryResource"
-	 *	</pre>
-	 *
-	 *@param  rootCollection                 Description of the Parameter
-	 *@return                                The collectionDesc value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	HashMap<String, Object> getCollectionDesc(String rootCollection)
-		throws EXistException, PermissionDeniedException;
-
-	HashMap<String, Object> describeCollection(String collectionName)
-		throws EXistException, PermissionDeniedException;
-	
-	HashMap<String, Object> describeResource(String resourceName)
-		throws EXistException, PermissionDeniedException;
-	
-	/**
-	 * Returns the number of resources in the collection identified by
-	 * collectionName.
-	 * 
-	 * @param collectionName
-	 * @return Number of resources
-	 * @throws EXistException
-	 * @throws PermissionDeniedException
-	 */
-	int getResourceCount(String collectionName)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	/**
-	 *  Retrieve a single node from a document. The node is identified by it's
-	 *  internal id.
-	 *
-	 *@param  doc                            the document containing the node
-	 *@param  id                             the node's internal id
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	byte[] retrieve(String doc, String id)
-		throws EXistException, PermissionDeniedException;
-
-	/**
-	 *  Retrieve a single node from a document. The node is identified by it's
-	 *  internal id.
-	 *
-	 *@param  doc                            the document containing the node
-	 *@param  id                             the node's internal id
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	byte[] retrieve(String doc, String id, HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException;
-
-	/**
-	 *  Retrieve a single node from a document. The node is identified by its
-	 *  internal id. It is fetched the first chunk, and the next ones should
-	 *  be fetched using getNextChunk or getNextExtendedChunk
-	 *
-	 *@param  doc                            the document containing the node
-	 *@param  id                             the node's internal id
-	 *@param  parameters                     a <code>HashMap</code> value
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	HashMap<String, Object> retrieveFirstChunk(String doc, String id, HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException;
-
-	String retrieveAsString(String doc, String id, HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	public byte[] retrieveAll(int resultId, HashMap<String, Object> parameters)
-	throws EXistException, PermissionDeniedException;
-	
-	public HashMap<String, Object> retrieveAllFirstChunk(int resultId, HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException;
-	
-   HashMap<String, Object> compile(byte[] xquery, HashMap<String, Object> parameters) throws Exception;
-   
-	HashMap<String, Object> queryP(byte[] xpath, HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException;
-
-	HashMap<String, Object> queryP(byte[] xpath, String docName, String s_id, HashMap<String, Object> parameters)
-            throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	/**
-	 *  execute XPath query and return howmany nodes from the result set,
-	 *  starting at position <code>start</code>. If <code>prettyPrint</code> is
-	 *  set to >0 (true), results are pretty printed.
-	 *
-	 *@param  howmany                        maximum number of results to
-	 *      return.
-	 *@param  start                          item in the result set to start
-	 *      with.
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 *@deprecated                           use Vector query() or int
-	 *      executeQuery() instead
-	 */
-	byte[] query(
-
-		byte[] xquery,
-		int howmany,
-		int start,
-		HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException;
-
-	/**
-	 *  execute XPath query and return a summary of hits per document and hits
-	 *  per doctype. This method returns a struct with the following fields:
-	 *
-	 *  <table border="1">
-	 *
-	 *    <tr>
-	 *
-	 *      <td>
-	 *        "queryTime"
-	 *      </td>
-	 *
-	 *      <td>
-	 *        int
-	 *      </td>
-	 *
-	 *    </tr>
-	 *
-	 *    <tr>
-	 *
-	 *      <td>
-	 *        "hits"
-	 *      </td>
-	 *
-	 *      <td>
-	 *        int
-	 *      </td>
-	 *
-	 *    </tr>
-	 *
-	 *    <tr>
-	 *
-	 *      <td>
-	 *        "documents"
-	 *      </td>
-	 *
-	 *      <td>
-	 *        array of array: Object[][3]
-	 *      </td>
-	 *
-	 *    </tr>
-	 *
-	 *    <tr>
-	 *
-	 *      <td>
-	 *        "doctypes"
-	 *      </td>
-	 *
-	 *      <td>
-	 *        array of array: Object[][2]
-	 *      </td>
-	 *
-	 *    </tr>
-	 *
-	 *  </table>
-	 *  Documents and doctypes represent tables where each row describes one
-	 *  document or doctype for which hits were found. Each document entry has
-	 *  the following structure: docId (int), docName (string), hits (int) The
-	 *  doctype entry has this structure: doctypeName (string), hits (int)
-	 *
-	 *@param  xquery                         Description of the Parameter
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 *@deprecated                           use Vector query() or int
-	 *      executeQuery() instead
-	 */
-	HashMap<String, Object> querySummary(String xquery)
-		throws EXistException, PermissionDeniedException;
-
-	/**
-	 * Returns a diagnostic dump of the expression structure after
-	 * compiling the query. The query is read from the query cache
-	 * if it has already been run before.
-	 * 
-	 * @param query
-	 * @throws EXistException
-	 */
-	public String printDiagnostics(String query, HashMap<String, Object> parameters)
-	throws EXistException, PermissionDeniedException;
-	
-	String createResourceId(String collection)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	/**
-	 *  Parse an XML document and store it into the database. The document will
-	 *  later be identified by <code>docName</code>. Some xmlrpc clients seem to
-	 *  have problems with character encodings when sending xml content. To
-	 *  avoid this, parse() accepts the xml document content as byte[]. If
-	 *  <code>overwrite</code> is >0, an existing document with the same name
-	 *  will be replaced by the new document.
-	 *
-	 *@param  xmlData                        The document data
-	 *@param  docName                      The path where the document will be stored 
-	 *@exception  EXistException
-	 *@exception  PermissionDeniedException
-	 */
-	boolean parse(byte[] xmlData, String docName)
-            throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	/**
-	 *  Parse an XML document and store it into the database. The document will
-	 *  later be identified by <code>docName</code>. Some xmlrpc clients seem to
-	 *  have problems with character encodings when sending xml content. To
-	 *  avoid this, parse() accepts the xml document content as byte[]. If
-	 *  <code>overwrite</code> is >0, an existing document with the same name
-	 *  will be replaced by the new document.
-	 *
-	 *@param  xmlData                        The document data
-	 *@param  docName                      The path where the document will be stored 
-	 *@param  overwrite                      Overwrite an existing document with the same path?
-	 *@exception  EXistException
-	 *@exception  PermissionDeniedException
-	 */
-	boolean parse(byte[] xmlData, String docName, int overwrite)
-	throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	boolean parse(byte[] xmlData, String docName, int overwrite, Date created, Date modified)
-	throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	boolean parse(String xml, String docName, int overwrite)
-            throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	boolean parse(String xml, String docName)
-            throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	/**
-	 * An alternative to parse() for larger XML documents. The document
-	 * is first uploaded chunk by chunk using upload(), then parseLocal() is
-	 * called to actually store the uploaded file.
-	 * 
-	 * @param chunk the current chunk
-	 * @param length total length of the file 
-	 * @return the name of the file to which the chunk has been appended.
-	 * @throws EXistException
-	 * @throws PermissionDeniedException
-	 */
-	String upload(byte[] chunk, int length)
-            throws EXistException, PermissionDeniedException, IOException;
-
-	/**
-	 * An alternative to parse() for larger XML documents. The document
-	 * is first uploaded chunk by chunk using upload(), then parseLocal() is
-	 * called to actually store the uploaded file.
-	 * 
-	 * @param chunk the current chunk
-	 * @param file the name of the file to which the chunk will be appended. This
-	 * should be the file name returned by the first call to upload.
-	 * @param length total length of the file 
-	 * @return the name of the file to which the chunk has been appended.
-	 * @throws EXistException
-	 * @throws PermissionDeniedException
-	 */
-	String upload(String file, byte[] chunk, int length)
-            throws EXistException, PermissionDeniedException, IOException;
-
-	String uploadCompressed(byte[] data, int length)
-            throws EXistException, PermissionDeniedException, IOException;
-	
-	String uploadCompressed(String file, byte[] data, int length)
-            throws EXistException, PermissionDeniedException, IOException;
-	
-	/**
-	 * Parse a file previously uploaded with upload.
-	 * 
-	 * The temporary file will be removed.
-	 * 
-	 * @param localFile
-	 * @throws EXistException
-	 * @throws IOException
-	 */
-	public boolean parseLocal(String localFile, String docName, boolean replace, String mimeType)
-            throws EXistException, PermissionDeniedException, SAXException, URISyntaxException;
-
-	public boolean parseLocalExt(String localFile, String docName, boolean replace, String mimeType, boolean treatAsXML)
-            throws EXistException, PermissionDeniedException, SAXException, URISyntaxException;
-
-	public boolean parseLocal(String localFile, String docName, boolean replace, String mimeType, Date created, Date modified)
-            throws EXistException, PermissionDeniedException, SAXException, URISyntaxException;
-	
-	public boolean parseLocalExt(String localFile, String docName, boolean replace, String mimeType, boolean treatAsXML, Date created, Date modified)
-            throws EXistException, PermissionDeniedException, SAXException, URISyntaxException;
-	
-	/**
-	 * Store data as a binary resource.
-	 * 
-	 * @param data the data to be stored
-	 * @param docName the path to the new document
-	 * @param replace if true, an old document with the same path will be overwritten
-	 * @throws EXistException
-	 * @throws PermissionDeniedException
-	 */
-	public boolean storeBinary(byte[] data, String docName, String mimeType, boolean replace)
-            throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	public boolean storeBinary(byte[] data, String docName, String mimeType, boolean replace, Date created, Date modified)
-            throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	/**
-	 *  Remove a document from the database.
-	 *
-	 * @param  docName path to the document to be removed
-	 *@exception  EXistException
-	 *@exception  PermissionDeniedException  
-	 */
-	boolean remove(String docName) throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	/**
-	 *  Remove an entire collection from the database.
-	 *
-	 *@param  name path to the collection to be removed.
-	 *@exception  EXistException
-	 *@exception  PermissionDeniedException 
-	 */
-	boolean removeCollection(String name)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
-
-	/** 
-	 * Create a new collection on the database.
-	 * 
-	 * @param name the path to the new collection.
-	 * @throws EXistException
-	 * @throws PermissionDeniedException
-	 */
-	boolean createCollection(String name)
-		throws EXistException, PermissionDeniedException;
-	
-	boolean createCollection(String name, Date created)
-	throws EXistException, PermissionDeniedException;
-
-	boolean configureCollection(String collection, String configuration)
-		throws EXistException, PermissionDeniedException;
-	
-	/**
-     * Execute XPath query and return a reference to the result set. The
-	 *  returned reference may be used later to get a summary of results or
-	 *  retrieve the actual hits.
-	 *
-     * @param  xpath                          Description of the Parameter
-     * @param  encoding                       Description of the Parameter
-     * @param parameters a <code>HashMap</code> value
-     * @return                                Description of the Return Value
-     * @exception  EXistException             Description of the Exception
-     * @exception  PermissionDeniedException  Description of the Exception
+    /**
+     * Shut down the database immediately.
+     *
+     * @return true if the shutdown succeeded, false otherwise
+     * @throws org.exist.security.PermissionDeniedException
      */
-    int executeQuery(byte[] xpath, String encoding, HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException;
+    public boolean shutdown() throws PermissionDeniedException;
 
-	int executeQuery(byte[] xpath, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException;
+    /**
+     * Shut down the database after the specified delay (in milliseconds).
+     *
+     * @param delay The delay in milliseconds
+     * @return true if the shutdown succeeded, false otherwise
+     * @throws PermissionDeniedException
+     * @Deprecated {@see org.exist.xmlrpc.RpcAPI#shutdown(long)
+     */
+    @Deprecated
+    public boolean shutdown(String delay) throws PermissionDeniedException;
 
-	int executeQuery(String xpath, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException;
-        
-	/**
-	 *  Execute XPath/Xquery from path file (stored inside eXist)
-	 *  returned reference may be used later to get a summary of results or
-	 *  retrieve the actual hits.
-	 */
-	HashMap<String, Object> execute(String path, HashMap<String, Object> parameters)
-	throws EXistException, PermissionDeniedException;
-	
-	/**
-	 *  Retrieve a summary of the result set identified by it's result-set-id.
-	 *  This method returns a struct with the following fields:
-	 *
-	 *  <tableborder="1">
-	 *
-	 *    <tr>
-	 *
-	 *      <td>
-	 *        "queryTime"
-	 *      </td>
-	 *
-	 *      <td>
-	 *        int
-	 *      </td>
-	 *
-	 *    </tr>
-	 *
-	 *    <tr>
-	 *
-	 *      <td>
-	 *        "hits"
-	 *      </td>
-	 *
-	 *      <td>
-	 *        int
-	 *      </td>
-	 *
-	 *    </tr>
-	 *
-	 *    <tr>
-	 *
-	 *      <td>
-	 *        "documents"
-	 *      </td>
-	 *
-	 *      <td>
-	 *        array of array: Object[][3]
-	 *      </td>
-	 *
-	 *    </tr>
-	 *
-	 *    <tr>
-	 *
-	 *      <td>
-	 *        "doctypes"
-	 *      </td>
-	 *
-	 *      <td>
-	 *        array of array: Object[][2]
-	 *      </td>
-	 *
-	 *    </tr>
-	 *
-	 *  </table>
-	 *  Documents and doctypes represent tables where each row describes one
-	 *  document or doctype for which hits were found. Each document entry has
-	 *  the following structure: docId (int), docName (string), hits (int) The
-	 *  doctype entry has this structure: doctypeName (string), hits (int)
-	 *
-	 *@param  resultId                       Description of the Parameter
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	HashMap<String, Object> querySummary(int resultId)
-		throws EXistException, PermissionDeniedException, XPathException;
+    /**
+     * Shut down the database after the specified delay (in milliseconds).
+     *
+     * @param delay The delay in milliseconds
+     * @return true if the shutdown succeeded, false otherwise
+     * @throws PermissionDeniedException
+     */
+    public boolean shutdown(long delay) throws PermissionDeniedException;
 
-	HashMap<String, Object> getPermissions(String resource)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
+    public boolean sync();
 
-	/**
-	 *  Get the number of hits in the result set identified by it's
-	 *  result-set-id.
-	 *
-	 *@param  resultId                       Description of the Parameter
-	 *@return                                The hits value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	int getHits(int resultId) throws EXistException, PermissionDeniedException;
+    /**
+     * Returns true if XACML is enabled for the current database instance
+     *
+     * @return if XACML is enabled
+     */
+    public boolean isXACMLEnabled();
 
-	/**
-	 *  Retrieve a single result from the result-set identified by resultId. The
-	 *  XML fragment at position num in the result set is returned.
-	 *
-	 *@param  resultId                       Description of the Parameter
-	 *@param  num                            Description of the Parameter
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	byte[] retrieve(int resultId, int num, HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException;
+    /**
+     * Retrieve document by name. XML content is indented if prettyPrint is set
+     * to >=0. Use supplied encoding for output.
+     *
+     * This method is provided to retrieve a document with encodings other than
+     * UTF-8. Since the data is handled as binary data, character encodings are
+     * preserved. byte[]-values are automatically BASE64-encoded by the XMLRPC
+     * library.
+     *
+     * @param name the document's name.
+     * @param prettyPrint pretty print XML if >0.
+     * @param encoding character encoding to use.
+     * @return Document data as binary array.
+     * @throws org.exist.EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     */
+    byte[] getDocument(String name, String encoding, int prettyPrint)
+            throws EXistException, PermissionDeniedException;
 
-	/**
-	 *  Retrieve a single result from the result-set identified by resultId. The
-	 *  XML fragment at position num in the result set is returned. It is
-	 *  fetched the first chunk, and the next ones should be fetched using
-	 *  getNextChunk or getNextExtendedChunk
-	 *
-	 *@param  resultId                       Description of the Parameter
-	 *@param  num                            Description of the Parameter
-	 *@param  parameters                     a <code>HashMap</code> value
-	 *@return                                Description of the Return Value
-	 *@exception  EXistException             Description of the Exception
-	 *@exception  PermissionDeniedException  Description of the Exception
-	 */
-	HashMap<String, Object> retrieveFirstChunk(int resultId, int num, HashMap<String, Object> parameters)
-		throws EXistException, PermissionDeniedException;
+    /**
+     * Retrieve document by name. XML content is indented if prettyPrint is set
+     * to >=0. Use supplied encoding for output and apply the specified
+     * stylesheet.
+     *
+     * This method is provided to retrieve a document with encodings other than
+     * UTF-8. Since the data is handled as binary data, character encodings are
+     * preserved. byte[]-values are automatically BASE64-encoded by the XMLRPC
+     * library.
+     *
+     * @param name the document's name.
+     * @param prettyPrint pretty print XML if >0.
+     * @param encoding character encoding to use.
+     * @param stylesheet
+     * @return The document value
+     * @throws org.exist.EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     */
+    byte[] getDocument(String name, String encoding, int prettyPrint, String stylesheet)
+            throws EXistException, PermissionDeniedException;
 
-	boolean addAccount(String name, String passwd, String digestPassword,Vector<String> groups, Boolean isEnabled, Integer umask, Map<String, String> metadata)
-		throws EXistException, PermissionDeniedException;
-        
-	boolean updateAccount(String name, String passwd, String digestPassword,Vector<String> groups)
-		throws EXistException, PermissionDeniedException;
+    /**
+     * Retrieve document by name. All optional output parameters are passed as
+     * key/value pairs int the <code>parameters</code>.
+     *
+     * Valid keys may either be taken from
+     * {@link javax.xml.transform.OutputKeys} or
+     * {@link org.exist.storage.serializers.EXistOutputKeys}. For example, the
+     * encoding is identified by the value of key
+     * {@link javax.xml.transform.OutputKeys#ENCODING}.
+     *
+     * @param name the document's name.
+     * @param parameters Map of parameters.
+     * @return The document value
+     * @throws org.exist.EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     */
+    byte[] getDocument(String name, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
 
-	boolean updateAccount(String name, String passwd, String digestPassword, Vector<String> groups, Boolean isEnabled, Integer umask, Map<String, String> metadata)
-		throws EXistException, PermissionDeniedException;
+    String getDocumentAsString(String name, int prettyPrint)
+            throws EXistException, PermissionDeniedException;
 
-	boolean addGroup(String name, Map<String, String> metadata) throws EXistException, PermissionDeniedException;
+    String getDocumentAsString(String name, int prettyPrint, String stylesheet)
+            throws EXistException, PermissionDeniedException;
 
-        boolean updateGroup(final String name, final Vector<String> managers, final Map<String, String> metadata) throws EXistException, PermissionDeniedException;
-        
-        Vector<String> getGroupMembers(final String groupName) throws EXistException, PermissionDeniedException;
-        
-        void addAccountToGroup(final String accountName, final String groupName) throws EXistException, PermissionDeniedException;
-        
-        void addGroupManager(final String manager, final String groupName) throws EXistException, PermissionDeniedException;
-        
-        public void removeGroupManager(final String groupName, final String manager) throws EXistException, PermissionDeniedException;
-        
-	boolean setPermissions(String resource, String permissions)
+    String getDocumentAsString(String name, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    /**
+     * Retrieve the specified document, but limit the number of bytes
+     * transmitted to avoid memory shortage on the server.
+     *
+     * @param name
+     * @param parameters
+     * @return 
+     * @throws EXistException
+     * @throws PermissionDeniedException
+     */
+    Map<String, Object> getDocumentData(String name, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    Map<String, Object> getNextChunk(String handle, int offset)
+            throws EXistException, PermissionDeniedException;
+
+    Map<String, Object> getNextExtendedChunk(String handle, String offset)
+            throws EXistException, PermissionDeniedException;
+
+    byte[] getBinaryResource(String name)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
-	boolean setPermissions(String resource, int permissions)
+    /**
+     * Does the document identified by <code>name</code> exist in the
+     * repository?
+     *
+     * @param name Description of the Parameter
+     * @return Description of the Return Value
+     * @throws org.exist.EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     * @throws java.net.URISyntaxException
+     */
+    boolean hasDocument(String name) throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * Does the Collection identified by <code>name</code> exist in the
+     * repository?
+     *
+     * @param name Description of the Parameter
+     * @return Description of the Return Value
+     * @throws org.exist.EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     * @throws java.net.URISyntaxException
+     */
+    boolean hasCollection(String name) throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    List<String> getCollectionListing(final String collection)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
-	boolean setPermissions(
-		String resource,
-		String owner,
-		String ownerGroup,
-		String permissions)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
+    /**
+     * Get a list of all documents contained in the database.
+     *
+     * @return list of document paths
+     * @throws org.exist.EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     */
+    List<String> getDocumentListing() throws EXistException, PermissionDeniedException;
 
-	boolean setPermissions(
-		String resource,
-		String owner,
-		String ownerGroup,
-		int permissions)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
+    /**
+     * Get a list of all documents contained in the collection.
+     *
+     * @param collection the collection to use.
+     * @return list of document paths
+     * @throws org.exist.EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     * @throws java.net.URISyntaxException
+     */
+    List<String> getDocumentListing(String collection)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    Map<String, List> listDocumentPermissions(String name)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    Map<XmldbURI, List> listCollectionPermissions(String name)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * Determines whether a Collection exists in the database and whether the
+     * user may open the collection
+     *
+     * @param collectionUri The URI of the collection of interest
+     *
+     * @return true if the collection exists and the user can open it, false if
+     * the collection does not exist
+     * @throws org.exist.EXistException
+     * @throws PermissionDeniedException If the user does not have permission to
+     * open the collection
+     */
+    boolean existsAndCanOpenCollection(final String collectionUri) throws EXistException, PermissionDeniedException;
+
+    /**
+     * Describe a collection: returns a struct with the following fields:
+     *
+     * <pre>
+     *	name				The name of the collection
+     *
+     *	owner				The name of the user owning the collection.
+     *
+     *	group				The group owning the collection.
+     *
+     *	permissions	The permissions that apply to this collection (int value)
+     *
+     *	created			The creation date of this collection (long value)
+     *
+     *	collections		An array containing the names of all subcollections.
+     *
+     *	documents		An array containing a struct for each document in the collection.
+     * </pre>
+     *
+     * Each of the elements in the "documents" array is another struct
+     * containing the properties of the document:
+     *
+     * <pre>
+     *	name				The full path of the document.
+     *
+     *	owner				The name of the user owning the document.
+     *
+     *	group				The group owning the document.
+     *
+     *	permissions	The permissions that apply to this document (int)
+     *
+     *	type					Type of the resource: either "XMLResource" or "BinaryResource"
+     * </pre>
+     *
+     * @param rootCollection Description of the Parameter
+     * @return The collectionDesc value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     */
+    Map<String, Object> getCollectionDesc(String rootCollection)
+            throws EXistException, PermissionDeniedException;
+
+    Map<String, Object> describeCollection(String collectionName)
+            throws EXistException, PermissionDeniedException;
+
+    Map<String, Object> describeResource(String resourceName)
+            throws EXistException, PermissionDeniedException;
+
+    /**
+     * Returns the number of resources in the collection identified by
+     * collectionName.
+     *
+     * @param collectionName
+     * @return Number of resources
+     * @throws EXistException
+     * @throws PermissionDeniedException
+     * @throws java.net.URISyntaxException
+     */
+    int getResourceCount(String collectionName)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * Retrieve a single node from a document. The node is identified by it's
+     * internal id.
+     *
+     * @param doc the document containing the node
+     * @param id the node's internal id
+     * @return Description of the Return Value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     */
+    byte[] retrieve(String doc, String id)
+            throws EXistException, PermissionDeniedException;
+
+    /**
+     * Retrieve a single node from a document. The node is identified by it's
+     * internal id.
+     *
+     * @param doc the document containing the node
+     * @param id the node's internal id
+     * @param parameters
+     * @return Description of the Return Value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     */
+    byte[] retrieve(String doc, String id, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    /**
+     * Retrieve a single node from a document. The node is identified by its
+     * internal id. It is fetched the first chunk, and the next ones should be
+     * fetched using getNextChunk or getNextExtendedChunk
+     *
+     * @param doc the document containing the node
+     * @param id the node's internal id
+     * @param parameters a <code>Map</code> value
+     * @return Description of the Return Value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     */
+    Map<String, Object> retrieveFirstChunk(String doc, String id, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    String retrieveAsString(String doc, String id, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    public byte[] retrieveAll(int resultId, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    public Map<String, Object> retrieveAllFirstChunk(int resultId, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    Map<String, Object> compile(byte[] xquery, Map<String, Object> parameters) throws Exception;
+
+    Map<String, Object> queryP(byte[] xpath, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    Map<String, Object> queryP(byte[] xpath, String docName, String s_id, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * execute XPath query and return howmany nodes from the result set,
+     * starting at position <code>start</code>. If <code>prettyPrint</code> is
+     * set to >0 (true), results are pretty printed.
+     *
+     * @param xquery
+     * @param howmany maximum number of results to return.
+     * @param start item in the result set to start with.
+     * @param parameters
+     * @return Description of the Return Value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     * @deprecated use List query() or int executeQuery() instead
+     */
+    byte[] query(
+            byte[] xquery,
+            int howmany,
+            int start,
+            Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    /**
+     * execute XPath query and return a summary of hits per document and hits
+     * per doctype. This method returns a struct with the following fields:
+     *
+     * <table border="1">
+     *  <tr>
+     *      <td>"queryTime"</td>
+     *      <td>int</td>
+     *  </tr>
+     *  <tr>
+     *      <td>"hits"</td>
+     *      <td>int</td>
+     *  </tr>
+     *  <tr>
+     *      <td>"documents"</td>
+     *      <td>array of array: Object[][3]</td>
+     *  </tr>
+     *  <tr>
+     *      <td>"doctypes"</td>
+     *      <td>array of array: Object[][2]</td>
+     *  </tr>
+     * </table>
+     * 
+     * Documents and doctypes represent tables where each row describes one
+     * document or doctype for which hits were found. Each document entry has
+     * the following structure: docId (int), docName (string), hits (int) The
+     * doctype entry has this structure: doctypeName (string), hits (int)
+     *
+     * @param xquery Description of the Parameter
+     * @return Description of the Return Value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     * @deprecated use List query() or int executeQuery() instead
+     */
+    Map<String, Object> querySummary(String xquery)
+            throws EXistException, PermissionDeniedException;
+
+    /**
+     * Returns a diagnostic dump of the expression structure after compiling the
+     * query. The query is read from the query cache if it has already been run
+     * before.
+     *
+     * @param query
+     * @param parameters
+     * @return 
+     * @throws EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     */
+    public String printDiagnostics(String query, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    String createResourceId(String collection)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * Parse an XML document and store it into the database. The document will
+     * later be identified by <code>docName</code>. Some xmlrpc clients seem to
+     * have problems with character encodings when sending xml content. To avoid
+     * this, parse() accepts the xml document content as byte[]. If
+     * <code>overwrite</code> is >0, an existing document with the same name
+     * will be replaced by the new document.
+     *
+     * @param xmlData The document data
+     * @param docName The path where the document will be stored
+     * @return 
+     * @exception EXistException
+     * @exception PermissionDeniedException
+     * @throws java.net.URISyntaxException
+     */
+    boolean parse(byte[] xmlData, String docName)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * Parse an XML document and store it into the database. The document will
+     * later be identified by <code>docName</code>. Some xmlrpc clients seem to
+     * have problems with character encodings when sending xml content. To avoid
+     * this, parse() accepts the xml document content as byte[]. If
+     * <code>overwrite</code> is >0, an existing document with the same name
+     * will be replaced by the new document.
+     *
+     * @param xmlData The document data
+     * @param docName The path where the document will be stored
+     * @param overwrite Overwrite an existing document with the same path?
+     * @return 
+     * @exception EXistException
+     * @exception PermissionDeniedException
+     * @throws java.net.URISyntaxException
+     */
+    boolean parse(byte[] xmlData, String docName, int overwrite)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean parse(byte[] xmlData, String docName, int overwrite, Date created, Date modified)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean parse(String xml, String docName, int overwrite)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean parse(String xml, String docName)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * An alternative to parse() for larger XML documents. The document is first
+     * uploaded chunk by chunk using upload(), then parseLocal() is called to
+     * actually store the uploaded file.
+     *
+     * @param chunk the current chunk
+     * @param length total length of the file
+     * @return the name of the file to which the chunk has been appended.
+     * @throws EXistException
+     * @throws PermissionDeniedException
+     * @throws java.io.IOException
+     */
+    String upload(byte[] chunk, int length)
+            throws EXistException, PermissionDeniedException, IOException;
+
+    /**
+     * An alternative to parse() for larger XML documents. The document is first
+     * uploaded chunk by chunk using upload(), then parseLocal() is called to
+     * actually store the uploaded file.
+     *
+     * @param chunk the current chunk
+     * @param file the name of the file to which the chunk will be appended.
+     * This should be the file name returned by the first call to upload.
+     * @param length total length of the file
+     * @return the name of the file to which the chunk has been appended.
+     * @throws EXistException
+     * @throws PermissionDeniedException
+     * @throws java.io.IOException
+     */
+    String upload(String file, byte[] chunk, int length)
+            throws EXistException, PermissionDeniedException, IOException;
+
+    String uploadCompressed(byte[] data, int length)
+            throws EXistException, PermissionDeniedException, IOException;
+
+    String uploadCompressed(String file, byte[] data, int length)
+            throws EXistException, PermissionDeniedException, IOException;
+
+    /**
+     * Parse a file previously uploaded with upload.
+     *
+     * The temporary file will be removed.
+     *
+     * @param localFile
+     * @param docName
+     * @param replace
+     * @param mimeType
+     * @return 
+     * @throws EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     * @throws org.xml.sax.SAXException
+     * @throws java.net.URISyntaxException
+     */
+    public boolean parseLocal(String localFile, String docName, boolean replace, String mimeType)
+            throws EXistException, PermissionDeniedException, SAXException, URISyntaxException;
+
+    public boolean parseLocalExt(String localFile, String docName, boolean replace, String mimeType, boolean treatAsXML)
+            throws EXistException, PermissionDeniedException, SAXException, URISyntaxException;
+
+    public boolean parseLocal(String localFile, String docName, boolean replace, String mimeType, Date created, Date modified)
+            throws EXistException, PermissionDeniedException, SAXException, URISyntaxException;
+
+    public boolean parseLocalExt(String localFile, String docName, boolean replace, String mimeType, boolean treatAsXML, Date created, Date modified)
+            throws EXistException, PermissionDeniedException, SAXException, URISyntaxException;
+
+    /**
+     * Store data as a binary resource.
+     *
+     * @param data the data to be stored
+     * @param docName the path to the new document
+     * @param mimeType
+     * @param replace if true, an old document with the same path will be
+     * overwritten
+     * @return 
+     * @throws EXistException
+     * @throws PermissionDeniedException
+     * @throws java.net.URISyntaxException
+     */
+    public boolean storeBinary(byte[] data, String docName, String mimeType, boolean replace)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    public boolean storeBinary(byte[] data, String docName, String mimeType, boolean replace, Date created, Date modified)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * Remove a document from the database.
+     *
+     * @param docName path to the document to be removed
+     * @return 
+     * @exception EXistException
+     * @exception PermissionDeniedException
+     * @throws java.net.URISyntaxException
+     */
+    boolean remove(String docName) throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * Remove an entire collection from the database.
+     *
+     * @param name path to the collection to be removed.
+     * @return 
+     * @exception EXistException
+     * @exception PermissionDeniedException
+     * @throws java.net.URISyntaxException
+     */
+    boolean removeCollection(String name)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * Create a new collection on the database.
+     *
+     * @param name the path to the new collection.
+     * @return 
+     * @throws EXistException
+     * @throws PermissionDeniedException
+     */
+    boolean createCollection(String name)
+            throws EXistException, PermissionDeniedException;
+
+    boolean createCollection(String name, Date created)
+            throws EXistException, PermissionDeniedException;
+
+    boolean configureCollection(String collection, String configuration)
+            throws EXistException, PermissionDeniedException;
+
+    /**
+     * Execute XPath query and return a reference to the result set. The
+     * returned reference may be used later to get a summary of results or
+     * retrieve the actual hits.
+     *
+     * @param xpath Description of the Parameter
+     * @param encoding Description of the Parameter
+     * @param parameters a <code>Map</code> value
+     * @return Description of the Return Value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     */
+    int executeQuery(byte[] xpath, String encoding, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    int executeQuery(byte[] xpath, Map<String, Object> parameters) throws EXistException, PermissionDeniedException;
+
+    int executeQuery(String xpath, Map<String, Object> parameters) throws EXistException, PermissionDeniedException;
+
+    /**
+     * Execute XPath/XQuery from path file (stored inside eXist) returned
+     * reference may be used later to get a summary of results or retrieve the
+     * actual hits.
+     * @param path
+     * @param parameters
+     * @return 
+     * @throws org.exist.EXistException
+     * @throws org.exist.security.PermissionDeniedException
+     */
+    Map<String, Object> execute(String path, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    /**
+     * Retrieve a summary of the result set identified by it's result-set-id.
+     * This method returns a struct with the following fields:
+     *
+     * <table border="1">
+     *  <tr>
+     *      <td>"queryTime"</td>
+     *      <td>int</td>
+     *  </tr>
+     *  <tr>
+     *      <td>"hits"</td>
+     *      <td>int</td>
+     *  </tr>
+     *  <tr>
+     *      <td>"documents"</td>
+     *      <td>array of array: Object[][3]</td>
+     *  </tr>
+     *  <tr>
+     *      <td>"doctypes"</td>
+     *      <td>array of array: Object[][2]</td>
+     *  </tr>
+     * </table>
+     * 
+     * Documents and doctypes represent tables where each row describes one
+     * document or doctype for which hits were found. Each document entry has
+     * the following structure: docId (int), docName (string), hits (int) The
+     * doctype entry has this structure: doctypeName (string), hits (int)
+     *
+     * @param resultId Description of the Parameter
+     * @return Description of the Return Value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     * @throws org.exist.xquery.XPathException
+     */
+    Map<String, Object> querySummary(int resultId)
+            throws EXistException, PermissionDeniedException, XPathException;
+
+    Map<String, Object> getPermissions(String resource)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    /**
+     * Get the number of hits in the result set identified by it's
+     * result-set-id.
+     *
+     * @param resultId Description of the Parameter
+     * @return The hits value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     */
+    int getHits(int resultId) throws EXistException, PermissionDeniedException;
+
+    /**
+     * Retrieve a single result from the result-set identified by resultId. The
+     * XML fragment at position num in the result set is returned.
+     *
+     * @param resultId Description of the Parameter
+     * @param num Description of the Parameter
+     * @param parameters
+     * @return Description of the Return Value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     */
+    byte[] retrieve(int resultId, int num, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    /**
+     * Retrieve a single result from the result-set identified by resultId. The
+     * XML fragment at position num in the result set is returned. It is fetched
+     * the first chunk, and the next ones should be fetched using getNextChunk
+     * or getNextExtendedChunk
+     *
+     * @param resultId Description of the Parameter
+     * @param num Description of the Parameter
+     * @param parameters a <code>Map</code> value
+     * @return Description of the Return Value
+     * @exception EXistException Description of the Exception
+     * @exception PermissionDeniedException Description of the Exception
+     */
+    Map<String, Object> retrieveFirstChunk(int resultId, int num, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException;
+
+    boolean addAccount(String name, String passwd, String digestPassword, List<String> groups, Boolean isEnabled, Integer umask, Map<String, String> metadata)
+            throws EXistException, PermissionDeniedException;
+
+    boolean updateAccount(String name, String passwd, String digestPassword, List<String> groups)
+            throws EXistException, PermissionDeniedException;
+
+    boolean updateAccount(String name, String passwd, String digestPassword, List<String> groups, Boolean isEnabled, Integer umask, Map<String, String> metadata)
+            throws EXistException, PermissionDeniedException;
+
+    boolean addGroup(String name, Map<String, String> metadata) throws EXistException, PermissionDeniedException;
+
+    boolean updateGroup(final String name, final List<String> managers, final Map<String, String> metadata) throws EXistException, PermissionDeniedException;
+
+    List<String> getGroupMembers(final String groupName) throws EXistException, PermissionDeniedException;
+
+    void addAccountToGroup(final String accountName, final String groupName) throws EXistException, PermissionDeniedException;
+
+    void addGroupManager(final String manager, final String groupName) throws EXistException, PermissionDeniedException;
+
+    public void removeGroupManager(final String groupName, final String manager) throws EXistException, PermissionDeniedException;
+
+    boolean setPermissions(String resource, String permissions)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean setPermissions(String resource, int permissions)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean setPermissions(
+            String resource,
+            String owner,
+            String ownerGroup,
+            String permissions)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean setPermissions(
+            String resource,
+            String owner,
+            String ownerGroup,
+            int permissions)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
 
     boolean setPermissions(
             final String resource,
@@ -795,122 +784,120 @@ public interface RpcAPI {
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
     public boolean chgrp(
-        final String resource,
-        final String ownerGroup)
-        throws EXistException, PermissionDeniedException, URISyntaxException;
+            final String resource,
+            final String ownerGroup)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
 
     public boolean chown(
-        final String resource,
-        final String owner)
-        throws EXistException, PermissionDeniedException, URISyntaxException;
+            final String resource,
+            final String owner)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
 
     public boolean chown(
-        final String resource,
-        final String owner,
-        final String ownerGroup)
-        throws EXistException, PermissionDeniedException, URISyntaxException;
+            final String resource,
+            final String owner,
+            final String ownerGroup)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
 
-	public boolean lockResource(String path, String userName)
-	throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	public boolean unlockResource(String path)
-	throws EXistException, PermissionDeniedException, URISyntaxException;
+    public boolean lockResource(String path, String userName)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
 
-	public String hasUserLock(String path)
-	throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	HashMap<String, Object> getAccount(String name) throws EXistException, PermissionDeniedException;
+    public boolean unlockResource(String path)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
 
-	Vector<HashMap<String, Object>> getAccounts() throws EXistException, PermissionDeniedException;
+    public String hasUserLock(String path)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
 
-	boolean removeAccount(String name) throws EXistException, PermissionDeniedException;
+    Map<String, Object> getAccount(String name) throws EXistException, PermissionDeniedException;
 
-        HashMap<String, Object> getGroup(String name) throws EXistException, PermissionDeniedException;
+    List<Map<String, Object>> getAccounts() throws EXistException, PermissionDeniedException;
 
-        void removeGroup(String name) throws EXistException, PermissionDeniedException;
+    boolean removeAccount(String name) throws EXistException, PermissionDeniedException;
 
-	Vector<String> getGroups() throws EXistException, PermissionDeniedException;
+    Map<String, Object> getGroup(String name) throws EXistException, PermissionDeniedException;
 
-	Vector<Vector<Object>> getIndexedElements(String collectionName, boolean inclusive)
-		throws EXistException, PermissionDeniedException, URISyntaxException;
+    void removeGroup(String name) throws EXistException, PermissionDeniedException;
 
-	Vector<Vector<Object>> scanIndexTerms(
+    List<String> getGroups() throws EXistException, PermissionDeniedException;
 
-		String collectionName,
-		String start,
-		String end,
-		boolean inclusive)
-		throws PermissionDeniedException, EXistException, URISyntaxException;
+    List<List> getIndexedElements(String collectionName, boolean inclusive)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
 
-	Vector<Vector<Object>> scanIndexTerms(String xpath,
-			String start, String end)
-			throws PermissionDeniedException, EXistException, XPathException;
-	
-	boolean releaseQueryResult(int handle);
+    List<List> scanIndexTerms(
+            String collectionName,
+            String start,
+            String end,
+            boolean inclusive)
+            throws PermissionDeniedException, EXistException, URISyntaxException;
+
+    List<List> scanIndexTerms(String xpath,
+            String start, String end)
+            throws PermissionDeniedException, EXistException, XPathException;
+
+    boolean releaseQueryResult(int handle);
 
     boolean releaseQueryResult(int handle, int hash);
 
-	int xupdate(String collectionName, byte[] xupdate)
+    int xupdate(String collectionName, byte[] xupdate)
             throws PermissionDeniedException, EXistException, SAXException, XPathException, LockException;
-	
-	int xupdateResource(String resource, byte[] xupdate)
-		throws PermissionDeniedException, EXistException, SAXException;
 
-	int xupdateResource(String resource, byte[] xupdate, String encoding)
+    int xupdateResource(String resource, byte[] xupdate)
+            throws PermissionDeniedException, EXistException, SAXException;
+
+    int xupdateResource(String resource, byte[] xupdate, String encoding)
             throws PermissionDeniedException, EXistException, SAXException, XPathException, LockException, URISyntaxException;
 
-		
-	Date getCreationDate(String collectionName)
-		throws PermissionDeniedException, EXistException, URISyntaxException;
-	
-	Vector<Date> getTimestamps(String documentName)
-		throws PermissionDeniedException, EXistException, URISyntaxException;
-		
-	boolean copyCollection(String name, String namedest)
-	    throws PermissionDeniedException, EXistException;
+    Date getCreationDate(String collectionName)
+            throws PermissionDeniedException, EXistException, URISyntaxException;
 
-	List<String> getDocumentChunk(String name, HashMap<String, Object> parameters)
-	throws EXistException, PermissionDeniedException, IOException;
-	
-	byte[] getDocumentChunk(String name, int start, int stop)
-	throws EXistException, PermissionDeniedException, IOException;
-	
-	boolean moveCollection(String collectionPath, String destinationPath, String newName)
+    List<Date> getTimestamps(String documentName)
+            throws PermissionDeniedException, EXistException, URISyntaxException;
+
+    boolean copyCollection(String name, String namedest)
+            throws PermissionDeniedException, EXistException;
+
+    List<String> getDocumentChunk(String name, Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException, IOException;
+
+    byte[] getDocumentChunk(String name, int start, int stop)
+            throws EXistException, PermissionDeniedException, IOException;
+
+    boolean moveCollection(String collectionPath, String destinationPath, String newName)
             throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	boolean moveResource(String docPath, String destinationPath, String newName)
+
+    boolean moveResource(String docPath, String destinationPath, String newName)
             throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	boolean copyCollection(String collectionPath, String destinationPath, String newName)
+
+    boolean copyCollection(String collectionPath, String destinationPath, String newName)
             throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	boolean copyResource(String docPath, String destinationPath, String newName)
+
+    boolean copyResource(String docPath, String destinationPath, String newName)
             throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	boolean reindexCollection(String name)
-	throws EXistException, PermissionDeniedException, URISyntaxException;
-	
-	boolean backup(String userbackup, String password, String destcollection, String collection)
-	throws EXistException, PermissionDeniedException;
-	
-	boolean dataBackup(String dest) throws PermissionDeniedException;
-    
+
+    boolean reindexCollection(String name)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean backup(String userbackup, String password, String destcollection, String collection)
+            throws EXistException, PermissionDeniedException;
+
+    boolean dataBackup(String dest) throws PermissionDeniedException;
+
     /// DWES
-    boolean isValid(String name)	throws EXistException, PermissionDeniedException, URISyntaxException;
-    
-    Vector<String> getDocType(String documentName)
-	throws PermissionDeniedException, EXistException, URISyntaxException;
-    
+    boolean isValid(String name) throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    List<String> getDocType(String documentName)
+            throws PermissionDeniedException, EXistException, URISyntaxException;
+
     boolean setDocType(String documentName, String doctypename, String publicid, String systemid)
-	throws EXistException, PermissionDeniedException, URISyntaxException;
-    
-    public void runCommand(XmldbURI collectionURI, Vector<String> params) throws EXistException, PermissionDeniedException;
-    
-    
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    public void runCommand(XmldbURI collectionURI, List<String> params) throws EXistException, PermissionDeniedException;
+
     public long getSubCollectionCreationTime(String parentPath, String name) throws EXistException, PermissionDeniedException, URISyntaxException;
-    public HashMap<String, Object> getSubCollectionPermissions(String parentPath, String name) throws EXistException, PermissionDeniedException, URISyntaxException;
-    public HashMap<String, Object> getSubResourcePermissions(String parentPath, String name) throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    public Map<String, Object> getSubCollectionPermissions(String parentPath, String name) throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    public Map<String, Object> getSubResourcePermissions(String parentPath, String name) throws EXistException, PermissionDeniedException, URISyntaxException;
 
     public boolean setTriggersEnabled(String path, String value) throws PermissionDeniedException;
 }
-

--- a/src/org/exist/xmlrpc/RpcConnection.java
+++ b/src/org/exist/xmlrpc/RpcConnection.java
@@ -21,6 +21,8 @@
  */
 package org.exist.xmlrpc;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.persistent.DocumentMetadata;
@@ -33,14 +35,6 @@ import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.NodeSet;
 import org.exist.dom.persistent.SortedNodeSet;
 import org.exist.dom.persistent.DefaultDocumentSet;
-import java.io.*;
-import java.net.URISyntaxException;
-import java.util.*;
-import java.util.zip.DeflaterOutputStream;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.Namespaces;
 import org.exist.Version;
@@ -100,6 +94,15 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
+import java.io.*;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.zip.DeflaterOutputStream;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import org.xmldb.api.base.XMLDBException;
+
 /**
  * This class implements the actual methods defined by
  * {@link org.exist.xmlrpc.RpcAPI}.
@@ -112,96 +115,69 @@ public class RpcConnection implements RpcAPI {
     private final static Logger LOG = LogManager.getLogger(RpcConnection.class);
 
     private final static int MAX_DOWNLOAD_CHUNK_SIZE = 0x40000;
-    
-    private final static String DEFAULT_ENCODING = "UTF-8";
+    private final static String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
-    protected XmldbRequestProcessorFactory factory;
+    private final XmldbRequestProcessorFactory factory;
+    private final Subject user;
 
-    protected Subject user;
-
-    /**
-     * Creates a new <code>RpcConnection</code> instance.
-     *
-     * @exception EXistException if an error occurs
-     */
-    public RpcConnection(XmldbRequestProcessorFactory factory, Subject user)
-    {
+    public RpcConnection(final XmldbRequestProcessorFactory factory, final Subject user) {
         super();
         this.factory = factory;
         this.user = user;
     }
 
-    private void handleException(Throwable e) throws EXistException, PermissionDeniedException {
-        LOG.debug(e.getMessage(), e);
-        if (e instanceof EXistException)
-            {throw (EXistException) e;}
-
-        else if (e instanceof PermissionDeniedException)
-            {throw (PermissionDeniedException) e;}
-        
-        else {
-            //System.out.println(e.getClass().getName());
-            throw new EXistException(e);
-        }
-    }
-    
     @Override
     public String getVersion() {
         return Version.getVersion();
     }
 
+    private void handleException(final Throwable e) throws EXistException, PermissionDeniedException {
+        LOG.debug(e.getMessage(), e);
+        if (e instanceof EXistException) {
+            throw (EXistException) e;
+        } else if (e instanceof PermissionDeniedException) {
+            throw (PermissionDeniedException) e;
+        } else {
+            throw new EXistException(e);
+        }
+    }
 
     @Override
-    public boolean createCollection(String name) throws EXistException, PermissionDeniedException {
+    public boolean createCollection(final String name) throws EXistException, PermissionDeniedException {
         return createCollection(name, null);
     }
 
-    /**
-     * The method <code>createCollection</code>
-     *
-     * @param name a <code>String</code> value
-     * @param created a <code>Date</code> value
-     * @exception Exception if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
-    public boolean createCollection(String name, Date created) throws EXistException, PermissionDeniedException {
+    public boolean createCollection(final String name, final Date created) throws EXistException, PermissionDeniedException {
         try {
-            return createCollection(XmldbURI.xmldbUriFor(name),created);
+            return createCollection(XmldbURI.xmldbUriFor(name), created);
         } catch (final URISyntaxException e) {
             handleException(e);
         }
         return false;
     }
-    
-    /**
-     * The method <code>createCollection</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @param created a <code>Date</code> value
-     * @exception Exception if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private boolean createCollection(XmldbURI collUri, Date created) throws PermissionDeniedException, EXistException {
+
+    private boolean createCollection(final XmldbURI collUri, final Date created) throws PermissionDeniedException, EXistException {
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
             Collection current = broker.getCollection(collUri);
-            if (current != null)
-            	{return true;}
+            if (current != null) {
+                return true;
+            }
 
             current = broker.getOrCreateCollection(transaction, collUri);
-            
+
             //TODO : register a lock (wich one ?) within the transaction ?
-            if (created != null)
-                {current.setCreationTime( created.getTime());}
+            if (created != null) {
+                current.setCreationTime(created.getTime());
+            }
             LOG.debug("creating collection " + collUri);
-            
+
             broker.saveCollection(transaction, current);
             transact.commit(transaction);
             broker.flush();
-            
+
             //broker.sync();
             LOG.info("collection " + collUri + " has been created");
             return true;
@@ -211,78 +187,57 @@ public class RpcConnection implements RpcAPI {
         }
         return false;
     }
-    
-    /**
-     * The method <code>configureCollection</code>
-     *
-     * @param collName a <code>String</code> value
-     * @param configuration a <code>String</code> value
-     * @exception EXistException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public boolean configureCollection(String collName, String configuration)
+    public boolean configureCollection(final String collName, final String configuration)
             throws EXistException, PermissionDeniedException {
         try {
-            return configureCollection(XmldbURI.xmldbUriFor(collName),configuration);
+            return configureCollection(XmldbURI.xmldbUriFor(collName), configuration);
         } catch (final URISyntaxException e) {
             handleException(e);
         }
         return false;
     }
 
-    /**
-     * The method <code>configureCollection</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @param configuration a <code>String</code> value
-     * @exception EXistException if an error occurs
-     */
-    private boolean configureCollection(XmldbURI collUri, String configuration)
-    throws EXistException, PermissionDeniedException {
+    private boolean configureCollection(final XmldbURI collUri, final String configuration)
+            throws EXistException, PermissionDeniedException {
         Collection collection = null;
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
             try {
-	            collection = broker.openCollection(collUri, Lock.READ_LOCK);
-	            if (collection == null) {
-	                transact.abort(transaction);
-	                throw new EXistException("collection " + collUri + " not found!");
-	            }
+                collection = broker.openCollection(collUri, Lock.READ_LOCK);
+                if (collection == null) {
+                    transact.abort(transaction);
+                    throw new EXistException("collection " + collUri + " not found!");
+                }
             } finally {
-            	if (collection != null)
-            		{collection.release(Lock.READ_LOCK);}
+                if (collection != null) {
+                    collection.release(Lock.READ_LOCK);
+                }
             }
             final CollectionConfigurationManager mgr = factory.getBrokerPool().getConfigurationManager();
             mgr.addConfiguration(transaction, broker, collection, configuration);
             transact.commit(transaction);
-            LOG.info("Configured '" + collection.getURI() + "'");  
+            LOG.info("Configured '" + collection.getURI() + "'");
         } catch (final CollectionConfigurationException e) {
             throw new EXistException(e.getMessage());
         }
         return false;
     }
-    
-    /**
-     * The method <code>createId</code>
-     *
-     * @param collName a <code>String</code> value
-     * @return a <code>String</code> value
-     * @exception EXistException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    public String createId(String collName) throws EXistException, URISyntaxException, PermissionDeniedException {
-    	return createId(XmldbURI.xmldbUriFor(collName));
+
+    public String createId(final String collName) throws EXistException, URISyntaxException, PermissionDeniedException {
+        return createId(XmldbURI.xmldbUriFor(collName));
     }
-    
-    private String createId(XmldbURI collUri) throws EXistException, PermissionDeniedException {
+
+    private String createId(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
         final DBBroker broker = factory.getBrokerPool().get(user);
         Collection collection = null;
         try {
             collection = broker.openCollection(collUri, Lock.READ_LOCK);
-            if (collection == null)
-                {throw new EXistException("collection " + collUri + " not found!");}
+            if (collection == null) {
+                throw new EXistException("collection " + collUri + " not found!");
+            }
             XmldbURI id;
             final Random rand = new Random();
             boolean ok;
@@ -290,62 +245,58 @@ public class RpcConnection implements RpcAPI {
                 ok = true;
                 id = XmldbURI.create(Integer.toHexString(rand.nextInt()) + ".xml");
                 // check if this id does already exist
-                if (collection.hasDocument(broker, id))
-                    {ok = false;}
-                
-                if (collection.hasSubcollection(broker, id))
-                    {ok = false;}
-                
+                if (collection.hasDocument(broker, id)) {
+                    ok = false;
+                }
+
+                if (collection.hasSubcollection(broker, id)) {
+                    ok = false;
+                }
+
             } while (!ok);
             return id.toString();
         } finally {
-            if(collection != null)
-                {collection.release(Lock.READ_LOCK);}
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>doQuery</code>
-     *
-     * @param broker a <code>DBBroker</code> value
-     * @param contextSet a <code>NodeSet</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>QueryResult</code> value
-     * @exception Exception if an error occurs
-     */
-    protected QueryResult doQuery(DBBroker broker, CompiledXQuery compiled,
-            NodeSet contextSet, HashMap<String, Object> parameters)
+
+    protected QueryResult doQuery(final DBBroker broker, final CompiledXQuery compiled,
+            final NodeSet contextSet, final Map<String, Object> parameters)
             throws Exception {
         final XQuery xquery = broker.getXQueryService();
         final XQueryPool pool = xquery.getXQueryPool();
-        
+
         checkPragmas(compiled.getContext(), parameters);
         LockedDocumentMap lockedDocuments = null;
         try {
             final long start = System.currentTimeMillis();
             lockedDocuments = beginProtected(broker, parameters);
-            if (lockedDocuments != null)
-                {compiled.getContext().setProtectedDocs(lockedDocuments);}
+            if (lockedDocuments != null) {
+                compiled.getContext().setProtectedDocs(lockedDocuments);
+            }
             final Properties outputProperties = new Properties();
             final Sequence result = xquery.execute(compiled, contextSet, outputProperties);
             // pass last modified date to the HTTP response
-            HTTPUtils.addLastModifiedHeader( result, compiled.getContext() );
+            HTTPUtils.addLastModifiedHeader(result, compiled.getContext());
             LOG.info("query took " + (System.currentTimeMillis() - start) + "ms.");
             return new QueryResult(result, outputProperties);
         } catch (final XPathException e) {
             return new QueryResult(e);
         } finally {
-            if(lockedDocuments != null) {
+            if (lockedDocuments != null) {
                 lockedDocuments.unlock();
             }
         }
     }
 
-    protected LockedDocumentMap beginProtected(DBBroker broker, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+    protected LockedDocumentMap beginProtected(final DBBroker broker, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         final String protectColl = (String) parameters.get(RpcAPI.PROTECTED_MODE);
-        if (protectColl == null)
-            {return null;}
+        if (protectColl == null) {
+            return null;
+        }
         do {
             MutableDocumentSet docs = null;
             final LockedDocumentMap lockedDocuments = new LockedDocumentMap();
@@ -355,82 +306,68 @@ public class RpcConnection implements RpcAPI {
                 coll.allDocs(broker, docs, true, lockedDocuments, Lock.WRITE_LOCK);
                 return lockedDocuments;
             } catch (final LockException e) {
-                LOG.debug("Deadlock detected. Starting over again. Docs: " + docs.getDocumentCount() + "; locked: " +
-                lockedDocuments.size());
+                LOG.debug("Deadlock detected. Starting over again. Docs: " + docs.getDocumentCount() + "; locked: "
+                        + lockedDocuments.size());
                 lockedDocuments.unlock();
             }
         } while (true);
     }
 
-    /**
-     * The method <code>compile</code>
-     *
-     * @param broker a <code>DBBroker</code> value
-     * @param source a <code>Source</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>CompiledXQuery</code> value
-     * @exception XPathException if an error occurs
-     * @exception IOException if an error occurs
-     * @throws PermissionDeniedException 
-     */
-    private CompiledXQuery compile(DBBroker broker, Source source, HashMap<String, Object> parameters) throws XPathException, IOException, PermissionDeniedException {
+    private CompiledXQuery compile(final DBBroker broker, final Source source, final Map<String, Object> parameters) throws XPathException, IOException, PermissionDeniedException {
         final XQuery xquery = broker.getXQueryService();
         final XQueryPool pool = xquery.getXQueryPool();
         CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
         XQueryContext context;
-        if(compiled == null)
-            {context = xquery.newContext(AccessContext.XMLRPC);}
-        else
-            {context = compiled.getContext();}
-    	final String base = (String) parameters.get(RpcAPI.BASE_URI);
-    	if(base!=null)
-    		{context.setBaseURI(new AnyURIValue(base));}
+        if (compiled == null) {
+            context = xquery.newContext(AccessContext.XMLRPC);
+        } else {
+            context = compiled.getContext();
+        }
+        final String base = (String) parameters.get(RpcAPI.BASE_URI);
+        if (base != null) {
+            context.setBaseURI(new AnyURIValue(base));
+        }
         final String moduleLoadPath = (String) parameters.get(RpcAPI.MODULE_LOAD_PATH);
-        if (moduleLoadPath != null)
-            {context.setModuleLoadPath(moduleLoadPath);}
-        final HashMap<String, String> namespaces = (HashMap<String, String>)parameters.get(RpcAPI.NAMESPACES);
-        if(namespaces != null && namespaces.size() > 0) {
+        if (moduleLoadPath != null) {
+            context.setModuleLoadPath(moduleLoadPath);
+        }
+        final Map<String, String> namespaces = (Map<String, String>) parameters.get(RpcAPI.NAMESPACES);
+        if (namespaces != null && namespaces.size() > 0) {
             context.declareNamespaces(namespaces);
         }
         //  declare static variables
-        final HashMap<String, Object> variableDecls = (HashMap<String, Object>)parameters.get(RpcAPI.VARIABLES);
-        if(variableDecls != null) {
+        final Map<String, Object> variableDecls = (Map<String, Object>) parameters.get(RpcAPI.VARIABLES);
+        if (variableDecls != null) {
             for (final Map.Entry<String, Object> entry : variableDecls.entrySet()) {
-            	if (LOG.isDebugEnabled())
-            		{LOG.debug("declaring " + entry.getKey().toString() + " = " + entry.getValue());}
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("declaring " + entry.getKey() + " = " + entry.getValue());
+                }
                 context.declareVariable(entry.getKey(), entry.getValue());
             }
         }
-        final Object[] staticDocuments = (Object[])parameters.get(RpcAPI.STATIC_DOCUMENTS);
-        if(staticDocuments != null) {
-        	try {
-            final XmldbURI[] d = new XmldbURI[staticDocuments.length];
-            for (int i = 0; i < staticDocuments.length; i++) {
-                XmldbURI next = XmldbURI.xmldbUriFor((String) staticDocuments[i]);
-                d[i] = next;
+        final Object[] staticDocuments = (Object[]) parameters.get(RpcAPI.STATIC_DOCUMENTS);
+        if (staticDocuments != null) {
+            try {
+                final XmldbURI[] d = new XmldbURI[staticDocuments.length];
+                for (int i = 0; i < staticDocuments.length; i++) {
+                    XmldbURI next = XmldbURI.xmldbUriFor((String) staticDocuments[i]);
+                    d[i] = next;
+                }
+                context.setStaticallyKnownDocuments(d);
+            } catch (final URISyntaxException e) {
+                throw new XPathException(e);
             }
-            context.setStaticallyKnownDocuments(d);
-        	} catch(final URISyntaxException e) {
-        		throw new XPathException(e);
-        	}
-        } else if(context.isBaseURIDeclared()) {
-            context.setStaticallyKnownDocuments(new XmldbURI[] { context.getBaseURI().toXmldbURI() });
+        } else if (context.isBaseURIDeclared()) {
+            context.setStaticallyKnownDocuments(new XmldbURI[]{context.getBaseURI().toXmldbURI()});
         }
-        if(compiled == null)
-            {compiled = xquery.compile(context, source);}
+        if (compiled == null) {
+            compiled = xquery.compile(context, source);
+        }
         return compiled;
     }
-    
-    /**
-     * The method <code>printDiagnostics</code>
-     *
-     * @param query a <code>String</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     */
+
     @Override
-    public String printDiagnostics(String query, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+    public String printDiagnostics(final String query, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
@@ -438,8 +375,9 @@ public class RpcConnection implements RpcAPI {
             final XQuery xquery = broker.getXQueryService();
             final XQueryPool pool = xquery.getXQueryPool();
             CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
-            if(compiled == null)
-                {compiled = compile(broker, source, parameters);}
+            if (compiled == null) {
+                compiled = compile(broker, source, parameters);
+            }
             final StringWriter writer = new StringWriter();
             compiled.dump(writer);
             return writer.toString();
@@ -452,59 +390,58 @@ public class RpcConnection implements RpcAPI {
         }
         return null;
     }
-    
+
     /**
      * Check if the XQuery contains pragmas that define serialization settings.
-     * If yes, copy the corresponding settings to the current set of output properties.
+     * If yes, copy the corresponding settings to the current set of output
+     * properties.
      *
      * @param context
+     * @param parameters
+     * @throws org.exist.xquery.XPathException
      */
-    protected void checkPragmas(XQueryContext context, HashMap<String, Object> parameters) throws XPathException {
+    protected void checkPragmas(final XQueryContext context, final Map<String, Object> parameters) throws XPathException {
         final Option pragma = context.getOption(Option.SERIALIZE_QNAME);
         checkPragmas(pragma, parameters);
     }
 
-    protected void checkPragmas(Option pragma, HashMap<String, Object> parameters) throws XPathException {
-        if(pragma == null)
-            {return;}
+    protected void checkPragmas(final Option pragma, final Map<String, Object> parameters) throws XPathException {
+        if (pragma == null) {
+            return;
+        }
         final String[] contents = pragma.tokenizeContents();
-        for(int i = 0; i < contents.length; i++) {
-            final String[] pair = Option.parseKeyValuePair(contents[i]);
-            if(pair == null)
-                {throw new XPathException("Unknown parameter found in " + pragma.getQName().getStringValue() +
-                        ": '" + contents[i] + "'");}
+        for (final String content : contents) {
+            final String[] pair = Option.parseKeyValuePair(content);
+            if (pair == null) {
+                throw new XPathException("Unknown parameter found in " + pragma.getQName().getStringValue()
+                        + ": '" + content + "'");
+            }
             LOG.debug("Setting serialization property from pragma: " + pair[0] + " = " + pair[1]);
             parameters.put(pair[0], pair[1]);
         }
     }
 
     @Override
-    public int executeQuery(byte[] xpath, String encoding, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+    public int executeQuery(final byte[] xpath, final String encoding, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         String xpathString = null;
-        if (encoding != null)
+        if (encoding != null) {
             try {
                 xpathString = new String(xpath, encoding);
             } catch (final UnsupportedEncodingException e) {
                 LOG.warn(e);
             }
+        }
 
-        if (xpathString == null)
-            {xpathString = new String(xpath);}
+        if (xpathString == null) {
+            xpathString = new String(xpath);
+        }
 
         LOG.debug("query: " + xpathString);
         return executeQuery(xpathString, parameters);
     }
 
-    /**
-     * The method <code>executeQuery</code>
-     *
-     * @param xpath a <code>String</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return an <code>int</code> value
-     * @exception Exception if an error occurs
-     */
     @Override
-    public int executeQuery(String xpath, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+    public int executeQuery(final String xpath, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         final long startTime = System.currentTimeMillis();
         DBBroker broker = null;
         Source source = null;
@@ -515,8 +452,9 @@ public class RpcConnection implements RpcAPI {
             compiled = compile(broker, source, parameters);
             final QueryResult result = doQuery(broker, compiled, null,
                     parameters);
-            if(result.hasErrors())
-                {throw result.getException();}
+            if (result.hasErrors()) {
+                throw result.getException();
+            }
             result.queryTime = System.currentTimeMillis() - startTime;
             return factory.resultSets.add(result);
 
@@ -524,35 +462,24 @@ public class RpcConnection implements RpcAPI {
             handleException(e);
 
         } finally {
-            if(compiled != null) {
+            if (compiled != null) {
                 compiled.getContext().runCleanupTasks();
-                broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
+                if(broker != null) {
+                    broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
+                }
             }
             factory.getBrokerPool().release(broker);
         }
         return -1;
     }
-    
-    /**
-     * The method <code>formatErrorMsg</code>
-     *
-     * @param message a <code>String</code> value
-     * @return a <code>String</code> value
-     */
-    protected String formatErrorMsg(String message) {
+
+    protected String formatErrorMsg(final String message) {
         return formatErrorMsg("error", message);
     }
-    
-    /**
-     * The method <code>formatErrorMsg</code>
-     *
-     * @param type a <code>String</code> value
-     * @param message a <code>String</code> value
-     * @return a <code>String</code> value
-     */
-    protected String formatErrorMsg(String type, String message) {
+
+    protected String formatErrorMsg(final String type, final String message) {
         final StringBuilder buf = new StringBuilder();
-        buf.append("<exist:result xmlns:exist=\""+ Namespaces.EXIST_NS + "\" ");
+        buf.append("<exist:result xmlns:exist=\"" + Namespaces.EXIST_NS + "\" ");
         buf.append("hitCount=\"0\">");
         buf.append('<');
         buf.append(type);
@@ -563,82 +490,67 @@ public class RpcConnection implements RpcAPI {
         buf.append("></exist:result>");
         return buf.toString();
     }
-    
+
     @Override
     public boolean existsAndCanOpenCollection(final String collectionUri) throws EXistException, PermissionDeniedException {
         final DBBroker broker = factory.getBrokerPool().get(user);
         Collection collection = null;
-        try {           
+        try {
             collection = broker.openCollection(XmldbURI.xmldbUriFor(collectionUri), Lock.READ_LOCK);
-            if(collection == null) {
+            if (collection == null) {
                 return false;
             }
-            
+
             return true;
-        } catch(final URISyntaxException use) {
+        } catch (final URISyntaxException use) {
             throw new EXistException("Collection '" + collectionUri + "' does not indicate a valid collection URI: " + use.getMessage(), use);
         } finally {
-            if(collection != null) {
+            if (collection != null) {
                 collection.release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getCollectionDesc</code>
-     *
-     * @param rootCollection a <code>String</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public HashMap<String, Object> getCollectionDesc(String rootCollection) throws EXistException, PermissionDeniedException {
+    public Map<String, Object> getCollectionDesc(final String rootCollection) throws EXistException, PermissionDeniedException {
         try {
-            return getCollectionDesc((rootCollection==null)?XmldbURI.ROOT_COLLECTION_URI:XmldbURI.xmldbUriFor(rootCollection));
+            return getCollectionDesc((rootCollection == null) ? XmldbURI.ROOT_COLLECTION_URI : XmldbURI.xmldbUriFor(rootCollection));
         } catch (final Throwable e) {
             handleException(e);
         }
         return null;
     }
-    
-    /**
-     * The method <code>getCollectionDesc</code>
-     *
-     * @param rootUri a <code>XmldbURI</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
-    private HashMap<String, Object> getCollectionDesc(final XmldbURI rootUri) throws Exception {
+
+    private Map<String, Object> getCollectionDesc(final XmldbURI rootUri) throws Exception {
         final DBBroker broker = factory.getBrokerPool().get(user);
         Collection collection = null;
-        try {           
+        try {
             collection = broker.openCollection(rootUri, Lock.READ_LOCK);
             if (collection == null) {
                 throw new EXistException("collection " + rootUri + " not found!");
             }
-            final HashMap<String, Object> desc = new HashMap<String, Object>();
-            final Vector<Map<String, Object>> docs = new Vector<Map<String, Object>>();
-            final Vector<String> collections = new Vector<String>();
+            final Map<String, Object> desc = new HashMap<>();
+            final List<Map<String, Object>> docs = new ArrayList<>();
+            final List<String> collections = new ArrayList<>();
             if (collection.getPermissionsNoLock().validate(user, Permission.READ)) {
-                for(final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
+                for (final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext();) {
                     final DocumentImpl doc = i.next();
                     final Permission perms = doc.getPermissions();
-                    
-                    final HashMap<String, Object> hash = new HashMap<String, Object>(4);
+
+                    final Map<String, Object> hash = new HashMap<>(4);
                     hash.put("name", doc.getFileURI().toString());
                     hash.put("owner", perms.getOwner().getName());
                     hash.put("group", perms.getGroup().getName());
-                    hash.put("permissions", Integer.valueOf(perms.getMode()));
+                    hash.put("permissions", perms.getMode());
                     hash.put("type", doc.getResourceType() == DocumentImpl.BINARY_FILE ? "BinaryResource" : "XMLResource");
-                    docs.addElement(hash);
+                    docs.add(hash);
                 }
-                for(final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext(); ) {
-                    collections.addElement(i.next().toString());
+                for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext();) {
+                    collections.add(i.next().toString());
                 }
             }
-            
+
             final Permission perms = collection.getPermissionsNoLock();
             desc.put("collections", collections);
             desc.put("documents", docs);
@@ -646,50 +558,33 @@ public class RpcConnection implements RpcAPI {
             desc.put("created", Long.toString(collection.getCreationTime()));
             desc.put("owner", perms.getOwner().getName());
             desc.put("group", perms.getGroup().getName());
-            desc.put("permissions", Integer.valueOf(perms.getMode()));
-            
+            desc.put("permissions", perms.getMode());
+
             return desc;
         } finally {
-            if(collection != null) {
+            if (collection != null) {
                 collection.release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>describeResource</code>
-     *
-     * @param resourceName a <code>String</code> value
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public HashMap<String, Object> describeResource(String resourceName)
-    throws EXistException, PermissionDeniedException {
+    public Map<String, Object> describeResource(final String resourceName)
+            throws EXistException, PermissionDeniedException {
         try {
             return describeResource(XmldbURI.xmldbUriFor(resourceName));
-        } catch (final Throwable e) {
+        } catch (final URISyntaxException | EXistException | PermissionDeniedException e) {
             handleException(e);
         }
         return null;
     }
-    
-    /**
-     * The method <code>describeResource</code>
-     *
-     * @param resourceUri a <code>XmldbURI</code> value
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private HashMap<String, Object> describeResource(final XmldbURI resourceUri)
-    throws EXistException, PermissionDeniedException {
+
+    private Map<String, Object> describeResource(final XmldbURI resourceUri)
+            throws EXistException, PermissionDeniedException {
         final DBBroker broker = factory.getBrokerPool().get(user);
         DocumentImpl doc = null;
-        final HashMap<String, Object> hash = new HashMap<String, Object>(5);
+        final Map<String, Object> hash = new HashMap<>(5);
         try {
             doc = broker.getXMLResource(resourceUri, Lock.READ_LOCK);
             if (doc == null) {
@@ -700,43 +595,35 @@ public class RpcConnection implements RpcAPI {
             hash.put("name", resourceUri.toString());
             hash.put("owner", perms.getOwner().getName());
             hash.put("group", perms.getGroup().getName());
-            hash.put("permissions", Integer.valueOf(perms.getMode()));
-            
-            if(perms instanceof ACLPermission) {
+            hash.put("permissions", perms.getMode());
+
+            if (perms instanceof ACLPermission) {
                 hash.put("acl", getACEs(perms));
             }
 
             hash.put("type",
                     doc.getResourceType() == DocumentImpl.BINARY_FILE
-                    ? "BinaryResource"
-                    : "XMLResource");
+                            ? "BinaryResource"
+                            : "XMLResource");
             final long resourceLength = doc.getContentLength();
-            hash.put("content-length", Integer.valueOf((resourceLength > (long)Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int)resourceLength));
-            hash.put("content-length-64bit", Long.valueOf(resourceLength).toString());
+            hash.put("content-length", (resourceLength > (long) Integer.MAX_VALUE) ? Integer.MAX_VALUE : (int) resourceLength);
+            hash.put("content-length-64bit", Long.toString(resourceLength));
             hash.put("mime-type", doc.getMetadata().getMimeType());
             hash.put("created", new Date(doc.getMetadata().getCreated()));
             hash.put("modified", new Date(doc.getMetadata().getLastModified()));
             return hash;
         } finally {
-            if(doc != null) {
+            if (doc != null) {
                 doc.getUpdateLock().release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
         }
     }
 
-    /**
-     * The method <code>describeCollection</code>
-     *
-     * @param rootCollection a <code>String</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
-    public HashMap<String, Object> describeCollection(String rootCollection) throws EXistException, PermissionDeniedException {
+    public Map<String, Object> describeCollection(final String rootCollection) throws EXistException, PermissionDeniedException {
         try {
-            return describeCollection((rootCollection==null)?XmldbURI.ROOT_COLLECTION_URI:XmldbURI.xmldbUriFor(rootCollection));
+            return describeCollection((rootCollection == null) ? XmldbURI.ROOT_COLLECTION_URI : XmldbURI.xmldbUriFor(rootCollection));
         } catch (final Throwable e) {
             handleException(e);
             return null;
@@ -745,26 +632,19 @@ public class RpcConnection implements RpcAPI {
 
     /**
      * The method <code>describeCollection</code>
-     * 
-     * Returns details of a collection
-     *  - collections (list of sub-collections)
-     *  - name
-     *  - created
-     *  - owner
-     *  - group
-     *  - permissions
-     *  - acl
-     * 
-     *  If you do not have read access on the collection,
-     *  the list of sub-collections will be empty, an exception
-     *  will not be thrown!
+     *
+     * Returns details of a collection - collections (list of sub-collections) -
+     * name - created - owner - group - permissions - acl
+     *
+     * If you do not have read access on the collection, the list of
+     * sub-collections will be empty, an exception will not be thrown!
      *
      * @param collUri a <code>XmldbURI</code> value
-     * @return a <code>HashMap</code> value
+     * @return a <code>Map</code> value
      * @exception Exception if an error occurs
      */
-    private HashMap<String, Object> describeCollection(final XmldbURI collUri)
-    throws Exception {
+    private Map<String, Object> describeCollection(final XmldbURI collUri)
+            throws Exception {
         final DBBroker broker = factory.getBrokerPool().get(user);
         Collection collection = null;
         try {
@@ -772,10 +652,10 @@ public class RpcConnection implements RpcAPI {
             if (collection == null) {
                 throw new EXistException("collection " + collUri + " not found!");
             }
-            final HashMap<String, Object> desc = new HashMap<String, Object>();
-            final List<String> collections = new ArrayList<String>();
+            final Map<String, Object> desc = new HashMap<>();
+            final List<String> collections = new ArrayList<>();
             if (collection.getPermissionsNoLock().validate(user, Permission.READ)) {
-                for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext(); ) {
+                for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext();) {
                     collections.add(i.next().toString());
                 }
             }
@@ -785,13 +665,13 @@ public class RpcConnection implements RpcAPI {
             desc.put("created", Long.toString(collection.getCreationTime()));
             desc.put("owner", perms.getOwner().getName());
             desc.put("group", perms.getGroup().getName());
-            desc.put("permissions", Integer.valueOf(perms.getMode()));
-            if(perms instanceof ACLPermission) {
+            desc.put("permissions", perms.getMode());
+            if (perms instanceof ACLPermission) {
                 desc.put("acl", getACEs(perms));
             }
             return desc;
         } finally {
-            if(collection != null) {
+            if (collection != null) {
                 collection.release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
@@ -799,10 +679,10 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public byte[] getDocument(String name, HashMap<String, Object> parametri) throws EXistException,
+    public byte[] getDocument(final String name, final Map<String, Object> parametri) throws EXistException,
             PermissionDeniedException {
 
-        String encoding = DEFAULT_ENCODING;
+        final String encoding;
         String compression = "no";
 
         if (parametri.get("encoding") == null) {
@@ -817,8 +697,9 @@ public class RpcConnection implements RpcAPI {
 
         try {
             final String xml = getDocumentAsString(name, parametri);
-            if (xml == null)
-                {throw new EXistException("document " + name + " not found!");}
+            if (xml == null) {
+                throw new EXistException("document " + name + " not found!");
+            }
             try {
                 if ("no".equals(compression)) {
                     return xml.getBytes(encoding);
@@ -837,23 +718,14 @@ public class RpcConnection implements RpcAPI {
                 }
 
             }
-        } catch (final Throwable e) {
+        } catch (final EXistException | PermissionDeniedException | IOException e) {
             handleException(e);
             return null;
         }
     }
 
-    /**
-     * The method <code>getDocument</code>
-     *
-     * @param docName a <code>String</code> value
-     * @param parametri a <code>HashMap</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
-    public String getDocumentAsString(String docName, HashMap<String, Object> parametri) throws EXistException, PermissionDeniedException {
+    public String getDocumentAsString(final String docName, final Map<String, Object> parametri) throws EXistException, PermissionDeniedException {
         try {
             return getDocumentAsString(XmldbURI.xmldbUriFor(docName), parametri);
 
@@ -863,18 +735,10 @@ public class RpcConnection implements RpcAPI {
         }
     }
 
-    /**
-     * The method <code>getDocument</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @param parametri a <code>HashMap</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     */
-    private String getDocumentAsString(XmldbURI docUri, HashMap<String, Object> parametri)
-    throws Exception {
+    private String getDocumentAsString(final XmldbURI docUri, final Map<String, Object> parametri)
+            throws Exception {
         DBBroker broker = null;
-        
+
         Collection collection = null;
         DocumentImpl doc = null;
         try {
@@ -884,7 +748,7 @@ public class RpcConnection implements RpcAPI {
                 LOG.debug("collection " + docUri.removeLastSegment() + " not found!");
                 return null;
             }
-            if(!collection.getPermissionsNoLock().validate(user, Permission.READ)) {
+            if (!collection.getPermissionsNoLock().validate(user, Permission.READ)) {
                 throw new PermissionDeniedException("Insufficient privileges to read resource");
             }
             doc = collection.getDocumentWithLock(broker, docUri.lastSegment(), Lock.READ_LOCK);
@@ -892,43 +756,37 @@ public class RpcConnection implements RpcAPI {
                 LOG.debug("document " + docUri + " not found!");
                 throw new EXistException("document not found");
             }
-            
-            if(!doc.getPermissions().validate(user, Permission.READ))
-                {throw new PermissionDeniedException("Insufficient privileges to read resource " + docUri);}
+
+            if (!doc.getPermissions().validate(user, Permission.READ)) {
+                throw new PermissionDeniedException("Insufficient privileges to read resource " + docUri);
+            }
             final Serializer serializer = broker.getSerializer();
-            serializer.setProperties(parametri);
+            serializer.setProperties(toProperties(parametri));
             final String xml = serializer.serialize(doc);
-            
+
             return xml;
         } catch (final NoSuchMethodError nsme) {
             LOG.error(nsme.getMessage(), nsme);
             return null;
         } finally {
-            if(collection != null)
-                {collection.releaseDocument(doc, Lock.READ_LOCK);}
-            if(collection != null)
-                {collection.release(Lock.READ_LOCK);}
+            if (collection != null) {
+                collection.releaseDocument(doc, Lock.READ_LOCK);
+            }
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getDocumentData</code>
-     *
-     * @param docName a <code>String</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
+
     @Override
-    public HashMap<String, Object> getDocumentData(final String docName, final HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException
-    {
-    	Collection collection = null;
-    	DocumentImpl doc = null;
-    	DBBroker broker = null;
-    	try {
+    public Map<String, Object> getDocumentData(final String docName, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
+        Collection collection = null;
+        DocumentImpl doc = null;
+        DBBroker broker = null;
+        try {
             broker = factory.getBrokerPool().get(user);
-            final XmldbURI docURI = XmldbURI.xmldbUriFor(docName);  
+            final XmldbURI docURI = XmldbURI.xmldbUriFor(docName);
             collection = broker.openCollection(docURI.removeLastSegment(), Lock.READ_LOCK);
             if (collection == null) {
                 LOG.debug("collection " + docURI.removeLastSegment() + " not found!");
@@ -940,45 +798,39 @@ public class RpcConnection implements RpcAPI {
             doc = collection.getDocumentWithLock(broker, docURI.lastSegment(), Lock.READ_LOCK);
             if (doc == null) {
                 LOG.debug("document " + docURI + " not found!");
-                throw new EXistException("document "+docURI+" not found");
+                throw new EXistException("document " + docURI + " not found");
             }
 
             //if(!doc.getPermissions().validate(user, Permission.READ)) {
             //  throw new PermissionDeniedException("Insufficient privileges to read resource " + docName);
             //}
-            String encoding = (String)parameters.get(OutputKeys.ENCODING);
-            if(encoding == null) {
+            String encoding = (String) parameters.get(OutputKeys.ENCODING);
+            if (encoding == null) {
                 encoding = DEFAULT_ENCODING;
             }
 
             // A tweak for very large resources, VirtualTempFile
-            final HashMap<String, Object> result = new HashMap<String, Object>();
+            final Map<String, Object> result = new HashMap<>();
             VirtualTempFile vtempFile = null;
             try {
-                vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE,MAX_DOWNLOAD_CHUNK_SIZE);
+                vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE, MAX_DOWNLOAD_CHUNK_SIZE);
                 vtempFile.setTempPrefix("eXistRPCC");
 
                 // binary check TODO dwes
-                if(doc.getResourceType() == DocumentImpl.XML_FILE) {
+                if (doc.getResourceType() == DocumentImpl.XML_FILE) {
                     vtempFile.setTempPostfix(".xml");
                     final Serializer serializer = broker.getSerializer();
-                    serializer.setProperties(parameters);
+                    serializer.setProperties(toProperties(parameters));
 
-                    Writer writer = null;
-                    try {
-                        writer = new OutputStreamWriter(vtempFile, encoding);
+                    try (Writer writer = new OutputStreamWriter(vtempFile, encoding)) {
                         serializer.serialize(doc, writer);
-                    } finally {
-                        if(writer != null) {
-                            writer.close();
-                        }
                     }
                 } else {
                     vtempFile.setTempPostfix(".bin");
-                    broker.readBinaryResource((BinaryDocument)doc, vtempFile);
+                    broker.readBinaryResource((BinaryDocument) doc, vtempFile);
                 }
             } finally {
-                if(vtempFile != null) {
+                if (vtempFile != null) {
                     vtempFile.close();
                 }
             }
@@ -986,7 +838,7 @@ public class RpcConnection implements RpcAPI {
             final byte[] firstChunk = vtempFile.getChunk(0);
             result.put("data", firstChunk);
             int offset = 0;
-            if(vtempFile.length()>MAX_DOWNLOAD_CHUNK_SIZE) {
+            if (vtempFile.length() > MAX_DOWNLOAD_CHUNK_SIZE) {
                 offset = firstChunk.length;
 
                 final int handle = factory.resultSets.add(new SerializedResult(vtempFile));
@@ -995,220 +847,166 @@ public class RpcConnection implements RpcAPI {
             } else {
                 vtempFile.delete();
             }
-            result.put("offset", Integer.valueOf(offset));
+            result.put("offset", offset);
 
             return result;
 
-    	} catch(final Throwable e) {
+        } catch (final EXistException | URISyntaxException | PermissionDeniedException | LockException | IOException | SAXException e) {
             handleException(e);
             return null;
-    	} finally {
-            if(collection != null) {
+        } finally {
+            if (collection != null) {
                 collection.releaseDocument(doc, Lock.READ_LOCK);
                 collection.getLock().release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
-    	}
+        }
     }
-    
-    /**
-     * The method <code>getNextChunk</code>
-     *
-     * @param handle a <code>String</code> value
-     * @param offset an <code>int</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
+
     @Override
-    public HashMap<String, Object> getNextChunk(String handle, int offset)
-    	throws EXistException, PermissionDeniedException
-    {
-    	try {
-    		final int resultId = Integer.parseInt(handle);
-    		final SerializedResult sr = factory.resultSets.getSerializedResult(resultId);
+    public Map<String, Object> getNextChunk(final String handle, final int offset)
+            throws EXistException, PermissionDeniedException {
+        try {
+            final int resultId = Integer.parseInt(handle);
+            final SerializedResult sr = factory.resultSets.getSerializedResult(resultId);
 
-    		if(sr==null)
-    			{throw new EXistException("Invalid handle specified");}
-    		// This will keep the serialized result in the cache
-    		sr.touch();
-    		final VirtualTempFile vfile = sr.result;
+            if (sr == null) {
+                throw new EXistException("Invalid handle specified");
+            }
+            // This will keep the serialized result in the cache
+            sr.touch();
+            final VirtualTempFile vfile = sr.result;
 
-    		if(offset <= 0 || offset > vfile.length()) {
-    			factory.resultSets.remove(resultId);
-    			throw new EXistException("No more data available");
-    		}
-    		final byte[] chunk = vfile.getChunk(offset);
-    		final long nextChunk = offset + chunk.length;
+            if (offset <= 0 || offset > vfile.length()) {
+                factory.resultSets.remove(resultId);
+                throw new EXistException("No more data available");
+            }
+            final byte[] chunk = vfile.getChunk(offset);
+            final long nextChunk = offset + chunk.length;
 
-    		final HashMap<String, Object> result = new HashMap<String, Object>();
-    		result.put("data", chunk);
-    		result.put("handle", handle);
-    		if(nextChunk > (long)Integer.MAX_VALUE || nextChunk == vfile.length()) {
-    			factory.resultSets.remove(resultId);
-    			result.put("offset", Integer.valueOf(0));
-    		} else
-    			{result.put("offset", Integer.valueOf((int)nextChunk));}
-    		return result;
-    	} catch (final Throwable e) {
-    		handleException(e);
-    		return null;
-    	}
+            final Map<String, Object> result = new HashMap<>();
+            result.put("data", chunk);
+            result.put("handle", handle);
+            if (nextChunk > (long) Integer.MAX_VALUE || nextChunk == vfile.length()) {
+                factory.resultSets.remove(resultId);
+                result.put("offset", 0);
+            } else {
+                result.put("offset", nextChunk);
+            }
+            return result;
+        } catch (final NumberFormatException | EXistException | IOException e) {
+            handleException(e);
+            return null;
+        }
     }
-    
-    /**
-     * The method <code>getNextExtendedChunk</code>
-     *
-     * @param handle a <code>String</code> value
-     * @param offset a <code>String</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
+
     @Override
-    public HashMap<String, Object> getNextExtendedChunk(String handle, String offset)
-    	throws EXistException, PermissionDeniedException
-    {
-    	try {
-    		final int resultId = Integer.parseInt(handle);
-    		final SerializedResult sr = factory.resultSets.getSerializedResult(resultId);
+    public Map<String, Object> getNextExtendedChunk(final String handle, final String offset)
+            throws EXistException, PermissionDeniedException {
+        try {
+            final int resultId = Integer.parseInt(handle);
+            final SerializedResult sr = factory.resultSets.getSerializedResult(resultId);
 
-    		if(sr==null)
-    			{throw new EXistException("Invalid handle specified");}
-    		// This will keep the serialized result in the cache
-    		sr.touch();
-    		final VirtualTempFile vfile = sr.result; 
+            if (sr == null) {
+                throw new EXistException("Invalid handle specified");
+            }
+            // This will keep the serialized result in the cache
+            sr.touch();
+            final VirtualTempFile vfile = sr.result;
 
-    		final long longOffset=new Long(offset).longValue();
-    		if(longOffset< 0 || longOffset > vfile.length()) {
-    			factory.resultSets.remove(resultId);
-    			throw new EXistException("No more data available");
-    		}
-    		final byte[] chunk = vfile.getChunk(longOffset);
-    		final long nextChunk = longOffset + chunk.length;
+            final long longOffset = Long.valueOf(offset);
+            if (longOffset < 0 || longOffset > vfile.length()) {
+                factory.resultSets.remove(resultId);
+                throw new EXistException("No more data available");
+            }
+            final byte[] chunk = vfile.getChunk(longOffset);
+            final long nextChunk = longOffset + chunk.length;
 
-    		final HashMap<String, Object> result = new HashMap<String, Object>();
-    		result.put("data", chunk);
-    		result.put("handle", handle);
-    		if(nextChunk == vfile.length()) {
-    			factory.resultSets.remove(resultId);
-    			result.put("offset", Long.toString(0));
-    		} else
-    			{result.put("offset", Long.toString(nextChunk));}
-    		return result;
+            final Map<String, Object> result = new HashMap<>();
+            result.put("data", chunk);
+            result.put("handle", handle);
+            if (nextChunk == vfile.length()) {
+                factory.resultSets.remove(resultId);
+                result.put("offset", Long.toString(0));
+            } else {
+                result.put("offset", Long.toString(nextChunk));
+            }
+            return result;
 
-    	} catch (final Throwable e) {
-    		handleException(e);
-    		return null;
-    	}
+        } catch (final NumberFormatException | EXistException | IOException e) {
+            handleException(e);
+            return null;
+        }
     }
-	
-    /**
-     * The method <code>getBinaryResource</code>
-     *
-     * @param name a <code>String</code> value
-     * @return a <code>byte[]</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public byte[] getBinaryResource(String name)
-    throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return getBinaryResource(XmldbURI.xmldbUriFor(name));
+    public byte[] getBinaryResource(final String name)
+            throws EXistException, PermissionDeniedException, URISyntaxException {
+        return getBinaryResource(XmldbURI.xmldbUriFor(name));
     }
-    
+
     private byte[] getBinaryResource(final XmldbURI name) throws EXistException, PermissionDeniedException {
         return getBinaryResource(name, Permission.READ);
     }
-    /**
-     * The method <code>getBinaryResource</code>
-     *
-     * @param name a <code>XmldbURI</code> value
-     * @return a <code>byte[]</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
+
     private byte[] getBinaryResource(final XmldbURI name, final int requiredPermissions) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         DocumentImpl doc = null;
         try {
             broker = factory.getBrokerPool().get(user);
             doc = broker.getXMLResource(name, Lock.READ_LOCK);
-            
-            if(doc == null) {
+
+            if (doc == null) {
                 throw new EXistException("Resource " + name + " not found");
             }
-            
-            if(doc.getResourceType() != DocumentImpl.BINARY_FILE) {
+
+            if (doc.getResourceType() != DocumentImpl.BINARY_FILE) {
                 throw new EXistException("Document " + name + " is not a binary resource");
             }
-            
-            if(!doc.getPermissions().validate(user, requiredPermissions)) {
+
+            if (!doc.getPermissions().validate(user, requiredPermissions)) {
                 throw new PermissionDeniedException("Insufficient privileges to access resource");
             }
-            
+
             try {
-                final InputStream is = broker.getBinaryResource((BinaryDocument)doc);
-		final long resourceSize = broker.getBinaryResourceSize((BinaryDocument)doc);
-		if(resourceSize > (long)Integer.MAX_VALUE) {
-                    throw new EXistException("Resource too big to be read using this method.");
-		}
-                final byte[] data = new byte[(int)resourceSize];
-                is.read(data);
-                is.close();
+                final byte[] data;
+                try (final InputStream is = broker.getBinaryResource((BinaryDocument) doc)) {
+                    final long resourceSize = broker.getBinaryResourceSize((BinaryDocument) doc);
+                    if (resourceSize > (long) Integer.MAX_VALUE) {
+                        throw new EXistException("Resource too big to be read using this method.");
+                    }
+                    data = new byte[(int) resourceSize];
+                    is.read(data);
+                }
                 return data;
-            } catch(final IOException ex) {
-               throw new EXistException("I/O error while reading resource.",ex);
+            } catch (final IOException ex) {
+                throw new EXistException("I/O error while reading resource.", ex);
             }
         } finally {
-            if(doc != null) {
+            if (doc != null) {
                 doc.getUpdateLock().release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>xupdate</code>
-     *
-     * @param collectionName a <code>String</code> value
-     * @param xupdate a <code>String</code> value
-     * @return an <code>int</code> value
-     * @exception SAXException if an error occurs
-     * @exception LockException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     * @exception XPathException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public int xupdate(String collectionName, byte[] xupdate) throws PermissionDeniedException, EXistException {
+    public int xupdate(final String collectionName, final byte[] xupdate) throws PermissionDeniedException, EXistException {
         try {
             return xupdate(XmldbURI.xmldbUriFor(collectionName), new String(xupdate, DEFAULT_ENCODING));
-            
-        } catch (final Throwable e) {
+
+        } catch (final URISyntaxException | UnsupportedEncodingException | SAXException | LockException | PermissionDeniedException | EXistException | XPathException e) {
             handleException(e);
             return -1;
         }
     }
-    
-    /**
-     * The method <code>xupdate</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @param xupdate a <code>String</code> value
-     * @return an <code>int</code> value
-     * @exception SAXException if an error occurs
-     * @exception LockException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     * @exception XPathException if an error occurs
-     */
-    private int xupdate(XmldbURI collUri, String xupdate)
-    throws SAXException, LockException, PermissionDeniedException, EXistException,
+
+    private int xupdate(final XmldbURI collUri, final String xupdate)
+            throws SAXException, LockException, PermissionDeniedException, EXistException,
             XPathException {
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
             final Collection collection = broker.getCollection(collUri);
             if (collection == null) {
                 transact.abort(transaction);
@@ -1219,8 +1017,8 @@ public class RpcConnection implements RpcAPI {
             final XUpdateProcessor processor = new XUpdateProcessor(broker, docs, AccessContext.XMLRPC);
             final Modification modifications[] = processor.parse(new InputSource(new StringReader(xupdate)));
             long mods = 0;
-            for (int i = 0; i < modifications.length; i++) {
-                mods += modifications[i].process(transaction);
+            for (final Modification modification : modifications) {
+                mods += modification.process(transaction);
                 broker.flush();
             }
             transact.commit(transaction);
@@ -1229,48 +1027,23 @@ public class RpcConnection implements RpcAPI {
             throw new EXistException(e.getMessage());
         }
     }
-    
-    /**
-     * The method <code>xupdateResource</code>
-     *
-     * @param resource a <code>String</code> value
-     * @param xupdate a <code>String</code> value
-     * @return an <code>int</code> value
-     * @exception SAXException if an error occurs
-     * @exception LockException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     * @exception XPathException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public int xupdateResource(String resource, byte[] xupdate, String encoding) throws PermissionDeniedException, EXistException {
+    public int xupdateResource(final String resource, final byte[] xupdate, final String encoding) throws PermissionDeniedException, EXistException {
         try {
             return xupdateResource(XmldbURI.xmldbUriFor(resource), new String(xupdate, encoding));
-        } catch (final Throwable e) {
+        } catch (final URISyntaxException | UnsupportedEncodingException | SAXException | LockException | PermissionDeniedException | EXistException | XPathException e) {
             handleException(e);
             return -1;
         }
     }
 
-    /**
-     * The method <code>xupdateResource</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @param xupdate a <code>String</code> value
-     * @return an <code>int</code> value
-     * @exception SAXException if an error occurs
-     * @exception LockException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     * @exception XPathException if an error occurs
-     */
-    private int xupdateResource(XmldbURI docUri, String xupdate)
-    throws SAXException, LockException, PermissionDeniedException, EXistException,
+    private int xupdateResource(final XmldbURI docUri, final String xupdate)
+            throws SAXException, LockException, PermissionDeniedException, EXistException,
             XPathException {
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
             final DocumentImpl doc = broker.getResource(docUri, Permission.READ);
             if (doc == null) {
                 transact.abort(transaction);
@@ -1283,8 +1056,8 @@ public class RpcConnection implements RpcAPI {
             final Modification modifications[] = processor.parse(new InputSource(
                     new StringReader(xupdate)));
             long mods = 0;
-            for (int i = 0; i < modifications.length; i++) {
-                mods += modifications[i].process(transaction);
+            for (final Modification modification : modifications) {
+                mods += modification.process(transaction);
                 broker.flush();
             }
             transact.commit(transaction);
@@ -1293,12 +1066,7 @@ public class RpcConnection implements RpcAPI {
             throw new EXistException(e.getMessage());
         }
     }
-    
-    /**
-     * The method <code>sync</code>
-     *
-     * @return a <code>boolean</code> value
-     */
+
     @Override
     public boolean sync() {
         DBBroker broker = null;
@@ -1306,179 +1074,112 @@ public class RpcConnection implements RpcAPI {
             broker = factory.getBrokerPool().get(factory.getBrokerPool().getSecurityManager().getSystemSubject());
             broker.sync(Sync.MAJOR_SYNC);
         } catch (final EXistException e) {
-        	LOG.warn(e.getMessage(), e);
+            LOG.warn(e.getMessage(), e);
         } finally {
             factory.getBrokerPool().release(broker);
         }
         return true;
     }
-    
-    /**
-     * The method <code>isXACMLEnabled</code>
-     *
-     * @return a <code>boolean</code> value
-     */
+
     @Override
     public boolean isXACMLEnabled() {
-    	return factory.getBrokerPool().getSecurityManager().isXACMLEnabled();
+        return factory.getBrokerPool().getSecurityManager().isXACMLEnabled();
     }
-    
-    /**
-     * The method <code>dataBackup</code>
-     *
-     * @param dest a <code>String</code> value
-     * @return a <code>boolean</code> value
-     */
+
     @Override
-    public boolean dataBackup(String dest ) {
-        factory.getBrokerPool().triggerSystemTask( new DataBackup(dest));
+    public boolean dataBackup(final String dest) {
+        factory.getBrokerPool().triggerSystemTask(new DataBackup(dest));
         return true;
     }
-    
-    /**
-     * The method <code>getDocumentListing</code>
-     *
-     * @return a <code>Vector</code> value
-     * @exception EXistException if an error occurs
-     */
+
     @Override
-    public Vector<String> getDocumentListing() throws EXistException, PermissionDeniedException {
+    public List<String> getDocumentListing() throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
             final DocumentSet docs = broker.getAllXMLResources(new DefaultDocumentSet());
             final XmldbURI names[] = docs.getNames();
-            final Vector<String> vec = new Vector<String>();
-            for (int i = 0; i < names.length; i++)
-                vec.addElement(names[i].toString());
-            
-            return vec;
+            final List<String> list = new ArrayList<>();
+            for (final XmldbURI name : names) {
+                list.add(name.toString());
+            }
+
+            return list;
         } finally {
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getCollectionListing</code>
-     *
-     * @param collName a <code>String</code> value
-     * @return a <code>Vector</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public Vector<String> getCollectionListing(final String collName) throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return getCollectionListing(XmldbURI.xmldbUriFor(collName));
+    public List<String> getCollectionListing(final String collName) throws EXistException, PermissionDeniedException, URISyntaxException {
+        return getCollectionListing(XmldbURI.xmldbUriFor(collName));
     }
 
-    /**
-     * The method <code>getCollectionListing</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @return a <code>Vector</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private Vector<String> getCollectionListing(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
+    private List<String> getCollectionListing(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         Collection collection = null;
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(collUri, Lock.READ_LOCK);
-            final Vector<String> vec = new Vector<String>();
+            final List<String> list = new ArrayList<>();
             if (collection == null) {
-            	if (LOG.isDebugEnabled()) {
-            		LOG.debug("collection " + collUri + " not found.");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("collection " + collUri + " not found.");
                 }
-                return vec;
+                return list;
             }
-            for(final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext(); ) {
-                vec.addElement(i.next().toString());
+            for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext();) {
+                list.add(i.next().toString());
             }
-            return vec;
+            return list;
         } finally {
-            if(collection != null) {
+            if (collection != null) {
                 collection.release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getDocumentListing</code>
-     *
-     * @param collName a <code>String</code> value
-     * @return a <code>Vector</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public Vector<String> getDocumentListing(String collName)
-    throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return getDocumentListing(XmldbURI.xmldbUriFor(collName));
+    public List<String> getDocumentListing(final String collName)
+            throws EXistException, PermissionDeniedException, URISyntaxException {
+        return getDocumentListing(XmldbURI.xmldbUriFor(collName));
     }
 
-    /**
-     * The method <code>getDocumentListing</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @return a <code>Vector</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private Vector<String> getDocumentListing(final XmldbURI collUri)
-    throws EXistException, PermissionDeniedException {
+    private List<String> getDocumentListing(final XmldbURI collUri)
+            throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         Collection collection = null;
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(collUri, Lock.READ_LOCK);
-            final Vector<String> vec = new Vector<String>();
+            final List<String> list = new ArrayList<>();
             if (collection == null) {
-            	if (LOG.isDebugEnabled()) {
-            		LOG.debug("collection " + collUri + " not found.");
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("collection " + collUri + " not found.");
                 }
-                return vec;
+                return list;
             }
-            for(final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
-                vec.addElement(i.next().getFileURI().toString());
+            for (final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext();) {
+                list.add(i.next().getFileURI().toString());
             }
-            return vec;
+            return list;
         } finally {
-            if(collection != null) {
+            if (collection != null) {
                 collection.release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getResourceCount</code>
-     *
-     * @param collectionName a <code>String</code> value
-     * @return an <code>int</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public int getResourceCount(String collectionName)
-    throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return getResourceCount(XmldbURI.xmldbUriFor(collectionName));
+    public int getResourceCount(final String collectionName)
+            throws EXistException, PermissionDeniedException, URISyntaxException {
+        return getResourceCount(XmldbURI.xmldbUriFor(collectionName));
     }
 
-    /**
-     * The method <code>getResourceCount</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @return an <code>int</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private int getResourceCount(XmldbURI collUri)
-    throws EXistException, PermissionDeniedException {
+    private int getResourceCount(final XmldbURI collUri)
+            throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         Collection collection = null;
         try {
@@ -1486,38 +1187,29 @@ public class RpcConnection implements RpcAPI {
             collection = broker.openCollection(collUri, Lock.READ_LOCK);
             return collection.getDocumentCount(broker);
         } finally {
-            if(collection != null)
-                {collection.release(Lock.READ_LOCK);}
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>createResourceId</code>
-     *
-     * @param collectionName a <code>String</code> value
-     * @return a <code>String</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public String createResourceId(String collectionName)
-    throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return createResourceId(XmldbURI.xmldbUriFor(collectionName));
+    public String createResourceId(final String collectionName)
+            throws EXistException, PermissionDeniedException, URISyntaxException {
+        return createResourceId(XmldbURI.xmldbUriFor(collectionName));
     }
-    
+
     /**
-     * Creates a unique name for a database resource
-     * Uniqueness is only guaranteed within the eXist instance
-     * 
-     * The name is based on a hex encoded string of a random integer
-     * and will have the format xxxxxxxx.xml where x is in the range
-     * 0 to 9 and a to f 
-     * 
-     * @return the unique resource name 
+     * Creates a unique name for a database resource Uniqueness is only
+     * guaranteed within the eXist instance
+     *
+     * The name is based on a hex encoded string of a random integer and will
+     * have the format xxxxxxxx.xml where x is in the range 0 to 9 and a to f
+     *
+     * @return the unique resource name
      */
-    private String createResourceId(XmldbURI collUri) throws EXistException, PermissionDeniedException {
+    private String createResourceId(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         Collection collection = null;
         try {
@@ -1530,80 +1222,61 @@ public class RpcConnection implements RpcAPI {
                 ok = true;
                 id = XmldbURI.create(Integer.toHexString(rand.nextInt()) + ".xml");
                 // check if this id does already exist
-                if (collection.hasDocument(broker, id))
-                    {ok = false;}
-                
-                if (collection.hasSubcollection(broker, id))
-                    {ok = false;}
-                
+                if (collection.hasDocument(broker, id)) {
+                    ok = false;
+                }
+
+                if (collection.hasSubcollection(broker, id)) {
+                    ok = false;
+                }
+
             } while (!ok);
             return id.toString();
         } finally {
-            if(collection != null)
-                {collection.release(Lock.READ_LOCK);}
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getHits</code>
-     *
-     * @param resultId an <code>int</code> value
-     * @return an <code>int</code> value
-     * @exception EXistException if an error occurs
-     */
+
     @Override
-    public int getHits(int resultId) throws EXistException {
+    public int getHits(final int resultId) throws EXistException {
         final QueryResult qr = factory.resultSets.getResult(resultId);
-        if (qr == null)
-            {throw new EXistException("result set unknown or timed out");}
+        if (qr == null) {
+            throw new EXistException("result set unknown or timed out");
+        }
         qr.touch();
-        if (qr.result == null)
-            {return 0;}
+        if (qr.result == null) {
+            return 0;
+        }
         return qr.result.getItemCount();
     }
-    
-    /**
-     * The method <code>getMode</code>
-     *
-     * @param name a <code>String</code> value
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public HashMap<String, Object> getPermissions(String name)
-    throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return getPermissions(XmldbURI.xmldbUriFor(name));
+    public Map<String, Object> getPermissions(final String name)
+            throws EXistException, PermissionDeniedException, URISyntaxException {
+        return getPermissions(XmldbURI.xmldbUriFor(name));
     }
 
-    /**
-     * The method <code>getMode</code>
-     *
-     * @param uri a <code>XmldbURI</code> value
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private HashMap<String, Object> getPermissions(XmldbURI uri) throws EXistException, PermissionDeniedException {
+    private Map<String, Object> getPermissions(final XmldbURI uri) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         Collection collection = null;
 
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(uri, Lock.READ_LOCK);
-            Permission perm = null;
-            if(collection == null) {
+            final Permission perm;
+            if (collection == null) {
                 DocumentImpl doc = null;
                 try {
                     doc = broker.getXMLResource(uri, Lock.READ_LOCK);
-                    if(doc == null) {
+                    if (doc == null) {
                         throw new EXistException("document or collection " + uri + " not found");
                     }
                     perm = doc.getPermissions();
                 } finally {
-                    if(doc != null) {
+                    if (doc != null) {
                         doc.getUpdateLock().release(Lock.READ_LOCK);
                     }
                 }
@@ -1611,26 +1284,26 @@ public class RpcConnection implements RpcAPI {
                 perm = collection.getPermissionsNoLock();
             }
 
-            final HashMap<String, Object> result = new HashMap<String, Object>();
+            final Map<String, Object> result = new HashMap<>();
             result.put("owner", perm.getOwner().getName());
             result.put("group", perm.getGroup().getName());
-            result.put("permissions", Integer.valueOf(perm.getMode()));
+            result.put("permissions", perm.getMode());
 
-            if(perm instanceof ACLPermission) {
+            if (perm instanceof ACLPermission) {
                 result.put("acl", getACEs(perm));
             }
             return result;
         } finally {
-            if(collection != null){
+            if (collection != null) {
                 collection.release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
         }
     }
-    
+
     @Override
-    public HashMap<String, Object> getSubCollectionPermissions(String parentPath, String name) throws EXistException, PermissionDeniedException, URISyntaxException {
-        
+    public Map<String, Object> getSubCollectionPermissions(final String parentPath, final String name) throws EXistException, PermissionDeniedException, URISyntaxException {
+
         final XmldbURI uri = XmldbURI.xmldbUriFor(parentPath);
         DBBroker broker = null;
         Collection collection = null;
@@ -1638,65 +1311,32 @@ public class RpcConnection implements RpcAPI {
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(uri, Lock.READ_LOCK);
-            Permission perm = null;
-            if(collection == null) {
+            final Permission perm;
+            if (collection == null) {
                 throw new EXistException("collection " + uri + " not found");
             } else {
                 perm = collection.getSubCollectionEntry(broker, name).getPermissions();
             }
 
-            final HashMap<String, Object> result = new HashMap<String, Object>();
+            final Map<String, Object> result = new HashMap<>();
             result.put("owner", perm.getOwner().getName());
             result.put("group", perm.getGroup().getName());
-            result.put("permissions", Integer.valueOf(perm.getMode()));
+            result.put("permissions", perm.getMode());
 
-            if(perm instanceof ACLPermission) {
+            if (perm instanceof ACLPermission) {
                 result.put("acl", getACEs(perm));
             }
             return result;
         } finally {
-            if(collection != null){
+            if (collection != null) {
                 collection.release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
         }
     }
-    
+
     @Override
-    public HashMap<String, Object> getSubResourcePermissions(String parentPath, String name) throws EXistException, PermissionDeniedException, URISyntaxException {
-         final XmldbURI uri = XmldbURI.xmldbUriFor(parentPath);
-        DBBroker broker = null;
-        Collection collection = null;
-
-        try {
-            broker = factory.getBrokerPool().get(user);
-            collection = broker.openCollection(uri, Lock.READ_LOCK);
-            Permission perm = null;
-            if(collection == null) {
-                throw new EXistException("collection " + uri + " not found");
-            } else {
-                perm = collection.getResourceEntry(broker, name).getPermissions();
-            }
-
-            final HashMap<String, Object> result = new HashMap<String, Object>();
-            result.put("owner", perm.getOwner().getName());
-            result.put("group", perm.getGroup().getName());
-            result.put("permissions", Integer.valueOf(perm.getMode()));
-
-            if(perm instanceof ACLPermission) {
-                result.put("acl", getACEs(perm));
-            }
-            return result;
-        } finally {
-            if(collection != null){
-                collection.release(Lock.READ_LOCK);
-            }
-            factory.getBrokerPool().release(broker);
-        }   
-    }
-    
-    @Override
-    public long getSubCollectionCreationTime(String parentPath, String name) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public Map<String, Object> getSubResourcePermissions(final String parentPath, final String name) throws EXistException, PermissionDeniedException, URISyntaxException {
         final XmldbURI uri = XmldbURI.xmldbUriFor(parentPath);
         DBBroker broker = null;
         Collection collection = null;
@@ -1704,208 +1344,182 @@ public class RpcConnection implements RpcAPI {
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(uri, Lock.READ_LOCK);
-            if(collection == null) {
+            final Permission perm;
+            if (collection == null) {
+                throw new EXistException("collection " + uri + " not found");
+            } else {
+                perm = collection.getResourceEntry(broker, name).getPermissions();
+            }
+
+            final Map<String, Object> result = new HashMap<>();
+            result.put("owner", perm.getOwner().getName());
+            result.put("group", perm.getGroup().getName());
+            result.put("permissions", perm.getMode());
+
+            if (perm instanceof ACLPermission) {
+                result.put("acl", getACEs(perm));
+            }
+            return result;
+        } finally {
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
+            factory.getBrokerPool().release(broker);
+        }
+    }
+
+    @Override
+    public long getSubCollectionCreationTime(final String parentPath, final String name) throws EXistException, PermissionDeniedException, URISyntaxException {
+        final XmldbURI uri = XmldbURI.xmldbUriFor(parentPath);
+        DBBroker broker = null;
+        Collection collection = null;
+
+        try {
+            broker = factory.getBrokerPool().get(user);
+            collection = broker.openCollection(uri, Lock.READ_LOCK);
+            if (collection == null) {
                 throw new EXistException("collection " + uri + " not found");
             } else {
                 return collection.getSubCollectionEntry(broker, name).getCreated();
             }
 
         } finally {
-            if(collection != null){
+            if (collection != null) {
                 collection.release(Lock.READ_LOCK);
             }
             factory.getBrokerPool().release(broker);
-        }   
+        }
     }
-    
-    private List<ACEAider> getACEs(Permission perm) {
-        final List<ACEAider> aces = new ArrayList<ACEAider>();
-        final ACLPermission aclPermission = (ACLPermission)perm;
-        for(int i = 0; i < aclPermission.getACECount(); i++) {
+
+    private List<ACEAider> getACEs(final Permission perm) {
+        final List<ACEAider> aces = new ArrayList<>();
+        final ACLPermission aclPermission = (ACLPermission) perm;
+        for (int i = 0; i < aclPermission.getACECount(); i++) {
             aces.add(new ACEAider(aclPermission.getACEAccessType(i), aclPermission.getACETarget(i), aclPermission.getACEWho(i), aclPermission.getACEMode(i)));
         }
         return aces;
     }
 
-    /**
-     * The method <code>listDocumentPermissions</code>
-     *
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
-    public HashMap<String, List<Object>> listDocumentPermissions(String name)
-    throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return listDocumentPermissions(XmldbURI.xmldbUriFor(name));
+    public Map<String, List> listDocumentPermissions(final String name)
+            throws EXistException, PermissionDeniedException, URISyntaxException {
+        return listDocumentPermissions(XmldbURI.xmldbUriFor(name));
     }
 
-    /**
-     * The method <code>listDocumentPermissions</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private HashMap<String, List<Object>> listDocumentPermissions(XmldbURI collUri) throws EXistException, PermissionDeniedException {
+    private Map<String, List> listDocumentPermissions(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         Collection collection = null;
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(collUri, Lock.READ_LOCK);
-            if (collection == null)
-                {throw new EXistException("Collection " + collUri + " not found");}
-            if (!collection.getPermissionsNoLock().validate(user, Permission.READ))
-                {throw new PermissionDeniedException(
-                        "not allowed to read collection " + collUri);}
-            final HashMap<String, List<Object>> result = new HashMap<String, List<Object>>(collection.getDocumentCount(broker));
+            if (collection == null) {
+                throw new EXistException("Collection " + collUri + " not found");
+            }
+            if (!collection.getPermissionsNoLock().validate(user, Permission.READ)) {
+                throw new PermissionDeniedException(
+                        "not allowed to read collection " + collUri);
+            }
+            final Map<String, List> result = new HashMap<>(collection.getDocumentCount(broker));
 
-            for (final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
-            	final DocumentImpl doc = i.next();
+            for (final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext();) {
+                final DocumentImpl doc = i.next();
 
                 final Permission perm = doc.getPermissions();
 
-                final List<Object> tmp = new ArrayList<Object>(3);
+                final List tmp = new ArrayList(3);
                 tmp.add(perm.getOwner().getName());
                 tmp.add(perm.getGroup().getName());
-                tmp.add(Integer.valueOf(perm.getMode()));
-                if(perm instanceof ACLPermission) {
+                tmp.add(perm.getMode());
+                if (perm instanceof ACLPermission) {
                     tmp.add(getACEs(perm));
                 }
                 result.put(doc.getFileURI().toString(), tmp);
             }
             return result;
         } finally {
-            if(collection != null)
-                {collection.release(Lock.READ_LOCK);}
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
 
-    /**
-     * The method <code>listCollectionPermissions</code>
-     *
-     * @param name a <code>String</code> value
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
-    public HashMap<XmldbURI, List<Object>> listCollectionPermissions(String name)
-    throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return listCollectionPermissions(XmldbURI.xmldbUriFor(name));
+    public Map<XmldbURI, List> listCollectionPermissions(final String name)
+            throws EXistException, PermissionDeniedException, URISyntaxException {
+        return listCollectionPermissions(XmldbURI.xmldbUriFor(name));
     }
 
-    /**
-     * The method <code>listCollectionPermissions</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private HashMap<XmldbURI, List<Object>> listCollectionPermissions(XmldbURI collUri)
-    throws EXistException, PermissionDeniedException {
+    private Map<XmldbURI, List> listCollectionPermissions(final XmldbURI collUri)
+            throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         Collection collection = null;
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(collUri, Lock.READ_LOCK);
-            if (collection == null)
-                {throw new EXistException("Collection " + collUri + " not found");}
-            if (!collection.getPermissionsNoLock().validate(user, Permission.READ))
-                {throw new PermissionDeniedException("not allowed to read collection " + collUri);}
-            final HashMap<XmldbURI, List<Object>> result = new HashMap<XmldbURI, List<Object>>(collection.getChildCollectionCount(broker));
-            for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext(); ) {
-            	final XmldbURI child = i.next();
-            	final XmldbURI path = collUri.append(child);
+            if (collection == null) {
+                throw new EXistException("Collection " + collUri + " not found");
+            }
+            if (!collection.getPermissionsNoLock().validate(user, Permission.READ)) {
+                throw new PermissionDeniedException("not allowed to read collection " + collUri);
+            }
+            final Map<XmldbURI, List> result = new HashMap<>(collection.getChildCollectionCount(broker));
+            for (final Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext();) {
+                final XmldbURI child = i.next();
+                final XmldbURI path = collUri.append(child);
                 final Collection childColl = broker.getCollection(path);
                 final Permission perm = childColl.getPermissionsNoLock();
-                final List<Object> tmp = new ArrayList<Object>(3);
+                final List tmp = new ArrayList(3);
                 tmp.add(perm.getOwner().getName());
                 tmp.add(perm.getGroup().getName());
-                tmp.add(Integer.valueOf(perm.getMode()));
-                if(perm instanceof ACLPermission) {
+                tmp.add(perm.getMode());
+                if (perm instanceof ACLPermission) {
                     tmp.add(getACEs(perm));
                 }
                 result.put(child, tmp);
             }
             return result;
         } finally {
-            if(collection != null)
-                {collection.release(Lock.READ_LOCK);}
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getCreationDate</code>
-     *
-     * @param collectionPath a <code>String</code> value
-     * @return a <code>Date</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public Date getCreationDate(String collectionPath)
-    throws PermissionDeniedException, EXistException, URISyntaxException {
-    	return getCreationDate(XmldbURI.xmldbUriFor(collectionPath));
+    public Date getCreationDate(final String collectionPath)
+            throws PermissionDeniedException, EXistException, URISyntaxException {
+        return getCreationDate(XmldbURI.xmldbUriFor(collectionPath));
     }
 
-    /**
-     * The method <code>getCreationDate</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @return a <code>Date</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     */
-    private Date getCreationDate(XmldbURI collUri)
-    throws PermissionDeniedException, EXistException {
+    private Date getCreationDate(final XmldbURI collUri)
+            throws PermissionDeniedException, EXistException {
         DBBroker broker = null;
         Collection collection = null;
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(collUri, Lock.READ_LOCK);
-            if (collection == null)
-                {throw new EXistException("collection " + collUri + " not found");}
+            if (collection == null) {
+                throw new EXistException("collection " + collUri + " not found");
+            }
             return new Date(collection.getCreationTime());
         } finally {
-            if(collection != null)
-                {collection.release(Lock.READ_LOCK);}
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getTimestamps</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @return a <code>Vector</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public Vector<Date> getTimestamps(String documentPath)
-    throws PermissionDeniedException, EXistException, URISyntaxException {
-    	return getTimestamps(XmldbURI.xmldbUriFor(documentPath));
+    public List<Date> getTimestamps(final String documentPath)
+            throws PermissionDeniedException, EXistException, URISyntaxException {
+        return getTimestamps(XmldbURI.xmldbUriFor(documentPath));
     }
 
-    /**
-     * The method <code>getTimestamps</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @return a <code>Vector</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     */
-    private Vector<Date> getTimestamps(XmldbURI docUri)
-    throws PermissionDeniedException, EXistException {
+    private List<Date> getTimestamps(final XmldbURI docUri)
+            throws PermissionDeniedException, EXistException {
         DBBroker broker = null;
         DocumentImpl doc = null;
         try {
@@ -1916,27 +1530,20 @@ public class RpcConnection implements RpcAPI {
                 throw new EXistException("document not found");
             }
             final DocumentMetadata metadata = doc.getMetadata();
-            final Vector<Date> vector = new Vector<Date>(2);
-            vector.addElement(new Date(metadata.getCreated()));
-            vector.addElement(new Date(metadata.getLastModified()));
-            return vector;
+            final List<Date> list = new ArrayList<>(2);
+            list.add(new Date(metadata.getCreated()));
+            list.add(new Date(metadata.getLastModified()));
+            return list;
         } finally {
-            if(doc != null)
-                {doc.getUpdateLock().release(Lock.READ_LOCK);}
+            if (doc != null) {
+                doc.getUpdateLock().release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getAccount</code>
-     *
-     * @param name a <code>String</code> value
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
+
     @Override
-    public HashMap<String, Object> getAccount(String name) throws EXistException, PermissionDeniedException {
+    public Map<String, Object> getAccount(final String name) throws EXistException, PermissionDeniedException {
 
         DBBroker broker = null;
         try {
@@ -1946,120 +1553,92 @@ public class RpcConnection implements RpcAPI {
             if (u == null) {
                 throw new EXistException("account '" + name + "' does not exist");
             }
-	        
-            final HashMap<String, Object> tab = new HashMap<String, Object>();
+
+            final Map<String, Object> tab = new HashMap<>();
             tab.put("uid", user.getId());
             tab.put("name", u.getName());
-
-            final Vector<String> groups = new Vector<String>();
-            final String[] groupNames = u.getGroups();
-            for(final String groupName : groupNames) {
-                groups.addElement(groupName);
-            }
-            tab.put("groups", groups);
+            tab.put("groups", Arrays.asList(u.getGroups()));
 
             final Group dg = u.getDefaultGroup();
-            if(dg != null) {
+            if (dg != null) {
                 tab.put("default-group-id", dg.getId());
                 tab.put("default-group-realmId", dg.getRealmId());
                 tab.put("default-group-name", dg.getName());
             }
-            
+
             tab.put("enabled", Boolean.toString(u.isEnabled()));
-            
+
             tab.put("umask", u.getUserMask());
-            
-            final Map<String, String> metadata = new HashMap<String, String>();
-            for(final SchemaType key : u.getMetadataKeys()) {
+
+            final Map<String, String> metadata = new HashMap<>();
+            for (final SchemaType key : u.getMetadataKeys()) {
                 metadata.put(key.getNamespace(), u.getMetadataValue(key));
             }
             tab.put("metadata", metadata);
-            
+
             return tab;
-        
+
         } finally {
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getAccounts</code>
-     *
-     * @return a <code>Vector</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
+
     @Override
-    public Vector<HashMap<String, Object>> getAccounts() throws EXistException, PermissionDeniedException {
-        
+    public List<Map<String, Object>> getAccounts() throws EXistException, PermissionDeniedException {
+
         final java.util.Collection<Account> users = factory.getBrokerPool().getSecurityManager().getUsers();
-        final Vector<HashMap<String, Object>> r = new Vector<HashMap<String, Object>>();
-        for(final Account user : users) {
-            final HashMap<String, Object> tab = new HashMap<String, Object>();
+        final List<Map<String, Object>> r = new ArrayList<>();
+        for (final Account user : users) {
+            final Map<String, Object> tab = new HashMap<>();
             tab.put("uid", user.getId());
-            
             tab.put("name", user.getName());
-            
-            final Vector<String> groups = new Vector<String>();
-            final String[] gl = user.getGroups();
-            for(int j = 0; j < gl.length; j++) {
-                groups.addElement(gl[j]);
-            }
-            tab.put("groups", groups);
-            
+            tab.put("groups", Arrays.asList(user.getGroups()));
             tab.put("enabled", Boolean.toString(user.isEnabled()));
             tab.put("umask", user.getUserMask());
-            
-            final Map<String, String> metadata = new HashMap<String, String>();
-            for(final SchemaType key : user.getMetadataKeys()) {
+
+            final Map<String, String> metadata = new HashMap<>();
+            for (final SchemaType key : user.getMetadataKeys()) {
                 metadata.put(key.getNamespace(), user.getMetadataValue(key));
             }
             tab.put("metadata", metadata);
-            r.addElement(tab);
+            r.add(tab);
         }
         return r;
     }
-    
-    /**
-     * The method <code>getGroups</code>
-     *
-     * @return a <code>Vector</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
+
     @Override
-    public Vector<String> getGroups() throws EXistException, PermissionDeniedException {
-    	final java.util.Collection<Group> groups = factory.getBrokerPool().getSecurityManager().getGroups();
-        final Vector<String> v = new Vector<String>(groups.size());
-        for(final Group group : groups) {
-            v.addElement(group.getName());
+    public List<String> getGroups() throws EXistException, PermissionDeniedException {
+        final java.util.Collection<Group> groups = factory.getBrokerPool().getSecurityManager().getGroups();
+        final List<String> v = new ArrayList<>(groups.size());
+        for (final Group group : groups) {
+            v.add(group.getName());
         }
         return v;
     }
 
     @Override
-    public HashMap<String, Object> getGroup(final String name) throws EXistException, PermissionDeniedException {
+    public Map<String, Object> getGroup(final String name) throws EXistException, PermissionDeniedException {
         try {
-            return executeWithBroker(new BrokerOperation<HashMap<String, Object>>() {
+            return executeWithBroker(new BrokerOperation<Map<String, Object>>() {
                 @Override
-                public HashMap<String, Object> withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
+                public Map<String, Object> withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
                     final SecurityManager securityManager = factory.getBrokerPool().getSecurityManager();
                     final Group group = securityManager.getGroup(name);
-                    if(group != null){
-                        final HashMap<String, Object> map = new HashMap<String, Object>();
+                    if (group != null) {
+                        final Map<String, Object> map = new HashMap<>();
                         map.put("id", group.getId());
                         map.put("realmId", group.getRealmId());
                         map.put("name", name);
-                        
+
                         final List<Account> groupManagers = group.getManagers();
-                        final Vector<String> managers = new Vector<String>(groupManagers.size());
-                        for(final Account groupManager : groupManagers) {
+                        final List<String> managers = new ArrayList<>(groupManagers.size());
+                        for (final Account groupManager : groupManagers) {
                             managers.add(groupManager.getName());
                         }
                         map.put("managers", managers);
 
-                        final Map<String, String> metadata = new HashMap<String, String>();
-                        for(final SchemaType key : group.getMetadataKeys()) {
+                        final Map<String, String> metadata = new HashMap<>();
+                        for (final SchemaType key : group.getMetadataKeys()) {
                             metadata.put(key.getNamespace(), group.getMetadataValue(key));
                         }
                         map.put("metadata", metadata);
@@ -2089,29 +1668,12 @@ public class RpcConnection implements RpcAPI {
         }
     }
 
-
-    
-    /**
-     * The method <code>hasDocument</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
-    public boolean hasDocument(String documentPath) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return hasDocument(XmldbURI.xmldbUriFor(documentPath));
+    public boolean hasDocument(final String documentPath) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return hasDocument(XmldbURI.xmldbUriFor(documentPath));
     }
 
-    /**
-     * The method <code>hasDocument</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean hasDocument(XmldbURI docUri) throws EXistException, PermissionDeniedException {
+    private boolean hasDocument(final XmldbURI docUri) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
@@ -2120,28 +1682,13 @@ public class RpcConnection implements RpcAPI {
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>hasCollection</code>
-     *
-     * @param collectionName a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public boolean hasCollection(String collectionName) throws EXistException, URISyntaxException, PermissionDeniedException {
-    	return hasCollection(XmldbURI.xmldbUriFor(collectionName));
+    public boolean hasCollection(final String collectionName) throws EXistException, URISyntaxException, PermissionDeniedException {
+        return hasCollection(XmldbURI.xmldbUriFor(collectionName));
     }
 
-    /**
-     * The method <code>hasCollection</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean hasCollection(XmldbURI collUri) throws EXistException, PermissionDeniedException {
+    private boolean hasCollection(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
@@ -2150,56 +1697,25 @@ public class RpcConnection implements RpcAPI {
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    
-    /**
-     * The method <code>parse</code>
-     *
-     * @param xml a <code>byte</code> value
-     * @param documentPath a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
     public boolean parse(byte[] xml, String documentPath, int overwrite) throws URISyntaxException, EXistException, PermissionDeniedException {
-        return parse(xml,documentPath, overwrite, null, null);
-    }
-    
-    /**
-     * The method <code>parse</code>
-     *
-     * @param xml a <code>byte</code> value
-     * @param documentPath a <code>String</code> value
-     * @param created a <code>Date</code> value
-     * @param modified a <code>Date</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    @Override
-    public boolean parse(byte[] xml, String documentPath,
-            int overwrite, Date created, Date modified) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return parse(xml,XmldbURI.xmldbUriFor(documentPath),overwrite,created,modified);
+        return parse(xml, documentPath, overwrite, null, null);
     }
 
-    /**
-     * The method <code>parse</code>
-     *
-     * @param xml a <code>byte</code> value
-     * @param docUri a <code>XmldbURI</code> value
-     * @param created a <code>Date</code> value
-     * @param modified a <code>Date</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean parse(byte[] xml, XmldbURI docUri,
-            int overwrite, Date created, Date modified) throws EXistException, PermissionDeniedException {
+    @Override
+    public boolean parse(final byte[] xml, final String documentPath,
+            final int overwrite, final Date created, final Date modified) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return parse(xml, XmldbURI.xmldbUriFor(documentPath), overwrite, created, modified);
+    }
+
+    private boolean parse(final byte[] xml, final XmldbURI docUri,
+            final int overwrite, final Date created, final Date modified) throws EXistException, PermissionDeniedException {
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
 
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction();
-            final InputStream is = new ByteArrayInputStream(xml)) {
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction();
+                final InputStream is = new ByteArrayInputStream(xml)) {
 
             final long startTime = System.currentTimeMillis();
 
@@ -2207,41 +1723,44 @@ public class RpcConnection implements RpcAPI {
             InputSource source = null;
             Collection collection = null;
             try {
-            	collection = broker.openCollection(docUri.removeLastSegment(), Lock.WRITE_LOCK);
-	            if (collection == null) {
-	                transact.abort(transaction);
-	                throw new EXistException("Collection " + docUri.removeLastSegment() + " not found");
-	            }
-	
-	            if (overwrite == 0) {
-	                final DocumentImpl old = collection.getDocument(broker, docUri.lastSegment());
-	                //TODO : register the lock within the transaction ?
-	                if (old != null) {
-	                    transact.abort(transaction);
-	                    throw new PermissionDeniedException("Document exists and overwrite is not allowed");
-	                }
-	            }
+                collection = broker.openCollection(docUri.removeLastSegment(), Lock.WRITE_LOCK);
+                if (collection == null) {
+                    transact.abort(transaction);
+                    throw new EXistException("Collection " + docUri.removeLastSegment() + " not found");
+                }
 
-	            source = new InputSource(is);
-	            info = collection.validateXMLResource(transaction, broker, docUri.lastSegment(), source);
-	            final MimeType mime = MimeTable.getInstance().getContentTypeFor(docUri.lastSegment());
-	            if (mime != null && mime.isXMLType()){
-	            	info.getDocument().getMetadata().setMimeType(mime.getName());
-	            }
-	            if (created != null)
-	                {info.getDocument().getMetadata().setCreated( created.getTime());}            
-	            
-	            if (modified != null)
-	                {info.getDocument().getMetadata().setLastModified( modified.getTime());}
-	            
+                if (overwrite == 0) {
+                    final DocumentImpl old = collection.getDocument(broker, docUri.lastSegment());
+                    //TODO : register the lock within the transaction ?
+                    if (old != null) {
+                        transact.abort(transaction);
+                        throw new PermissionDeniedException("Document exists and overwrite is not allowed");
+                    }
+                }
+
+                source = new InputSource(is);
+                info = collection.validateXMLResource(transaction, broker, docUri.lastSegment(), source);
+                final MimeType mime = MimeTable.getInstance().getContentTypeFor(docUri.lastSegment());
+                if (mime != null && mime.isXMLType()) {
+                    info.getDocument().getMetadata().setMimeType(mime.getName());
+                }
+                if (created != null) {
+                    info.getDocument().getMetadata().setCreated(created.getTime());
+                }
+
+                if (modified != null) {
+                    info.getDocument().getMetadata().setLastModified(modified.getTime());
+                }
+
             } finally {
-            	if (collection != null)
-            		{collection.release(Lock.WRITE_LOCK);}
+                if (collection != null) {
+                    collection.release(Lock.WRITE_LOCK);
+                }
             }
-            
+
             collection.store(transaction, broker, info, source, false);
             transact.commit(transaction);
-            
+
             LOG.debug("parsing " + docUri + " took " + (System.currentTimeMillis() - startTime) + "ms.");
             return true;
 
@@ -2250,278 +1769,198 @@ public class RpcConnection implements RpcAPI {
             return false;
         }
     }
-    
-    
-    
+
     /**
      * Parse a file previously uploaded with upload.
      *
      * The temporary file will be removed.
      *
      * @param localFile
+     * @param documentPath
+     * @param overwrite
+     * @param mimeType
+     * @return
      * @throws EXistException
-     * @throws IOException
+     * @throws java.net.URISyntaxException
      */
-    public boolean parseLocal(String localFile, String documentPath,
-            int overwrite, String mimeType) throws Exception, URISyntaxException {
+    public boolean parseLocal(final String localFile, final String documentPath,
+            final int overwrite, final String mimeType) throws Exception, URISyntaxException {
         return parseLocal(localFile, documentPath, overwrite, mimeType, null, null);
     }
-    
+
     /**
-     * Parse a file previously uploaded with upload, forcing it to XML or Binary.
+     * Parse a file previously uploaded with upload, forcing it to XML or
+     * Binary.
      *
      * The temporary file will be removed.
      *
      * @param localFile
+     * @param documentPath
+     * @param overwrite
+     * @param mimeType
+     * @param isXML
+     * @return
      * @throws EXistException
-     * @throws IOException
+     * @throws java.net.URISyntaxException
      */
-    public boolean parseLocalExt(String localFile, String documentPath,
-            int overwrite, String mimeType, int isXML) throws Exception, URISyntaxException {
+    public boolean parseLocalExt(final String localFile, final String documentPath,
+            final int overwrite, final String mimeType, final int isXML) throws Exception, URISyntaxException {
         return parseLocalExt(localFile, documentPath, overwrite, mimeType, isXML, null, null);
     }
-    
-    /**
-     * The method <code>parseLocal</code>
-     *
-     * @param localFile a <code>String</code> value
-     * @param docUri a <code>XmldbURI</code> value
-     * @param mimeType a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
+
     @SuppressWarnings("unused")
-	private boolean parseLocal(String localFile, XmldbURI docUri,
-            int overwrite, String mimeType) throws Exception {
+    private boolean parseLocal(final String localFile, final XmldbURI docUri,
+            final int overwrite, final String mimeType) throws Exception {
         return parseLocal(localFile, docUri, overwrite, mimeType, null, null, null);
     }
-    
-    /**
-     * The method <code>parseLocal</code>
-     *
-     * @param localFile a <code>String</code> value
-     * @param docUri a <code>XmldbURI</code> value
-     * @param mimeType a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
+
     @SuppressWarnings("unused")
-	private boolean parseLocalExt(String localFile, XmldbURI docUri,
-            int overwrite, String mimeType, int isXML) throws Exception {
-        return parseLocal(localFile, docUri, overwrite, mimeType, Boolean.valueOf(isXML!=0), null, null);
+    private boolean parseLocalExt(final String localFile, final XmldbURI docUri,
+            final int overwrite, final String mimeType, final int isXML) throws Exception {
+        return parseLocal(localFile, docUri, overwrite, mimeType, isXML != 0, null, null);
     }
-    
-    /**
-     * The method <code>parseLocal</code>
-     *
-     * @param localFile a <code>String</code> value
-     * @param documentPath a <code>String</code> value
-     * @param mimeType a <code>String</code> value
-     * @param created a <code>Date</code> value
-     * @param modified a <code>Date</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    public boolean parseLocal(String localFile, String documentPath, int overwrite,
-                              String mimeType, Date created, Date modified) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return parseLocal(localFile,XmldbURI.xmldbUriFor(documentPath), overwrite, mimeType, null, created, modified);
-    }
-    
-    /**
-     * The method <code>parseLocal</code>
-     *
-     * @param localFile a <code>String</code> value
-     * @param documentPath a <code>String</code> value
-     * @param mimeType a <code>String</code> value
-     * @param created a <code>Date</code> value
-     * @param modified a <code>Date</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    public boolean parseLocalExt(String localFile, String documentPath, int overwrite,
-                              String mimeType, int isXML, Date created, Date modified) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return parseLocal(localFile,XmldbURI.xmldbUriFor(documentPath), overwrite, mimeType, Boolean.valueOf(isXML!=0), created, modified);
-    }
-    
-    /**
-     * The method <code>parseLocal</code>
-     *
-     * @param localFile a <code>String</code> value
-     * @param docUri a <code>XmldbURI</code> value
-     * @param mimeType a <code>String</code> value
-     * @param created a <code>Date</code> value
-     * @param modified a <code>Date</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean parseLocal(String localFile, XmldbURI docUri, int overwrite, String mimeType, Boolean isXML, Date created, Date modified)
-    	throws EXistException, PermissionDeniedException
-    {
-    	VirtualTempFileInputSource source=null;
 
-    	try {
-    		final int handle = Integer.parseInt(localFile);
-    		final SerializedResult sr = factory.resultSets.getSerializedResult(handle);
-    		if(sr==null)
-    			{throw new EXistException("Invalid handle specified");}
-    		
-    		source = new VirtualTempFileInputSource(sr.result);
-    		
-    		// Unlinking the VirtualTempFile from the SerializeResult
-    		sr.result=null;
-    		factory.resultSets.remove(handle);
-    	} catch(final NumberFormatException nfe) {
+    public boolean parseLocal(final String localFile, final String documentPath, final int overwrite,
+            final String mimeType, final Date created, final Date modified) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return parseLocal(localFile, XmldbURI.xmldbUriFor(documentPath), overwrite, mimeType, null, created, modified);
+    }
+
+    public boolean parseLocalExt(final String localFile, final String documentPath, final int overwrite,
+            final String mimeType, final int isXML, final Date created, final Date modified) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return parseLocal(localFile, XmldbURI.xmldbUriFor(documentPath), overwrite, mimeType, isXML != 0, created, modified);
+    }
+
+    private boolean parseLocal(final String localFile, final XmldbURI docUri, final int overwrite, final String mimeType, final Boolean isXML, final Date created, final Date modified)
+            throws EXistException, PermissionDeniedException {
+        VirtualTempFileInputSource source = null;
+
+        try {
+            final int handle = Integer.parseInt(localFile);
+            final SerializedResult sr = factory.resultSets.getSerializedResult(handle);
+            if (sr == null) {
+                throw new EXistException("Invalid handle specified");
+            }
+
+            source = new VirtualTempFileInputSource(sr.result);
+
+            // Unlinking the VirtualTempFile from the SerializeResult
+            sr.result = null;
+            factory.resultSets.remove(handle);
+        } catch (final NumberFormatException nfe) {
     		// As this file can be a non-temporal one, we should not
-    		// blindly erase it!
-    		final File file = new File(localFile);
-        	if (!file.canRead())
-        		{throw new EXistException("unable to read file " + file.getAbsolutePath());}
-        	
-        	source = new VirtualTempFileInputSource(file);
-    	} catch(final IOException ioe) {
-			throw new EXistException("Error preparing virtual temp file for parsing");
-    	}
+            // blindly erase it!
+            final File file = new File(localFile);
+            if (!file.canRead()) {
+                throw new EXistException("unable to read file " + file.getAbsolutePath());
+            }
 
-    	final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-    	DocumentImpl doc = null;
+            source = new VirtualTempFileInputSource(file);
+        } catch (final IOException ioe) {
+            throw new EXistException("Error preparing virtual temp file for parsing");
+        }
 
-    	// DWES
-    	MimeType mime = MimeTable.getInstance().getContentType(mimeType);
-    	if (mime == null)
-    		{mime = MimeType.BINARY_TYPE;}
+        final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
+        final DocumentImpl doc;
 
-    	final boolean treatAsXML=(isXML!=null && isXML.booleanValue()) || (isXML==null && mime.isXMLType());
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
-    		Collection collection = null;
-    		IndexInfo info = null;
+        // DWES
+        MimeType mime = MimeTable.getInstance().getContentType(mimeType);
+        if (mime == null) {
+            mime = MimeType.BINARY_TYPE;
+        }
 
-    		try {
+        final boolean treatAsXML = (isXML != null && isXML) || (isXML == null && mime.isXMLType());
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
+            Collection collection = null;
+            IndexInfo info = null;
 
-    			collection = broker.openCollection(docUri.removeLastSegment(), Lock.WRITE_LOCK);
-    			if (collection == null) {
-    				transact.abort(transaction);
-    				throw new EXistException("Collection " + docUri.removeLastSegment() + " not found");
-    			}
+            try {
 
-    			if (overwrite == 0) {
-    				final DocumentImpl old = collection.getDocument(broker, docUri.lastSegment());
-    				if (old != null) {
-    					transact.abort(transaction);
-    					throw new PermissionDeniedException("Old document exists and overwrite is not allowed");
-    				}
-    			}
+                collection = broker.openCollection(docUri.removeLastSegment(), Lock.WRITE_LOCK);
+                if (collection == null) {
+                    transact.abort(transaction);
+                    throw new EXistException("Collection " + docUri.removeLastSegment() + " not found");
+                }
 
-    			//XML
-    			if(treatAsXML) {
-    				info = collection.validateXMLResource(transaction, broker, docUri.lastSegment(), source);
-    				if (created != null)
-    					{info.getDocument().getMetadata().setCreated(created.getTime());}	                
-    				if (modified != null)
-    					{info.getDocument().getMetadata().setLastModified(modified.getTime());}	                
-    			} else {
-    				final InputStream is = source.getByteStream();
-    				doc = collection.addBinaryResource(transaction, broker, docUri.lastSegment(), is, 
-    						mime.getName(), source.getByteStreamLength());
-    				is.close();
-    				if (created != null)
-    					{doc.getMetadata().setCreated(created.getTime());}
-    				if (modified != null)
-    					{doc.getMetadata().setLastModified(modified.getTime());}
-    			}
+                if (overwrite == 0) {
+                    final DocumentImpl old = collection.getDocument(broker, docUri.lastSegment());
+                    if (old != null) {
+                        transact.abort(transaction);
+                        throw new PermissionDeniedException("Old document exists and overwrite is not allowed");
+                    }
+                }
 
-    		} finally {
-    			if (collection != null)
-    				{collection.release(Lock.WRITE_LOCK);}
-    		}
+                //XML
+                if (treatAsXML) {
+                    info = collection.validateXMLResource(transaction, broker, docUri.lastSegment(), source);
+                    if (created != null) {
+                        info.getDocument().getMetadata().setCreated(created.getTime());
+                    }
+                    if (modified != null) {
+                        info.getDocument().getMetadata().setLastModified(modified.getTime());
+                    }
+                } else {
+                    final InputStream is = source.getByteStream();
+                    doc = collection.addBinaryResource(transaction, broker, docUri.lastSegment(), is,
+                            mime.getName(), source.getByteStreamLength());
+                    is.close();
+                    if (created != null) {
+                        doc.getMetadata().setCreated(created.getTime());
+                    }
+                    if (modified != null) {
+                        doc.getMetadata().setLastModified(modified.getTime());
+                    }
+                }
 
-    		// DWES why seperate store?
-    		if(treatAsXML){
-    			collection.store(transaction, broker, info, source, false);
-    		}
+            } finally {
+                if (collection != null) {
+                    collection.release(Lock.WRITE_LOCK);
+                }
+            }
 
-    		// generic
-    		transact.commit(transaction);
+            // DWES why seperate store?
+            if (treatAsXML) {
+                collection.store(transaction, broker, info, source, false);
+            }
 
-    	} catch (final Throwable e) {
-    		handleException(e);
-    	} finally {
-        	// DWES there are situations the file is not cleaned up
-    		if(source!=null)
-    			{source.free();}
-    	}
+            // generic
+            transact.commit(transaction);
 
-    	return true; // when arrived here, insert/update was successful
+        } catch (final Throwable e) {
+            handleException(e);
+        } finally {
+            // DWES there are situations the file is not cleaned up
+            source.free();
+        }
+
+        return true; // when arrived here, insert/update was successful
     }
-    
-    /**
-     * The method <code>storeBinary</code>
-     *
-     * @param data a <code>byte</code> value
-     * @param documentPath a <code>String</code> value
-     * @param mimeType a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    public boolean storeBinary(byte[] data, String documentPath, String mimeType,
-            int overwrite) throws Exception, URISyntaxException {
+
+    public boolean storeBinary(final byte[] data, final String documentPath, final String mimeType,
+            final int overwrite) throws Exception, URISyntaxException {
         return storeBinary(data, documentPath, mimeType, overwrite, null, null);
     }
 
-    /**
-     * The method <code>storeBinary</code>
-     *
-     * @param data a <code>byte</code> value
-     * @param docUri a <code>XmldbURI</code> value
-     * @param mimeType a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
     @SuppressWarnings("unused")
-	private boolean storeBinary(byte[] data, XmldbURI docUri, String mimeType,
-            int overwrite) throws Exception {
+    private boolean storeBinary(final byte[] data, final XmldbURI docUri, final String mimeType,
+            final int overwrite) throws Exception {
         return storeBinary(data, docUri, mimeType, overwrite, null, null);
     }
 
-    /**
-     * The method <code>storeBinary</code>
-     *
-     * @param data a <code>byte</code> value
-     * @param documentPath a <code>String</code> value
-     * @param mimeType a <code>String</code> value
-     * @param created a <code>Date</code> value
-     * @param modified a <code>Date</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    public boolean storeBinary(byte[] data, String documentPath, String mimeType,
-            int overwrite, Date created, Date modified) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return storeBinary(data,XmldbURI.xmldbUriFor(documentPath),mimeType,overwrite,created,modified);
-    }    
-    /**
-     * The method <code>storeBinary</code>
-     *
-     * @param data a <code>byte</code> value
-     * @param docUri a <code>XmldbURI</code> value
-     * @param mimeType a <code>String</code> value
-     * @param created a <code>Date</code> value
-     * @param modified a <code>Date</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean storeBinary(byte[] data, XmldbURI docUri, String mimeType,
-            int overwrite, Date created, Date modified) throws EXistException, PermissionDeniedException {
-        DocumentImpl doc = null;   
+    public boolean storeBinary(final byte[] data, final String documentPath, final String mimeType,
+            final int overwrite, final Date created, final Date modified) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return storeBinary(data, XmldbURI.xmldbUriFor(documentPath), mimeType, overwrite, created, modified);
+    }
+
+    private boolean storeBinary(final byte[] data, final XmldbURI docUri, final String mimeType,
+            final int overwrite, final Date created, final Date modified) throws EXistException, PermissionDeniedException {
+        DocumentImpl doc = null;
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
             final Collection collection = broker.openCollection(docUri.removeLastSegment(), Lock.WRITE_LOCK);
             if (collection == null) {
-            	transact.abort(transaction);
+                transact.abort(transaction);
                 throw new EXistException("Collection " + docUri.removeLastSegment() + " not found");
             }
             // keep the write lock in the transaction
@@ -2529,17 +1968,19 @@ public class RpcConnection implements RpcAPI {
             if (overwrite == 0) {
                 final DocumentImpl old = collection.getDocument(broker, docUri.lastSegment());
                 if (old != null) {
-                	transact.abort(transaction);
+                    transact.abort(transaction);
                     throw new PermissionDeniedException("Old document exists and overwrite is not allowed");
                 }
             }
             LOG.debug("Storing binary resource to collection " + collection.getURI());
-            
+
             doc = collection.addBinaryResource(transaction, broker, docUri.lastSegment(), data, mimeType);
-            if (created != null)
-                {doc.getMetadata().setCreated(created.getTime());}
-            if (modified != null)
-                {doc.getMetadata().setLastModified(modified.getTime());}
+            if (created != null) {
+                doc.getMetadata().setCreated(created.getTime());
+            }
+            if (modified != null) {
+                doc.getMetadata().setLastModified(modified.getTime());
+            }
             transact.commit(transaction);
 
         } catch (final Throwable e) {
@@ -2549,80 +1990,61 @@ public class RpcConnection implements RpcAPI {
         }
         return doc != null;
     }
-    
-    /**
-     * The method <code>upload</code>
-     *
-     * @param chunk a <code>byte</code> value
-     * @param length an <code>int</code> value
-     * @param fileName a <code>String</code> value
-     * @param compressed a <code>boolean</code> value
-     * @return a <code>String</code> value
-     * @exception EXistException if an error occurs
-     * @exception IOException if an error occurs
-     */
-    public String upload(byte[] chunk, int length, String fileName, boolean compressed)
-    	throws EXistException, IOException
-    {
+
+    public String upload(final byte[] chunk, final int length, String fileName, final boolean compressed)
+            throws EXistException, IOException {
         VirtualTempFile vtempFile;
         if (fileName == null || fileName.length() == 0) {
             // create temporary file
-        	vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE,MAX_DOWNLOAD_CHUNK_SIZE);
-        	vtempFile.setTempPrefix("rpc");
-        	vtempFile.setTempPostfix(".xml");
-			final int handle = factory.resultSets.add(new SerializedResult(vtempFile));
+            vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE, MAX_DOWNLOAD_CHUNK_SIZE);
+            vtempFile.setTempPrefix("rpc");
+            vtempFile.setTempPostfix(".xml");
+            final int handle = factory.resultSets.add(new SerializedResult(vtempFile));
             fileName = Integer.toString(handle);
         } else {
 //            LOG.debug("appending to file " + fileName);
-        	try {
-        		final int handle = Integer.parseInt(fileName);
-        		final SerializedResult sr = factory.resultSets.getSerializedResult(handle);
-        		if(sr==null)
-        			{throw new EXistException("Invalid handle specified");}
-        		// This will keep the serialized result in the cache
-        		sr.touch();
-        		vtempFile = sr.result;
-        	} catch(final NumberFormatException nfe) {
-       			throw new EXistException("Syntactically invalid handle specified");
-        	}
+            try {
+                final int handle = Integer.parseInt(fileName);
+                final SerializedResult sr = factory.resultSets.getSerializedResult(handle);
+                if (sr == null) {
+                    throw new EXistException("Invalid handle specified");
+                }
+                // This will keep the serialized result in the cache
+                sr.touch();
+                vtempFile = sr.result;
+            } catch (final NumberFormatException nfe) {
+                throw new EXistException("Syntactically invalid handle specified");
+            }
         }
-        if (compressed)
-            {Compressor.uncompress(chunk, vtempFile);}
-        else
-            {vtempFile.write(chunk, 0, length);}
-        
+        if (compressed) {
+            Compressor.uncompress(chunk, vtempFile);
+        } else {
+            vtempFile.write(chunk, 0, length);
+        }
+
         return fileName;
     }
-    
-    /**
-     * The method <code>printAll</code>
-     *
-     * @param broker a <code>DBBroker</code> value
-     * @param resultSet a <code>Sequence</code> value
-     * @param howmany an <code>int</code> value
-     * @param start an <code>int</code> value
-     * @param properties a <code>HashMap</code> value
-     * @param queryTime a <code>long</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     */
-    protected String printAll(DBBroker broker, Sequence resultSet, int howmany,
-            int start, HashMap<String, Object> properties, long queryTime) throws Exception {
+
+    protected String printAll(final DBBroker broker, final Sequence resultSet, int howmany,
+            int start, final Map<String, Object> properties, long queryTime) throws Exception {
         if (resultSet.isEmpty()) {
             final StringBuilder buf = new StringBuilder();
             final String opt = (String) properties.get(OutputKeys.OMIT_XML_DECLARATION);
-            if (opt == null || opt.equalsIgnoreCase("no"))
-                {buf.append("<?xml version=\"1.0\"?>\n");}
+            if (opt == null || opt.equalsIgnoreCase("no")) {
+                buf.append("<?xml version=\"1.0\"?>\n");
+            }
             buf.append("<exist:result xmlns:exist=\"").append(Namespaces.EXIST_NS).append("\" ");
             buf.append("hitCount=\"0\"/>");
             return buf.toString();
         }
-        if (howmany > resultSet.getItemCount() || howmany == 0)
-            {howmany = resultSet.getItemCount();}
-        
-        if (start < 1 || start > resultSet.getItemCount())
-            {throw new EXistException("start parameter out of range");}
-        
+        if (howmany > resultSet.getItemCount() || howmany == 0) {
+            howmany = resultSet.getItemCount();
+        }
+
+        if (start < 1 || start > resultSet.getItemCount()) {
+            throw new EXistException("start parameter out of range");
+        }
+
         final StringWriter writer = new StringWriter();
         writer.write("<exist:result xmlns:exist=\"");
         writer.write(Namespaces.EXIST_NS);
@@ -2633,16 +2055,17 @@ public class RpcConnection implements RpcAPI {
         writer.write("\" count=\"");
         writer.write(Integer.toString(howmany));
         writer.write("\">\n");
-        
+
         final Serializer serializer = broker.getSerializer();
         serializer.reset();
-        serializer.setProperties(properties);
-        
+        serializer.setProperties(toProperties(properties));
+
         Item item;
         for (int i = --start; i < start + howmany; i++) {
             item = resultSet.itemAt(i);
-            if (item == null)
-                {continue;}
+            if (item == null) {
+                continue;
+            }
             if (item.getType() == Type.ELEMENT) {
                 final NodeValue node = (NodeValue) item;
                 writer.write(serializer.serialize(node));
@@ -2657,17 +2080,9 @@ public class RpcConnection implements RpcAPI {
         writer.write("\n</exist:result>");
         return writer.toString();
     }
-    
-    /**
-     * The method <code>compile</code>
-     *
-     * @param query a <code>String</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
-    public HashMap<String, Object> compile(String query, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
-        final HashMap<String, Object> ret = new HashMap<String, Object>();
+
+    public Map<String, Object> compile(final String query, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
+        final Map<String, Object> ret = new HashMap<>();
         DBBroker broker = null;
         XQueryPool pool = null;
         CompiledXQuery compiled = null;
@@ -2677,37 +2092,28 @@ public class RpcConnection implements RpcAPI {
             final XQuery xquery = broker.getXQueryService();
             pool = xquery.getXQueryPool();
             compiled = compile(broker, source, parameters);
-            
+
         } catch (final XPathException e) {
             ret.put(RpcAPI.ERROR, e.getMessage());
-            if(e.getLine() != 0) {
-                ret.put(RpcAPI.LINE, Integer.valueOf(e.getLine()));
-                ret.put(RpcAPI.COLUMN, Integer.valueOf(e.getColumn()));
+            if (e.getLine() != 0) {
+                ret.put(RpcAPI.LINE, e.getLine());
+                ret.put(RpcAPI.COLUMN, e.getColumn());
             }
 
-        } catch (final Throwable e) {
+        } catch (final EXistException | IOException | PermissionDeniedException e) {
             handleException(e);
 
         } finally {
             factory.getBrokerPool().release(broker);
-            if(compiled != null && pool != null)
-                {pool.returnCompiledXQuery(source, compiled);}
+            if (compiled != null && pool != null) {
+                pool.returnCompiledXQuery(source, compiled);
+            }
         }
         return ret;
     }
-    
-    /**
-     * The method <code>query</code>
-     *
-     * @param xpath a <code>String</code> value
-     * @param howmany an <code>int</code> value
-     * @param start an <code>int</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     */
-    public String query(String xpath, int howmany, int start,
-            HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+
+    public String query(final String xpath, final int howmany, final int start,
+            final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         final long startTime = System.currentTimeMillis();
         String result = null;
         DBBroker broker = null;
@@ -2718,13 +2124,15 @@ public class RpcConnection implements RpcAPI {
             source = new StringSource(xpath);
             compiled = compile(broker, source, parameters);
             final QueryResult qr = doQuery(broker, compiled, null, parameters);
-            if (qr == null)
-                {return "<?xml version=\"1.0\"?>\n"
+            if (qr == null) {
+                return "<?xml version=\"1.0\"?>\n"
                         + "<exist:result xmlns:exist=\"" + Namespaces.EXIST_NS + "\" "
-                        + "hitCount=\"0\"/>";}
-            if (qr.hasErrors())
-                {throw qr.getException();}
-            
+                        + "hitCount=\"0\"/>";
+            }
+            if (qr.hasErrors()) {
+                throw qr.getException();
+            }
+
             result = printAll(broker, qr.result, howmany, start, parameters,
                     (System.currentTimeMillis() - startTime));
 
@@ -2732,50 +2140,31 @@ public class RpcConnection implements RpcAPI {
             handleException(e);
 
         } finally {
-            if(compiled != null) {
+            if (compiled != null) {
                 compiled.getContext().runCleanupTasks();
-                broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
+                if (broker != null) {
+                    broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
+                }
             }
             factory.getBrokerPool().release(broker);
         }
         return result;
     }
-    
-    /**
-     * The method <code>queryP</code>
-     *
-     * @param xpath a <code>String</code> value
-     * @param documentPath a <code>String</code> value
-     * @param s_id a <code>String</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    public HashMap<String, Object> queryP(String xpath, String documentPath,
-            String s_id, HashMap<String, Object> parameters) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return queryP(xpath,
-                      (documentPath==null) ? null : XmldbURI.xmldbUriFor(documentPath),
-                      s_id, parameters);
-    }    
-    
-    /**
-     * The method <code>queryP</code>
-     *
-     * @param xpath a <code>String</code> value
-     * @param docUri a <code>XmldbURI</code> value
-     * @param s_id a <code>String</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
-    private HashMap<String, Object> queryP(String xpath, XmldbURI docUri,
-            String s_id, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+
+    public Map<String, Object> queryP(final String xpath, final String documentPath,
+            final String s_id, final Map<String, Object> parameters) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return queryP(xpath,
+                (documentPath == null) ? null : XmldbURI.xmldbUriFor(documentPath),
+                s_id, parameters);
+    }
+
+    private Map<String, Object> queryP(final String xpath, final XmldbURI docUri,
+            final String s_id, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         final long startTime = System.currentTimeMillis();
         final String sortBy = (String) parameters.get(RpcAPI.SORT_EXPR);
-        
-        final HashMap<String, Object> ret = new HashMap<String, Object>();
-        final List<Object> result = new ArrayList<Object>();
+
+        final Map<String, Object> ret = new HashMap<>();
+        final List result = new ArrayList();
         NodeSet nodes = null;
         QueryResult queryResult;
         Sequence resultSeq = null;
@@ -2789,8 +2178,8 @@ public class RpcConnection implements RpcAPI {
                 final Object[] docs = new Object[1];
                 docs[0] = docUri.toString();
                 parameters.put(RpcAPI.STATIC_DOCUMENTS, docs);
-                
-                if(s_id.length() > 0) {
+
+                if (s_id.length() > 0) {
                     final NodeId nodeId = factory.getBrokerPool().getNodeFactory().createFromString(s_id);
                     final NodeProxy node = new NodeProxy(doc, nodeId);
                     nodes = new ExtArrayNodeSet(1);
@@ -2799,143 +2188,26 @@ public class RpcConnection implements RpcAPI {
             }
             source = new StringSource(xpath);
             compiled = compile(broker, source, parameters);
-            
+
             queryResult = doQuery(broker, compiled, nodes, parameters);
-            if (queryResult == null)
-                {return ret;}
-            if (queryResult.hasErrors()) {
-                // return an error description
-                final XPathException e = queryResult.getException();
-                ret.put(RpcAPI.ERROR, e.getMessage());
-                if(e.getLine() != 0) {
-                    ret.put(RpcAPI.LINE, Integer.valueOf(e.getLine()));
-                    ret.put(RpcAPI.COLUMN, Integer.valueOf(e.getColumn()));
-                }
-                return ret;
-            }
-            resultSeq = queryResult.result;
-            if (LOG.isDebugEnabled())
-            	{LOG.debug("found " + resultSeq.getItemCount());}
-            
-            if (sortBy != null) {
-                SortedNodeSet sorted = new SortedNodeSet(factory.getBrokerPool(), user,
-                        sortBy, AccessContext.XMLRPC);
-                sorted.addAll(resultSeq);
-                resultSeq = sorted;
-            }
-            NodeProxy p;
-            Vector<String> entry;
-            if (resultSeq != null) {
-                final SequenceIterator i = resultSeq.iterate();
-                if (i != null) {
-                    Item next;
-                    while (i.hasNext()) {
-                        next = i.nextItem();
-                        if (Type.subTypeOf(next.getType(), Type.NODE)) {
-                            entry = new Vector<String>();
-                            if (((NodeValue) next).getImplementationType() == NodeValue.PERSISTENT_NODE) {
-                                p = (NodeProxy) next;
-                                entry.addElement(p.getOwnerDocument().getURI().toString());
-                                entry.addElement(p.getNodeId().toString());
-                            } else {
-                                entry.addElement("temp_xquery/" + next.hashCode());
-                                entry.addElement(String.valueOf(((NodeImpl) next).getNodeNumber()));
-                            }
-                            result.add(entry);
-                        } else
-                            {result.add(next.getStringValue());}
-                    }
-                } else {
-                    LOG.debug("sequence iterator is null. Should not");
-                }
-            } else
-                {LOG.debug("result sequence is null. Skipping it...");}
-
-        } catch (final Throwable e) {
-            handleException(e);
-            return null;
-
-        } finally {
-            
-            if(compiled != null) {
-                compiled.getContext().runCleanupTasks();
-                broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
-            }
-            
-            factory.getBrokerPool().release(broker);
-        }
-        
-        queryResult.result = resultSeq;
-        queryResult.queryTime = (System.currentTimeMillis() - startTime);
-        final int id = factory.resultSets.add(queryResult);
-        ret.put("id", Integer.valueOf(id));
-        ret.put("hash", Integer.valueOf(queryResult.hashCode()));
-        ret.put("results", result);
-        return ret;
-    }
-    
-    
-    /**
-     * The method <code>execute</code>
-     *
-     * @param pathToQuery database path pointing to a stored XQuery
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
-    @Override
-    public HashMap<String, Object> execute(final String pathToQuery, final HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
-        final long startTime = System.currentTimeMillis();
-        
-        final String sortBy = (String) parameters.get(RpcAPI.SORT_EXPR);
-        
-        final HashMap<String, Object> ret = new HashMap<String, Object>();
-        final List<Object> result = new ArrayList<Object>();
-        final NodeSet nodes = null;
-        QueryResult queryResult;
-        Sequence resultSeq = null;
-        DBBroker broker = null;
-        BinaryDocument xquery = null;
-        Source source = null;
-        CompiledXQuery compiled = null;
-        try {
-            broker = factory.getBrokerPool().get(user);
-            
-            xquery = (BinaryDocument)broker.getResource(XmldbURI.createInternal(pathToQuery), Lock.READ_LOCK);
-            
-            if(xquery == null) {
-                throw new EXistException("Resource " + pathToQuery + " not found");
-            }
-
-            if(xquery.getResourceType() != DocumentImpl.BINARY_FILE) {
-                throw new EXistException("Document " + pathToQuery + " is not a binary resource");
-            }
-
-            if(!xquery.getPermissions().validate(user, Permission.READ | Permission.EXECUTE)) {
-                throw new PermissionDeniedException("Insufficient privileges to access resource");
-            }
-            
-            source = new DBSource(broker, xquery, true);
-            compiled = compile(broker, source, parameters);
-            queryResult = doQuery(broker, compiled, nodes, parameters);
-            if(queryResult == null) {
+            if (queryResult == null) {
                 return ret;
             }
             if (queryResult.hasErrors()) {
                 // return an error description
                 final XPathException e = queryResult.getException();
                 ret.put(RpcAPI.ERROR, e.getMessage());
-                if(e.getLine() != 0) {
-                    ret.put(RpcAPI.LINE, Integer.valueOf(e.getLine()));
-                    ret.put(RpcAPI.COLUMN, Integer.valueOf(e.getColumn()));
+                if (e.getLine() != 0) {
+                    ret.put(RpcAPI.LINE, e.getLine());
+                    ret.put(RpcAPI.COLUMN, e.getColumn());
                 }
                 return ret;
             }
             resultSeq = queryResult.result;
             if (LOG.isDebugEnabled()) {
-            	LOG.debug("found " + resultSeq.getItemCount());
+                LOG.debug("found " + resultSeq.getItemCount());
             }
-            
+
             if (sortBy != null) {
                 SortedNodeSet sorted = new SortedNodeSet(factory.getBrokerPool(), user,
                         sortBy, AccessContext.XMLRPC);
@@ -2951,17 +2223,14 @@ public class RpcConnection implements RpcAPI {
                     while (i.hasNext()) {
                         next = i.nextItem();
                         if (Type.subTypeOf(next.getType(), Type.NODE)) {
-                            entry = new ArrayList<String>();
+                            entry = new ArrayList<>();
                             if (((NodeValue) next).getImplementationType() == NodeValue.PERSISTENT_NODE) {
                                 p = (NodeProxy) next;
                                 entry.add(p.getOwnerDocument().getURI().toString());
                                 entry.add(p.getNodeId().toString());
                             } else {
-                                entry.add("temp_xquery/"
-                                        + next.hashCode());
-                                entry.add(String
-                                        .valueOf(((NodeImpl) next)
-                                        .getNodeNumber()));
+                                entry.add("temp_xquery/" + next.hashCode());
+                                entry.add(String.valueOf(((NodeImpl) next).getNodeNumber()));
                             }
                             result.add(entry);
                         } else {
@@ -2980,67 +2249,168 @@ public class RpcConnection implements RpcAPI {
             return null;
 
         } finally {
-            if(compiled != null) {
+
+            if (compiled != null) {
                 compiled.getContext().runCleanupTasks();
-                broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
+                if (broker != null) {
+                    broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
+                }
+            }
+
+            factory.getBrokerPool().release(broker);
+        }
+
+        queryResult.result = resultSeq;
+        queryResult.queryTime = (System.currentTimeMillis() - startTime);
+        final int id = factory.resultSets.add(queryResult);
+        ret.put("id", id);
+        ret.put("hash", queryResult.hashCode());
+        ret.put("results", result);
+        return ret;
+    }
+
+    @Override
+    public Map<String, Object> execute(final String pathToQuery, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
+        final long startTime = System.currentTimeMillis();
+
+        final String sortBy = (String) parameters.get(RpcAPI.SORT_EXPR);
+
+        final Map<String, Object> ret = new HashMap<>();
+        final List result = new ArrayList();
+        final NodeSet nodes = null;
+        QueryResult queryResult;
+        Sequence resultSeq = null;
+        DBBroker broker = null;
+        BinaryDocument xquery = null;
+        Source source = null;
+        CompiledXQuery compiled = null;
+        try {
+            broker = factory.getBrokerPool().get(user);
+
+            xquery = (BinaryDocument) broker.getResource(XmldbURI.createInternal(pathToQuery), Lock.READ_LOCK);
+
+            if (xquery == null) {
+                throw new EXistException("Resource " + pathToQuery + " not found");
+            }
+
+            if (xquery.getResourceType() != DocumentImpl.BINARY_FILE) {
+                throw new EXistException("Document " + pathToQuery + " is not a binary resource");
+            }
+
+            if (!xquery.getPermissions().validate(user, Permission.READ | Permission.EXECUTE)) {
+                throw new PermissionDeniedException("Insufficient privileges to access resource");
+            }
+
+            source = new DBSource(broker, xquery, true);
+            compiled = compile(broker, source, parameters);
+            queryResult = doQuery(broker, compiled, nodes, parameters);
+            if (queryResult == null) {
+                return ret;
+            }
+            if (queryResult.hasErrors()) {
+                // return an error description
+                final XPathException e = queryResult.getException();
+                ret.put(RpcAPI.ERROR, e.getMessage());
+                if (e.getLine() != 0) {
+                    ret.put(RpcAPI.LINE, e.getLine());
+                    ret.put(RpcAPI.COLUMN, e.getColumn());
+                }
+                return ret;
+            }
+            resultSeq = queryResult.result;
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("found " + resultSeq.getItemCount());
+            }
+
+            if (sortBy != null) {
+                SortedNodeSet sorted = new SortedNodeSet(factory.getBrokerPool(), user,
+                        sortBy, AccessContext.XMLRPC);
+                sorted.addAll(resultSeq);
+                resultSeq = sorted;
+            }
+            NodeProxy p;
+            List<String> entry;
+            if (resultSeq != null) {
+                final SequenceIterator i = resultSeq.iterate();
+                if (i != null) {
+                    Item next;
+                    while (i.hasNext()) {
+                        next = i.nextItem();
+                        if (Type.subTypeOf(next.getType(), Type.NODE)) {
+                            entry = new ArrayList<>();
+                            if (((NodeValue) next).getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                                p = (NodeProxy) next;
+                                entry.add(p.getOwnerDocument().getURI().toString());
+                                entry.add(p.getNodeId().toString());
+                            } else {
+                                entry.add("temp_xquery/"
+                                        + next.hashCode());
+                                entry.add(String
+                                        .valueOf(((NodeImpl) next)
+                                                .getNodeNumber()));
+                            }
+                            result.add(entry);
+                        } else {
+                            result.add(next.getStringValue());
+                        }
+                    }
+                } else {
+                    LOG.debug("sequence iterator is null. Should not");
+                }
+            } else {
+                LOG.debug("result sequence is null. Skipping it...");
+            }
+
+        } catch (final Throwable e) {
+            handleException(e);
+            return null;
+
+        } finally {
+            if (compiled != null) {
+                compiled.getContext().runCleanupTasks();
+                if (broker != null) {
+                    broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
+                }
             }
             factory.getBrokerPool().release(broker);
-            
-            if(xquery != null) {
+
+            if (xquery != null) {
                 xquery.getUpdateLock().release(Lock.READ_LOCK);
             }
         }
         queryResult.result = resultSeq;
         queryResult.queryTime = (System.currentTimeMillis() - startTime);
         final int id = factory.resultSets.add(queryResult);
-        ret.put("id", Integer.valueOf(id));
-        ret.put("hash", Integer.valueOf(queryResult.hashCode()));
+        ret.put("id", id);
+        ret.put("hash", queryResult.hashCode());
         ret.put("results", result);
         return ret;
     }
-    
-    /**
-     * The method <code>releaseQueryResult</code>
-     *
-     * @param handle an <code>int</code> value
-     */
+
     @Override
-    public boolean releaseQueryResult(int handle) {
+    public boolean releaseQueryResult(final int handle) {
         factory.resultSets.remove(handle);
         LOG.debug("removed query result with handle " + handle);
         return true;
     }
 
     @Override
-    public boolean releaseQueryResult(int handle, int hash) {
+    public boolean releaseQueryResult(final int handle, final int hash) {
         factory.resultSets.remove(handle, hash);
         LOG.debug("removed query result with handle " + handle);
         return true;
     }
 
-    /**
-     * The method <code>remove</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
-    public boolean remove(String documentPath) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return remove(XmldbURI.xmldbUriFor(documentPath));
-    }    
+    public boolean remove(final String documentPath) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return remove(XmldbURI.xmldbUriFor(documentPath));
+    }
 
-    /**
-     * The method <code>remove</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean remove(XmldbURI docUri) throws EXistException, PermissionDeniedException {
+    private boolean remove(final XmldbURI docUri) throws EXistException, PermissionDeniedException {
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        Collection collection = null;
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
+        Collection collection;
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
             collection = broker.openCollection(docUri.removeLastSegment(), Lock.WRITE_LOCK);
             if (collection == null) {
                 transact.abort(transaction);
@@ -3054,11 +2424,12 @@ public class RpcConnection implements RpcAPI {
                 transact.abort(transaction);
                 throw new EXistException("Document " + docUri + " not found");
             }
-            
-            if(doc.getResourceType() == DocumentImpl.BINARY_FILE)
-                {collection.removeBinaryResource(transaction, broker, doc);}
-            else
-                {collection.removeXMLResource(transaction, broker, docUri.lastSegment());}
+
+            if (doc.getResourceType() == DocumentImpl.BINARY_FILE) {
+                collection.removeBinaryResource(transaction, broker, doc);
+            } else {
+                collection.removeXMLResource(transaction, broker, docUri.lastSegment());
+            }
             transact.commit(transaction);
             return true;
 
@@ -3067,35 +2438,20 @@ public class RpcConnection implements RpcAPI {
             return false;
         }
     }
-    
-    /**
-     * The method <code>removeCollection</code>
-     *
-     * @param collectionName a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public boolean removeCollection(String collectionName) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return removeCollection(XmldbURI.xmldbUriFor(collectionName));
-    } 
-    
-    /**
-     * The method <code>removeCollection</code>
-     *
-     * @param collURI a <code>XmldbURI</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean removeCollection(XmldbURI collURI) throws EXistException, PermissionDeniedException {
+    public boolean removeCollection(final String collectionName) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return removeCollection(XmldbURI.xmldbUriFor(collectionName));
+    }
+
+    private boolean removeCollection(final XmldbURI collURI) throws EXistException, PermissionDeniedException {
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        Collection collection = null;
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
+        Collection collection;
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
             collection = broker.openCollection(collURI, Lock.WRITE_LOCK);
             if (collection == null) {
-            	transact.abort(transaction);
+                transact.abort(transaction);
                 return false;
             }
             // keep the write lock in the transaction
@@ -3110,23 +2466,15 @@ public class RpcConnection implements RpcAPI {
             return false;
         }
     }
-    
-    /**
-     * The method <code>removeUser</code>
-     *
-     * @param name a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
+
     @Override
     public boolean removeAccount(final String name) throws EXistException, PermissionDeniedException {
         final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
-        
-        if(!manager.hasAdminPrivileges(user)) {
+
+        if (!manager.hasAdminPrivileges(user)) {
             throw new PermissionDeniedException("you are not allowed to remove users");
         }
-        
+
         try {
             executeWithBroker(new BrokerOperation<Void>() {
                 @Override
@@ -3138,73 +2486,54 @@ public class RpcConnection implements RpcAPI {
         } catch (final URISyntaxException use) {
             throw new EXistException(use.getMessage(), use);
         }
-        
+
         return true;
     }
 
     @Override
-    public byte[] retrieve(String doc, String id, HashMap<String, Object> parameters)
+    public byte[] retrieve(final String doc, final String id, final Map<String, Object> parameters)
             throws EXistException, PermissionDeniedException {
-        String xml = null;
         try {
-            xml = retrieveAsString(doc, id, parameters);
+            final String xml = retrieveAsString(doc, id, parameters);
             try {
                 String encoding = (String) parameters.get(OutputKeys.ENCODING);
-                if (encoding == null)
-                    {encoding = DEFAULT_ENCODING;}
+                if (encoding == null) {
+                    encoding = DEFAULT_ENCODING;
+                }
                 return xml.getBytes(encoding);
             } catch (final UnsupportedEncodingException uee) {
                 LOG.warn(uee);
                 return xml.getBytes();
             }
 
-        } catch (final Throwable e) {
+        } catch (final URISyntaxException | EXistException | PermissionDeniedException e) {
             handleException(e);
             return null;
         }
     }
 
-    /**
-     * The method <code>retrieve</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @param s_id a <code>String</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
-    public String retrieveAsString(String documentPath, String s_id,
-            HashMap<String, Object> parameters) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return retrieve(XmldbURI.xmldbUriFor(documentPath),s_id,parameters);
-    }    
+    public String retrieveAsString(final String documentPath, final String s_id,
+            final Map<String, Object> parameters) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return retrieve(XmldbURI.xmldbUriFor(documentPath), s_id, parameters);
+    }
 
-    /**
-     * The method <code>retrieve</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @param s_id a <code>String</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     */
-    private String retrieve(XmldbURI docUri, String s_id,
-            HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+    private String retrieve(final XmldbURI docUri, final String s_id,
+            final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
             final NodeId nodeId = factory.getBrokerPool().getNodeFactory().createFromString(s_id);
             DocumentImpl doc;
-                LOG.debug("loading doc " + docUri);
-                doc = (DocumentImpl) broker.getXMLResource(docUri);
+            LOG.debug("loading doc " + docUri);
+            doc = (DocumentImpl) broker.getXMLResource(docUri);
             final NodeProxy node = new NodeProxy(doc, nodeId);
             final Serializer serializer = broker.getSerializer();
             serializer.reset();
-            serializer.setProperties(parameters);
+            serializer.setProperties(toProperties(parameters));
             return serializer.serialize(node);
 
-        } catch (final Throwable e) {
+        } catch (final EXistException | PermissionDeniedException | SAXException e) {
             handleException(e);
             return null;
 
@@ -3213,99 +2542,88 @@ public class RpcConnection implements RpcAPI {
         }
     }
 
-    /**
-     * The method <code>retrieveFirstChunk</code>
-     *
-     * @param docName a <code>String</code> value
-     * @param id a <code>String</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
     @Override
-    public HashMap<String, Object> retrieveFirstChunk(String docName, String id, HashMap<String, Object> parameters)
-    	throws EXistException, PermissionDeniedException
-    {
-    	DBBroker broker = null;
-    	String encoding = (String) parameters.get(OutputKeys.ENCODING);
-    	if (encoding == null)
-    		{encoding = DEFAULT_ENCODING;}
-    	String compression = "no";
-    	if (((String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT)) != null) {
-    		compression = (String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT);
-    	}
-    	try {
-    		final XmldbURI docUri=XmldbURI.xmldbUriFor(docName);
-    		broker = factory.getBrokerPool().get(user);
-    		final NodeId nodeId = factory.getBrokerPool().getNodeFactory().createFromString(id);
-    		DocumentImpl doc;
-    		LOG.debug("loading doc " + docUri);
-    		doc = (DocumentImpl) broker.getXMLResource(docUri);
-    		final NodeProxy node = new NodeProxy(doc, nodeId);
+    public Map<String, Object> retrieveFirstChunk(final String docName, final String id, final Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException {
+        DBBroker broker = null;
+        String encoding = (String) parameters.get(OutputKeys.ENCODING);
+        if (encoding == null) {
+            encoding = DEFAULT_ENCODING;
+        }
+        String compression = "no";
+        if (((String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT)) != null) {
+            compression = (String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT);
+        }
+        try {
+            final XmldbURI docUri = XmldbURI.xmldbUriFor(docName);
+            broker = factory.getBrokerPool().get(user);
+            final NodeId nodeId = factory.getBrokerPool().getNodeFactory().createFromString(id);
+            DocumentImpl doc;
+            LOG.debug("loading doc " + docUri);
+            doc = (DocumentImpl) broker.getXMLResource(docUri);
+            final NodeProxy node = new NodeProxy(doc, nodeId);
 
-    		final Serializer serializer = broker.getSerializer();
-    		serializer.reset();
-    		serializer.setProperties(parameters);
+            final Serializer serializer = broker.getSerializer();
+            serializer.reset();
+            serializer.setProperties(toProperties(parameters));
 
-    		final HashMap<String, Object> result = new HashMap<String, Object>();
-    		VirtualTempFile vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE,MAX_DOWNLOAD_CHUNK_SIZE);
-    		vtempFile.setTempPrefix("eXistRPCC");
-    		vtempFile.setTempPostfix(".xml");
+            final Map<String, Object> result = new HashMap<>();
+            VirtualTempFile vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE, MAX_DOWNLOAD_CHUNK_SIZE);
+            vtempFile.setTempPrefix("eXistRPCC");
+            vtempFile.setTempPostfix(".xml");
 
-    		OutputStream os=null;
-    		if("yes".equals(compression)) {
-    			LOG.debug("get result with compression");
-    			os = new DeflaterOutputStream(vtempFile);
-    		} else {
-    			os = vtempFile;
-    		}
-    		try {
-    			final Writer writer = new OutputStreamWriter(os, encoding);
-    			try {
-    				serializer.serialize(node, writer);
-    			} finally {
-    				writer.close();
-    			}
-    		} finally {
-    			try {
-    				os.close();
-    			} catch(final IOException ioe) {
-    				//IgnoreIT(R)
-    			}
-    			if(os!=vtempFile)
-    				try {
-    					vtempFile.close();
-    				} catch(final IOException ioe) {
-    					//IgnoreIT(R)
-    				}
-    		}
+            OutputStream os = null;
+            if ("yes".equals(compression)) {
+                LOG.debug("get result with compression");
+                os = new DeflaterOutputStream(vtempFile);
+            } else {
+                os = vtempFile;
+            }
+            try {
+                try (final Writer writer = new OutputStreamWriter(os, encoding)) {
+                    serializer.serialize(node, writer);
+                }
+            } finally {
+                try {
+                    os.close();
+                } catch (final IOException ioe) {
+                    //IgnoreIT(R)
+                }
+                if (os != vtempFile) {
+                    try {
+                        vtempFile.close();
+                    } catch (final IOException ioe) {
+                        //IgnoreIT(R)
+                    }
+                }
+            }
 
-    		final byte[] firstChunk = vtempFile.getChunk(0);
-    		result.put("data", firstChunk);
-    		int offset = 0;
-    		if(vtempFile.length() > MAX_DOWNLOAD_CHUNK_SIZE) {
-    			offset = firstChunk.length;
+            final byte[] firstChunk = vtempFile.getChunk(0);
+            result.put("data", firstChunk);
+            int offset = 0;
+            if (vtempFile.length() > MAX_DOWNLOAD_CHUNK_SIZE) {
+                offset = firstChunk.length;
 
-    			final int handle = factory.resultSets.add(new SerializedResult(vtempFile));
-    			result.put("handle", Integer.toString(handle));
-    			result.put("supports-long-offset", Boolean.TRUE);
-    		} else {
-    			vtempFile.delete();
-    		}
-    		result.put("offset", Integer.valueOf(offset));
-    		return result;
+                final int handle = factory.resultSets.add(new SerializedResult(vtempFile));
+                result.put("handle", Integer.toString(handle));
+                result.put("supports-long-offset", Boolean.TRUE);
+            } else {
+                vtempFile.delete();
+            }
+            result.put("offset", offset);
+            return result;
 
-    	} catch (final Throwable e) {
-    		handleException(e);
-    		return null;
+        } catch (final URISyntaxException | EXistException | PermissionDeniedException | IOException | SAXException e) {
+            handleException(e);
+            return null;
 
-    	} finally {
-    		factory.getBrokerPool().release(broker);
-    	}
+        } finally {
+            factory.getBrokerPool().release(broker);
+        }
     }
 
     @Override
-    public byte[] retrieve(int resultId, int num, HashMap<String, Object> parameters)
+    public byte[] retrieve(int resultId, int num, Map<String, Object> parameters)
             throws EXistException, PermissionDeniedException {
         String compression = "no";
         if (((String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT)) != null) {
@@ -3315,8 +2633,9 @@ public class RpcConnection implements RpcAPI {
         try {
             final String xml = retrieveAsString(resultId, num, parameters);
             String encoding = (String) parameters.get(OutputKeys.ENCODING);
-            if (encoding == null)
-                {encoding = DEFAULT_ENCODING;}
+            if (encoding == null) {
+                encoding = DEFAULT_ENCODING;
+            }
             try {
 
                 if ("no".equals(compression)) {
@@ -3342,36 +2661,29 @@ public class RpcConnection implements RpcAPI {
         }
     }
 
-    /**
-     * The method <code>retrieve</code>
-     *
-     * @param resultId an <code>int</code> value
-     * @param num an <code>int</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     */
-    private String retrieveAsString(int resultId, int num,
-            HashMap<String, Object> parameters) throws Exception {
+    private String retrieveAsString(final int resultId, final int num,
+            final Map<String, Object> parameters) throws Exception {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
             final QueryResult qr = factory.resultSets.getResult(resultId);
-            if (qr == null)
-                {throw new EXistException("result set unknown or timed out");}
+            if (qr == null) {
+                throw new EXistException("result set unknown or timed out");
+            }
             qr.touch();
             final Item item = qr.result.itemAt(num);
-            if (item == null)
-                {throw new EXistException("index out of range");}
-            
-            if(Type.subTypeOf(item.getType(), Type.NODE)) {
-                final NodeValue nodeValue = (NodeValue)item;
+            if (item == null) {
+                throw new EXistException("index out of range");
+            }
+
+            if (Type.subTypeOf(item.getType(), Type.NODE)) {
+                final NodeValue nodeValue = (NodeValue) item;
                 final Serializer serializer = broker.getSerializer();
                 serializer.reset();
                 for (final Map.Entry<Object, Object> entry : qr.serialization.entrySet()) {
                     parameters.put(entry.getKey().toString(), entry.getValue().toString());
                 }
-                serializer.setProperties(parameters);
+                serializer.setProperties(toProperties(parameters));
                 return serializer.serialize(nodeValue);
             } else {
                 return item.getStringValue();
@@ -3381,119 +2693,106 @@ public class RpcConnection implements RpcAPI {
         }
     }
 
-    /**
-     * The method <code>retrieveFirstChunk</code>
-     *
-     * @param resultId an <code>int</code> value
-     * @param num an <code>int</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
     @Override
-    public HashMap<String, Object> retrieveFirstChunk(int resultId, int num, HashMap<String, Object> parameters)
-    	throws EXistException, PermissionDeniedException
-    {
-    	String encoding = (String) parameters.get(OutputKeys.ENCODING);
-    	if (encoding == null)
-    		{encoding = DEFAULT_ENCODING;}
-    	String compression = "no";
-    	if (((String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT)) != null) {
-    		compression = (String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT);
-    	}
-    	DBBroker broker = null;
-    	try {
-    		broker = factory.getBrokerPool().get(user);
-    		final QueryResult qr = factory.resultSets.getResult(resultId);
-    		if (qr == null)
-    			{throw new EXistException("result set unknown or timed out: " + resultId);}
-    		qr.touch();
-    		final Item item = qr.result.itemAt(num);
-    		if (item == null)
-    			{throw new EXistException("index out of range");}
+    public Map<String, Object> retrieveFirstChunk(final int resultId, final int num, final Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException {
+        String encoding = (String) parameters.get(OutputKeys.ENCODING);
+        if (encoding == null) {
+            encoding = DEFAULT_ENCODING;
+        }
+        String compression = "no";
+        if (((String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT)) != null) {
+            compression = (String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT);
+        }
+        DBBroker broker = null;
+        try {
+            broker = factory.getBrokerPool().get(user);
+            final QueryResult qr = factory.resultSets.getResult(resultId);
+            if (qr == null) {
+                throw new EXistException("result set unknown or timed out: " + resultId);
+            }
+            qr.touch();
+            final Item item = qr.result.itemAt(num);
+            if (item == null) {
+                throw new EXistException("index out of range");
+            }
 
-    		final HashMap<String, Object> result = new HashMap<String, Object>();
-    		VirtualTempFile vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE,MAX_DOWNLOAD_CHUNK_SIZE);
-    		vtempFile.setTempPrefix("eXistRPCC");
-    		vtempFile.setTempPostfix(".xml");
+            final Map<String, Object> result = new HashMap<>();
+            VirtualTempFile vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE, MAX_DOWNLOAD_CHUNK_SIZE);
+            vtempFile.setTempPrefix("eXistRPCC");
+            vtempFile.setTempPostfix(".xml");
 
-    		OutputStream os=null;
-    		if("yes".equals(compression)) {
-    			LOG.debug("get result with compression");
-    			os = new DeflaterOutputStream(vtempFile);
-    		} else {
-    			os = vtempFile;
-    		}
-    		try {
-    			final Writer writer = new OutputStreamWriter(os, encoding);
-    			try {
-    				if(Type.subTypeOf(item.getType(), Type.NODE)) {
-    					final NodeValue nodeValue = (NodeValue)item;
-    					final Serializer serializer = broker.getSerializer();
-    					serializer.reset();
-    					for (final Map.Entry<Object, Object> entry : qr.serialization.entrySet()) {
-    						parameters.put(entry.getKey().toString(), entry.getValue().toString());
-    					}
-    					serializer.setProperties(parameters);
+            OutputStream os;
+            if ("yes".equals(compression)) {
+                LOG.debug("get result with compression");
+                os = new DeflaterOutputStream(vtempFile);
+            } else {
+                os = vtempFile;
+            }
+            try {
+                try (final Writer writer = new OutputStreamWriter(os, encoding)) {
+                    if (Type.subTypeOf(item.getType(), Type.NODE)) {
+                        final NodeValue nodeValue = (NodeValue) item;
+                        final Serializer serializer = broker.getSerializer();
+                        serializer.reset();
+                        for (final Map.Entry<Object, Object> entry : qr.serialization.entrySet()) {
+                            parameters.put(entry.getKey().toString(), entry.getValue().toString());
+                        }
+                        serializer.setProperties(toProperties(parameters));
 
-    					serializer.serialize(nodeValue, writer);
-    				} else {
-    					writer.write(item.getStringValue());
-    				}
-    			} finally {
-    				try {
-    					writer.close();
-    				} catch(final IOException ioe) {
-    					//IgnoreIT(R)
-    				}
-    			}
-    		} finally {
-    			try {
-    				os.close();
-    			} catch(final IOException ioe) {
-    				//IgnoreIT(R)
-    			}
-    			if(os!=vtempFile)
-    				try {
-    					vtempFile.close();
-    				} catch(final IOException ioe) {
-    					//IgnoreIT(R)
-    				}
-    		}
+                        serializer.serialize(nodeValue, writer);
+                    } else {
+                        writer.write(item.getStringValue());
+                    }
+                }
+            } finally {
+                try {
+                    os.close();
+                } catch (final IOException ioe) {
+                    //IgnoreIT(R)
+                }
+                if (os != vtempFile) {
+                    try {
+                        vtempFile.close();
+                    } catch (final IOException ioe) {
+                        //IgnoreIT(R)
+                    }
+                }
+            }
 
-    		final byte[] firstChunk = vtempFile.getChunk(0);
-    		result.put("data", firstChunk);
-    		int offset = 0;
-    		if(vtempFile.length() > MAX_DOWNLOAD_CHUNK_SIZE) {
-    			offset = firstChunk.length;
+            final byte[] firstChunk = vtempFile.getChunk(0);
+            result.put("data", firstChunk);
+            int offset = 0;
+            if (vtempFile.length() > MAX_DOWNLOAD_CHUNK_SIZE) {
+                offset = firstChunk.length;
 
-    			final int handle = factory.resultSets.add(new SerializedResult(vtempFile));
-    			result.put("handle", Integer.toString(handle));
-    			result.put("supports-long-offset", Boolean.TRUE);
-    		} else {
-    			vtempFile.delete();
-    		}
-    		result.put("offset", Integer.valueOf(offset));
-    		return result;
+                final int handle = factory.resultSets.add(new SerializedResult(vtempFile));
+                result.put("handle", Integer.toString(handle));
+                result.put("supports-long-offset", Boolean.TRUE);
+            } else {
+                vtempFile.delete();
+            }
+            result.put("offset", offset);
+            return result;
 
-    	} catch (final Throwable e) {
-    		handleException(e);
-    		return null;
+        } catch (final EXistException | IOException | SAXException | XPathException e) {
+            handleException(e);
+            return null;
 
-    	} finally {
-    		factory.getBrokerPool().release(broker);
-    	}
+        } finally {
+            factory.getBrokerPool().release(broker);
+        }
     }
 
-
     @Override
-    public byte[] retrieveAll(int resultId, HashMap<String, Object> parameters) throws EXistException,
+    public byte[] retrieveAll(final int resultId, final Map<String, Object> parameters) throws EXistException,
             PermissionDeniedException {
         try {
             final String xml = retrieveAllAsString(resultId, parameters);
             String encoding = (String) parameters.get(OutputKeys.ENCODING);
-            if (encoding == null)
-                {encoding = DEFAULT_ENCODING;}
+            if (encoding == null) {
+                encoding = DEFAULT_ENCODING;
+            }
             try {
                 return xml.getBytes(encoding);
             } catch (final UnsupportedEncodingException uee) {
@@ -3507,52 +2806,36 @@ public class RpcConnection implements RpcAPI {
         }
     }
 
-    /**
-     * The method <code>retrieveAll</code>
-     *
-     * @param resultId an <code>int</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     */
-    private String retrieveAllAsString(int resultId, HashMap<String, Object> parameters) throws Exception {
+    private String retrieveAllAsString(final int resultId, final Map<String, Object> parameters) throws Exception {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
             final QueryResult qr = factory.resultSets.getResult(resultId);
-            if (qr == null)
-                {throw new EXistException("result set unknown or timed out");}
+            if (qr == null) {
+                throw new EXistException("result set unknown or timed out");
+            }
             qr.touch();
             final Serializer serializer = broker.getSerializer();
             serializer.reset();
             serializer.setProperties(qr.serialization);
-            
+
             final SAXSerializer handler = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
             final StringWriter writer = new StringWriter();
-            handler.setOutput(writer, getProperties(parameters));
-            
+            handler.setOutput(writer, toProperties(parameters));
+
 //			serialize results
             handler.startDocument();
             handler.startPrefixMapping("exist", Namespaces.EXIST_NS);
             final AttributesImpl attribs = new AttributesImpl();
-            attribs.addAttribute(
-                    "",
-                    "hitCount",
-                    "hitCount",
-                    "CDATA",
-                    Integer.toString(qr.result.getItemCount()));
-            handler.startElement(
-            		Namespaces.EXIST_NS,
-                    "result",
-                    "exist:result",
-                    attribs);
+            attribs.addAttribute("", "hitCount", "hitCount", "CDATA", Integer.toString(qr.result.getItemCount()));
+            handler.startElement(Namespaces.EXIST_NS, "result", "exist:result", attribs);
             Item current;
             char[] value;
-            for(final SequenceIterator i = qr.result.iterate(); i.hasNext(); ) {
+            for (final SequenceIterator i = qr.result.iterate(); i.hasNext();) {
                 current = i.nextItem();
-                if(Type.subTypeOf(current.getType(), Type.NODE))
-                    {current.toSAX(broker, handler, null);}
-                else {
+                if (Type.subTypeOf(current.getType(), Type.NODE)) {
+                    current.toSAX(broker, handler, null);
+                } else {
                     value = current.toString().toCharArray();
                     handler.characters(value, 0, value.length);
                 }
@@ -3566,140 +2849,131 @@ public class RpcConnection implements RpcAPI {
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>retrieveAllFirstChunk</code>
-     *
-     * @param resultId an <code>int</code> value
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     */
+
     @Override
-    public HashMap<String, Object> retrieveAllFirstChunk(int resultId, HashMap<String, Object> parameters)
-    	throws EXistException, PermissionDeniedException
-    {
-    	String encoding = (String) parameters.get(OutputKeys.ENCODING);
-    	if (encoding == null)
-    		{encoding = DEFAULT_ENCODING;}
-    	String compression = "no";
-    	if (((String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT)) != null) {
-    		compression = (String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT);
-    	}
-    	DBBroker broker = null;
-    	try {
-    		broker = factory.getBrokerPool().get(user);
-    		final QueryResult qr = factory.resultSets.getResult(resultId);
-    		if (qr == null)
-    			{throw new EXistException("result set unknown or timed out");}
-    		qr.touch();
-    		final Serializer serializer = broker.getSerializer();
-    		serializer.reset();
-    		for (final Map.Entry<Object, Object> entry : qr.serialization.entrySet()) {
-    			parameters.put(entry.getKey().toString(), entry.getValue().toString());
-    		}
-    		serializer.setProperties(parameters);
-    		final SAXSerializer handler = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
+    public Map<String, Object> retrieveAllFirstChunk(final int resultId, final Map<String, Object> parameters)
+            throws EXistException, PermissionDeniedException {
+        String encoding = (String) parameters.get(OutputKeys.ENCODING);
+        if (encoding == null) {
+            encoding = DEFAULT_ENCODING;
+        }
+        String compression = "no";
+        if (((String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT)) != null) {
+            compression = (String) parameters.get(EXistOutputKeys.COMPRESS_OUTPUT);
+        }
+        DBBroker broker = null;
+        try {
+            broker = factory.getBrokerPool().get(user);
+            final QueryResult qr = factory.resultSets.getResult(resultId);
+            if (qr == null) {
+                throw new EXistException("result set unknown or timed out");
+            }
+            qr.touch();
+            final Serializer serializer = broker.getSerializer();
+            serializer.reset();
+            for (final Map.Entry<Object, Object> entry : qr.serialization.entrySet()) {
+                parameters.put(entry.getKey().toString(), entry.getValue().toString());
+            }
+            serializer.setProperties(toProperties(parameters));
+            final SAXSerializer handler = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
 
-    		final HashMap<String, Object> result = new HashMap<String, Object>();
-    		VirtualTempFile vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE,MAX_DOWNLOAD_CHUNK_SIZE);
-    		vtempFile.setTempPrefix("eXistRPCC");
-    		vtempFile.setTempPostfix(".xml");
+            final Map<String, Object> result = new HashMap<>();
+            VirtualTempFile vtempFile = new VirtualTempFile(MAX_DOWNLOAD_CHUNK_SIZE, MAX_DOWNLOAD_CHUNK_SIZE);
+            vtempFile.setTempPrefix("eXistRPCC");
+            vtempFile.setTempPostfix(".xml");
 
-    		OutputStream os=null;
-    		if("yes".equals(compression)) {
-    			LOG.debug("get result with compression");
-    			os = new DeflaterOutputStream(vtempFile);
-    		} else {
-    			os = vtempFile;
-    		}
-    		try {
-    			final Writer writer = new OutputStreamWriter(os, encoding);
-    			try {
-    				handler.setOutput(writer, getProperties(parameters));
+            OutputStream os;
+            if ("yes".equals(compression)) {
+                LOG.debug("get result with compression");
+                os = new DeflaterOutputStream(vtempFile);
+            } else {
+                os = vtempFile;
+            }
+            try {
+                try (final Writer writer = new OutputStreamWriter(os, encoding)) {
+                    handler.setOutput(writer, toProperties(parameters));
 
-    				// serialize results
-    				handler.startDocument();
-    				handler.startPrefixMapping("exist", Namespaces.EXIST_NS);
-    				final AttributesImpl attribs = new AttributesImpl();
-    				attribs.addAttribute(
-    						"",
-    						"hitCount",
-    						"hitCount",
-    						"CDATA",
-    						Integer.toString(qr.result.getItemCount()));
-    				handler.startElement(
-    						Namespaces.EXIST_NS,
-    						"result",
-    						"exist:result",
-    						attribs);
-    				Item current;
-    				char[] value;
-    				for(final SequenceIterator i = qr.result.iterate(); i.hasNext(); ) {
-    					current = i.nextItem();
-    					if(Type.subTypeOf(current.getType(), Type.NODE))
-    						{((NodeValue)current).toSAX(broker, handler, null);}
-    					else {
-    						value = current.toString().toCharArray();
-    						handler.characters(value, 0, value.length);
-    					}
-    				}
-    				handler.endElement(Namespaces.EXIST_NS, "result", "exist:result");
-    				handler.endPrefixMapping("exist");
-    				handler.endDocument();
-    				SerializerPool.getInstance().returnObject(handler);
-    			} finally {
-    				writer.close();
-    			}
-    		} finally {
-    			try {
-    				os.close();
-    			} catch(final IOException ioe) {
-    				//IgnoreIT(R)
-    			}
-    			if(os!=vtempFile)
-    				try {
-    					vtempFile.close();
-    				} catch(final IOException ioe) {
-    					//IgnoreIT(R)
-    				}
-    		}
+                    // serialize results
+                    handler.startDocument();
+                    handler.startPrefixMapping("exist", Namespaces.EXIST_NS);
+                    final AttributesImpl attribs = new AttributesImpl();
+                    attribs.addAttribute(
+                            "",
+                            "hitCount",
+                            "hitCount",
+                            "CDATA",
+                            Integer.toString(qr.result.getItemCount()));
+                    handler.startElement(
+                            Namespaces.EXIST_NS,
+                            "result",
+                            "exist:result",
+                            attribs);
+                    Item current;
+                    char[] value;
+                    for (final SequenceIterator i = qr.result.iterate(); i.hasNext();) {
+                        current = i.nextItem();
+                        if (Type.subTypeOf(current.getType(), Type.NODE)) {
+                            ((NodeValue) current).toSAX(broker, handler, null);
+                        } else {
+                            value = current.toString().toCharArray();
+                            handler.characters(value, 0, value.length);
+                        }
+                    }
+                    handler.endElement(Namespaces.EXIST_NS, "result", "exist:result");
+                    handler.endPrefixMapping("exist");
+                    handler.endDocument();
+                    SerializerPool.getInstance().returnObject(handler);
+                }
+            } finally {
+                try {
+                    os.close();
+                } catch (final IOException ioe) {
+                    //IgnoreIT(R)
+                }
+                if (os != vtempFile) {
+                    try {
+                        vtempFile.close();
+                    } catch (final IOException ioe) {
+                        //IgnoreIT(R)
+                    }
+                }
+            }
 
-    		final byte[] firstChunk = vtempFile.getChunk(0);
-    		result.put("data", firstChunk);
-    		int offset = 0;
-    		if(vtempFile.length() > MAX_DOWNLOAD_CHUNK_SIZE) {
-    			offset = firstChunk.length;
+            final byte[] firstChunk = vtempFile.getChunk(0);
+            result.put("data", firstChunk);
+            int offset = 0;
+            if (vtempFile.length() > MAX_DOWNLOAD_CHUNK_SIZE) {
+                offset = firstChunk.length;
 
-    			final int handle = factory.resultSets.add(new SerializedResult(vtempFile));
-    			result.put("handle", Integer.toString(handle));
-    			result.put("supports-long-offset", Boolean.TRUE);
-    		} else {
-    			vtempFile.delete();
-    		}
-    		result.put("offset", Integer.valueOf(offset));
-    		return result;
+                final int handle = factory.resultSets.add(new SerializedResult(vtempFile));
+                result.put("handle", Integer.toString(handle));
+                result.put("supports-long-offset", Boolean.TRUE);
+            } else {
+                vtempFile.delete();
+            }
+            result.put("offset", offset);
+            return result;
 
-    	} catch (final Throwable e) {
-    		handleException(e);
-    		return null;
+        } catch (final EXistException | IOException | SAXException | XPathException e) {
+            handleException(e);
+            return null;
 
-    	} finally {
-    		factory.getBrokerPool().release(broker);
-    	}
+        } finally {
+            factory.getBrokerPool().release(broker);
+        }
     }
 
     private interface BrokerOperation<R> {
-        public R withBroker(DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException;
+        public R withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException;
     }
 
-    private <R> R executeWithBroker(BrokerOperation<R> brokerOperation) throws EXistException, URISyntaxException, PermissionDeniedException {
+    private <R> R executeWithBroker(final BrokerOperation<R> brokerOperation) throws EXistException, URISyntaxException, PermissionDeniedException {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
             return brokerOperation.withBroker(broker);
         } finally {
-            if(broker != null) {
+            if (broker != null) {
                 factory.getBrokerPool().release(broker);
             }
         }
@@ -3710,9 +2984,9 @@ public class RpcConnection implements RpcAPI {
         executeWithBroker(new BrokerOperation<Void>() {
             @Override
             public Void withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
-                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier(){
+                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier() {
                     @Override
-                    public void modify(Permission permission) throws PermissionDeniedException {
+                    public void modify(final Permission permission) throws PermissionDeniedException {
                         permission.setGroup(ownerGroup);
                     }
                 });
@@ -3728,9 +3002,9 @@ public class RpcConnection implements RpcAPI {
         executeWithBroker(new BrokerOperation<Void>() {
             @Override
             public Void withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
-                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier(){
+                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier() {
                     @Override
-                    public void modify(Permission permission) throws PermissionDeniedException {
+                    public void modify(final Permission permission) throws PermissionDeniedException {
                         permission.setOwner(owner);
                     }
                 });
@@ -3746,9 +3020,9 @@ public class RpcConnection implements RpcAPI {
         executeWithBroker(new BrokerOperation<Void>() {
             @Override
             public Void withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
-                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier(){
+                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier() {
                     @Override
-                    public void modify(Permission permission) throws PermissionDeniedException {
+                    public void modify(final Permission permission) throws PermissionDeniedException {
                         permission.setOwner(owner);
                         permission.setGroup(ownerGroup);
                     }
@@ -3756,20 +3030,18 @@ public class RpcConnection implements RpcAPI {
                 return null;
             }
         });
-        
+
         return true;
     }
-
-
 
     @Override
     public boolean setPermissions(final String resource, final int permissions) throws EXistException, PermissionDeniedException, URISyntaxException {
         executeWithBroker(new BrokerOperation<Void>() {
             @Override
             public Void withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
-                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier(){
+                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier() {
                     @Override
-                    public void modify(Permission permission) throws PermissionDeniedException {
+                    public void modify(final Permission permission) throws PermissionDeniedException {
                         permission.setMode(permissions);
                     }
                 });
@@ -3782,82 +3054,58 @@ public class RpcConnection implements RpcAPI {
 
     @Override
     public boolean setPermissions(final String resource, final String permissions) throws EXistException, PermissionDeniedException, URISyntaxException {
-         executeWithBroker(new BrokerOperation<Void>() {
+        executeWithBroker(new BrokerOperation<Void>() {
             @Override
             public Void withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
-                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier(){
+                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier() {
                     @Override
-                    public void modify(Permission permission) throws PermissionDeniedException {
+                    public void modify(final Permission permission) throws PermissionDeniedException {
                         try {
                             permission.setMode(permissions);
-                        } catch(final SyntaxException se) {
+                        } catch (final SyntaxException se) {
                             throw new PermissionDeniedException("Unrecognised mode syntax: " + se.getMessage(), se);
                         }
                     }
                 });
                 return null;
             }
-         });
+        });
 
         return true;
     }
 
-    /**
-     * The method <code>setMode</code>
-     *
-     * @param resource a <code>String</code> value
-     * @param owner a <code>String</code> value
-     * @param ownerGroup a <code>String</code> value
-     * @param permissions a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
     public boolean setPermissions(final String resource, final String owner, final String ownerGroup, final String permissions) throws EXistException, PermissionDeniedException, URISyntaxException {
-         executeWithBroker(new BrokerOperation<Void>() {
+        executeWithBroker(new BrokerOperation<Void>() {
             @Override
             public Void withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
-                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier(){
+                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier() {
                     @Override
-                    public void modify(Permission permission) throws PermissionDeniedException {
+                    public void modify(final Permission permission) throws PermissionDeniedException {
                         permission.setOwner(owner);
                         permission.setGroup(ownerGroup);
                         try {
                             permission.setMode(permissions);
-                        } catch(final SyntaxException se) {
+                        } catch (final SyntaxException se) {
                             throw new PermissionDeniedException("Unrecognised mode syntax: " + se.getMessage(), se);
                         }
                     }
                 });
                 return null;
-             }
+            }
         });
 
         return true;
     }
-    
-    /**
-     * The method <code>setMode</code>
-     *
-     * @param resource a <code>String</code> value
-     * @param owner a <code>String</code> value
-     * @param ownerGroup a <code>String</code> value
-     * @param permissions an <code>int</code> value
-     * @return a <code>boolean</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
     public boolean setPermissions(final String resource, final String owner, final String ownerGroup, final int permissions) throws EXistException, PermissionDeniedException, URISyntaxException {
-         executeWithBroker(new BrokerOperation<Void>() {
+        executeWithBroker(new BrokerOperation<Void>() {
             @Override
             public Void withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
-                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier(){
+                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier() {
                     @Override
-                    public void modify(Permission permission) throws PermissionDeniedException {
+                    public void modify(final Permission permission) throws PermissionDeniedException {
                         permission.setOwner(owner);
                         permission.setGroup(ownerGroup);
                         permission.setMode(permissions);
@@ -3873,20 +3121,20 @@ public class RpcConnection implements RpcAPI {
 
     @Override
     public boolean setPermissions(final String resource, final String owner, final String group, final int mode, final List<ACEAider> aces) throws EXistException, PermissionDeniedException, URISyntaxException {
-         executeWithBroker(new BrokerOperation<Void>() {
+        executeWithBroker(new BrokerOperation<Void>() {
             @Override
             public Void withBroker(final DBBroker broker) throws EXistException, URISyntaxException, PermissionDeniedException {
-                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier(){
+                PermissionFactory.updatePermissions(broker, XmldbURI.xmldbUriFor(resource), new PermissionModifier() {
                     @Override
-                    public void modify(Permission permission) throws PermissionDeniedException {
+                    public void modify(final Permission permission) throws PermissionDeniedException {
                         permission.setOwner(owner);
                         permission.setGroup(group);
                         permission.setMode(mode);
 
-                        if(permission instanceof ACLPermission) {
-                            final ACLPermission aclPermission = ((ACLPermission)permission);
+                        if (permission instanceof ACLPermission) {
+                            final ACLPermission aclPermission = ((ACLPermission) permission);
                             aclPermission.clear();
-                            for(final ACEAider ace : aces) {
+                            for (final ACEAider ace : aces) {
                                 aclPermission.addACE(ace.getAccessType(), ace.getTarget(), ace.getWho(), ace.getMode());
                             }
                         }
@@ -3894,67 +3142,56 @@ public class RpcConnection implements RpcAPI {
                 });
                 return null;
             }
-         });
+        });
 
         return true;
     }
-    
-    /**
-     * The method <code>addAccount</code>
-     *
-     * @param name a <code>String</code> value
-     * @param passwd a <code>String</code> value
-     * @param passwdDigest a <code>String</code> value
-     * @param groups a <code>Vector</code> value
-     * @return a <code>boolean</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
+
     @Override
-    public boolean addAccount(final String name, String passwd, final String passwdDigest, final Vector<String> groups, final Boolean enabled, final Integer umask, final Map<String, String> metadata) throws EXistException, PermissionDeniedException {
-        
-    	if(passwd.length() == 0) {
+    public boolean addAccount(final String name, String passwd, final String passwdDigest, final List<String> groups, final Boolean enabled, final Integer umask, final Map<String, String> metadata) throws EXistException, PermissionDeniedException {
+
+        if (passwd.length() == 0) {
             passwd = null;
         }
-        
-    	final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
 
-    	if(manager.hasAccount(name)) {
-            throw new PermissionDeniedException("Account '"+name+"' exist");
+        final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
+
+        if (manager.hasAccount(name)) {
+            throw new PermissionDeniedException("Account '" + name + "' exist");
         }
 
-        if(!manager.hasAdminPrivileges(user)) {
-            throw new PermissionDeniedException("Account '"+user.getName()+"' not allowed to create new account");
+        if (!manager.hasAdminPrivileges(user)) {
+            throw new PermissionDeniedException("Account '" + user.getName() + "' not allowed to create new account");
         }
 
         final UserAider u = new UserAider(name);
         u.setEncodedPassword(passwd);
         u.setPasswordDigest(passwdDigest);
 
-        for(final String g : groups) {
-            if(!u.hasGroup(g)) {
+        for (final String g : groups) {
+            if (!u.hasGroup(g)) {
                 u.addGroup(g);
             }
         }
-        
-        if(enabled != null) {
+
+        if (enabled != null) {
             u.setEnabled(enabled);
         }
-        
-        if(umask != null) {
+
+        if (umask != null) {
             u.setUserMask(umask);
         }
-        
-        if(metadata != null) {
-            for(final String key : metadata.keySet()) {
-                if(AXSchemaType.valueOfNamespace(key) != null) {
+
+        if (metadata != null) {
+            for (final String key : metadata.keySet()) {
+                if (AXSchemaType.valueOfNamespace(key) != null) {
                     u.setMetadataValue(AXSchemaType.valueOfNamespace(key), metadata.get(key));
-                } else if(EXistSchemaType.valueOfNamespace(key) != null) {
+                } else if (EXistSchemaType.valueOfNamespace(key) != null) {
                     u.setMetadataValue(EXistSchemaType.valueOfNamespace(key), metadata.get(key));
                 }
             }
         }
-        
+
         try {
             executeWithBroker(new BrokerOperation<Void>() {
                 @Override
@@ -3963,50 +3200,50 @@ public class RpcConnection implements RpcAPI {
                     return null;
                 }
             });
-        } catch(final URISyntaxException use) {
+        } catch (final URISyntaxException use) {
             throw new EXistException(use.getMessage(), use);
         }
-        
+
         return true;
     }
 
     @Override
-    public boolean updateAccount(final String name, final String passwd, final String passwdDigest, final Vector<String> groups) throws EXistException, PermissionDeniedException {
-    	return updateAccount(name, passwd, passwdDigest, groups, null, null, null);
+    public boolean updateAccount(final String name, final String passwd, final String passwdDigest, final List<String> groups) throws EXistException, PermissionDeniedException {
+        return updateAccount(name, passwd, passwdDigest, groups, null, null, null);
     }
 
     @Override
-    public boolean updateAccount(final String name, String passwd, final String passwdDigest, final Vector<String> groups, final Boolean enabled, final Integer umask, final Map<String, String> metadata) throws EXistException, PermissionDeniedException {
-        if(passwd.length() == 0) {
+    public boolean updateAccount(final String name, String passwd, final String passwdDigest, final List<String> groups, final Boolean enabled, final Integer umask, final Map<String, String> metadata) throws EXistException, PermissionDeniedException {
+        if (passwd.length() == 0) {
             passwd = null;
         }
-        
+
         final UserAider account = new UserAider(name);
         account.setEncodedPassword(passwd);
         account.setPasswordDigest(passwdDigest);
 
-        for(final String g : groups) {
+        for (final String g : groups) {
             account.addGroup(g);
         }
-        
-        if(enabled != null) {
+
+        if (enabled != null) {
             account.setEnabled(enabled);
         }
-        
-        if(umask != null) {
+
+        if (umask != null) {
             account.setUserMask(umask);
         }
-        
-        if(metadata != null) {
-            for(final String key : metadata.keySet()) {
-                if(AXSchemaType.valueOfNamespace(key) != null) {
+
+        if (metadata != null) {
+            for (final String key : metadata.keySet()) {
+                if (AXSchemaType.valueOfNamespace(key) != null) {
                     account.setMetadataValue(AXSchemaType.valueOfNamespace(key), metadata.get(key));
-                } else if(EXistSchemaType.valueOfNamespace(key) != null) {
+                } else if (EXistSchemaType.valueOfNamespace(key) != null) {
                     account.setMetadataValue(EXistSchemaType.valueOfNamespace(key), metadata.get(key));
                 }
             }
         }
-        
+
         final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
         try {
             return executeWithBroker(new BrokerOperation<Boolean>() {
@@ -4021,27 +3258,26 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public boolean addGroup(String name, Map<String, String> metadata) throws EXistException, PermissionDeniedException {
-        
-    	final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
+    public boolean addGroup(final String name, final Map<String, String> metadata) throws EXistException, PermissionDeniedException {
 
-    	if(!manager.hasGroup(name)) {
-            
-            if(!manager.hasAdminPrivileges(user)) {
+        final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
+
+        if (!manager.hasGroup(name)) {
+
+            if (!manager.hasAdminPrivileges(user)) {
                 throw new PermissionDeniedException("Not allowed to create group");
             }
-            
+
             final Group role = new GroupAider(name);
-            
-            for(final String key : metadata.keySet()) {
-                if(AXSchemaType.valueOfNamespace(key) != null) {
+
+            for (final String key : metadata.keySet()) {
+                if (AXSchemaType.valueOfNamespace(key) != null) {
                     role.setMetadataValue(AXSchemaType.valueOfNamespace(key), metadata.get(key));
-                } else if(EXistSchemaType.valueOfNamespace(key) != null) {
+                } else if (EXistSchemaType.valueOfNamespace(key) != null) {
                     role.setMetadataValue(EXistSchemaType.valueOfNamespace(key), metadata.get(key));
                 }
             }
-            
-            
+
             try {
                 executeWithBroker(new BrokerOperation<Void>() {
                     @Override
@@ -4055,21 +3291,21 @@ public class RpcConnection implements RpcAPI {
                 throw new EXistException(use.getMessage(), use);
             }
         }
-        
-    	return false;
+
+        return false;
     }
-    
+
     public boolean setUserPrimaryGroup(final String username, final String groupName) throws EXistException, PermissionDeniedException {
         final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
 
-    	if(!manager.hasGroup(groupName)) {
+        if (!manager.hasGroup(groupName)) {
             throw new EXistException("Group '" + groupName + "' does not exist!");
         }
-        
-        if(!manager.hasAdminPrivileges(user)) {
+
+        if (!manager.hasAdminPrivileges(user)) {
             throw new PermissionDeniedException("Not allowed to modify user");
         }
-        
+
         try {
             executeWithBroker(new BrokerOperation<Void>() {
                 @Override
@@ -4086,30 +3322,30 @@ public class RpcConnection implements RpcAPI {
             throw new EXistException(use.getMessage(), use);
         }
     }
-    
+
     @Override
-    public boolean updateGroup(final String name, final Vector<String> managers, final Map<String, String> metadata) throws EXistException, PermissionDeniedException {
-       
+    public boolean updateGroup(final String name, final List<String> managers, final Map<String, String> metadata) throws EXistException, PermissionDeniedException {
+
         final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
 
-    	if(manager.hasGroup(name)) {
-        
+        if (manager.hasGroup(name)) {
+
             final GroupAider group = new GroupAider(name);
-        
-            for(final String groupManager : managers) {
+
+            for (final String groupManager : managers) {
                 group.addManager(new UserAider(groupManager));
             }
 
-            if(metadata != null) {
-                for(final String key : metadata.keySet()) {
-                    if(AXSchemaType.valueOfNamespace(key) != null) {
+            if (metadata != null) {
+                for (final String key : metadata.keySet()) {
+                    if (AXSchemaType.valueOfNamespace(key) != null) {
                         group.setMetadataValue(AXSchemaType.valueOfNamespace(key), metadata.get(key));
-                    } else if(EXistSchemaType.valueOfNamespace(key) != null) {
+                    } else if (EXistSchemaType.valueOfNamespace(key) != null) {
                         group.setMetadataValue(EXistSchemaType.valueOfNamespace(key), metadata.get(key));
                     }
                 }
             }
-            
+
             try {
                 executeWithBroker(new BrokerOperation<Void>() {
                     @Override
@@ -4122,32 +3358,32 @@ public class RpcConnection implements RpcAPI {
             } catch (final URISyntaxException use) {
                 throw new EXistException(use.getMessage(), use);
             }
-            
+
         } else {
             return false;
         }
     }
 
     @Override
-    public Vector<String> getGroupMembers(final String groupName) throws EXistException, PermissionDeniedException {
-        
+    public List<String> getGroupMembers(final String groupName) throws EXistException, PermissionDeniedException {
+
         try {
             final List<String> groupMembers = executeWithBroker(new BrokerOperation<List<String>>() {
                 @Override
-                public List<String> withBroker(final DBBroker broker)  {
+                public List<String> withBroker(final DBBroker broker) {
                     return broker.getBrokerPool().getSecurityManager().findAllGroupMembers(groupName);
                 }
 
             });
-            return new Vector<String>(groupMembers);
+            return new ArrayList<>(groupMembers);
         } catch (final URISyntaxException use) {
             throw new EXistException(use.getMessage(), use);
         }
     }
-    
+
     @Override
     public void addAccountToGroup(final String accountName, final String groupName) throws EXistException, PermissionDeniedException {
-         try {
+        try {
             executeWithBroker(new BrokerOperation<Void>() {
                 @Override
                 public Void withBroker(final DBBroker broker) throws EXistException, PermissionDeniedException {
@@ -4155,7 +3391,7 @@ public class RpcConnection implements RpcAPI {
                     final Account account = sm.getAccount(accountName);
                     account.addGroup(groupName);
                     sm.updateAccount(account);
-                    
+
                     return null;
                 }
             });
@@ -4165,7 +3401,7 @@ public class RpcConnection implements RpcAPI {
             throw new EXistException(pde.getMessage(), pde);
         }
     }
-    
+
     @Override
     public void addGroupManager(final String manager, final String groupName) throws EXistException, PermissionDeniedException {
         try {
@@ -4173,12 +3409,12 @@ public class RpcConnection implements RpcAPI {
                 @Override
                 public Void withBroker(final DBBroker broker) throws EXistException, PermissionDeniedException {
                     final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    
+
                     final Account account = sm.getAccount(manager);
                     final Group group = sm.getGroup(groupName);
                     group.addManager(account);
                     sm.updateGroup(group);
-                    
+
                     return null;
                 }
             });
@@ -4188,7 +3424,7 @@ public class RpcConnection implements RpcAPI {
             throw new EXistException(pde.getMessage(), pde);
         }
     }
-    
+
     @Override
     public void removeGroupManager(final String groupName, final String manager) throws EXistException, PermissionDeniedException {
         try {
@@ -4198,10 +3434,10 @@ public class RpcConnection implements RpcAPI {
                     final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
                     final Group group = sm.getGroup(groupName);
                     final Account account = sm.getAccount(manager);
-                    
+
                     group.removeManager(account);
                     sm.updateGroup(group);
-                    
+
                     return null;
                 }
             });
@@ -4211,18 +3447,18 @@ public class RpcConnection implements RpcAPI {
             throw new EXistException(pde.getMessage(), pde);
         }
     }
-    
+
     public void removeGroupMember(final String group, final String member) throws EXistException, PermissionDeniedException {
         try {
             executeWithBroker(new BrokerOperation<Void>() {
                 @Override
                 public Void withBroker(final DBBroker broker) throws EXistException, PermissionDeniedException {
                     final SecurityManager sm = broker.getBrokerPool().getSecurityManager();
-                    
+
                     final Account account = sm.getAccount(member);
                     account.remGroup(group);
                     sm.updateAccount(account);
-                    
+
                     return null;
                 }
             });
@@ -4232,129 +3468,124 @@ public class RpcConnection implements RpcAPI {
             throw new EXistException(pde.getMessage(), pde);
         }
     }
-            
 
     /**
      * Added by {Marco.Tampucci, Massimo.Martinelli} @isti.cnr.it
-     * 
-     * modified by Chris Tomlinson based on above updateAccount - it appears that this
-     * code can rely on the SecurityManager to enforce policy about whether user
-     * is or is not permitted to update the Account with name.
-     * 
+     *
+     * modified by Chris Tomlinson based on above updateAccount - it appears
+     * that this code can rely on the SecurityManager to enforce policy about
+     * whether user is or is not permitted to update the Account with name.
+     *
      * This is called via RemoteUserManagementService.addUserGroup(Account)
+     *
+     * @param name
+     * @return
+     * @throws org.exist.security.PermissionDeniedException
      */
-    public boolean updateAccount(String name, Vector<String> groups) throws EXistException,
-    PermissionDeniedException {
+    public boolean updateAccount(final String name, final List<String> groups) throws EXistException, PermissionDeniedException {
 
-    	final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
+        final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
         DBBroker broker = null;
 
         try {
-        	broker = factory.getBrokerPool().get(user);
-        	
-        	Account u;
+            broker = factory.getBrokerPool().get(user);
 
-        	if (!manager.hasAccount(name)) {
-        		u = new UserAider(name);
-        	} else {
-        		u = manager.getAccount(name);
-        	}
+            Account u;
 
-        	for (final String g : groups) {
-        		if (!u.hasGroup(g)) {
-        			u.addGroup(g);
-        		}
-        	}
+            if (!manager.hasAccount(name)) {
+                u = new UserAider(name);
+            } else {
+                u = manager.getAccount(name);
+            }
 
-        	return manager.updateAccount(u);
-        	
-        } catch (final Exception ex) {
-        	LOG.debug("addUserGroup encountered error", ex);
-        	return false;
+            for (final String g : groups) {
+                if (!u.hasGroup(g)) {
+                    u.addGroup(g);
+                }
+            }
+
+            return manager.updateAccount(u);
+
+        } catch (final EXistException | PermissionDeniedException ex) {
+            LOG.debug("addUserGroup encountered error", ex);
+            return false;
         } finally {
-        	factory.getBrokerPool().release(broker);
+            factory.getBrokerPool().release(broker);
         }
     }
-    
+
     /**
      * Added by {Marco.Tampucci, Massimo.Martinelli} @isti.cnr.it
-     * 
-     * modified by Chris Tomlinson based on above updateAccount - it appears that this
-     * code can rely on the SecurityManager to enforce policy about whether user
-     * is or is not permitted to update the Account with name.
-     * 
-     * This is called via RemoteUserManagementService.removeGroup(Account, String)
+     *
+     * modified by Chris Tomlinson based on above updateAccount - it appears
+     * that this code can rely on the SecurityManager to enforce policy about
+     * whether user is or is not permitted to update the Account with name.
+     *
+     * This is called via RemoteUserManagementService.removeGroup(Account,
+     * String)
+     *
+     * @param name
+     * @param groups
+     * @param rgroup
+     * @return
+     * @throws org.exist.EXistException
+     * @throws org.exist.security.PermissionDeniedException
      */
-    public boolean updateAccount(String name, Vector<String> groups, String rgroup) throws EXistException,
-    PermissionDeniedException {
+    public boolean updateAccount(final String name, final List<String> groups, final String rgroup) throws EXistException, PermissionDeniedException {
 
-    	final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
-    	
-    	DBBroker broker = null;
+        final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
 
-    	try {
-    		broker = factory.getBrokerPool().get(user);
+        DBBroker broker = null;
 
-    		final Account u = manager.getAccount(name);
-    		
-    		for (final String g : groups) {
-    			if (g.equals(rgroup)) {
-    				u.remGroup(g);
-    			}
-    		}
-    		
-    		return manager.updateAccount(u);
+        try {
+            broker = factory.getBrokerPool().get(user);
 
-    	} catch (final Exception ex) {
-    		LOG.debug("removeGroup encountered error", ex);
-    		return false;
-    	} finally {
-    		factory.getBrokerPool().release(broker);
+            final Account u = manager.getAccount(name);
+
+            for (final String g : groups) {
+                if (g.equals(rgroup)) {
+                    u.remGroup(g);
+                }
+            }
+
+            return manager.updateAccount(u);
+
+        } catch (final EXistException | PermissionDeniedException ex) {
+            LOG.debug("removeGroup encountered error", ex);
+            return false;
+        } finally {
+            factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>lockResource</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @param userName a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    @Override
-    public boolean lockResource(String documentPath, String userName) throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return lockResource(XmldbURI.xmldbUriFor(documentPath),userName);
-    }    
 
-    /**
-     * The method <code>lockResource</code>
-     *
-     * @param docURI a <code>XmldbURI</code> value
-     * @param userName a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean lockResource(XmldbURI docURI, String userName) throws EXistException, PermissionDeniedException {
+    @Override
+    public boolean lockResource(final String documentPath, final String userName) throws EXistException, PermissionDeniedException, URISyntaxException {
+        return lockResource(XmldbURI.xmldbUriFor(documentPath), userName);
+    }
+
+    private boolean lockResource(final XmldbURI docURI, final String userName) throws EXistException, PermissionDeniedException {
         DocumentImpl doc = null;
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
-            doc = broker.getXMLResource(docURI, Lock.WRITE_LOCK);           
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
+            doc = broker.getXMLResource(docURI, Lock.WRITE_LOCK);
             if (doc == null) {
                 throw new EXistException("Resource " + docURI + " not found");
             }
             //TODO : register the lock within the transaction ?
-            if (!doc.getPermissions().validate(user, Permission.WRITE))
-                {throw new PermissionDeniedException("User is not allowed to lock resource " + docURI);}
+            if (!doc.getPermissions().validate(user, Permission.WRITE)) {
+                throw new PermissionDeniedException("User is not allowed to lock resource " + docURI);
+            }
             final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
-            if (!(userName.equals(user.getName()) || manager.hasAdminPrivileges(user)))
-                {throw new PermissionDeniedException("User " + user.getName() + " is not allowed " +
-                        "to lock the resource for user " + userName);}
+            if (!(userName.equals(user.getName()) || manager.hasAdminPrivileges(user))) {
+                throw new PermissionDeniedException("User " + user.getName() + " is not allowed "
+                        + "to lock the resource for user " + userName);
+            }
             final Account lockOwner = doc.getUserLock();
-            if(lockOwner != null && (!lockOwner.equals(user)) && (!manager.hasAdminPrivileges(user)))
-                {throw new PermissionDeniedException("Resource is already locked by user " +
-                        lockOwner.getName());}
+            if (lockOwner != null && (!lockOwner.equals(user)) && (!manager.hasAdminPrivileges(user))) {
+                throw new PermissionDeniedException("Resource is already locked by user "
+                        + lockOwner.getName());
+            }
             doc.setUserLock(user);
             broker.storeXMLResource(transaction, doc);
             transact.commit(transaction);
@@ -4364,91 +3595,67 @@ public class RpcConnection implements RpcAPI {
             handleException(e);
             return false;
         } finally {
-            if(doc != null) {
+            if (doc != null) {
                 doc.getUpdateLock().release(Lock.WRITE_LOCK);
             }
         }
     }
-    
-    /**
-     * The method <code>hasUserLock</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    @Override
-    public String hasUserLock(String documentPath) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return hasUserLock(XmldbURI.xmldbUriFor(documentPath));
-    }    
 
-    /**
-     * The method <code>hasUserLock</code>
-     *
-     * @param docURI a <code>XmldbURI</code> value
-     * @return a <code>String</code> value
-     * @exception Exception if an error occurs
-     */
-    private String hasUserLock(XmldbURI docURI) throws EXistException, PermissionDeniedException {
+    @Override
+    public String hasUserLock(final String documentPath) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return hasUserLock(XmldbURI.xmldbUriFor(documentPath));
+    }
+
+    private String hasUserLock(final XmldbURI docURI) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         DocumentImpl doc = null;
         try {
             broker = factory.getBrokerPool().get(user);
             doc = broker.getXMLResource(docURI, Lock.READ_LOCK);
-            if (doc == null)
-                {throw new EXistException("Resource " + docURI + " not found");}
-            if(!doc.getPermissions().validate(user, Permission.READ))
-                {throw new PermissionDeniedException("Insufficient privileges to read resource");}
+            if (doc == null) {
+                throw new EXistException("Resource " + docURI + " not found");
+            }
+            if (!doc.getPermissions().validate(user, Permission.READ)) {
+                throw new PermissionDeniedException("Insufficient privileges to read resource");
+            }
             final Account u = doc.getUserLock();
             return u == null ? "" : u.getName();
 
-        } catch (final Throwable e) {
+        } catch (final EXistException | PermissionDeniedException e) {
             handleException(e);
             return null;
 
         } finally {
-            if(doc != null)
-                {doc.getUpdateLock().release(Lock.READ_LOCK);}
+            if (doc != null) {
+                doc.getUpdateLock().release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>unlockResource</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    @Override
-    public boolean unlockResource(String documentPath) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	return unlockResource(XmldbURI.xmldbUriFor(documentPath));
-    }    
 
-    /**
-     * The method <code>unlockResource</code>
-     *
-     * @param docURI a <code>XmldbURI</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean unlockResource(XmldbURI docURI) throws EXistException, PermissionDeniedException {
+    @Override
+    public boolean unlockResource(final String documentPath) throws URISyntaxException, EXistException, PermissionDeniedException {
+        return unlockResource(XmldbURI.xmldbUriFor(documentPath));
+    }
+
+    private boolean unlockResource(final XmldbURI docURI) throws EXistException, PermissionDeniedException {
         DocumentImpl doc = null;
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
             doc = broker.getXMLResource(docURI, Lock.WRITE_LOCK);
-            if (doc == null)
-                {throw new EXistException("Resource " + docURI + " not found");}
-            if (!doc.getPermissions().validate(user, Permission.WRITE))
-                {throw new PermissionDeniedException("User is not allowed to lock resource " + docURI);}
+            if (doc == null) {
+                throw new EXistException("Resource " + docURI + " not found");
+            }
+            if (!doc.getPermissions().validate(user, Permission.WRITE)) {
+                throw new PermissionDeniedException("User is not allowed to lock resource " + docURI);
+            }
             final SecurityManager manager = factory.getBrokerPool().getSecurityManager();
             final Account lockOwner = doc.getUserLock();
-            if(lockOwner != null && (!lockOwner.equals(user)) && (!manager.hasAdminPrivileges(user)))
-                {throw new PermissionDeniedException("Resource is already locked by user " +
-                        lockOwner.getName());}
+            if (lockOwner != null && (!lockOwner.equals(user)) && (!manager.hasAdminPrivileges(user))) {
+                throw new PermissionDeniedException("Resource is already locked by user "
+                        + lockOwner.getName());
+            }
             doc.setUserLock(null);
             broker.storeXMLResource(transaction, doc);
             transact.commit(transaction);
@@ -4458,42 +3665,37 @@ public class RpcConnection implements RpcAPI {
             handleException(e);
             return false;
         } finally {
-            if(doc != null) {
+            if (doc != null) {
                 doc.getUpdateLock().release(Lock.WRITE_LOCK);
             }
         }
     }
-    
-    /**
-     * The method <code>summary</code>
-     *
-     * @param xpath a <code>String</code> value
-     * @return a <code>HashMap</code> value
-     * @exception Exception if an error occurs
-     */
-    public HashMap<String, Object> summary(String xpath) throws EXistException, PermissionDeniedException {
+
+    public Map<String, Object> summary(final String xpath) throws EXistException, PermissionDeniedException {
         final long startTime = System.currentTimeMillis();
         DBBroker broker = null;
         Source source = null;
         CompiledXQuery compiled = null;
-        final HashMap<String, Object> parameters = new HashMap<String, Object>();
+        final Map<String, Object> parameters = new HashMap<>();
         try {
             broker = factory.getBrokerPool().get(user);
             source = new StringSource(xpath);
             compiled = compile(broker, source, parameters);
             final QueryResult qr = doQuery(broker, compiled, null, parameters);
-            if (qr == null)
-                {return new HashMap<String, Object>();}
-            if (qr.hasErrors())
-                {throw qr.getException();}
-            final HashMap<String, NodeCount> map = new HashMap<String, NodeCount>();
-            final HashMap<String, DoctypeCount> doctypes = new HashMap<String, DoctypeCount>();
+            if (qr == null) {
+                return new HashMap<>();
+            }
+            if (qr.hasErrors()) {
+                throw qr.getException();
+            }
+            final Map<String, NodeCount> map = new HashMap<>();
+            final Map<String, DoctypeCount> doctypes = new HashMap<>();
             NodeProxy p;
             String docName;
             DocumentType doctype;
             NodeCount counter;
             DoctypeCount doctypeCounter;
-            for (final SequenceIterator i = qr.result.iterate(); i.hasNext(); ) {
+            for (final SequenceIterator i = qr.result.iterate(); i.hasNext();) {
                 final Item item = i.nextItem();
                 if (Type.subTypeOf(item.getType(), Type.NODE)) {
                     final NodeValue nv = (NodeValue) item;
@@ -4508,11 +3710,12 @@ public class RpcConnection implements RpcAPI {
                             counter = new NodeCount(p.getOwnerDocument());
                             map.put(docName, counter);
                         }
-                        if (doctype == null)
-                            {continue;}
+                        if (doctype == null) {
+                            continue;
+                        }
                         if (doctypes.containsKey(doctype.getName())) {
                             doctypeCounter = (DoctypeCount) doctypes.get(doctype
-                                .getName());
+                                    .getName());
                             doctypeCounter.inc();
                         } else {
                             doctypeCounter = new DoctypeCount(doctype);
@@ -4521,73 +3724,66 @@ public class RpcConnection implements RpcAPI {
                     }
                 }
             }
-            final HashMap<String, Object> result = new HashMap<String, Object>();
-            result.put("queryTime", Integer.valueOf((int)(System.currentTimeMillis() - startTime)));
-            result.put("hits", Integer.valueOf(qr.result.getItemCount()));
-            final Vector<Vector<Object>> documents = new Vector<Vector<Object>>();
-            Vector<Object> hitsByDoc;
+            final Map<String, Object> result = new HashMap<>();
+            result.put("queryTime", System.currentTimeMillis() - startTime);
+            result.put("hits", qr.result.getItemCount());
+            final List<List> documents = new ArrayList<>();
             for (final NodeCount nodeCounter : map.values()) {
-                hitsByDoc = new Vector<Object>();
-                hitsByDoc.addElement(nodeCounter.doc.getFileURI().toString());
-                hitsByDoc.addElement(Integer.valueOf(nodeCounter.doc.getDocId()));
-                hitsByDoc.addElement(Integer.valueOf(nodeCounter.count));
-                documents.addElement(hitsByDoc);
+                final List hitsByDoc = new ArrayList();
+                hitsByDoc.add(nodeCounter.doc.getFileURI().toString());
+                hitsByDoc.add(nodeCounter.doc.getDocId());
+                hitsByDoc.add(nodeCounter.count);
+                documents.add(hitsByDoc);
             }
             result.put("documents", documents);
-            final Vector<Vector<Object>> dtypes = new Vector<Vector<Object>>();
-            Vector<Object> hitsByType;
 
+            final List<List> dtypes = new ArrayList<>();
             for (final DoctypeCount docTemp : doctypes.values()) {
-                hitsByType = new Vector<Object>();
-                hitsByType.addElement(docTemp.doctype.getName());
-                hitsByType.addElement(Integer.valueOf(docTemp.count));
-                dtypes.addElement(hitsByType);
+                final List hitsByType = new ArrayList();
+                hitsByType.add(docTemp.doctype.getName());
+                hitsByType.add(docTemp.count);
+                dtypes.add(hitsByType);
             }
             result.put("doctypes", dtypes);
             return result;
 
-        } catch(final Throwable e) {
+        } catch (final Throwable e) {
             handleException(e);
             return null;
 
         } finally {
-            if(compiled != null) {
+            if (compiled != null) {
                 compiled.getContext().runCleanupTasks();
-                broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
+                if (broker != null) {
+                    broker.getXQueryService().getXQueryPool().returnCompiledXQuery(source, compiled);
+                }
             }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>summary</code>
-     *
-     * @param resultId an <code>int</code> value
-     * @return a <code>HashMap</code> value
-     * @exception EXistException if an error occurs
-     * @exception XPathException if an error occurs
-     */
-    public HashMap<String, Object> summary(int resultId) throws EXistException, XPathException {
+
+    public Map<String, Object> summary(final int resultId) throws EXistException, XPathException {
         final QueryResult qr = factory.resultSets.getResult(resultId);
-        if (qr == null)
-            {throw new EXistException("result set unknown or timed out");}
+        if (qr == null) {
+            throw new EXistException("result set unknown or timed out");
+        }
         qr.touch();
-        final HashMap<String, Object> result = new HashMap<String, Object>();
-        result.put("queryTime", Integer.valueOf((int)qr.queryTime));
+        final Map<String, Object> result = new HashMap<>();
+        result.put("queryTime", qr.queryTime);
         if (qr.result == null) {
-            result.put("hits", Integer.valueOf(0));
+            result.put("hits", 0);
             return result;
         }
         final DBBroker broker = factory.getBrokerPool().get(user);
         try {
-            final HashMap<String, NodeCount> map = new HashMap<String, NodeCount>();
-            final HashMap<String, DoctypeCount> doctypes = new HashMap<String, DoctypeCount>();
+            final Map<String, NodeCount> map = new HashMap<>();
+            final Map<String, DoctypeCount> doctypes = new HashMap<>();
             NodeProxy p;
             String docName;
             DocumentType doctype;
             NodeCount counter;
             DoctypeCount doctypeCounter;
-            for (final SequenceIterator i = qr.result.iterate(); i.hasNext(); ) {
+            for (final SequenceIterator i = qr.result.iterate(); i.hasNext();) {
                 final Item item = i.nextItem();
                 if (Type.subTypeOf(item.getType(), Type.NODE)) {
                     final NodeValue nv = (NodeValue) item;
@@ -4602,11 +3798,12 @@ public class RpcConnection implements RpcAPI {
                             counter = new NodeCount(p.getOwnerDocument());
                             map.put(docName, counter);
                         }
-                        if (doctype == null)
-                            {continue;}
+                        if (doctype == null) {
+                            continue;
+                        }
                         if (doctypes.containsKey(doctype.getName())) {
                             doctypeCounter = (DoctypeCount) doctypes.get(doctype
-                                .getName());
+                                    .getName());
                             doctypeCounter.inc();
                         } else {
                             doctypeCounter = new DoctypeCount(doctype);
@@ -4615,24 +3812,24 @@ public class RpcConnection implements RpcAPI {
                     }
                 }
             }
-            result.put("hits", Integer.valueOf(qr.result.getItemCount()));
-            final Vector<Vector<Object>> documents = new Vector<Vector<Object>>();
-            Vector<Object> hitsByDoc;
+            result.put("hits", qr.result.getItemCount());
+
+            final List<List> documents = new ArrayList<>();
             for (final NodeCount nodeCounter : map.values()) {
-                hitsByDoc = new Vector<Object>();
-                hitsByDoc.addElement(nodeCounter.doc.getFileURI().toString());
-                hitsByDoc.addElement(Integer.valueOf(nodeCounter.doc.getDocId()));
-                hitsByDoc.addElement(Integer.valueOf(nodeCounter.count));
-                documents.addElement(hitsByDoc);
+                final List hitsByDoc = new ArrayList();
+                hitsByDoc.add(nodeCounter.doc.getFileURI().toString());
+                hitsByDoc.add(nodeCounter.doc.getDocId());
+                hitsByDoc.add(nodeCounter.count);
+                documents.add(hitsByDoc);
             }
             result.put("documents", documents);
-            final Vector<Vector<Object>> dtypes = new Vector<Vector<Object>>();
-            Vector<Object> hitsByType;
+
+            final List<List> dtypes = new ArrayList<>();
             for (final DoctypeCount docTemp : doctypes.values()) {
-                hitsByType = new Vector<Object>();
-                hitsByType.addElement(docTemp.doctype.getName());
-                hitsByType.addElement(Integer.valueOf(docTemp.count));
-                dtypes.addElement(hitsByType);
+                final List hitsByType = new ArrayList();
+                hitsByType.add(docTemp.doctype.getName());
+                hitsByType.add(docTemp.count);
+                dtypes.add(hitsByType);
             }
             result.put("doctypes", dtypes);
             return result;
@@ -4640,327 +3837,216 @@ public class RpcConnection implements RpcAPI {
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>getIndexedElements</code>
-     *
-     * @param collectionName a <code>String</code> value
-     * @param inclusive a <code>boolean</code> value
-     * @return a <code>Vector</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    @Override
-    public Vector<Vector<Object>> getIndexedElements(String collectionName,
-            boolean inclusive) throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return getIndexedElements(XmldbURI.xmldbUriFor(collectionName),inclusive);
-    }    
 
-    /**
-     * The method <code>getIndexedElements</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @param inclusive a <code>boolean</code> value
-     * @return a <code>Vector</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private Vector<Vector<Object>> getIndexedElements(XmldbURI collUri,
-            boolean inclusive) throws EXistException, PermissionDeniedException {
+    @Override
+    public List<List> getIndexedElements(final String collectionName,
+            final boolean inclusive) throws EXistException, PermissionDeniedException, URISyntaxException {
+        return getIndexedElements(XmldbURI.xmldbUriFor(collectionName), inclusive);
+    }
+
+    private List<List> getIndexedElements(final XmldbURI collUri,
+            final boolean inclusive) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         Collection collection = null;
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(collUri, Lock.READ_LOCK);
-            if (collection == null)
-                {throw new EXistException("collection " + collUri + " not found");}
+            if (collection == null) {
+                throw new EXistException("collection " + collUri + " not found");
+            }
             final Occurrences occurrences[] = broker.getElementIndex().scanIndexedElements(collection,
                     inclusive);
-            final Vector<Vector<Object>> result = new Vector<Vector<Object>>(occurrences.length);
-            for (int i = 0; i < occurrences.length; i++) {
-                final QName qname = (QName)occurrences[i].getTerm();
-                final Vector<Object> temp = new Vector<Object>(4);
-                temp.addElement(qname.getLocalPart());
-                temp.addElement(qname.getNamespaceURI());
-                temp.addElement(qname.getPrefix() == null ? "" : qname.getPrefix());
-                temp.addElement(Integer.valueOf(occurrences[i].getOccurrences()));
-                result.addElement(temp);
+            final List<List> result = new ArrayList<>(occurrences.length);
+            for (final Occurrences occurrence : occurrences) {
+                final QName qname = (QName) occurrence.getTerm();
+                final List temp = new ArrayList(4);
+                temp.add(qname.getLocalPart());
+                temp.add(qname.getNamespaceURI());
+                temp.add(qname.getPrefix() == null ? "" : qname.getPrefix());
+                temp.add(occurrence.getOccurrences());
+                result.add(temp);
             }
             return result;
         } finally {
-            if(collection != null)
-                {collection.release(Lock.READ_LOCK);}
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>scanIndexTerms</code>
-     *
-     * @param collectionName a <code>String</code> value
-     * @param start a <code>String</code> value
-     * @param end a <code>String</code> value
-     * @param inclusive a <code>boolean</code> value
-     * @return a <code>Vector</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    @Override
-    public Vector<Vector<Object>> scanIndexTerms(String collectionName,
-            String start, String end, boolean inclusive)
-            throws PermissionDeniedException, EXistException, URISyntaxException {
-    	return scanIndexTerms(XmldbURI.xmldbUriFor(collectionName),start,end,inclusive);
-    }    
 
-    /**
-     * The method <code>scanIndexTerms</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @param start a <code>String</code> value
-     * @param end a <code>String</code> value
-     * @param inclusive a <code>boolean</code> value
-     * @return a <code>Vector</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     */
-    private Vector<Vector<Object>> scanIndexTerms(XmldbURI collUri,
-            String start, String end, boolean inclusive)
+    @Override
+    public List<List> scanIndexTerms(final String collectionName,
+            final String start, final String end, final boolean inclusive)
+            throws PermissionDeniedException, EXistException, URISyntaxException {
+        return scanIndexTerms(XmldbURI.xmldbUriFor(collectionName), start, end, inclusive);
+    }
+
+    private List<List> scanIndexTerms(final XmldbURI collUri,
+            final String start, final String end, final boolean inclusive)
             throws PermissionDeniedException, EXistException {
         DBBroker broker = null;
         Collection collection = null;
         try {
             broker = factory.getBrokerPool().get(user);
             collection = broker.openCollection(collUri, Lock.READ_LOCK);
-            if (collection == null)
-                {throw new EXistException("collection " + collUri + " not found");}
+            if (collection == null) {
+                throw new EXistException("collection " + collUri + " not found");
+            }
             final MutableDocumentSet docs = new DefaultDocumentSet();
             collection.allDocs(broker, docs, inclusive);
             final NodeSet nodes = docs.docsToNodeSet();
-            final Vector<Vector<Object>> result = scanIndexTerms(start, end, broker, docs, nodes);
+            final List<List> result = scanIndexTerms(start, end, broker, docs, nodes);
             return result;
         } finally {
-            if(collection != null)
-                {collection.release(Lock.READ_LOCK);}
+            if (collection != null) {
+                collection.release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>scanIndexTerms</code>
-     *
-     * @param xpath a <code>String</code> value
-     * @param start a <code>String</code> value
-     * @param end a <code>String</code> value
-     * @return a <code>Vector</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     * @exception XPathException if an error occurs
-     */
+
     @Override
-    public Vector<Vector<Object>> scanIndexTerms(String xpath,
-            String start, String end)
+    public List<List> scanIndexTerms(final String xpath,
+            final String start, final String end)
             throws PermissionDeniedException, EXistException, XPathException {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
             final XQuery xquery = broker.getXQueryService();
             final Sequence nodes = xquery.execute(xpath, null, AccessContext.XMLRPC);
-            final Vector<Vector<Object>> result = scanIndexTerms(start, end, broker, nodes.getDocumentSet(), nodes.toNodeSet());
+            final List<List> result = scanIndexTerms(start, end, broker, nodes.getDocumentSet(), nodes.toNodeSet());
             return result;
         } finally {
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * @param start
-     * @param end
-     * @param broker
-     * @param docs
-     * @throws PermissionDeniedException
-     */
-    private Vector<Vector<Object>> scanIndexTerms(String start, String end, DBBroker broker, DocumentSet docs, NodeSet nodes)
-    throws PermissionDeniedException {
-        final Occurrences occurrences[] =
-                broker.getTextEngine().scanIndexTerms(docs, nodes, start, end);
-        final Vector<Vector<Object>> result = new Vector<Vector<Object>>(occurrences.length);
-        Vector<Object> temp;
-        for (int i = 0; i < occurrences.length; i++) {
-            temp = new Vector<Object>(2);
-            temp.addElement(occurrences[i].getTerm().toString());
-            temp.addElement(Integer.valueOf(occurrences[i].getOccurrences()));
-            result.addElement(temp);
+
+    private List<List> scanIndexTerms(final String start, final String end, final DBBroker broker, final DocumentSet docs, final NodeSet nodes)
+            throws PermissionDeniedException {
+        final Occurrences occurrences[]
+                = broker.getTextEngine().scanIndexTerms(docs, nodes, start, end);
+        final List<List> result = new ArrayList<>(occurrences.length);
+        for (final Occurrences occurrence : occurrences) {
+            final List temp = new ArrayList(2);
+            temp.add(occurrence.getTerm().toString());
+            temp.add(occurrence.getOccurrences());
+            result.add(temp);
         }
         return result;
     }
-    
-    /**
-     * The method <code>synchronize</code>
-     *
-     */
+
     public void synchronize() {
     }
-    
-    /**
-     * The method <code>getProperties</code>
-     *
-     * @param parameters a <code>HashMap</code> value
-     * @return a <code>Properties</code> value
-     */
-    private Properties getProperties(HashMap<String, Object> parameters) {
+
+    private Properties toProperties(final Map<String, Object> parameters) {
         final Properties properties = new Properties();
-        for (final Map.Entry<String, Object> entry : parameters.entrySet()) {
-            properties.setProperty(entry.getKey(), entry.getValue().toString());
-        }
+        properties.putAll(parameters);
         return properties;
     }
-    
-    /**
-     * The class <code>CachedQuery</code>
-     *
-     */
+
     class CachedQuery {
-        
-        PathExpr expression;
-        String queryString;
-        long timestamp;
-        
-        public CachedQuery(PathExpr expr, String query) {
+
+        final PathExpr expression;
+        final String queryString;
+        final long timestamp;
+
+        public CachedQuery(final PathExpr expr, final String query) {
             this.expression = expr;
             this.queryString = query;
             this.timestamp = System.currentTimeMillis();
         }
     }
-    
-    /**
-     * The class <code>DoctypeCount</code>
-     *
-     */
+
     class DoctypeCount {
+
         int count = 1;
-        DocumentType doctype;
-        
-        /**
-         * Constructor for the DoctypeCount object
-         *
-         * @param doctype
-         *                   Description of the Parameter
-         */
-        public DoctypeCount(DocumentType doctype) {
+        final DocumentType doctype;
+
+        public DoctypeCount(final DocumentType doctype) {
             this.doctype = doctype;
         }
-        
+
         public void inc() {
             count++;
         }
     }
-    
-    /**
-     * The class <code>NodeCount</code>
-     *
-     */
+
     class NodeCount {
+
         int count = 1;
-        DocumentImpl doc;
-        
-        /**
-         * Constructor for the NodeCount object
-         *
-         * @param doc
-         *                   Description of the Parameter
-         */
-        public NodeCount(DocumentImpl doc) {
+        final DocumentImpl doc;
+
+        public NodeCount(final DocumentImpl doc) {
             this.doc = doc;
         }
-        
+
         public void inc() {
             count++;
         }
     }
-    
+
 //	FIXME: Check it for possible security hole. Check name.
     @Override
-    public byte[] getDocumentChunk(String name, int start, int len)
-    throws EXistException, PermissionDeniedException, IOException {
+    public byte[] getDocumentChunk(final String name, final int start, final int len)
+            throws EXistException, PermissionDeniedException, IOException {
         final File file = new File(System.getProperty("java.io.tmpdir")
-        + File.separator + name);
-        if (!file.canRead())
-            {throw new EXistException("unable to read file " + name);}
-        if (file.length() < start+len)
-            {throw new EXistException("address too big " + name);}
+                + File.separator + name);
+        if (!file.canRead()) {
+            throw new EXistException("unable to read file " + name);
+        }
+        if (file.length() < start + len) {
+            throw new EXistException("address too big " + name);
+        }
         final byte buffer[] = new byte[len];
-        final RandomAccessFile os = new RandomAccessFile(file.getAbsolutePath(), "r");
-        LOG.debug("Read from: " + start + " to: " + (start + len));
-        os.seek(start);
-        os.read(buffer);
-        os.close();
+        try(final RandomAccessFile os = new RandomAccessFile(file.getAbsolutePath(), "r")) {
+            LOG.debug("Read from: " + start + " to: " + (start + len));
+            os.seek(start);
+            os.read(buffer);
+        }
         return buffer;
     }
-    
-    /**
-     * The method <code>moveOrCopyResource</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @param destinationPath a <code>String</code> value
-     * @param newName a <code>String</code> value
-     * @param move a <code>boolean</code> value
-     * @return a <code>boolean</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    public boolean moveOrCopyResource(String documentPath, String destinationPath,
-            String newName, boolean move)
-            throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return moveOrCopyResource(XmldbURI.xmldbUriFor(documentPath),
-    			XmldbURI.xmldbUriFor(destinationPath),XmldbURI.xmldbUriFor(newName),move);
-    }    
 
-    /**
-     * The method <code>moveOrCopyResource</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @param destUri a <code>XmldbURI</code> value
-     * @param newName a <code>XmldbURI</code> value
-     * @param move a <code>boolean</code> value
-     * @return a <code>boolean</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private boolean moveOrCopyResource(XmldbURI docUri, XmldbURI destUri,
-            XmldbURI newName, boolean move)
+    public boolean moveOrCopyResource(final String documentPath, final String destinationPath,
+            final String newName, final boolean move)
+            throws EXistException, PermissionDeniedException, URISyntaxException {
+        return moveOrCopyResource(XmldbURI.xmldbUriFor(documentPath),
+                XmldbURI.xmldbUriFor(destinationPath), XmldbURI.xmldbUriFor(newName), move);
+    }
+
+    private boolean moveOrCopyResource(final XmldbURI docUri, final XmldbURI destUri,
+            final XmldbURI newName, final boolean move)
             throws EXistException, PermissionDeniedException {
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
         Collection collection = null;
         Collection destination = null;
         DocumentImpl doc = null;
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
-        	//TODO : use  transaction.registerLock(collection.getLock(), Lock.WRITE_LOCK);
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
+            //TODO : use  transaction.registerLock(collection.getLock(), Lock.WRITE_LOCK);
             collection = broker.openCollection(docUri.removeLastSegment(), move ? Lock.WRITE_LOCK : Lock.READ_LOCK);
             if (collection == null) {
                 transact.abort(transaction);
                 throw new EXistException("Collection " + docUri.removeLastSegment() + " not found");
-            }           
+            }
             doc = collection.getDocumentWithLock(broker, docUri.lastSegment(), Lock.WRITE_LOCK);
-            if(doc == null) {
+            if (doc == null) {
                 transact.abort(transaction);
                 throw new EXistException("Document " + docUri + " not found");
             }
             //TODO : register the lock within the transaction ?
-            
+
             // get destination collection
             destination = broker.openCollection(destUri, Lock.WRITE_LOCK);
-            if(destination == null) {
+            if (destination == null) {
                 transact.abort(transaction);
                 throw new EXistException("Destination collection " + destUri + " not found");
             }
-            if(move)
-                {broker.moveResource(transaction, doc, destination, newName);}
-            else
-                {broker.copyResource(transaction, doc, destination, newName);}
+            if (move) {
+                broker.moveResource(transaction, doc, destination, newName);
+            } else {
+                broker.copyResource(transaction, doc, destination, newName);
+            }
             transact.commit(transaction);
             return true;
         } catch (final LockException e) {
@@ -4968,70 +4054,47 @@ public class RpcConnection implements RpcAPI {
         } catch (final IOException | TriggerException e) {
             throw new EXistException("Exception [" + e.getMessage() + "] on document " + docUri);
         } finally {
-            if(doc != null) {
+            if (doc != null) {
                 doc.getUpdateLock().release(Lock.WRITE_LOCK);
             }
-            if(collection != null) {
+            if (collection != null) {
                 collection.release(move ? Lock.WRITE_LOCK : Lock.READ_LOCK);
             }
-            if(destination != null) {
+            if (destination != null) {
                 destination.release(Lock.WRITE_LOCK);
             }
         }
     }
-    
-    /**
-     * The method <code>moveOrCopyCollection</code>
-     *
-     * @param collectionName a <code>String</code> value
-     * @param destinationPath a <code>String</code> value
-     * @param newName a <code>String</code> value
-     * @param move a <code>boolean</code> value
-     * @return a <code>boolean</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
-    public boolean moveOrCopyCollection(String collectionName, String destinationPath,
-            String newName, boolean move)
+
+    public boolean moveOrCopyCollection(final String collectionName, final String destinationPath,
+            final String newName, final boolean move)
             throws EXistException, PermissionDeniedException, URISyntaxException {
-    	return moveOrCopyCollection(XmldbURI.xmldbUriFor(collectionName),
-    			XmldbURI.xmldbUriFor(destinationPath),XmldbURI.xmldbUriFor(newName),move);
-    }    
-    
-    /**
-     * The method <code>moveOrCopyCollection</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @param destUri a <code>XmldbURI</code> value
-     * @param newName a <code>XmldbURI</code> value
-     * @param move a <code>boolean</code> value
-     * @return a <code>boolean</code> value
-     * @exception EXistException if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private boolean moveOrCopyCollection(XmldbURI collUri, XmldbURI destUri,
-            XmldbURI newName, boolean move)
+        return moveOrCopyCollection(XmldbURI.xmldbUriFor(collectionName),
+                XmldbURI.xmldbUriFor(destinationPath), XmldbURI.xmldbUriFor(newName), move);
+    }
+
+    private boolean moveOrCopyCollection(final XmldbURI collUri, final XmldbURI destUri,
+            final XmldbURI newName, final boolean move)
             throws EXistException, PermissionDeniedException {
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
         Collection collection = null;
         Collection destination = null;
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
             // get source document
             //TODO : use  transaction.registerLock(collection.getLock(), Lock.WRITE_LOCK);
             collection = broker.openCollection(collUri, move ? Lock.WRITE_LOCK : Lock.READ_LOCK);
             if (collection == null) {
                 transact.abort(transaction);
                 throw new EXistException("Collection " + collUri + " not found");
-            }            
+            }
             // get destination collection
             destination = broker.openCollection(destUri, Lock.WRITE_LOCK);
-            if(destination == null) {
+            if (destination == null) {
                 transact.abort(transaction);
                 throw new EXistException("Destination collection " + destUri + " not found");
-            }            
-            if(move) {
+            }
+            if (move) {
                 broker.moveCollection(transaction, collection, destination, newName);
             } else {
                 broker.copyCollection(transaction, collection, destination, newName);
@@ -5042,154 +4105,101 @@ public class RpcConnection implements RpcAPI {
             throw new PermissionDeniedException(e.getMessage());
         } catch (final IOException | TriggerException e) {
             throw new EXistException(e.getMessage());
-		} finally {
-            if(collection != null) {
+        } finally {
+            if (collection != null) {
                 collection.release(move ? Lock.WRITE_LOCK : Lock.READ_LOCK);
             }
-            if(destination != null) {
+            if (destination != null) {
                 destination.release(Lock.WRITE_LOCK);
             }
         }
     }
-    
-    /**
-     * The method <code>reindexCollection</code>
-     *
-     * @param collectionName a <code>String</code> value
-     * @exception Exception if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public boolean reindexCollection(String collectionName) throws URISyntaxException, EXistException, PermissionDeniedException {
-    	reindexCollection(XmldbURI.xmldbUriFor(collectionName));
+    public boolean reindexCollection(final String collectionName) throws URISyntaxException, EXistException, PermissionDeniedException {
+        reindexCollection(XmldbURI.xmldbUriFor(collectionName));
         return true;
-    }    
-    
-    /**
-     * The method <code>reindexCollection</code>
-     *
-     * @param collUri a <code>XmldbURI</code> value
-     * @exception Exception if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    private void reindexCollection(XmldbURI collUri) throws EXistException, PermissionDeniedException {
+    }
+
+    private void reindexCollection(final XmldbURI collUri) throws EXistException, PermissionDeniedException {
         DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
             broker.reindexCollection(collUri);
             LOG.debug("collection " + collUri + " and sub collection reindexed");
 
-        } catch (final Throwable e) {
+        } catch (final EXistException | PermissionDeniedException e) {
             handleException(e);
 
         } finally {
             factory.getBrokerPool().release(broker);
         }
     }
-    
-    /**
-     * The method <code>backup</code>
-     *
-     * @param userbackup a <code>String</code> value
-     * @param password a <code>String</code> value
-     * @param destcollection a <code>String</code> value
-     * @param collection a <code>String</code> value
-     * @exception Exception if an error occurs
-     * @exception PermissionDeniedException if an error occurs
-     */
-    @Override
-    public boolean backup(String userbackup, String password,
-	String destcollection, String collection) throws EXistException, PermissionDeniedException {
-    	try {
-    		   final Backup backup = new Backup(
-    				userbackup,
-                    password, 
-                    destcollection+"-backup",
-                    XmldbURI.xmldbUriFor(XmldbURI.EMBEDDED_SERVER_URI.toString() + collection));
-                backup.backup(false, null);
 
-            } catch (final Throwable e) {
-                handleException(e);
-			}
+    @Override
+    public boolean backup(final String userbackup, final String password,
+            final String destcollection, final String collection) throws EXistException, PermissionDeniedException {
+        try {
+            final Backup backup = new Backup(
+                    userbackup,
+                    password,
+                    destcollection + "-backup",
+                    XmldbURI.xmldbUriFor(XmldbURI.EMBEDDED_SERVER_URI.toString() + collection));
+            backup.backup(false, null);
+
+        } catch (final URISyntaxException | XMLDBException | IOException | SAXException e) {
+            handleException(e);
+        }
         return true;
     }
-    
+
     /**
-     *   Validate if specified document is Valid.
+     * Validate if specified document is Valid.
      *
-     * @param documentPath   Path to XML document in database
-     * @throws java.lang.Exception  Generic exception
-     * @throws PermissionDeniedException  User is not allowed to perform action.
+     * @param documentPath Path to XML document in database
      * @return TRUE if document is valid, FALSE if not or errors or.....
+     * @throws java.net.URISyntaxException
+     * @throws PermissionDeniedException User is not allowed to perform action.
+     * @throws org.exist.EXistException
      */
     @Override
-    public boolean isValid(String documentPath)
+    public boolean isValid(final String documentPath)
             throws PermissionDeniedException, URISyntaxException, EXistException {
-    	return isValid(XmldbURI.xmldbUriFor(documentPath));
-    }   
-    
-    /**
-     * The method <code>isValid</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @return a <code>boolean</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception Exception if an error occurs
-     */
-    private boolean isValid(XmldbURI docUri) throws EXistException, PermissionDeniedException {
-        boolean isValid=false;
+        return isValid(XmldbURI.xmldbUriFor(documentPath));
+    }
+
+    private boolean isValid(final XmldbURI docUri) throws EXistException, PermissionDeniedException {
 
         try {
             // Setup validator
             final Validator validator = new Validator(factory.getBrokerPool());
-            
+
             // Get inputstream
             // TODO DWES reconsider
-            final InputStream is = new EmbeddedInputStream( new XmldbURL(docUri) );
-            
-            // Perform validation
-            final ValidationReport report = validator.validate(is); 
-            
-            // Return validation result
-            isValid = report.isValid();
-            
+            try (final InputStream is = new EmbeddedInputStream(new XmldbURL(docUri))) {
+                // Perform validation
+                final ValidationReport report = validator.validate(is);
+
+                // Return validation result
+                return report.isValid();
+            }
         } catch (final Throwable e) {
             handleException(e);
             return false;
         }
-        
-        return isValid;
     }
-    
-    /**
-     * The method <code>getDocType</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @return a <code>Vector</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
+
     @Override
-    public Vector<String> getDocType(String documentPath)
-    throws PermissionDeniedException, EXistException, URISyntaxException {
-    	return getDocType(XmldbURI.xmldbUriFor(documentPath));
-    }    
-    
-    /**
-     * The method <code>getDocType</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @return a <code>Vector</code> value
-     * @exception PermissionDeniedException if an error occurs
-     * @exception EXistException if an error occurs
-     */
-    private Vector<String> getDocType(XmldbURI docUri)
-    throws PermissionDeniedException, EXistException {
+    public List<String> getDocType(final String documentPath)
+            throws PermissionDeniedException, EXistException, URISyntaxException {
+        return getDocType(XmldbURI.xmldbUriFor(documentPath));
+    }
+
+    private List<String> getDocType(final XmldbURI docUri)
+            throws PermissionDeniedException, EXistException {
         DBBroker broker = null;
         DocumentImpl doc = null;
-        
+
         try {
             broker = factory.getBrokerPool().get(user);
             doc = broker.getXMLResource(docUri, Lock.READ_LOCK);
@@ -5197,89 +4207,66 @@ public class RpcConnection implements RpcAPI {
                 LOG.debug("document " + docUri + " not found!");
                 throw new EXistException("document not found");
             }
-            
-            final Vector<String> vector = new Vector<String>(3);
-                        
-            if (doc.getDoctype() != null)
-            {            	
-            	vector.addElement(doc.getDoctype().getName()); 
-            	
-            	if (doc.getDoctype().getPublicId() != null) {  
-            		vector.addElement(doc.getDoctype().getPublicId());             	  
-            	} else {
-            		vector.addElement("");
-            	}
-            		
-            	if (doc.getDoctype().getSystemId() != null) {
-            		vector.addElement(doc.getDoctype().getSystemId());
-            	} else {
-            		vector.addElement("");
-            	}
-            } else
-            {
-            	vector.addElement("");
-            	vector.addElement("");
-            	vector.addElement("");
+
+            final List<String> list = new ArrayList<>(3);
+
+            if (doc.getDoctype() != null) {
+                list.add(doc.getDoctype().getName());
+
+                if (doc.getDoctype().getPublicId() != null) {
+                    list.add(doc.getDoctype().getPublicId());
+                } else {
+                    list.add("");
+                }
+
+                if (doc.getDoctype().getSystemId() != null) {
+                    list.add(doc.getDoctype().getSystemId());
+                } else {
+                    list.add("");
+                }
+            } else {
+                list.add("");
+                list.add("");
+                list.add("");
             }
-            return vector;
+            return list;
         } finally {
-            if(doc != null)
-                {doc.getUpdateLock().release(Lock.READ_LOCK);}
+            if (doc != null) {
+                doc.getUpdateLock().release(Lock.READ_LOCK);
+            }
             factory.getBrokerPool().release(broker);
         }
     }
-    
 
-    /**
-     * The method <code>setDocType</code>
-     *
-     * @param documentPath a <code>String</code> value
-     * @param doctypename a <code>String</code> value
-     * @param publicid a <code>String</code> value
-     * @param systemid a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     * @exception URISyntaxException if an error occurs
-     */
     @Override
-    public boolean setDocType(String documentPath, String doctypename, String publicid, String systemid) throws
+    public boolean setDocType(final String documentPath, final String doctypename, final String publicid, final String systemid) throws
             URISyntaxException, EXistException, PermissionDeniedException {
-    	return setDocType(XmldbURI.xmldbUriFor(documentPath),doctypename, publicid, systemid);
-    }    
+        return setDocType(XmldbURI.xmldbUriFor(documentPath), doctypename, publicid, systemid);
+    }
 
-    /**
-     * The method <code>setDocType</code>
-     *
-     * @param docUri a <code>XmldbURI</code> value
-     * @param doctypename a <code>String</code> value
-     * @param publicid a <code>String</code> value
-     * @param systemid a <code>String</code> value
-     * @return a <code>boolean</code> value
-     * @exception Exception if an error occurs
-     */
-    private boolean setDocType(XmldbURI docUri, String doctypename, String publicid, String systemid) throws EXistException, PermissionDeniedException {
+    private boolean setDocType(final XmldbURI docUri, final String doctypename, final String publicid, final String systemid) throws EXistException, PermissionDeniedException {
         DocumentImpl doc = null;
         DocumentType result = null;
         final TransactionManager transact = factory.getBrokerPool().getTransactionManager();
-        try(final DBBroker broker = factory.getBrokerPool().get(user);
-            final Txn transaction = transact.beginTransaction()) {
-            doc = broker.getXMLResource(docUri, Lock.WRITE_LOCK);          
+        try (final DBBroker broker = factory.getBrokerPool().get(user);
+                final Txn transaction = transact.beginTransaction()) {
+            doc = broker.getXMLResource(docUri, Lock.WRITE_LOCK);
             if (doc == null) {
-            	transact.abort(transaction);
+                transact.abort(transaction);
                 throw new EXistException("Resource " + docUri + " not found");
             }
             //TODO : register the lock within the transaction ?
             if (!doc.getPermissions().validate(user, Permission.WRITE)) {
-            	transact.abort(transaction);
-            	throw new PermissionDeniedException("User is not allowed to lock resource " + docUri);
+                transact.abort(transaction);
+                throw new PermissionDeniedException("User is not allowed to lock resource " + docUri);
             }
-            
+
             if (!"".equals(doctypename)) {
-            	result = new DocumentTypeImpl(doctypename,
-            			"".equals(publicid) ? null : publicid,
-            			"".equals(systemid) ? null : systemid );            	
+                result = new DocumentTypeImpl(doctypename,
+                        "".equals(publicid) ? null : publicid,
+                        "".equals(systemid) ? null : systemid);
             }
-            	            
+
             doc.setDocumentType(result);
             broker.storeXMLResource(transaction, doc);
             transact.commit(transaction);
@@ -5289,77 +4276,75 @@ public class RpcConnection implements RpcAPI {
             handleException(e);
             return false;
         } finally {
-            if(doc != null) {
+            if (doc != null) {
                 doc.getUpdateLock().release(Lock.WRITE_LOCK);
             }
         }
     }
 
     @Override
-    public boolean copyResource(String docPath, String destinationPath, String newName) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public boolean copyResource(final String docPath, final String destinationPath, final String newName) throws EXistException, PermissionDeniedException, URISyntaxException {
         return moveOrCopyResource(docPath, destinationPath, newName, false);
     }
 
     @Override
-    public boolean copyCollection(String collectionPath, String destinationPath, String newName) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public boolean copyCollection(final String collectionPath, final String destinationPath, final String newName) throws EXistException, PermissionDeniedException, URISyntaxException {
         return moveOrCopyCollection(collectionPath, destinationPath, newName, false);
     }
 
     @Override
-    public boolean moveResource(String docPath, String destinationPath, String newName) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public boolean moveResource(final String docPath, final String destinationPath, final String newName) throws EXistException, PermissionDeniedException, URISyntaxException {
         return moveOrCopyResource(docPath, destinationPath, newName, true);
     }
 
     @Override
-    public boolean moveCollection(String collectionPath, String destinationPath, String newName) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public boolean moveCollection(final String collectionPath, final String destinationPath, final String newName) throws EXistException, PermissionDeniedException, URISyntaxException {
         return moveOrCopyCollection(collectionPath, destinationPath, newName, true);
     }
 
     @Override
-    public List<String> getDocumentChunk(String name, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException, IOException {
-        final List<String> result = new ArrayList<String>(2);
-        File file;
-        file = File.createTempFile("rpc", ".xml");
+    public List<String> getDocumentChunk(final String name, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException, IOException {
+        final List<String> result = new ArrayList<>(2);
+        final File file = File.createTempFile("rpc", ".xml");
         file.deleteOnExit();
-        final FileOutputStream os = new FileOutputStream(file.getAbsolutePath(), true);
-        os.write(getDocument(name, parameters));
-        os.close();
+        try (final FileOutputStream os = new FileOutputStream(file.getAbsolutePath(), true)) {
+            os.write(getDocument(name, parameters));
+        }
         result.add(file.getName());
         result.add(Long.toString(file.length()));
         return result;
     }
 
     @Override
-    public boolean copyCollection(String name, String namedest) throws PermissionDeniedException, EXistException {
+    public boolean copyCollection(final String name, final String namedest) throws PermissionDeniedException, EXistException {
         try {
             createCollection(namedest);
 
-            final HashMap<String, Object> parametri = new HashMap<String, Object>();
+            final Map<String, Object> parametri = new HashMap<>();
             parametri.put(OutputKeys.INDENT, "no");
             parametri.put(EXistOutputKeys.EXPAND_XINCLUDES, "no");
             parametri.put(OutputKeys.ENCODING, DEFAULT_ENCODING);
 
-            final HashMap<String, Object> lista = getCollectionDesc(name);
-            final Object[] collezioni = (Object[]) lista.get("collections");
-            final Object[] documents = (Object[]) lista.get("documents");
+            final Map<String, Object> desc = getCollectionDesc(name);
+            final Object[] collections = (Object[]) desc.get("collections");
+            final Object[] documents = (Object[]) desc.get("documents");
 
             //ricrea le directory
-            String nome;
-            for (int i = 0; i < collezioni.length; i++) {
-                nome = collezioni[i].toString();
+            for (final Object collection : collections) {
+                final String nome = collection.toString();
                 createCollection(namedest + "/" + nome);
                 copyCollection(name + "/" + nome, namedest + "/" + nome);
             }
 
             //Copy i file
-            HashMap<String, Object> hash;
             int p, dsize = documents.length;
             for (int i = 0; i < dsize; i++) {
-                hash = (HashMap<String, Object>) documents[i];
-                nome = (String) hash.get("name");
+                final Map<String, Object> hash = (Map<String, Object>) documents[i];
+                String nome = (String) hash.get("name");
                 //TODO : use dedicated function in XmldbURI
-                if ((p = nome.lastIndexOf("/")) != Constants.STRING_NOT_FOUND)
-                    {nome = nome.substring(p + 1);}
+                if ((p = nome.lastIndexOf("/")) != Constants.STRING_NOT_FOUND) {
+                    nome = nome.substring(p + 1);
+                }
 
                 final byte[] xml = getDocument(name + "/" + nome, parametri);
                 parse(xml, namedest + "/" + nome);
@@ -5367,82 +4352,82 @@ public class RpcConnection implements RpcAPI {
 
             return true;
 
-        } catch (final Throwable e) {
+        } catch (final EXistException | PermissionDeniedException | URISyntaxException e) {
             handleException(e);
             return false;
         }
     }
 
     @Override
-    public int xupdateResource(String resource, byte[] xupdate) throws PermissionDeniedException, EXistException, SAXException {
+    public int xupdateResource(final String resource, final byte[] xupdate) throws PermissionDeniedException, EXistException, SAXException {
         return xupdateResource(resource, xupdate, DEFAULT_ENCODING);
     }
 
     @Override
-    public HashMap<String, Object> querySummary(int resultId) throws EXistException, PermissionDeniedException, XPathException {
+    public Map<String, Object> querySummary(final int resultId) throws EXistException, PermissionDeniedException, XPathException {
         return summary(resultId);
     }
 
     @Override
-    public int executeQuery(byte[] xpath, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+    public int executeQuery(final byte[] xpath, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         return executeQuery(xpath, null, parameters);
     }
 
     @Override
-    public boolean storeBinary(byte[] data, String docName, String mimeType, boolean replace, Date created, Date modified) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public boolean storeBinary(final byte[] data, final String docName, final String mimeType, final boolean replace, final Date created, final Date modified) throws EXistException, PermissionDeniedException, URISyntaxException {
         return storeBinary(data, docName, mimeType, replace ? 1 : 0, created, modified);
     }
 
     @Override
-    public boolean storeBinary(byte[] data, String docName, String mimeType, boolean replace) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public boolean storeBinary(final byte[] data, final String docName, final String mimeType, final boolean replace) throws EXistException, PermissionDeniedException, URISyntaxException {
         return storeBinary(data, docName, mimeType, replace ? 1 : 0, null, null);
     }
 
     @Override
-    public boolean parseLocalExt(String localFile, String docName, boolean replace, String mimeType, boolean treatAsXML, Date created, Date modified) throws EXistException, PermissionDeniedException, SAXException, URISyntaxException {
+    public boolean parseLocalExt(final String localFile, final String docName, final boolean replace, final String mimeType, final boolean treatAsXML, final Date created, final Date modified) throws EXistException, PermissionDeniedException, SAXException, URISyntaxException {
         return parseLocalExt(localFile, docName, replace ? 1 : 0, mimeType, treatAsXML ? 1 : 0, created, modified);
     }
 
     @Override
-    public boolean parseLocal(String localFile, String docName, boolean replace, String mimeType, Date created, Date modified) throws EXistException, PermissionDeniedException, SAXException, URISyntaxException {
+    public boolean parseLocal(final String localFile, final String docName, final boolean replace, final String mimeType, final Date created, final Date modified) throws EXistException, PermissionDeniedException, SAXException, URISyntaxException {
         return parseLocal(localFile, docName, replace ? 1 : 0, mimeType, created, modified);
     }
 
     @Override
-    public boolean parseLocalExt(String localFile, String docName, boolean replace, String mimeType, boolean treatAsXML) throws EXistException, PermissionDeniedException, SAXException, URISyntaxException {
+    public boolean parseLocalExt(final String localFile, final String docName, final boolean replace, final String mimeType, final boolean treatAsXML) throws EXistException, PermissionDeniedException, SAXException, URISyntaxException {
         return parseLocalExt(localFile, docName, replace ? 1 : 0, mimeType, treatAsXML ? 1 : 0, null, null);
     }
 
     @Override
-    public boolean parseLocal(String localFile, String docName, boolean replace, String mimeType) throws EXistException, PermissionDeniedException, SAXException, URISyntaxException {
+    public boolean parseLocal(final String localFile, final String docName, final boolean replace, final String mimeType) throws EXistException, PermissionDeniedException, SAXException, URISyntaxException {
         return parseLocal(localFile, docName, replace ? 1 : 0, mimeType, null, null);
     }
 
     @Override
-    public String uploadCompressed(String file, byte[] data, int length) throws EXistException, PermissionDeniedException, IOException {
+    public String uploadCompressed(final String file, final byte[] data, final int length) throws EXistException, PermissionDeniedException, IOException {
         return upload(data, length, file, true);
     }
 
     @Override
-    public String uploadCompressed(byte[] data, int length) throws EXistException, PermissionDeniedException, IOException {
+    public String uploadCompressed(final byte[] data, final int length) throws EXistException, PermissionDeniedException, IOException {
         return upload(data, length, null, true);
     }
 
     @Override
-    public String upload(String file, byte[] chunk, int length) throws EXistException, PermissionDeniedException, IOException {
+    public String upload(final String file, final byte[] chunk, final int length) throws EXistException, PermissionDeniedException, IOException {
         return upload(chunk, length, file, false);
     }
 
     @Override
-    public String upload(byte[] chunk, int length) throws EXistException, PermissionDeniedException, IOException {
+    public String upload(final byte[] chunk, final int length) throws EXistException, PermissionDeniedException, IOException {
         return upload(chunk, length, null, false);
     }
 
     @Override
-    public boolean parse(String xml, String docName) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public boolean parse(final String xml, final String docName) throws EXistException, PermissionDeniedException, URISyntaxException {
         try {
             return parse(xml.getBytes(DEFAULT_ENCODING), docName, 0);
-            
+
         } catch (final UnsupportedEncodingException e) {
             handleException(e);
             return false;
@@ -5450,7 +4435,7 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public boolean parse(String xml, String docName, int overwrite) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public boolean parse(final String xml, final String docName, final int overwrite) throws EXistException, PermissionDeniedException, URISyntaxException {
         try {
             return parse(xml.getBytes(DEFAULT_ENCODING), docName, overwrite);
 
@@ -5461,19 +4446,17 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public boolean parse(byte[] xmlData, String docName) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public boolean parse(final byte[] xmlData, final String docName) throws EXistException, PermissionDeniedException, URISyntaxException {
         return parse(xmlData, docName, 0);
     }
 
-    /** @deprecated Use XmldbURI version instead */
     @Override
-    public HashMap<String, Object> querySummary(String xquery) throws EXistException, PermissionDeniedException {
+    public Map<String, Object> querySummary(final String xquery) throws EXistException, PermissionDeniedException {
         return summary(xquery);
     }
 
-    /** @deprecated Use XmldbURI version instead */
     @Override
-    public byte[] query(byte[] xquery, int howmany, int start, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+    public byte[] query(final byte[] xquery, final int howmany, final int start, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         try {
             final String result = query(new String(xquery, DEFAULT_ENCODING), howmany, start, parameters);
             return result.getBytes(DEFAULT_ENCODING);
@@ -5485,7 +4468,7 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public HashMap<String, Object> queryP(byte[] xpath, String docName, String s_id, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException, URISyntaxException {
+    public Map<String, Object> queryP(final byte[] xpath, final String docName, final String s_id, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException, URISyntaxException {
         try {
             return queryP(new String(xpath, DEFAULT_ENCODING), docName, s_id, parameters);
         } catch (final UnsupportedEncodingException e) {
@@ -5495,10 +4478,10 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public HashMap<String, Object> queryP(byte[] xpath, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+    public Map<String, Object> queryP(final byte[] xpath, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         try {
             return queryP(new String(xpath, DEFAULT_ENCODING), (XmldbURI) null, null, parameters);
-            
+
         } catch (final UnsupportedEncodingException e) {
             handleException(e);
             return null;
@@ -5506,10 +4489,10 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public HashMap<String, Object> compile(byte[] xquery, HashMap<String, Object> parameters) throws EXistException, PermissionDeniedException {
+    public Map<String, Object> compile(final byte[] xquery, final Map<String, Object> parameters) throws EXistException, PermissionDeniedException {
         try {
             return compile(new String(xquery, DEFAULT_ENCODING), parameters);
-            
+
         } catch (final UnsupportedEncodingException e) {
             handleException(e);
             return null;
@@ -5517,13 +4500,13 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public byte[] retrieve(String doc, String id) throws EXistException, PermissionDeniedException {
+    public byte[] retrieve(final String doc, final String id) throws EXistException, PermissionDeniedException {
         return retrieve(doc, id, null);
     }
 
     @Override
-    public String getDocumentAsString(String name, int prettyPrint, String stylesheet) throws EXistException, PermissionDeniedException {
-        final HashMap<String, Object> parametri = new HashMap<String, Object>();
+    public String getDocumentAsString(final String name, final int prettyPrint, final String stylesheet) throws EXistException, PermissionDeniedException {
+        final Map<String, Object> parametri = new HashMap<>();
 
         if (prettyPrint > 0) {
             parametri.put(OutputKeys.INDENT, "yes");
@@ -5538,13 +4521,13 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public String getDocumentAsString(String name, int prettyPrint) throws EXistException, PermissionDeniedException {
+    public String getDocumentAsString(final String name, final int prettyPrint) throws EXistException, PermissionDeniedException {
         return getDocumentAsString(name, prettyPrint, null);
     }
 
     @Override
-    public byte[] getDocument(String name, String encoding, int prettyPrint, String stylesheet) throws EXistException, PermissionDeniedException {
-        final HashMap<String, Object> parametri = new HashMap<String, Object>();
+    public byte[] getDocument(final String name, final String encoding, final int prettyPrint, final String stylesheet) throws EXistException, PermissionDeniedException {
+        final Map<String, Object> parametri = new HashMap<>();
 
         if (prettyPrint > 0) {
             parametri.put(OutputKeys.INDENT, "yes");
@@ -5561,32 +4544,35 @@ public class RpcConnection implements RpcAPI {
         //String xml = con.getDocument(user, name, (prettyPrint > 0),
         // encoding, stylesheet);
         final byte[] xml = getDocument(name, parametri);
-        if (xml == null)
-            {throw new EXistException("document " + name + " not found!");}
+        if (xml == null) {
+            throw new EXistException("document " + name + " not found!");
+        }
         return xml;
     }
 
     @Override
-    public byte[] getDocument(String name, String encoding, int prettyPrint) throws EXistException, PermissionDeniedException {
+    public byte[] getDocument(final String name, final String encoding, final int prettyPrint) throws EXistException, PermissionDeniedException {
         return getDocument(name, encoding, prettyPrint, null);
     }
-    
-    public boolean setTriggersEnabled(String path, String value) throws PermissionDeniedException{
-    	DBBroker broker = null;
-    	final boolean triggersEnabled = Boolean.parseBoolean(value); 
-		try {
-			broker = factory.getBrokerPool().get(user);
-	    	final Collection collection = broker.getCollection(XmldbURI.create(path));
-	    	if (collection == null)
-	    		{return false;}
-	    	collection.setTriggersEnabled(triggersEnabled);
-		} catch (final EXistException e) {
+
+    @Override
+    public boolean setTriggersEnabled(final String path, final String value) throws PermissionDeniedException {
+        DBBroker broker = null;
+        final boolean triggersEnabled = Boolean.parseBoolean(value);
+        try {
+            broker = factory.getBrokerPool().get(user);
+            final Collection collection = broker.getCollection(XmldbURI.create(path));
+            if (collection == null) {
+                return false;
+            }
+            collection.setTriggersEnabled(triggersEnabled);
+        } catch (final EXistException e) {
             LOG.warn(triggersEnabled ? "Enable" : "Disable" + " triggers failed", e);
             return false;
-		} finally {
-			factory.getBrokerPool().release(broker);
-		}
-    	return true;
+        } finally {
+            factory.getBrokerPool().release(broker);
+        }
+        return true;
     }
 
     @Override
@@ -5595,14 +4581,15 @@ public class RpcConnection implements RpcAPI {
     }
 
     @Override
-    public boolean shutdown(String delay) throws PermissionDeniedException {
+    public boolean shutdown(final String delay) throws PermissionDeniedException {
         return shutdown(Long.parseLong(delay));
     }
 
     @Override
-    public boolean shutdown(long delay) throws PermissionDeniedException {
-        if (!user.hasDbaRole())
-            {throw new PermissionDeniedException("not allowed to shut down" + "the database");}
+    public boolean shutdown(final long delay) throws PermissionDeniedException {
+        if (!user.hasDbaRole()) {
+            throw new PermissionDeniedException("not allowed to shut down" + "the database");
+        }
         if (delay > 0) {
             final TimerTask task = new TimerTask() {
                 @Override
@@ -5629,17 +4616,17 @@ public class RpcConnection implements RpcAPI {
         brokerPool.exitServiceMode(user);
     }
 
-	@Override
-	public void runCommand(XmldbURI collectionURI, Vector<String> params) throws EXistException, PermissionDeniedException {
+    @Override
+    public void runCommand(final XmldbURI collectionURI, final List<String> params) throws EXistException, PermissionDeniedException {
 
-		DBBroker broker = null;
+        DBBroker broker = null;
         try {
             broker = factory.getBrokerPool().get(user);
-            
+
             org.exist.plugin.command.Commands.command(collectionURI, params.toArray(new String[params.size()]));
 
-		} finally {
+        } finally {
             factory.getBrokerPool().release(broker);
         }
-	}
+    }
 }

--- a/src/org/exist/xmlrpc/RpcConnection.java
+++ b/src/org/exist/xmlrpc/RpcConnection.java
@@ -1,23 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2013 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.xmlrpc;
 

--- a/src/org/exist/xmlrpc/RpcServlet.java
+++ b/src/org/exist/xmlrpc/RpcServlet.java
@@ -26,7 +26,6 @@ import org.apache.xmlrpc.XmlRpcHandler;
 import org.apache.xmlrpc.server.AbstractReflectiveHandlerMapping;
 import org.apache.xmlrpc.server.RequestProcessorFactoryFactory;
 import org.apache.xmlrpc.server.XmlRpcHandlerMapping;
-import org.apache.xmlrpc.server.XmlRpcNoSuchHandlerException;
 import org.apache.xmlrpc.webserver.XmlRpcServlet;
 import org.exist.EXistException;
 import org.exist.http.Descriptor;
@@ -40,33 +39,32 @@ import java.io.IOException;
 public class RpcServlet extends XmlRpcServlet {
 
 	private static final long serialVersionUID = -1003413291835771186L;
-
     private static boolean useDefaultUser = true;
 
     public static boolean isUseDefaultUser() {
         return useDefaultUser;
     }
 
-    public static void setUseDefaultUser(boolean useDefaultUser) {
+    public static void setUseDefaultUser(final boolean useDefaultUser) {
         RpcServlet.useDefaultUser = useDefaultUser;
     }
 
-	@Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+    @Override
+    public void doPost(HttpServletRequest request, final HttpServletResponse response) throws IOException, ServletException {
         // Request logger
 
         final Descriptor descriptor = Descriptor.getDescriptorSingleton();
-        if( descriptor.allowRequestLogging() && !descriptor.requestsFiltered()) {
+        if (descriptor.allowRequestLogging() && !descriptor.requestsFiltered()) {
             // Wrap HttpServletRequest, because both request Logger and xmlrpc
             // need the request InputStream, which is consumed when read.
             request =
-                new HttpServletRequestWrapper(request, /*formEncoding*/ "utf-8" );
+                    new HttpServletRequestWrapper(request, /*formEncoding*/ "utf-8");
             descriptor.doLogRequestInReplayLog(request);
         }
 
         try {
             super.doPost(request, response);
-        } catch (final Throwable e){
+        } catch (final Throwable e) {
             log("Problem during XmlRpc execution", e);
             throw new ServletException("An unknown error occurred: " + e.getMessage(), e);
         }
@@ -84,10 +82,12 @@ public class RpcServlet extends XmlRpcServlet {
 
         RequestProcessorFactory instance = null;
 
-        public RequestProcessorFactory getRequestProcessorFactory(Class pClass) throws XmlRpcException {
+        @Override
+        public RequestProcessorFactory getRequestProcessorFactory(final Class pClass) throws XmlRpcException {
             try {
-                if (instance == null)
-                    {instance = new XmldbRequestProcessorFactory("exist", useDefaultUser);}
+                if (instance == null) {
+                    instance = new XmldbRequestProcessorFactory("exist", useDefaultUser);
+                }
                 return instance;
             } catch (final EXistException e) {
                 throw new XmlRpcException("Failed to initialize XMLRPC interface: " + e.getMessage(), e);
@@ -100,13 +100,15 @@ public class RpcServlet extends XmlRpcServlet {
         private DefaultHandlerMapping() throws XmlRpcException {
         }
 
-        public void loadDefault(Class<?> clazz) throws XmlRpcException {
+        public void loadDefault(final Class<?> clazz) throws XmlRpcException {
             registerPublicMethods("Default", clazz);
         }
 
-        public XmlRpcHandler getHandler(String pHandlerName) throws XmlRpcNoSuchHandlerException, XmlRpcException {
-            if (pHandlerName.indexOf('.') < 0)
-                {pHandlerName = "Default." + pHandlerName;}
+        @Override
+        public XmlRpcHandler getHandler(String pHandlerName) throws XmlRpcException {
+            if (pHandlerName.indexOf('.') < 0) {
+                pHandlerName = "Default." + pHandlerName;
+            }
             return super.getHandler(pHandlerName);
         }
     }

--- a/src/org/exist/xmlrpc/RpcServlet.java
+++ b/src/org/exist/xmlrpc/RpcServlet.java
@@ -1,23 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-07 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- * $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.xmlrpc;
 

--- a/src/org/exist/xmlrpc/RpcServlet.java
+++ b/src/org/exist/xmlrpc/RpcServlet.java
@@ -19,6 +19,8 @@
  */
 package org.exist.xmlrpc;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.xmlrpc.XmlRpcException;
 import org.apache.xmlrpc.XmlRpcHandler;
 import org.apache.xmlrpc.server.AbstractReflectiveHandlerMapping;
@@ -37,6 +39,7 @@ import java.io.IOException;
 public class RpcServlet extends XmlRpcServlet {
 
 	private static final long serialVersionUID = -1003413291835771186L;
+    private static final Logger LOG = LogManager.getLogger(RpcServlet.class);
     private static boolean useDefaultUser = true;
 
     public static boolean isUseDefaultUser() {
@@ -62,9 +65,17 @@ public class RpcServlet extends XmlRpcServlet {
 
         try {
             super.doPost(request, response);
-        } catch (final Throwable e) {
-            log("Problem during XmlRpc execution", e);
-            throw new ServletException("An unknown error occurred: " + e.getMessage(), e);
+        } catch (final Throwable e){
+            LOG.error("Problem during XmlRpc execution", e);
+            final String exceptionMessage;
+            if (e instanceof XmlRpcException) {
+                final Throwable linkedException = ((XmlRpcException)e).linkedException;
+                LOG.error(linkedException.getMessage(), linkedException);
+                exceptionMessage = "An error occurred: " + e.getMessage() + ": " + linkedException.getMessage();
+            } else {
+                exceptionMessage = "An unknown error occurred: " + e.getMessage();
+            }
+            throw new ServletException(exceptionMessage, e);
         }
     }
 

--- a/src/org/exist/xmlrpc/SerializedResult.java
+++ b/src/org/exist/xmlrpc/SerializedResult.java
@@ -1,3 +1,22 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.exist.xmlrpc;
 
 import org.exist.util.VirtualTempFile;

--- a/src/org/exist/xmlrpc/SerializedResult.java
+++ b/src/org/exist/xmlrpc/SerializedResult.java
@@ -6,41 +6,41 @@ import org.exist.xquery.XPathException;
 /**
  * Simple container for the results of a query. Used to cache
  * query results that may be retrieved later by the client.
- * 
+ *
  * @author jmfernandez
  */
-public class SerializedResult
-	extends AbstractCachedResult
-{
-	protected VirtualTempFile result;
-	
-	// set upon failure
-	protected XPathException exception = null;
-	
-	public SerializedResult(VirtualTempFile result) {
-		this(result, 0);
-	}
-	
-	public SerializedResult(VirtualTempFile result, long queryTime) {
-		super(queryTime);
-		this.result = result;
-	}
-	
-	public SerializedResult(XPathException e) {
-		exception = e;
-	}
-	
-	/**
-	 * @return Returns the result.
-	 */
-	public VirtualTempFile getResult() {
-		return result;
-	}
-	
-	public void free() {
-		if(result!=null) {
-			result.delete();
-			result = null;
-		}
-	}
+public class SerializedResult extends AbstractCachedResult {
+    protected VirtualTempFile result;
+
+    // set upon failure
+    protected XPathException exception = null;
+
+    public SerializedResult(final VirtualTempFile result) {
+        this(result, 0);
+    }
+
+    public SerializedResult(final VirtualTempFile result, final long queryTime) {
+        super(queryTime);
+        this.result = result;
+    }
+
+    public SerializedResult(final XPathException e) {
+        exception = e;
+    }
+
+    /**
+     * @return Returns the result.
+     */
+    @Override
+    public VirtualTempFile getResult() {
+        return result;
+    }
+
+    @Override
+    public void free() {
+        if (result != null) {
+            result.delete();
+            result = null;
+        }
+    }
 }

--- a/src/org/exist/xmlrpc/XmldbRequestProcessorFactory.java
+++ b/src/org/exist/xmlrpc/XmldbRequestProcessorFactory.java
@@ -1,23 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2010 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.xmlrpc;
 

--- a/src/org/exist/xmlrpc/function/XmlRpcCollectionFunction.java
+++ b/src/org/exist/xmlrpc/function/XmlRpcCollectionFunction.java
@@ -1,0 +1,61 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xmlrpc.function;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.util.LockException;
+import org.exist.util.function.TriFunction2E;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+/**
+ * Specialisation of FunctionE which deals with
+ * XML-RPC server operations; Predominantly converts exceptions
+ * from the database into EXistException types
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface XmlRpcCollectionFunction<R> extends TriFunction2E<Collection, DBBroker, Txn, R, EXistException, PermissionDeniedException> {
+
+    @Override
+    default R apply(final org.exist.collections.Collection collection, final DBBroker broker, final Txn transaction) throws EXistException, PermissionDeniedException {
+        try {
+            return applyXmlRpc(collection, broker, transaction);
+        } catch(final  IOException | SAXException | LockException e) {
+            throw new EXistException(e);
+        }
+    }
+
+    /**
+     * Signature for lambda function which takes a collection
+     *
+     * @param collection The database collection
+     * @param broker The database broker for the XML-RPC function
+     * @param transaction The transaction for the XML-RPC function
+     */
+    R applyXmlRpc(org.exist.collections.Collection collection, final DBBroker broker, final Txn transaction) throws EXistException, PermissionDeniedException, IOException, SAXException, LockException;
+}

--- a/src/org/exist/xmlrpc/function/XmlRpcCompiledXQueryFunction.java
+++ b/src/org/exist/xmlrpc/function/XmlRpcCompiledXQueryFunction.java
@@ -1,0 +1,53 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xmlrpc.function;
+
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.util.function.Function2E;
+import org.exist.xquery.CompiledXQuery;
+import org.exist.xquery.XPathException;
+
+/**
+ * Specialisation of FunctionE which deals with
+ * XML-RPC server operations; Predominantly converts exceptions
+ * from the database into EXistException types
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface XmlRpcCompiledXQueryFunction<R> extends Function2E<CompiledXQuery, R, EXistException, PermissionDeniedException> {
+
+    @Override
+    default R apply(final CompiledXQuery compiledQuery) throws EXistException, PermissionDeniedException {
+        try {
+            return applyXmlRpc(compiledQuery);
+        } catch(final XPathException e) {
+            throw new EXistException(e);
+        }
+    }
+
+    /**
+     * Signature for lambda function which takes a compiled XQuery
+     *
+     * @param compiledQuery The compiled XQuery
+     */
+    R applyXmlRpc(final CompiledXQuery compiledQuery) throws EXistException, PermissionDeniedException, XPathException;
+}

--- a/src/org/exist/xmlrpc/function/XmlRpcDocumentFunction.java
+++ b/src/org/exist/xmlrpc/function/XmlRpcDocumentFunction.java
@@ -1,0 +1,57 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xmlrpc.function;
+
+import org.exist.EXistException;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.util.function.TriFunction2E;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+/**
+ * Specialisation of FunctionE which deals with
+ * XML-RPC server operations; Predominantly converts exceptions
+ * from the database into EXistException types
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface XmlRpcDocumentFunction<R> extends TriFunction2E<DocumentImpl, DBBroker, Txn, R, EXistException, PermissionDeniedException> {
+
+    @Override
+    default R apply(final DocumentImpl document, final DBBroker broker, final Txn transaction) throws EXistException, PermissionDeniedException {
+        try {
+            return applyXmlRpc(document, broker, transaction);
+        } catch(final SAXException | IOException e) {
+            throw new EXistException(e);
+        }
+    }
+
+    /**
+     * Signature for lambda function which takes a document
+     *
+     * @param document The database collection
+     */
+    R applyXmlRpc(final DocumentImpl document, final DBBroker broker, final Txn transaction) throws EXistException, PermissionDeniedException, SAXException, IOException;
+}

--- a/src/org/exist/xmlrpc/function/XmlRpcFunction.java
+++ b/src/org/exist/xmlrpc/function/XmlRpcFunction.java
@@ -1,0 +1,58 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xmlrpc.function;
+
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.util.LockException;
+import org.exist.util.function.BiFunction2E;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+/**
+ * Specialisation of BiFunctionE which deals with
+ * XML-RPC server operations; Predominantly converts exceptions
+ * from the database into EXistException types
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+@FunctionalInterface
+public interface XmlRpcFunction<R> extends BiFunction2E<DBBroker, Txn, R, EXistException, PermissionDeniedException> {
+
+    @Override
+    default R apply(final DBBroker broker, final Txn transaction) throws EXistException, PermissionDeniedException {
+        try {
+            return applyXmlRpc(broker, transaction);
+        } catch(final LockException | IOException | SAXException e) {
+            throw new EXistException(e);
+        }
+    }
+
+    /**
+     * Signature for lambda function which takes a broker and transaction
+     *
+     * @param broker The database broker for the XML-RPC function
+     * @param transaction The transaction for the XML-RPC function
+     */
+    R applyXmlRpc(final DBBroker broker, final Txn transaction) throws EXistException, PermissionDeniedException, LockException, SAXException, IOException;
+}

--- a/test/src/org/exist/storage/XIncludeSerializerTest.java
+++ b/test/src/org/exist/storage/XIncludeSerializerTest.java
@@ -1,23 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2014 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage;
 

--- a/test/src/org/exist/storage/XIncludeSerializerTest.java
+++ b/test/src/org/exist/storage/XIncludeSerializerTest.java
@@ -40,17 +40,18 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author jim fuller at webcomposite.com
- * 
+ *
  * Test XInclude Serialiser via REST/XMLRPC/WEBDAV/SOAP interfaces
  */
 public class XIncludeSerializerTest {
 
-	private static JettyStart server = null;
-    
+    private static JettyStart server = null;
+
     private final static XmldbURI XINCLUDE_COLLECTION = XmldbURI.ROOT_COLLECTION_URI.append("xinclude_test");
     private final static XmldbURI XINCLUDE_NESTED_COLLECTION = XmldbURI.ROOT_COLLECTION_URI.append("xinclude_test/data");
 
@@ -58,86 +59,85 @@ public class XIncludeSerializerTest {
     private final static String XMLRPC_URI = "http://127.0.0.1:" + System.getProperty("jetty.port") + "/xmlrpc";
     private final static String REST_URI = "http://admin:admin@127.0.0.1:" + System.getProperty("jetty.port") + "/db/xinclude_test";
 
-    private final static String XML_DATA1 =
-    	"<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>" +
-    	"<root>" +
-    	"<xi:include href='metatags.xml'/>" +
-    	"</root>" +
-    	"</test>";
-    
-    private final static String XML_DATA2 =
-    	"<html>" +
-    	"<head>" +
-    	"<metatag xml:id='metatag' name='test' description='test'/>" +
-    	"</head>" +
-    	"</html>";
+    private final static String XML_DATA1
+            = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<xi:include href='metatags.xml'/>"
+            + "</root>"
+            + "</test>";
 
-    private final static String XML_DATA3 =
-    	"<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>" +
-    	"<root>" +
-    	"<xi:include href='../xinclude_test/data/metatags.xml'/>" +
-    	"</root>" +
-    	"</test>";
+    private final static String XML_DATA2
+            = "<html>"
+            + "<head>"
+            + "<metatag xml:id='metatag' name='test' description='test'/>"
+            + "</head>"
+            + "</html>";
 
-    private final static String XML_DATA4 =
-    	"<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>" +
-    	"<root>" +
-    	"<xi:include href='data/metatags.xml'/>" +
-    	"</root>" +
-    	"</test>";
+    private final static String XML_DATA3
+            = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<xi:include href='../xinclude_test/data/metatags.xml'/>"
+            + "</root>"
+            + "</test>";
 
-    private final static String XML_DATA5 =
-        "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>" +
-    	"<root>" +
-    	"<xi:include href='data/metatags.xml' xpointer='xpointer(//metatag)'/>" +
-    	"</root>" +
-    	"</test>";
+    private final static String XML_DATA4
+            = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<xi:include href='data/metatags.xml'/>"
+            + "</root>"
+            + "</test>";
 
-    private final static String XML_DATA6 =
-        "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>" +
-    	"<root>" +
-    	"<xi:include href='data/metatags.xml' xpointer='metatag'/>" +
-    	"</root>" +
-    	"</test>";
+    private final static String XML_DATA5
+            = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<xi:include href='data/metatags.xml' xpointer='xpointer(//metatag)'/>"
+            + "</root>"
+            + "</test>";
 
-    private final static String XML_DATA7 =
-        "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>" +
-    	"<root>" +
-    	"<xi:include href='data/unknown.xml'>" +
-        "<xi:fallback><warning>Not found</warning></xi:fallback>" +
-        "</xi:include>" +
-        "</root>" +
-    	"</test>";
+    private final static String XML_DATA6
+            = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<xi:include href='data/metatags.xml' xpointer='metatag'/>"
+            + "</root>"
+            + "</test>";
 
-    private final static String XML_DATA8 =
-        "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>" +
-    	"<root>" +
-    	"<xi:include href='data/unknown.xml'/>" +
-        "</root>" +
-    	"</test>";
+    private final static String XML_DATA7
+            = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<xi:include href='data/unknown.xml'>"
+            + "<xi:fallback><warning>Not found</warning></xi:fallback>"
+            + "</xi:include>"
+            + "</root>"
+            + "</test>";
 
-    private final static String XML_RESULT ="<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"+
-    "<root>" +
-    "<html>" +
-    "<head>"+
-    "<metatag xml:id='metatag' name='test' description='test'/>" +
-    "</head>" +
-    "</html>" +
-    "</root>"+
-    "</test>";
+    private final static String XML_DATA8
+            = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<xi:include href='data/unknown.xml'/>"
+            + "</root>"
+            + "</test>";
 
-    private final static String XML_RESULT_XPOINTER = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"+
-    "<root>" +
-    "<metatag xml:id='metatag' name='test' description='test'/>" +
-    "</root>"+
-    "</test>";
+    private final static String XML_RESULT = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<html>"
+            + "<head>"
+            + "<metatag xml:id='metatag' name='test' description='test'/>"
+            + "</head>"
+            + "</html>"
+            + "</root>"
+            + "</test>";
 
-    private final static String XML_RESULT_FALLBACK1 = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"+
-        "<root>" +
-        "<warning>Not found</warning>" +
-        "</root>" +
-    	"</test>";
+    private final static String XML_RESULT_XPOINTER = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<metatag xml:id='metatag' name='test' description='test'/>"
+            + "</root>"
+            + "</test>";
 
+    private final static String XML_RESULT_FALLBACK1 = "<test xmlns:xi='" + XIncludeFilter.XINCLUDE_NS + "'>"
+            + "<root>"
+            + "<warning>Not found</warning>"
+            + "</root>"
+            + "</test>";
 
     @Test
     public void absSimpleREST() throws IOException, SAXException {
@@ -146,18 +146,19 @@ public class XIncludeSerializerTest {
 
         // we use honest http
         final HttpURLConnection connect = getConnection(uri);
-	    connect.setRequestMethod("GET");
-	    connect.connect();
+        connect.setRequestMethod("GET");
+        connect.connect();
 
-	    final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
-	    String line;
-	    final StringBuffer out = new StringBuffer();
-	    while ((line = reader.readLine()) != null) {
-	        out.append(line);
-	        out.append("\r\n");
-	    }
-	    
-	    final String responseXML = out.toString();
+        final StringBuilder out = new StringBuilder();
+        try(final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                out.append(line);
+                out.append("\r\n");
+            }
+        }
+
+        final String responseXML = out.toString();
 
         final Diff myDiff = new Diff(XML_RESULT, responseXML);
         assertTrue("pieces of XML are similar " + myDiff, myDiff.similar());
@@ -167,19 +168,19 @@ public class XIncludeSerializerTest {
     @Test
     public void relSimpleREST1() throws IOException, SAXException {
         final String uri = REST_URI + "/test_relative1.xml?_indent=no&_wrap=no";
-      
-        final HttpURLConnection connect = getConnection(uri);
- 	    connect.setRequestMethod("GET");
- 	    connect.connect();
 
- 	    final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
- 	    String line;
- 	    final StringBuffer out = new StringBuffer();
- 	    while ((line = reader.readLine()) != null) {
- 	        out.append(line);
- 	        out.append("\r\n");
- 	    }
- 	    final String responseXML = out.toString();
+        final HttpURLConnection connect = getConnection(uri);
+        connect.setRequestMethod("GET");
+        connect.connect();
+
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
+        String line;
+        final StringBuilder out = new StringBuilder();
+        while ((line = reader.readLine()) != null) {
+            out.append(line);
+            out.append("\r\n");
+        }
+        final String responseXML = out.toString();
 
         final Diff myDiff = new Diff(XML_RESULT, responseXML);
         assertTrue("pieces of XML are similar " + myDiff, myDiff.similar());
@@ -190,24 +191,24 @@ public class XIncludeSerializerTest {
     public void relSimpleREST2() throws IOException, SAXException {
         // path needs to indicate indent and wrap is off
         final String uri = REST_URI + "/test_relative2.xml?_indent=no&_wrap=no";
-      
-        final HttpURLConnection connect = getConnection(uri);
- 	    connect.setRequestMethod("GET");
- 	    connect.connect();
 
- 	    final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
- 	    String line;
- 	    final StringBuffer out = new StringBuffer();
- 	    while ((line = reader.readLine()) != null) {
- 	        out.append(line);
- 	        out.append("\r\n");
- 	    }
- 	    final String responseXML = out.toString();
+        final HttpURLConnection connect = getConnection(uri);
+        connect.setRequestMethod("GET");
+        connect.connect();
+
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
+        String line;
+        final StringBuilder out = new StringBuilder();
+        while ((line = reader.readLine()) != null) {
+            out.append(line);
+            out.append("\r\n");
+        }
+        final String responseXML = out.toString();
 
         final Diff myDiff = new Diff(XML_RESULT, responseXML);
         assertTrue("pieces of XML are similar " + myDiff, myDiff.similar());
         assertTrue("but are they identical? " + myDiff, myDiff.identical());
-     }
+    }
 
     @Test
     public void xpointerREST3() throws IOException, SAXException {
@@ -219,7 +220,7 @@ public class XIncludeSerializerTest {
 
         final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
         String line;
-        StringBuffer out = new StringBuffer();
+        StringBuilder out = new StringBuilder();
         while ((line = reader.readLine()) != null) {
             out.append(line);
             out.append("\r\n");
@@ -241,7 +242,7 @@ public class XIncludeSerializerTest {
 
         final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
         String line;
-        final StringBuffer out = new StringBuffer();
+        final StringBuilder out = new StringBuilder();
         while ((line = reader.readLine()) != null) {
             out.append(line);
             out.append("\r\n");
@@ -263,7 +264,7 @@ public class XIncludeSerializerTest {
 
         final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
         String line;
-        final StringBuffer out = new StringBuffer();
+        final StringBuilder out = new StringBuilder();
         while ((line = reader.readLine()) != null) {
             out.append(line);
             out.append("\r\n");
@@ -285,7 +286,7 @@ public class XIncludeSerializerTest {
 
         final BufferedReader reader = new BufferedReader(new InputStreamReader(connect.getInputStream(), "UTF-8"));
         String line;
-        final StringBuffer out = new StringBuffer();
+        final StringBuilder out = new StringBuilder();
         while ((line = reader.readLine()) != null) {
             out.append(line);
             out.append("\r\n");
@@ -294,16 +295,10 @@ public class XIncludeSerializerTest {
     }
 
     //TODO add full url test e.g. http://www.example.org/test.xml for xinclude
-    
-    
     //TODO add simple and relative url with xpointer
     //ex. <xi:include href="../javascript.xml#xpointer(html/head)"/>
-
-    
     //TODO add simple and relative url with xpointer and namespaces
     // ex. <xi:include href="../javascript.xml#xmlns(x=http://www.w3.org/1999/xhtml)xpointer(/x:html/x:head)"/>
-    
-    
     /*
      * XML-RPC tests
      *
@@ -314,21 +309,15 @@ public class XIncludeSerializerTest {
      * WebDAV tests
      *
      */
-    
     //TODO check serialisation via this interface, simple and relative???
     // probably overkill
-     
     /*
      * SOAP tests
      *
      */
     // probably overkill
- 
-
-   
     //TODO check serialisation via this interface, simple and relative???
     // probably overkill
-   
     /*
      * helper functions
      *
@@ -348,14 +337,13 @@ public class XIncludeSerializerTest {
         client.setConfig(config);
         return client;
     }
-   
+
    //TODO create reader for xml
- 
     /*
      * SetUp / TearDown functions
      *
      */
-	@BeforeClass
+    @BeforeClass
     public static void startDB() throws XmlRpcException, MalformedURLException {
         //Don't worry about closing the server : the shutdownDB hook will do the job
         if (server == null) {
@@ -364,78 +352,77 @@ public class XIncludeSerializerTest {
         }
 
         final XmlRpcClient xmlrpc = getClient();
-        final Vector<Object> params = new Vector<Object>();
-        params.addElement(XINCLUDE_COLLECTION.toString());
+        final List<Object> params = new ArrayList<>();
+        params.add(XINCLUDE_COLLECTION.toString());
         xmlrpc.execute("createCollection", params);
 
         params.clear();
-        params.addElement(XINCLUDE_NESTED_COLLECTION.toString());
+        params.add(XINCLUDE_NESTED_COLLECTION.toString());
         xmlrpc.execute("createCollection", params);
 
         params.clear();
-        params.addElement(XML_DATA1);
-        params.addElement("/db/xinclude_test/test_simple.xml");
-        params.addElement(new Integer(1));
+        params.add(XML_DATA1);
+        params.add("/db/xinclude_test/test_simple.xml");
+        params.add(1);
         xmlrpc.execute("parse", params);
 
         params.clear();
-        params.addElement(XML_DATA2);
-        params.addElement("/db/xinclude_test/metatags.xml");
-        params.addElement(new Integer(1));
+        params.add(XML_DATA2);
+        params.add("/db/xinclude_test/metatags.xml");
+        params.add(1);
         xmlrpc.execute("parse", params);
 
         params.clear();
-        params.addElement(XML_DATA2);
-        params.addElement("/db/xinclude_test/data/metatags.xml");
-        params.addElement(new Integer(1));
+        params.add(XML_DATA2);
+        params.add("/db/xinclude_test/data/metatags.xml");
+        params.add(1);
         xmlrpc.execute("parse", params);
 
         params.clear();
-        params.addElement(XML_DATA3);
-        params.addElement("/db/xinclude_test/test_relative1.xml");
-        params.addElement(new Integer(1));
+        params.add(XML_DATA3);
+        params.add("/db/xinclude_test/test_relative1.xml");
+        params.add(1);
         xmlrpc.execute("parse", params);
 
         params.clear();
-        params.addElement(XML_DATA4);
-        params.addElement("/db/xinclude_test/test_relative2.xml");
-        params.addElement(new Integer(1));
+        params.add(XML_DATA4);
+        params.add("/db/xinclude_test/test_relative2.xml");
+        params.add(1);
         xmlrpc.execute("parse", params);
 
         params.clear();
-        params.addElement(XML_DATA5);
-        params.addElement("/db/xinclude_test/test_xpointer1.xml");
-        params.addElement(new Integer(1));
+        params.add(XML_DATA5);
+        params.add("/db/xinclude_test/test_xpointer1.xml");
+        params.add(1);
         xmlrpc.execute("parse", params);
 
         params.clear();
-        params.addElement(XML_DATA6);
-        params.addElement("/db/xinclude_test/test_xpointer2.xml");
-        params.addElement(new Integer(1));
+        params.add(XML_DATA6);
+        params.add("/db/xinclude_test/test_xpointer2.xml");
+        params.add(1);
         xmlrpc.execute("parse", params);
 
         params.clear();
-        params.addElement(XML_DATA7);
-        params.addElement("/db/xinclude_test/test_fallback1.xml");
-        params.addElement(new Integer(1));
+        params.add(XML_DATA7);
+        params.add("/db/xinclude_test/test_fallback1.xml");
+        params.add(1);
         xmlrpc.execute("parse", params);
 
         params.clear();
-        params.addElement(XML_DATA8);
-        params.addElement("/db/xinclude_test/test_fallback2.xml");
-        params.addElement(new Integer(1));
+        params.add(XML_DATA8);
+        params.add("/db/xinclude_test/test_fallback2.xml");
+        params.add(1);
         xmlrpc.execute("parse", params);
     }
 
     @AfterClass
     public static void stopDB() throws XmlRpcException, MalformedURLException {
         final XmlRpcClient xmlrpc = getClient();
-        final Vector<Object> params = new Vector<Object>();
-        params.addElement("/db/xinclude_test");
+        final List<Object> params = new ArrayList<>();
+        params.add("/db/xinclude_test");
         xmlrpc.execute("removeCollection", params);
     }
 
-    
     public static void main(String[] args) {
         org.junit.runner.JUnitCore.runClasses(XIncludeSerializerTest.class);
     }

--- a/test/src/org/exist/xmldb/RemoteCollectionTest.java
+++ b/test/src/org/exist/xmldb/RemoteCollectionTest.java
@@ -116,13 +116,13 @@ public class RemoteCollectionTest extends RemoteDBTest {
 	
 	public void testListResources() {
 		try {
-		    ArrayList<String> xmlNames = new ArrayList<String>();
+		    ArrayList<String> xmlNames = new ArrayList<>();
 		    xmlNames.add("xml1");
 		    xmlNames.add("xml2");
 		    xmlNames.add("xml3");
 		    createResources(xmlNames, "XMLResource");
 		    
-		    ArrayList<String> binaryNames = new ArrayList<String>();
+		    ArrayList<String> binaryNames = new ArrayList<>();
 		    binaryNames.add("b1");
 		    binaryNames.add("b2");
 		    createResources(binaryNames, "BinaryResource");
@@ -147,8 +147,7 @@ public class RemoteCollectionTest extends RemoteDBTest {
 		try {
 			Collection c = DatabaseManager.getCollection(URI + XmldbURI.ROOT_COLLECTION, "admin", "");
 			assertNull(c.getChildCollection("b"));
-			
-			System.err.println("col="+ c.getName());
+
 			String parentName = c.getName() + "/" + System.currentTimeMillis();
 			String colName = parentName + "/a";
 			c = DatabaseManager.getCollection(URI + parentName, "admin", null);

--- a/test/src/org/exist/xmlrpc/MoveResourceTest.java
+++ b/test/src/org/exist/xmlrpc/MoveResourceTest.java
@@ -13,15 +13,26 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.Hashtable;
-import java.util.Vector;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
- * Test for deadlocks when moving resources from one collection to another.
- * Uses two threads: one stores a document, then moves it to another collection.
+ * Test for deadlocks when moving resources from one collection to another. Uses
+ * two threads: one stores a document, then moves it to another collection.
  * Based on XML-RPC. The second thread tries to execute a query via REST.
  *
- * Due to the complex move task, threads will deadlock almost immediately if 
+ * Due to the complex move task, threads will deadlock almost immediately if
  * something's wrong with collection locking.
  */
 public class MoveResourceTest extends TestCase {
@@ -29,7 +40,7 @@ public class MoveResourceTest extends TestCase {
     public static void main(String[] args) {
         TestRunner.run(MoveResourceTest.class);
     }
-    
+
     private JettyStart server;
 
     // jetty.port.standalone
@@ -41,37 +52,42 @@ public class MoveResourceTest extends TestCase {
         super(string);
     }
 
-    public void testMove() {
-        Thread thread1 = new MoveThread();
-        Thread thread2 = new CheckThread();
-        Thread thread3 = new CheckThread();
+    @Test
+    public void testMove() throws InterruptedException, ExecutionException {
 
-        thread1.start();
-        thread2.start();
-        thread3.start();
-        try {
-            thread1.join();
-            thread2.join();
-            thread3.join();
-        } catch (InterruptedException e) {
+        final List<Callable<Void>> tasks = new ArrayList<>();
+        tasks.add(new MoveThread());
+        tasks.add(new CheckThread());
+        tasks.add(new CheckThread());
+
+        final ExecutorService service = Executors.newFixedThreadPool(tasks.size());
+        final CompletionService<Void> cs = new ExecutorCompletionService<>(service);
+        tasks.stream().forEach((task) -> {
+            cs.submit(task);
+        });
+
+        //wait for all tasks to complete
+        final int n = tasks.size();
+        for (int i = 0; i < n; i++) {
+            cs.take().get();
         }
     }
-    
+
     private void createCollection(XmlRpcClient client, XmldbURI collection) throws IOException, XmlRpcException {
-        Vector<Object> params = new Vector<Object>();
-        params.addElement(collection.toString());
-        Boolean result = (Boolean)client.execute("createCollection", params);
-        assertTrue(result.booleanValue());
+        List<Object> params = new ArrayList<>();
+        params.add(collection.toString());
+        Boolean result = (Boolean) client.execute("createCollection", params);
+        assertTrue(result);
     }
 
     private String readData() throws IOException {
         String existHome = System.getProperty("exist.home");
-        File existDir = existHome==null ? new File(".") : new File(existHome);
-        File f = new File(existDir,"samples/shakespeare/r_and_j.xml");
+        File existDir = existHome == null ? new File(".") : new File(existHome);
+        File f = new File(existDir, "samples/shakespeare/r_and_j.xml");
         assertNotNull(f);
 
         Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(f), "UTF-8"));
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         char[] ch = new char[1024];
         int len;
         while ((len = reader.read(ch)) > 0) {
@@ -80,145 +96,121 @@ public class MoveResourceTest extends TestCase {
         return buf.toString();
     }
 
-    private class MoveThread extends Thread {
+    private class MoveThread implements Callable<Void> {
 
-        public void run() {
+        @Override
+        public Void call() throws IOException, XmlRpcException, InterruptedException {
             for (int i = 0; i < 100; i++) {
-                try {
-                    XmldbURI sourceColl = XmldbURI.ROOT_COLLECTION_URI.append("source" + i);
-                    XmldbURI targetColl1 = XmldbURI.ROOT_COLLECTION_URI.append("target");
-                    XmldbURI targetColl2 = targetColl1.append("test" + i);
-                    XmldbURI sourceResource = sourceColl.append("source.xml");
-                    XmldbURI targetResource = targetColl2.append("copied.xml");
+                XmldbURI sourceColl = XmldbURI.ROOT_COLLECTION_URI.append("source" + i);
+                XmldbURI targetColl1 = XmldbURI.ROOT_COLLECTION_URI.append("target");
+                XmldbURI targetColl2 = targetColl1.append("test" + i);
+                XmldbURI sourceResource = sourceColl.append("source.xml");
+                XmldbURI targetResource = targetColl2.append("copied.xml");
 
-                    //Creating collections
-                    XmlRpcClient xmlrpc = getClient();
+                XmlRpcClient xmlrpc = getClient();
 
-                    createCollection(xmlrpc, sourceColl);
-                    createCollection(xmlrpc, targetColl1);
-                    createCollection(xmlrpc, targetColl2);
+                createCollection(xmlrpc, sourceColl);
+                createCollection(xmlrpc, targetColl1);
+                createCollection(xmlrpc, targetColl2);
 
-                    //Storing document
-                    Vector<Object> params = new Vector<Object>();
-                    params.addElement(readData());
-                    params.addElement(sourceResource.toString());
-                    params.addElement(new Integer(1));
+                List<Object> params = new ArrayList<>();
+                params.add(readData());
+                params.add(sourceResource.toString());
+                params.add(1);
 
-                    Boolean result = (Boolean)xmlrpc.execute("parse", params);
-                    assertTrue(result.booleanValue());
+                Boolean result = (Boolean) xmlrpc.execute("parse", params);
+                assertTrue(result);
 
-                    //Moving resource
-                    params.clear();
-                    params.addElement(sourceResource.toString());
-                    params.addElement(targetColl2.toString());
-                    params.addElement("copied.xml");
+                params.clear();
+                params.add(sourceResource.toString());
+                params.add(targetColl2.toString());
+                params.add("copied.xml");
 
-                    xmlrpc.execute( "moveResource", params );
+                xmlrpc.execute("moveResource", params);
 
-                    //Retrieving document
-                    Hashtable<String, String> options = new Hashtable<String, String>();
-                    options.put("indent", "yes");
-                    options.put("encoding", "UTF-8");
-                    options.put("expand-xincludes", "yes");
-                    options.put("process-xsl-pi", "no");
+                Map<String, String> options = new HashMap<>();
+                options.put("indent", "yes");
+                options.put("encoding", "UTF-8");
+                options.put("expand-xincludes", "yes");
+                options.put("process-xsl-pi", "no");
 
-                    params.clear();
-                    params.addElement( targetResource.toString() );
-                    params.addElement( options );
+                params.clear();
+                params.add(targetResource.toString());
+                params.add(options);
 
-                    byte[] data = (byte[]) xmlrpc.execute( "getDocument", params );
-                    assertTrue(data != null && data.length > 0);
+                byte[] data = (byte[]) xmlrpc.execute("getDocument", params);
+                assertTrue(data != null && data.length > 0);
 
-                    synchronized (this) {
-                        wait(250);
-                    }
-
-                    //Removing created collections
-                    params.clear();
-                    params.addElement(sourceColl.toString());
-                    xmlrpc.execute("removeCollection", params);
-
-                    params.setElementAt(targetColl1.toString(), 0);
-                    xmlrpc.execute("removeCollection", params);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    fail(e.getMessage());
+                synchronized (this) {
+                    wait(250);
                 }
+
+                params.clear();
+                params.add(sourceColl.toString());
+                xmlrpc.execute("removeCollection", params);
+
+                params.set(0, targetColl1.toString());
+                xmlrpc.execute("removeCollection", params);
             }
+            return null;
         }
     }
 
-    private class CheckThread extends Thread {
+    private class CheckThread implements Callable<Void> {
 
-        public void run() {
+        @Override
+        public Void call() throws IOException, InterruptedException {
             String reqUrl = REST_URI + "/db?_query=" + URLEncoder.encode("collection('/db')//SPEECH[SPEAKER = 'JULIET']");
             for (int i = 0; i < 200; i++) {
-                try {
-                    URL url = new URL(reqUrl);
-                    HttpURLConnection connect = (HttpURLConnection) url.openConnection();
-                    connect.setRequestMethod("GET");
-                    connect.connect();
-    
-                    int r = connect.getResponseCode();
-                    assertEquals("Server returned response code " + r, 200, r);
+                URL url = new URL(reqUrl);
+                HttpURLConnection connect = (HttpURLConnection) url.openConnection();
+                connect.setRequestMethod("GET");
+                connect.connect();
 
-                    readResponse(connect.getInputStream());
+                int r = connect.getResponseCode();
+                assertEquals("Server returned response code " + r, 200, r);
 
-                    synchronized (this) {
-                        wait(250);
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    fail(e.getMessage());
+                try (final InputStream is = connect.getInputStream()) {
+                    readResponse(is);
                 }
-            }
-        }
 
-        protected String readResponse(InputStream is) {
-            try {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
-                String line;
-                StringBuffer out = new StringBuffer();
-                while ((line = reader.readLine()) != null) {
-                    out.append(line);
-                    out.append("\r\n");
+                synchronized (this) {
+                    wait(250);
                 }
-                return out.toString();
-            } catch (Exception e) {
-                fail(e.getMessage());
             }
             return null;
         }
+
+        private String readResponse(final InputStream is) throws IOException {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+            String line;
+            StringBuilder out = new StringBuilder();
+            while ((line = reader.readLine()) != null) {
+                out.append(line);
+                out.append("\r\n");
+            }
+            return out.toString();
+        }
     }
 
+    @Before
+    @Override
     protected void setUp() {
-		//Don't worry about closing the server : the shutdownDB hook will do the job
-		initServer();
-	}
-
-    protected static XmlRpcClient getClient() {
-        try {
-            XmlRpcClient client = new XmlRpcClient();
-            XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
-            config.setEnabledForExtensions(true);
-            config.setServerURL(new URL(URI));
-            config.setBasicUserName("admin");
-            config.setBasicPassword("");
-            client.setConfig(config);
-            return client;
-        } catch (MalformedURLException e) {
-            return null;
+        //Don't worry about closing the server : the shutdownDB hook will do the job
+        if (server == null) {
+            server = new JettyStart();
+            server.run();
         }
     }
 
-	private void initServer() {
-		try {
-			if (server == null) {
-				server = new JettyStart();
-                server.run();
-			}
-	    } catch (Exception e) {
-	        fail(e.getMessage());
-	    }
-	}
+    protected static XmlRpcClient getClient() throws MalformedURLException {
+        XmlRpcClient client = new XmlRpcClient();
+        XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+        config.setEnabledForExtensions(true);
+        config.setServerURL(new URL(URI));
+        config.setBasicUserName("admin");
+        config.setBasicPassword("");
+        client.setConfig(config);
+        return client;
+    }
 }

--- a/test/src/org/exist/xmlrpc/MoveResourceTest.java
+++ b/test/src/org/exist/xmlrpc/MoveResourceTest.java
@@ -1,3 +1,22 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.exist.xmlrpc;
 
 import junit.framework.TestCase;

--- a/test/src/org/exist/xmlrpc/XmlRpcTest.java
+++ b/test/src/org/exist/xmlrpc/XmlRpcTest.java
@@ -1,23 +1,21 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2004-2009 The eXist Project
+ * Copyright (C) 2001-2015 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *  
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
- *  $Id$
  */
 package org.exist.xmlrpc;
 

--- a/test/src/org/exist/xmlrpc/XmlRpcTest.java
+++ b/test/src/org/exist/xmlrpc/XmlRpcTest.java
@@ -21,10 +21,11 @@
  */
 package org.exist.xmlrpc;
 
+import java.io.IOException;
 import org.apache.xmlrpc.XmlRpcException;
 import org.apache.xmlrpc.client.XmlRpcClient;
 import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
-import org.custommonkey.xmlunit.XMLAssert;
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import org.exist.jetty.JettyStart;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.security.MessageDigester;
@@ -33,80 +34,88 @@ import org.exist.test.TestConstants;
 import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.junit.AfterClass;
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.xml.transform.OutputKeys;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.*;
+import java.nio.charset.StandardCharsets;
 import org.exist.security.Permission;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.util.*;
+
+import org.junit.After;
+import org.xml.sax.SAXException;
+
 /**
  * JUnit test for XMLRPC interface methods.
+ *
  * @author wolf
  * @author Pierrick Brihaye <pierrick.brihaye@free.fr>
  * @author ljo
  */
-public class XmlRpcTest {    
-	
+public class XmlRpcTest {
+
     private static JettyStart server = null;
     // jetty.port.standalone
     private final static String URI = "http://localhost:" + System.getProperty("jetty.port", "8088") + "/xmlrpc";
-        
+
     private final static XmldbURI TARGET_COLLECTION = XmldbURI.ROOT_COLLECTION_URI.append("xmlrpc");
-    
+
     private final static XmldbURI TARGET_RESOURCE = TARGET_COLLECTION.append(TestConstants.TEST_XML_URI);
-    
+
     public final static XmldbURI MODULE_RESOURCE = TARGET_COLLECTION.append(TestConstants.TEST_MODULE_URI);
-    
+
     private final static XmldbURI SPECIAL_COLLECTION = TARGET_COLLECTION.append(TestConstants.SPECIAL_NAME);
-    
+
     private final static XmldbURI SPECIAL_RESOURCE = SPECIAL_COLLECTION.append(TestConstants.SPECIAL_XML_URI);
-    
-    private final static String XML_DATA =
-    	"<test>" +
-    	"<para>\u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF</para>" +
-		"<para>\uC5F4\uB2E8\uACC4</para>" +
-    	"</test>";
-    
-    private final static String XSL_DATA =
-    	"<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" " +
-    	"version=\"1.0\">" +
-		"<xsl:param name=\"testparam\"/>" +
-		"<xsl:template match=\"test\"><test><xsl:apply-templates/></test></xsl:template>" +
-		"<xsl:template match=\"para\">" +
-		"<p><xsl:value-of select=\"$testparam\"/>: <xsl:apply-templates/></p></xsl:template>" +
-		"</xsl:stylesheet>";
-    
-    public final static String MODULE_DATA =
-    	"module namespace tm = \"http://exist-db.org/test/module\"; " +
-    	"declare variable $tm:imported-external-string as xs:string external;";
-    
-    public final static String QUERY_MODULE_DATA =
-    	"xquery version \"1.0\";" +
-    	"declare namespace tm-query = \"http://exist-db.org/test/module/query\";" +
-    	"import module namespace tm = \"http://exist-db.org/test/module\" " +
-        "at \"xmldb:exist://" + MODULE_RESOURCE.toString() + "\"; " +
-        "declare variable $tm-query:local-external-string as xs:string external;" +
-        "($tm:imported-external-string, $tm-query:local-external-string)";
-    
-    
-	public XmlRpcTest() {
-	}
-	
+
+    private final static String XML_DATA
+            = "<test>"
+            + "<para>\u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF</para>"
+            + "<para>\uC5F4\uB2E8\uACC4</para>"
+            + "</test>";
+
+    private final static String XSL_DATA
+            = "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" "
+            + "version=\"1.0\">"
+            + "<xsl:param name=\"testparam\"/>"
+            + "<xsl:template match=\"test\"><test><xsl:apply-templates/></test></xsl:template>"
+            + "<xsl:template match=\"para\">"
+            + "<p><xsl:value-of select=\"$testparam\"/>: <xsl:apply-templates/></p></xsl:template>"
+            + "</xsl:stylesheet>";
+
+    public final static String MODULE_DATA
+            = "module namespace tm = \"http://exist-db.org/test/module\"; "
+            + "declare variable $tm:imported-external-string as xs:string external;";
+
+    public final static String QUERY_MODULE_DATA
+            = "xquery version \"1.0\";"
+            + "declare namespace tm-query = \"http://exist-db.org/test/module/query\";"
+            + "import module namespace tm = \"http://exist-db.org/test/module\" "
+            + "at \"xmldb:exist://" + MODULE_RESOURCE.toString() + "\"; "
+            + "declare variable $tm-query:local-external-string as xs:string external;"
+            + "($tm:imported-external-string, $tm-query:local-external-string)";
+
+    public XmlRpcTest() {
+    }
+
     @BeforeClass
     public static void setUp() {
-		//Don't worry about closing the server : the shutdownDB hook will do the job
-		initServer();		
-	}
+        //Don't worry about closing the server : the shutdownDB hook will do the job
+        initServer();
+    }
 
     @AfterClass
     public static void stopServer() {
-		server.shutdown();
+        server.shutdown();
         server = null;
         System.gc();
         try {
@@ -116,458 +125,388 @@ public class XmlRpcTest {
         }
     }
 
-    protected void tearDown() {
+    @After
+    public void tearDown() throws XmlRpcException, MalformedURLException {
         XmlRpcClient xmlrpc = getClient();
-        try {
-            List<String> params = new ArrayList<String>(1);
-            params.add(TARGET_COLLECTION.toString());
-            @SuppressWarnings("unused")
-			Boolean b = (Boolean) xmlrpc.execute("removeCollection", params);
-        } catch (XmlRpcException e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
+        List<String> params = new ArrayList<>(1);
+        params.add(TARGET_COLLECTION.toString());
+        @SuppressWarnings("unused")
+        Boolean b = (Boolean) xmlrpc.execute("removeCollection", params);
+    }
+
+    private static void initServer() {
+        if (server == null) {
+            server = new JettyStart();
+            server.run();
         }
     }
 
-	private static void initServer() {
-		try {
-			if (server == null) {
-				server = new JettyStart();
-                server.run();
-            }
-	    } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());  
-	    }
-    }
+    @Test
+    public void testStoreAndRetrieve() throws XmlRpcException, IOException {
+        XmlRpcClient xmlrpc = getClient();
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        Boolean result = (Boolean) xmlrpc.execute("createCollection", params);
+        assertTrue(result);
 
-	@Test
-	public void testStoreAndRetrieve() {
-		try {
-			XmlRpcClient xmlrpc = getClient();
-			Vector<Object> params = new Vector<Object>();
-			params.addElement(TARGET_COLLECTION.toString());
-			Boolean result = (Boolean)xmlrpc.execute("createCollection", params);
-			Assert.assertTrue(result.booleanValue());
+        params.clear();
+        params.add(XML_DATA);
+        params.add(TARGET_RESOURCE.toString());
+        params.add(1);
 
-			params.clear();
-			params.addElement(XML_DATA);
-			params.addElement(TARGET_RESOURCE.toString());
-			params.addElement(new Integer(1));
+        result = (Boolean) xmlrpc.execute("parse", params);
+        assertTrue(result);
 
-			result = (Boolean)xmlrpc.execute("parse", params);
-			Assert.assertTrue(result.booleanValue());
+        Map<String, String> options = new HashMap<>();
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add(options);
 
-            HashMap<String, String> options = new HashMap<String, String>();
-            params.clear();
-            params.addElement(TARGET_RESOURCE.toString());
-            params.addElement(options);
+        byte[] data = (byte[]) xmlrpc.execute("getDocument", params);
+        assertNotNull(data);
 
-			byte[] data = (byte[]) xmlrpc.execute( "getDocument", params );
-            Assert.assertNotNull(data);
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add(StandardCharsets.UTF_8.name());
+        params.add(0);
 
-            params.clear();
-            params.addElement(TARGET_RESOURCE.toString());
-            params.addElement("UTF-8");
-            params.addElement(0);
+        data = (byte[]) xmlrpc.execute("getDocument", params);
+        assertNotNull(data);
 
-            data = (byte[]) xmlrpc.execute( "getDocument", params );
-            Assert.assertNotNull(data);
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add(0);
+        String sdata = (String) xmlrpc.execute("getDocumentAsString", params);
+        assertNotNull(data);
 
-            params.clear();
-            params.addElement(TARGET_RESOURCE.toString());
-            params.addElement(0);
-            String sdata = (String) xmlrpc.execute( "getDocumentAsString", params );
-            Assert.assertNotNull(data);
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        params.add(options);
+        Map table = (Map) xmlrpc.execute("getDocumentData", params);
 
-            params.clear();
-            params.addElement(TARGET_RESOURCE.toString());
-            params.addElement(options);
-            HashMap<?,?> table = (HashMap<?,?>) xmlrpc.execute("getDocumentData", params);
-            ByteArrayOutputStream os = new ByteArrayOutputStream();
-            int offset = ((Integer)table.get("offset")).intValue();
-            data = (byte[])table.get("data");
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            int offset = (int) table.get("offset");
+            data = (byte[]) table.get("data");
             os.write(data);
-            while(offset > 0) {
+            while (offset > 0) {
                 params.clear();
                 params.add(table.get("handle"));
-                params.add(Integer.valueOf(offset));
-                table = (HashMap<?,?>) xmlrpc.execute("getNextChunk", params);
-                offset = ((Integer)table.get("offset")).intValue();
-                data = (byte[])table.get("data");
+                params.add(offset);
+                table = (Map<?, ?>) xmlrpc.execute("getNextChunk", params);
+                offset = (int) table.get("offset");
+                data = (byte[]) table.get("data");
                 os.write(data);
             }
             data = os.toByteArray();
-            Assert.assertTrue(data.length > 0);
-
-            params.clear();
-            params.addElement(TARGET_RESOURCE.toString());
-            Boolean b = (Boolean) xmlrpc.execute( "hasDocument", params );
-            Assert.assertTrue(b.booleanValue());
-	    } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-	    }
-	}
-
-	private void storeData() {
-		try {
-			XmlRpcClient xmlrpc = getClient();
-			Vector<Object> params = new Vector<Object>();
-			params.addElement(TARGET_COLLECTION.toString());
-			Boolean result = (Boolean)xmlrpc.execute("createCollection", params);
-			Assert.assertTrue(result.booleanValue());
-
-			params.clear();
-			params.addElement(XML_DATA);
-			params.addElement(TARGET_RESOURCE.toString());
-			params.addElement(Integer.valueOf(1));
-			
-			result = (Boolean)xmlrpc.execute("parse", params);
-			Assert.assertTrue(result.booleanValue());
-
-			params.setElementAt(XSL_DATA, 0);
-			params.setElementAt(TARGET_COLLECTION.append("test.xsl").toString(), 1);
-			result = (Boolean)xmlrpc.execute("parse", params);
-			Assert.assertTrue(result.booleanValue());
-
-			params.setElementAt(MODULE_DATA.getBytes(UTF_8), 0);
-			params.setElementAt(MODULE_RESOURCE.toString(), 1);
-			params.setElementAt(MimeType.XQUERY_TYPE.getName(), 2);
-			params.addElement(Boolean.TRUE);
-			result = (Boolean)xmlrpc.execute("storeBinary", params);
-			Assert.assertTrue(result.booleanValue());
-
-	    } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());  
-	    }			
-	}
-
-	@Test
-    public void testRemoveCollection() {
-        storeData();
-        XmlRpcClient xmlrpc = getClient();
-        try {
-            List<Object> params = new ArrayList<Object>(1);
-            params.add(TARGET_COLLECTION.toString());
-            Boolean b = (Boolean) xmlrpc.execute("hasCollection", params);
-            Assert.assertTrue(b.booleanValue());
-
-            b = (Boolean) xmlrpc.execute("removeCollection", params);
-            Assert.assertTrue(b.booleanValue());
-
-            b = (Boolean) xmlrpc.execute("hasCollection", params);
-            Assert.assertFalse(b.booleanValue());
-        } catch (XmlRpcException e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
+            assertTrue(data.length > 0);
         }
+
+        params.clear();
+        params.add(TARGET_RESOURCE.toString());
+        Boolean b = (Boolean) xmlrpc.execute("hasDocument", params);
+        assertTrue(b);
     }
 
-	@Test
-    public void testRemoveDoc() {
-        storeData();
+    private void storeData() throws XmlRpcException, MalformedURLException {
         XmlRpcClient xmlrpc = getClient();
-        try {
-            List<Object> params = new ArrayList<Object>(1);
-            params.add(TARGET_RESOURCE.toString());
-            Boolean b = (Boolean) xmlrpc.execute("hasDocument", params);
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_COLLECTION.toString());
+        Boolean result = (Boolean) xmlrpc.execute("createCollection", params);
+        assertTrue(result);
 
-            Assert.assertTrue(b.booleanValue());
+        params.clear();
+        params.add(XML_DATA);
+        params.add(TARGET_RESOURCE.toString());
+        params.add(1);
 
-            b = (Boolean) xmlrpc.execute("remove", params);
-            Assert.assertTrue(b.booleanValue());
+        result = (Boolean) xmlrpc.execute("parse", params);
+        assertTrue(result);
 
-            b = (Boolean) xmlrpc.execute("hasDocument", params);
-            Assert.assertFalse(b.booleanValue());
-        } catch (XmlRpcException e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-        }
+        params.set(0, XSL_DATA);
+        params.set(1, TARGET_COLLECTION.append("test.xsl").toString());
+        result = (Boolean) xmlrpc.execute("parse", params);
+        assertTrue(result);
+
+        params.set(0, MODULE_DATA.getBytes(UTF_8));
+        params.set(1, MODULE_RESOURCE.toString());
+        params.set(2, MimeType.XQUERY_TYPE.getName());
+        params.add(Boolean.TRUE);
+        result = (Boolean) xmlrpc.execute("storeBinary", params);
+        assertTrue(result);
     }
 
-	@Test
-	public void testRetrieveDoc() {
+    @Test
+    public void testRemoveCollection() throws XmlRpcException, MalformedURLException {
         storeData();
-		Hashtable<String, String> options = new Hashtable<String, String>();
+        XmlRpcClient xmlrpc = getClient();
+        List params = new ArrayList(1);
+        params.add(TARGET_COLLECTION.toString());
+        Boolean b = (Boolean) xmlrpc.execute("hasCollection", params);
+        assertTrue(b);
+
+        b = (Boolean) xmlrpc.execute("removeCollection", params);
+        assertTrue(b);
+
+        b = (Boolean) xmlrpc.execute("hasCollection", params);
+        assertFalse(b);
+    }
+
+    @Test
+    public void testRemoveDoc() throws XmlRpcException, MalformedURLException {
+        storeData();
+        XmlRpcClient xmlrpc = getClient();
+        List params = new ArrayList(1);
+        params.add(TARGET_RESOURCE.toString());
+        Boolean b = (Boolean) xmlrpc.execute("hasDocument", params);
+
+        assertTrue(b);
+
+        b = (Boolean) xmlrpc.execute("remove", params);
+        assertTrue(b);
+
+        b = (Boolean) xmlrpc.execute("hasDocument", params);
+        assertFalse(b);
+    }
+
+    @Test
+    public void testRetrieveDoc() throws XmlRpcException, MalformedURLException {
+        storeData();
+        Map<String, String> options = new HashMap<>();
         options.put("indent", "yes");
-        options.put("encoding", "UTF-8");
+        options.put("encoding", StandardCharsets.UTF_8.name());
         options.put("expand-xincludes", "yes");
         options.put("process-xsl-pi", "no");
-        
-        Vector<Object> params = new Vector<Object>();
-        params.addElement( TARGET_RESOURCE.toString() ); 
-        params.addElement( options );
-        
-        try {
-	        // execute the call
-			XmlRpcClient xmlrpc = getClient();
-			byte[] data = (byte[]) xmlrpc.execute( "getDocument", params );
 
-			options.put("stylesheet", "test.xsl");
-			data = (byte[]) xmlrpc.execute( "getDocument", params );
-	    } catch (Exception e) {            
-	    	Assert.fail(e.getMessage());  
-	    }			
-	}
-	
-	@Test
-	public void testCharEncoding() {
-        storeData();
-		try {
-			Vector<Object> params = new Vector<Object>();
-			String query = "distinct-values(//para)";
-			params.addElement(query.getBytes(UTF_8));
-			params.addElement(new Hashtable<Object, Object>());
-			XmlRpcClient xmlrpc = getClient();
-	        HashMap<?,?> result = (HashMap<?,?>) xmlrpc.execute( "queryP", params );
-	        Object[] resources = (Object[]) result.get("results");
-	        //TODO : check the number of resources before !
-	        Assert.assertEquals(resources.length, 2);
-	        String value = (String)resources[0];
-	        Assert.assertEquals(value, "\u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF");
-	        value = (String)resources[1];
-	        Assert.assertEquals(value, "\uC5F4\uB2E8\uACC4");
-	    } catch (Exception e) {            
-	    	Assert.fail(e.getMessage());
-        }
-	}
-	
-	@Test
-	public void testQuery() {
-        storeData();
-		try {
-			Vector<Object> params = new Vector<Object>();
-			String query = 
-				"(::pragma exist:serialize indent=no::) //para";
-			params.addElement(query.getBytes(UTF_8));
-			params.addElement(Integer.valueOf(10));
-			params.addElement(Integer.valueOf(1));
-			params.addElement(new Hashtable());
-			XmlRpcClient xmlrpc = getClient();
-	        byte[] result = (byte[]) xmlrpc.execute( "query", params );
-	        Assert.assertNotNull(result);
-	        Assert.assertTrue(result.length > 0);
-	    } catch (Exception e) {            
-	    	Assert.fail(e.getMessage());  
-	    }	        
-	}	
-	
-	@Test
-	public void testQueryWithStylesheet() {
-        storeData();
-		try {
-			HashMap<String, String> options = new HashMap<String, String>();
-			options.put(EXistOutputKeys.STYLESHEET, "test.xsl");
-			options.put(EXistOutputKeys.STYLESHEET_PARAM + ".testparam", "Test");
-			options.put(OutputKeys.OMIT_XML_DECLARATION, "yes");
-			//TODO : check the number of resources before !
-			Vector<Object> params = new Vector<Object>();
-			String query = "//para[1]";
-			params.addElement(query.getBytes(UTF_8));
-			params.addElement(options);
-			XmlRpcClient xmlrpc = getClient();
-	        Integer handle = (Integer) xmlrpc.execute( "executeQuery", params );
-	        Assert.assertNotNull(handle);
-	        
-	        params.clear();
-	        params.addElement(handle);
-	        params.addElement(Integer.valueOf(0));
-	        params.addElement(options);
-	        byte[] item = (byte[]) xmlrpc.execute( "retrieve", params );
-	        Assert.assertNotNull(item);
-	        Assert.assertTrue(item.length > 0);
-	        String out = new String(item, UTF_8);
-	        XMLAssert.assertXMLEqual("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
-	        		"<p>Test: \u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF</p>", out);
-	    } catch (Exception e) {            
-	    	Assert.fail(e.getMessage());  
-	    }	        
-	}
+        List<Object> params = new ArrayList<>();
+        params.add(TARGET_RESOURCE.toString());
+        params.add(options);
 
-    @Test
-    public void testCompile() {
-        storeData();
-		try {
-			Vector<Object> params = new Vector<Object>();
-			String query = "<a>Invalid<a>";
-			params.addElement(query.getBytes(UTF_8));
-			params.addElement(new Hashtable<Object, Object>());
-			XmlRpcClient xmlrpc = getClient();
-	        Map stats = (Map) xmlrpc.execute( "compile", params );
-	        Assert.assertNotNull(stats);
-            Assert.assertNotNull(stats.get("error"));
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        // execute the call
+        XmlRpcClient xmlrpc = getClient();
+        byte[] data = (byte[]) xmlrpc.execute("getDocument", params);
+
+        options.put("stylesheet", "test.xsl");
+        data = (byte[]) xmlrpc.execute("getDocument", params);
     }
 
     @Test
-    public void testAddAccount() {
-        try {
-            String user = "rudi";
-            String passwd = "pass";
-            String simpleMd5 = MessageDigester.md5(passwd, true);
-            String digest = MessageDigester.md5(user + ":exist:" + passwd, false);
-            List<Object> params = new ArrayList<Object>(12);
-			params.add("rudi");
-			params.add(simpleMd5);
-			params.add(digest);
-			params.add(new String[] { "guest" });
-			params.add(true);
-                        params.add(Permission.DEFAULT_UMASK);
-			params.add(new HashMap<String, String>());
-            
-			XmlRpcClient xmlrpc = getClient();
-			xmlrpc.execute("addAccount", params);
-
-            XmlRpcClientConfigImpl config = (XmlRpcClientConfigImpl) xmlrpc.getClientConfig();
-            config.setBasicUserName("admin");
-            config.setBasicPassword("");
-            xmlrpc.execute("sync", new ArrayList());
-		} catch (Exception e) {
-			Assert.fail(e.getMessage());
-		}
+    public void testCharEncoding() throws XmlRpcException, MalformedURLException {
+        storeData();
+        List<Object> params = new ArrayList<>();
+        String query = "distinct-values(//para)";
+        params.add(query.getBytes(UTF_8));
+        params.add(new HashMap<>());
+        XmlRpcClient xmlrpc = getClient();
+        HashMap<?, ?> result = (HashMap<?, ?>) xmlrpc.execute("queryP", params);
+        Object[] resources = (Object[]) result.get("results");
+        //TODO : check the number of resources before !
+        assertEquals(2, resources.length);
+        String value = (String) resources[0];
+        assertEquals("\u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF", value);
+        value = (String) resources[1];
+        assertEquals("\uC5F4\uB2E8\uACC4", value);
     }
 
-	@Test
-	public void testExecuteQuery() {
+    @Test
+    public void testQuery() throws XmlRpcException, MalformedURLException {
         storeData();
-		try {
-			Vector<Object> params = new Vector<Object>();
-			String query = "distinct-values(//para)";
-			params.addElement(query.getBytes(UTF_8));
-			params.addElement(new Hashtable<Object, Object>());
-			XmlRpcClient xmlrpc = getClient();
-	        Integer handle = (Integer) xmlrpc.execute( "executeQuery", params );
-	        Assert.assertNotNull(handle);
-	        
-	        params.clear();
-	        params.addElement(handle);
-	        Integer hits = (Integer) xmlrpc.execute( "getHits", params );
-	        Assert.assertNotNull(hits);
-	        
-	        Assert.assertEquals(hits.intValue(), 2);	        
-        
-	        params.addElement(new Integer(0));
-	        params.addElement(new Hashtable<Object, Object>());
-	        byte[] item = (byte[]) xmlrpc.execute( "retrieve", params );
-	        
-	        params.clear();
-	        params.addElement(handle);
-	        params.addElement(Integer.valueOf(1));
-	        params.addElement(new Hashtable<Object, Object>());
-	        item = (byte[]) xmlrpc.execute( "retrieve", params );
-	    } catch (Exception e) {            
-	    	Assert.fail(e.getMessage());  
-	    }	        
-	}
-	
-	@Test
-	public void testQueryModuleExternalVar() {
-        storeData();
-		try {
-			Vector<Object> params = new Vector<Object>();
-			params.addElement(QUERY_MODULE_DATA.getBytes(UTF_8));
-			
-			Hashtable<String, Object> qp = new Hashtable<String, Object>();
-			
-			HashMap<String, Object> namespaceDecls = new HashMap<String, Object>();
-			namespaceDecls.put("tm", "http://exist-db.org/test/module");
-			namespaceDecls.put("tm-query", "http://exist-db.org/test/module/query");
-			qp.put(RpcAPI.NAMESPACES, namespaceDecls);
-			
-			HashMap<String, Object> variableDecls = new HashMap<String, Object>();
-			variableDecls.put("tm:imported-external-string", "imported-string-value");
-			variableDecls.put("tm-query:local-external-string", "local-string-value");
-			qp.put(RpcAPI.VARIABLES, variableDecls);
-			
-			params.addElement(qp);
-			
-			XmlRpcClient xmlrpc = getClient();
-			HashMap<String, Object[]> result = (HashMap) xmlrpc.execute("queryP", params);
-	        Object[] resources = (Object[]) result.get("results");
-	        Assert.assertEquals(resources.length, 2);
-	        String value = (String) resources[0];
-	        Assert.assertEquals(value, "imported-string-value");
-	        value = (String) resources[1];
-	        Assert.assertEquals(value, "local-string-value");
-	        
-	    } catch (Exception e) {            
-	    	Assert.fail(e.getMessage());  
-	    }	        
-	}
-	
-	@Test
-	public void testCollectionWithAccentsAndSpaces() {
-        storeData();
-		try {
-			Vector<Object> params = new Vector<Object>();
-			params.addElement(SPECIAL_COLLECTION.toString());
-			XmlRpcClient xmlrpc = getClient();
-			xmlrpc.execute( "createCollection", params );
+        List<Object> params = new ArrayList<>();
+        String query
+                = "(::pragma exist:serialize indent=no::) //para";
+        params.add(query.getBytes(UTF_8));
+        params.add(10);
+        params.add(1);
+        params.add(new HashMap());
+        XmlRpcClient xmlrpc = getClient();
+        byte[] result = (byte[]) xmlrpc.execute("query", params);
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+    }
 
-			params.clear();
-			params.addElement(XML_DATA);
-			params.addElement(SPECIAL_RESOURCE.toString());
-			params.addElement(Integer.valueOf(1));
-			
-			Boolean result = (Boolean)xmlrpc.execute("parse", params);
-			Assert.assertTrue(result.booleanValue());
-			
-			params.clear();
-			params.addElement(SPECIAL_COLLECTION.removeLastSegment().toString());
-	
-			HashMap collection = (HashMap) xmlrpc.execute("describeCollection", params);
-			Object[] collections = (Object[]) collection.get("collections");
-			boolean foundMatch=false;
-			String targetCollectionName = SPECIAL_COLLECTION.lastSegment().toString();
-			for (int i = 0; i < collections.length; i++) {
-				String childName = (String) collections[i];
-				if(childName.equals(targetCollectionName)) {
-					foundMatch=true;
-					break;
-				}
-			}
-			Assert.assertTrue("added collection not found", foundMatch);
+    @Test
+    public void testQueryWithStylesheet() throws XmlRpcException, MalformedURLException, SAXException, IOException {
+        storeData();
+        Map<String, String> options = new HashMap<>();
+        options.put(EXistOutputKeys.STYLESHEET, "test.xsl");
+        options.put(EXistOutputKeys.STYLESHEET_PARAM + ".testparam", "Test");
+        options.put(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        //TODO : check the number of resources before !
+        List<Object> params = new ArrayList<>();
+        String query = "//para[1]";
+        params.add(query.getBytes(UTF_8));
+        params.add(options);
+        XmlRpcClient xmlrpc = getClient();
+        Integer handle = (Integer) xmlrpc.execute("executeQuery", params);
+        assertNotNull(handle);
 
-			HashMap<String, String> options = new HashMap<String, String>();
-	        options.put("indent", "yes");
-	        options.put("encoding", "UTF-8");
-	        options.put("expand-xincludes", "yes");
-	        options.put("process-xsl-pi", "no");
-	        
-	        params.clear();
-	        params.addElement( SPECIAL_RESOURCE.toString() ); 
-	        params.addElement( options );
-	        
-	        // execute the call
-			byte[] data = (byte[]) xmlrpc.execute( "getDocument", params );
-	    } catch (Exception e) {            
-	    	Assert.fail(e.getMessage());  
-	    }			
-	}
-	
-	protected XmlRpcClient getClient() {
-        try {
-            XmlRpcClient client = new XmlRpcClient();
-            XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
-            config.setEnabledForExtensions(true);
-            config.setServerURL(new URL(URI));
-            config.setBasicUserName("admin");
-            config.setBasicPassword("");
-            client.setConfig(config);
-            return client;
-        } catch (MalformedURLException e) {
-        	e.printStackTrace();
-            return null;
+        params.clear();
+        params.add(handle);
+        params.add(0);
+        params.add(options);
+        byte[] item = (byte[]) xmlrpc.execute("retrieve", params);
+        assertNotNull(item);
+        assertTrue(item.length > 0);
+        String out = new String(item, UTF_8);
+        assertXMLEqual("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<p>Test: \u00E4\u00E4\u00F6\u00F6\u00FC\u00FC\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC\u00DF\u00DF</p>", out);
+    }
+
+    @Test
+    public void testCompile() throws XmlRpcException, MalformedURLException {
+        storeData();
+        List<Object> params = new ArrayList<>();
+        String query = "<a>Invalid<a>";
+        params.add(query.getBytes(UTF_8));
+        params.add(new HashMap<>());
+        XmlRpcClient xmlrpc = getClient();
+        Map stats = (Map) xmlrpc.execute("compile", params);
+        assertNotNull(stats);
+        assertNotNull(stats.get("error"));
+    }
+
+    @Test
+    public void testAddAccount() throws MalformedURLException, XmlRpcException {
+        String user = "rudi";
+        String passwd = "pass";
+        String simpleMd5 = MessageDigester.md5(passwd, true);
+        String digest = MessageDigester.md5(user + ":exist:" + passwd, false);
+        List<Object> params = new ArrayList<>(12);
+        params.add("rudi");
+        params.add(simpleMd5);
+        params.add(digest);
+        params.add(new String[]{"guest"});
+        params.add(true);
+        params.add(Permission.DEFAULT_UMASK);
+        params.add(new HashMap<>());
+
+        XmlRpcClient xmlrpc = getClient();
+        xmlrpc.execute("addAccount", params);
+
+        XmlRpcClientConfigImpl config = (XmlRpcClientConfigImpl) xmlrpc.getClientConfig();
+        config.setBasicUserName("admin");
+        config.setBasicPassword("");
+        xmlrpc.execute("sync", Collections.EMPTY_LIST);
+    }
+
+    @Test
+    public void testExecuteQuery() throws XmlRpcException, MalformedURLException {
+        storeData();
+        List<Object> params = new ArrayList<>();
+        String query = "distinct-values(//para)";
+        params.add(query.getBytes(UTF_8));
+        params.add(new HashMap<>());
+        XmlRpcClient xmlrpc = getClient();
+        Integer handle = (Integer) xmlrpc.execute("executeQuery", params);
+        assertNotNull(handle);
+
+        params.clear();
+        params.add(handle);
+        Integer hits = (Integer) xmlrpc.execute("getHits", params);
+        assertNotNull(hits);
+
+        assertEquals(2, hits.intValue());
+
+        params.add(0);
+        params.add(new HashMap());
+        byte[] item = (byte[]) xmlrpc.execute("retrieve", params);
+
+        params.clear();
+        params.add(handle);
+        params.add(1);
+        params.add(new HashMap());
+        item = (byte[]) xmlrpc.execute("retrieve", params);
+    }
+
+    @Test
+    public void testQueryModuleExternalVar() throws XmlRpcException, MalformedURLException {
+        storeData();
+        List<Object> params = new ArrayList<>();
+        params.add(QUERY_MODULE_DATA.getBytes(UTF_8));
+
+        Map<String, Object> qp = new HashMap<>();
+
+        Map<String, Object> namespaceDecls = new HashMap<>();
+        namespaceDecls.put("tm", "http://exist-db.org/test/module");
+        namespaceDecls.put("tm-query", "http://exist-db.org/test/module/query");
+        qp.put(RpcAPI.NAMESPACES, namespaceDecls);
+
+        Map<String, Object> variableDecls = new HashMap<>();
+        variableDecls.put("tm:imported-external-string", "imported-string-value");
+        variableDecls.put("tm-query:local-external-string", "local-string-value");
+        qp.put(RpcAPI.VARIABLES, variableDecls);
+
+        params.add(qp);
+
+        XmlRpcClient xmlrpc = getClient();
+        Map<String, Object[]> result = (Map<String, Object[]>) xmlrpc.execute("queryP", params);
+        Object[] resources = (Object[]) result.get("results");
+        assertEquals(2, resources.length);
+        String value = (String) resources[0];
+        assertEquals("imported-string-value", value);
+        value = (String) resources[1];
+        assertEquals("local-string-value", value);
+    }
+
+    @Test
+    public void testCollectionWithAccentsAndSpaces() throws XmlRpcException, MalformedURLException {
+        storeData();
+        List<Object> params = new ArrayList<>();
+        params.add(SPECIAL_COLLECTION.toString());
+        XmlRpcClient xmlrpc = getClient();
+        xmlrpc.execute("createCollection", params);
+
+        params.clear();
+        params.add(XML_DATA);
+        params.add(SPECIAL_RESOURCE.toString());
+        params.add(1);
+
+        Boolean result = (Boolean) xmlrpc.execute("parse", params);
+        assertTrue(result);
+
+        params.clear();
+        params.add(SPECIAL_COLLECTION.removeLastSegment().toString());
+
+        HashMap collection = (HashMap) xmlrpc.execute("describeCollection", params);
+        Object[] collections = (Object[]) collection.get("collections");
+        boolean foundMatch = false;
+        String targetCollectionName = SPECIAL_COLLECTION.lastSegment().toString();
+        for (int i = 0; i < collections.length; i++) {
+            String childName = (String) collections[i];
+            if (childName.equals(targetCollectionName)) {
+                foundMatch = true;
+                break;
+            }
         }
+        assertTrue("added collection not found", foundMatch);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("indent", "yes");
+        options.put("encoding", StandardCharsets.UTF_8.name());
+        options.put("expand-xincludes", "yes");
+        options.put("process-xsl-pi", "no");
+
+        params.clear();
+        params.add(SPECIAL_RESOURCE.toString());
+        params.add(options);
+
+        // execute the call
+        byte[] data = (byte[]) xmlrpc.execute("getDocument", params);
     }
 
-	public static void main(String[] args) {
-		org.junit.runner.JUnitCore.main(XmlRpcTest.class.getName());
-		//Explicit shutdownDB for the shutdownDB hook
-		System.exit(0);		
-	}	
+    protected XmlRpcClient getClient() throws MalformedURLException {
+        XmlRpcClient client = new XmlRpcClient();
+        XmlRpcClientConfigImpl config = new XmlRpcClientConfigImpl();
+        config.setEnabledForExtensions(true);
+        config.setServerURL(new URL(URI));
+        config.setBasicUserName("admin");
+        config.setBasicPassword("");
+        client.setConfig(config);
+        return client;
+    }
+
+    public static void main(String[] args) {
+        org.junit.runner.JUnitCore.main(XmlRpcTest.class.getName());
+        //Explicit shutdownDB for the shutdownDB hook
+        System.exit(0);
+    }
 }

--- a/test/src/org/exist/xquery/XqueryRemoteTests.java
+++ b/test/src/org/exist/xquery/XqueryRemoteTests.java
@@ -33,7 +33,7 @@ public class XqueryRemoteTests {
     }
 
     public static Test suite() {
-        XPathQueryTest.setURI("xmldb:exist://localhost:" + System.getProperty("jetty.port") + "/xmlrpc" + XmldbURI.ROOT_COLLECTION);
+        XPathQueryTest.setURI("xmldb:exist://localhost:" + System.getProperty("jetty.port", "8088") + "/xmlrpc" + XmldbURI.ROOT_COLLECTION);
         return new JUnit4TestAdapter(XPathQueryTest.class);
     }
 }


### PR DESCRIPTION
This is a refactor of the XML-RPC API. Through the use of Java 8 lambda expressions we the following advantages:

1) A huge reduction in code, including the removal of duplicated code.

2) Correct use of Broker/Txn/Lock. The lambda expressions ensure that when we take a resource we always return it.

3) Correct User security.

4) Consistent exception handling.