### PR TITLE
Better expath compatibility checks

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -6,7 +6,8 @@
 project.name = eXist-db
 project.version = 2.3dev
 project.version.numeric = 2.3.0
-project.codename = Ruesselsheim
+project.source = develop
+project.codename = Berlin
 
 # build settings
 build.debug = on

--- a/build.properties
+++ b/build.properties
@@ -4,8 +4,8 @@
 #
 # $Id$
 project.name = eXist-db
-project.version = 2.2
-project.version.numeric = 2.2
+project.version = 2.3dev
+project.version.numeric = 2.3.0
 project.codename = Ruesselsheim
 
 # build settings

--- a/build/scripts/build-impl.xml
+++ b/build/scripts/build-impl.xml
@@ -270,6 +270,7 @@
     <target name="jar" depends="git.details,compile,compile-aspectj"
         description="Create eXist-db unsigned jar files">
         <filter token="version" value="${project.version}"/>
+	<filter token="semver" value="${project.version.numeric}"/>
         <filter token="build" value="${DSTAMP}"/>
         <filter token="git.commit" value="${git.commit}"/>
 

--- a/build/scripts/build-impl.xml
+++ b/build/scripts/build-impl.xml
@@ -271,6 +271,7 @@
         description="Create eXist-db unsigned jar files">
         <filter token="version" value="${project.version}"/>
 	<filter token="semver" value="${project.version.numeric}"/>
+	<filter token="source" value="${project.source}"/>
         <filter token="build" value="${DSTAMP}"/>
         <filter token="git.commit" value="${git.commit}"/>
 

--- a/src/org/exist/repo/ClasspathHelper.java
+++ b/src/org/exist/repo/ClasspathHelper.java
@@ -2,13 +2,16 @@ package org.exist.repo;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.SystemProperties;
 import org.exist.start.Classpath;
 import org.exist.start.EXistClassLoader;
 import org.exist.storage.BrokerPool;
 import org.expath.pkg.repo.*;
 import org.expath.pkg.repo.Package;
+import org.expath.pkg.repo.deps.ProcessorDependency;
 
 import java.io.*;
