### PR TITLE
Rest URLs consistency

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -59,7 +59,7 @@ set_java_options;
 # save LANG
 set_locale_lang;
 
-JAVA_ENDORSED_DIRS="$EXIST_HOME"/lib/endorsed
+JAVA_ENDORSED_DIRS="$EXIST_HOME"/lib/endorsed:"$EXIST_HOME"/lib/test
 
 PROFILER_OPTS=-agentlib:yjpagent
 

--- a/src/org/exist/http/RESTServer.java
+++ b/src/org/exist/http/RESTServer.java
@@ -387,13 +387,7 @@ public class RESTServer {
         }
         // Process the request
         DocumentImpl resource = null;
-        String pathStr = path; // path comes straight from jetty via EXistServlet
-        // eat trailing slash(es), else collection resources might not be found
-        while(pathStr.endsWith("/")) { pathStr = pathStr.substring(0, pathStr.length()-1); }
-        // collapse preceding slashes, else resources might not be found
-        while(pathStr.startsWith("//")) { pathStr = pathStr.substring(1); }
-        // path is understood to be already in its encoded form
-        final XmldbURI pathUri = XmldbURI.createInternal(pathStr);
+        final XmldbURI pathUri = XmldbURI.createInternal(path);
         try {
             // check if path leads to an XQuery resource
             final String xquery_mime_type = MimeType.XQUERY_TYPE.getName();
@@ -542,7 +536,7 @@ public class RESTServer {
             throws BadRequestException, PermissionDeniedException,
             NotFoundException, IOException {
         
-        final XmldbURI pathUri = XmldbURI.create(path);
+        final XmldbURI pathUri = XmldbURI.createInternal(path);
         if (checkForXQueryTarget(broker, pathUri, request, response)) {
             return;
         }
@@ -622,7 +616,7 @@ public class RESTServer {
         }
 
         final Properties outputProperties = new Properties(defaultOutputKeysProperties);
-        final XmldbURI pathUri = XmldbURI.create(path);
+        final XmldbURI pathUri = XmldbURI.createInternal(path);
         DocumentImpl resource = null;
 
         final String encoding = outputProperties.getProperty(OutputKeys.ENCODING);
@@ -1116,7 +1110,7 @@ public class RESTServer {
 
     public void doDelete(final DBBroker broker, final String path, final HttpServletRequest request, final HttpServletResponse response)
             throws PermissionDeniedException, NotFoundException, IOException, BadRequestException {
-        final XmldbURI pathURI = XmldbURI.create(path);
+        final XmldbURI pathURI = XmldbURI.createInternal(path);
         if (checkForXQueryTarget(broker, pathURI, request, response)) {
             return;
         }
@@ -1274,7 +1268,7 @@ public class RESTServer {
             }
         }
 
-        final XmldbURI pathUri = XmldbURI.create(path);
+        final XmldbURI pathUri = XmldbURI.createInternal(path);
         try {
             final Source source = new StringSource(query);
             final XQuery xquery = broker.getXQueryService();

--- a/src/org/exist/http/RESTServer.java
+++ b/src/org/exist/http/RESTServer.java
@@ -32,7 +32,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -388,7 +387,13 @@ public class RESTServer {
         }
         // Process the request
         DocumentImpl resource = null;
-        final XmldbURI pathUri = XmldbURI.create(URLDecoder.decode(path, "UTF-8"));
+        String pathStr = path; // path comes straight from jetty via EXistServlet
+        // eat trailing slash(es), else collection resources might not be found
+        while(pathStr.endsWith("/")) { pathStr = pathStr.substring(0, pathStr.length()-1); }
+        // collapse preceding slashes, else resources might not be found
+        while(pathStr.startsWith("//")) { pathStr = pathStr.substring(1); }
+        // path is understood to be already in its encoded form
+        final XmldbURI pathUri = XmldbURI.createInternal(pathStr);
         try {
             // check if path leads to an XQuery resource
             final String xquery_mime_type = MimeType.XQUERY_TYPE.getName();

--- a/src/org/exist/http/servlets/EXistServlet.java
+++ b/src/org/exist/http/servlets/EXistServlet.java
@@ -169,11 +169,6 @@ public class EXistServlet extends AbstractExistHttpServlet {
             path = "";
         }
 
-        final int p = path.lastIndexOf(';');
-        if (p != Constants.STRING_NOT_FOUND) {
-            path = path.substring(0, p);
-        }
-
         return path;
     }
 

--- a/src/org/exist/http/servlets/EXistServlet.java
+++ b/src/org/exist/http/servlets/EXistServlet.java
@@ -44,6 +44,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.EOFException;
 import java.io.IOException;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  * Implements the REST-style interface if eXist is running within a Servlet
  * engine. The real work is done by class {@link org.exist.http.RESTServer}.
@@ -162,12 +165,29 @@ public class EXistServlet extends AbstractExistHttpServlet {
     /**
      * @param request
      */
-    private String adjustPath(HttpServletRequest request) {
+    private String adjustPath(HttpServletRequest request) throws ServletException {
         String path = request.getPathInfo();
 
         if (path == null) {
             path = "";
         }
+
+LOG.info(" In: " + path);
+        // path contains both required and superficial escapes,
+        // as different user agents use different conventions;
+        // for the sake of interoperability, remove any unnecessary escapes
+        try {
+            // URI.create undoes _all_ escaping, so protect slashes first
+            URI u = URI.create("file://" + path.replaceAll("%2F", "%252F"));
+            // URI four-argument constructor recreates all the necessary ones
+            URI v = new URI("http", "host", u.getPath(), null).normalize();
+            // unprotect slashes in now normalized path
+            path = v.getRawPath().replaceAll("%252F", "%2F");
+        } catch (final URISyntaxException e) {
+            throw new ServletException(e.getMessage(), e);
+        }
+        // path now is in proper canonical encoded form
+LOG.info("Out: " + path);
 
         return path;
     }

--- a/src/org/exist/http/servlets/EXistServlet.java
+++ b/src/org/exist/http/servlets/EXistServlet.java
@@ -124,7 +124,7 @@ public class EXistServlet extends AbstractExistHttpServlet {
 
         DBBroker broker = null;
         try {
-            final XmldbURI dbpath = XmldbURI.create(path);
+            final XmldbURI dbpath = XmldbURI.createInternal(path);
             broker = getPool().get(user);
             final Collection collection = broker.getCollection(dbpath);
             if (collection != null) {
@@ -169,7 +169,7 @@ public class EXistServlet extends AbstractExistHttpServlet {
         String path = request.getPathInfo();
 
         if (path == null) {
-            path = "";
+            return "";
         }
 
 LOG.info(" In: " + path);
@@ -185,6 +185,10 @@ LOG.info(" In: " + path);
             path = v.getRawPath().replaceAll("%252F", "%2F");
         } catch (final URISyntaxException e) {
             throw new ServletException(e.getMessage(), e);
+        }
+        // eat trailing slashes, else collections might not be found
+        while(path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
         }
         // path now is in proper canonical encoded form
 LOG.info("Out: " + path);

--- a/test/src/org/exist/http/RESTServiceTest.java
+++ b/test/src/org/exist/http/RESTServiceTest.java
@@ -126,9 +126,9 @@ public class RESTServiceTest {
      */
     // Below String mostly contains the PCHAR set literally; the colon fails though, so its omitted…
     // Also in the mix: some (mandatory except %27) escapes, some multibyte UTF-8 characters
-    // and a superficial directory traversal
+    // and a superficial directory traversal and a superficial double slash too
     private final static String RESOURCE_URI_PLUS = SERVER_URI + XmldbURI.ROOT_COLLECTION +
-            "/test/../test/A-Za-z0-9_~!$&'()*+,;=@%20%23%25%27%2F%3F%5B%5Däöü.xml";
+            "/test//../test/A-Za-z0-9_~!$&'()*+,;=@%20%23%25%27%2F%3F%5B%5Däöü.xml";
 
     private final static String XML_DATA = "<test>"
             + "<para>\u00E4\u00E4\u00FC\u00FC\u00F6\u00F6\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC</para>"

--- a/test/src/org/exist/http/RESTServiceTest.java
+++ b/test/src/org/exist/http/RESTServiceTest.java
@@ -124,9 +124,11 @@ public class RESTServiceTest {
 
      ** Beware, some chars valid in a path-segment must not be in a filename (mostly NTFS)
      */
-    // Below String contains the PCHAR set; the colon fails though, so its omitted…
+    // Below String mostly contains the PCHAR set literally; the colon fails though, so its omitted…
+    // Also in the mix: some (mandatory except %27) escapes, some multibyte UTF-8 characters
+    // and a superficial directory traversal
     private final static String RESOURCE_URI_PLUS = SERVER_URI + XmldbURI.ROOT_COLLECTION +
-            "/test/A-Za-z0-9_~!$&'()*+,;=@.xml";
+            "/test/../test/A-Za-z0-9_~!$&'()*+,;=@%20%23%25%27%2F%3F%5B%5Däöü.xml";
 
     private final static String XML_DATA = "<test>"
             + "<para>\u00E4\u00E4\u00FC\u00FC\u00F6\u00F6\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC</para>"

--- a/test/src/org/exist/http/RESTServiceTest.java
+++ b/test/src/org/exist/http/RESTServiceTest.java
@@ -73,7 +73,61 @@ public class RESTServiceTest {
             SERVER_URI_REDIRECTED + XmldbURI.ROOT_COLLECTION + "/test";
 
     private final static String RESOURCE_URI = SERVER_URI + XmldbURI.ROOT_COLLECTION + "/test/test.xml";
-    
+
+    /* About path components of URIs:
+
+     ** reserved characters # http://tools.ietf.org/html/rfc3986#section-2.2
+     *
+     *  gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+     *  sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
+     *              / "*" / "+" / "," / ";" / "="
+     *  reserved    = gen-delims / sub-delims
+        RCHAR=": / ? # [ ] @ ! $ & ' ( ) *  + , ; ="
+
+     ** path-segment # http://tools.ietf.org/html/rfc3986#section-3.3
+     *
+     *  unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
+     *  pct-encoded = "%" HEXDIG HEXDIG
+     *  sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
+     *              / "*" / "+" / "," / ";" / "="
+     *  pchar       = unreserved / pct-encoded / sub-delims / ":" / "@"
+
+     ** So, characters literally allowed in a path-segment are:
+        PCHAR="A-Z a-z 0-9 - . _ ~ ! $ & ' ( ) *  + , ; = : @"
+
+     ** All the rest has to be percent-encoded
+     *  the percent sign itself MUST start a code
+     *  reserved+ chars in need of encoding - in a path-segment - are:
+     *       /   ?   #   [   ]   %
+     *  %20 %2F %3F %23 %5B %5D %25
+
+     ** Interoperability /rest/ space:
+     *  most webbrowsers act mostly correct
+     *  curl does _no_ encoding on its own
+     *  all browsers send a bare / as is (user error? will separate path-segments)
+     *  all browsers send a bare ? as is (user error? will start the query-string)
+     *  no browser sends a bare # at all (user error? will start the fragment-identifier)
+     *  chrome and msie send [] verbatim (wrong? apache can accomodate…)
+     *  all browsers send a bare % as is (user error? will start an escape, apache returns Bad Request)
+
+     ** Interoperability /webdav/ space:
+     *  the GET and PUT methods mirror /rest/ space
+     *  These characters are not allowed in an NFTS filename
+        INTFS='/ \ : *   ? " < > |'
+     *  of those, Macintosh HFS only prohibits the colon
+     *  most other UN*X FSs only prohibit the slash
+     *  Quick test with bash on Linux extfs:
+        TWDAV="$PCHAR $RCHAR $INTFS %"
+     *  set -f; for fn in $TWDAV; do echo T__${fn}__ > /tmp/T__${fn}__; done
+     *  only the slash will error out (twice)
+     *  anything in this set can be thrown at webdav!
+
+     ** Beware, some chars valid in a path-segment must not be in a filename (mostly NTFS)
+     */
+    // Below String contains the PCHAR set; the colon fails though, so its omitted…
+    private final static String RESOURCE_URI_PLUS = SERVER_URI + XmldbURI.ROOT_COLLECTION +
+            "/test/A-Za-z0-9_~!$&'()*+,;=@.xml";
+
     private final static String XML_DATA = "<test>"
             + "<para>\u00E4\u00E4\u00FC\u00FC\u00F6\u00F6\u00C4\u00C4\u00D6\u00D6\u00DC\u00DC</para>"
             + "</test>";
@@ -286,6 +340,14 @@ public class RESTServiceTest {
         assertEquals("Server returned response code " + r, 201, r);
 
         doGet();
+    }
+
+    @Test
+    public void testPutPlus() throws IOException {
+        int r = uploadDataPlus();
+        assertEquals("Server returned response code " + r, 201, r);
+
+        doGetPlus();
     }
 
     @Test
@@ -593,6 +655,37 @@ public class RESTServiceTest {
     
     private void doGet() throws IOException {
         HttpURLConnection connect = getConnection(RESOURCE_URI);
+        connect.setRequestMethod("GET");
+        connect.connect();
+
+        int r = connect.getResponseCode();
+        assertEquals("Server returned response code " + r, 200, r);
+        String contentType = connect.getContentType();
+        int semicolon = contentType.indexOf(';');
+        if (semicolon > 0) {
+            contentType = contentType.substring(0, semicolon).trim();
+        }
+        assertEquals("Server returned content type " + contentType, "application/xml", contentType);
+
+        readResponse(connect.getInputStream());
+    }
+
+    private int uploadDataPlus() throws IOException {
+        HttpURLConnection connect = getConnection(RESOURCE_URI_PLUS);
+        connect.setRequestProperty("Authorization", "Basic " + credentials);
+        connect.setRequestMethod("PUT");
+        connect.setDoOutput(true);
+        connect.setRequestProperty("ContentType", "application/xml");
+        Writer writer = new OutputStreamWriter(connect.getOutputStream(), "UTF-8");
+        writer.write(XML_DATA);
+        writer.close();
+
+        connect.connect();
+        return connect.getResponseCode();
+    }
+
+    private void doGetPlus() throws IOException {
+        HttpURLConnection connect = getConnection(RESOURCE_URI_PLUS);
         connect.setRequestMethod("GET");
         connect.connect();
 


### PR DESCRIPTION
Resources containing certain characters (mostly from the RFC 3986 reserved set) cannot be GET by the name, that was used to PUT them: The included unit test case spells them out in full detail. The rest of the branch makes the unit test succeed.

Beware that this is just a starting point: Some further normalization will be necessary to deliver cross user agent interoperability; eg. the encoded path may contain superficial escape sequences. Yet the place for that might rather be the XmldbURI class.