### PR TITLE
Decouple XQuery service from DBBroker

### DIFF
--- a/extensions/debuggee/src/org/exist/debuggee/DebuggeeImpl.java
+++ b/extensions/debuggee/src/org/exist/debuggee/DebuggeeImpl.java
@@ -133,14 +133,14 @@ public class DebuggeeImpl implements Debuggee {
 	
 	        XQuery xquery = broker.getXQueryService();
 			
-	        XQueryContext queryContext = xquery.newContext(AccessContext.REST);
+	        XQueryContext queryContext = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
 	
 			// Find correct script load path
 			queryContext.setModuleLoadPath(XmldbURI.create(uri).removeLastSegment().toString());
 	
 			CompiledXQuery compiled;
 			try {
-				compiled = xquery.compile(queryContext, source);
+				compiled = xquery.compile(broker, queryContext, source);
 			} catch (IOException e) {
 				e.printStackTrace();
 				return null;

--- a/extensions/debuggee/src/org/exist/debuggee/DebuggeeImpl.java
+++ b/extensions/debuggee/src/org/exist/debuggee/DebuggeeImpl.java
@@ -131,7 +131,7 @@ public class DebuggeeImpl implements Debuggee {
 	
 	        if (source == null) return null;
 	
-	        XQuery xquery = broker.getXQueryService();
+	        XQuery xquery = broker.getBrokerPool().getXQueryService();
 			
 	        XQueryContext queryContext = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
 	

--- a/extensions/debuggee/src/org/exist/debuggee/DebuggeeJointImpl.java
+++ b/extensions/debuggee/src/org/exist/debuggee/DebuggeeJointImpl.java
@@ -470,9 +470,9 @@ public class DebuggeeJointImpl implements DebuggeeJoint, Status {
 			context.undeclareGlobalVariable(Debuggee.IDEKEY);
 			
 			XQuery service = broker.getXQueryService();
-			CompiledXQuery compiled = service.compile(context, script);
+			CompiledXQuery compiled = service.compile(broker, context, script);
 			
-			Sequence resultSequence = service.execute(compiled, null);
+			Sequence resultSequence = service.execute(broker, compiled, null);
 	
 	        SAXSerializer sax = null;
 	        Serializer serializer = broker.getSerializer();

--- a/extensions/debuggee/src/org/exist/debuggee/DebuggeeJointImpl.java
+++ b/extensions/debuggee/src/org/exist/debuggee/DebuggeeJointImpl.java
@@ -469,7 +469,7 @@ public class DebuggeeJointImpl implements DebuggeeJoint, Status {
 			context.undeclareGlobalVariable(Debuggee.SESSION);
 			context.undeclareGlobalVariable(Debuggee.IDEKEY);
 			
-			XQuery service = broker.getXQueryService();
+			XQuery service = broker.getBrokerPool().getXQueryService();
 			CompiledXQuery compiled = service.compile(broker, context, script);
 			
 			Sequence resultSequence = service.execute(broker, compiled, null);

--- a/extensions/debuggee/src/org/exist/debuggee/ScriptRunner.java
+++ b/extensions/debuggee/src/org/exist/debuggee/ScriptRunner.java
@@ -78,7 +78,7 @@ public class ScriptRunner implements Runnable, Observer {
 
 	        XQuery xquery = broker.getXQueryService();
 
-	        xquery.execute(expression, null);
+	        xquery.execute(broker, expression, null);
 
 //	        XQueryContext context = expression.getContext();
 //	        

--- a/extensions/debuggee/src/org/exist/debuggee/ScriptRunner.java
+++ b/extensions/debuggee/src/org/exist/debuggee/ScriptRunner.java
@@ -76,7 +76,7 @@ public class ScriptRunner implements Runnable, Observer {
 			
 			broker = db.get(null);
 
-	        XQuery xquery = broker.getXQueryService();
+	        XQuery xquery = broker.getBrokerPool().getXQueryService();
 
 	        xquery.execute(broker, expression, null);
 

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
@@ -74,13 +74,13 @@ public class XQueryCompiler {
             
                     //compile the query
                     final XQuery xquery = broker.getXQueryService();
-                    final XQueryContext context = xquery.newContext(AccessContext.REST);
+                    final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
                     final Source source = new DBSource(broker, (BinaryDocument)document, true);
 
                     //set the module load path for any module imports that are relative
                     context.setModuleLoadPath(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + ((XmldbURI)source.getKey()).removeLastSegment());
                     
-                    return broker.getXQueryService().compile(context, source);
+                    return broker.getXQueryService().compile(broker, context, source);
                 } else {
                     throw new RestXqServiceCompilationException("Invalid mimetype '" +  metadata.getMimeType() + "' for XQuery: "  + document.getURI().toString().toString());
                 }

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
@@ -73,14 +73,14 @@ public class XQueryCompiler {
                 if(metadata.getMimeType().equals(XQUERY_MIME_TYPE)){
             
                     //compile the query
-                    final XQuery xquery = broker.getXQueryService();
+                    final XQuery xquery = broker.getBrokerPool().getXQueryService();
                     final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
                     final Source source = new DBSource(broker, (BinaryDocument)document, true);
 
                     //set the module load path for any module imports that are relative
                     context.setModuleLoadPath(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + ((XmldbURI)source.getKey()).removeLastSegment());
                     
-                    return broker.getXQueryService().compile(broker, context, source);
+                    return broker.getBrokerPool().getXQueryService().compile(broker, context, source);
                 } else {
                     throw new RestXqServiceCompilationException("Invalid mimetype '" +  metadata.getMimeType() + "' for XQuery: "  + document.getURI().toString().toString());
                 }

--- a/extensions/fluent/src/org/exist/fluent/Database.java
+++ b/extensions/fluent/src/org/exist/fluent/Database.java
@@ -352,7 +352,7 @@ public class Database {
 	private Sequence adoptInternal(Object o) {
 		DBBroker broker = acquireBroker();
 		try {
-			XQueryContext context = broker.getXQueryService().newContext(AccessContext.INTERNAL_PREFIX_LOOKUP);
+			XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.INTERNAL_PREFIX_LOOKUP);
 			context.declareNamespaces(namespaceBindings.getCombinedMap());
 			context.setBackwardsCompatibility(false);
 			context.setStaticallyKnownDocuments(DocumentSet.EMPTY_DOCUMENT_SET);

--- a/extensions/fluent/src/org/exist/fluent/QueryService.java
+++ b/extensions/fluent/src/org/exist/fluent/QueryService.java
@@ -303,7 +303,7 @@ public class QueryService implements Cloneable {
 			if (overrideDocs != null) docs = overrideDocs;
 			final org.exist.source.Source source = buildQuerySource(query, params, "execute");
 			final XQuery xquery = broker.getXQueryService();
-			final XQueryPool pool = xquery.getXQueryPool();
+			final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 			CompiledXQuery compiledQuery = pool.borrowCompiledXQuery(broker, source);
 			MutableDocumentSet docsToLock = new DefaultDocumentSet();
 			if (docs != null) docsToLock.addAll(docs);
@@ -311,7 +311,7 @@ public class QueryService implements Cloneable {
 			try {
 				XQueryContext context;
 				if (compiledQuery == null) {
-					context = xquery.newContext(AccessContext.INTERNAL_PREFIX_LOOKUP);
+					context = new XQueryContext(broker.getBrokerPool(), AccessContext.INTERNAL_PREFIX_LOOKUP);
 					buildXQueryStaticContext(context, true);
 				} else {
 					context = compiledQuery.getContext();
@@ -320,12 +320,12 @@ public class QueryService implements Cloneable {
 				buildXQueryDynamicContext(context, params, docsToLock, true);
 				t2 = System.currentTimeMillis();
 				if (compiledQuery == null) {
-					compiledQuery = xquery.compile(context, source);
+					compiledQuery = xquery.compile(broker, context, source);
 					t3 = System.currentTimeMillis();
 				}
 				docsToLock.lock(broker, false, false);
 				try {
-					return new ItemList(xquery.execute(wrap(compiledQuery, wrapperFactory, context), base), namespaceBindings.extend(), db);
+					return new ItemList(xquery.execute(broker, wrap(compiledQuery, wrapperFactory, context), base), namespaceBindings.extend(), db);
 				} finally {
 					docsToLock.unlock(false);
 					t4 = System.currentTimeMillis();
@@ -536,7 +536,7 @@ public class QueryService implements Cloneable {
 			prepareContext(broker);
 			final org.exist.source.Source source = buildQuerySource(query, params, "analyze");
 			final XQuery xquery = broker.getXQueryService();
-			final XQueryPool pool = xquery.getXQueryPool();
+			final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 			CompiledXQuery compiledQuery = pool.borrowCompiledXQuery(broker, source);
 			try {
 				AnalysisXQueryContext context;
@@ -545,7 +545,7 @@ public class QueryService implements Cloneable {
 					buildXQueryStaticContext(context, false);
 					buildXQueryDynamicContext(context, params, null, false);
 					t2 = System.currentTimeMillis();
-					compiledQuery = xquery.compile(context, source);
+					compiledQuery = xquery.compile(broker, context, source);
 					t3 = System.currentTimeMillis();
 				} else {
 					context = (AnalysisXQueryContext) compiledQuery.getContext();

--- a/extensions/fluent/src/org/exist/fluent/QueryService.java
+++ b/extensions/fluent/src/org/exist/fluent/QueryService.java
@@ -302,7 +302,7 @@ public class QueryService implements Cloneable {
 			prepareContext(broker);
 			if (overrideDocs != null) docs = overrideDocs;
 			final org.exist.source.Source source = buildQuerySource(query, params, "execute");
-			final XQuery xquery = broker.getXQueryService();
+			final XQuery xquery = broker.getBrokerPool().getXQueryService();
 			final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 			CompiledXQuery compiledQuery = pool.borrowCompiledXQuery(broker, source);
 			MutableDocumentSet docsToLock = new DefaultDocumentSet();
@@ -535,7 +535,7 @@ public class QueryService implements Cloneable {
 			broker = db.acquireBroker();
 			prepareContext(broker);
 			final org.exist.source.Source source = buildQuerySource(query, params, "analyze");
-			final XQuery xquery = broker.getXQueryService();
+			final XQuery xquery = broker.getBrokerPool().getXQueryService();
 			final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 			CompiledXQuery compiledQuery = pool.borrowCompiledXQuery(broker, source);
 			try {

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -301,7 +301,7 @@ public class LuceneIndexTest {
             checkIndex(docs, broker, new QName[] { attrQN }, "center", 1);
             checkIndex(docs, broker, new QName[] { attrQN }, "right", 1);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "/section[ft:query(p, 'content')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -333,7 +333,7 @@ public class LuceneIndexTest {
             checkIndex(docs, broker, new QName[] { new QName("a") }, "x", 1);
             checkIndex(docs, broker, new QName[] { new QName("c") }, "x", 1);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "/test[ft:query(a, 'x')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -362,7 +362,7 @@ public class LuceneIndexTest {
             checkIndex(docs, broker, new QName[] { new QName("p") }, "ignore", 0);
             checkIndex(docs, broker, new QName[]{new QName("p")}, "warnings", 1);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "/article[ft:query(head, 'title')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -433,7 +433,7 @@ public class LuceneIndexTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
                 final Txn transaction = transact.beginTransaction()) {
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
 
             Sequence seq = xquery.execute(broker, "for $a in ft:query((//b|//c), 'AAA') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
@@ -501,7 +501,7 @@ public class LuceneIndexTest {
         configureAndStore(COLLECTION_CONFIG6, XML6, "test.xml");
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "for $a in ft:query((//b|//c), 'AAA') " +
                     "order by ft:score($a) descending return $a/local-name(.)", null, AccessContext.TEST);
@@ -516,7 +516,7 @@ public class LuceneIndexTest {
         configureAndStore(COLLECTION_CONFIG1, XML7, "test.xml");
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
 
             final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
@@ -648,7 +648,7 @@ public class LuceneIndexTest {
             checkIndex(docs, broker, new QName[] { new QName("head") }, "TITLE", 1);
             checkIndex(docs, broker, new QName[] { new QName("p") }, "uppercase", 1);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "/section[ft:query(p, 'UPPERCASE')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -668,7 +668,7 @@ public class LuceneIndexTest {
     public void MultiTermQueryRewriteMethod() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         configureAndStore(COLLECTION_CONFIG8, XML9, "test.xml");
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "declare namespace tei=\"http://www.tei-c.org/ns/1.0\";" +
             " for $expr in (\"au*\", \"ha*\", \"ma*\", \"za*\", \"ya*\", \"ra*\", \"qa*\")" +
@@ -710,7 +710,7 @@ public class LuceneIndexTest {
         configureAndStore(COLLECTION_CONFIG1, "samples/shakespeare");
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
 
             try(final Txn transaction = transact.beginTransaction()) {
@@ -744,7 +744,7 @@ public class LuceneIndexTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final Txn transaction = transact.beginTransaction()) {
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//SPEECH[ft:query(LINE, 'love')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -798,7 +798,7 @@ public class LuceneIndexTest {
             checkIndex(docs, broker, new QName[] { new QName("item") }, null, 5);
             checkIndex(docs, broker, new QName[] { new QName("condition") }, null, 2);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -876,7 +876,7 @@ public class LuceneIndexTest {
             assertEquals("chair", occur[0].getTerm());
             checkIndex(docs, broker, new QName[] { new QName("item") }, null, 5);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -1040,7 +1040,7 @@ public class LuceneIndexTest {
             assertEquals("chair", occur[0].getTerm());
             checkIndex(docs, broker, new QName[] { new QName("item") }, null, 5);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -1117,7 +1117,7 @@ public class LuceneIndexTest {
             assertEquals("chair", occur[0].getTerm());
             checkIndex(docs, broker, new QName[] { new QName("item") }, null, 5);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
             assertNotNull(seq);

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -303,23 +303,23 @@ public class LuceneIndexTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("/section[ft:query(p, 'content')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "/section[ft:query(p, 'content')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/section[ft:query(p/@rend, 'center')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/section[ft:query(p/@rend, 'center')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/section[ft:query(hi, 'just')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/section[ft:query(hi, 'just')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
 
-            seq = xquery.execute("/section[ft:query(p/*, 'just')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/section[ft:query(p/*, 'just')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/section[ft:query(head/*, 'just')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/section[ft:query(head/*, 'just')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
         }
@@ -335,15 +335,15 @@ public class LuceneIndexTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("/test[ft:query(a, 'x')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "/test[ft:query(a, 'x')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/test[ft:query(.//c, 'x')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/test[ft:query(.//c, 'x')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/test[ft:query(b, 'x')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/test[ft:query(b, 'x')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
         }
@@ -360,67 +360,67 @@ public class LuceneIndexTest {
             checkIndex(docs, broker, new QName[] { new QName("p") }, "dangerous", 1);
             checkIndex(docs, broker, new QName[] { new QName("p") }, "note", 0);
             checkIndex(docs, broker, new QName[] { new QName("p") }, "ignore", 0);
-            checkIndex(docs, broker, new QName[] { new QName("p") }, "warnings", 1);
+            checkIndex(docs, broker, new QName[]{new QName("p")}, "warnings", 1);
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("/article[ft:query(head, 'title')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "/article[ft:query(head, 'title')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(p, 'highlighted')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(p, 'highlighted')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(p, 'mixed')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(p, 'mixed')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(p, 'mix')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(p, 'mix')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(p, 'dangerous')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(p, 'dangerous')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(p, 'ous')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(p, 'ous')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(p, 'danger')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(p, 'danger')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(p, 'note')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(p, 'note')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(., 'highlighted')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(., 'highlighted')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(., 'mixed')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(., 'mixed')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(., 'dangerous')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(., 'dangerous')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(., 'warnings')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(., 'warnings')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(., 'danger')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(., 'danger')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
 
-            seq = xquery.execute("/article[ft:query(., 'note')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(., 'note')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
             
-            seq = xquery.execute("/article[ft:query(., 'ignore')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/article[ft:query(., 'ignore')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
         }
@@ -436,7 +436,7 @@ public class LuceneIndexTest {
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
 
-            Sequence seq = xquery.execute("for $a in ft:query((//b|//c), 'AAA') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "for $a in ft:query((//b|//c), 'AAA') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(5, seq.getItemCount());
             assertEquals("AAA on b2", seq.itemAt(0).getStringValue());
@@ -446,13 +446,13 @@ public class LuceneIndexTest {
             assertEquals("AAA on c2", seq.itemAt(4).getStringValue());
 
             // path: /a/b
-            seq = xquery.execute("for $a in ft:query(/a/b, 'AAA') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "for $a in ft:query(/a/b, 'AAA') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(2, seq.getItemCount());
             assertEquals("AAA on b2", seq.itemAt(0).getStringValue());
             assertEquals("AAA on b1", seq.itemAt(1).getStringValue());
 
-            seq = xquery.execute("for $a in ft:query(//@att, 'att') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "for $a in ft:query(//@att, 'att') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(4, seq.getItemCount());
             assertEquals("att on b2", seq.itemAt(0).getStringValue());
@@ -484,7 +484,7 @@ public class LuceneIndexTest {
             proc.reset();
             transact.commit(transaction);
 
-            seq = xquery.execute("for $a in ft:query((//b|//c), 'AAA') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "for $a in ft:query((//b|//c), 'AAA') order by ft:score($a) descending return xs:string($a)", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(5, seq.getItemCount());
             assertEquals("AAA on b2", seq.itemAt(0).getStringValue());
@@ -503,7 +503,7 @@ public class LuceneIndexTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("for $a in ft:query((//b|//c), 'AAA') " +
+            Sequence seq = xquery.execute(broker, "for $a in ft:query((//b|//c), 'AAA') " +
                     "order by ft:score($a) descending return $a/local-name(.)", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(3, seq.getItemCount());
@@ -520,31 +520,31 @@ public class LuceneIndexTest {
             assertNotNull(xquery);
 
             final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
-            final CompiledXQuery compiled = xquery.compile(context, "declare variable $q external; " +
+            final CompiledXQuery compiled = xquery.compile(broker, context, "declare variable $q external; " +
                     "ft:query(//p, util:parse($q)/query)");
 
             context.declareVariable("q", "<query><term>heiterkeit</term></query>");
-            Sequence seq = xquery.execute(compiled, null);
+            Sequence seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
             context.declareVariable("q",
-                "<query>" +
-                "   <bool>" +
-                "       <term>heiterkeit</term><term>blablabla</term>" +
-                "   </bool>" +
-                "</query>");
-            seq = xquery.execute(compiled, null);
+                    "<query>" +
+                            "   <bool>" +
+                            "       <term>heiterkeit</term><term>blablabla</term>" +
+                            "   </bool>" +
+                            "</query>");
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
             context.declareVariable("q",
-                "<query>" +
-                "   <bool>" +
-                "       <term occur='should'>heiterkeit</term><term occur='should'>blablabla</term>" +
-                "   </bool>" +
-                "</query>");
-            seq = xquery.execute(compiled, null);
+                    "<query>" +
+                            "   <bool>" +
+                            "       <term occur='should'>heiterkeit</term><term occur='should'>blablabla</term>" +
+                            "   </bool>" +
+                            "</query>");
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -554,7 +554,7 @@ public class LuceneIndexTest {
                 "       <term occur='must'>heiterkeit</term><term occur='must'>blablabla</term>" +
                 "   </bool>" +
                 "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
 
@@ -564,7 +564,7 @@ public class LuceneIndexTest {
                 "       <term occur='must'>heiterkeit</term><term occur='not'>herzen</term>" +
                 "   </bool>" +
                 "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
 
@@ -574,7 +574,7 @@ public class LuceneIndexTest {
                 "       <phrase occur='must'>wunderbare heiterkeit</phrase><term occur='must'>herzen</term>" +
                 "   </bool>" +
                 "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -582,7 +582,7 @@ public class LuceneIndexTest {
                     "<query>" +
                     "   <phrase slop='5'>heiterkeit seele eingenommen</phrase>" +
                     "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -591,7 +591,7 @@ public class LuceneIndexTest {
                 "<query>" +
                 "   <phrase slop='5'><term>heiter*</term><term>se?nnnle*</term></phrase>" +
                 "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -599,7 +599,7 @@ public class LuceneIndexTest {
                 "<query>" +
                 "   <wildcard>?eiter*</wildcard>" +
                 "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -607,7 +607,7 @@ public class LuceneIndexTest {
                 "<query>" +
                 "   <fuzzy max-edits='2'>selee</fuzzy>" +
                 "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -618,7 +618,7 @@ public class LuceneIndexTest {
                 "       <wildcard occur='should'>bla*</wildcard>" +
                 "   </bool>" +
                 "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -626,7 +626,7 @@ public class LuceneIndexTest {
                 "<query>" +
                 "   <regex>heit.*keit</regex>" +
                 "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -634,7 +634,7 @@ public class LuceneIndexTest {
                 "<query>" +
                 "   <phrase><term>wunderbare</term><regex>heit.*keit</regex></phrase>" +
                 "</query>");
-            seq = xquery.execute(compiled, null);
+            seq = xquery.execute(broker, compiled, null);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
         }
@@ -650,15 +650,15 @@ public class LuceneIndexTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("/section[ft:query(p, 'UPPERCASE')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "/section[ft:query(p, 'UPPERCASE')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/section[ft:query(head, 'TITLE')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/section[ft:query(head, 'TITLE')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("/section[ft:query(head, 'title')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/section[ft:query(head, 'title')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
         }
@@ -670,7 +670,7 @@ public class LuceneIndexTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("declare namespace tei=\"http://www.tei-c.org/ns/1.0\";" +
+            Sequence seq = xquery.execute(broker, "declare namespace tei=\"http://www.tei-c.org/ns/1.0\";" +
             " for $expr in (\"au*\", \"ha*\", \"ma*\", \"za*\", \"ya*\", \"ra*\", \"qa*\")" +
             " let $query := <query><wildcard>{$expr}</wildcard></query>" +
             " return for $hit in //tei:p[ft:query(., $query)]" +
@@ -679,7 +679,7 @@ public class LuceneIndexTest {
             assertEquals(10, seq.getItemCount());
             assertEquals("aus", seq.itemAt(0).getStringValue());
 
-	    seq = xquery.execute("declare namespace tei=\"http://www.tei-c.org/ns/1.0\";" +
+	    seq = xquery.execute(broker, "declare namespace tei=\"http://www.tei-c.org/ns/1.0\";" +
             " for $expr in (\"ha*\", \"ma*\")" +
             " let $query := <query><wildcard>{$expr}</wildcard></query>" +
             " return for $hit in //tei:p[ft:query(., $query)]" +
@@ -714,14 +714,14 @@ public class LuceneIndexTest {
             assertNotNull(xquery);
 
             try(final Txn transaction = transact.beginTransaction()) {
-                Sequence seq = xquery.execute("//LINE[ft:query(., 'bark')]", null, AccessContext.TEST);
+                Sequence seq = xquery.execute(broker, "//LINE[ft:query(., 'bark')]", null, AccessContext.TEST);
                 assertNotNull(seq);
                 assertEquals(6, seq.getItemCount());
 
                 root.removeXMLResource(transaction, broker, XmldbURI.create("r_and_j.xml"));
                 transact.commit(transaction);
 
-                seq = xquery.execute("//LINE[ft:query(., 'bark')]", null, AccessContext.TEST);
+                seq = xquery.execute(broker, "//LINE[ft:query(., 'bark')]", null, AccessContext.TEST);
                 assertNotNull(seq);
                 assertEquals(3, seq.getItemCount());
             }
@@ -730,7 +730,7 @@ public class LuceneIndexTest {
                 root.removeXMLResource(transaction, broker, XmldbURI.create("hamlet.xml"));
                 transact.commit(transaction);
 
-                Sequence seq = xquery.execute("//LINE[ft:query(., 'bark')]", null, AccessContext.TEST);
+                Sequence seq = xquery.execute(broker, "//LINE[ft:query(., 'bark')]", null, AccessContext.TEST);
                 assertNotNull(seq);
                 assertEquals(1, seq.getItemCount());
             }
@@ -746,7 +746,7 @@ public class LuceneIndexTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//SPEECH[ft:query(LINE, 'love')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//SPEECH[ft:query(LINE, 'love')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(166, seq.getItemCount());
 
@@ -800,7 +800,7 @@ public class LuceneIndexTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -878,7 +878,7 @@ public class LuceneIndexTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -1042,7 +1042,7 @@ public class LuceneIndexTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -1119,7 +1119,7 @@ public class LuceneIndexTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ft:query(description, 'chair')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneMatchListenerTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneMatchListenerTest.java
@@ -134,14 +134,14 @@ public class LuceneMatchListenerTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//para[ft:query(., 'mixed')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//para[ft:query(., 'mixed')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq);
             XMLAssert.assertEquals("<para>some paragraph with <hi>" + MATCH_START + "mixed" +
                     MATCH_END + "</hi> content.</para>", result);
 
-            seq = xquery.execute("//para[ft:query(., '+nested +inner +elements')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ft:query(., '+nested +inner +elements')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
@@ -149,14 +149,14 @@ public class LuceneMatchListenerTest {
                     MATCH_END + "</hi> " + MATCH_START +
                     "inner" + MATCH_END + "</note> " + MATCH_START + "elements" + MATCH_END + ".</para>", result);
 
-            seq = xquery.execute("//para[ft:query(term, 'term')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ft:query(term, 'term')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
             XMLAssert.assertEquals("<para>a third paragraph with <term>" + MATCH_START + "term" + MATCH_END +
                     "</term>.</para>", result);
 
-            seq = xquery.execute("//para[ft:query(., '+double +match')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ft:query(., '+double +match')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
@@ -164,7 +164,7 @@ public class LuceneMatchListenerTest {
                     MATCH_START + "match" + MATCH_END + " " + MATCH_START + "double" + MATCH_END + " " +
                     MATCH_START + "match" + MATCH_END + "</para>", result);
 
-            seq = xquery.execute(
+            seq = xquery.execute(broker,
                     "for $para in //para[ft:query(., '+double +match')] return\n" +
                             "   <hit>{$para}</hit>", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -191,13 +191,13 @@ public class LuceneMatchListenerTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//para[ft:query(., 'mixed')]/hi", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//para[ft:query(., 'mixed')]/hi", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq);
             XMLAssert.assertXpathEvaluatesTo("1", "count(//exist:match)", result);
 
-            seq = xquery.execute("//para[ft:query(., 'nested')]/note", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ft:query(., 'nested')]/note", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
@@ -220,13 +220,13 @@ public class LuceneMatchListenerTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//hi[ft:query(., 'mixed')]/ancestor::para", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//hi[ft:query(., 'mixed')]/ancestor::para", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq);
             XMLAssert.assertXpathEvaluatesTo("1", "count(//exist:match)", result);
 
-            seq = xquery.execute("//hi[ft:query(., 'nested')]/parent::note", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//hi[ft:query(., 'nested')]/parent::note", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
@@ -249,21 +249,21 @@ public class LuceneMatchListenerTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//p[ft:query(., 'mixed')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//p[ft:query(., 'mixed')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq);
             XMLAssert.assertEquals("<p>Paragraphs with <s>" + MATCH_START + "mix" + MATCH_END +
                     "</s><s>ed</s> content are <s>danger</s>ous.</p>", result);
 
-            seq = xquery.execute("//p[ft:query(., 'ignored')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//p[ft:query(., 'ignored')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
             XMLAssert.assertEquals("<p>A simple<note>sic</note> paragraph with <hi>highlighted</hi> text <note>and a note</note> to be " +
                     MATCH_START + "ignored" + MATCH_END + ".</p>", result);
 
-            seq = xquery.execute("//p[ft:query(., 'highlighted')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//p[ft:query(., 'highlighted')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
@@ -271,13 +271,13 @@ public class LuceneMatchListenerTest {
                     "highlighted" + MATCH_END + "</hi> text <note>and a note</note> to be " +
                     "ignored.</p>", result);
 
-            seq = xquery.execute("//p[ft:query(., 'highlighted')]/hi", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//p[ft:query(., 'highlighted')]/hi", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);
             XMLAssert.assertEquals("<hi>" + MATCH_START + "highlighted" + MATCH_END + "</hi>", result);
             
-            seq = xquery.execute("//head[ft:query(., 'title')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//head[ft:query(., 'title')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq);

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneMatchListenerTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneMatchListenerTest.java
@@ -132,7 +132,7 @@ public class LuceneMatchListenerTest {
 
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//para[ft:query(., 'mixed')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -189,7 +189,7 @@ public class LuceneMatchListenerTest {
 
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//para[ft:query(., 'mixed')]/hi", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -218,7 +218,7 @@ public class LuceneMatchListenerTest {
 
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//hi[ft:query(., 'mixed')]/ancestor::para", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -247,7 +247,7 @@ public class LuceneMatchListenerTest {
 
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//p[ft:query(., 'mixed')]", null, AccessContext.TEST);
             assertNotNull(seq);

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
@@ -116,7 +116,7 @@ public class CustomIndexTest {
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -196,7 +196,7 @@ public class CustomIndexTest {
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -312,7 +312,7 @@ public class CustomIndexTest {
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -372,7 +372,7 @@ public class CustomIndexTest {
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -424,7 +424,7 @@ public class CustomIndexTest {
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -461,7 +461,7 @@ public class CustomIndexTest {
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -485,7 +485,7 @@ public class CustomIndexTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final Txn transaction = transact.beginTransaction()) {
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -512,8 +512,7 @@ public class CustomIndexTest {
     @Test
     public void query() throws PermissionDeniedException, XPathException, EXistException {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
-
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -537,8 +536,7 @@ public class CustomIndexTest {
     @Test
     public void indexKeys() throws SAXException, PermissionDeniedException, XPathException, EXistException {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
-
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             
             Sequence seq = xquery.execute(broker, "util:index-key-occurrences(/test/item, 'cha', 'ngram-index')", null, AccessContext.TEST);

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
@@ -118,7 +118,7 @@ public class CustomIndexTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -198,7 +198,7 @@ public class CustomIndexTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -314,7 +314,7 @@ public class CustomIndexTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -374,7 +374,7 @@ public class CustomIndexTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -426,7 +426,7 @@ public class CustomIndexTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -463,15 +463,15 @@ public class CustomIndexTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("//section[ngram:contains(para, '123')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//section[ngram:contains(para, '123')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("//section[ngram:contains(para, '123')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//section[ngram:contains(para, '123')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -487,7 +487,7 @@ public class CustomIndexTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -501,7 +501,7 @@ public class CustomIndexTest {
 
             checkIndex(broker, docs, "cha", 0);
 
-            seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
 
@@ -515,19 +515,19 @@ public class CustomIndexTest {
 
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//item[ngram:contains(., 'cha')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("//section[ngram:contains(*, '123')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//section[ngram:contains(*, '123')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("//section[ngram:contains(para, '123')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//section[ngram:contains(para, '123')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("//*[ngram:contains(., '567')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//*[ngram:contains(., '567')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
@@ -541,22 +541,22 @@ public class CustomIndexTest {
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
             
-            Sequence seq = xquery.execute("util:index-key-occurrences(/test/item, 'cha', 'ngram-index')", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "util:index-key-occurrences(/test/item, 'cha', 'ngram-index')", null, AccessContext.TEST);
             //Sequence seq = xquery.execute("util:index-key-occurrences(/test/item, 'cha', 'org.exist.indexing.impl.NGramIndex')", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("util:index-key-occurrences(/test/item, 'le8', 'ngram-index')", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "util:index-key-occurrences(/test/item, 'le8', 'ngram-index')", null, AccessContext.TEST);
             //seq = xquery.execute("util:index-key-occurrences(/test/item, 'le8', 'org.exist.indexing.impl.NGramIndex')", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 
-            seq = xquery.execute("util:index-key-documents(/test/item, 'le8', 'ngram-index')", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "util:index-key-documents(/test/item, 'le8', 'ngram-index')", null, AccessContext.TEST);
             //seq = xquery.execute("util:index-key-documents(/test/item, 'le8', 'org.exist.indexing.impl.NGramIndex')", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             
-            seq = xquery.execute("util:index-key-documents(/test/item, 'le8', 'ngram-index')", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "util:index-key-documents(/test/item, 'le8', 'ngram-index')", null, AccessContext.TEST);
             //seq = xquery.execute("util:index-key-doucments(/test/item, 'le8', 'org.exist.indexing.impl.NGramIndex')", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -573,7 +573,7 @@ public class CustomIndexTest {
             
             String query = queryBody + "util:index-keys(/test/item, \'\', util:function(xs:QName(\'local:callback\'), 2), 1000, 'ngram-index')";
             //String query = queryBody + "util:index-keys(/test/item, \'\', util:function(xs:QName(\'local:callback\'), 2), 1000, 'org.exist.indexing.impl.NGramIndex')";
-            seq = xquery.execute(query, null, AccessContext.TEST);
+            seq = xquery.execute(broker, query, null, AccessContext.TEST);
             assertNotNull(seq);
             //TODO : check cardinality
             StringWriter out = new StringWriter();

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
@@ -129,28 +129,28 @@ public class MatchListenerTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//para[ngram:contains(., 'mixed')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'mixed')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>some paragraph with <hi>" + MATCH_START + "mixed" +
                     MATCH_END + "</hi> content.</para>", result);
 
-            seq = xquery.execute("//para[ngram:contains(., 'content')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ngram:contains(., 'content')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>some paragraph with <hi>mixed</hi> " + MATCH_START + "content" +
                     MATCH_END + ".</para>", result);
 
-            seq = xquery.execute("//para[ngram:contains(., 'nested')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ngram:contains(., 'nested')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>another paragraph with <note><hi>" + MATCH_START + "nested" + MATCH_END +
                     "</hi> inner</note> elements.</para>", result);
 
-            seq = xquery.execute("//para[ngram:contains(., 'content') and ngram:contains(., 'mixed')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ngram:contains(., 'content') and ngram:contains(., 'mixed')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
@@ -166,8 +166,7 @@ public class MatchListenerTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-
-            final Sequence seq = xquery.execute("//para[ngram:contains(., 'mixed')]/hi", null, AccessContext.TEST);
+            final Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'mixed')]/hi", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             final String result = queryResult2String(broker, seq, 0);
@@ -182,13 +181,13 @@ public class MatchListenerTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//para[ngram:contains(., 'nested')]/note", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'nested')]/note", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<note><hi>" + MATCH_START + "nested" + MATCH_END + "</hi> inner</note>", result);
 
-            seq = xquery.execute("//para[ngram:contains(., 'nested')]//hi", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ngram:contains(., 'nested')]//hi", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
@@ -204,19 +203,19 @@ public class MatchListenerTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//para[ngram:contains(term, 'term')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//para[ngram:contains(term, 'term')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>a third paragraph with <term>" + MATCH_START + "term" + MATCH_END + "</term>.</para>", result);
 
-            seq = xquery.execute("//term[ngram:contains(., 'term')]/..", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//term[ngram:contains(., 'term')]/..", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>a third paragraph with <term>" + MATCH_START + "term" + MATCH_END + "</term>.</para>", result);
 
-            seq = xquery.execute("//term[ngram:contains(., 'term')]/ancestor::para", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//term[ngram:contains(., 'term')]/ancestor::para", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
@@ -232,14 +231,14 @@ public class MatchListenerTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//para[ngram:contains(., 'mixed content')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'mixed content')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>some paragraph with <hi>" + MATCH_START + "mixed" +
                 MATCH_END + "</hi>" + MATCH_START + " content" + MATCH_END + ".</para>", result);
 
-            seq = xquery.execute("//para[ngram:contains(., 'with mixed content')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ngram:contains(., 'with mixed content')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
@@ -247,14 +246,14 @@ public class MatchListenerTest {
                 MATCH_START + "mixed" + MATCH_END + "</hi>" + MATCH_START + " content" + MATCH_END +
                 ".</para>", result);
 
-            seq = xquery.execute("//para[ngram:contains(., 'with nested')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ngram:contains(., 'with nested')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>another paragraph " + MATCH_START + "with " + MATCH_END +
                 "<note><hi>" + MATCH_START + "nested" + MATCH_END + "</hi> inner</note> elements.</para>", result);
 
-            seq = xquery.execute("//para[ngram:contains(., 'with nested inner elements')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ngram:contains(., 'with nested inner elements')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
@@ -271,14 +270,14 @@ public class MatchListenerTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq = xquery.execute("//para[ngram:contains(note, 'nested inner')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//para[ngram:contains(note, 'nested inner')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>another paragraph with <note><hi>" + MATCH_START + "nested" + MATCH_END +
                 "</hi>" + MATCH_START + " inner" + MATCH_END + "</note> elements.</para>", result);
 
-            seq = xquery.execute("//note[ngram:contains(., 'nested inner')]/parent::para", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//note[ngram:contains(., 'nested inner')]/parent::para", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
@@ -295,21 +294,21 @@ public class MatchListenerTest {
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
 
-            Sequence seq = xquery.execute("//para[ngram:contains(., 'double match')]", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'double match')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             String result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>" + MATCH_START + "double match" + MATCH_END + " " +
                 MATCH_START + "double match" + MATCH_END + "</para>", result);
 
-            seq = xquery.execute("//para[ngram:contains(., 'aaa aaa')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ngram:contains(., 'aaa aaa')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
             XMLAssert.assertEquals("<para>" + MATCH_START + "aaa aaa" + MATCH_END
                 + " aaa</para>", result);
 
-            seq = xquery.execute("//para[ngram:ends-with(., 'aaa aaa')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//para[ngram:ends-with(., 'aaa aaa')]", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
             result = queryResult2String(broker, seq, 0);
@@ -326,7 +325,7 @@ public class MatchListenerTest {
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
 
-            Sequence seq = xquery.execute("//para[ngram:wildcard-contains(., 'double.*match')]", null,
+            Sequence seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., 'double.*match')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -334,7 +333,7 @@ public class MatchListenerTest {
             XMLAssert
                 .assertEquals("<para>" + MATCH_START + "double match double match" + MATCH_END + "</para>", result);
 
-            seq = xquery.execute("//para[ngram:wildcard-contains(., 'paragraph.*content\\.')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., 'paragraph.*content\\.')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -344,7 +343,7 @@ public class MatchListenerTest {
                 + "</para>", result);
 
             String wildcardQuery = "...with.*[tn].*ele.ent[sc].*";
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -364,7 +363,7 @@ public class MatchListenerTest {
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = "\\*.*\\?";
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -376,7 +375,7 @@ public class MatchListenerTest {
 
             wildcardQuery = ".est[][?]tes.";
 
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -386,7 +385,7 @@ public class MatchListenerTest {
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
 
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '^" + wildcardQuery + "')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '^" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -396,7 +395,7 @@ public class MatchListenerTest {
 
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
 
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "$')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '" + wildcardQuery + "$')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -407,7 +406,7 @@ public class MatchListenerTest {
             match = xpe.evaluate("//exist:match", XMLUnit.buildControlDocument(result));
 
             wildcardQuery = "^aaa.aaa$";
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -418,7 +417,7 @@ public class MatchListenerTest {
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = ".+simple";
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -429,7 +428,7 @@ public class MatchListenerTest {
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = "a s.?i.?m.?p.?l.?e.?";
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -440,7 +439,7 @@ public class MatchListenerTest {
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = "a s.?i.?m.?p.?l.?e.?";
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
@@ -451,7 +450,7 @@ public class MatchListenerTest {
             assertMatches(wildcardQuery, match);
 
             wildcardQuery = "b.{3,6}c";
-            seq = xquery.execute("//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
+            seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., '" + wildcardQuery + "')]", null,
                 AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(2, seq.getItemCount());
@@ -479,7 +478,7 @@ public class MatchListenerTest {
 
             final String[] strings = new String[] { "龍", "龍護", "曰龍護", "名曰龍護" };
             for (int i = 0; i < strings.length; i++) {
-                final Sequence seq = xquery.execute(
+                final Sequence seq = xquery.execute(broker, 
                         "declare namespace tei=\"http://www.tei-c.org/ns/1.0\";\n" +
                         "//tei:p[ngram:contains(., '" + strings[i] + "')]",
                         null, AccessContext.TEST);
@@ -503,7 +502,7 @@ public class MatchListenerTest {
 
             final String[] strings = new String[] { "龍", "龍護", "曰龍護", "名曰龍護" };
             for (int i = 0; i < strings.length; i++) {
-                final Sequence seq = xquery.execute(
+                final Sequence seq = xquery.execute(broker, 
                         "declare namespace tei=\"http://www.tei-c.org/ns/1.0\";\n" +
                         "for $para in //tei:p[ngram:contains(., '" + strings[i] + "')]\n" +
                         "return\n" +

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
@@ -127,7 +127,7 @@ public class MatchListenerTest {
         configureAndStore(CONF1, XML);
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'mixed')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -164,7 +164,8 @@ public class MatchListenerTest {
         configureAndStore(CONF1, XML);
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
-            final XQuery xquery = broker.getXQueryService();
+
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             final Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'mixed')]/hi", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -179,7 +180,8 @@ public class MatchListenerTest {
         configureAndStore(CONF1, XML);
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
-            final XQuery xquery = broker.getXQueryService();
+
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'nested')]/note", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -201,7 +203,7 @@ public class MatchListenerTest {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//para[ngram:contains(term, 'term')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -229,7 +231,7 @@ public class MatchListenerTest {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'mixed content')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -268,7 +270,7 @@ public class MatchListenerTest {
         configureAndStore(CONF2, XML);
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(broker, "//para[ngram:contains(note, 'nested inner')]", null, AccessContext.TEST);
             assertNotNull(seq);
@@ -291,7 +293,7 @@ public class MatchListenerTest {
         configureAndStore(CONF1, XML);
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
 
             Sequence seq = xquery.execute(broker, "//para[ngram:contains(., 'double match')]", null, AccessContext.TEST);
@@ -321,8 +323,7 @@ public class MatchListenerTest {
         configureAndStore(CONF1, XML);
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
-
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
 
             Sequence seq = xquery.execute(broker, "//para[ngram:wildcard-contains(., 'double.*match')]", null,
@@ -472,8 +473,7 @@ public class MatchListenerTest {
         configureAndStore(CONF3, XML2);
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
-
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
 
             final String[] strings = new String[] { "龍", "龍護", "曰龍護", "名曰龍護" };
@@ -497,7 +497,7 @@ public class MatchListenerTest {
         configureAndStore(CONF3, XML2);
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject());) {
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
 
             final String[] strings = new String[] { "龍", "龍護", "曰龍護", "名曰龍護" };

--- a/extensions/indexes/spatial/test/src/org/exist/indexing/spatial/GMLIndexTest.java
+++ b/extensions/indexes/spatial/test/src/org/exist/indexing/spatial/GMLIndexTest.java
@@ -193,7 +193,7 @@ public class GMLIndexTest extends TestCase {
         try {
             pool = BrokerPool.getInstance();
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             Sequence seq = xquery.execute(
                 "declare namespace gml = 'http://www.opengis.net/gml'; " +
@@ -278,7 +278,7 @@ public class GMLIndexTest extends TestCase {
             pool = BrokerPool.getInstance();
             assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             String query = "import module namespace spatial='http://exist-db.org/xquery/spatial' " +
                 "at 'java:org.exist.examples.indexing.spatial.module.SpatialModule'; " +
@@ -378,7 +378,7 @@ public class GMLIndexTest extends TestCase {
             pool = BrokerPool.getInstance();
             assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             String query = "import module namespace spatial='http://exist-db.org/xquery/spatial' " +
                 "at 'java:org.exist.examples.indexing.spatial.module.SpatialModule'; " +
@@ -735,7 +735,7 @@ public class GMLIndexTest extends TestCase {
             pool = BrokerPool.getInstance();
             assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             String query = "import module namespace spatial='http://exist-db.org/xquery/spatial' " +
                 "at 'java:org.exist.examples.indexing.spatial.module.SpatialModule'; " +
@@ -1003,7 +1003,7 @@ public class GMLIndexTest extends TestCase {
             pool = BrokerPool.getInstance();
             assertNotNull(pool);
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             String query = "import module namespace spatial='http://exist-db.org/xquery/spatial' " +
                 "at 'java:org.exist.examples.indexing.spatial.module.SpatialModule'; " +

--- a/extensions/security/openid/src/org/exist/security/realm/openid/OpenIDUtility.java
+++ b/extensions/security/openid/src/org/exist/security/realm/openid/OpenIDUtility.java
@@ -124,13 +124,13 @@ public class OpenIDUtility {
                 return false;
             }
 
-            XQueryContext context = xquery.newContext(AccessContext.REST);
+            XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
 
-            CompiledXQuery compiled = xquery.compile(context, source);
+            CompiledXQuery compiled = xquery.compile(broker, context, source);
 
             Properties outputProperties = new Properties();
 
-            Sequence result = xquery.execute(compiled, null, outputProperties);
+            Sequence result = xquery.execute(broker, compiled, null, outputProperties);
             LOG.info("XQuery execution results: " + result.toString());
 
         } catch (Exception e) {

--- a/extensions/security/openid/src/org/exist/security/realm/openid/OpenIDUtility.java
+++ b/extensions/security/openid/src/org/exist/security/realm/openid/OpenIDUtility.java
@@ -117,7 +117,7 @@ public class OpenIDUtility {
             }
 
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
 
             if (xquery == null) {
                 LOG.error("broker unable to retrieve XQueryService");

--- a/extensions/xUnit/src/main/java/org/exist/xquery/xUnit/xUnit.java
+++ b/extensions/xUnit/src/main/java/org/exist/xquery/xUnit/xUnit.java
@@ -61,7 +61,7 @@ public class xUnit {
         	db = BrokerPool.getInstance();
         	broker = db.get(db.getSecurityManager().getGuestSubject());
         	
-        	XQuery xquery = broker.getXQueryService();
+        	XQuery xquery = broker.getBrokerPool().getXQueryService();
         	
         	XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
         	//context.setModuleLoadPath();

--- a/extensions/xUnit/src/main/java/org/exist/xquery/xUnit/xUnit.java
+++ b/extensions/xUnit/src/main/java/org/exist/xquery/xUnit/xUnit.java
@@ -63,12 +63,12 @@ public class xUnit {
         	
         	XQuery xquery = broker.getXQueryService();
         	
-        	XQueryContext context = xquery.newContext(AccessContext.TEST);
+        	XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
         	//context.setModuleLoadPath();
         	
             Source query = new ClassLoaderSource(source);
             
-            CompiledXQuery compiledQuery = xquery.compile(context, query);
+            CompiledXQuery compiledQuery = xquery.compile(broker, context, query);
             
 			for(Iterator<UserDefinedFunction> i = context.localFunctions(); i.hasNext(); ) {
 				UserDefinedFunction func = i.next();

--- a/extensions/xqdoc/src/org/exist/xqdoc/xquery/Scan.java
+++ b/extensions/xqdoc/src/org/exist/xqdoc/xquery/Scan.java
@@ -161,7 +161,7 @@ public class Scan extends BasicFunction {
     }
 
     private Sequence normalize(NodeValue input) throws IOException, XPathException {
-        XQuery xquery = context.getBroker().getXQueryService();
+        XQuery xquery = context.getBroker().getBrokerPool().getXQueryService();
         if (normalizeXQuery == null) {
             Source source = new ClassLoaderSource(NORMALIZE_XQUERY);
             XQueryContext xc = new XQueryContext(context.getBroker().getBrokerPool(), AccessContext.INITIALIZE);

--- a/extensions/xqdoc/src/org/exist/xqdoc/xquery/Scan.java
+++ b/extensions/xqdoc/src/org/exist/xqdoc/xquery/Scan.java
@@ -164,9 +164,9 @@ public class Scan extends BasicFunction {
         XQuery xquery = context.getBroker().getXQueryService();
         if (normalizeXQuery == null) {
             Source source = new ClassLoaderSource(NORMALIZE_XQUERY);
-            XQueryContext xc = xquery.newContext(AccessContext.INITIALIZE);
+            XQueryContext xc = new XQueryContext(context.getBroker().getBrokerPool(), AccessContext.INITIALIZE);
             try {
-                normalizeXQuery = xquery.compile(xc, source);
+                normalizeXQuery = xquery.compile(context.getBroker(), xc, source);
             } catch(final PermissionDeniedException e) {
                 throw new XPathException(this, e);
             }
@@ -174,7 +174,7 @@ public class Scan extends BasicFunction {
         
         try {
             normalizeXQuery.getContext().declareVariable("xqdoc:doc", input);
-            return xquery.execute(normalizeXQuery, Sequence.EMPTY_SEQUENCE);
+            return xquery.execute(context.getBroker(), normalizeXQuery, Sequence.EMPTY_SEQUENCE);
         } catch(final PermissionDeniedException e) {
             throw new XPathException(this, e);
         }

--- a/src/org/exist/atom/modules/AtomFeeds.java
+++ b/src/org/exist/atom/modules/AtomFeeds.java
@@ -218,7 +218,7 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 	public void getEntryById(DBBroker broker, String path, String id,
 			OutgoingMessage response) throws EXistException,
 			BadRequestException, PermissionDeniedException {
-		final XQuery xquery = broker.getXQueryService();
+		final XQuery xquery = broker.getBrokerPool().getXQueryService();
 		final XQueryPool xqueryPool = broker.getBrokerPool().getXQueryPool();
 		CompiledXQuery feedQuery = xqueryPool.borrowCompiledXQuery(
 				broker, entryByIdSource);
@@ -291,7 +291,7 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 			throws EXistException, BadRequestException,
 			PermissionDeniedException {
 		
-		final XQuery xquery = broker.getXQueryService();
+		final XQuery xquery = broker.getBrokerPool().getXQueryService();
 		final XQueryPool xqueryPool = broker.getBrokerPool().getXQueryPool();
 		CompiledXQuery feedQuery = xqueryPool.borrowCompiledXQuery(
 				broker, getFeedSource);

--- a/src/org/exist/atom/modules/AtomFeeds.java
+++ b/src/org/exist/atom/modules/AtomFeeds.java
@@ -44,6 +44,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.security.xacml.AccessContext;
 import org.exist.source.URLSource;
 import org.exist.storage.DBBroker;
+import org.exist.storage.XQueryPool;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.serializer.SAXSerializer;
@@ -218,14 +219,15 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 			OutgoingMessage response) throws EXistException,
 			BadRequestException, PermissionDeniedException {
 		final XQuery xquery = broker.getXQueryService();
-		CompiledXQuery feedQuery = xquery.getXQueryPool().borrowCompiledXQuery(
+		final XQueryPool xqueryPool = broker.getBrokerPool().getXQueryPool();
+		CompiledXQuery feedQuery = xqueryPool.borrowCompiledXQuery(
 				broker, entryByIdSource);
 
 		XQueryContext context;
 		if (feedQuery == null) {
-			context = xquery.newContext(AccessContext.REST);
+			context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
 			try {
-				feedQuery = xquery.compile(context, entryByIdSource);
+				feedQuery = xquery.compile(broker, context, entryByIdSource);
 			} catch (final XPathException ex) {
 				throw new EXistException("Cannot compile xquery "
 						+ entryByIdSource.getURL(), ex);
@@ -242,7 +244,7 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 
 		try {
 			context.declareVariable("id", id);
-			final Sequence resultSequence = xquery.execute(feedQuery, null);
+			final Sequence resultSequence = xquery.execute(broker, feedQuery, null);
 			if (resultSequence.isEmpty()) {
 				throw new BadRequestException("No topic was found.");
 			}
@@ -280,7 +282,7 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 					+ entryByIdSource.getURL(), ex);
 
 		} finally {
-			xquery.getXQueryPool().returnCompiledXQuery(entryByIdSource, feedQuery);
+			xqueryPool.returnCompiledXQuery(entryByIdSource, feedQuery);
 		}
 
 	}
@@ -290,14 +292,15 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 			PermissionDeniedException {
 		
 		final XQuery xquery = broker.getXQueryService();
-		CompiledXQuery feedQuery = xquery.getXQueryPool().borrowCompiledXQuery(
+		final XQueryPool xqueryPool = broker.getBrokerPool().getXQueryPool();
+		CompiledXQuery feedQuery = xqueryPool.borrowCompiledXQuery(
 				broker, getFeedSource);
 
 		XQueryContext context;
 		if (feedQuery == null) {
-			context = xquery.newContext(AccessContext.REST);
+			context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
 			try {
-				feedQuery = xquery.compile(context, getFeedSource);
+				feedQuery = xquery.compile(broker, context, getFeedSource);
 			} catch (final XPathException ex) {
 				throw new EXistException("Cannot compile xquery "
 						+ getFeedSource.getURL(), ex);
@@ -316,7 +319,7 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 		);
 
 		try {
-			final Sequence resultSequence = xquery.execute(feedQuery, null);
+			final Sequence resultSequence = xquery.execute(broker, feedQuery, null);
 			if (resultSequence.isEmpty()) {
 				throw new BadRequestException("No feed was found.");
 			}
@@ -353,7 +356,7 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 			throw new EXistException("Cannot execute xquery " + getFeedSource.getURL(), ex);
 
 		} finally {
-			xquery.getXQueryPool().returnCompiledXQuery(getFeedSource, feedQuery);
+			xqueryPool.returnCompiledXQuery(getFeedSource, feedQuery);
 		}
 	}
 }

--- a/src/org/exist/atom/modules/Query.java
+++ b/src/org/exist/atom/modules/Query.java
@@ -196,7 +196,7 @@ public class Query extends AtomModuleBase implements Atom {
 			if (collection == null)
 				{throw new BadRequestException("Collection " + request.getPath() + " does not exist.");}
 
-			final XQuery xquery = broker.getXQueryService();
+			final XQuery xquery = broker.getBrokerPool().getXQueryService();
 
 			final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
 			context.setModuleLoadPath(getContext().getModuleLoadPath());
@@ -322,7 +322,7 @@ public class Query extends AtomModuleBase implements Atom {
 		if (collection == null)
 			{throw new BadRequestException("Collection " + request.getPath() + " does not exist.");}
 
-		final XQuery xquery = broker.getXQueryService();
+		final XQuery xquery = broker.getBrokerPool().getXQueryService();
 		CompiledXQuery feedQuery = broker.getBrokerPool().getXQueryPool().borrowCompiledXQuery(broker, config.querySource);
 
 		XQueryContext context;

--- a/src/org/exist/collections/triggers/XQueryStartupTrigger.java
+++ b/src/org/exist/collections/triggers/XQueryStartupTrigger.java
@@ -264,7 +264,7 @@ public class XQueryStartupTrigger implements StartupTrigger {
 
             } else {
                 // Setup xquery service
-                XQuery service = broker.getXQueryService();
+                XQuery service = broker.getBrokerPool().getXQueryService();
                 context = new XQueryContext(broker.getBrokerPool(), AccessContext.TRIGGER);
 
                 // Allow use of modules with relative paths

--- a/src/org/exist/collections/triggers/XQueryStartupTrigger.java
+++ b/src/org/exist/collections/triggers/XQueryStartupTrigger.java
@@ -265,14 +265,14 @@ public class XQueryStartupTrigger implements StartupTrigger {
             } else {
                 // Setup xquery service
                 XQuery service = broker.getXQueryService();
-                context = service.newContext(AccessContext.TRIGGER);
+                context = new XQueryContext(broker.getBrokerPool(), AccessContext.TRIGGER);
 
                 // Allow use of modules with relative paths
                 String moduleLoadPath = StringUtils.substringBeforeLast(path, "/");
                 context.setModuleLoadPath(moduleLoadPath);
 
                 // Compile query
-                CompiledXQuery compiledQuery = service.compile(context, source);
+                CompiledXQuery compiledQuery = service.compile(broker, context, source);
 
                 LOG.info(String.format("Starting Xquery at '%s'", path));
 
@@ -280,7 +280,7 @@ public class XQueryStartupTrigger implements StartupTrigger {
                 context.prepareForExecution();
 
                 // Execute
-                Sequence result = service.execute(compiledQuery, null);
+                Sequence result = service.execute(broker, compiledQuery, null);
 
                 // Log results
                 LOG.info(String.format("Result xquery: '%s'", result.getStringValue()));

--- a/src/org/exist/collections/triggers/XQueryTrigger.java
+++ b/src/org/exist/collections/triggers/XQueryTrigger.java
@@ -273,13 +273,13 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
 		}
 		TriggerStatePerThread.setTransaction(transaction);
 		
-		final XQueryContext context = service.newContext(AccessContext.TRIGGER);
+		final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TRIGGER);
          //TODO : further initialisations ?
         CompiledXQuery compiledQuery;
         try
         {
         	//compile the XQuery
-        	compiledQuery = service.compile(context, query);
+        	compiledQuery = service.compile(broker, context, query);
 
         	//declare external variables
         	context.declareVariable(bindingPrefix + "type", EVENT_TYPE_PREPARE);
@@ -334,7 +334,7 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
         try {
         	//TODO : should we provide another contextSet ?
 	        final NodeSet contextSet = NodeSet.EMPTY_SET;
-			service.execute(compiledQuery, contextSet);
+			service.execute(broker, compiledQuery, contextSet);
 			//TODO : should we have a special processing ?
 			LOG.debug("Trigger fired for prepare");
         } catch(final XPathException e) {
@@ -359,11 +359,11 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
 		if(!TriggerStatePerThread.verifyUniqueTriggerPerThreadBeforeFinish(this, src))
 			{return;}
 		
-        final XQueryContext context = service.newContext(AccessContext.TRIGGER);
+        final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TRIGGER);
         CompiledXQuery compiledQuery = null;
         try {
         	//compile the XQuery
-        	compiledQuery = service.compile(context, query);
+        	compiledQuery = service.compile(broker, context, query);
         	
         	//declare external variables
         	context.declareVariable(bindingPrefix + "type", EVENT_TYPE_FINISH);
@@ -414,7 +414,7 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
         try {
         	//TODO : should we provide another contextSet ?
 	        final NodeSet contextSet = NodeSet.EMPTY_SET;	        
-			service.execute(compiledQuery, contextSet);
+			service.execute(broker, compiledQuery, contextSet);
 			//TODO : should we have a special processing ?
         } catch (final XPathException e) {
         	//Should never be reached
@@ -445,7 +445,7 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
 		}
 		TriggerStatePerThread.setTransaction(transaction);
 		
-		final XQueryContext context = service.newContext(AccessContext.TRIGGER);
+		final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TRIGGER);
         if (query instanceof DBSource) {
             context.setModuleLoadPath(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + ((DBSource)query).getDocumentPath().removeLastSegment().toString());
         }
@@ -453,7 +453,7 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
         CompiledXQuery compiledQuery;
         try {
         	//compile the XQuery
-        	compiledQuery = service.compile(context, query);
+        	compiledQuery = service.compile(broker, context, query);
 
         	//declare user defined parameters as external variables
         	for(final Iterator itUserVarName = userDefinedVariables.keySet().iterator(); itUserVarName.hasNext();) {

--- a/src/org/exist/collections/triggers/XQueryTrigger.java
+++ b/src/org/exist/collections/triggers/XQueryTrigger.java
@@ -224,7 +224,7 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
  			//old
  			if(urlQuery != null || strQuery != null)
  			{
-				service = broker.getXQueryService();
+				service = broker.getBrokerPool().getXQueryService();
 				
 				return;
  			}

--- a/src/org/exist/http/AuditTrailSessionListener.java
+++ b/src/org/exist/http/AuditTrailSessionListener.java
@@ -133,18 +133,18 @@ public class AuditTrailSessionListener implements HttpSessionListener {
                     return;
                 }
 
-                final XQueryPool xqpool = xquery.getXQueryPool();
+                final XQueryPool xqpool = pool.getXQueryPool();
                 CompiledXQuery compiled = xqpool.borrowCompiledXQuery(broker, source);
                 XQueryContext context;
                 if (compiled == null)
-                    {context = xquery.newContext(AccessContext.REST);}
+                    {context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);}
                 else
                     {context = compiled.getContext();}
                 context.setStaticallyKnownDocuments(new XmldbURI[] { pathUri });
                 context.setBaseURI(new AnyURIValue(pathUri.toString()));
 
                 if (compiled == null)
-                    {compiled = xquery.compile(context, source);}
+                    {compiled = xquery.compile(broker, context, source);}
                 else {
                     compiled.getContext().updateContext(context);
                     context.getWatchDog().reset();
@@ -155,7 +155,7 @@ public class AuditTrailSessionListener implements HttpSessionListener {
 
                 try {
                     final long startTime = System.currentTimeMillis();
-                    result = xquery.execute(compiled, null, outputProperties);
+                    result = xquery.execute(broker, compiled, null, outputProperties);
                     final long queryTime = System.currentTimeMillis() - startTime;
                     LOG.info("XQuery execution results: " + result.toString()  + " in " + queryTime + "ms.");
                 } finally {

--- a/src/org/exist/http/AuditTrailSessionListener.java
+++ b/src/org/exist/http/AuditTrailSessionListener.java
@@ -126,7 +126,7 @@ public class AuditTrailSessionListener implements HttpSessionListener {
                 }
 
 
-                final XQuery xquery = broker.getXQueryService();
+                final XQuery xquery = pool.getXQueryService();
 
                 if (xquery == null) {
                     LOG.error("broker unable to retrieve XQueryService");

--- a/src/org/exist/http/RESTServer.java
+++ b/src/org/exist/http/RESTServer.java
@@ -1272,7 +1272,7 @@ public class RESTServer {
         final XmldbURI pathUri = XmldbURI.create(path);
         try {
             final Source source = new StringSource(query);
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = broker.getBrokerPool().getXQueryService();
             final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
             CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
 
@@ -1453,7 +1453,7 @@ public class RESTServer {
             throws XPathException, BadRequestException, PermissionDeniedException {
 
         final Source source = new DBSource(broker, (BinaryDocument) resource, true);
-        final XQuery xquery = broker.getXQueryService();
+        final XQuery xquery = broker.getBrokerPool().getXQueryService();
         final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
         XQueryContext context;
 
@@ -1515,7 +1515,7 @@ public class RESTServer {
             throws XPathException, BadRequestException, PermissionDeniedException {
 
         final URLSource source = new URLSource(this.getClass().getResource("run-xproc.xq"));
-        final XQuery xquery = broker.getXQueryService();
+        final XQuery xquery = broker.getBrokerPool().getXQueryService();
         final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
         XQueryContext context;
         CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);

--- a/src/org/exist/http/RESTServer.java
+++ b/src/org/exist/http/RESTServer.java
@@ -1273,12 +1273,12 @@ public class RESTServer {
         try {
             final Source source = new StringSource(query);
             final XQuery xquery = broker.getXQueryService();
-            final XQueryPool pool = xquery.getXQueryPool();
+            final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
             CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
 
             XQueryContext context;
             if (compiled == null) {
-                context = xquery.newContext(AccessContext.REST);
+                context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
             } else {
                 context = compiled.getContext();
             }
@@ -1290,7 +1290,7 @@ public class RESTServer {
             declareVariables(context, variables, request, response);
 
             if (compiled == null) {
-                compiled = xquery.compile(context, source);
+                compiled = xquery.compile(broker, context, source);
             } else {
                 compiled.getContext().updateContext(context);
                 context.getWatchDog().reset();
@@ -1298,7 +1298,7 @@ public class RESTServer {
 
             try {
                 final long startTime = System.currentTimeMillis();
-                final Sequence resultSequence = xquery.execute(compiled, null, outputProperties);
+                final Sequence resultSequence = xquery.execute(broker, compiled, null, outputProperties);
                 final long queryTime = System.currentTimeMillis() - startTime;
 
                 if (LOG.isDebugEnabled()) {
@@ -1454,7 +1454,7 @@ public class RESTServer {
 
         final Source source = new DBSource(broker, (BinaryDocument) resource, true);
         final XQuery xquery = broker.getXQueryService();
-        final XQueryPool pool = xquery.getXQueryPool();
+        final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
         XQueryContext context;
 
         CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
@@ -1462,7 +1462,7 @@ public class RESTServer {
             // special header to indicate that the query is not returned from
             // cache
             response.setHeader("X-XQuery-Cached", "false");
-            context = xquery.newContext(AccessContext.REST);
+            context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
 
         } else {
             response.setHeader("X-XQuery-Cached", "true");
@@ -1483,7 +1483,7 @@ public class RESTServer {
 
         if (compiled == null) {
             try {
-                compiled = xquery.compile(context, source);
+                compiled = xquery.compile(broker, context, source);
             } catch (final IOException e) {
                 throw new BadRequestException("Failed to read query from " + resource.getURI(), e);
             }
@@ -1495,7 +1495,7 @@ public class RESTServer {
                 && "yes".equals(outputProperties.getProperty("_wrap"));
 
         try {
-            final Sequence result = xquery.execute(compiled, null, outputProperties);
+            final Sequence result = xquery.execute(broker, compiled, null, outputProperties);
             writeResults(response, broker, result, -1, 1, false, outputProperties, wrap);
 
         } finally {
@@ -1516,11 +1516,11 @@ public class RESTServer {
 
         final URLSource source = new URLSource(this.getClass().getResource("run-xproc.xq"));
         final XQuery xquery = broker.getXQueryService();
-        final XQueryPool pool = xquery.getXQueryPool();
+        final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
         XQueryContext context;
         CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
         if (compiled == null) {
-            context = xquery.newContext(AccessContext.REST);
+            context = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
         } else {
             context = compiled.getContext();
         }
@@ -1555,7 +1555,7 @@ public class RESTServer {
         reqw.setPathInfo(pathInfo);
         if (compiled == null) {
             try {
-                compiled = xquery.compile(context, source);
+                compiled = xquery.compile(broker, context, source);
             } catch (final IOException e) {
                 throw new BadRequestException("Failed to read query from "
                         + source.getURL(), e);
@@ -1563,7 +1563,7 @@ public class RESTServer {
         }
 
         try {
-            final Sequence result = xquery.execute(compiled, null, outputProperties);
+            final Sequence result = xquery.execute(broker, compiled, null, outputProperties);
             writeResults(response, broker, result, -1, 1, false, outputProperties, false);
         } finally {
             pool.returnCompiledXQuery(source, compiled);

--- a/src/org/exist/http/servlets/XQueryServlet.java
+++ b/src/org/exist/http/servlets/XQueryServlet.java
@@ -436,7 +436,7 @@ public class XQueryServlet extends AbstractExistHttpServlet {
         DBBroker broker = null;
         try {
         	broker = getPool().get(user);
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = broker.getBrokerPool().getXQueryService();
             CompiledXQuery query = getPool().getXQueryPool().borrowCompiledXQuery(broker, source);
 
             XQueryContext context;

--- a/src/org/exist/http/servlets/XQueryServlet.java
+++ b/src/org/exist/http/servlets/XQueryServlet.java
@@ -437,14 +437,14 @@ public class XQueryServlet extends AbstractExistHttpServlet {
         try {
         	broker = getPool().get(user);
             final XQuery xquery = broker.getXQueryService();
-            CompiledXQuery query = xquery.getXQueryPool().borrowCompiledXQuery(broker, source);
+            CompiledXQuery query = getPool().getXQueryPool().borrowCompiledXQuery(broker, source);
 
             XQueryContext context;
             if (query==null) {
-               context = xquery.newContext(AccessContext.REST);
+               context = new XQueryContext(getPool(), AccessContext.REST);
                context.setModuleLoadPath(moduleLoadPath);
                try {
-            	   query = xquery.compile(context, source);
+            	   query = xquery.compile(broker, context, source);
                    
                } catch (final XPathException ex) {
                   throw new EXistException("Cannot compile xquery: "+ ex.getMessage(), ex);
@@ -489,11 +489,11 @@ public class XQueryServlet extends AbstractExistHttpServlet {
 
             Sequence resultSequence;
             try {
-                resultSequence = xquery.execute(query, null, outputProperties);
+                resultSequence = xquery.execute(broker, query, null, outputProperties);
                 
             } finally {
                 context.runCleanupTasks();
-                xquery.getXQueryPool().returnCompiledXQuery(source, query);
+                getPool().getXQueryPool().returnCompiledXQuery(source, query);
             }
 
             final String mediaType = outputProperties.getProperty(OutputKeys.MEDIA_TYPE);

--- a/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -673,7 +673,7 @@ public class XQueryURLRewrite extends HttpServlet {
         }
         final String basePath = staticRewrite == null ? "." : staticRewrite.getTarget();
         
-        final XQuery xquery = broker.getXQueryService();
+        final XQuery xquery = broker.getBrokerPool().getXQueryService();
         final XQueryPool xqyPool = broker.getBrokerPool().getXQueryPool();
 		
         CompiledXQuery compiled = null;

--- a/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -674,7 +674,7 @@ public class XQueryURLRewrite extends HttpServlet {
         final String basePath = staticRewrite == null ? "." : staticRewrite.getTarget();
         
         final XQuery xquery = broker.getXQueryService();
-        final XQueryPool xqyPool = xquery.getXQueryPool();
+        final XQueryPool xqyPool = broker.getBrokerPool().getXQueryPool();
 		
         CompiledXQuery compiled = null;
         if (compiledCache) {
@@ -682,7 +682,7 @@ public class XQueryURLRewrite extends HttpServlet {
         }
         XQueryContext queryContext;
         if (compiled == null) {
-			queryContext = xquery.newContext(AccessContext.REST);
+			queryContext = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
 		} else {
 			queryContext = compiled.getContext();
 		}
@@ -691,7 +691,7 @@ public class XQueryURLRewrite extends HttpServlet {
         declareVariables(queryContext, sourceInfo, staticRewrite, basePath, request, response);
         if (compiled == null) {
 			try {
-				compiled = xquery.compile(queryContext, sourceInfo.source);
+				compiled = xquery.compile(broker, queryContext, sourceInfo.source);
 			} catch (final IOException e) {
 				throw new ServletException("Failed to read query from " + query, e);
 			}
@@ -706,7 +706,7 @@ public class XQueryURLRewrite extends HttpServlet {
 //      outputProperties.put("base-uri", collectionURI.toString());
 
         try {
-			return xquery.execute(compiled, null, outputProperties);
+			return xquery.execute(broker, compiled, null, outputProperties);
 		} finally {
             queryContext.runCleanupTasks();
 			xqyPool.returnCompiledXQuery(sourceInfo.source, compiled);

--- a/src/org/exist/launcher/Launcher.java
+++ b/src/org/exist/launcher/Launcher.java
@@ -434,7 +434,7 @@ public class Launcher extends Observable implements Observer {
             pool = BrokerPool.getInstance();
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
             final XQuery xquery = broker.getXQueryService();
-            final Sequence pkgs = xquery.execute("repo:list()", null, AccessContext.INITIALIZE);
+            final Sequence pkgs = xquery.execute(broker, "repo:list()", null, AccessContext.INITIALIZE);
             for (final SequenceIterator i = pkgs.iterate(); i.hasNext(); ) {
                 final ExistRepository.Notification notification = new ExistRepository.Notification(ExistRepository.Action.INSTALL, i.nextItem().getStringValue());
                 update(pool.getExpathRepo(), notification);

--- a/src/org/exist/launcher/Launcher.java
+++ b/src/org/exist/launcher/Launcher.java
@@ -433,7 +433,7 @@ public class Launcher extends Observable implements Observer {
         try {
             pool = BrokerPool.getInstance();
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             final Sequence pkgs = xquery.execute(broker, "repo:list()", null, AccessContext.INITIALIZE);
             for (final SequenceIterator i = pkgs.iterate(); i.hasNext(); ) {
                 final ExistRepository.Notification notification = new ExistRepository.Notification(ExistRepository.Action.INSTALL, i.nextItem().getStringValue());

--- a/src/org/exist/management/impl/SanityReport.java
+++ b/src/org/exist/management/impl/SanityReport.java
@@ -200,14 +200,14 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
     		
     		if (checkQueryEngine) {
     			final XQuery xquery = broker.getXQueryService();
-    			final XQueryPool xqPool = xquery.getXQueryPool();
+    			final XQueryPool xqPool = pool.getXQueryPool();
     			CompiledXQuery compiled = xqPool.borrowCompiledXQuery(broker, TEST_XQUERY);
     			if (compiled == null) {
-    				final XQueryContext context = xquery.newContext(AccessContext.TEST);
-    				compiled = xquery.compile(context, TEST_XQUERY);
+    				final XQueryContext context = new XQueryContext(pool, AccessContext.TEST);
+    				compiled = xquery.compile(broker, context, TEST_XQUERY);
     			}
 				try {
-					xquery.execute(compiled, null);
+					xquery.execute(broker, compiled, null);
 				} finally {
 					xqPool.returnCompiledXQuery(TEST_XQUERY, compiled);
 				}

--- a/src/org/exist/management/impl/SanityReport.java
+++ b/src/org/exist/management/impl/SanityReport.java
@@ -199,7 +199,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
     		broker = pool.get(pool.getSecurityManager().getGuestSubject());
     		
     		if (checkQueryEngine) {
-    			final XQuery xquery = broker.getXQueryService();
+    			final XQuery xquery = pool.getXQueryService();
     			final XQueryPool xqPool = pool.getXQueryPool();
     			CompiledXQuery compiled = xqPool.borrowCompiledXQuery(broker, TEST_XQUERY);
     			if (compiled == null) {

--- a/src/org/exist/repo/Deployment.java
+++ b/src/org/exist/repo/Deployment.java
@@ -562,7 +562,7 @@ public class Deployment {
             LOG.warn("The XQuery resource specified in the <setup> element was not found");
             return Sequence.EMPTY_SEQUENCE;
         }
-        final XQuery xqs = broker.getXQueryService();
+        final XQuery xqs = broker.getBrokerPool().getXQueryService();
         final XQueryContext ctx = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
         ctx.declareVariable("dir", tempDir.getAbsolutePath());
         final File home = broker.getConfiguration().getExistHome();

--- a/src/org/exist/repo/Deployment.java
+++ b/src/org/exist/repo/Deployment.java
@@ -563,7 +563,7 @@ public class Deployment {
             return Sequence.EMPTY_SEQUENCE;
         }
         final XQuery xqs = broker.getXQueryService();
-        final XQueryContext ctx = xqs.newContext(AccessContext.REST);
+        final XQueryContext ctx = new XQueryContext(broker.getBrokerPool(), AccessContext.REST);
         ctx.declareVariable("dir", tempDir.getAbsolutePath());
         final File home = broker.getConfiguration().getExistHome();
         ctx.declareVariable("home", home.getAbsolutePath());
@@ -579,8 +579,8 @@ public class Deployment {
 
         CompiledXQuery compiled;
         try {
-            compiled = xqs.compile(ctx, new FileSource(xquery, "UTF-8", false));
-            return xqs.execute(compiled, null);
+            compiled = xqs.compile(broker, ctx, new FileSource(xquery, "UTF-8", false));
+            return xqs.execute(broker, compiled, null);
         } catch (final PermissionDeniedException e) {
             throw new PackageException(e.getMessage(), e);
         }

--- a/src/org/exist/scheduler/UserXQueryJob.java
+++ b/src/org/exist/scheduler/UserXQueryJob.java
@@ -167,13 +167,13 @@ public class UserXQueryJob extends UserJob {
 
                 //execute the xquery
                 final XQuery xquery = broker.getXQueryService();
-                xqPool = xquery.getXQueryPool();
+                xqPool = pool.getXQueryPool();
 
                 //try and get a pre-compiled query from the pool
                 compiled = xqPool.borrowCompiledXQuery(broker, source);
 
                 if(compiled == null) {
-                    context = xquery.newContext(AccessContext.REST); //TODO should probably have its own AccessContext.SCHEDULER
+                    context = new XQueryContext(pool, AccessContext.REST); //TODO should probably have its own AccessContext.SCHEDULER
                 } else {
                     context = compiled.getContext();
                 }
@@ -189,7 +189,7 @@ public class UserXQueryJob extends UserJob {
                 if(compiled == null) {
 
                     try {
-                        compiled = xquery.compile(context, source);
+                        compiled = xquery.compile(broker, context, source);
                     }
                     catch(final IOException e) {
                         abort("Failed to read query from " + xqueryresource);
@@ -212,7 +212,7 @@ public class UserXQueryJob extends UserJob {
                     }
                 }
 
-                xquery.execute(compiled, null);
+                xquery.execute(broker, compiled, null);
 
             } else {
                 LOG.warn("XQuery User Job not found: " + xqueryresource + ", job not scheduled");

--- a/src/org/exist/scheduler/UserXQueryJob.java
+++ b/src/org/exist/scheduler/UserXQueryJob.java
@@ -166,7 +166,7 @@ public class UserXQueryJob extends UserJob {
             if(source != null) {
 
                 //execute the xquery
-                final XQuery xquery = broker.getXQueryService();
+                final XQuery xquery = pool.getXQueryService();
                 xqPool = pool.getXQueryPool();
 
                 //try and get a pre-compiled query from the pool

--- a/src/org/exist/security/internal/SMEvents.java
+++ b/src/org/exist/security/internal/SMEvents.java
@@ -110,9 +110,9 @@ public class SMEvents implements Configurable {
             if(source == null) {return;}
 
             final XQuery xquery = broker.getXQueryService();
-            final XQueryContext context = xquery.newContext(AccessContext.XMLDB);
+            final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.XMLDB);
 
-            final CompiledXQuery compiled = xquery.compile(context, source);
+            final CompiledXQuery compiled = xquery.compile(broker, context, source);
 
 //            Sequence result = xquery.execute(compiled, subject.getName());
 

--- a/src/org/exist/security/internal/SMEvents.java
+++ b/src/org/exist/security/internal/SMEvents.java
@@ -109,7 +109,7 @@ public class SMEvents implements Configurable {
             final Source source = getQuerySource(broker, scriptURI, script);
             if(source == null) {return;}
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = broker.getBrokerPool().getXQueryService();
             final XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.XMLDB);
 
             final CompiledXQuery compiled = xquery.compile(broker, context, source);

--- a/src/org/exist/storage/BrokerPool.java
+++ b/src/org/exist/storage/BrokerPool.java
@@ -66,6 +66,7 @@ import org.exist.util.Configuration.StartupTriggerConfig;
 import org.exist.xmldb.ShutdownListener;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.PerformanceStats;
+import org.exist.xquery.XQuery;
 import org.expath.pkg.repo.PackageException;
 
 import java.io.File;
@@ -176,6 +177,10 @@ public class BrokerPool implements Database {
 
     private static Observer statusObserver = null;
     private StatusReporter statusReporter = null;
+
+    private final XQuery xqueryService = new XQuery();
+
+
 
     /**
      * Whether of not the JVM should run the shutdown thread.
@@ -1400,6 +1405,15 @@ public class BrokerPool implements Database {
      */
     public XQueryPool getXQueryPool() {
         return xQueryPool;
+    }
+
+    /**
+     * Retuns the XQuery Service
+     *
+     * @return The XQuery service
+     */
+    public XQuery getXQueryService() {
+        return xqueryService;
     }
 
     /**

--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -102,8 +102,6 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
 
     private Subject subject = null;
 
-    protected XQuery xqueryService;
-
     private int referenceCount = 0;
 
     protected String id;
@@ -121,7 +119,6 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
         if (temp != null)
             {caseSensitive = temp.booleanValue();}
         this.pool = pool;
-        xqueryService = new XQuery();
         initIndexModules();
     }
 
@@ -181,13 +178,6 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
 
     public IndexController getIndexController() {
         return indexController;
-    }
-
-    /**
-     * @return A reference to the global {@link XQuery} service.
-     */
-    public XQuery getXQueryService() {
-        return xqueryService;
     }
 
     public abstract ElementIndex getElementIndex();

--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -121,7 +121,7 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
         if (temp != null)
             {caseSensitive = temp.booleanValue();}
         this.pool = pool;
-        xqueryService = new XQuery(this);
+        xqueryService = new XQuery();
         initIndexModules();
     }
 

--- a/src/org/exist/storage/serializers/XIncludeFilter.java
+++ b/src/org/exist/storage/serializers/XIncludeFilter.java
@@ -415,13 +415,13 @@ public class XIncludeFilter implements Receiver {
                     source = new StringSource(xpointer);
                 }
                 final XQuery xquery = serializer.broker.getXQueryService();
-                final XQueryPool pool = xquery.getXQueryPool();
+                final XQueryPool pool = serializer.broker.getBrokerPool().getXQueryPool();
                 XQueryContext context;
                 CompiledXQuery compiled = pool.borrowCompiledXQuery(serializer.broker, source);
                 if (compiled != null)
                     {context = compiled.getContext();}
                 else
-                    {context = xquery.newContext(AccessContext.XINCLUDE);}
+                    {context = new XQueryContext(serializer.broker.getBrokerPool(), AccessContext.XINCLUDE);}
                 context.declareNamespaces(namespaces);
                 context.declareNamespace("xinclude", XINCLUDE_NS);
                 
@@ -460,7 +460,7 @@ public class XIncludeFilter implements Receiver {
 
                 if(compiled == null) {
                     try {
-                        compiled = xquery.compile(context, source, xpointer != null);
+                        compiled = xquery.compile(serializer.broker, context, source, xpointer != null);
                     } catch (final IOException e) {
                         throw new SAXException("I/O error while reading query for xinclude: " + e.getMessage(), e);
                     }
@@ -469,7 +469,7 @@ public class XIncludeFilter implements Receiver {
                 Sequence contextSeq = null;
                 if (memtreeDoc != null)
                     {contextSeq = memtreeDoc;}
-                final Sequence seq = xquery.execute(compiled, contextSeq);
+                final Sequence seq = xquery.execute(serializer.broker, compiled, contextSeq);
 
                 if(Type.subTypeOf(seq.getItemType(), Type.NODE)) {
                     if (LOG.isDebugEnabled())

--- a/src/org/exist/storage/serializers/XIncludeFilter.java
+++ b/src/org/exist/storage/serializers/XIncludeFilter.java
@@ -414,7 +414,7 @@ public class XIncludeFilter implements Receiver {
                     xpointer = checkNamespaces(xpointer);
                     source = new StringSource(xpointer);
                 }
-                final XQuery xquery = serializer.broker.getXQueryService();
+                final XQuery xquery = serializer.broker.getBrokerPool().getXQueryService();
                 final XQueryPool pool = serializer.broker.getBrokerPool().getXQueryPool();
                 XQueryContext context;
                 CompiledXQuery compiled = pool.borrowCompiledXQuery(serializer.broker, source);

--- a/src/org/exist/validation/internal/DatabaseResources.java
+++ b/src/org/exist/validation/internal/DatabaseResources.java
@@ -140,7 +140,7 @@ public class DatabaseResources {
             broker = brokerPool.get(user);
             
             final XQuery xquery = broker.getXQueryService();
-            final XQueryContext context = xquery.newContext(AccessContext.INTERNAL_PREFIX_LOOKUP);
+            final XQueryContext context = new XQueryContext(brokerPool, AccessContext.INTERNAL_PREFIX_LOOKUP);
             
             if(collection!=null){
                 context.declareVariable(COLLECTION, collection);
@@ -158,9 +158,9 @@ public class DatabaseResources {
                 context.declareVariable(CATALOG, catalogPath);
             }
             
-            CompiledXQuery compiled = xquery.compile(context, new ClassLoaderSource(queryPath) );
+            CompiledXQuery compiled = xquery.compile(broker, context, new ClassLoaderSource(queryPath) );
             
-            result = xquery.execute(compiled, null);
+            result = xquery.execute(broker, compiled, null);
             
         } catch (final EXistException | XPathException | IOException | PermissionDeniedException ex) {
             logger.error("Problem executing xquery", ex);

--- a/src/org/exist/validation/internal/DatabaseResources.java
+++ b/src/org/exist/validation/internal/DatabaseResources.java
@@ -139,7 +139,7 @@ public class DatabaseResources {
         try {
             broker = brokerPool.get(user);
             
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = brokerPool.getXQueryService();
             final XQueryContext context = new XQueryContext(brokerPool, AccessContext.INTERNAL_PREFIX_LOOKUP);
             
             if(collection!=null){

--- a/src/org/exist/xmldb/LocalXPathQueryService.java
+++ b/src/org/exist/xmldb/LocalXPathQueryService.java
@@ -200,7 +200,7 @@ public class LocalXPathQueryService extends AbstractLocalService implements XPat
             setupContext(null, context);
 
             final XQuery xquery = broker.getXQueryService();
-            result = xquery.execute(expr, contextSet, properties);
+            result = xquery.execute(broker, expr, contextSet, properties);
         } catch (final Exception e) {
             // need to catch all runtime exceptions here to be able to release locked documents
             throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
@@ -239,12 +239,12 @@ public class LocalXPathQueryService extends AbstractLocalService implements XPat
             final XmldbURI[] docs = new XmldbURI[]{XmldbURI.create(collection.getName())};
 
             final XQuery xquery = broker.getXQueryService();
-            final XQueryPool pool = xquery.getXQueryPool();
+            final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 
             XQueryContext context;
             CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
             if (compiled == null) {
-                context = xquery.newContext(accessCtx);
+                context = new XQueryContext(broker.getBrokerPool(), accessCtx);
             } else {
                 context = compiled.getContext();
             }
@@ -259,11 +259,11 @@ public class LocalXPathQueryService extends AbstractLocalService implements XPat
             setupContext(source, context);
 
             if (compiled == null) {
-                compiled = xquery.compile(context, source);
+                compiled = xquery.compile(broker, context, source);
             }
 
             try {
-                final Sequence result = xquery.execute(compiled, null, properties);
+                final Sequence result = xquery.execute(broker, compiled, null, properties);
                 if(LOG.isDebugEnabled()) {
                     LOG.debug("query took " + (System.currentTimeMillis() - start) + " ms.");
                 }
@@ -300,11 +300,11 @@ public class LocalXPathQueryService extends AbstractLocalService implements XPat
     private Either<XPathException, CompiledExpression> compileAndCheck(final DBBroker broker, final Txn transaction, final String query) throws XMLDBException {
         final long start = System.currentTimeMillis();
         final XQuery xquery = broker.getXQueryService();
-        final XQueryContext context = xquery.newContext(accessCtx);
+        final XQueryContext context = new XQueryContext(broker.getBrokerPool(), accessCtx);
 
         try {
             setupContext(null, context);
-            final CompiledExpression expr = xquery.compile(context, query);
+            final CompiledExpression expr = xquery.compile(broker, context, query);
             if(LOG.isDebugEnabled()) {
                 LOG.debug("compilation took " + (System.currentTimeMillis() - start));
             }

--- a/src/org/exist/xmldb/LocalXPathQueryService.java
+++ b/src/org/exist/xmldb/LocalXPathQueryService.java
@@ -199,7 +199,7 @@ public class LocalXPathQueryService extends AbstractLocalService implements XPat
             }
             setupContext(null, context);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = brokerPool.getXQueryService();
             result = xquery.execute(broker, expr, contextSet, properties);
         } catch (final Exception e) {
             // need to catch all runtime exceptions here to be able to release locked documents
@@ -238,8 +238,8 @@ public class LocalXPathQueryService extends AbstractLocalService implements XPat
 
             final XmldbURI[] docs = new XmldbURI[]{XmldbURI.create(collection.getName())};
 
-            final XQuery xquery = broker.getXQueryService();
-            final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
+            final XQuery xquery = brokerPool.getXQueryService();
+            final XQueryPool pool = brokerPool.getXQueryPool();
 
             XQueryContext context;
             CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
@@ -299,7 +299,7 @@ public class LocalXPathQueryService extends AbstractLocalService implements XPat
 
     private Either<XPathException, CompiledExpression> compileAndCheck(final DBBroker broker, final Txn transaction, final String query) throws XMLDBException {
         final long start = System.currentTimeMillis();
-        final XQuery xquery = broker.getXQueryService();
+        final XQuery xquery = broker.getBrokerPool().getXQueryService();
         final XQueryContext context = new XQueryContext(broker.getBrokerPool(), accessCtx);
 
         try {

--- a/src/org/exist/xmlrpc/RpcConnection.java
+++ b/src/org/exist/xmlrpc/RpcConnection.java
@@ -235,7 +235,7 @@ public class RpcConnection implements RpcAPI {
 
     protected QueryResult doQuery(final DBBroker broker, final CompiledXQuery compiled,
             final NodeSet contextSet, final Map<String, Object> parameters) throws XPathException, EXistException, PermissionDeniedException {
-        final XQuery xquery = broker.getXQueryService();
+        final XQuery xquery = broker.getBrokerPool().getXQueryService();
 
         checkPragmas(compiled.getContext(), parameters);
         LockedDocumentMap lockedDocuments = null;
@@ -286,7 +286,7 @@ public class RpcConnection implements RpcAPI {
      */
     @Deprecated
     private CompiledXQuery compile(final DBBroker broker, final Source source, final Map<String, Object> parameters) throws XPathException, IOException, PermissionDeniedException {
-        final XQuery xquery = broker.getXQueryService();
+        final XQuery xquery = broker.getBrokerPool().getXQueryService();
         final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
         CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
         XQueryContext context;

--- a/src/org/exist/xquery/functions/fn/FunLang.java
+++ b/src/org/exist/xquery/functions/fn/FunLang.java
@@ -98,7 +98,7 @@ public class FunLang extends Function {
 	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
 		super.analyze(contextInfo);
 		try {
-			query = context.getBroker().getXQueryService().compile(context, queryString);
+			query = context.getBroker().getXQueryService().compile(context.getBroker(), context, queryString);
 		} catch (final PermissionDeniedException e) {
 			throw new XPathException(this, e);
 		}		

--- a/src/org/exist/xquery/functions/fn/FunLang.java
+++ b/src/org/exist/xquery/functions/fn/FunLang.java
@@ -98,7 +98,7 @@ public class FunLang extends Function {
 	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
 		super.analyze(contextInfo);
 		try {
-			query = context.getBroker().getXQueryService().compile(context.getBroker(), context, queryString);
+			query = context.getBroker().getBrokerPool().getXQueryService().compile(context.getBroker(), context, queryString);
 		} catch (final PermissionDeniedException e) {
 			throw new XPathException(this, e);
 		}		

--- a/src/org/exist/xquery/functions/system/ClearXQueryCache.java
+++ b/src/org/exist/xquery/functions/system/ClearXQueryCache.java
@@ -61,7 +61,7 @@ public class ClearXQueryCache extends BasicFunction {
     	
     	final DBBroker broker = context.getBroker();
     	
-    	final XQuery xquery = broker.getXQueryService();
+    	final XQuery xquery = broker.getBrokerPool().getXQueryService();
 		final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 		
 		pool.clear();

--- a/src/org/exist/xquery/functions/system/ClearXQueryCache.java
+++ b/src/org/exist/xquery/functions/system/ClearXQueryCache.java
@@ -62,7 +62,7 @@ public class ClearXQueryCache extends BasicFunction {
     	final DBBroker broker = context.getBroker();
     	
     	final XQuery xquery = broker.getXQueryService();
-		final XQueryPool pool = xquery.getXQueryPool();
+		final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 		
 		pool.clear();
 		

--- a/src/org/exist/xquery/functions/util/Eval.java
+++ b/src/org/exist/xquery/functions/util/Eval.java
@@ -330,7 +330,7 @@ public class Eval extends BasicFunction {
         final XQueryContext innerContext;
         if (contextInit != null) {
             // eval-with-context: initialize a new context
-            innerContext = xqueryService.newContext(evalContext.getAccessContext());
+            innerContext = new XQueryContext(context.getBroker().getBrokerPool(), evalContext.getAccessContext());
             initContextSequence = initContext(contextInit.getNode(), innerContext);
         } else {
             // use the existing outer context
@@ -429,17 +429,17 @@ public class Eval extends BasicFunction {
     private Sequence execute(DBBroker broker, XQuery xqueryService, Source querySource, XQueryContext innerContext, Sequence exprContext, boolean cache) throws XPathException {
 
         CompiledXQuery compiled = null;
-        final XQueryPool pool = xqueryService.getXQueryPool();
+        final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 
         try {
             compiled = cache ? pool.borrowCompiledXQuery(broker, querySource) : null;
             if(compiled == null) {
-                compiled = xqueryService.compile(innerContext, querySource);
+                compiled = xqueryService.compile(broker, innerContext, querySource);
             } else {
                 compiled.getContext().updateContext(innerContext);
             }
 
-            Sequence sequence = xqueryService.execute(compiled, exprContext, false);
+            Sequence sequence = xqueryService.execute(broker, compiled, exprContext, false);
             ValueSequence newSeq = new ValueSequence();
             newSeq.keepUnOrdered(unordered);
             boolean hasSupplements = false;

--- a/src/org/exist/xquery/functions/util/Eval.java
+++ b/src/org/exist/xquery/functions/util/Eval.java
@@ -326,7 +326,7 @@ public class Eval extends BasicFunction {
 
         // fixme! - hook for debugger here /ljo
 
-        final XQuery xqueryService = evalContext.getBroker().getXQueryService();
+        final XQuery xqueryService = evalContext.getBroker().getBrokerPool().getXQueryService();
         final XQueryContext innerContext;
         if (contextInit != null) {
             // eval-with-context: initialize a new context

--- a/src/org/exist/xupdate/Conditional.java
+++ b/src/org/exist/xupdate/Conditional.java
@@ -71,12 +71,12 @@ public class Conditional extends Modification {
 			EXistException, XPathException, TriggerException {
 		LOG.debug("Processing xupdate:if ...");
 		final XQuery xquery = broker.getXQueryService();
-		final XQueryPool pool = xquery.getXQueryPool();
+		final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 		final Source source = new StringSource(selectStmt);
 		CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
 		XQueryContext context;
 		if(compiled == null)
-		    {context = xquery.newContext(getAccessContext());}
+		    {context = new XQueryContext(broker.getBrokerPool(), getAccessContext());}
 		else
 		    {context = compiled.getContext();}
 
@@ -86,14 +86,14 @@ public class Conditional extends Modification {
 		declareVariables(context);
 		if(compiled == null)
 			try {
-				compiled = xquery.compile(context, source);
+				compiled = xquery.compile(broker, context, source);
 			} catch (final IOException e) {
 				throw new EXistException("An exception occurred while compiling the query: " + e.getMessage());
 			}
 		
 		Sequence seq = null;
 		try {
-			seq = xquery.execute(compiled, null);
+			seq = xquery.execute(broker, compiled, null);
 		} finally {
 			pool.returnCompiledXQuery(source, compiled);
 		}

--- a/src/org/exist/xupdate/Conditional.java
+++ b/src/org/exist/xupdate/Conditional.java
@@ -70,7 +70,7 @@ public class Conditional extends Modification {
 	public long process(Txn transaction) throws PermissionDeniedException, LockException,
 			EXistException, XPathException, TriggerException {
 		LOG.debug("Processing xupdate:if ...");
-		final XQuery xquery = broker.getXQueryService();
+		final XQuery xquery = broker.getBrokerPool().getXQueryService();
 		final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 		final Source source = new StringSource(selectStmt);
 		CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);

--- a/src/org/exist/xupdate/Modification.java
+++ b/src/org/exist/xupdate/Modification.java
@@ -151,7 +151,7 @@ public abstract class Modification {
 	 */
 	protected NodeList select(DocumentSet docs)
 		throws PermissionDeniedException, EXistException, XPathException {
-		final XQuery xquery = broker.getXQueryService();
+		final XQuery xquery = broker.getBrokerPool().getXQueryService();
 		final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 		final Source source = new StringSource(selectStmt);
 		CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);

--- a/src/org/exist/xupdate/Modification.java
+++ b/src/org/exist/xupdate/Modification.java
@@ -152,12 +152,12 @@ public abstract class Modification {
 	protected NodeList select(DocumentSet docs)
 		throws PermissionDeniedException, EXistException, XPathException {
 		final XQuery xquery = broker.getXQueryService();
-		final XQueryPool pool = xquery.getXQueryPool();
+		final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
 		final Source source = new StringSource(selectStmt);
 		CompiledXQuery compiled = pool.borrowCompiledXQuery(broker, source);
 		XQueryContext context;
 		if(compiled == null)
-		    {context = xquery.newContext(getAccessContext());}
+		    {context = new XQueryContext(broker.getBrokerPool(), getAccessContext());}
 		else
 		    {context = compiled.getContext();}
 
@@ -166,14 +166,14 @@ public abstract class Modification {
 		declareVariables(context);
 		if(compiled == null)
 			try {
-				compiled = xquery.compile(context, source);
+				compiled = xquery.compile(broker, context, source);
 			} catch (final IOException e) {
 				throw new EXistException("An exception occurred while compiling the query: " + e.getMessage());
 			}
 		
 		Sequence resultSeq = null;
 		try {
-			resultSeq = xquery.execute(compiled, null);
+			resultSeq = xquery.execute(broker, compiled, null);
 		} finally {
 			pool.returnCompiledXQuery(source, compiled);
 		}

--- a/test/src/org/exist/TestDataGenerator.java
+++ b/test/src/org/exist/TestDataGenerator.java
@@ -54,7 +54,7 @@ public class TestDataGenerator {
     public File[] generate(DBBroker broker, Collection collection, String xqueryContent) throws SAXException {
         try {
             DocumentSet docs = collection.allDocs(broker, new DefaultDocumentSet(), true);
-            XQuery service = broker.getXQueryService();
+            XQuery service = broker.getBrokerPool().getXQueryService();
             XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
             context.declareVariable("filename", "");
             context.declareVariable("count", "0");

--- a/test/src/org/exist/TestDataGenerator.java
+++ b/test/src/org/exist/TestDataGenerator.java
@@ -55,21 +55,21 @@ public class TestDataGenerator {
         try {
             DocumentSet docs = collection.allDocs(broker, new DefaultDocumentSet(), true);
             XQuery service = broker.getXQueryService();
-            XQueryContext context = service.newContext(AccessContext.TEST);
+            XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
             context.declareVariable("filename", "");
             context.declareVariable("count", "0");
             context.setStaticallyKnownDocuments(docs);
 
             String query = IMPORT + xqueryContent;
 
-            CompiledXQuery compiled = service.compile(context, query);
+            CompiledXQuery compiled = service.compile(broker, context, query);
 
             for (int i = 0; i < count; i++) {
                 generatedFiles[i] = File.createTempFile(prefix, ".xml");
 
                 context.declareVariable("filename", generatedFiles[i].getName());
                 context.declareVariable("count", new Integer(i));
-                Sequence results = service.execute(compiled, Sequence.EMPTY_SEQUENCE);
+                Sequence results = service.execute(broker, compiled, Sequence.EMPTY_SEQUENCE);
 
                 Serializer serializer = broker.getSerializer();
                 serializer.reset();

--- a/test/src/org/exist/dom/memtree/DOMIndexerTest.java
+++ b/test/src/org/exist/dom/memtree/DOMIndexerTest.java
@@ -123,7 +123,7 @@ public class DOMIndexerTest {
             pool = BrokerPool.getInstance();
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
             XQuery xquery = broker.getXQueryService();
-            Sequence result = xquery.execute(XQUERY, null, AccessContext.TEST);
+            Sequence result = xquery.execute(broker, XQUERY, null, AccessContext.TEST);
             int count = result.getItemCount();
             StringWriter out = new StringWriter();
             Properties props = new Properties();

--- a/test/src/org/exist/dom/memtree/DOMIndexerTest.java
+++ b/test/src/org/exist/dom/memtree/DOMIndexerTest.java
@@ -122,7 +122,7 @@ public class DOMIndexerTest {
         try {
             pool = BrokerPool.getInstance();
             broker = pool.get(pool.getSecurityManager().getSystemSubject());
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = broker.getBrokerPool().getXQueryService();
             Sequence result = xquery.execute(broker, XQUERY, null, AccessContext.TEST);
             int count = result.getItemCount();
             StringWriter out = new StringWriter();

--- a/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
+++ b/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
@@ -404,7 +404,7 @@ public class BasicNodeSetTest {
     
     private static Sequence executeQuery(DBBroker broker, String query, int expected, String expectedResult) throws XPathException, SAXException, PermissionDeniedException {
         XQuery xquery = broker.getXQueryService();
-        Sequence seq = xquery.execute(query, null, AccessContext.TEST);
+        Sequence seq = xquery.execute(broker, query, null, AccessContext.TEST);
         assertEquals(expected, seq.getItemCount());
         
         if (expectedResult != null) {

--- a/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
+++ b/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
@@ -403,7 +403,7 @@ public class BasicNodeSetTest {
     }
     
     private static Sequence executeQuery(DBBroker broker, String query, int expected, String expectedResult) throws XPathException, SAXException, PermissionDeniedException {
-        XQuery xquery = broker.getXQueryService();
+        XQuery xquery = broker.getBrokerPool().getXQueryService();
         Sequence seq = xquery.execute(broker, query, null, AccessContext.TEST);
         assertEquals(expected, seq.getItemCount());
         

--- a/test/src/org/exist/numbering/DLNStorageTest.java
+++ b/test/src/org/exist/numbering/DLNStorageTest.java
@@ -39,9 +39,8 @@ public class DLNStorageTest {
     @Test
     public void nodeStorage() throws Exception {
         BrokerPool pool = BrokerPool.getInstance();
-
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             // test element ids
             Sequence seq = xquery.execute(broker, "doc('/db/test/test_string.xml')/test/para",

--- a/test/src/org/exist/numbering/DLNStorageTest.java
+++ b/test/src/org/exist/numbering/DLNStorageTest.java
@@ -44,7 +44,7 @@ public class DLNStorageTest {
             XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
             // test element ids
-            Sequence seq = xquery.execute("doc('/db/test/test_string.xml')/test/para",
+            Sequence seq = xquery.execute(broker, "doc('/db/test/test_string.xml')/test/para",
                     null, AccessContext.TEST);
             assertEquals(3, seq.getItemCount());
             NodeProxy comment = (NodeProxy) seq.itemAt(0);
@@ -54,14 +54,14 @@ public class DLNStorageTest {
             comment = (NodeProxy) seq.itemAt(2);
             assertEquals(comment.getNodeId().toString(), "1.5");
 
-            seq = xquery.execute("doc('/db/test/test_string.xml')/test//a",
+            seq = xquery.execute(broker, "doc('/db/test/test_string.xml')/test//a",
                     null, AccessContext.TEST);
             assertEquals(1, seq.getItemCount());
             NodeProxy a = (NodeProxy) seq.itemAt(0);
             assertEquals("1.3.2", a.getNodeId().toString());
 
             // test attribute id
-            seq = xquery.execute("doc('/db/test/test_string.xml')/test//a/@href",
+            seq = xquery.execute(broker, "doc('/db/test/test_string.xml')/test//a/@href",
                     null, AccessContext.TEST);
             assertEquals(1, seq.getItemCount());
             NodeProxy href = (NodeProxy) seq.itemAt(0);
@@ -78,7 +78,7 @@ public class DLNStorageTest {
             assertEquals(href.getStringValue(), "#");
 
             // test text node
-            seq = xquery.execute("doc('/db/test/test_string.xml')/test//b/text()",
+            seq = xquery.execute(broker, "doc('/db/test/test_string.xml')/test//b/text()",
                     null, AccessContext.TEST);
             assertEquals(1, seq.getItemCount());
             NodeProxy text = (NodeProxy) seq.itemAt(0);

--- a/test/src/org/exist/storage/AbstractUpdateTest.java
+++ b/test/src/org/exist/storage/AbstractUpdateTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractUpdateTest {
                 }
             }
             
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             final Sequence seq = xquery.execute(broker, "/products/product[last()]", null, AccessContext.TEST);
             for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
                 Item next = i.nextItem();

--- a/test/src/org/exist/storage/AbstractUpdateTest.java
+++ b/test/src/org/exist/storage/AbstractUpdateTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractUpdateTest {
             }
             
             final XQuery xquery = broker.getXQueryService();
-            final Sequence seq = xquery.execute("/products/product[last()]", null, AccessContext.TEST);
+            final Sequence seq = xquery.execute(broker, "/products/product[last()]", null, AccessContext.TEST);
             for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
                 Item next = i.nextItem();
             }

--- a/test/src/org/exist/storage/DirtyShutdownTest.java
+++ b/test/src/org/exist/storage/DirtyShutdownTest.java
@@ -96,7 +96,7 @@ public class DirtyShutdownTest {
 
             try(final Txn transaction = transact.beginTransaction()) {
                 XQuery xquery = broker.getXQueryService();
-                xquery.execute(query, null, AccessContext.TEST);
+                xquery.execute(broker, query, null, AccessContext.TEST);
                 transact.commit(transaction);
             }
         } catch (Exception e) {

--- a/test/src/org/exist/storage/DirtyShutdownTest.java
+++ b/test/src/org/exist/storage/DirtyShutdownTest.java
@@ -95,7 +95,7 @@ public class DirtyShutdownTest {
             }
 
             try(final Txn transaction = transact.beginTransaction()) {
-                XQuery xquery = broker.getXQueryService();
+                XQuery xquery = pool.getXQueryService();
                 xquery.execute(broker, query, null, AccessContext.TEST);
                 transact.commit(transaction);
             }

--- a/test/src/org/exist/storage/LargeValuesTest.java
+++ b/test/src/org/exist/storage/LargeValuesTest.java
@@ -150,7 +150,7 @@ public class LargeValuesTest {
             }
 //            XQuery xquery = broker.getXQueryService();
 //            DocumentSet docs = broker.getAllXMLResources(new DefaultDocumentSet());
-//            Sequence result = xquery.execute("//key/@id/string()", docs.docsToNodeSet(), AccessContext.TEST);
+//            Sequence result = xquery.execute(broker, "//key/@id/string()", docs.docsToNodeSet(), AccessContext.TEST);
 //            assertEquals(KEY_COUNT, result.getItemCount());
 //            for (SequenceIterator i = result.iterate(); i.hasNext();) {
 //                Item item = i.nextItem();

--- a/test/src/org/exist/storage/LowLevelText.java
+++ b/test/src/org/exist/storage/LowLevelText.java
@@ -52,7 +52,7 @@ public class LowLevelText {
 
 		XQuery xquery = broker.getXQueryService();
 		XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
-		preCompiledXQuery = xquery.compile(context, stringSource);
+		preCompiledXQuery = xquery.compile(broker, context, stringSource);
 	}
 
 	@After

--- a/test/src/org/exist/storage/LowLevelText.java
+++ b/test/src/org/exist/storage/LowLevelText.java
@@ -50,7 +50,7 @@ public class LowLevelText {
 		pool = new XQueryPool(configuration);
 		stringSource = new StringSource(TEST_XQUERY_SOURCE);
 
-		XQuery xquery = broker.getXQueryService();
+		XQuery xquery = brokerPool.getXQueryService();
 		XQueryContext context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
 		preCompiledXQuery = xquery.compile(broker, context, stringSource);
 	}

--- a/test/src/org/exist/storage/RangeIndexUpdateTest.java
+++ b/test/src/org/exist/storage/RangeIndexUpdateTest.java
@@ -103,7 +103,7 @@ public class RangeIndexUpdateTest {
 
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            final Sequence seq = xquery.execute("//item[. = 'Chair']", null, AccessContext.TEST);
+            final Sequence seq = xquery.execute(broker, "//item[. = 'Chair']", null, AccessContext.TEST);
             assertNotNull(seq);
             assertEquals(1, seq.getItemCount());
 

--- a/test/src/org/exist/storage/RangeIndexUpdateTest.java
+++ b/test/src/org/exist/storage/RangeIndexUpdateTest.java
@@ -101,7 +101,7 @@ public class RangeIndexUpdateTest {
             checkIndex(broker, docs, ITEM_QNAME, new StringValue("Table892.25"), 1);
             checkIndex(broker, docs, ITEM_QNAME, new StringValue("Cabinet1525.00"), 1);
 
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             final Sequence seq = xquery.execute(broker, "//item[. = 'Chair']", null, AccessContext.TEST);
             assertNotNull(seq);

--- a/test/src/org/exist/storage/RecoveryTest.java
+++ b/test/src/org/exist/storage/RecoveryTest.java
@@ -206,7 +206,7 @@ public class RecoveryTest {
             doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(files[files.length - 1].getName()), Lock.READ_LOCK);
             assertNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/'" + files[files.length - 1].getName() + " should not exist anymore", doc);
             
-            final XQuery xquery = broker.getXQueryService();
+            final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
             final Sequence seq = xquery.execute(broker, "//SPEECH[ft:query(LINE, 'king')]", null, AccessContext.TEST);
             assertNotNull(seq);

--- a/test/src/org/exist/storage/RecoveryTest.java
+++ b/test/src/org/exist/storage/RecoveryTest.java
@@ -208,7 +208,7 @@ public class RecoveryTest {
             
             final XQuery xquery = broker.getXQueryService();
             assertNotNull(xquery);
-            final Sequence seq = xquery.execute("//SPEECH[ft:query(LINE, 'king')]", null, AccessContext.TEST);
+            final Sequence seq = xquery.execute(broker, "//SPEECH[ft:query(LINE, 'king')]", null, AccessContext.TEST);
             assertNotNull(seq);
             for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
                 final Item next = i.nextItem();

--- a/test/src/org/exist/storage/ShutdownTest.java
+++ b/test/src/org/exist/storage/ShutdownTest.java
@@ -93,7 +93,7 @@ public class ShutdownTest {
 
                 final XQuery xquery = broker.getXQueryService();
                 assertNotNull(xquery);
-                final Sequence result = xquery.execute("//SPEECH[ft:query(LINE, 'love')]", Sequence.EMPTY_SEQUENCE, AccessContext.TEST);
+                final Sequence result = xquery.execute(broker, "//SPEECH[ft:query(LINE, 'love')]", Sequence.EMPTY_SEQUENCE, AccessContext.TEST);
                 assertNotNull(result);
                 assertEquals(result.getItemCount(), 160);
 

--- a/test/src/org/exist/storage/ShutdownTest.java
+++ b/test/src/org/exist/storage/ShutdownTest.java
@@ -91,7 +91,7 @@ public class ShutdownTest {
                     }
                 }
 
-                final XQuery xquery = broker.getXQueryService();
+                final XQuery xquery = pool.getXQueryService();
                 assertNotNull(xquery);
                 final Sequence result = xquery.execute(broker, "//SPEECH[ft:query(LINE, 'love')]", Sequence.EMPTY_SEQUENCE, AccessContext.TEST);
                 assertNotNull(result);

--- a/test/src/org/exist/xmldb/CollectionConfigurationTest.java
+++ b/test/src/org/exist/xmldb/CollectionConfigurationTest.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xmldb;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.exist.security.Account;
 import org.junit.After;
@@ -750,7 +751,7 @@ public class CollectionConfigurationTest {
         assertEquals(0, result.getSize());
     }
 
-   @Test
+   @Test @Ignore
    public void rangeIndex1() throws XMLDBException {
        Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
        
@@ -867,7 +868,7 @@ public class CollectionConfigurationTest {
        assertEquals(1, result.getSize());
   }   
 
-   @Test
+   @Test @Ignore
     public void rangeIndex2() throws XMLDBException {
        Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
 
@@ -984,7 +985,7 @@ public class CollectionConfigurationTest {
        assertEquals(1, result.getSize());
   }
 
-   @Test
+   @Test @Ignore
     public void rangeIndex3() throws XMLDBException {
         Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
         
@@ -1069,7 +1070,7 @@ public class CollectionConfigurationTest {
         assertTrue(exceptionCaught);
     }
 
-   @Test
+   @Test @Ignore
    public void rangeIndexOverAttributes() throws XMLDBException {
        Collection testCollection = DatabaseManager.getCollection(ROOT_URI + "/" + TEST_COLLECTION);
        

--- a/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -205,10 +205,10 @@ public class ConstructedNodesRecoveryTest {
 	        XQuery service = broker.getXQueryService();
 	        assertNotNull(service);
 	        
-	        CompiledXQuery compiled = service.compile(service.newContext(AccessContext.TEST), new StringSource(xquery));
+	        CompiledXQuery compiled = service.compile(broker, new XQueryContext(pool, AccessContext.TEST), new StringSource(xquery));
 	        assertNotNull(compiled);
 	        
-	        Sequence result = service.execute(compiled, null);
+	        Sequence result = service.execute(broker, compiled, null);
 	        assertNotNull(result);
 	       
 	        assertEquals(expectedResults.length, result.getItemCount());

--- a/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -202,7 +202,7 @@ public class ConstructedNodesRecoveryTest {
 	        createTempChildCollection(broker, transact, "testchild2");
             
             //execute an xquery
-	        XQuery service = broker.getXQueryService();
+	        XQuery service = pool.getXQueryService();
 	        assertNotNull(service);
 	        
 	        CompiledXQuery compiled = service.compile(broker, new XQueryContext(pool, AccessContext.TEST), new StringSource(xquery));

--- a/test/src/org/exist/xquery/XQueryUpdateTest.java
+++ b/test/src/org/exist/xquery/XQueryUpdateTest.java
@@ -48,31 +48,31 @@ public class XQueryUpdateTest {
 
             XQuery xquery = broker.getXQueryService();
             String query =
-                    "   declare variable $i external;\n" +
-                            "	update insert\n" +
-                            "		<product id='id{$i}' num='{$i}'>\n" +
-                            "			<description>Description {$i}</description>\n" +
-                            "			<price>{$i + 1.0}</price>\n" +
-                            "			<stock>{$i * 10}</stock>\n" +
-                            "		</product>\n" +
-                            "	into /products";
-            XQueryContext context = xquery.newContext(AccessContext.TEST);
-            CompiledXQuery compiled = xquery.compile(context, query);
+            	"   declare variable $i external;\n" +
+            	"	update insert\n" +
+            	"		<product id='id{$i}' num='{$i}'>\n" +
+            	"			<description>Description {$i}</description>\n" +
+            	"			<price>{$i + 1.0}</price>\n" +
+            	"			<stock>{$i * 10}</stock>\n" +
+            	"		</product>\n" +
+            	"	into /products";
+            XQueryContext context = new XQueryContext(pool, AccessContext.TEST);
+            CompiledXQuery compiled = xquery.compile(broker, context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
                 context.declareVariable("i", Integer.valueOf(i));
-                xquery.execute(compiled, null);
+                xquery.execute(broker, compiled, null);
             }
 
-            Sequence seq = xquery.execute("/products", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "/products", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
             Serializer serializer = broker.getSerializer();
             serializer.serialize((NodeValue) seq.itemAt(0));
 
-            seq = xquery.execute("//product", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
 
-            seq = xquery.execute("//product[price > 0.0]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[price > 0.0]", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
         }
     }
@@ -86,36 +86,36 @@ public class XQueryUpdateTest {
 
             XQuery xquery = broker.getXQueryService();
             String query =
-                    "   declare variable $i external;\n" +
-                            "	update insert\n" +
-                            "		attribute name { concat('n', $i) }\n" +
-                            "	into //product[@num = $i]";
-            XQueryContext context = xquery.newContext(AccessContext.TEST);
-            CompiledXQuery compiled = xquery.compile(context, query);
+            	"   declare variable $i external;\n" +
+            	"	update insert\n" +
+            	"		attribute name { concat('n', $i) }\n" +
+            	"	into //product[@num = $i]";
+            XQueryContext context = new XQueryContext(pool, AccessContext.TEST);
+            CompiledXQuery compiled = xquery.compile(broker, context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
                 context.declareVariable("i", Integer.valueOf(i));
-                xquery.execute(compiled, null);
+                xquery.execute(broker, compiled, null);
             }
 
-            Sequence seq = xquery.execute("/products", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "/products", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
             Serializer serializer = broker.getSerializer();
             serializer.serialize((NodeValue) seq.itemAt(0));
 
-            seq = xquery.execute("//product", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
 
-            seq = xquery.execute("//product[@name = 'n20']", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[@name = 'n20']", null, AccessContext.TEST);
             assertEquals(1, seq.getItemCount());
 
             store(broker, "attribs.xml", "<test attr1='aaa' attr2='bbb'>ccc</test>");
             query = "update insert attribute attr1 { 'eee' } into /test";
 
             //testing duplicate attribute ...
-            xquery.execute(query, null, AccessContext.TEST);
+            xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("xmldb:document('" + TEST_COLLECTION + "/attribs.xml')/test[@attr1 = 'eee']", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "xmldb:document('" + TEST_COLLECTION + "/attribs.xml')/test[@attr1 = 'eee']", null, AccessContext.TEST);
             assertEquals(1, seq.getItemCount());
             serializer.serialize((NodeValue) seq.itemAt(0));
         }
@@ -135,34 +135,34 @@ public class XQueryUpdateTest {
                             "   into /products";
 
             XQuery xquery = broker.getXQueryService();
-            xquery.execute(query, null, AccessContext.TEST);
+            xquery.execute(broker, query, null, AccessContext.TEST);
 
             query =
-                    "   declare variable $i external;\n" +
-                            "   update insert\n" +
-                            "       <product id='id{$i}'>\n" +
-                            "           <description>Description {$i}</description>\n" +
-                            "           <price>{$i + 1.0}</price>\n" +
-                            "           <stock>{$i * 10}</stock>\n" +
-                            "       </product>\n" +
-                            "   preceding /products/product[1]";
-            XQueryContext context = xquery.newContext(AccessContext.TEST);
-            CompiledXQuery compiled = xquery.compile(context, query);
+                "   declare variable $i external;\n" +
+                "   update insert\n" +
+                "       <product id='id{$i}'>\n" +
+                "           <description>Description {$i}</description>\n" +
+                "           <price>{$i + 1.0}</price>\n" +
+                "           <stock>{$i * 10}</stock>\n" +
+                "       </product>\n" +
+                "   preceding /products/product[1]";
+            XQueryContext context = new XQueryContext(pool, AccessContext.TEST);
+            CompiledXQuery compiled = xquery.compile(broker, context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
                 context.declareVariable("i", Integer.valueOf(i));
-                xquery.execute(compiled, null);
+                xquery.execute(broker, compiled, null);
             }
 
-            Sequence seq = xquery.execute("/products", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "/products", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
             Serializer serializer = broker.getSerializer();
             serializer.serialize((NodeValue) seq.itemAt(0));
 
-            seq = xquery.execute("//product", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND + 1, seq.getItemCount());
 
-            seq = xquery.execute("//product[price > 0.0]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[price > 0.0]", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
         }
     }
@@ -181,34 +181,34 @@ public class XQueryUpdateTest {
                             "   into /products";
 
             XQuery xquery = broker.getXQueryService();
-            xquery.execute(query, null, AccessContext.TEST);
+            xquery.execute(broker, query, null, AccessContext.TEST);
 
             query =
-                    "   declare variable $i external;\n" +
-                            "   update insert\n" +
-                            "       <product id='id{$i}'>\n" +
-                            "           <description>Description {$i}</description>\n" +
-                            "           <price>{$i + 1.0}</price>\n" +
-                            "           <stock>{$i * 10}</stock>\n" +
-                            "       </product>\n" +
-                            "   following /products/product[1]";
-            XQueryContext context = xquery.newContext(AccessContext.TEST);
-            CompiledXQuery compiled = xquery.compile(context, query);
+                "   declare variable $i external;\n" +
+                "   update insert\n" +
+                "       <product id='id{$i}'>\n" +
+                "           <description>Description {$i}</description>\n" +
+                "           <price>{$i + 1.0}</price>\n" +
+                "           <stock>{$i * 10}</stock>\n" +
+                "       </product>\n" +
+                "   following /products/product[1]";
+            XQueryContext context = new XQueryContext(pool, AccessContext.TEST);
+            CompiledXQuery compiled = xquery.compile(broker, context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
                 context.declareVariable("i", Integer.valueOf(i));
-                xquery.execute(compiled, null);
+                xquery.execute(broker, compiled, null);
             }
 
-            Sequence seq = xquery.execute("/products", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "/products", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
             Serializer serializer = broker.getSerializer();
             serializer.serialize((NodeValue) seq.itemAt(0));
 
-            seq = xquery.execute("//product", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND + 1, seq.getItemCount());
 
-            seq = xquery.execute("//product[price > 0.0]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[price > 0.0]", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
         }
     }
@@ -223,68 +223,68 @@ public class XQueryUpdateTest {
             XQuery xquery = broker.getXQueryService();
 
             String query =
-                    "declare option exist:output-size-limit '-1';\n" +
-                            "for $prod at $i in //product return\n" +
-                            "	update value $prod/description\n" +
-                            "	with concat('Updated Description', $i)";
-            Sequence seq = xquery.execute(query, null, AccessContext.TEST);
+            	"declare option exist:output-size-limit '-1';\n" +
+            	"for $prod at $i in //product return\n" +
+                "	update value $prod/description\n" +
+                "	with concat('Updated Description', $i)";
+            Sequence seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("//product[starts-with(description, 'Updated')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[starts-with(description, 'Updated')]", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
 
             Serializer serializer = broker.getSerializer();
             serializer.serialize((NodeValue) seq.itemAt(0));
 
             for (int i = 1; i <= ITEMS_TO_APPEND; i++) {
-                seq = xquery.execute("//product[description &= 'Description" + i + "']", null, AccessContext.TEST);
+                seq = xquery.execute(broker, "//product[description &= 'Description" + i + "']", null, AccessContext.TEST);
                 assertEquals(1, seq.getItemCount());
                 serializer.serialize((NodeValue) seq.itemAt(0));
             }
-            seq = xquery.execute("//product[description &= 'Updated']", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[description &= 'Updated']", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
 
             serializer.serialize((NodeValue) seq.itemAt(0));
 
             query =
-                    "declare option exist:output-size-limit '-1';\n" +
-                            "for $prod at $count in //product return\n" +
-                            "	update value $prod/stock/text()\n" +
-                            "	with (400 + $count)";
-            seq = xquery.execute(query, null, AccessContext.TEST);
+            	"declare option exist:output-size-limit '-1';\n" +
+            	"for $prod at $count in //product return\n" +
+                "	update value $prod/stock/text()\n" +
+                "	with (400 + $count)";
+            seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("//product[stock > 400]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[stock > 400]", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
-            seq = xquery.execute("//product[stock &= '401']", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[stock &= '401']", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
             serializer.serialize((NodeValue) seq.itemAt(0));
 
             query =
-                    "declare option exist:output-size-limit '-1';\n" +
-                            "for $prod in //product return\n" +
-                            "	update value $prod/@num\n" +
-                            "	with xs:int($prod/@num) * 3";
-            seq = xquery.execute(query, null, AccessContext.TEST);
+            	"declare option exist:output-size-limit '-1';\n" +
+            	"for $prod in //product return\n" +
+                "	update value $prod/@num\n" +
+                "	with xs:int($prod/@num) * 3";
+            seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("/products", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/products", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
-            seq = xquery.execute("//product[@num = 3]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[@num = 3]", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
             serializer.serialize((NodeValue) seq.itemAt(0));
 
             query =
-                    "declare option exist:output-size-limit '-1';\n" +
-                            "for $prod in //product return\n" +
-                            "	update value $prod/stock\n" +
-                            "	with (<local>10</local>,<external>1</external>)";
-            seq = xquery.execute(query, null, AccessContext.TEST);
+            	"declare option exist:output-size-limit '-1';\n" +
+            	"for $prod in //product return\n" +
+                "	update value $prod/stock\n" +
+                "	with (<local>10</local>,<external>1</external>)";
+            seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("/products", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "/products", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
-            seq = xquery.execute("//product/stock/external[. = 1]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product/stock/external[. = 1]", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
         }
     }
@@ -297,13 +297,13 @@ public class XQueryUpdateTest {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
             XQuery xquery = broker.getXQueryService();
 
-            String query =
-                    "for $prod in //product return\n" +
-                            "	update delete $prod\n";
-            Sequence seq = xquery.execute(query, null, AccessContext.TEST);
+        	String query =
+        		"for $prod in //product return\n" +
+        		"	update delete $prod\n";
+        	Sequence seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("//product", null, AccessContext.TEST);
-            assertEquals(seq.getItemCount(), 0);
+        	seq = xquery.execute(broker, "//product", null, AccessContext.TEST);
+        	assertEquals(seq.getItemCount(), 0);
 
         }
     }
@@ -318,19 +318,19 @@ public class XQueryUpdateTest {
             XQuery xquery = broker.getXQueryService();
 
             String query =
-                    "for $prod in //product return\n" +
-                            "	update rename $prod/description as 'desc'\n";
-            Sequence seq = xquery.execute(query, null, AccessContext.TEST);
+            	"for $prod in //product return\n" +
+            	"	update rename $prod/description as 'desc'\n";
+            Sequence seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("//product/desc", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product/desc", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
 
             query =
-                    "for $prod in //product return\n" +
-                            "	update rename $prod/@num as 'count'\n";
-            seq = xquery.execute(query, null, AccessContext.TEST);
+            	"for $prod in //product return\n" +
+            	"	update rename $prod/@num as 'count'\n";
+            seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("//product/@count", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product/@count", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
 
         }
@@ -346,27 +346,27 @@ public class XQueryUpdateTest {
             XQuery xquery = broker.getXQueryService();
 
             String query =
-                    "for $prod in //product return\n" +
-                            "	update replace $prod/description with <desc>An updated description.</desc>\n";
-            Sequence seq = xquery.execute(query, null, AccessContext.TEST);
+            	"for $prod in //product return\n" +
+            	"	update replace $prod/description with <desc>An updated description.</desc>\n";
+            Sequence seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("//product/desc", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product/desc", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
 
             query =
-                    "for $prod in //product return\n" +
-                            "	update replace $prod/@num with '1'\n";
-            seq = xquery.execute(query, null, AccessContext.TEST);
+            	"for $prod in //product return\n" +
+            	"	update replace $prod/@num with '1'\n";
+            seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("//product/@num", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product/@num", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
 
             query =
-                    "for $prod in //product return\n" +
-                            "	update replace $prod/desc/text() with 'A new update'\n";
-            seq = xquery.execute(query, null, AccessContext.TEST);
+            	"for $prod in //product return\n" +
+            	"	update replace $prod/desc/text() with 'A new update'\n";
+            seq = xquery.execute(broker, query, null, AccessContext.TEST);
 
-            seq = xquery.execute("//product[starts-with(desc, 'A new')]", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product[starts-with(desc, 'A new')]", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), ITEMS_TO_APPEND);
         }
     }
@@ -386,7 +386,7 @@ public class XQueryUpdateTest {
                             ")";
             XQuery xquery = broker.getXQueryService();
             @SuppressWarnings("unused")
-            Sequence result = xquery.execute(query, null, AccessContext.TEST);
+			Sequence result = xquery.execute(broker, query, null, AccessContext.TEST);
         }
     }
 
@@ -396,25 +396,25 @@ public class XQueryUpdateTest {
 
             XQuery xquery = broker.getXQueryService();
             String query =
-                    "   declare variable $i external;\n" +
-                            "	update insert\n" +
-                            "		<product>\n" +
-                            "			<description><![CDATA[me & you <>]]></description>\n" +
-                            "		</product>\n" +
-                            "	into /products";
-            XQueryContext context = xquery.newContext(AccessContext.TEST);
-            CompiledXQuery compiled = xquery.compile(context, query);
+            	"   declare variable $i external;\n" +
+            	"	update insert\n" +
+            	"		<product>\n" +
+            	"			<description><![CDATA[me & you <>]]></description>\n" +
+            	"		</product>\n" +
+            	"	into /products";
+            XQueryContext context = new XQueryContext(pool, AccessContext.TEST);
+            CompiledXQuery compiled = xquery.compile(broker, context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
-                xquery.execute(compiled, null);
+                xquery.execute(broker, compiled, null);
             }
 
-            Sequence seq = xquery.execute("/products", null, AccessContext.TEST);
+            Sequence seq = xquery.execute(broker, "/products", null, AccessContext.TEST);
             assertEquals(seq.getItemCount(), 1);
 
             Serializer serializer = broker.getSerializer();
             serializer.serialize((NodeValue) seq.itemAt(0));
 
-            seq = xquery.execute("//product", null, AccessContext.TEST);
+            seq = xquery.execute(broker, "//product", null, AccessContext.TEST);
             assertEquals(ITEMS_TO_APPEND, seq.getItemCount());
         }
     }
@@ -432,7 +432,7 @@ public class XQueryUpdateTest {
 
             XQuery xquery = broker.getXQueryService();
             @SuppressWarnings("unused")
-            Sequence result = xquery.execute(query, null, AccessContext.TEST);
+			Sequence result = xquery.execute(broker, query, null, AccessContext.TEST);
         }
     }
 

--- a/test/src/org/exist/xquery/XQueryUpdateTest.java
+++ b/test/src/org/exist/xquery/XQueryUpdateTest.java
@@ -46,7 +46,7 @@ public class XQueryUpdateTest {
     public void append() throws EXistException, PermissionDeniedException, XPathException, SAXException {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             String query =
             	"   declare variable $i external;\n" +
             	"	update insert\n" +
@@ -84,7 +84,7 @@ public class XQueryUpdateTest {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             String query =
             	"   declare variable $i external;\n" +
             	"	update insert\n" +
@@ -134,7 +134,7 @@ public class XQueryUpdateTest {
                             "       </product>\n" +
                             "   into /products";
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             xquery.execute(broker, query, null, AccessContext.TEST);
 
             query =
@@ -180,7 +180,7 @@ public class XQueryUpdateTest {
                             "       </product>\n" +
                             "   into /products";
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             xquery.execute(broker, query, null, AccessContext.TEST);
 
             query =
@@ -220,7 +220,7 @@ public class XQueryUpdateTest {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
 
             String query =
             	"declare option exist:output-size-limit '-1';\n" +
@@ -295,7 +295,7 @@ public class XQueryUpdateTest {
         append();
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
 
         	String query =
         		"for $prod in //product return\n" +
@@ -315,7 +315,7 @@ public class XQueryUpdateTest {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
 
             String query =
             	"for $prod in //product return\n" +
@@ -343,7 +343,7 @@ public class XQueryUpdateTest {
 
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
 
             String query =
             	"for $prod in //product return\n" +
@@ -378,13 +378,13 @@ public class XQueryUpdateTest {
 
             String query =
                     "let $progress := /progress\n" +
-                            "for $i in 1 to 100\n" +
-                            "let $done := $progress/@done\n" +
-                            "return (\n" +
-                            "   update value $done with xs:int($done + 1),\n" +
-                            "   xs:int(/progress/@done)\n" +
-                            ")";
-            XQuery xquery = broker.getXQueryService();
+                    "for $i in 1 to 100\n" +
+                    "let $done := $progress/@done\n" +
+                    "return (\n" +
+                    "   update value $done with xs:int($done + 1),\n" +
+                    "   xs:int(/progress/@done)\n" +
+                    ")";
+            XQuery xquery = pool.getXQueryService();
             @SuppressWarnings("unused")
 			Sequence result = xquery.execute(broker, query, null, AccessContext.TEST);
         }
@@ -394,7 +394,7 @@ public class XQueryUpdateTest {
     public void appendCDATA() throws EXistException, PermissionDeniedException, XPathException, SAXException {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             String query =
             	"   declare variable $i external;\n" +
             	"	update insert\n" +
@@ -424,13 +424,13 @@ public class XQueryUpdateTest {
     public void insertAttribDoc_1730726() throws EXistException, PermissionDeniedException, XPathException {
         try(final DBBroker broker = pool.get(pool.getSecurityManager().getSystemSubject())) {
             String query =
-                    "declare namespace xmldb = \"http://exist-db.org/xquery/xmldb\"; " +
-                            "let $uri := xmldb:store(\"/db\", \"insertAttribDoc.xml\", <C/>) " +
-                            "let $node := doc($uri)/element() " +
-                            "let $attrib := <Value f=\"ATTRIB VALUE\"/>/@* " +
-                            "return update insert $attrib into $node";
+                "declare namespace xmldb = \"http://exist-db.org/xquery/xmldb\"; "+
+                "let $uri := xmldb:store(\"/db\", \"insertAttribDoc.xml\", <C/>) "+
+                "let $node := doc($uri)/element() "+
+                "let $attrib := <Value f=\"ATTRIB VALUE\"/>/@* "+
+                "return update insert $attrib into $node";
 
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = pool.getXQueryService();
             @SuppressWarnings("unused")
 			Sequence result = xquery.execute(broker, query, null, AccessContext.TEST);
         }

--- a/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
+++ b/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
@@ -225,7 +225,7 @@ public class QT3TS_To_junit {
             throw new IOException("QT3 junit tests folder unreadable.");
         }
 
-        XQuery xqs = broker.getXQueryService();
+        XQuery xqs = db.getXQueryService();
         
         Sequence results = xqs.execute(broker, tsQuery, null, AccessContext.TEST);
         
@@ -244,7 +244,7 @@ public class QT3TS_To_junit {
     		"let $catalog := xmldb:document('/db/QT3/"+file+"') " +
     		"return $catalog//qt:test-case";
 
-        XQuery xqs = broker.getXQueryService();
+        XQuery xqs = db.getXQueryService();
         Sequence results = xqs.execute(broker, tsQuery, null, AccessContext.TEST);
         
         testCases(src, file, name, results);

--- a/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
+++ b/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
@@ -227,7 +227,7 @@ public class QT3TS_To_junit {
 
         XQuery xqs = broker.getXQueryService();
         
-        Sequence results = xqs.execute(tsQuery, null, AccessContext.TEST);
+        Sequence results = xqs.execute(broker, tsQuery, null, AccessContext.TEST);
         
         for (NodeProxy p : results.toNodeSet()) {
         	NamedNodeMap attrs = p.getNode().getAttributes();
@@ -245,7 +245,7 @@ public class QT3TS_To_junit {
     		"return $catalog//qt:test-case";
 
         XQuery xqs = broker.getXQueryService();
-        Sequence results = xqs.execute(tsQuery, null, AccessContext.TEST);
+        Sequence results = xqs.execute(broker, tsQuery, null, AccessContext.TEST);
         
         testCases(src, file, name, results);
 	}

--- a/test/src/org/exist/xquery/xqts/QT3TS_case.java
+++ b/test/src/org/exist/xquery/xqts/QT3TS_case.java
@@ -87,7 +87,7 @@ public class QT3TS_case extends TestCase {
 
             String query = "xmldb:document('" + file + "')";
 
-            return xquery.execute(query, null, AccessContext.TEST);
+            return xquery.execute(broker, query, null, AccessContext.TEST);
 
         } finally {
             db.release(broker);
@@ -107,7 +107,7 @@ public class QT3TS_case extends TestCase {
             String query = "declare namespace qt='" + QT_NS + "';\n" + "let $testCases := xmldb:document('/db/QT3/" + file + "')\n"
                     + "let $tc := $testCases//qt:environment\n" + "return $tc";
 
-            Sequence result = xquery.execute(query, null, AccessContext.TEST);
+            Sequence result = xquery.execute(broker, query, null, AccessContext.TEST);
 
             String col = XmldbURI.create("/db/QT3/" + file).removeLastSegment().toString();
 
@@ -157,7 +157,7 @@ public class QT3TS_case extends TestCase {
                     + "let $tc := $testCases//qt:environment[@name eq '" + name + "']\n" + "let $catalog := xmldb:document('/db/QT3/catalog.xml')\n"
                     + "let $cat := $catalog//qt:environment[@name eq '" + name + "']\n" + "return ($tc, $cat)";
 
-            Sequence result = xquery.execute(query, null, AccessContext.TEST);
+            Sequence result = xquery.execute(broker, query, null, AccessContext.TEST);
 
             String col = XmldbURI.create("/db/QT3/" + file).removeLastSegment().toString();
 
@@ -216,7 +216,7 @@ public class QT3TS_case extends TestCase {
 
             XQuery xqs = broker.getXQueryService();
 
-            Sequence results = xqs.execute(query, null, AccessContext.TEST);
+            Sequence results = xqs.execute(broker, query, null, AccessContext.TEST);
 
             Assert.assertFalse("", results.isEmpty());
 
@@ -269,19 +269,19 @@ public class QT3TS_case extends TestCase {
                                         if ("xs:date".equals(type)) {
                                             var.setStaticType(Type.DATE);
 
-                                            Sequence res = xquery.execute(el.getAttribute("select"), null, AccessContext.TEST);
+                                            Sequence res = xquery.execute(broker, el.getAttribute("select"), null, AccessContext.TEST);
                                             Assert.assertEquals(1, res.getItemCount());
                                             var.setValue(res);
                                         } else if ("xs:dateTime".equals(type)) {
                                             var.setStaticType(Type.DATE_TIME);
 
-                                            Sequence res = xquery.execute(el.getAttribute("select"), null, AccessContext.TEST);
+                                            Sequence res = xquery.execute(broker, el.getAttribute("select"), null, AccessContext.TEST);
                                             Assert.assertEquals(1, res.getItemCount());
                                             var.setValue(res);
                                         } else if ("xs:string".equals(type)) {
                                             var.setStaticType(Type.STRING);
 
-                                            Sequence res = xquery.execute(el.getAttribute("select"), null, AccessContext.TEST);
+                                            Sequence res = xquery.execute(broker, el.getAttribute("select"), null, AccessContext.TEST);
                                             Assert.assertEquals(1, res.getItemCount());
                                             var.setValue(res);
                                         } else {
@@ -320,8 +320,8 @@ public class QT3TS_case extends TestCase {
                 }
                 context.setStaticallyKnownDocuments(contextDocs);
             }
-            final CompiledXQuery compiled = xquery.compile(context, xquery3declaration + caseScript);
-            result = xquery.execute(compiled, contextSequence);
+            final CompiledXQuery compiled = xquery.compile(broker, context, xquery3declaration + caseScript);
+            result = xquery.execute(broker, compiled, contextSequence);
 
             for (int i = 0; i < expected.getLength(); i++) {
                 Node node = expected.item(i);

--- a/test/src/org/exist/xquery/xqts/QT3TS_case.java
+++ b/test/src/org/exist/xquery/xqts/QT3TS_case.java
@@ -81,7 +81,7 @@ public class QT3TS_case extends TestCase {
 
         try {
             broker = db.get(db.getSecurityManager().getSystemSubject());
-            xquery = broker.getXQueryService();
+            xquery = broker.getBrokerPool().getXQueryService();
 
             broker.getConfiguration().setProperty(XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, true);
 
@@ -100,7 +100,7 @@ public class QT3TS_case extends TestCase {
         DBBroker broker = null;
         try {
             broker = db.get(db.getSecurityManager().getSystemSubject());
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = broker.getBrokerPool().getXQueryService();
 
             broker.getConfiguration().setProperty(XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, true);
 
@@ -149,7 +149,7 @@ public class QT3TS_case extends TestCase {
         DBBroker broker = null;
         try {
             broker = db.get(db.getSecurityManager().getSystemSubject());
-            XQuery xquery = broker.getXQueryService();
+            XQuery xquery = broker.getBrokerPool().getXQueryService();
 
             broker.getConfiguration().setProperty(XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, true);
 
@@ -205,7 +205,7 @@ public class QT3TS_case extends TestCase {
         Set<String> extectedError = new HashSet<String>();
         try {
             broker = db.get(db.getSecurityManager().getSystemSubject());
-            xquery = broker.getXQueryService();
+            xquery = broker.getBrokerPool().getXQueryService();
 
             final XQueryContext context = new XQueryContext(db, AccessContext.TEST);
 
@@ -214,7 +214,7 @@ public class QT3TS_case extends TestCase {
             String query = "declare namespace qt='" + QT_NS + "';\n" + "let $testCases := xmldb:document('/db/QT3/" + file + "')\n"
                     + "let $tc := $testCases//qt:test-case[@name eq \"" + tcName + "\"]\n" + "return $tc";
 
-            XQuery xqs = broker.getXQueryService();
+            XQuery xqs = broker.getBrokerPool().getXQueryService();
 
             Sequence results = xqs.execute(broker, query, null, AccessContext.TEST);
 

--- a/test/src/org/exist/xquery/xqts/XQTS_To_junit.java
+++ b/test/src/org/exist/xquery/xqts/XQTS_To_junit.java
@@ -203,7 +203,7 @@ public class XQTS_To_junit {
 
         XQuery xqs = broker.getXQueryService();
         
-        Sequence results = xqs.execute(query, null, AccessContext.TEST);
+        Sequence results = xqs.execute(broker, query, null, AccessContext.TEST);
 
         if (! results.isEmpty()) {
             String catalog = (String) results.itemAt(0).getStringValue();
@@ -255,7 +255,7 @@ public class XQTS_To_junit {
         query += "\treturn xs:string($testGroup/@name)";
 
         XQuery xqs = broker.getXQueryService();
-        Sequence results = xqs.execute(query, null, AccessContext.TEST);
+        Sequence results = xqs.execute(broker, query, null, AccessContext.TEST);
 
         if (!results.isEmpty()) {
             File subfolder;
@@ -334,7 +334,7 @@ public class XQTS_To_junit {
             "\treturn xs:string($testGroup/@name)";
 
         XQuery xqs = broker.getXQueryService();
-        Sequence results = xqs.execute(query, null, AccessContext.TEST);
+        Sequence results = xqs.execute(broker, query, null, AccessContext.TEST);
 
         if (!results.isEmpty()) {
             folder.mkdirs();

--- a/test/src/org/exist/xquery/xqts/XQTS_To_junit.java
+++ b/test/src/org/exist/xquery/xqts/XQTS_To_junit.java
@@ -201,7 +201,7 @@ public class XQTS_To_junit {
             "let $XQTSCatalog := xmldb:document('/db/XQTS/XQTSCatalog.xml') "+
             "return xs:string($XQTSCatalog/catalog:test-suite/@version)";
 
-        XQuery xqs = broker.getXQueryService();
+        XQuery xqs = db.getXQueryService();
         
         Sequence results = xqs.execute(broker, query, null, AccessContext.TEST);
 
@@ -254,7 +254,7 @@ public class XQTS_To_junit {
 
         query += "\treturn xs:string($testGroup/@name)";
 
-        XQuery xqs = broker.getXQueryService();
+        XQuery xqs = db.getXQueryService();
         Sequence results = xqs.execute(broker, query, null, AccessContext.TEST);
 
         if (!results.isEmpty()) {
@@ -333,7 +333,7 @@ public class XQTS_To_junit {
             "for $testGroup in $XQTSCatalog//catalog:test-group[@name = '"+testGroup+"']/catalog:test-case"+
             "\treturn xs:string($testGroup/@name)";
 
-        XQuery xqs = broker.getXQueryService();
+        XQuery xqs = db.getXQueryService();
         Sequence results = xqs.execute(broker, query, null, AccessContext.TEST);
 
         if (!results.isEmpty()) {

--- a/test/src/org/exist/xquery/xqts/XQTS_case.java
+++ b/test/src/org/exist/xquery/xqts/XQTS_case.java
@@ -140,7 +140,7 @@ public class XQTS_case extends TestCase {
             broker = db.get(db.getSecurityManager().getSystemSubject());
             broker.getConfiguration().setProperty( XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, true);
 
-            xquery = broker.getXQueryService();
+            xquery = db.getXQueryService();
 
             prepare(broker, xquery);
 

--- a/test/src/org/exist/xquery/xqts/XQTS_case.java
+++ b/test/src/org/exist/xquery/xqts/XQTS_case.java
@@ -93,7 +93,7 @@ public class XQTS_case extends TestCase {
             "let $XQTSCatalog := xmldb:document('/db/XQTS/XQTSCatalog.xml') "+
             "return $XQTSCatalog//catalog:sources//catalog:source";
 
-            Sequence results = xquery.execute(query, null, AccessContext.TEST);
+            Sequence results = xquery.execute(broker, query, null, AccessContext.TEST);
 
             for (NodeProxy node : results.toNodeSet()) {
                 ElementImpl source = (ElementImpl) node.getNode();
@@ -107,7 +107,7 @@ public class XQTS_case extends TestCase {
                 "let $XQTSCatalog := xmldb:document('/db/XQTS/XQTSCatalog.xml') "+
                 "return $XQTSCatalog//catalog:sources//catalog:module";
 
-            Sequence results = xquery.execute(query, null, AccessContext.TEST);
+            Sequence results = xquery.execute(broker, query, null, AccessContext.TEST);
 
             for (NodeProxy node : results.toNodeSet()) {
                 ElementImpl source = (ElementImpl) node.getNode();
@@ -149,7 +149,7 @@ public class XQTS_case extends TestCase {
             "let $tc := $XQTSCatalog/catalog:test-suite//catalog:test-group[@name eq \""+testGroup+"\"]/catalog:test-case[@name eq \""+testCase+"\"]\n"+
             "return $tc";
 
-            Sequence results = xquery.execute(query, null, AccessContext.TEST);
+            Sequence results = xquery.execute(broker, query, null, AccessContext.TEST);
             
             Assert.assertFalse("", !results.hasOne());
 
@@ -209,7 +209,7 @@ public class XQTS_case extends TestCase {
             try {
                 XQueryContext context;
 
-                context = xquery.newContext(AccessContext.TEST);
+                context = new XQueryContext(broker.getBrokerPool(), AccessContext.TEST);
 
                 //map modules' namespaces to location 
                 Map<String, String> moduleMap = (Map<String, String>)broker.getConfiguration().getProperty(XQueryContext.PROPERTY_STATIC_MODULE_MAP);
@@ -251,10 +251,10 @@ public class XQTS_case extends TestCase {
                 if ("runtime-error".equals(scenario)) {
                 	try {
                         //compile
-                        CompiledXQuery compiled = xquery.compile(context, new FileSource(caseScript, "UTF8", true));
+                        CompiledXQuery compiled = xquery.compile(broker, context, new FileSource(caseScript, "UTF8", true));
 
                         //execute
-                        result = xquery.execute(compiled, contextSequence);
+                        result = xquery.execute(broker, compiled, contextSequence);
                         
                         if (outputFiles.getLength() != 0) {
                             //can be answered
@@ -285,10 +285,10 @@ public class XQTS_case extends TestCase {
                     }
                 } else {
                     //compile
-                    CompiledXQuery compiled = xquery.compile(context, new FileSource(caseScript, "UTF8", true));
+                    CompiledXQuery compiled = xquery.compile(broker, context, new FileSource(caseScript, "UTF8", true));
 
                     //execute
-                    result = xquery.execute(compiled, contextSequence);
+                    result = xquery.execute(broker, compiled, contextSequence);
 
                     //check answer
 	                for (int i = 0; i < outputFiles.getLength(); i++) {


### PR DESCRIPTION
This completes some work started and suggested by @shabanovd in 9f1c0c8.

1) Decouples XQuery service from `DBBroker`.

2) Moves `getXQueryService()` from `DBBroker` to `BrokerPool`.