### PR TITLE
[bugfix] New range index incorrectly processed != like =

### DIFF
--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndex.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndex.java
@@ -49,6 +49,7 @@ public class RangeIndex extends LuceneIndex {
         EQ ("eq"),
         GE ("ge"),
         LE ("le"),
+        NE ("ne"),
         ENDS_WITH ("ends-with"),
         STARTS_WITH ("starts-with"),
         CONTAINS ("contains"),

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/FieldLookup.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/FieldLookup.java
@@ -73,6 +73,14 @@ public class FieldLookup extends Function implements Optimizable {
             true
         ),
         new FunctionSignature(
+            new QName("field-ne", RangeIndexModule.NAMESPACE_URI, RangeIndexModule.PREFIX),
+            "General field lookup function based on non-equality comparison. Normally this will be used by the query optimizer.",
+            PARAMETER_TYPE,
+            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
+                    "all nodes from the field set whose node value is not equal to the key."),
+            true
+        ),
+        new FunctionSignature(
             new QName("field-gt", RangeIndexModule.NAMESPACE_URI, RangeIndexModule.PREFIX),
                 "General field lookup function based on greater-than comparison. Normally this will be used by the query optimizer.",
             PARAMETER_TYPE,

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/Lookup.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/Lookup.java
@@ -39,6 +39,7 @@ import org.exist.xquery.value.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -89,6 +90,13 @@ public class Lookup extends Function implements Optimizable {
             PARAMETER_TYPE,
             new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
                     "all nodes from the input node set whose node value is equal to the key.")
+        ),
+        new FunctionSignature(
+            new QName("ne", RangeIndexModule.NAMESPACE_URI, RangeIndexModule.PREFIX),
+            DESCRIPTION,
+            PARAMETER_TYPE,
+            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
+                    "all nodes from the input node set whose node value is not equal to the key.")
         ),
         new FunctionSignature(
             new QName("starts-with", RangeIndexModule.NAMESPACE_URI, RangeIndexModule.PREFIX),

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeIndexModule.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeIndexModule.java
@@ -45,6 +45,7 @@ public class RangeIndexModule extends AbstractInternalModule {
         new FunctionDef(Lookup.signatures[6], Lookup.class),
         new FunctionDef(Lookup.signatures[7], Lookup.class),
         new FunctionDef(Lookup.signatures[8], Lookup.class),
+        new FunctionDef(Lookup.signatures[9], Lookup.class),
         new FunctionDef(FieldLookup.signatures[0], FieldLookup.class),
         new FunctionDef(FieldLookup.signatures[1], FieldLookup.class),
         new FunctionDef(FieldLookup.signatures[2], FieldLookup.class),
@@ -55,6 +56,7 @@ public class RangeIndexModule extends AbstractInternalModule {
         new FunctionDef(FieldLookup.signatures[7], FieldLookup.class),
         new FunctionDef(FieldLookup.signatures[8], FieldLookup.class),
         new FunctionDef(FieldLookup.signatures[9], FieldLookup.class),
+        new FunctionDef(FieldLookup.signatures[10], FieldLookup.class),
         new FunctionDef(Optimize.signature, Optimize.class),
         new FunctionDef(IndexKeys.signatures[0], IndexKeys.class),
         new FunctionDef(IndexKeys.signatures[1], IndexKeys.class)
@@ -67,6 +69,7 @@ public class RangeIndexModule extends AbstractInternalModule {
         OPERATOR_MAP.put("gt", RangeIndex.Operator.GT);
         OPERATOR_MAP.put("ge", RangeIndex.Operator.GE);
         OPERATOR_MAP.put("le", RangeIndex.Operator.LE);
+        OPERATOR_MAP.put("ne", RangeIndex.Operator.NE);
         OPERATOR_MAP.put("starts-with", RangeIndex.Operator.STARTS_WITH);
         OPERATOR_MAP.put("ends-with", RangeIndex.Operator.ENDS_WITH);
         OPERATOR_MAP.put("contains", RangeIndex.Operator.CONTAINS);

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeQueryRewriter.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeQueryRewriter.java
@@ -204,6 +204,10 @@ public class RangeQueryRewriter extends QueryRewriter {
                             break;
                     }
                     break;
+                case Constants.NEQ:
+                    operator = RangeIndex.Operator.NE;
+                    break;
+
             }
         } else if (expr instanceof InternalFunctionCall) {
             InternalFunctionCall fcall = (InternalFunctionCall) expr;

--- a/extensions/indexes/range/test/src/xquery/optimizer.xql
+++ b/extensions/indexes/range/test/src/xquery/optimizer.xql
@@ -127,6 +127,30 @@ function ot:optimize-eq-string($name as xs:string) {
 
 declare
     %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2]")
+function ot:optimize-ne-string($name as xs:string) {
+    collection($ot:COLLECTION)//address[name != $name]
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2]")
+function ot:optimize-ne-string2($name as xs:string) {
+    collection($ot:COLLECTION)//address[name ne $name]
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2]")
+function ot:optimize-ne-string-self($name as xs:string) {
+    collection($ot:COLLECTION)//address/name[. ne $name]
+};
+
+declare
+    %test:stats
     %test:args("Rudi")
     %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2]")
 function ot:optimize-starts-with-string($name as xs:string) {
@@ -179,6 +203,20 @@ declare
     %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2]")
 function ot:optimize-lt-string($name as xs:string) {
     collection($ot:COLLECTION)//address[name < $name]
+};
+
+declare
+    %test:args("Rudi Rüssel")
+    %test:assertEquals(3)
+function ot:ne-string($name as xs:string) {
+    count(collection($ot:COLLECTION)//address[name != $name])
+};
+
+declare
+    %test:args("Rudi Rüssel")
+    %test:assertEquals(3)
+function ot:ne-string-self($name as xs:string) {
+    count(collection($ot:COLLECTION)//address/name[. != $name])
 };
 
 declare
@@ -246,6 +284,21 @@ declare
     %test:assertEquals(1)
 function ot:eq-field($city as xs:string) {
     count(collection($ot:COLLECTION)//address[city = $city])
+};
+
+declare
+    %test:stats
+    %test:args("Rüsselsheim")
+    %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2]")
+function ot:optimize-ne-field($city as xs:string) {
+    collection($ot:COLLECTION)//address[city != $city]
+};
+
+declare
+    %test:args("Rüsselsheim")
+    %test:assertEquals(3)
+function ot:ne-field($city as xs:string) {
+    count(collection($ot:COLLECTION)//address[city != $city])
 };
 
 declare


### PR DESCRIPTION
Optimiser did rewrite comparisons using the != or ne operator. However, the index did not support this operator and replaced it by =, leading to wrong query results!