### PR TITLE
Make it possible to output JSON array for single items of all types

### DIFF
--- a/src/org/exist/storage/serializers/EXistOutputKeys.java
+++ b/src/org/exist/storage/serializers/EXistOutputKeys.java
@@ -72,6 +72,11 @@ public class EXistOutputKeys {
     public final static String JSON_NODE_OUTPUT_METHOD = "json-node-output-method";
 
     /**
+     * Defines the output for JSON serializing to array even if only one item.
+     */
+    public final static String JSON_ARRAY_OUTPUT = "json-array-output";
+
+    /**
      * Determines whether the presence of multiple keys in a map item with the same string value
      * will or will not raise serialization error err:SERE0022.
      */

--- a/src/org/exist/util/serializer/json/JSONSerializer.java
+++ b/src/org/exist/util/serializer/json/JSONSerializer.java
@@ -61,7 +61,7 @@ public class JSONSerializer {
     private void serializeSequence(Sequence sequence, JsonGenerator generator) throws IOException, XPathException, SAXException {
         if (sequence.isEmpty()) {
             generator.writeNull();
-        } else if (sequence.hasOne()) {
+        } else if (sequence.hasOne() && "no".equals(outputProperties.getProperty(EXistOutputKeys.JSON_ARRAY_OUTPUT, "no"))) {
             serializeItem(sequence.itemAt(0), generator);
         } else {
             generator.writeStartArray();


### PR DESCRIPTION
Adding possiblity to output JSON array in JSONSerializer for single items of all types with outputkey json-array-output, eg, declare option exist:serialize "method=json json-array-output=yes"; or util:declare-option.