### PR TITLE
JMX interface enhancements

### DIFF
--- a/src/org/exist/management/impl/ProcessReportMBean.java
+++ b/src/org/exist/management/impl/ProcessReportMBean.java
@@ -25,13 +25,55 @@ import javax.management.openmbean.TabularData;
 
 public interface ProcessReportMBean {
 
-    public TabularData getScheduledJobs();
+    TabularData getScheduledJobs();
 
-    public TabularData getRunningJobs();
+    TabularData getRunningJobs();
 
-    public TabularData getRunningQueries();
+    TabularData getRunningQueries();
 
-    public TabularData getRecentQueryHistory();
+    TabularData getRecentQueryHistory();
 
-    public void killQuery(int id);
+    void killQuery(int id);
+
+    /**
+     * Configures the recent query history.
+     *
+     * @param minTimeRecorded minimum execution time of queries recorded in the recent query history
+     * @param historyTimespan time span (in milliseconds) for which the stats for an executed query should
+     * be kept in the recent query history
+     * @param trackURI Enable request tracking: for every executed query, try to figure out which HTTP
+     * URL triggered it (if applicable)
+     */
+    void configure(long minTimeRecorded, long historyTimespan, boolean trackURI);
+
+    /**
+     * Sets the time span (in milliseconds) for which the stats for an executed query should
+     * be kept in the recent query history.
+     *
+     * @param time
+     */
+    void setHistoryTimespan(long time);
+
+    long getHistoryTimespan();
+
+    /**
+     * Sets the minimum execution time of queries recorded in the recent query history.
+     * Queries faster than this are not recorded.
+     *
+     * @param time
+     */
+    void setMinTime(long time);
+
+    long getMinTime();
+
+    /**
+     * Enable request tracking: for every executed query, try to figure out which HTTP
+     * URL triggered it (if applicable). For performance reasons this is disabled by default,
+     * though the overhead should be small.
+     *
+     * @param track
+     */
+    void setTrackRequestURI(boolean track);
+
+    boolean getTrackRequestURI();
 }

--- a/src/org/exist/xquery/XQuery.java
+++ b/src/org/exist/xquery/XQuery.java
@@ -308,11 +308,12 @@ public class XQuery {
                 return result;
             } finally {
                 context.getProfiler().traceQueryEnd(context);
+                // track query stats before context is reset
+                broker.getBrokerPool().getProcessMonitor().queryCompleted(context.getWatchDog());
                 expression.reset();
                 if(resetContext) {
                     context.reset();
                 }
-                broker.getBrokerPool().getProcessMonitor().queryCompleted(context.getWatchDog());
             }
             
         } finally {

--- a/src/org/exist/xquery/XQueryWatchDog.java
+++ b/src/org/exist/xquery/XQueryWatchDog.java
@@ -57,7 +57,9 @@ public class XQueryWatchDog {
     private long startTime;
     
     private boolean terminate = false;
-    
+
+    private String runningThread = null;
+
     /**
      * 
      */
@@ -66,7 +68,26 @@ public class XQueryWatchDog {
         configureDefaults();
         reset();
     }
-    
+
+    /**
+     * Track the name of the thread currently running this query.
+     * Used for JMX stats.
+     *
+     * @param name
+     */
+    public void setRunningThread(String name) {
+        this.runningThread = name;
+    }
+
+    /**
+     * Get the name of last thread which has been running this query.
+     *
+     * @return
+     */
+    public String getRunningThread() {
+        return runningThread;
+    }
+
     private void configureDefaults() {
     	final DBBroker broker = context.getBroker();
         final Configuration conf = broker.getBrokerPool().getConfiguration();


### PR DESCRIPTION
Fix and extend JMX interface to provide more information required to diagnose bottlenecks on a live production system: 

1. use DelayQueue for recent query log, so it shows all queries during the past X minutes which were slower than X ms (configurable)
2. add thread names, so query stacks, lock manager output and thread dumps can be connected
3. optional: log the URI which triggered an xquery where possible

The changes were made during the past months while analyzing runtime issues on real production systems. They fill in some missing bits and pieces which are required to diagnose performance and concurrency issues.

monex 0.8 is able to display the additional information, though any jmx client will work (or just call /exist/status to get an XML dump).