### PR TITLE
[bugfix] Match highlighting failed for lucene prefix query

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
@@ -189,7 +189,7 @@ public class LuceneUtil {
     }
 
     private static void extractTermsFromPrefix(PrefixQuery query, Map<Object, Query> terms, IndexReader reader, boolean includeFields) throws IOException {
-        extractTerms(query.rewrite(reader), terms, reader, includeFields);
+        extractTermsFromMultiTerm(query, terms, reader, includeFields);
     }
 
     private static void extractTermsFromPhrase(PhraseQuery query, Map<Object, Query> terms, boolean includeFields) {


### PR DESCRIPTION
Lucene automatically rewrites prefix queries matching more than a few hundred index terms. Match highlighting thus failed for those queries, leading to inconsistent behaviour.