### PR TITLE
[bugfix] Correct CLASSPATH for building src from a Windows install

### DIFF
--- a/installer/scripts/build.bat
+++ b/installer/scripts/build.bat
@@ -11,7 +11,7 @@ set EXIST_HOME=$INSTALL_PATH
 
 :gotExistHome
 set ANT_HOME=%EXIST_HOME%\tools\ant
-set _LIBJARS=%CLASSPATH%;%ANT_HOME%\lib\ant-launcher.jar;%EXIST_HOME%\lib\test\junit-4.8.2.jar;%JAVA_HOME%\lib\tools.jar
+set _LIBJARS=%CLASSPATH%;%ANT_HOME%\lib\ant-launcher-1.9.4.jar;%EXIST_HOME%\lib\test\junit-4.12.jar;%JAVA_HOME%\lib\tools.jar
 
 set JAVA_ENDORSED_DIRS=%EXIST_HOME%\lib\endorsed
 


### PR DESCRIPTION
Was missed from - https://github.com/eXist-db/exist/commit/e6027f3c19ae21acf61fbe65d74a3c04152394f8