+import java.util.Collection;
 
 /**
  * Helper class to construct classpath for expath modules containing
@@ -17,6 +20,9 @@ import java.io.*;
 public class ClasspathHelper {
 
     private final static Logger LOG = LogManager.getLogger(ClasspathHelper.class);
+
+    // if no eXist version is specified in the expath-pkg.xml, we assume it is 2.2 or older
+    private final static PackageLoader.Version DEFAULT_VERSION = new PackageLoader.Version("1.4.0", "2.2.1");
 
     public static void updateClasspath(BrokerPool pool) {
         final ClassLoader loader = pool.getClassLoader();
@@ -27,10 +33,15 @@ public class ClasspathHelper {
         ((EXistClassLoader)loader).addURLs(cp);
     }
 
-    public static void updateClasspath(BrokerPool pool, org.expath.pkg.repo.Package pkg) {
+    public static void updateClasspath(BrokerPool pool, org.expath.pkg.repo.Package pkg) throws PackageException {
         final ClassLoader loader = pool.getClassLoader();
         if (!(loader instanceof EXistClassLoader))
             {return;}
+        if (!isCompatible(pkg)) {
+            LOG.warn("Package " + pkg.getName() + " is not compatible with this version of eXist. " +
+                "To avoid conflicts, Java libraries shipping with this package are not loaded.");
+            return;
+        }
         final FileSystemStorage.FileSystemResolver resolver = (FileSystemStorage.FileSystemResolver) pkg.getResolver();
         final File packageDir = resolver.resolveResourceAsFile(".");
         final Classpath cp = new Classpath();
@@ -47,17 +58,42 @@ public class ClasspathHelper {
             final ExistRepository repo = pool.getExpathRepo();
             for (final Packages pkgs : repo.getParentRepo().listPackages()) {
                 final Package pkg = pkgs.latest();
-                try {
-                    final FileSystemStorage.FileSystemResolver resolver = (FileSystemStorage.FileSystemResolver) pkg.getResolver();
-                    final File packageDir = resolver.resolveResourceAsFile(".");
-                    scanPackageDir(classpath, packageDir);
-                } catch (final IOException e) {
-                    LOG.warn("An error occurred while updating classpath for package " + pkg.getName(), e);
+                if (!isCompatible(pkg)) {
+                    LOG.warn("Package " + pkg.getName() + " is not compatible with this version of eXist. " +
+                            "To avoid conflicts, Java libraries shipping with this package are not loaded.");
+                } else {
+                    try {
+                        final FileSystemStorage.FileSystemResolver resolver = (FileSystemStorage.FileSystemResolver) pkg.getResolver();
+                        final File packageDir = resolver.resolveResourceAsFile(".");
+                        scanPackageDir(classpath, packageDir);
+                    } catch (final IOException e) {
+                        LOG.warn("An error occurred while updating classpath for package " + pkg.getName(), e);
+                    }
                 }
             }
         } catch (final Exception e) {
             LOG.warn("An error occurred while updating classpath for packages", e);
         }
+    }
+
+    private static boolean isCompatible(Package pkg) throws PackageException {
+        // determine the eXistdb version this package is compatible with
+        final Collection<ProcessorDependency> processorDeps = pkg.getProcessorDeps();
+        final String procVersion = SystemProperties.getInstance().getSystemProperty("product-semver", "1.0");
+        PackageLoader.Version processorVersion = DEFAULT_VERSION;
+        for (ProcessorDependency dependency: processorDeps) {
+            if (Deployment.PROCESSOR_NAME.equals(dependency.getProcessor())) {
+                if (dependency.getSemver() != null) {
+                    processorVersion = new PackageLoader.Version(dependency.getSemver(), true);
+                } else if (dependency.getSemverMax() != null || dependency.getSemverMin() != null) {
+                    processorVersion = new PackageLoader.Version(dependency.getSemverMin(), dependency.getSemverMax());
+                } else if (dependency.getVersions() != null) {
+                    processorVersion = new PackageLoader.Version(dependency.getVersions(), false);
+                }
+                break;
+            }
+        }
+        return processorVersion.getDependencyVersion().isCompatible(procVersion);
     }
 
     private static void scanPackageDir(Classpath classpath, File module) throws IOException {

--- a/src/org/exist/system.properties
+++ b/src/org/exist/system.properties
@@ -2,5 +2,6 @@ vendor=eXist-db Project
 vendor-url=http://exist-db.org
 product-name=eXist
 product-version=@version@
+product-semver=@semver@
 product-build=@build@
 git-commit=@git.commit@


### PR DESCRIPTION
Avoid installing incompatible Java packages from the package repo. Right now there is no protection against installing a xar package containing incompatible Java libraries.

This PR handles two scenarios:

1. the user tries to install an incompatible xar package: enforce checks of semver-min/-max during deployment. Refuse to deploy a package which indicates to be incompatible with the current eXistdb build.
2. the user updates an eXistdb built from git and has some old xar packages installed: this is the worst case because it will likely mess up the class loader, leading to a broken eXist install. Fix: make the class loader ignore jars from packages defining a version dependency not compatible with the semver of the current eXistdb build.

With this PR, package authors can finally provide different xar package versions for different builds of eXistdb. For example, a xar may define a dependency on the 2.2.x series of eXist by adding the following line to expath-pkg.xml:

```xquery
<dependency processor="http://exist-db.org" semver-max="2.2"/>
```

The next version of the xar may then define:

```xquery
<dependency processor="http://exist-db.org" semver-min="2.3.0"/>
```

so it will be chosen for eXistdb > 2.3.0. Because older versions of eXist do not report a usable version number, the code assumes 2.2.0.

This pull request will be complemented by changes to the public app repository and the dashboard: both should only offer compatible xar packages for deployment.

Closes #559.