### PR TITLE
add missing space in log output

### DIFF
--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/ExistXqueryRegistry.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/ExistXqueryRegistry.java
@@ -290,7 +290,7 @@ public class ExistXqueryRegistry {
                     final List<RestXqService> services = findServices(broker, dependantModule);
                     registerServices(broker, services);
                 } else {
-                    LOG.info("Dependant '" + compiledModuleUri + "' has been resolved. Dependency on: " + dependant + "was removed");
+                    LOG.info("Dependant '" + compiledModuleUri + "' has been resolved. Dependency on: " + dependant + " was removed");
                     
                     //we need to remove dependant from the dependenciesTree of dependant
                     removeDependency(dependant, compiledModuleUri);


### PR DESCRIPTION
reexamineModulesWithResolvedDependencies:293 logged information with a missing space:

> Dependant '/db/apps/hsg/api/content.xqm' has been resolved. Dependency on: /db/apps/hsg/api/urls.xqmwas removed

This adds a space, e.g., between "urls.xqm" and "was"