### PR TITLE
[performance] Remove extra parentheses around context node

### DIFF
--- a/src/org/exist/xquery/LocationStep.java
+++ b/src/org/exist/xquery/LocationStep.java
@@ -1378,6 +1378,10 @@ public class LocationStep extends Step {
 		visitor.visitLocationStep(this);
 	}
 
+	public void setParent(Expression parent) {
+		this.parent = parent;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * 

--- a/test/src/xquery/optimizer/optimizer.xql
+++ b/test/src/xquery/optimizer/optimizer.xql
@@ -85,6 +85,14 @@ declare
     %test:stats
     %test:args("Rudi Rüssel")
     %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
+function ot:optimize-filter-context-step($name as xs:string) {
+    collection($ot:COLLECTION)//(address)[name = $name]/city/text()
+};
+
+declare
+    %test:stats
+    %test:args("Rudi Rüssel")
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
 function ot:optimize-sequence($name as xs:string) {
     (collection($ot:COLLECTION)//address[name = $name]/city/text(), "xxx")
 };


### PR DESCRIPTION
An expression like /a/b/(c)[. = "d"] wasn't optimized though that's easily possible.

Closes #522