### PR TITLE
indexer parameter has wrong name in documentation

### DIFF
--- a/conf.xml.tmpl
+++ b/conf.xml.tmpl
@@ -406,8 +406,8 @@
             Changing the parameter will only have an effect on newly loaded 
             files, not old ones.
         
-        - suppress-whitespace-mixed-content:
-            preserve the white space inside a mixed content node
+        - preserve-whitespace-mixed-content:
+            preserve the white space inside a mixed content node: "yes" or "no".
         
         - tokenizer:
             this attribute invokes the Java class used to tokenize a string into


### PR DESCRIPTION
suppress-whitespace-mixed-content => preserve-whitespace-mixed-content

I think preserve-whitespace-mixed-content should be set to "yes" by default, to preserve meaningful whitespace in docbook, tei, etc. Where does whitespace in mixed-content get in the way in other formats?