### PR TITLE
LuceneIndexWorker.getFieldContent using old API

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/LuceneModule.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/LuceneModule.java
@@ -60,6 +60,7 @@ public class LuceneModule extends AbstractInternalModule {
         new FunctionDef(RemoveIndex.signature, RemoveIndex.class),
         new FunctionDef(Search.signatures[0], Search.class),
         new FunctionDef(Search.signatures[1], Search.class),
+        new FunctionDef(Search.signatures[2], Search.class),
         new FunctionDef(GetField.signatures[0], GetField.class)
     };
 

--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/Search.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/Search.java
@@ -60,6 +60,19 @@ public class Search extends BasicFunction {
      */
     public final static FunctionSignature signatures[] = {
         new FunctionSignature(
+                new QName("search", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+                "Search for (non-XML) data with lucene",
+                new SequenceType[]{
+                        new FunctionParameterSequenceType("path", Type.STRING, Cardinality.ZERO_OR_MORE,
+                                "URI paths of documents or collections in database. Collection URIs should end on a '/'."),
+                        new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
+                                "query string"),
+                        new FunctionParameterSequenceType("fields", Type.STRING, Cardinality.ZERO_OR_MORE,
+                                "Fields to return in search results")
+                },
+                new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,
+                        "All documents that are match by the query")),
+        new FunctionSignature(
             new QName("search", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
             "Search for (non-XML) data with lucene",
             new SequenceType[]{
@@ -96,7 +109,7 @@ public class Search extends BasicFunction {
             // Only match documents that match these URLs 
             List<String> toBeMatchedURIs = new ArrayList<>();
 
-            Sequence pathSeq = getArgumentCount() == 2 ? args[0] : contextSequence;
+            Sequence pathSeq = getArgumentCount() > 1 ? args[0] : contextSequence;
             if (pathSeq == null)
             	return Sequence.EMPTY_SEQUENCE;
             
@@ -123,12 +136,21 @@ public class Search extends BasicFunction {
             else
             	query = args[1].itemAt(0).getStringValue();
 
+            String[] fields = null;
+            if (getArgumentCount() == 3) {
+                fields = new String[args[2].getItemCount()];
+                int j = 0;
+                for (SequenceIterator i = args[2].iterate(); i.hasNext(); ) {
+                    fields[j++] = i.nextItem().getStringValue();
+                }
+            }
+
             // Get the lucene worker
             LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker()
                     .getIndexController().getWorkerByIndexId(LuceneIndex.ID);
 
             // Perform search
-            report = index.search(context, toBeMatchedURIs, query);
+            report = index.search(context, toBeMatchedURIs, query, fields);
 
 
         } catch (XPathException ex) {

--- a/extensions/indexes/lucene/test/src/xquery/lucene/plain-ft-functions.xml
+++ b/extensions/indexes/lucene/test/src/xquery/lucene/plain-ft-functions.xml
@@ -32,22 +32,22 @@
         <code><![CDATA[
         ft:index( "/db/binary/data1.txt", 
         <doc>
-            <field name="title">text</field>
+            <field name="title" store="yes">text</field>
             <field name="para">some text</field>
         </doc> ), 
         ft:index( "/db/binary/data2.txt", 
         <doc>
-            <field name="title">more text</field>
+            <field name="title" store="yes">more text</field>
             <field name="para">even more text</field>
         </doc> ),
         ft:index( "/db/binary/data3.txt", 
         <doc>
-            <field name="title">foobar title</field>
+            <field name="title" store="yes">foobar title</field>
             <field name="para">even more foobar</field>
         </doc> ),
         ft:index( "/db/binary/data4.txt", 
         <doc>
-            <field name="title">another foobar title</field>
+            <field name="title" store="yes">another foobar title</field>
             <field name="para">foobaar even more foobar</field>
         </doc> )
         ]]>
@@ -134,5 +134,19 @@
         data( ft:search(("/db/binary/","/db/binary/data4.txt"), "para:foobaar")//@uri )
         ]]></code>
         <expected>/db/binary/data4.txt</expected>
+    </test>
+    <test output="xml"> 
+        <task>Test Index 5 - retrieving values</task>
+        <code><![CDATA[ 
+        ft:search("/db/binary/", 'title:"another foobar"', "title")//field
+        ]]></code>
+        <expected><field name="title"><exist:match xmlns:exist="http://exist.sourceforge.net/NS/exist">another foobar</exist:match> title</field></expected>
+    </test>
+    <test output="text"> 
+        <task>Test Index 6 - get-field</task>
+        <code><![CDATA[ 
+        ft:get-field("/db/binary/data4.txt", "title")
+        ]]></code>
+        <expected>another foobar title</expected>
     </test>
 </TestSet>


### PR DESCRIPTION
* getFieldContent still uses old Lucene API: fails for larger data sets or returns random result
* related: extend ft:search to optionally return selected field content of hits for sorting and display

Closes #562 