### PR TITLE
[bugfix] Fix issue with filtered expression

### DIFF
--- a/src/org/exist/xquery/ConcatExpr.java
+++ b/src/org/exist/xquery/ConcatExpr.java
@@ -66,4 +66,9 @@ public class ConcatExpr extends PathExpr {
 	public int getCardinality() {
 		return Cardinality.EXACTLY_ONE;
 	}
+
+	@Override
+	public Expression simplify() {
+		return this;
+	}
 }

--- a/src/org/exist/xquery/FilteredExpression.java
+++ b/src/org/exist/xquery/FilteredExpression.java
@@ -49,10 +49,7 @@ public class FilteredExpression extends AbstractExpression {
      */
     public FilteredExpression(XQueryContext context, Expression expr) {
         super(context);
-        if (expr.getSubExpressionCount() == 1) {
-            expr = expr.getSubExpression(0);
-        }
-        this.expression = expr;
+        this.expression = expr.simplify();
     }
 
     public void addPredicate(Predicate pred) {

--- a/test/src/xquery/optimizer/optimizer.xql
+++ b/test/src/xquery/optimizer/optimizer.xql
@@ -407,3 +407,14 @@ declare
 function ot:optimize-grouped-context2($name as xs:string) {
     collection($ot:COLLECTION)//(name|foo)[ft:query(., $name)]
 };
+
+declare %private function ot:collection-helper($path as xs:string) {
+    collection($path)//address
+};
+
+declare
+    %test:args("Rudi Rüssel")
+    %test:assertEquals("Rüsselsheim")
+function ot:do-not-simplify($name as xs:string) {
+    ot:collection-helper($ot:COLLECTION)[ft:query(name, $name)]/city/string()
+};


### PR DESCRIPTION
Simplify context expression only if it is a PathExpr. Added test case.

Issue introduced by 138f187