### PR TITLE
normalize-unicode fix

### DIFF
--- a/test/src/xquery/fn.xql
+++ b/test/src/xquery/fn.xql
@@ -1,0 +1,24 @@
+xquery version "3.0";
+
+module namespace fnt="http://exist-db.org/test/fn";
+
+import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+declare variable $fnt:composed := '&#x00C5;&#x0073;&#x0074;&#x0072;&#x00F6;&#x006D;';
+declare variable $fnt:decomposed := '&#x0041;&#x030A;&#x0073;&#x0074;&#x0072;&#x006F;&#x0308;&#x006D;';
+
+declare 
+    %test:args("NFC")
+    %test:assertEquals(6, 6)
+    %test:args("NFD")
+    %test:assertEquals(8, 8)
+    %test:args("NFKD")
+    %test:assertEquals(8, 8)
+    %test:args("NFKC")
+    %test:assertEquals(6, 6)
+    %test:args("XYZ")
+    %test:assertError
+function fnt:normalize-unicode($normalization-form as xs:string) {
+    count(string-to-codepoints(normalize-unicode($fnt:composed, $normalization-form))),
+    count(string-to-codepoints(normalize-unicode($fnt:decomposed, $normalization-form)))
+};

--- a/test/src/xquery/suite.xql
+++ b/test/src/xquery/suite.xql
@@ -9,5 +9,6 @@ test:suite((
     inspect:module-functions(xs:anyURI("positional.xql")),
     inspect:module-functions(xs:anyURI("count.xql")),
     inspect:module-functions(xs:anyURI("serializer.xql")),
-    inspect:module-functions(xs:anyURI("comments.xql"))
+    inspect:module-functions(xs:anyURI("comments.xql")),
+    inspect:module-functions(xs:anyURI("fn.xql"))
 ))


### PR DESCRIPTION
normalize-unicode had no effect even though icu4j was called. Java now supports normalization out of the box, so replace the current, complex code which depends on icu4j being installed. java.text.Normalizer is straightforward to use and works as expected.

Closes #443