### PR TITLE
Ignore sequence-library.jar from svn extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ installer/scripts/
 lib/extensions/
 lib/user/icu4j*.jar
 lib/user/je*.jar
+lib/user/sequence-library-*.jar
 lib/user/svnkit*.jar
 lib/user/uuid*.jar
 local.*


### PR DESCRIPTION
This jar was added with #480 to `extensions/svn/extension.xml`