### PR TITLE
Admin client user fixes

### DIFF
--- a/src/org/exist/client/InteractiveClient.java
+++ b/src/org/exist/client/InteractiveClient.java
@@ -865,7 +865,7 @@ public class InteractiveClient {
                         if (p1.equals(p2)) {
                             break;
                         }
-                        System.out.println(EOL + "entered passwords differ. Try again...");
+                        messageln("Entered passwords differ. Try again...");
                         
                     }
                     final UserAider user = new UserAider(args[1]);
@@ -878,19 +878,24 @@ public class InteractiveClient {
                             user.addGroup(group);
                         }
                     }
+
+                    if(user.getGroups().length == 0) {
+                        messageln("No groups specified, will be a member of the '" + SecurityManager.GUEST_GROUP +"' group!");
+                        user.addGroup(SecurityManager.GUEST_GROUP);
+                    }
                     
                     mgtService.addAccount(user);
-                    System.out.println("user " + user + " created.");
+                    messageln("User '" + user.getName() + "' created.");
                 } catch (final Exception e) {
-                    System.out.println("ERROR: " + e.getMessage());
+                    errorln("ERROR: " + e.getMessage());
                     e.printStackTrace();
                 }
             } else if (args[0].equalsIgnoreCase("users")) {
                 final UserManagementService mgtService = (UserManagementService) current
                         .getService("UserManagementService", "1.0");
                 final Account users[] = mgtService.getAccounts();
-                System.out.println("User\t\tGroups");
-                System.out.println("-----------------------------------------");
+                messageln("User\t\tGroups");
+                messageln("-----------------------------------------");
                 for (int i = 0; i < users.length; i++) {
                     System.out.print(users[i].getName() + "\t\t");
                     final String[] groups = users[i].getGroups();
@@ -908,7 +913,7 @@ public class InteractiveClient {
                     return true;
                 }
                 if (args.length < 2) {
-                    System.out.println("Usage: passwd username");
+                    messageln("Usage: passwd username");
                     return true;
                 }
                 try {
@@ -916,7 +921,7 @@ public class InteractiveClient {
                             .getService("UserManagementService", "1.0");
                     final Account user = mgtService.getAccount(args[1]);
                     if (user == null) {
-                        System.out.println("no such user.");
+                        messageln("no such user.");
                         return true;
                     }
                     String p1;
@@ -933,7 +938,8 @@ public class InteractiveClient {
                     mgtService.updateAccount(user);
                     properties.setProperty("password", p1);
                 } catch (final Exception e) {
-                    System.err.println("ERROR: " + e.getMessage());
+                    errorln("ERROR: " + e.getMessage());
+                    e.printStackTrace();
                 }
             } else if (args[0].equalsIgnoreCase("chmod")) {
                 if (args.length < 2) {

--- a/src/org/exist/client/InteractiveClient.java
+++ b/src/org/exist/client/InteractiveClient.java
@@ -303,6 +303,8 @@ public class InteractiveClient {
      * @exception Exception   Description of the Exception
      */
     protected void connect() throws Exception {
+        System.out.println("Connecting to database...");
+
         final String uri = properties.getProperty(InteractiveClient.URI);
         if (startGUI && frame != null) {
             frame.setStatus("connecting to " + uri);
@@ -330,6 +332,8 @@ public class InteractiveClient {
         if (startGUI && frame != null) {
             frame.setStatus("connected to " + uri + " as user " + properties.getProperty("user"));
         }
+
+        System.out.println("Connected :-)");
     }
     
     /**

--- a/src/org/exist/client/security/UserManagerDialog.java
+++ b/src/org/exist/client/security/UserManagerDialog.java
@@ -397,10 +397,6 @@ public class UserManagerDialog extends javax.swing.JFrame {
             JOptionPane.showMessageDialog(this, "Could not edit user '" + selectedUsername + "': " + xmldbe.getMessage(), "User Manager Error", JOptionPane.ERROR_MESSAGE);
         }
     }//GEN-LAST:event_miEditUserActionPerformed
-
-    protected interface Reconnecter {
-        public UserManagementService reconnect(final String password) throws XMLDBException;
-    }
     
     private UserManagementService reconnectClientAndUserManager(final String password) throws XMLDBException {
         //get client to reconnect with edited users new password
@@ -421,19 +417,16 @@ public class UserManagerDialog extends javax.swing.JFrame {
             public void complete(final String response) {
                 //get client to reconnect with edited users new password
                 try {
+                    System.out.println("Detected logged-in user password change, reconnecting to server...");
                     that.userManagementService = reconnectClientAndUserManager(response);
+                    System.out.println("Reconnected.");
                 } catch(final XMLDBException xmldbe) {
                     JOptionPane.showMessageDialog(that, "Could not edit user '" + getSelectedUsername() + "': " + xmldbe.getMessage(), "User Manager Error", JOptionPane.ERROR_MESSAGE);
                 }
             }
         };
-        
-        final EditUserDialog userDialog = new EditUserDialog(userManagementService, account, new Reconnecter() {
-            @Override
-            public UserManagementService reconnect(final String password) throws XMLDBException {
-                return reconnectClientAndUserManager(password);
-            }
-        });
+
+        final EditUserDialog userDialog = new EditUserDialog(userManagementService, account);
         if(getSelectedUsername().equals(currentUser)) {
             //register for password update event, if we are changing the password
             //of the current user


### PR DESCRIPTION
* Don't reconnect unless we are changing the logged-in users password
* Only reconnect once when changing the logged-in users password
* Only reconnect when changing the logged-in users password, not also to change group membership
* Don't allow users to be added without a group (console mode).