### PR TITLE
NPE in structural index

### DIFF
--- a/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
+++ b/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
@@ -309,7 +309,7 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
             this.docs = docs;
             this.selector = selector;
             this.parent = parent;
-            if (qname.getNameType() != type) {
+            if (qname != null && qname.getNameType() != type) {
                 this.qname = new QName(qname.getLocalPart(), qname.getNamespaceURI(), qname.getPrefix(), type);
             } else {
                 this.qname = qname;
@@ -369,7 +369,7 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
             this.result = result;
             this.selfAsContext = selfAsContext;
             this.parent = parent;
-            if (qname.getNameType() != type) {
+            if (qname != null && qname.getNameType() != type) {
                 this.qname = new QName(qname.getLocalPart(), qname.getNamespaceURI(), qname.getPrefix(), type);
             } else {
                 this.qname = qname;


### PR DESCRIPTION
NPE in structural index caused by 3410c6b. Forgot to commit the change, sorry. Test suite fails.