### PR TITLE
[bugfix] Make test in set_locale_lang not fail with too many arguments error

### DIFF
--- a/bin/functions.d/eXist-settings.sh
+++ b/bin/functions.d/eXist-settings.sh
@@ -32,8 +32,8 @@ set_locale_lang() {
 	OLD_LANG="${LANG}";
     fi
 # set LANG to UTF-8
-    if [ $(locale -a | grep -i "UTF-8" | head -n 1) ] || \
-       [ $(locale -a | grep -i "utf8" | head -n 1) ]; then
+    if [ $(locale -a | grep -ia "UTF-8" | head -n 1) ] || \
+       [ $(locale -a | grep -ia "utf8" | head -n 1) ]; then
 	if [ $(echo "${LANG}" |grep "\.") ]; then
 	    LANG=$(echo "${LANG}" | cut -f1 -d'.')
 	    LANG="${LANG}".UTF-8


### PR DESCRIPTION
by setting binary-files=text for grep.