### PR TITLE
Closure variable bug

### DIFF
--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -2079,9 +2079,9 @@ public class XQueryContext implements BinaryValueManager, Context
      * @throws XPathException
      */
     public void restoreStack(List<Variable> stack) throws XPathException {
-    	for (final Variable var : stack) {
-    		declareVariableBinding((LocalVariable) var);
-    	}
+        for (int i = stack.size() - 1; i > -1; i--) {
+            declareVariableBinding((LocalVariable)stack.get(i));
+        }
     }
     
     /**
@@ -2584,7 +2584,7 @@ public class XQueryContext implements BinaryValueManager, Context
             // clear all variables registered after var. they should be out of scope.
             LocalVariable outOfScope = var.after;
             while (outOfScope != null) {
-                if (!outOfScope.isClosureVar()) {
+                if (outOfScope != var && !outOfScope.isClosureVar()) {
                     outOfScope.destroy(this, resultSeq);
                 }
                 outOfScope = outOfScope.after;

--- a/test/src/xquery/xquery3/higher-order.xml
+++ b/test/src/xquery/xquery3/higher-order.xml
@@ -736,4 +736,14 @@ return
     $f()]]></code>
         <expected>1 2 3 4 5 6 7 8 9 10</expected>
     </test>
+    <test output="text">
+        <task>Closure test: redefined variable</task>
+        <code><![CDATA[xquery version "3.0";
+
+let $a := ()
+let $a := if ($a) then $a else "b"
+return
+    function() { $a }()]]></code>
+        <expected>b</expected>
+    </test>
 </TestSet>


### PR DESCRIPTION
Closure variables were restored in reverse order when calling inline function, so variable lookups got messed up. Closes #683