### PR TITLE
[bugfix] array:tail incorrectly unwraps nested array.

### DIFF
--- a/src/org/exist/xquery/functions/array/ArrayType.java
+++ b/src/org/exist/xquery/functions/array/ArrayType.java
@@ -87,7 +87,7 @@ public class ArrayType extends FunctionReference implements Lookup.LookupSupport
     public Sequence tail() throws XPathException {
         if (vector.length() == 2) {
             final Sequence tail = vector.nth(1);
-            return tail.getItemType() == Type.ARRAY ? tail : new ArrayType(context, tail);
+            return new ArrayType(context, tail);
         }
         return new ArrayType(context, RT.subvec(vector, 1, vector.length()));
     }

--- a/test/src/xquery/arrays/arrays.xql
+++ b/test/src/xquery/arrays/arrays.xql
@@ -265,7 +265,7 @@ function arr:tail1() {
 declare
     %test:assertEquals(2)
 function arr:tail2() {
-    array:tail([1, [2, 3]])(1)
+    array:tail([1, [2, 3]])(1)(1)
 };
 
 declare
@@ -278,6 +278,12 @@ declare
     %test:assertError("FOAY0001")
 function arr:tail-empty() {
     array:tail([])
+};
+
+declare 
+    %test:assertEquals(2, 3)
+function arr:tail-on-array() {
+    array:tail([1,[2,3]])?*?*
 };
 
 declare


### PR DESCRIPTION
array:tail([1,[2,3]]) should return [[2, 3]].

Closes #695 