### PR TITLE
Fix bin/shutdown.sh not shutting down the database

### DIFF
--- a/src/org/exist/xmldb/LocalDatabaseInstanceManager.java
+++ b/src/org/exist/xmldb/LocalDatabaseInstanceManager.java
@@ -19,9 +19,13 @@
  */
 package org.exist.xmldb;
 
+import java.util.Properties;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import org.exist.scheduler.SystemTaskJob;
+import org.exist.scheduler.impl.ShutdownTask;
+import org.exist.scheduler.impl.SystemTaskJobImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
@@ -53,24 +57,13 @@ public class LocalDatabaseInstanceManager extends AbstractLocalService implement
     }
 
     @Override
-    public void shutdown(long delay) throws XMLDBException {
+    public void shutdown(final long delay) throws XMLDBException {
         if(!user.hasDbaRole()) {
             throw new XMLDBException(ErrorCodes.PERMISSION_DENIED, "only users in group dba may shut down the database");
         }
-        
-        if(delay > 0) {
-            final TimerTask task = new TimerTask() {
-                @Override
-                public void run() {
-                    brokerPool.shutdown();
-                }
-            };
-            
-            final Timer timer = new Timer();
-            timer.schedule(task, delay);
-        } else {
-            brokerPool.shutdown();
-        }
+
+        final SystemTaskJob shutdownJob = new SystemTaskJobImpl("xmldb:local-api.shutdown", new ShutdownTask());
+        brokerPool.getScheduler().createPeriodicJob(0, shutdownJob, delay, new Properties(), 0);
     }
 
 

--- a/src/org/exist/xmlrpc/RpcConnection.java
+++ b/src/org/exist/xmlrpc/RpcConnection.java
@@ -46,6 +46,7 @@ import org.exist.numbering.NodeId;
 import org.exist.protocolhandler.embedded.EmbeddedInputStream;
 import org.exist.protocolhandler.xmldb.XmldbURL;
 import org.exist.scheduler.SystemTaskJob;
+import org.exist.scheduler.impl.ShutdownTask;
 import org.exist.scheduler.impl.SystemTaskJobImpl;
 import org.exist.security.ACLPermission;
 import org.exist.security.AXSchemaType;
@@ -73,7 +74,6 @@ import org.exist.storage.serializers.Serializer;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.Txn;
 import org.exist.util.Compressor;
-import org.exist.util.Configuration;
 import org.exist.util.LockException;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
@@ -3434,22 +3434,7 @@ public class RpcConnection implements RpcAPI {
             throw new PermissionDeniedException("not allowed to shut down" + "the database");
         }
 
-        final SystemTaskJob shutdownJob = new SystemTaskJobImpl("rpc-api.shutdown", new SystemTask() {
-            @Override
-            public void configure(final Configuration config, final Properties properties) throws EXistException {
-            }
-
-            @Override
-            public void execute(final DBBroker broker) throws EXistException {
-                broker.getBrokerPool().shutdown();
-            }
-
-            @Override
-            public boolean afterCheckpoint() {
-                return true;
-            }
-        });
-
+        final SystemTaskJob shutdownJob = new SystemTaskJobImpl("rpc-api.shutdown", new ShutdownTask());
         return factory.getBrokerPool().getScheduler().createPeriodicJob(0, shutdownJob, delay, new Properties(), 0);
     }
 


### PR DESCRIPTION
Fixes deadlock issue when using Quartz to schedule the database shutdown and also switched XML:DB Local API to use same approach as XML-RPC/XML:DB
Remote API.

Closes https://github.com/eXist-db/exist/issues/602