### PR TITLE
[performance] Sequence type checks

### DIFF
--- a/src/org/exist/dom/persistent/NodeProxy.java
+++ b/src/org/exist/dom/persistent/NodeProxy.java
@@ -40,15 +40,7 @@ import org.exist.xquery.Expression;
 import org.exist.xquery.NodeTest;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
-import org.exist.xquery.value.AtomicValue;
-import org.exist.xquery.value.Item;
-import org.exist.xquery.value.MemoryNodeSet;
-import org.exist.xquery.value.NodeValue;
-import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceIterator;
-import org.exist.xquery.value.StringValue;
-import org.exist.xquery.value.Type;
-import org.exist.xquery.value.UntypedAtomicValue;
+import org.exist.xquery.value.*;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -117,6 +109,8 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     private Match match = null;
 
     private ContextItem context = null;
+
+    private QName qname = null;
 
     /**
      * Creates a new <code>NodeProxy</code> instance.
@@ -204,6 +198,18 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     @Override
     public NodeId getNodeId() {
         return nodeId;
+    }
+
+    @Override
+    public QName getQName() {
+        if (qname == null) {
+            getNode();
+        }
+        return qname;
+    }
+
+    public void setQName(QName qname) {
+        this.qname = qname;
     }
 
     @Override
@@ -338,6 +344,7 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
             final NodeImpl realNode = (NodeImpl) doc.getNode(this);
             if(realNode != null) {
                 this.nodeType = realNode.getNodeType();
+                this.qname = realNode.getQName();
             }
             return realNode;
         }

--- a/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
+++ b/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
@@ -101,7 +101,7 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
     public NodeSet findElementsByTagName(byte type, DocumentSet docs, QName qname, NodeSelector selector, Expression parent) {
         final Lock lock = index.btree.getLock();
         final NewArrayNodeSet result = new NewArrayNodeSet();
-        final FindElementsCallback callback = new FindElementsCallback(type, result, docs, selector, parent);
+        final FindElementsCallback callback = new FindElementsCallback(type, qname, result, docs, selector, parent);
 
         // for each document id range, scan the index to find matches
         for (final Range range : getDocIdRanges(docs)) {
@@ -179,7 +179,7 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
     public NodeSet findDescendantsByTagName(byte type, QName qname, int axis, DocumentSet docs, NodeSet contextSet, int contextId, Expression parent) {
         final Lock lock = index.btree.getLock();
         final NewArrayNodeSet result = new NewArrayNodeSet();
-        final FindDescendantsCallback callback = new FindDescendantsCallback(type, axis, contextId, result, parent);
+        final FindDescendantsCallback callback = new FindDescendantsCallback(type, axis, qname, contextId, result, parent);
         try {
             lock.acquire(Lock.READ_LOCK);
             for (final NodeProxy ancestor : contextSet) {
@@ -259,7 +259,7 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
     		NodeSet contextSet, int contextId) {
         final Lock lock = index.btree.getLock();
         final NewArrayNodeSet result = new NewArrayNodeSet();
-        final FindDescendantsCallback callback = new FindDescendantsCallback(type, axis, contextId, useSelfAsContext, result, null);
+        final FindDescendantsCallback callback = new FindDescendantsCallback(type, axis, null, contextId, useSelfAsContext, result, null);
         for (final NodeProxy ancestor : contextSet) {
             final DocumentImpl doc = ancestor.getOwnerDocument();
             final NodeId ancestorId = ancestor.getNodeId();
@@ -297,17 +297,23 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
     
     private class FindElementsCallback implements BTreeCallback {
         byte type;
+        QName qname;
         DocumentSet docs;
         NewArrayNodeSet result;
         NodeSelector selector;
         Expression parent;
 
-        FindElementsCallback(byte type, NewArrayNodeSet result, DocumentSet docs, NodeSelector selector, Expression parent) {
+        FindElementsCallback(byte type, QName qname, NewArrayNodeSet result, DocumentSet docs, NodeSelector selector, Expression parent) {
             this.type = type;
             this.result = result;
             this.docs = docs;
             this.selector = selector;
             this.parent = parent;
+            if (qname.getNameType() != type) {
+                this.qname = new QName(qname.getLocalPart(), qname.getNamespaceURI(), qname.getPrefix(), type);
+            } else {
+                this.qname = qname;
+            }
         }
 
         public boolean indexInfo(Value value, long pointer) throws TerminatedException {
@@ -321,12 +327,18 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
                 if (selector == null) {
                     final NodeProxy storedNode = new NodeProxy(doc, nodeId,
                         type == ElementValue.ATTRIBUTE ? Node.ATTRIBUTE_NODE : Node.ELEMENT_NODE, pointer);
+                    if (qname != null) {
+                        storedNode.setQName(qname);
+                    }
                     result.add(storedNode);
                 } else {
                     final NodeProxy storedNode = selector.match(doc, nodeId);
                     if (storedNode != null) {
                         storedNode.setNodeType(type == ElementValue.ATTRIBUTE ? Node.ATTRIBUTE_NODE : Node.ELEMENT_NODE);
                         storedNode.setInternalAddress(pointer);
+                        if (qname != null) {
+                            storedNode.setQName(qname);
+                        }
                         result.add(storedNode);
                     }
                 }
@@ -338,6 +350,7 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
     private class FindDescendantsCallback implements BTreeCallback {
         int axis;
         byte type;
+        QName qname;
         NodeProxy ancestor;
         DocumentImpl doc;
         int contextId;
@@ -345,17 +358,22 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
         boolean selfAsContext = false;
         Expression parent;
 
-        FindDescendantsCallback(byte type, int axis, int contextId, NewArrayNodeSet result, Expression parent) {
-        	this(type, axis, contextId, false, result, parent);
-        };
+        FindDescendantsCallback(byte type, int axis, QName qname, int contextId, NewArrayNodeSet result, Expression parent) {
+        	this(type, axis, qname, contextId, false, result, parent);
+        }
         
-        FindDescendantsCallback(byte type, int axis, int contextId, boolean selfAsContext, NewArrayNodeSet result, Expression parent) {
+        FindDescendantsCallback(byte type, int axis, QName qname, int contextId, boolean selfAsContext, NewArrayNodeSet result, Expression parent) {
             this.type = type;
             this.axis = axis;
             this.contextId = contextId;
             this.result = result;
             this.selfAsContext = selfAsContext;
             this.parent = parent;
+            if (qname.getNameType() != type) {
+                this.qname = new QName(qname.getLocalPart(), qname.getNamespaceURI(), qname.getPrefix(), type);
+            } else {
+                this.qname = qname;
+            }
         }
 
         void setAncestor(DocumentImpl doc, NodeProxy ancestor) {
@@ -378,6 +396,9 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
             if (match) {
                 final NodeProxy storedNode =
                     new NodeProxy(doc, nodeId, type == ElementValue.ATTRIBUTE ? Node.ATTRIBUTE_NODE : Node.ELEMENT_NODE, pointer);
+                if (qname != null) {
+                    storedNode.setQName(qname);
+                }
                 result.add(storedNode);
                 if (Expression.NO_CONTEXT_ID != contextId) {
                 	if (selfAsContext)

--- a/src/org/exist/xquery/value/NodeValue.java
+++ b/src/org/exist/xquery/value/NodeValue.java
@@ -22,6 +22,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.dom.QName;
 import org.exist.numbering.NodeId;
 import org.exist.xquery.XPathException;
 import org.w3c.dom.Document;
@@ -77,7 +78,8 @@ public interface NodeValue extends Item, Sequence {
 	
     public void addContextNode(int contextId, NodeValue node);
     
-    
+    public QName getQName();
+
 	/** Retrieve the actual node. This operation is <strong>expensive</strong>.
 	 * @return The actual node.
 	 */

--- a/src/org/exist/xquery/value/SequenceType.java
+++ b/src/org/exist/xquery/value/SequenceType.java
@@ -124,14 +124,13 @@ public class SequenceType {
 			{return false;}
 		if(nodeName != null) {
 			//TODO : how to improve performance ?
-            if (realNode == null)
-                {realNode = ((NodeValue)item).getNode();}
+            final QName realName = ((NodeValue)item).getQName();
 			if (nodeName.getNamespaceURI() != null) {
-				if (!nodeName.getNamespaceURI().equals(realNode.getNamespaceURI()))
+				if (!nodeName.getNamespaceURI().equals(realName.getNamespaceURI()))
 					{return false;}
 			}
 			if (nodeName.getLocalPart() != null) {
-				return nodeName.getLocalPart().equals(realNode.getLocalName());
+				return nodeName.getLocalPart().equals(realName.getLocalPart());
 			}
 		}
 		return true;


### PR DESCRIPTION
Sequence type checks cause node names to be loaded repeatedly. Results in severe performance loss in recursive functions if parameters are typed (as they should be), because the same nodes may be loaded over and over again. 

Fix by caching the node name where available. Preserve known node names when using structural index lookup.