### PR TITLE
Deadlock when storing binary resource

### DIFF
--- a/src/org/exist/collections/Collection.java
+++ b/src/org/exist/collections/Collection.java
@@ -1850,7 +1850,29 @@ public class Collection extends Observable implements Comparable<Collection>, Ca
         return new BinaryDocument(broker.getBrokerPool(), this, docUri);
     }
 
-    // Streaming
+    /**
+     * Store a binary resource by reading the given InputStream.
+     *
+     * Locks the collection while the resource is being saved. Triggers will be called after the collection
+     * has been unlocked while keeping a lock on the resource to prevent modification.
+     *
+     * Callers should not lock the collection before calling this method as this may lead to deadlocks.
+     *
+     * @param transaction the transaction to use
+     * @param broker current broker
+     * @param blob the binary resource to store the data into
+     * @param is the input stream to read data from
+     * @param mimeType mime-type for the data
+     * @param size size hint to be stored with metadata
+     * @param created creation timestamp
+     * @param modified last modified timestamp
+     * @return the updated binary document
+     * @throws EXistException
+     * @throws PermissionDeniedException
+     * @throws LockException
+     * @throws TriggerException
+     * @throws IOException
+     */
     public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final BinaryDocument blob, final InputStream is, final String mimeType, final long size, final Date created, final Date modified) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
         final Database db = broker.getBrokerPool();
         if (db.isReadOnly()) {

--- a/src/org/exist/repo/Deployment.java
+++ b/src/org/exist/repo/Deployment.java
@@ -605,16 +605,7 @@ public class Deployment {
             LOG.warn(e);
         }
 
-        try {
-            // lock the collection while we store the files
-            // TODO: could be released after each operation
-            collection.getLock().acquire(Lock.WRITE_LOCK);
-            storeFiles(directory, collection, inRootDir);
-        } catch (final LockException e) {
-            e.printStackTrace();
-        } finally {
-            collection.getLock().release(Lock.WRITE_LOCK);
-        }
+        storeFiles(directory, collection, inRootDir);
 
         // scan sub directories
         final File[] files = directory.listFiles();


### PR DESCRIPTION
Storing a binary resource caused a deadlock when the after*Document trigger was called, in particular if that trigger tried to lock another collection (as the restxq trigger inevitably does when compiling imported modules). The deadlock occurs most often when installing xar packages into the db (because many XQuery scripts are updated), but it may also be triggered in other situations.

Fix: Collection.addBinaryResource must release the collection lock before calling any after* triggers. Instead it keeps a read lock on the document to prevent concurrent modification.

Also, the package collection should not remain locked while files are being installed. This is another source of potential deadlocks, but at least limits concurrency.