### PR TITLE
[bugfix] Memory leak in ValueSequence

### DIFF
--- a/src/org/exist/xquery/value/ValueSequence.java
+++ b/src/org/exist/xquery/value/ValueSequence.java
@@ -111,7 +111,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
             add(item);
         }
     }
-    
+
     public void keepUnOrdered(boolean flag) {
     	keepUnOrdered = flag;
     }
@@ -361,6 +361,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 
     @Override
     public void destroy(XQueryContext context, Sequence contextSequence) {
+        holderVar = null;
         for (int i = 0; i <= size; i++) {
             values[i].destroy(context, contextSequence);
         }


### PR DESCRIPTION
ValueSequence keeps reference to query variable, which is thus not garbage collected. This dramatically increases the memory footprint of the sequence and may easily lead to out of memory issues if the sequence is stored into e.g. an HTTP session. Fix by cleaning up the reference when the sequence runs out of scope.

A small fix with huge impact... Closes #574