### PR TITLE
Make log4j write to $sys:exist.home

### DIFF
--- a/bin/functions.d/eXist-settings.sh
+++ b/bin/functions.d/eXist-settings.sh
@@ -11,7 +11,7 @@ get_exist_home() {
 			p="$PWD/$1"
 		;;
 	esac
-		(cd $(/usr/bin/dirname "$p") ; /bin/pwd)
+		(cd "$(/usr/bin/dirname "$p")" ; /bin/pwd)
 }
 
 check_exist_home() {
@@ -20,6 +20,10 @@ check_exist_home() {
 	EXIST_HOME="$EXIST_HOME_1/..";
     fi
 
+    if [[ "$EXIST_HOME" =~ ' ' ]] ; then
+	echo "Path to eXist-db MUST NOT contain spaces! Exiting now…" > /dev/stderr;
+	exit 1;
+    fi
     if [ ! -f "${EXIST_HOME}/start.jar" ]; then
 	echo "Unable to find start.jar. Please set EXIST_HOME to point to your installation directory." > /dev/stderr;
 	exit 1;

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">webapp/WEB-INF/logs</Property>
+        <Property name="logs">${sys:exist.home}/webapp/WEB-INF/logs</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>


### PR DESCRIPTION
even when starting up from a different directory than $EXIST_HOME

E.g: `cd /tmp; /opt/eXist/bin/startup.sh` fails when property not pased

Should not impact the wrapper, does it? Or the WAR?