### PR TITLE
[bugfix] Avoid potential lock-up when running test-suite

### DIFF
--- a/test/src/org/exist/http/RESTServiceTest.java
+++ b/test/src/org/exist/http/RESTServiceTest.java
@@ -165,9 +165,6 @@ public class RESTServiceTest {
         if (server == null) {
             server = new JettyStart();
             server.run();
-            while (!server.isStarted()) {
-                Thread.sleep(1000);
-            }
         }
     }
 

--- a/test/src/org/exist/security/RestApiSecurityTest.java
+++ b/test/src/org/exist/security/RestApiSecurityTest.java
@@ -168,9 +168,6 @@ public class RestApiSecurityTest extends AbstractApiSecurityTest {
         if (server == null) {
             server = new JettyStart();
             server.run();
-            while (!server.isStarted()) {
-                Thread.sleep(1000);
-            }
         }
     }
 

--- a/test/src/org/exist/xmldb/RemoteDBTest.java
+++ b/test/src/org/exist/xmldb/RemoteDBTest.java
@@ -50,9 +50,7 @@ public abstract class RemoteDBTest extends TestCase {
 		try {
 			if (server == null) {
 				server = new JettyStart();
-				if (!server.isStarted()) {
-                    server.run();
-                }
+                server.run();
 			}
         } catch (Exception e) {
         	e.printStackTrace();


### PR DESCRIPTION
Under extreme circumstances these wait loops can cause the test-suite to hang forever. They are also not actually needed as demonstrated elsewhere in the test-suite codebase.