### PR TITLE
Use modification dates to extract only the resources that are newer than their destination files.

### DIFF
--- a/src/org/exist/ant/XMLDBExtractTask.java
+++ b/src/org/exist/ant/XMLDBExtractTask.java
@@ -33,6 +33,7 @@ import org.xmldb.api.modules.XMLResource;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.serializer.SerializerPool;
 import org.exist.xmldb.ExtendedResource;
+import org.exist.xmldb.EXistResource;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
+import java.util.Date;
 import java.util.Properties;
 
 import javax.xml.transform.OutputKeys;
@@ -247,21 +249,13 @@ public class XMLDBExtractTask extends AbstractXMLDBTask
             dest = new File( dest, fname );
         }
 
-        if( !dest.exists() || ( overwrite == true ) ) {
+        if( !dest.exists() || ( overwrite == true ) || ((EXistResource) res).getLastModificationTime().after( new Date( dest.lastModified() ) ) ) {
             log( "Extracting resource: " + res.getId() + " to " + destFile.getAbsolutePath(), Project.MSG_INFO );
 
             if( res instanceof XMLResource ) {
                 writeXMLResource( (XMLResource)res, dest );
             } else if( res instanceof ExtendedResource ) {
                 writeBinaryResource( (ExtendedResource)res, dest );
-            }
-        } else {
-            final String msg = "Destination file " + dest.getAbsolutePath() + " exists. Use overwrite property to overwrite this file.";
-
-            if( failonerror ) {
-                throw( new BuildException( msg ) );
-            } else {
-                log( msg, Project.MSG_ERR );
             }
         }
     }

--- a/test/src/ant/xmldb.xml
+++ b/test/src/ant/xmldb.xml
@@ -103,6 +103,23 @@
 
 
      </target>
+     
+    <target name="test_modificationtime_XMLDBExtract" description="check that it extracts only if resource newer than dest file">
+        <!-- setup -->
+        <xdb:extract uri="${test.coll}/antunit" resource="logo.jpg" destfile="antunit/newdir/logo1.jpg" overwrite="true" user="${exist.user}" password="${exist.password}"/>
+        <xdb:extract uri="${test.coll}/antunit" resource="logo.jpg" destfile="antunit/newdir/logo2.jpg" overwrite="true" user="${exist.user}" password="${exist.password}"/>
+
+        <!-- check extract if dest files older than resource -->
+        <touch file="antunit/newdir/logo2.jpg" millis="0"/>
+        <xdb:extract uri="${test.coll}/antunit" resource="logo.jpg" destfile="antunit/newdir/logo2.jpg" user="${exist.user}" password="${exist.password}"/>
+        <uptodate property="updated" srcfile="antunit/newdir/logo1.jpg" targetfile="antunit/newdir/logo2.jpg"/>
+        <au:assertEquals expected="true" actual="${updated}" message="resource not extracted while dest file older than resource"/>
+
+        <!-- check no extract if dest file newer than resource -->
+        <xdb:extract uri="${test.coll}/antunit" resource="logo.jpg" destfile="antunit/newdir/logo1.jpg" user="${exist.user}" password="${exist.password}"/>
+        <uptodate property="updated" srcfile="antunit/newdir/logo1.jpg" targetfile="antunit/newdir/logo2.jpg"/>
+        <au:assertEquals expected="true" actual="${updated}" message="resource extracted while dest file newer than resource"/>
+     </target>
 
      <target name="problem_overwritedirs_XMLDBExtract" description="repeat extract dir/file test to test overwritedirs property">
 


### PR DESCRIPTION
When destination file already exists, it compares the timestamps of resource and destination file and, by default, extracts the resource only if it is newer than the destination file.
