### PR TITLE
[bugfix] Make sure the query rewriter does not silently fail 

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
@@ -197,7 +197,7 @@ public class LuceneUtil {
     }
 
     private static Query rewrite(MultiTermQuery query, IndexReader reader) throws IOException {
-        query.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE_DEFAULT);
+        query.setRewriteMethod(new MultiTermQuery.ConstantScoreAutoRewrite());
         return query.rewrite(reader);
     }
 }

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
@@ -25,11 +25,18 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import org.apache.lucene.index.AtomicReaderContext;
 import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexReaderContext;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.*;
+import org.apache.lucene.util.AttributeSource;
 import org.apache.lucene.util.BytesRef;
+
 import org.exist.dom.QName;
 import org.exist.dom.persistent.SymbolTable;
 import org.exist.numbering.NodeId;
@@ -170,19 +177,19 @@ public class LuceneUtil {
     }
 
     private static void extractTermsFromWildcard(WildcardQuery query, Map<Object, Query> terms, IndexReader reader, boolean includeFields) throws IOException {
-        extractTerms(rewrite(query, reader), terms, reader, includeFields);
+        extractTermsFromMultiTerm(query, terms, reader, includeFields);
     }
 
     private static void extractTermsFromRegex(RegexpQuery query, Map<Object, Query> terms, IndexReader reader, boolean includeFields) throws IOException {
-        extractTerms(rewrite(query, reader), terms, reader, includeFields);
+        extractTermsFromMultiTerm(query, terms, reader, includeFields);
     }
 
     private static void extractTermsFromFuzzy(FuzzyQuery query, Map<Object, Query> terms, IndexReader reader, boolean includeFields) throws IOException {
-        extractTerms(query.rewrite(reader), terms, reader, includeFields);
+        extractTermsFromMultiTerm(query, terms, reader, includeFields);
     }
 
     private static void extractTermsFromPrefix(PrefixQuery query, Map<Object, Query> terms, IndexReader reader, boolean includeFields) throws IOException {
-    	extractTerms(rewrite(query, reader), terms, reader, includeFields);
+        extractTerms(query.rewrite(reader), terms, reader, includeFields);
     }
 
     private static void extractTermsFromPhrase(PhraseQuery query, Map<Object, Query> terms, boolean includeFields) {
@@ -197,7 +204,61 @@ public class LuceneUtil {
     }
 
     private static Query rewrite(MultiTermQuery query, IndexReader reader) throws IOException {
-        query.setRewriteMethod(new MultiTermQuery.ConstantScoreAutoRewrite());
+        query.setRewriteMethod(MultiTermQuery.CONSTANT_SCORE_AUTO_REWRITE_DEFAULT);
         return query.rewrite(reader);
     }
+
+    private static void extractTermsFromMultiTerm(MultiTermQuery query, Map<Object, Query> termsMap, IndexReader reader, boolean includeFields) throws IOException {
+        TERM_EXTRACTOR.extractTerms(query, termsMap, reader, includeFields);
+    }
+
+    private static final MultiTermExtractor TERM_EXTRACTOR = new MultiTermExtractor();
+
+    /*
+     * A class for extracting MultiTerms (all of them).
+     * Subclassing MultiTermQuery.RewriteMethod
+     * to gain access to its protected method getTermsEnum
+     */
+    private static class MultiTermExtractor extends MultiTermQuery.RewriteMethod {
+
+        public void extractTerms(MultiTermQuery query, Map<Object, Query> termsMap, IndexReader reader, boolean includeFields) throws IOException {
+            IndexReaderContext topReaderContext = reader.getContext();
+            for (AtomicReaderContext context : topReaderContext.leaves()) {
+                final Fields fields = context.reader().fields();
+                if (fields == null) {
+                    // reader has no fields
+                    continue;
+                }
+
+                final Terms terms = fields.terms(query.getField());
+                if (terms == null) {
+                    // field does not exist
+                    continue;
+                }
+
+                TermsEnum termsEnum = getTermsEnum(query, terms, new AttributeSource());
+                assert termsEnum != null;
+
+                if (termsEnum == TermsEnum.EMPTY) {
+                    continue;
+		}
+
+                BytesRef bytes;
+                while ((bytes = termsEnum.next()) != null) {
+                    Term term = new Term(query.getField(), BytesRef.deepCopyOf(bytes));
+                    if (includeFields) {
+                        termsMap.put(term, query);
+                    } else {
+                        termsMap.put(term.text(), query);
+		    }
+                }
+            }
+        }
+
+        @Override
+        public Query rewrite(IndexReader reader, MultiTermQuery query) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    };
+
 }

--- a/extensions/indexes/lucene/test/src/xquery/lucene/queries.xml
+++ b/extensions/indexes/lucene/test/src/xquery/lucene/queries.xml
@@ -15,9 +15,10 @@
 					<!-- Lucene index is configured below -->
 					<lucene>
 						<analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
-						<analyzer id="stop" class="org.apache.lucene.analysis.StopAnalyzer"/>
-						<analyzer id="keyword" class="org.apache.lucene.analysis.KeywordAnalyzer"/>
+						<analyzer id="stop" class="org.apache.lucene.analysis.core.StopAnalyzer"/>
+						<analyzer id="keyword" class="org.apache.lucene.analysis.core.KeywordAnalyzer"/>
 						<text qname="p"/>
+						<text qname="tei:p"/>
 						<text qname="id" field="id" analyzer="keyword"/>
 						<text qname="para" analyzer="stop"/>
 						<text qname="b"/>
@@ -48,6 +49,7 @@
 					<y>Nested <z>nodes</z></y>
 				</x>
 				<id>A11</id>
+				<p xmlns="http://www.tei-c.org/ns/1.0">erste aus haus maus zaus yaus raus qaus leisten</p>
 			</test>
 		</store>
 		<store collection="/db/lucene" name="text2.xml">
@@ -462,6 +464,25 @@
 				<exist:match xmlns:exist="http://exist.sourceforge.net/NS/exist">neun</exist:match>
 			</b>
 		</expected>
+	</test>
+		<test output="xml">
+		<task>Match highlighting: wildcard query TEI NS MultiTermQueryRewriteMetod no silent fail due to limits/cutoffs but return all results</task>
+		<code><![CDATA[
+            declare namespace tei="http://www.tei-c.org/ns/1.0";
+            declare namespace exist="http://exist.sourceforge.net/NS/exist";
+            for $expr in
+	     ("aus",  "haus",  "maus",  "zaus",  "yaus",  "raus",  "qaus",
+              "a*",   "h*",    "m*",    "z*",    "y*",    "r*",    "q*",
+              "au*",  "ha*",   "ma*",   "za*",   "ya*",   "ra*",   "qa*",
+              "aus*", "hau*",  "mau*",  "zau*",  "yau*",  "rau*",  "qau*",
+              "a*s",  "h*s",   "m*s",   "z*s",   "y*s",   "r*s",   "q*s",
+              "au*s", "ha*s",  "ma*s",  "za*s",  "ya*s",  "ra*s",  "qa*s")
+	    let $query := <query><wildcard>{$expr}</wildcard></query>
+            return for $hit in doc("/db/lucene/text1.xml")//tei:p[ft:query(., $query)]
+            return
+                util:expand($hit)//exist:match
+	]]></code>
+		<xpath>count($output) eq 42</xpath>
 	</test>
 	<test output="xml">
 		<task>Match highlighting: regex query</task>


### PR DESCRIPTION
(or fail with maxClauseCount exceeded) but chooses the most suitable one depending on terms and docs quote which the static one does not do.