### PR TITLE
Feature/bugfix namespace stack

### DIFF
--- a/src/org/exist/xquery/ModuleContext.java
+++ b/src/org/exist/xquery/ModuleContext.java
@@ -515,14 +515,17 @@ public class ModuleContext extends XQueryContext {
         parentContext.declareInScopeNamespace(prefix, uri);
     }
 
+    @Override
     public void pushInScopeNamespaces(boolean inherit) {
         parentContext.pushInScopeNamespaces(inherit);
     }
 
+    @Override
     public void pushInScopeNamespaces() {
         parentContext.pushInScopeNamespaces();
     }
 
+    @Override
     public void popInScopeNamespaces() {
         parentContext.popInScopeNamespaces();
     }

--- a/src/org/exist/xquery/XPathException.java
+++ b/src/org/exist/xquery/XPathException.java
@@ -42,11 +42,19 @@ public class XPathException extends Exception {
 
     private XACMLSource source = null;
 
+    /**
+     * @deprecated Use a constructor with errorCode
+     */
+    @Deprecated
     public XPathException(String message) {
         super();
         this.message = message;
     }
 
+    /**
+     * @deprecated Use a constructor with errorCode
+     */
+    @Deprecated
     public XPathException(int line, int column, String message) {
         super();
         this.message = message;
@@ -70,11 +78,12 @@ public class XPathException extends Exception {
     }
 
     /**
-     * Use constructor with errorCode and errorVal.
-     * 
      * @param expr XPath expression
      * @param message Exception message
+     *
+     * @deprecated Use a constructor with errorCode
      */
+    @Deprecated
     public XPathException(Expression expr, String message) {
         super();
         this.message = message;
@@ -112,7 +121,7 @@ public class XPathException extends Exception {
     }
 
     /**
-     * Use constructor with errorCode and errorVal
+     * @deprecated Use a constructor with errorCode
      */
     @Deprecated
     public XPathException(XQueryAST ast, String message) {
@@ -134,25 +143,35 @@ public class XPathException extends Exception {
         }
     }
 
+    /**
+     * @deprecated Use a constructor with errorCode
+     */
     @Deprecated
     public XPathException(Throwable cause) {
         super(cause);
     }
 
+    /**
+     * @deprecated Use a constructor with errorCode
+     */
     @Deprecated
     public XPathException(String message, Throwable cause) {
         super(cause);
         this.message = message;
     }
 
-
+    /**
+     * @deprecated Use a constructor with errorCode
+     */
+    @Deprecated
     public XPathException(Expression expr, Throwable cause) {
         this(expr, ErrorCodes.ERROR, cause.getMessage(), null, cause);
     }
 
     /**
-     * Use constructor with errorCode and errorVal
+     * @deprecated Use a constructor with errorCode
      */
+    @Deprecated
     public XPathException(Expression expr, String message, Throwable cause) {
         this(expr, ErrorCodes.ERROR, message, null, cause);
     }
@@ -201,6 +220,10 @@ public class XPathException extends Exception {
         }
     }
 
+    /**
+     * @deprecated Use a constructor with errorCode
+     */
+    @Deprecated
     protected XPathException(int line, int column, String message, Throwable cause) {
         super(cause);
         this.message = message;
@@ -208,6 +231,9 @@ public class XPathException extends Exception {
         this.column = column;
     }
 
+    /**
+     * @deprecated Use a constructor with errorCode
+     */
     @Deprecated
     public XPathException(int line, int column, Throwable cause) {
         super(cause);

--- a/src/org/exist/xquery/functions/request/GetContextPath.java
+++ b/src/org/exist/xquery/functions/request/GetContextPath.java
@@ -70,9 +70,9 @@ public class GetContextPath extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
@@ -81,7 +81,7 @@ public class GetContextPath extends BasicFunction {
             else
                 {return new StringValue(((RequestWrapper) value.getObject()).getServletPath());}
         } else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetCookieNames.java
+++ b/src/org/exist/xquery/functions/request/GetCookieNames.java
@@ -28,12 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -97,6 +92,6 @@ public class GetCookieNames extends BasicFunction {
 			return Sequence.EMPTY_SEQUENCE;
 		}
 		else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 }

--- a/src/org/exist/xquery/functions/request/GetCookieValue.java
+++ b/src/org/exist/xquery/functions/request/GetCookieValue.java
@@ -28,12 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
@@ -102,7 +97,7 @@ public class GetCookieValue extends BasicFunction {
 			return Sequence.EMPTY_SEQUENCE;
 		}
 		else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 	// TODO: remove this hack after fixing HTTP 1.1	

--- a/src/org/exist/xquery/functions/request/GetData.java
+++ b/src/org/exist/xquery/functions/request/GetData.java
@@ -83,17 +83,17 @@ public class GetData extends BasicFunction {
         final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 
         if(var == null || var.getValue() == null) {
-            throw new XPathException(this, "No request object found in the current XQuery context.");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");
         }
 
         if(var.getValue().getItemType() != Type.JAVA_OBJECT) {
-            throw new XPathException(this, "Variable $request is not bound to an Java object.");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");
         }
 
         final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 
         if(!(value.getObject() instanceof RequestWrapper)) {
-            throw new XPathException(this, "Variable $request is not bound to a Request object.");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");
         }
         final RequestWrapper request = (RequestWrapper)value.getObject();
 

--- a/src/org/exist/xquery/functions/request/GetHeader.java
+++ b/src/org/exist/xquery/functions/request/GetHeader.java
@@ -26,13 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XPathUtil;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
@@ -81,7 +75,7 @@ public class GetHeader extends BasicFunction {
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if (var == null || var.getValue() == null
 				|| var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this,
+			{throw new XPathException(this, ErrorCodes.XPDY0002,
 					"Variable $request is not bound to an Java object.");}
 
 		// get parameters
@@ -97,7 +91,7 @@ public class GetHeader extends BasicFunction {
 				return XPathUtil.javaObjectToXPath(headerValue, null, false);
 			}
 		} else
-			{throw new XPathException(
+			{throw new XPathException(this, ErrorCodes.XPDY0002,
 					"Variable $request is not bound to a Request object.");}
 	}
 }

--- a/src/org/exist/xquery/functions/request/GetHeaderNames.java
+++ b/src/org/exist/xquery/functions/request/GetHeaderNames.java
@@ -28,12 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -80,9 +75,9 @@ public class GetHeaderNames extends BasicFunction {
                 // request object is read from global variable $request
                 final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
                 if(var == null || var.getValue() == null)
-                        {throw new XPathException(this, "No request object found in the current XQuery context.");}
+                        {throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
                 if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-                        {throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+                        {throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
                 final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
                 if (value.getObject() instanceof RequestWrapper)
                 {
@@ -95,6 +90,6 @@ public class GetHeaderNames extends BasicFunction {
                         return result;
                 }
                 else
-                	{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+                	{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
         }
 }

--- a/src/org/exist/xquery/functions/request/GetHostname.java
+++ b/src/org/exist/xquery/functions/request/GetHostname.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -70,16 +65,16 @@ public class GetHostname extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		
 		if (value.getObject() instanceof RequestWrapper) {
 			return new StringValue(((RequestWrapper) value.getObject()).getRemoteHost());
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetMethod.java
+++ b/src/org/exist/xquery/functions/request/GetMethod.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -70,14 +65,14 @@ public class GetMethod extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
 			return new StringValue(((RequestWrapper) value.getObject()).getMethod());
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 }

--- a/src/org/exist/xquery/functions/request/GetParameter.java
+++ b/src/org/exist/xquery/functions/request/GetParameter.java
@@ -26,13 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XPathUtil;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
@@ -103,7 +97,7 @@ public class GetParameter extends BasicFunction {
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if (var == null || var.getValue() == null || var.getValue().getItemType() != Type.JAVA_OBJECT) {
 			if( failOnError ) {
-				throw new XPathException(this, "Variable $request is not bound to an Java object.");
+				throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");
 			} else {
 				return args[1];
 			}

--- a/src/org/exist/xquery/functions/request/GetParameterNames.java
+++ b/src/org/exist/xquery/functions/request/GetParameterNames.java
@@ -28,12 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -77,9 +72,9 @@ public class GetParameterNames extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
 			final ValueSequence result = new ValueSequence();
@@ -92,6 +87,6 @@ public class GetParameterNames extends BasicFunction {
 			}
 			return result;
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 }

--- a/src/org/exist/xquery/functions/request/GetPathInfo.java
+++ b/src/org/exist/xquery/functions/request/GetPathInfo.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -71,16 +66,16 @@ public class GetPathInfo extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
             final String path = ((RequestWrapper) value.getObject()).getPathInfo();
             return new StringValue(path == null ? "" : path);
         } else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetQueryString.java
+++ b/src/org/exist/xquery/functions/request/GetQueryString.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -72,7 +67,7 @@ public class GetQueryString extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if (var == null || var.getValue() == null || var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 
@@ -89,6 +84,6 @@ public class GetQueryString extends BasicFunction {
 			}
 		}
 		else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 }

--- a/src/org/exist/xquery/functions/request/GetRemoteAddr.java
+++ b/src/org/exist/xquery/functions/request/GetRemoteAddr.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -70,16 +65,16 @@ public class GetRemoteAddr extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		
 		if (value.getObject() instanceof RequestWrapper) {
 			return new StringValue(((RequestWrapper) value.getObject()).getRemoteAddr());
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetRemoteHost.java
+++ b/src/org/exist/xquery/functions/request/GetRemoteHost.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -70,15 +65,15 @@ public class GetRemoteHost extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
 			return new StringValue(((RequestWrapper) value.getObject()).getRemoteHost());
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetRemotePort.java
+++ b/src/org/exist/xquery/functions/request/GetRemotePort.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.JavaObjectValue;
@@ -70,15 +65,15 @@ public class GetRemotePort extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
 			return new IntegerValue(((RequestWrapper) value.getObject()).getRemotePort());
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetRequestAttribute.java
+++ b/src/org/exist/xquery/functions/request/GetRequestAttribute.java
@@ -26,13 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XPathUtil;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 
 import java.util.Enumeration;
@@ -80,9 +74,9 @@ public class GetRequestAttribute extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
@@ -98,7 +92,7 @@ public class GetRequestAttribute extends BasicFunction {
                 return names;
             }
         } else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetScheme.java
+++ b/src/org/exist/xquery/functions/request/GetScheme.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -71,14 +66,14 @@ public class GetScheme extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
 			return new StringValue(((RequestWrapper) value.getObject()).getScheme());
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 }

--- a/src/org/exist/xquery/functions/request/GetServerName.java
+++ b/src/org/exist/xquery/functions/request/GetServerName.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -50,7 +45,7 @@ public class GetServerName extends BasicFunction {
 			new QName("get-server-name", RequestModule.NAMESPACE_URI, RequestModule.PREFIX),
 			"Returns the server nodename of the current request.",
 			null,
-			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the server nodename of the current request"));
+			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the server host name of the current request"));
 	
 	/**
 	 * @param context
@@ -70,15 +65,15 @@ public class GetServerName extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
 			return new StringValue(((RequestWrapper) value.getObject()).getServerName());
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetServerPort.java
+++ b/src/org/exist/xquery/functions/request/GetServerPort.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.JavaObjectValue;
@@ -70,15 +65,15 @@ public class GetServerPort extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
 			return new IntegerValue(((RequestWrapper) value.getObject()).getServerPort());
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetURI.java
+++ b/src/org/exist/xquery/functions/request/GetURI.java
@@ -27,12 +27,7 @@ import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
 import org.exist.http.urlrewrite.XQueryURLRewrite;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.AnyURIValue;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
@@ -80,9 +75,9 @@ public class GetURI extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if (value.getObject() instanceof RequestWrapper) {
@@ -93,6 +88,6 @@ public class GetURI extends BasicFunction {
             else
                 {return new AnyURIValue(attr.toString());}
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}	
 }

--- a/src/org/exist/xquery/functions/request/GetURL.java
+++ b/src/org/exist/xquery/functions/request/GetURL.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -70,16 +65,16 @@ public class GetURL extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		
 		if (value.getObject() instanceof RequestWrapper) {
 			return new StringValue(((RequestWrapper) value.getObject()).getRequestURL().toString());
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 	
 }

--- a/src/org/exist/xquery/functions/request/GetUploadedFile.java
+++ b/src/org/exist/xquery/functions/request/GetUploadedFile.java
@@ -30,12 +30,7 @@ import java.util.List;
 
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.Base64BinaryValueType;
 import org.exist.xquery.value.BinaryValueFromFile;
 import org.exist.xquery.value.FunctionParameterSequenceType;
@@ -81,11 +76,11 @@ public class GetUploadedFile extends BasicFunction {
         // request object is read from global variable $request
         final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
         if (var == null || var.getValue() == null) {
-            throw new XPathException(this, "No request object found in the current XQuery context.");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");
         }
 
         if (var.getValue().getItemType() != Type.JAVA_OBJECT) {
-            throw new XPathException(this, "Variable $request is not bound to an Java object.");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");
         }
 
         // get parameters
@@ -139,7 +134,7 @@ public class GetUploadedFile extends BasicFunction {
 
             return result;
         } else {
-            throw new XPathException(this, "Variable $request is not bound to a Request object.");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");
         }
     }
 }

--- a/src/org/exist/xquery/functions/request/GetUploadedFileName.java
+++ b/src/org/exist/xquery/functions/request/GetUploadedFileName.java
@@ -28,12 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
@@ -78,9 +73,9 @@ public class GetUploadedFileName extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		// get parameters
 		final String uploadParamName = args[0].getStringValue();
@@ -98,7 +93,7 @@ public class GetUploadedFileName extends BasicFunction {
 			}
 			return result;
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 
 }

--- a/src/org/exist/xquery/functions/request/GetUploadedFileSize.java
+++ b/src/org/exist/xquery/functions/request/GetUploadedFileSize.java
@@ -29,12 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.DoubleValue;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
@@ -79,9 +74,9 @@ public class GetUploadedFileSize extends BasicFunction {
 		// request object is read from global variable $request
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 
 		// get parameters
 		final String uploadParamName = args[0].getStringValue();
@@ -99,7 +94,7 @@ public class GetUploadedFileSize extends BasicFunction {
 			}
 			return result;
 		} else
-			{throw new XPathException(this, "Variable $request is not bound to a Request object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");}
 	}
 
 }

--- a/src/org/exist/xquery/functions/request/IsMultiPartContent.java
+++ b/src/org/exist/xquery/functions/request/IsMultiPartContent.java
@@ -28,12 +28,7 @@ import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
 
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.BooleanValue;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
@@ -72,17 +67,17 @@ public class IsMultiPartContent extends BasicFunction {
         // request object is read from global variable $request
         final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
         if (var == null || var.getValue() == null) {
-            throw new XPathException(this, "No request object found in the current XQuery context.");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");
         }
         if (var.getValue().getItemType() != Type.JAVA_OBJECT) {
-            throw new XPathException(this, "Variable $request is not bound to an Java object.");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");
         }
 
         final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
         if (value.getObject() instanceof RequestWrapper) {
             return new BooleanValue(((RequestWrapper) value.getObject()).isMultipartContent());
         } else {
-            throw new XPathException(this, "Variable $request is not bound to a Request object.");
+            throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");
         }
     }
 }

--- a/src/org/exist/xquery/functions/request/SetAttribute.java
+++ b/src/org/exist/xquery/functions/request/SetAttribute.java
@@ -26,14 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.JavaObjectValue;
@@ -88,11 +81,11 @@ public class SetAttribute extends Function {
 		Variable var = myModule.resolveVariable( RequestModule.REQUEST_VAR );
 		
 		if( var == null || var.getValue() == null ) {
-			throw( new XPathException( this, "Request not set" ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Request not set" ) );
 		}
 
 		if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-			throw( new XPathException( this, "Variable $request is not bound to a Java object." ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Java object." ) );
 		}
 
 		JavaObjectValue request = (JavaObjectValue)var.getValue().itemAt( 0 );
@@ -104,7 +97,7 @@ public class SetAttribute extends Function {
 		if( request.getObject() instanceof RequestWrapper ) {
 			((RequestWrapper)request.getObject()).setAttribute( attribName, attribValue );
 		} else {
-			throw(  new XPathException( this, "Type error: variable $request is not bound to a request object" ) );
+			throw(  new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $request is not bound to a request object" ) );
 		}
 
 		return( Sequence.EMPTY_SEQUENCE );

--- a/src/org/exist/xquery/functions/response/RedirectTo.java
+++ b/src/org/exist/xquery/functions/response/RedirectTo.java
@@ -27,12 +27,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.exist.dom.QName;
 import org.exist.http.servlets.ResponseWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -82,11 +77,11 @@ public class RedirectTo extends BasicFunction
         final Variable       var         = myModule.resolveVariable( ResponseModule.RESPONSE_VAR );
 
         if( ( var == null ) || ( var.getValue() == null ) ) {
-            throw( new XPathException( this, "No response object found in the current XQuery context." ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "No response object found in the current XQuery context." ) );
         }
 
         if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-            throw( new XPathException( this, "Variable $response is not bound to an Java object." ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $response is not bound to an Java object." ) );
         }
 
         final JavaObjectValue value = (JavaObjectValue)var.getValue().itemAt( 0 );
@@ -100,7 +95,7 @@ public class RedirectTo extends BasicFunction
                 throw( new XPathException( this, "An IO exception occurred during redirect: " + e.getMessage(), e ) );
             }
         } else {
-            throw( new XPathException( this, "Variable response is not bound to a response object." ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable response is not bound to a response object." ) );
         }
         
         return( Sequence.EMPTY_SEQUENCE );

--- a/src/org/exist/xquery/functions/response/SetCookie.java
+++ b/src/org/exist/xquery/functions/response/SetCookie.java
@@ -27,14 +27,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.exist.dom.QName;
 import org.exist.http.servlets.ResponseWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.BooleanValue;
 import org.exist.xquery.value.DurationValue;
 import org.exist.xquery.value.FunctionParameterSequenceType;
@@ -113,11 +106,11 @@ public class SetCookie extends Function
         final Variable       var      = myModule.resolveVariable( ResponseModule.RESPONSE_VAR );
 
         if( ( var == null ) || ( var.getValue() == null ) ) {
-            throw( new XPathException( this, "Response not set" ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Response not set" ) );
         }
 
         if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-            throw( new XPathException( this, "Variable $response is not bound to a Java object." ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $response is not bound to a Java object." ) );
         }
         final JavaObjectValue response  = (JavaObjectValue)var.getValue().itemAt( 0 );
 
@@ -183,7 +176,7 @@ public class SetCookie extends Function
                 }
             }
         } else {
-            throw( new XPathException( this, "Type error: variable $response is not bound to a response object" ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $response is not bound to a response object" ) );
         }
         
         return( Sequence.EMPTY_SEQUENCE );

--- a/src/org/exist/xquery/functions/response/SetDateHeader.java
+++ b/src/org/exist/xquery/functions/response/SetDateHeader.java
@@ -27,14 +27,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.exist.dom.QName;
 import org.exist.http.servlets.ResponseWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.DateTimeValue;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Item;
@@ -92,11 +85,11 @@ public class SetDateHeader extends Function
         final Variable       var      = myModule.resolveVariable( ResponseModule.RESPONSE_VAR );
 
         if( ( var == null ) || ( var.getValue() == null ) ) {
-            throw( new XPathException( this, "Response not set" ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Response not set" ) );
         }
 
         if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-            throw( new XPathException( this, "Variable $response is not bound to a Java object." ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $response is not bound to a Java object." ) );
         }
         final JavaObjectValue response = (JavaObjectValue)var.getValue().itemAt( 0 );
 
@@ -108,7 +101,7 @@ public class SetDateHeader extends Function
         if( response.getObject() instanceof ResponseWrapper ) {
             ( (ResponseWrapper)response.getObject() ).setDateHeader( name, value );
         } else {
-            throw( new XPathException( this, "Type error: variable $response is not bound to a response object" ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $response is not bound to a response object" ) );
         }
 
         return( Sequence.EMPTY_SEQUENCE );

--- a/src/org/exist/xquery/functions/response/SetHeader.java
+++ b/src/org/exist/xquery/functions/response/SetHeader.java
@@ -27,14 +27,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.exist.dom.QName;
 import org.exist.http.servlets.ResponseWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.functions.request.RequestModule;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Item;
@@ -100,11 +93,11 @@ public class SetHeader extends Function
         final Variable       var      = myModule.resolveVariable( ResponseModule.RESPONSE_VAR );
 
         if( ( var == null ) || ( var.getValue() == null ) ) {
-            throw( new XPathException( this, "Response not set" ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Response not set" ) );
         }
 
         if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-            throw( new XPathException( this, "Variable $response is not bound to a Java object." ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $response is not bound to a Java object." ) );
         }
         final JavaObjectValue response = (JavaObjectValue)var.getValue().itemAt( 0 );
 
@@ -116,7 +109,7 @@ public class SetHeader extends Function
         if( response.getObject() instanceof ResponseWrapper ) {
             ( (ResponseWrapper)response.getObject() ).setHeader( name, value );
         } else {
-            throw( new XPathException( this, "Type error: variable $response is not bound to a response object" ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $response is not bound to a response object" ) );
         }
 
         return( Sequence.EMPTY_SEQUENCE );

--- a/src/org/exist/xquery/functions/response/SetStatusCode.java
+++ b/src/org/exist/xquery/functions/response/SetStatusCode.java
@@ -27,14 +27,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.exist.dom.QName;
 import org.exist.http.servlets.ResponseWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.Item;
@@ -92,11 +85,11 @@ public class SetStatusCode extends Function
         final Variable       var      = myModule.resolveVariable( ResponseModule.RESPONSE_VAR );
 
         if( ( var == null ) || ( var.getValue() == null ) ) {
-            throw( new XPathException( this, "Response not set" ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Response not set" ) );
         }
 
         if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-            throw( new XPathException( this, "Variable $response is not bound to a Java object." ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $response is not bound to a Java object." ) );
         } 
         final JavaObjectValue response = (JavaObjectValue)var.getValue().itemAt( 0 );
 
@@ -107,7 +100,7 @@ public class SetStatusCode extends Function
         if( response.getObject() instanceof ResponseWrapper ) {
             ( (ResponseWrapper)response.getObject() ).setStatusCode( code );
         } else {
-            throw( new XPathException( this, "Type error: variable $response is not bound to a response object" ) );
+            throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $response is not bound to a response object" ) );
         }
 
         return( Sequence.EMPTY_SEQUENCE );

--- a/src/org/exist/xquery/functions/response/Stream.java
+++ b/src/org/exist/xquery/functions/response/Stream.java
@@ -38,13 +38,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.serializer.SerializerPool;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Option;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -103,14 +97,14 @@ public class Stream extends BasicFunction {
         final Variable respVar = myModule.resolveVariable(ResponseModule.RESPONSE_VAR);
         
         if(respVar == null)
-            {throw new XPathException(this, "No response object found in the current XQuery context.");}
+            {throw new XPathException(this, ErrorCodes.XPDY0002, "No response object found in the current XQuery context.");}
         
         if(respVar.getValue().getItemType() != Type.JAVA_OBJECT)
-            {throw new XPathException(this, "Variable $response is not bound to an Java object.");}
+            {throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $response is not bound to an Java object.");}
         final JavaObjectValue respValue = (JavaObjectValue) respVar.getValue().itemAt(0);
         
         if (!"org.exist.http.servlets.HttpResponseWrapper".equals(respValue.getObject().getClass().getName()))
-            {throw new XPathException(this, signature.toString() + " can only be used within the EXistServlet or XQueryServlet");}
+            {throw new XPathException(this, ErrorCodes.XPDY0002, signature.toString() + " can only be used within the EXistServlet or XQueryServlet");}
         
         final ResponseWrapper response = (ResponseWrapper) respValue.getObject();
         

--- a/src/org/exist/xquery/functions/response/StreamBinary.java
+++ b/src/org/exist/xquery/functions/response/StreamBinary.java
@@ -26,12 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.exist.dom.QName;
 import org.exist.http.servlets.ResponseWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -83,17 +78,17 @@ public class StreamBinary extends BasicFunction {
         final Variable respVar = myModule.resolveVariable(ResponseModule.RESPONSE_VAR);
 
         if((respVar == null) || (respVar.getValue() == null)) {
-            throw (new XPathException(this, "No response object found in the current XQuery context."));
+            throw (new XPathException(this, ErrorCodes.XPDY0002, "No response object found in the current XQuery context."));
         }
 
         if(respVar.getValue().getItemType() != Type.JAVA_OBJECT) {
-            throw (new XPathException(this, "Variable $response is not bound to an Java object."));
+            throw (new XPathException(this, ErrorCodes.XPDY0002, "Variable $response is not bound to an Java object."));
         }
 
         final JavaObjectValue respValue = (JavaObjectValue) respVar.getValue().itemAt(0);
 
         if(!"org.exist.http.servlets.HttpResponseWrapper".equals(respValue.getObject().getClass().getName())) {
-            throw (new XPathException(this, signature.toString() + " can only be used within the EXistServlet or XQueryServlet"));
+            throw (new XPathException(this, ErrorCodes.XPDY0002, signature.toString() + " can only be used within the EXistServlet or XQueryServlet"));
         }
 
         final ResponseWrapper response = (ResponseWrapper) respValue.getObject();

--- a/src/org/exist/xquery/functions/session/Clear.java
+++ b/src/org/exist/xquery/functions/session/Clear.java
@@ -28,12 +28,7 @@ import java.util.Enumeration;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceType;
@@ -72,9 +67,9 @@ public class Clear extends BasicFunction {
 		//session object is read from global variable $session
 		final Variable var = myModule.resolveVariable(SessionModule.SESSION_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "Session not set");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Session not set");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $session is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $session is not bound to an Java object.");}
 		final JavaObjectValue session = (JavaObjectValue) var.getValue().itemAt(0);
 		
 		if(session.getObject() instanceof SessionWrapper)
@@ -88,6 +83,6 @@ public class Clear extends BasicFunction {
 			return Sequence.EMPTY_SEQUENCE;
 		}
 		else
-			{throw new XPathException(this, "Type error: variable $session is not bound to a session object");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object");}
 	}
 }

--- a/src/org/exist/xquery/functions/session/EncodeURL.java
+++ b/src/org/exist/xquery/functions/session/EncodeURL.java
@@ -26,12 +26,7 @@ package org.exist.xquery.functions.session;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.ResponseWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.functions.response.ResponseModule;
 import org.exist.xquery.value.AnyURIValue;
 import org.exist.xquery.value.FunctionParameterSequenceType;
@@ -75,10 +70,10 @@ public class EncodeURL extends BasicFunction {
 		// request object is read from global variable $response
 		final Variable var = myModule.resolveVariable(ResponseModule.RESPONSE_VAR);
 		if(var == null || var.getValue() == null) {
-			throw new XPathException(this, "No request object found in the current XQuery context.");
+			throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");
 		}
 		if(var.getValue().getItemType() != Type.JAVA_OBJECT) {
-			throw new XPathException(this, "Variable $response is not bound to an Java object.");
+			throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $response is not bound to an Java object.");
 		}
 		
 		// get parameters
@@ -89,7 +84,7 @@ public class EncodeURL extends BasicFunction {
 		if(value.getObject() instanceof ResponseWrapper) {
 			return new AnyURIValue(((ResponseWrapper)value.getObject()).encodeURL(url));
 		} else {
-			throw new XPathException(this, "Variable $response is not bound to a Response object.");
+			throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $response is not bound to a Response object.");
 		}
 	}
 }

--- a/src/org/exist/xquery/functions/session/GetAttribute.java
+++ b/src/org/exist/xquery/functions/session/GetAttribute.java
@@ -25,13 +25,7 @@ package org.exist.xquery.functions.session;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XPathUtil;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.Item;
@@ -83,7 +77,7 @@ public class GetAttribute extends Function
 		}
 		
 		if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-			throw( new XPathException( this, "Variable $session is not bound to a Java object." ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $session is not bound to a Java object." ) );
 		}
 
 		final JavaObjectValue session = (JavaObjectValue)var.getValue().itemAt( 0 );
@@ -113,7 +107,7 @@ public class GetAttribute extends Function
 				return( Sequence.EMPTY_SEQUENCE );
 			}
 		} else {
-			throw( new XPathException( this, "Type error: variable $session is not bound to a session object" ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object" ) );
 		}
 	}
 }

--- a/src/org/exist/xquery/functions/session/GetAttributeNames.java
+++ b/src/org/exist/xquery/functions/session/GetAttributeNames.java
@@ -28,12 +28,7 @@ import java.util.Enumeration;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
@@ -75,9 +70,9 @@ public class GetAttributeNames extends BasicFunction {
 		// session object is read from global variable $session
 		final Variable var = myModule.resolveVariable(SessionModule.SESSION_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "Session not set");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Session not set");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $session is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $session is not bound to an Java object.");}
 		final JavaObjectValue session = (JavaObjectValue) var.getValue().itemAt(0);
 		
 		if(session.getObject() instanceof SessionWrapper)
@@ -92,6 +87,6 @@ public class GetAttributeNames extends BasicFunction {
 			return result;
 		}
 		else
-			{throw new XPathException(this, "Type error: variable $session is not bound to a session object");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object");}
 	}
 }

--- a/src/org/exist/xquery/functions/session/GetCreationTime.java
+++ b/src/org/exist/xquery/functions/session/GetCreationTime.java
@@ -27,15 +27,7 @@ import java.util.Date;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XPathUtil;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.DateTimeValue;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.Item;
@@ -92,7 +84,7 @@ public class GetCreationTime extends Function
 		}
 		
 		if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-			throw( new XPathException( this, "Variable $session is not bound to a Java object." ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $session is not bound to a Java object." ) );
 		}
 
 		final JavaObjectValue session = (JavaObjectValue)var.getValue().itemAt( 0 );
@@ -106,7 +98,7 @@ public class GetCreationTime extends Function
 				return new DateTimeValue(new Date(0));
 			}
 		} else {
-			throw( new XPathException( this, "Type error: variable $session is not bound to a session object" ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object" ) );
 		}
 	}
 }

--- a/src/org/exist/xquery/functions/session/GetID.java
+++ b/src/org/exist/xquery/functions/session/GetID.java
@@ -26,12 +26,7 @@ package org.exist.xquery.functions.session;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.JavaObjectValue;
@@ -72,9 +67,9 @@ public class GetID extends Function
 		/* session object is read from global variable $session */
 		final Variable var = myModule.resolveVariable(SessionModule.SESSION_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "Session not set");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Session not set");}
 		if(var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $session is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $session is not bound to an Java object.");}
 		final JavaObjectValue session = (JavaObjectValue) var.getValue().itemAt(0);
 		
 		if(session.getObject() instanceof SessionWrapper)
@@ -86,7 +81,7 @@ public class GetID extends Function
 		}
 		else
 		{
-			throw new XPathException(this, "Type error: variable $session is not bound to a session object");
+			throw new XPathException(this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object");
 		}
 	}
 }

--- a/src/org/exist/xquery/functions/session/GetLastAccessedTime.java
+++ b/src/org/exist/xquery/functions/session/GetLastAccessedTime.java
@@ -27,15 +27,7 @@ import java.util.Date;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XPathUtil;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.DateTimeValue;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.Item;
@@ -95,7 +87,7 @@ public class GetLastAccessedTime extends Function
 		}
 		
 		if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-			throw( new XPathException( this, "Variable $session is not bound to a Java object." ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $session is not bound to a Java object." ) );
 		}
 
 		final JavaObjectValue session = (JavaObjectValue)var.getValue().itemAt( 0 );
@@ -109,7 +101,7 @@ public class GetLastAccessedTime extends Function
 				return new DateTimeValue(new Date(0));
 			}
 		} else {
-			throw( new XPathException( this, "Type error: variable $session is not bound to a session object" ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object" ) );
 		}
 	}
 }

--- a/src/org/exist/xquery/functions/session/GetMaxInactiveInterval.java
+++ b/src/org/exist/xquery/functions/session/GetMaxInactiveInterval.java
@@ -26,13 +26,7 @@ package org.exist.xquery.functions.session;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XPathUtil;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.JavaObjectValue;
@@ -82,7 +76,7 @@ public class GetMaxInactiveInterval extends Function
 		}
 		
 		if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-			throw( new XPathException( this, "Variable $session is not bound to a Java object." ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $session is not bound to a Java object." ) );
 		}
 
 		final JavaObjectValue session = (JavaObjectValue)var.getValue().itemAt( 0 );
@@ -96,7 +90,7 @@ public class GetMaxInactiveInterval extends Function
 				return( XPathUtil.javaObjectToXPath( Integer.valueOf(-1), context ) );
 			}
 		} else {
-			throw( new XPathException( this, "Type error: variable $session is not bound to a session object" ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object" ) );
 		}
 	}
 }

--- a/src/org/exist/xquery/functions/session/Invalidate.java
+++ b/src/org/exist/xquery/functions/session/Invalidate.java
@@ -26,12 +26,7 @@ package org.exist.xquery.functions.session;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceType;
@@ -71,18 +66,18 @@ public class Invalidate extends BasicFunction {
 		if(var == null || var.getValue() == null) { 
 			//Always called as "invalidate") because the translation is made at compile time			
 			if (!isCalledAs("invalidate"))
-				{throw new XPathException(this, SessionModule.SESSION_VAR + " not set");}
+				{throw new XPathException(this, ErrorCodes.XPDY0002, SessionModule.SESSION_VAR + " not set");}
 			return Sequence.EMPTY_SEQUENCE;
 		}
 		if(var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, SessionModule.SESSION_VAR + " is not bound to a Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, SessionModule.SESSION_VAR + " is not bound to a Java object.");}
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		if(value.getObject() instanceof SessionWrapper) {
 			final SessionWrapper session = (SessionWrapper)value.getObject();
 			session.invalidate();
 			return Sequence.EMPTY_SEQUENCE;
 		} else
-			{throw new XPathException(this, SessionModule.SESSION_VAR + " is not bound to a session object");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, SessionModule.SESSION_VAR + " is not bound to a session object");}
     }
 
 }

--- a/src/org/exist/xquery/functions/session/RemoveAttribute.java
+++ b/src/org/exist/xquery/functions/session/RemoveAttribute.java
@@ -26,14 +26,7 @@ package org.exist.xquery.functions.session;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.JavaObjectValue;
@@ -81,9 +74,9 @@ public class RemoveAttribute extends Function {
 		// session object is read from global variable $session
 		final Variable var = myModule.resolveVariable(SessionModule.SESSION_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "Session not set");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Session not set");}
 		if(var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $session is not bound to a Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $session is not bound to a Java object.");}
 		final JavaObjectValue session = (JavaObjectValue) var.getValue().itemAt(0);
 		
 		// get attribute name parameter
@@ -91,7 +84,7 @@ public class RemoveAttribute extends Function {
 		if(session.getObject() instanceof SessionWrapper)
 			{((SessionWrapper)session.getObject()).removeAttribute(attrib);}
 		else
-			{throw new XPathException(this, "Type error: variable $session is not bound to a session object");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object");}
 
 		return Sequence.EMPTY_SEQUENCE;
 	}

--- a/src/org/exist/xquery/functions/session/SessionModule.java
+++ b/src/org/exist/xquery/functions/session/SessionModule.java
@@ -26,12 +26,7 @@ import java.util.Map;
 import org.exist.dom.QName;
 import org.exist.http.servlets.RequestWrapper;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.AbstractInternalModule;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionDef;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.functions.request.RequestModule;
 import org.exist.xquery.value.JavaObjectValue;
 import org.exist.xquery.value.Type;
@@ -121,11 +116,11 @@ public class SessionModule extends AbstractInternalModule
 		final Variable var = myModule.resolveVariable( RequestModule.REQUEST_VAR );
 		
 		if( var == null || var.getValue() == null ) {
-			throw( new XPathException( fn, "No request object found in the current XQuery context." ) );
+			throw( new XPathException( fn, ErrorCodes.XPDY0002, "No request object found in the current XQuery context." ) );
 		}
 	
 		if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-			throw( new XPathException( fn, "Variable $request is not bound to an Java object." ) );
+			throw( new XPathException( fn, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object." ) );
 		}
 
 		final JavaObjectValue value = (JavaObjectValue)var.getValue().itemAt( 0 );
@@ -137,7 +132,7 @@ public class SessionModule extends AbstractInternalModule
 			sessionModule.declareVariable( SessionModule.SESSION_VAR, session );
 			ret = (JavaObjectValue)sessionModule.resolveVariable( SessionModule.SESSION_VAR ).getValue().itemAt( 0 );
 		} else {
-			throw( new XPathException( fn, "Variable $request is not bound to a Request object." ) );
+			throw( new XPathException( fn, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object." ) );
 		}
 		
 		return( ret );

--- a/src/org/exist/xquery/functions/session/SetAttribute.java
+++ b/src/org/exist/xquery/functions/session/SetAttribute.java
@@ -26,14 +26,7 @@ package org.exist.xquery.functions.session;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.JavaObjectValue;
@@ -95,7 +88,7 @@ public class SetAttribute extends Function
 			// No saved session, so create one
 			session = SessionModule.createSession( context, this );
 		} else if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-			throw( new XPathException( this, "Variable $session is not bound to a Java object." ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $session is not bound to a Java object." ) );
 		} else {
 			session = (JavaObjectValue)var.getValue().itemAt( 0 );
 		}
@@ -107,7 +100,7 @@ public class SetAttribute extends Function
 		if( session.getObject() instanceof SessionWrapper ) {
 			((SessionWrapper)session.getObject()).setAttribute (attribName, attribValue );
 		} else {
-			throw( new XPathException( this, "Type error: variable $session is not bound to a session object" ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object" ) );
 		}
 
 		return( Sequence.EMPTY_SEQUENCE );

--- a/src/org/exist/xquery/functions/session/SetCurrentUser.java
+++ b/src/org/exist/xquery/functions/session/SetCurrentUser.java
@@ -30,12 +30,7 @@ import org.exist.http.servlets.SessionWrapper;
 import org.exist.security.AuthenticationException;
 import org.exist.security.SecurityManager;
 import org.exist.security.Subject;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.functions.request.RequestModule;
 import org.exist.xquery.value.BooleanValue;
 import org.exist.xquery.value.FunctionParameterSequenceType;
@@ -80,9 +75,9 @@ public class SetCurrentUser extends BasicFunction {
 		// request object is read from global variable $session
 		final Variable var = myModule.resolveVariable(RequestModule.REQUEST_VAR);
 		if(var == null || var.getValue() == null)
-			{throw new XPathException(this, "No request object found in the current XQuery context.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context.");}
 		if (var.getValue().getItemType() != Type.JAVA_OBJECT)
-			{throw new XPathException(this, "Variable $request is not bound to an Java object.");}
+			{throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object.");}
 		final JavaObjectValue value = (JavaObjectValue) var.getValue().itemAt(0);
 		
 		if(value.getObject() instanceof RequestWrapper)
@@ -115,7 +110,7 @@ public class SetCurrentUser extends BasicFunction {
 		}
 		else
 		{
-			throw new XPathException(this, "Variable $request is not bound to a Request object.");
+			throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $request is not bound to a Request object.");
 		}
 	}
 

--- a/src/org/exist/xquery/functions/session/SetMaxInactiveInterval.java
+++ b/src/org/exist/xquery/functions/session/SetMaxInactiveInterval.java
@@ -25,14 +25,7 @@ package org.exist.xquery.functions.session;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Dependency;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Profiler;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.Item;
@@ -96,7 +89,7 @@ public class SetMaxInactiveInterval extends Function
 			// No saved session, so create one
 			session = SessionModule.createSession( context, this );
 		} else if( var.getValue().getItemType() != Type.JAVA_OBJECT ) {
-			throw( new XPathException( this, "Variable $session is not bound to a Java object." ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $session is not bound to a Java object." ) );
 		} else {
 			session = (JavaObjectValue)var.getValue().itemAt( 0 );
 		}
@@ -107,7 +100,7 @@ public class SetMaxInactiveInterval extends Function
 		if( session.getObject() instanceof SessionWrapper ) {
 			((SessionWrapper)session.getObject()).setMaxInactiveInterval(interval);
 		} else {
-			throw( new XPathException( this, "Type error: variable $session is not bound to a session object" ) );
+			throw( new XPathException( this, ErrorCodes.XPDY0002, "Type error: variable $session is not bound to a session object" ) );
 		}
 
 		return( Sequence.EMPTY_SEQUENCE );

--- a/src/org/exist/xquery/functions/transform/Transform.java
+++ b/src/org/exist/xquery/functions/transform/Transform.java
@@ -70,14 +70,7 @@ import org.exist.storage.serializers.Serializer;
 import org.exist.storage.serializers.XIncludeFilter;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.xmldb.XmldbURI;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Constants;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Option;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.functions.response.ResponseModule;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
@@ -286,13 +279,13 @@ public class Transform extends BasicFunction {
             // response object is read from global variable $response
             final Variable respVar = myModule.resolveVariable(ResponseModule.RESPONSE_VAR);
             if(respVar == null)
-                {throw new XPathException(this, "No response object found in the current XQuery context.");}
+                {throw new XPathException(this, ErrorCodes.XPDY0002, "No response object found in the current XQuery context.");}
             if(respVar.getValue().getItemType() != Type.JAVA_OBJECT)
-                {throw new XPathException(this, "Variable $response is not bound to an Java object.");}
+                {throw new XPathException(this, ErrorCodes.XPDY0002, "Variable $response is not bound to an Java object.");}
             final JavaObjectValue respValue = (JavaObjectValue)
                 respVar.getValue().itemAt(0);
             if (!"org.exist.http.servlets.HttpResponseWrapper".equals(respValue.getObject().getClass().getName()))
-                {throw new XPathException(this, signatures[1].toString() +
+                {throw new XPathException(this, ErrorCodes.XPDY0002, signatures[1].toString() +
                         " can only be used within the EXistServlet or XQueryServlet");}
             final ResponseWrapper response = (ResponseWrapper) respValue.getObject();
             

--- a/src/org/exist/xquery/functions/xmldb/XMLDBAuthenticate.java
+++ b/src/org/exist/xquery/functions/xmldb/XMLDBAuthenticate.java
@@ -33,12 +33,7 @@ import org.exist.security.SecurityManager;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.xmldb.XmldbURI;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.Variable;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.functions.request.RequestModule;
 import org.exist.xquery.functions.session.SessionModule;
 import org.exist.xquery.value.BooleanValue;
@@ -242,12 +237,11 @@ public class XMLDBAuthenticate extends BasicFunction {
 			
 			if( reqVar == null || reqVar.getValue() == null ) {
 			    logger.error("No request object found in the current XQuery context.");
-
-			    throw( new XPathException( this, "No request object found in the current XQuery context." ) );
+			    throw( new XPathException( this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context." ) );
 			}
 			if( reqVar.getValue().getItemType() != Type.JAVA_OBJECT ) {
 			    logger.error( "Variable $request is not bound to an Java object.");
-				throw( new XPathException( this, "Variable $request is not bound to an Java object." ) );
+				throw( new XPathException( this, ErrorCodes.XPDY0002, "Variable $request is not bound to an Java object." ) );
 			}
 			
 			final JavaObjectValue reqValue = (JavaObjectValue)reqVar.getValue().itemAt( 0) ;


### PR DESCRIPTION
Fixes a bug where the XQuery Context is not cleaned up if a variable reference cannot be resolved. This leads to the first run of the query producing one error, and all subsequent runs producing a different (wrong) error.