### PR TITLE
Removes the need of reflection for Loggables

### DIFF
--- a/src/org/exist/storage/CreateBinaryLoggable.java
+++ b/src/org/exist/storage/CreateBinaryLoggable.java
@@ -1,87 +1,87 @@
 /*
- * RenameBinaryLoggable.java
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
  *
- * Created on December 9, 2007, 1:57 PM
+ * http://exist-db.org
  *
- * To change this template, choose Tools | Template Manager
- * and open the template in the editor.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-
 package org.exist.storage;
 
 import java.io.File;
 import java.nio.ByteBuffer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import java.nio.charset.StandardCharsets;
+
 import org.exist.storage.journal.AbstractLoggable;
 import org.exist.storage.journal.LogException;
 import org.exist.storage.txn.Txn;
 
 /**
- *
  * @author alex
  */
 public class CreateBinaryLoggable extends AbstractLoggable {
+    private File original;
 
-   protected final static Logger LOG = LogManager.getLogger(RenameBinaryLoggable.class);
-   
-   DBBroker broker;
-   File original;
-   
-   /**
-    * Creates a new instance of RenameBinaryLoggable
-    */
-   public CreateBinaryLoggable(DBBroker broker,Txn txn,File original)
-   {
-      super(NativeBroker.LOG_CREATE_BINARY,txn.getId());
-      this.broker = broker;
-      this.original = original;
-   }
-   
-   public CreateBinaryLoggable(DBBroker broker,long transactionId) {
-      super(NativeBroker.LOG_CREATE_BINARY,transactionId);
-      this.broker = broker;
-   }
-   
-   /* (non-Javadoc)
-    * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-    */
-   public void write(ByteBuffer out) {
-      final String originalPath = original.getAbsolutePath();
-      final byte [] data = originalPath.getBytes();
-      out.putInt(data.length);
-      out.put(data);
+    /**
+     * Creates a new instance of RenameBinaryLoggable
+     */
+    public CreateBinaryLoggable(final DBBroker broker, final Txn txn, final File original) {
+        super(NativeBroker.LOG_CREATE_BINARY, txn.getId());
+        this.original = original;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
-       final int size = in.getInt();
-       final byte [] data = new byte[size];
-       in.get(data);
-       original = new File(new String(data));
+    public CreateBinaryLoggable(final DBBroker broker, final long transactionId) {
+        super(NativeBroker.LOG_CREATE_BINARY, transactionId);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
+    public void write(final ByteBuffer out) {
+        final String originalPath = original.getAbsolutePath();
+        final byte[] data = originalPath.getBytes(StandardCharsets.UTF_8);
+        out.putInt(data.length);
+        out.put(data);
+    }
+
+    @Override
+    public void read(final ByteBuffer in) {
+        final int size = in.getInt();
+        final byte[] data = new byte[size];
+        in.get(data);
+        original = new File(new String(data, StandardCharsets.UTF_8));
+    }
+
+    @Override
     public int getLogSize() {
         return 4 + original.getAbsolutePath().getBytes().length;
     }
 
+    @Override
     public void redo() throws LogException {
-       // TODO: do we need to redo?  The file was stored...
+        // TODO: do we need to redo?  The file was stored...
     }
-    
+
+    @Override
     public void undo() throws LogException {
-       if (!original.delete()) {
-          throw new LogException("Cannot delete binary resource "+original);
-       }
+        if (!original.delete()) {
+            throw new LogException("Cannot delete binary resource " + original);
+        }
     }
-    
-     public String dump() {
-        return super.dump() + " - create binary "+original;
+
+    @Override
+    public String dump() {
+        return super.dump() + " - create binary " + original;
     }
 
 }

--- a/src/org/exist/storage/CreateBinaryLoggable.java
+++ b/src/org/exist/storage/CreateBinaryLoggable.java
@@ -64,7 +64,7 @@ public class CreateBinaryLoggable extends AbstractLoggable {
 
     @Override
     public int getLogSize() {
-        return 4 + original.getAbsolutePath().getBytes().length;
+        return 4 + original.getAbsolutePath().getBytes(StandardCharsets.UTF_8).length;
     }
 
     @Override

--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -119,9 +119,9 @@ public class NativeBroker extends DBBroker {
     public final static byte LOG_UPDATE_BINARY = 0x42;
 
     static {
-        LogEntryTypes.addEntryType(LOG_RENAME_BINARY, RenameBinaryLoggable.class);
-        LogEntryTypes.addEntryType(LOG_CREATE_BINARY, CreateBinaryLoggable.class);
-        LogEntryTypes.addEntryType(LOG_UPDATE_BINARY, UpdateBinaryLoggable.class);
+        LogEntryTypes.addEntryType(LOG_RENAME_BINARY, RenameBinaryLoggable::new);
+        LogEntryTypes.addEntryType(LOG_CREATE_BINARY, CreateBinaryLoggable::new);
+        LogEntryTypes.addEntryType(LOG_UPDATE_BINARY, UpdateBinaryLoggable::new);
     }
 
     public static final byte PREPEND_DB_ALWAYS = 0;

--- a/src/org/exist/storage/RenameBinaryLoggable.java
+++ b/src/org/exist/storage/RenameBinaryLoggable.java
@@ -22,6 +22,7 @@ package org.exist.storage;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -57,11 +58,11 @@ public class RenameBinaryLoggable extends AbstractLoggable {
     @Override
     public void write(final ByteBuffer out) {
         final String originalPath = original.getAbsolutePath();
-        byte[] data = originalPath.getBytes();
+        byte[] data = originalPath.getBytes(StandardCharsets.UTF_8);
         out.putInt(data.length);
         out.put(data);
         final String backupPath = backup.getAbsolutePath();
-        data = backupPath.getBytes();
+        data = backupPath.getBytes(StandardCharsets.UTF_8);
         out.putInt(data.length);
         out.put(data);
     }
@@ -71,17 +72,17 @@ public class RenameBinaryLoggable extends AbstractLoggable {
         int size = in.getInt();
         byte[] data = new byte[size];
         in.get(data);
-        original = new File(new String(data));
+        original = new File(new String(data, StandardCharsets.UTF_8));
         size = in.getInt();
         data = new byte[size];
         in.get(data);
-        backup = new File(new String(data));
+        backup = new File(new String(data, StandardCharsets.UTF_8));
         LOG.debug("Rename binary read: " + original + " -> " + backup);
     }
 
     @Override
     public int getLogSize() {
-        return 8 + original.getAbsolutePath().getBytes().length + backup.getAbsolutePath().getBytes().length;
+        return 8 + original.getAbsolutePath().getBytes(StandardCharsets.UTF_8).length + backup.getAbsolutePath().getBytes(StandardCharsets.UTF_8).length;
     }
 
     @Override

--- a/src/org/exist/storage/RenameBinaryLoggable.java
+++ b/src/org/exist/storage/RenameBinaryLoggable.java
@@ -1,16 +1,28 @@
 /*
- * RenameBinaryLoggable.java
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
  *
- * Created on December 9, 2007, 1:57 PM
+ * http://exist-db.org
  *
- * To change this template, choose Tools | Template Manager
- * and open the template in the editor.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-
 package org.exist.storage;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.storage.journal.AbstractLoggable;
@@ -18,82 +30,74 @@ import org.exist.storage.journal.LogException;
 import org.exist.storage.txn.Txn;
 
 /**
- *
  * @author alex
  */
 public class RenameBinaryLoggable extends AbstractLoggable {
 
-   protected final static Logger LOG = LogManager.getLogger(RenameBinaryLoggable.class);
-   
-   DBBroker broker;
-   File original;
-   File backup;
-   /**
-    * Creates a new instance of RenameBinaryLoggable
-    */
-   public RenameBinaryLoggable(DBBroker broker,Txn txn,File original,File backup)
-   {
-      super(NativeBroker.LOG_RENAME_BINARY,txn.getId());
-      this.broker = broker;
-      this.original = original;
-      this.backup = backup;
-      LOG.debug("Rename binary created "+original+" -> "+backup);
-   }
-   
-   public RenameBinaryLoggable(DBBroker broker,long transactionId) {
-      super(NativeBroker.LOG_RENAME_BINARY,transactionId);
-      this.broker = broker;
-      LOG.debug("Rename binary created ...");
-   }
-   
-   /* (non-Javadoc)
-    * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-    */
-   public void write(ByteBuffer out) {
-      final String originalPath = original.getAbsolutePath();
-      byte [] data = originalPath.getBytes();
-      out.putInt(data.length);
-      out.put(data);
-      final String backupPath = backup.getAbsolutePath();
-      data = backupPath.getBytes();
-      out.putInt(data.length);
-      out.put(data);
+    private final static Logger LOG = LogManager.getLogger(RenameBinaryLoggable.class);
+
+    private File original;
+    private File backup;
+
+    /**
+     * Creates a new instance of RenameBinaryLoggable
+     */
+    public RenameBinaryLoggable(final DBBroker broker, final Txn txn, final File original, final File backup) {
+        super(NativeBroker.LOG_RENAME_BINARY, txn.getId());
+        this.original = original;
+        this.backup = backup;
+        LOG.debug("Rename binary created " + original + " -> " + backup);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
-       int size = in.getInt();
-       byte [] data = new byte[size];
-       in.get(data);
-       original = new File(new String(data));
-       size = in.getInt();
-       data = new byte[size];
-       in.get(data);
-       backup = new File(new String(data));
-       LOG.debug("Rename binary read: "+original+" -> "+backup);
+    public RenameBinaryLoggable(final DBBroker broker, final long transactionId) {
+        super(NativeBroker.LOG_RENAME_BINARY, transactionId);
+        LOG.debug("Rename binary created ...");
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
+    public void write(final ByteBuffer out) {
+        final String originalPath = original.getAbsolutePath();
+        byte[] data = originalPath.getBytes();
+        out.putInt(data.length);
+        out.put(data);
+        final String backupPath = backup.getAbsolutePath();
+        data = backupPath.getBytes();
+        out.putInt(data.length);
+        out.put(data);
+    }
+
+    @Override
+    public void read(final ByteBuffer in) {
+        int size = in.getInt();
+        byte[] data = new byte[size];
+        in.get(data);
+        original = new File(new String(data));
+        size = in.getInt();
+        data = new byte[size];
+        in.get(data);
+        backup = new File(new String(data));
+        LOG.debug("Rename binary read: " + original + " -> " + backup);
+    }
+
+    @Override
     public int getLogSize() {
         return 8 + original.getAbsolutePath().getBytes().length + backup.getAbsolutePath().getBytes().length;
     }
 
+    @Override
     public void redo() throws LogException {
     }
-    
+
+    @Override
     public void undo() throws LogException {
-       LOG.debug("Undo rename: "+original);
-       if (!backup.renameTo(original)) {
-          throw new LogException("Cannot move original "+original+" to backup file "+backup);
-       }
-    }
-    
-     public String dump() {
-        return super.dump() + " - rename "+original+" to "+backup;
+        LOG.debug("Undo rename: " + original);
+        if (!backup.renameTo(original)) {
+            throw new LogException("Cannot move original " + original + " to backup file " + backup);
+        }
     }
 
+    @Override
+    public String dump() {
+        return super.dump() + " - rename " + original + " to " + backup;
+    }
 }

--- a/src/org/exist/storage/UpdateBinaryLoggable.java
+++ b/src/org/exist/storage/UpdateBinaryLoggable.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,11 +59,11 @@ public class UpdateBinaryLoggable extends AbstractLoggable {
     @Override
     public void write(final ByteBuffer out) {
         final String originalPath = original.getAbsolutePath();
-        byte[] data = originalPath.getBytes();
+        byte[] data = originalPath.getBytes(StandardCharsets.UTF_8);
         out.putInt(data.length);
         out.put(data);
         final String backupPath = backup.getAbsolutePath();
-        data = backupPath.getBytes();
+        data = backupPath.getBytes(StandardCharsets.UTF_8);
         out.putInt(data.length);
         out.put(data);
     }
@@ -72,16 +73,16 @@ public class UpdateBinaryLoggable extends AbstractLoggable {
         int size = in.getInt();
         byte[] data = new byte[size];
         in.get(data);
-        original = new File(new String(data));
+        original = new File(new String(data, StandardCharsets.UTF_8));
         size = in.getInt();
         data = new byte[size];
         in.get(data);
-        backup = new File(new String(data));
+        backup = new File(new String(data, StandardCharsets.UTF_8));
     }
 
     @Override
     public int getLogSize() {
-        return 8 + original.getAbsolutePath().getBytes().length + backup.getAbsolutePath().getBytes().length;
+        return 8 + original.getAbsolutePath().getBytes(StandardCharsets.UTF_8).length + backup.getAbsolutePath().getBytes(StandardCharsets.UTF_8).length;
     }
 
     @Override

--- a/src/org/exist/storage/UpdateBinaryLoggable.java
+++ b/src/org/exist/storage/UpdateBinaryLoggable.java
@@ -1,12 +1,23 @@
 /*
- * RenameBinaryLoggable.java
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
  *
- * Created on December 9, 2007, 1:57 PM
+ * http://exist-db.org
  *
- * To change this template, choose Tools | Template Manager
- * and open the template in the editor.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
-
 package org.exist.storage;
 
 import java.io.File;
@@ -14,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.storage.journal.AbstractLoggable;
@@ -21,89 +33,78 @@ import org.exist.storage.journal.LogException;
 import org.exist.storage.txn.Txn;
 
 /**
- *
  * @author alex
  */
 public class UpdateBinaryLoggable extends AbstractLoggable {
 
-   protected final static Logger LOG = LogManager.getLogger(RenameBinaryLoggable.class);
-   
-   DBBroker broker;
-   File original;
-   File backup;
-   /**
-    * Creates a new instance of RenameBinaryLoggable
-    */
-   public UpdateBinaryLoggable(DBBroker broker,Txn txn,File original,File backup)
-   {
-      super(NativeBroker.LOG_UPDATE_BINARY,txn.getId());
-      this.broker = broker;
-      this.original = original;
-      this.backup = backup;
-   }
-   
-   public UpdateBinaryLoggable(DBBroker broker,long transactionId) {
-      super(NativeBroker.LOG_UPDATE_BINARY,transactionId);
-      this.broker = broker;
-   }
-   
-   /* (non-Javadoc)
-    * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-    */
-   public void write(ByteBuffer out) {
-      final String originalPath = original.getAbsolutePath();
-      byte [] data = originalPath.getBytes();
-      out.putInt(data.length);
-      out.put(data);
-      final String backupPath = backup.getAbsolutePath();
-      data = backupPath.getBytes();
-      out.putInt(data.length);
-      out.put(data);
+    private final static Logger LOG = LogManager.getLogger(UpdateBinaryLoggable.class);
+
+    private File original;
+    private File backup;
+
+    /**
+     * Creates a new instance of RenameBinaryLoggable
+     */
+    public UpdateBinaryLoggable(final DBBroker broker, final Txn txn, File original, final File backup) {
+        super(NativeBroker.LOG_UPDATE_BINARY, txn.getId());
+        this.original = original;
+        this.backup = backup;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
-       int size = in.getInt();
-       byte [] data = new byte[size];
-       in.get(data);
-       original = new File(new String(data));
-       size = in.getInt();
-       data = new byte[size];
-       in.get(data);
-       backup = new File(new String(data));
+    public UpdateBinaryLoggable(final DBBroker broker, final long transactionId) {
+        super(NativeBroker.LOG_UPDATE_BINARY, transactionId);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
+    public void write(final ByteBuffer out) {
+        final String originalPath = original.getAbsolutePath();
+        byte[] data = originalPath.getBytes();
+        out.putInt(data.length);
+        out.put(data);
+        final String backupPath = backup.getAbsolutePath();
+        data = backupPath.getBytes();
+        out.putInt(data.length);
+        out.put(data);
+    }
+
+    @Override
+    public void read(final ByteBuffer in) {
+        int size = in.getInt();
+        byte[] data = new byte[size];
+        in.get(data);
+        original = new File(new String(data));
+        size = in.getInt();
+        data = new byte[size];
+        in.get(data);
+        backup = new File(new String(data));
+    }
+
+    @Override
     public int getLogSize() {
         return 8 + original.getAbsolutePath().getBytes().length + backup.getAbsolutePath().getBytes().length;
     }
 
+    @Override
     public void redo() throws LogException {
-       // TODO: is there something to do?  The file has been written
-    }
-    
-    public void undo() throws LogException {
-       try {
-          final FileInputStream is = new FileInputStream(backup);
-          final FileOutputStream os = new FileOutputStream(original);
-          final byte [] buffer = new byte[4096];
-          int len;
-          while ((len=is.read(buffer))>=0) {
-             os.write(buffer,0,len);
-          }
-          os.close();
-          is.close();
-       } catch (final IOException ex) {
-          
-       }
-    }
-    
-     public String dump() {
-        return super.dump() + " - update "+original+" to "+backup;
+        // TODO: is there something to do?  The file has been written
     }
 
+    @Override
+    public void undo() throws LogException {
+        try(final FileInputStream is = new FileInputStream(backup);
+                final FileOutputStream os = new FileOutputStream(original)) {
+            final byte[] buffer = new byte[4096];
+            int len = -1;
+            while ((len = is.read(buffer)) > -1) {
+                os.write(buffer, 0, len);
+            }
+        } catch (final IOException ioe) {
+            LOG.error(ioe);
+        }
+    }
+
+    @Override
+    public String dump() {
+        return super.dump() + " - update " + original + " to " + backup;
+    }
 }

--- a/src/org/exist/storage/btree/BTAbstractLoggable.java
+++ b/src/org/exist/storage/btree/BTAbstractLoggable.java
@@ -1,24 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Team
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
  *
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.btree;
 
@@ -31,39 +29,36 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public abstract class BTAbstractLoggable extends AbstractLoggable {
+    private byte fileId;
+    private NativeBroker broker;
 
-	protected byte fileId;
-    protected NativeBroker broker;
-    
-	/**
-	 * @param type
-	 * @param fileId
-	 */
-	public BTAbstractLoggable(byte type, byte fileId, Txn transaction) {
-		super(type, transaction.getId());
+    public BTAbstractLoggable(final byte type, final byte fileId, final Txn transaction) {
+        super(type, transaction.getId());
         this.fileId = fileId;
-	}
+    }
 
-	public BTAbstractLoggable(byte type, DBBroker broker, long transactionId) {
-		super(type, transactionId);
-		this.broker = (NativeBroker) broker;
-	}
-    
+    public BTAbstractLoggable(final byte type, final DBBroker broker, final long transactionId) {
+        super(type, transactionId);
+        this.broker = (NativeBroker) broker;
+    }
+
     protected BTree getStorage() {
         return broker.getStorage(fileId);
     }
-    
-    public void read(ByteBuffer in) {
+
+    @Override
+    public void read(final ByteBuffer in) {
         fileId = in.get();
     }
-    
-    public void write(ByteBuffer out) {
+
+    @Override
+    public void write(final ByteBuffer out) {
         out.put(fileId);
     }
-    
+
+    @Override
     public int getLogSize() {
         return 1;
     }

--- a/src/org/exist/storage/btree/BTree.java
+++ b/src/org/exist/storage/btree/BTree.java
@@ -137,13 +137,13 @@ public class BTree extends Paged implements Lockable {
 
     static {
         // register the log entry types used for the BTree
-        LogEntryTypes.addEntryType(LOG_INSERT_VALUE, InsertValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_UPDATE_VALUE, UpdateValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_REMOVE_VALUE, RemoveValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_CREATE_BNODE, CreateBTNodeLoggable.class);
-        LogEntryTypes.addEntryType(LOG_UPDATE_PAGE, UpdatePageLoggable.class);
-        LogEntryTypes.addEntryType(LOG_SET_PARENT, SetParentLoggable.class);
-        LogEntryTypes.addEntryType(LOG_SET_LINK, SetPageLinkLoggable.class);
+        LogEntryTypes.addEntryType(LOG_INSERT_VALUE, InsertValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_UPDATE_VALUE, UpdateValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_REMOVE_VALUE, RemoveValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_CREATE_BNODE, CreateBTNodeLoggable::new);
+        LogEntryTypes.addEntryType(LOG_UPDATE_PAGE, UpdatePageLoggable::new);
+        LogEntryTypes.addEntryType(LOG_SET_PARENT, SetParentLoggable::new);
+        LogEntryTypes.addEntryType(LOG_SET_LINK, SetPageLinkLoggable::new);
     }
 
     protected DefaultCacheManager cacheManager;

--- a/src/org/exist/storage/dom/AddLinkLoggable.java
+++ b/src/org/exist/storage/dom/AddLinkLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -31,66 +30,55 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public class AddLinkLoggable extends AbstractLoggable {
-
     protected long pageNum;
     protected short tid;
     protected long link;
     private DOMFile domDb = null;
-    
-    /**
-     * @param transaction 
-     * @param pageNum 
-     * @param tid 
-     * @param link 
-     */
-    public AddLinkLoggable(Txn transaction, long pageNum, short tid, long link) {
+
+    public AddLinkLoggable(final Txn transaction, final long pageNum, final short tid, final long link) {
         super(DOMFile.LOG_ADD_LINK, transaction.getId());
         this.pageNum = pageNum;
         this.tid = tid;
         this.link = link;
     }
 
-    public AddLinkLoggable(DBBroker broker, long transactId) {
+    public AddLinkLoggable(final DBBroker broker, final long transactId) {
         super(DOMFile.LOG_ADD_LINK, transactId);
-        this.domDb = ((NativeBroker)broker).getDOMFile();
+        this.domDb = ((NativeBroker) broker).getDOMFile();
     }
-    
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
+
+    @Override
+    public void write(final ByteBuffer out) {
         out.putInt((int) pageNum);
         out.putShort(tid);
         out.putLong(link);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         pageNum = in.getInt();
         tid = in.getShort();
         link = in.getLong();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 14;
     }
-    
+
+    @Override
     public void redo() throws LogException {
         domDb.redoAddLink(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoAddLink(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - created link on page: " + pageNum + " for tid: " + tid;
     }

--- a/src/org/exist/storage/dom/AddMovedValueLoggable.java
+++ b/src/org/exist/storage/dom/AddMovedValueLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -29,54 +28,48 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public class AddMovedValueLoggable extends AddValueLoggable {
-
     protected long backLink;
-    
-    /**
-     * @param transaction
-     * @param pageNum
-     * @param tid
-     * @param value
-     */
-    public AddMovedValueLoggable(Txn transaction, long pageNum, short tid,
-            byte[] value, long backLink) {
+
+    public AddMovedValueLoggable(final Txn transaction, final long pageNum, final short tid, final byte[] value,
+                                 final long backLink) {
         super(DOMFile.LOG_ADD_MOVED_REC, transaction, pageNum, tid, value);
         this.backLink = backLink;
     }
 
-    /**
-     * @param broker
-     * @param transactionId
-     */
-    public AddMovedValueLoggable(DBBroker broker, long transactionId) {
+    public AddMovedValueLoggable(final DBBroker broker, final long transactionId) {
         super(DOMFile.LOG_ADD_MOVED_REC, broker, transactionId);
     }
 
-    public void write(ByteBuffer out) {
+    @Override
+    public void write(final ByteBuffer out) {
         super.write(out);
         out.putLong(backLink);
     }
-    
-    public void read(ByteBuffer in) {
+
+    @Override
+    public void read(final ByteBuffer in) {
         super.read(in);
         backLink = in.getLong();
     }
-    
+
+    @Override
     public int getLogSize() {
         return super.getLogSize() + 8;
     }
-    
+
+    @Override
     public void redo() throws LogException {
         domDb.redoAddMovedValue(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoAddMovedValue(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - moved value; tid = " + tid + " to page " + pageNum + "; len = " + value.length;
     }

--- a/src/org/exist/storage/dom/AddValueLoggable.java
+++ b/src/org/exist/storage/dom/AddValueLoggable.java
@@ -1,24 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Team
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
  *
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -31,71 +29,75 @@ import org.exist.storage.journal.LogException;
 import org.exist.storage.txn.Txn;
 
 public class AddValueLoggable extends AbstractLoggable {
-
-	protected DOMFile domDb;
-	protected long pageNum;
-	protected short tid;
-	protected byte[] value;
+    protected DOMFile domDb;
+    protected long pageNum;
+    protected short tid;
+    protected byte[] value;
 
     public AddValueLoggable() {
         super(DOMFile.LOG_ADD_VALUE, 0);
     }
-    
-    public AddValueLoggable(Txn transaction, long pageNum, short tid, byte[] value) {
+
+    public AddValueLoggable(final Txn transaction, final long pageNum, final short tid, final byte[] value) {
         this(DOMFile.LOG_ADD_VALUE, transaction, pageNum, tid, value);
     }
-    
-	protected AddValueLoggable(byte id, Txn transaction, long pageNum, short tid, byte[] value) {
-		super(id, transaction.getId());
-		this.pageNum = pageNum;
-		this.tid = tid;
-		this.value = value;
-	}
-	
-    public AddValueLoggable(DBBroker broker, long transactionId) {
+
+    protected AddValueLoggable(final byte id, final Txn transaction, final long pageNum, final short tid, final byte[] value) {
+        super(id, transaction.getId());
+        this.pageNum = pageNum;
+        this.tid = tid;
+        this.value = value;
+    }
+
+    public AddValueLoggable(final DBBroker broker, final long transactionId) {
         this(DOMFile.LOG_ADD_VALUE, broker, transactionId);
     }
-    
-	protected AddValueLoggable(byte id, DBBroker broker, long transactionId) {
-		super(id, transactionId);
-		this.domDb = ((NativeBroker)broker).getDOMFile();
-	}
- 
-    public void clear(Txn transaction, long pageNum, short tid, byte[] value) {
+
+    protected AddValueLoggable(final byte id, final DBBroker broker, final long transactionId) {
+        super(id, transactionId);
+        this.domDb = ((NativeBroker) broker).getDOMFile();
+    }
+
+    public void clear(final Txn transaction, final long pageNum, final short tid, final byte[] value) {
         super.clear(transaction.getId());
         this.pageNum = pageNum;
         this.tid = tid;
         this.value = value;
     }
-    
-	public void write(ByteBuffer out) {
-		out.putInt((int)pageNum);
-		out.putShort(tid);
-		out.putShort((short)value.length);
-		out.put(value);
-	}
 
-	public void read(ByteBuffer in) {
-		pageNum = in.getInt();
-		tid = in.getShort();
-		value = new byte[in.getShort()];
-		in.get(value);
-	}
+    @Override
+    public void write(final ByteBuffer out) {
+        out.putInt((int) pageNum);
+        out.putShort(tid);
+        out.putShort((short) value.length);
+        out.put(value);
+    }
 
-	public int getLogSize() {
-		return 8 + value.length;
-	}
+    @Override
+    public void read(final ByteBuffer in) {
+        pageNum = in.getInt();
+        tid = in.getShort();
+        value = new byte[in.getShort()];
+        in.get(value);
+    }
 
+    @Override
+    public int getLogSize() {
+        return 8 + value.length;
+    }
+
+    @Override
     public void redo() throws LogException {
         domDb.redoAddValue(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoAddValue(this);
     }
-    
-	public String dump() {
-		return super.dump() + " - added value; tid = " + tid + " to page " + pageNum;
-	}
 
+    @Override
+    public String dump() {
+        return super.dump() + " - added value; tid = " + tid + " to page " + pageNum;
+    }
 }

--- a/src/org/exist/storage/dom/CreatePageLoggable.java
+++ b/src/org/exist/storage/dom/CreatePageLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -33,67 +32,62 @@ import org.exist.storage.txn.Txn;
  * @author wolf
  */
 public class CreatePageLoggable extends AbstractLoggable {
- 
-	protected long prevPage;
-	protected long newPage;
+    protected long prevPage;
+    protected long newPage;
     protected long nextPage;
     protected short nextTID;
-	private DOMFile domDb = null;
+    private DOMFile domDb = null;
 
-    public CreatePageLoggable(Txn transaction, long prevPage, long newPage, long nextPage) {
-        this(transaction, prevPage, newPage, nextPage, (short)-1);
+    public CreatePageLoggable(final Txn transaction, final long prevPage, final long newPage, final long nextPage) {
+        this(transaction, prevPage, newPage, nextPage, (short) -1);
     }
-    
-	public CreatePageLoggable(Txn transaction, long prevPage, long newPage, long nextPage, short nextTID) {
-		super(DOMFile.LOG_CREATE_PAGE, transaction.getId());
-		this.prevPage = prevPage;
-		this.newPage = newPage;
+
+    public CreatePageLoggable(final Txn transaction, final long prevPage, final long newPage, final long nextPage, final short nextTID) {
+        super(DOMFile.LOG_CREATE_PAGE, transaction.getId());
+        this.prevPage = prevPage;
+        this.newPage = newPage;
         this.nextPage = nextPage;
         this.nextTID = nextTID;
-	}
-	
-	public CreatePageLoggable(DBBroker broker, long transactId) {
-		super(DOMFile.LOG_CREATE_PAGE, transactId);
-		this.domDb = ((NativeBroker)broker).getDOMFile();
-	}
-	
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
-		out.putInt((int)prevPage);
-		out.putInt((int)newPage);
-        out.putInt((int)nextPage);
+    }
+
+    public CreatePageLoggable(final DBBroker broker, final long transactId) {
+        super(DOMFile.LOG_CREATE_PAGE, transactId);
+        this.domDb = ((NativeBroker) broker).getDOMFile();
+    }
+
+    @Override
+    public void write(final ByteBuffer out) {
+        out.putInt((int) prevPage);
+        out.putInt((int) newPage);
+        out.putInt((int) nextPage);
         out.putShort(nextTID);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
-		prevPage = in.getInt();
-		newPage = in.getInt();
+    @Override
+    public void read(final ByteBuffer in) {
+        prevPage = in.getInt();
+        newPage = in.getInt();
         nextPage = in.getInt();
         nextTID = in.getShort();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 14;
     }
-	
+
+    @Override
     public void redo() throws LogException {
         domDb.redoCreatePage(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoCreatePage(this);
     }
-    
-	public String dump() {
-		return super.dump() + " - new page created: " + newPage + "; prev. page: " + prevPage + "; next page: " +
-            nextPage;
-	}
+
+    @Override
+    public String dump() {
+        return super.dump() + " - new page created: " + newPage + "; prev. page: " + prevPage + "; next page: " + nextPage;
+    }
 }

--- a/src/org/exist/storage/dom/DOMFile.java
+++ b/src/org/exist/storage/dom/DOMFile.java
@@ -150,20 +150,20 @@ public class DOMFile extends BTree implements Lockable {
 
     static {
         // register log entry types for this db file
-        LogEntryTypes.addEntryType(LOG_CREATE_PAGE, CreatePageLoggable.class);
-        LogEntryTypes.addEntryType(LOG_ADD_VALUE, AddValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_REMOVE_VALUE, RemoveValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_REMOVE_EMPTY_PAGE, RemoveEmptyPageLoggable.class);
-        LogEntryTypes.addEntryType(LOG_UPDATE_VALUE, UpdateValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_REMOVE_PAGE, RemovePageLoggable.class);
-        LogEntryTypes.addEntryType(LOG_WRITE_OVERFLOW, WriteOverflowPageLoggable.class);
-        LogEntryTypes.addEntryType(LOG_REMOVE_OVERFLOW, RemoveOverflowLoggable.class);
-        LogEntryTypes.addEntryType(LOG_INSERT_RECORD, InsertValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_SPLIT_PAGE, SplitPageLoggable.class);
-        LogEntryTypes.addEntryType(LOG_ADD_LINK, AddLinkLoggable.class);
-        LogEntryTypes.addEntryType(LOG_ADD_MOVED_REC, AddMovedValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_UPDATE_HEADER, UpdateHeaderLoggable.class);
-        LogEntryTypes.addEntryType(LOG_UPDATE_LINK, UpdateLinkLoggable.class);
+        LogEntryTypes.addEntryType(LOG_CREATE_PAGE, CreatePageLoggable::new);
+        LogEntryTypes.addEntryType(LOG_ADD_VALUE, AddValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_REMOVE_VALUE, RemoveValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_REMOVE_EMPTY_PAGE, RemoveEmptyPageLoggable::new);
+        LogEntryTypes.addEntryType(LOG_UPDATE_VALUE, UpdateValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_REMOVE_PAGE, RemovePageLoggable::new);
+        LogEntryTypes.addEntryType(LOG_WRITE_OVERFLOW, WriteOverflowPageLoggable::new);
+        LogEntryTypes.addEntryType(LOG_REMOVE_OVERFLOW, RemoveOverflowLoggable::new);
+        LogEntryTypes.addEntryType(LOG_INSERT_RECORD, InsertValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_SPLIT_PAGE, SplitPageLoggable::new);
+        LogEntryTypes.addEntryType(LOG_ADD_LINK, AddLinkLoggable::new);
+        LogEntryTypes.addEntryType(LOG_ADD_MOVED_REC, AddMovedValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_UPDATE_HEADER, UpdateHeaderLoggable::new);
+        LogEntryTypes.addEntryType(LOG_UPDATE_LINK, UpdateLinkLoggable::new);
     }
 
     public final static short FILE_FORMAT_VERSION_ID = 9;
@@ -1567,8 +1567,9 @@ public class DOMFile extends BTree implements Lockable {
 
     /**
      * Remove the link at the specified position from the file.
-     * 
-     * @param p
+     *
+     * @param transaction
+     * @param pointer
      */
     private void removeLink(Txn transaction, long pointer) {
         final RecordPos rec = findRecord(pointer, false);

--- a/src/org/exist/storage/dom/InsertValueLoggable.java
+++ b/src/org/exist/storage/dom/InsertValueLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -31,60 +30,47 @@ import org.exist.storage.txn.Txn;
 
 /**
  * Insert a value into a data page.
- * 
+ *
  * @author wolf
  */
 public class InsertValueLoggable extends AbstractLoggable {
-
-    protected DOMFile domDb;
+    private DOMFile domDb;
     protected byte isOverflow;
     protected long pageNum;
     protected short tid;
     protected byte[] value;
     protected int offset;
-    
-    /**
-     * @param transaction 
-     * @param pageNum 
-     * @param isOverflow 
-     * @param tid 
-     * @param value 
-     * @param offset 
-     */
-    public InsertValueLoggable(Txn transaction, long pageNum, boolean isOverflow, short tid, byte[] value, int offset) {
+
+    public InsertValueLoggable(final Txn transaction, final long pageNum, final boolean isOverflow, final short tid, final byte[] value, final int offset) {
         super(DOMFile.LOG_INSERT_RECORD, transaction.getId());
         this.pageNum = pageNum;
-        this.isOverflow = (isOverflow ? (byte)1 : 0);
+        this.isOverflow = (isOverflow ? (byte) 1 : 0);
         this.tid = tid;
         this.value = value;
         this.offset = offset;
     }
 
-    public InsertValueLoggable(DBBroker broker, long transactionId) {
+    public InsertValueLoggable(final DBBroker broker, final long transactionId) {
         super(DOMFile.LOG_INSERT_RECORD, transactionId);
-        this.domDb = ((NativeBroker)broker).getDOMFile();
+        this.domDb = ((NativeBroker) broker).getDOMFile();
     }
-    
+
     protected boolean isOverflow() {
         return isOverflow == 1;
     }
-    
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
-        out.putInt((int)pageNum);
+
+    @Override
+    public void write(final ByteBuffer out) {
+        out.putInt((int) pageNum);
         out.put(isOverflow);
         out.putInt(offset);
         out.putShort(tid);
-        out.putShort((short)value.length);
+        out.putShort((short) value.length);
         out.put(value);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         pageNum = in.getInt();
         isOverflow = in.get();
         offset = in.getInt();
@@ -93,23 +79,24 @@ public class InsertValueLoggable extends AbstractLoggable {
         in.get(value);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 13 + value.length;
     }
 
+    @Override
     public void redo() throws LogException {
         domDb.redoInsertValue(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoInsertValue(this);
     }
-    
+
+    @Override
     public String dump() {
-        return super.dump() + " - inserted value; tid = " + tid + " in page " + pageNum + 
-            "; bytes: " + value.length + "; offset: " + offset;
+        return super.dump() + " - inserted value; tid = " + tid + " in page " + pageNum +
+                "; bytes: " + value.length + "; offset: " + offset;
     }
 }

--- a/src/org/exist/storage/dom/RemoveEmptyPageLoggable.java
+++ b/src/org/exist/storage/dom/RemoveEmptyPageLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -31,66 +30,55 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public class RemoveEmptyPageLoggable extends AbstractLoggable {
-
     private DOMFile domDb;
     protected long pageNum;
     protected long prevPage;
     protected long nextPage;
-    
-    /**
-     * @param transaction 
-     * @param pageNum 
-     * @param prevPage 
-     * @param nextPage 
-     */
-    public RemoveEmptyPageLoggable(Txn transaction, long pageNum, long prevPage, long nextPage) {
+
+    public RemoveEmptyPageLoggable(final Txn transaction, final long pageNum, final long prevPage, final long nextPage) {
         super(DOMFile.LOG_REMOVE_EMPTY_PAGE, transaction.getId());
         this.pageNum = pageNum;
         this.prevPage = prevPage;
         this.nextPage = nextPage;
     }
 
-    public RemoveEmptyPageLoggable(DBBroker broker, long transactionId) {
+    public RemoveEmptyPageLoggable(final DBBroker broker, final long transactionId) {
         super(DOMFile.LOG_REMOVE_EMPTY_PAGE, transactionId);
-        this.domDb = ((NativeBroker)broker).getDOMFile();
+        this.domDb = ((NativeBroker) broker).getDOMFile();
     }
-    
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
+
+    @Override
+    public void write(final ByteBuffer out) {
         out.putInt((int) pageNum);
         out.putInt((int) prevPage);
         out.putInt((int) nextPage);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         pageNum = in.getInt();
         prevPage = in.getInt();
         nextPage = in.getInt();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 12;
     }
-    
+
+    @Override
     public void redo() throws LogException {
         domDb.redoRemoveEmptyPage(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoRemoveEmptyPage(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - removed page " + pageNum;
     }

--- a/src/org/exist/storage/dom/RemoveOverflowLoggable.java
+++ b/src/org/exist/storage/dom/RemoveOverflowLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -31,42 +30,36 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public class RemoveOverflowLoggable extends AbstractLoggable {
-
     private DOMFile domDb;
     protected long pageNum;
     protected long nextPage;
     protected byte[] oldData;
-    
-    public RemoveOverflowLoggable(Txn transaction, long pageNum, long nextPage,
-            byte[] oldData) {
+
+    public RemoveOverflowLoggable(final Txn transaction, final long pageNum, final long nextPage,
+                                  final byte[] oldData) {
         super(DOMFile.LOG_REMOVE_OVERFLOW, transaction.getId());
         this.pageNum = pageNum;
         this.nextPage = nextPage;
         this.oldData = oldData;
     }
-    
-    public RemoveOverflowLoggable(DBBroker broker, long transactionId) {
+
+    public RemoveOverflowLoggable(final DBBroker broker, final long transactionId) {
         super(DOMFile.LOG_REMOVE_OVERFLOW, transactionId);
-        this.domDb = ((NativeBroker)broker).getDOMFile();
+        this.domDb = ((NativeBroker) broker).getDOMFile();
     }
-    
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
+
+    @Override
+    public void write(final ByteBuffer out) {
         out.putInt((int) pageNum);
         out.putInt((int) nextPage);
         out.putShort((short) oldData.length);
         out.put(oldData);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         pageNum = in.getInt();
         nextPage = in.getInt();
         final short len = in.getShort();
@@ -74,21 +67,22 @@ public class RemoveOverflowLoggable extends AbstractLoggable {
         in.get(oldData);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 10 + oldData.length;
     }
 
+    @Override
     public void redo() throws LogException {
         domDb.redoRemoveOverflow(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoRemoveOverflow(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - removed overflow page " + pageNum;
     }

--- a/src/org/exist/storage/dom/RemovePageLoggable.java
+++ b/src/org/exist/storage/dom/RemovePageLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -34,7 +33,6 @@ import org.exist.storage.txn.Txn;
  *
  */
 public class RemovePageLoggable extends AbstractLoggable {
-
     private DOMFile domDb;
     protected long pageNum;
     protected long prevPage;
@@ -43,19 +41,9 @@ public class RemovePageLoggable extends AbstractLoggable {
     protected int oldLen;
     protected short oldTid;
     protected short oldRecCnt;
-    
-    /**
-     * @param transaction 
-     * @param pageNum 
-     * @param prevPage 
-     * @param nextPage 
-     * @param oldData 
-     * @param oldLen 
-     * @param oldTid 
-     * @param oldRecCnt 
-     */
-    public RemovePageLoggable(Txn transaction, long pageNum, long prevPage, long nextPage,
-            byte[] oldData, int oldLen, short oldTid, short oldRecCnt) {
+
+    public RemovePageLoggable(final Txn transaction, final long pageNum, final long prevPage, final long nextPage,
+                              final byte[] oldData, final int oldLen, final short oldTid, final short oldRecCnt) {
         super(DOMFile.LOG_REMOVE_PAGE, transaction.getId());
         this.pageNum = pageNum;
         this.prevPage = prevPage;
@@ -66,15 +54,13 @@ public class RemovePageLoggable extends AbstractLoggable {
         this.oldRecCnt = oldRecCnt;
     }
 
-    public RemovePageLoggable(DBBroker broker, long transactionId) {
+    public RemovePageLoggable(final DBBroker broker, final long transactionId) {
         super(DOMFile.LOG_REMOVE_PAGE, transactionId);
         this.domDb = ((NativeBroker)broker).getDOMFile();
     }
     
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
+    @Override
+    public void write(final ByteBuffer out) {
         out.putInt((int) pageNum);
         out.putInt((int) prevPage);
         out.putInt((int) nextPage);
@@ -84,10 +70,8 @@ public class RemovePageLoggable extends AbstractLoggable {
         out.put(oldData, 0, oldLen);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         pageNum = in.getInt();
         prevPage = in.getInt();
         nextPage = in.getInt();
@@ -98,21 +82,22 @@ public class RemovePageLoggable extends AbstractLoggable {
         in.get(oldData, 0, oldLen);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 18 + oldLen;
     }
 
+    @Override
     public void redo() throws LogException {
         domDb.redoRemovePage(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoRemovePage(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - removed page " + pageNum;
     }

--- a/src/org/exist/storage/dom/RemoveValueLoggable.java
+++ b/src/org/exist/storage/dom/RemoveValueLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -31,7 +30,6 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public class RemoveValueLoggable extends AbstractLoggable {
 
@@ -42,18 +40,9 @@ public class RemoveValueLoggable extends AbstractLoggable {
     protected byte[] oldData;
     protected boolean isOverflow;
     protected long backLink;
-    
-    /**
-     * @param transaction 
-     * @param pageNum 
-     * @param tid 
-     * @param offset 
-     * @param oldData 
-     * @param isOverflow 
-     * @param backLink 
-     */
-    public RemoveValueLoggable(Txn transaction, long pageNum, short tid, int offset, byte[] oldData, 
-            boolean isOverflow, long backLink) {
+
+    public RemoveValueLoggable(final Txn transaction, final long pageNum, final short tid, final int offset,
+                               final byte[] oldData, final boolean isOverflow, final long backLink) {
         super(DOMFile.LOG_REMOVE_VALUE, transaction.getId());
         this.pageNum = pageNum;
         this.tid = tid;
@@ -63,56 +52,55 @@ public class RemoveValueLoggable extends AbstractLoggable {
         this.backLink = backLink;
     }
 
-    public RemoveValueLoggable(DBBroker broker, long transactionId) {
+    public RemoveValueLoggable(final DBBroker broker, final long transactionId) {
         super(DOMFile.LOG_REMOVE_VALUE, transactionId);
-        this.domDb = ((NativeBroker)broker).getDOMFile();
+        this.domDb = ((NativeBroker) broker).getDOMFile();
     }
-    
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
-        out.put((byte)(isOverflow ? 1 : 0));
-        out.putInt((int)pageNum);
+
+    @Override
+    public void write(final ByteBuffer out) {
+        out.put((byte) (isOverflow ? 1 : 0));
+        out.putInt((int) pageNum);
         out.putShort(tid);
         out.putShort((short) offset);
         out.putShort((short) oldData.length);
         out.put(oldData);
-        if (ItemId.isRelocated(tid))
+        if (ItemId.isRelocated(tid)) {
             out.putLong(backLink);
+        }
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         isOverflow = in.get() == 1;
         pageNum = in.getInt();
         tid = in.getShort();
         offset = in.getShort();
         oldData = new byte[in.getShort()];
         in.get(oldData);
-        if (ItemId.isRelocated(tid))
+        if (ItemId.isRelocated(tid)) {
             backLink = in.getLong();
+        }
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 11 + oldData.length + (ItemId.isRelocated(tid) ? 8 : 0);
     }
 
+    @Override
     public void redo() throws LogException {
         domDb.redoRemoveValue(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoRemoveValue(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - removed value; tid = " + ItemId.getId(tid) + " from page " + pageNum + " at " + offset +
-            "; len = " + oldData.length;
+                "; len = " + oldData.length;
     }
 }

--- a/src/org/exist/storage/dom/SplitPageLoggable.java
+++ b/src/org/exist/storage/dom/SplitPageLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -32,7 +31,6 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public class SplitPageLoggable extends AbstractLoggable implements Loggable {
 
@@ -41,40 +39,31 @@ public class SplitPageLoggable extends AbstractLoggable implements Loggable {
     protected byte[] oldData;
     protected int oldLen;
     private DOMFile domDb = null;
-    
-    public SplitPageLoggable(Txn transaction, long pageNum, int splitOffset, byte[] oldData, int oldLen) {
+
+    public SplitPageLoggable(final Txn transaction, final long pageNum, final int splitOffset, final byte[] oldData,
+                             final int oldLen) {
         super(DOMFile.LOG_SPLIT_PAGE, transaction.getId());
         this.pageNum = pageNum;
         this.splitOffset = splitOffset;
         this.oldData = oldData;
         this.oldLen = oldLen;
     }
-    
-    /**
-     * 
-     * 
-     * @param broker 
-     * @param transactId 
-     */
-    public SplitPageLoggable(DBBroker broker, long transactId) {
+
+    public SplitPageLoggable(final DBBroker broker, final long transactId) {
         super(DOMFile.LOG_SPLIT_PAGE, transactId);
-        this.domDb = ((NativeBroker)broker).getDOMFile();
+        this.domDb = ((NativeBroker) broker).getDOMFile();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
+    @Override
+    public void write(final ByteBuffer out) {
         out.putInt((int) pageNum);
         out.putInt(splitOffset);
         out.putShort((short) oldLen);
         out.put(oldData, 0, oldLen);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         pageNum = in.getInt();
         splitOffset = in.getInt();
         oldLen = in.getShort();
@@ -82,23 +71,23 @@ public class SplitPageLoggable extends AbstractLoggable implements Loggable {
         in.get(oldData, 0, oldLen);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 10 + oldLen;
     }
-    
+
+    @Override
     public void redo() throws LogException {
         domDb.redoSplitPage(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoSplitPage(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - page split: " + pageNum + " at offset: " + splitOffset;
     }
-
 }

--- a/src/org/exist/storage/dom/UpdateHeaderLoggable.java
+++ b/src/org/exist/storage/dom/UpdateHeaderLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -31,29 +30,17 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public class UpdateHeaderLoggable extends AbstractLoggable {
-
     protected long pageNum;
     protected long nextPage;
     protected long prevPage;
     protected long oldNext;
     protected long oldPrev;
     private DOMFile domDb = null;
-    
-    /**
-     * 
-     * 
-     * @param transaction 
-     * @param prevPage 
-     * @param pageNum 
-     * @param nextPage 
-     * @param oldPrev 
-     * @param oldNext 
-     */
-    public UpdateHeaderLoggable(Txn transaction, long prevPage, long pageNum, long nextPage,
-            long oldPrev, long oldNext) {
+
+    public UpdateHeaderLoggable(final Txn transaction, final long prevPage, final long pageNum, final long nextPage,
+                                final long oldPrev, final long oldNext) {
         super(DOMFile.LOG_UPDATE_HEADER, transaction.getId());
         this.prevPage = prevPage;
         this.pageNum = pageNum;
@@ -62,15 +49,13 @@ public class UpdateHeaderLoggable extends AbstractLoggable {
         this.oldNext = oldNext;
     }
 
-    public UpdateHeaderLoggable(DBBroker broker, long transactId) {
+    public UpdateHeaderLoggable(final DBBroker broker, final long transactId) {
         super(DOMFile.LOG_UPDATE_HEADER, transactId);
-        this.domDb = ((NativeBroker)broker).getDOMFile();
+        this.domDb = ((NativeBroker) broker).getDOMFile();
     }
-    
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
+
+    @Override
+    public void write(final ByteBuffer out) {
         out.putInt((int) prevPage);
         out.putInt((int) pageNum);
         out.putInt((int) nextPage);
@@ -78,10 +63,8 @@ public class UpdateHeaderLoggable extends AbstractLoggable {
         out.putInt((int) oldNext);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         prevPage = in.getInt();
         pageNum = in.getInt();
         nextPage = in.getInt();
@@ -89,23 +72,24 @@ public class UpdateHeaderLoggable extends AbstractLoggable {
         oldNext = in.getInt();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 20;
     }
 
+    @Override
     public void redo() throws LogException {
         domDb.redoUpdateHeader(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoUpdateHeader(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - update header of page " + pageNum + ": prev = " + prevPage +
-            "; next = " + nextPage + "; oldPrev = " + oldPrev + "; oldNext = " + oldNext;
+                "; next = " + nextPage + "; oldPrev = " + oldPrev + "; oldNext = " + oldNext;
     }
 }

--- a/src/org/exist/storage/dom/UpdateLinkLoggable.java
+++ b/src/org/exist/storage/dom/UpdateLinkLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -30,14 +29,13 @@ import org.exist.storage.journal.LogException;
 import org.exist.storage.txn.Txn;
 
 public class UpdateLinkLoggable extends AbstractLoggable {
-
     protected long pageNum;
     protected int offset;
     protected long link;
     protected long oldLink;
     private DOMFile domDb = null;
-    
-    public UpdateLinkLoggable(Txn transaction, long pageNum, int offset, long link, long oldLink) {
+
+    public UpdateLinkLoggable(final Txn transaction, final long pageNum, final int offset, final long link, final long oldLink) {
         super(DOMFile.LOG_UPDATE_LINK, transaction.getId());
         this.pageNum = pageNum;
         this.offset = offset;
@@ -45,37 +43,43 @@ public class UpdateLinkLoggable extends AbstractLoggable {
         this.oldLink = oldLink;
     }
 
-    public UpdateLinkLoggable(DBBroker broker, long transactId) {
+    public UpdateLinkLoggable(final DBBroker broker, final long transactId) {
         super(DOMFile.LOG_UPDATE_LINK, transactId);
-        this.domDb = ((NativeBroker)broker).getDOMFile();
+        this.domDb = ((NativeBroker) broker).getDOMFile();
     }
-    
-    public void write(ByteBuffer out) {
+
+    @Override
+    public void write(final ByteBuffer out) {
         out.putInt((int) pageNum);
         out.putShort((short) offset);
         out.putLong(link);
         out.putLong(oldLink);
     }
 
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         pageNum = in.getInt();
         offset = in.getShort();
         link = in.getLong();
         oldLink = in.getLong();
     }
 
+    @Override
     public int getLogSize() {
         return 22;
     }
 
+    @Override
     public void redo() throws LogException {
         domDb.redoUpdateLink(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoUpdateLink(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - updated link on page: " + pageNum + " at offset: " + offset;
     }

--- a/src/org/exist/storage/dom/UpdateValueLoggable.java
+++ b/src/org/exist/storage/dom/UpdateValueLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -33,16 +32,15 @@ import org.exist.storage.txn.Txn;
  * @author wolf
  */
 public class UpdateValueLoggable extends AbstractLoggable {
-
     protected DOMFile domDb;
     protected long pageNum;
     protected short tid;
     protected byte[] value;
     protected byte[] oldValue;
     protected int oldOffset;
-    
-    public UpdateValueLoggable(Txn transaction, long pageNum, short tid,
-            byte[] value, byte[] oldValue, int oldOffset) {
+
+    public UpdateValueLoggable(final Txn transaction, final long pageNum, final short tid,
+                               final byte[] value, final byte[] oldValue, final int oldOffset) {
         super(DOMFile.LOG_UPDATE_VALUE, transaction.getId());
         this.pageNum = pageNum;
         this.tid = tid;
@@ -51,21 +49,23 @@ public class UpdateValueLoggable extends AbstractLoggable {
         this.oldOffset = oldOffset;
     }
 
-    public UpdateValueLoggable(DBBroker broker, long transactionId) {
+    public UpdateValueLoggable(final DBBroker broker, final long transactionId) {
         super(DOMFile.LOG_UPDATE_VALUE, transactionId);
-        this.domDb = ((NativeBroker)broker).getDOMFile();
+        this.domDb = ((NativeBroker) broker).getDOMFile();
     }
 
-    public void write(ByteBuffer out) {
-        out.putInt((int)pageNum);
+    @Override
+    public void write(final ByteBuffer out) {
+        out.putInt((int) pageNum);
         out.putShort(tid);
-        out.putShort((short)value.length);
+        out.putShort((short) value.length);
         out.put(value);
         out.putShort((short) oldOffset);
-        out.put(oldValue, oldOffset, value.length);        
+        out.put(oldValue, oldOffset, value.length);
     }
 
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         pageNum = in.getInt();
         tid = in.getShort();
         value = new byte[in.getShort()];
@@ -75,18 +75,22 @@ public class UpdateValueLoggable extends AbstractLoggable {
         in.get(oldValue);
     }
 
+    @Override
     public int getLogSize() {
         return 10 + (value.length * 2);
     }
-    
+
+    @Override
     public void redo() throws LogException {
         domDb.redoUpdateValue(this);
     }
-    
+
+    @Override
     public void undo() throws LogException {
         domDb.undoUpdateValue(this);
     }
-    
+
+    @Override
     public String dump() {
         return super.dump() + " - updated value; tid = " + ItemId.getId(tid) + " to page " + pageNum;
     }

--- a/src/org/exist/storage/dom/WriteOverflowPageLoggable.java
+++ b/src/org/exist/storage/dom/WriteOverflowPageLoggable.java
@@ -1,24 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Team
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
  *
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.dom;
 
@@ -33,73 +31,60 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public class WriteOverflowPageLoggable extends AbstractLoggable {
+    protected long pageNum;
+    protected long nextPage;
+    protected Value value;
+    private DOMFile domDb = null;
 
-	protected long pageNum;
-	protected long nextPage;
-	protected Value value;
-	private DOMFile domDb = null;
-	
-	/**
-     * 
-     * 
-     * @param transaction 
-     * @param pageNum 
-     * @param nextPage 
-     * @param value 
-     */
-	public WriteOverflowPageLoggable(Txn transaction, long pageNum, long nextPage, Value value) {
-		super(DOMFile.LOG_WRITE_OVERFLOW, transaction.getId());
-		this.pageNum = pageNum;
-		this.nextPage = nextPage;
-		this.value = value;
-	}
+    public WriteOverflowPageLoggable(final Txn transaction, final long pageNum, final long nextPage, final Value value) {
+        super(DOMFile.LOG_WRITE_OVERFLOW, transaction.getId());
+        this.pageNum = pageNum;
+        this.nextPage = nextPage;
+        this.value = value;
+    }
 
-	public WriteOverflowPageLoggable(DBBroker broker, long transactId) {
-		super(DOMFile.LOG_WRITE_OVERFLOW, transactId);
-		this.domDb = ((NativeBroker)broker).getDOMFile();
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-	 */
-	public void write(ByteBuffer out) {
-		out.putInt((int) pageNum);
-		out.putInt((int) nextPage);
-		out.putShort((short) value.getLength());
-		out.put(value.data(), value.start(), value.getLength());
-	}
+    public WriteOverflowPageLoggable(final DBBroker broker, final long transactId) {
+        super(DOMFile.LOG_WRITE_OVERFLOW, transactId);
+        this.domDb = ((NativeBroker) broker).getDOMFile();
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-	 */
-	public void read(ByteBuffer in) {
-		pageNum = in.getInt();
-		nextPage = in.getInt();
-		final int len = in.getShort();
-		final byte[] data = new byte[len];
-		in.get(data);
-		value = new Value(data);
-	}
+    @Override
+    public void write(final ByteBuffer out) {
+        out.putInt((int) pageNum);
+        out.putInt((int) nextPage);
+        out.putShort((short) value.getLength());
+        out.put(value.data(), value.start(), value.getLength());
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.storage.log.Loggable#getLogSize()
-	 */
-	public int getLogSize() {
-		return 10 + value.getLength();
-	}
+    @Override
+    public void read(final ByteBuffer in) {
+        pageNum = in.getInt();
+        nextPage = in.getInt();
+        final int len = in.getShort();
+        final byte[] data = new byte[len];
+        in.get(data);
+        value = new Value(data);
+    }
 
-	public void redo() throws LogException {
-		domDb.redoWriteOverflow(this);
-	}
-	
-	public void undo() throws LogException {
-		domDb.undoWriteOverflow(this);
-	}
-	
-	public String dump() {
-		return super.dump() + " - writing overflow page " + pageNum + "; next: " + nextPage;
-	}
+    @Override
+    public int getLogSize() {
+        return 10 + value.getLength();
+    }
+
+    @Override
+    public void redo() throws LogException {
+        domDb.redoWriteOverflow(this);
+    }
+
+    @Override
+    public void undo() throws LogException {
+        domDb.undoWriteOverflow(this);
+    }
+
+    @Override
+    public String dump() {
+        return super.dump() + " - writing overflow page " + pageNum + "; next: " + nextPage;
+    }
 }

--- a/src/org/exist/storage/index/AbstractBFileLoggable.java
+++ b/src/org/exist/storage/index/AbstractBFileLoggable.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.index;
 
@@ -30,55 +29,41 @@ import org.exist.storage.txn.Txn;
 
 /**
  * @author wolf
- *
  */
 public abstract class AbstractBFileLoggable extends AbstractLoggable {
-
-    protected NativeBroker broker;
+    private NativeBroker broker;
     protected byte fileId;
-    
-    /**
-     * 
-     * 
-     * @param fileId 
-     * @param transaction 
-     * @param type 
-     */
-    public AbstractBFileLoggable(byte type, byte fileId, Txn transaction) {
+
+    public AbstractBFileLoggable(final byte type, final byte fileId, final Txn transaction) {
         super(type, transaction.getId());
         this.fileId = fileId;
     }
 
-    public AbstractBFileLoggable(DBBroker broker, long transactionId) {
+    public AbstractBFileLoggable(final DBBroker broker, final long transactionId) {
         super(BFile.LOG_CREATE_PAGE, transactionId);
         this.broker = (NativeBroker) broker;
     }
-    
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
+
+    @Override
+    public void write(final ByteBuffer out) {
         out.put(fileId);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
         fileId = in.get();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 1;
     }
-    
+
     protected BFile getIndexFile() {
         return (BFile) broker.getStorage(fileId);
     }
 
+    @Override
     public String dump() {
         return super.dump() + " [BFile]";
     }

--- a/src/org/exist/storage/index/BFile.java
+++ b/src/org/exist/storage/index/BFile.java
@@ -128,16 +128,16 @@ public class BFile extends BTree {
 
     static {
         // register log entry types for this db file
-        LogEntryTypes.addEntryType(LOG_CREATE_PAGE, CreatePageLoggable.class);
-        LogEntryTypes.addEntryType(LOG_STORE_VALUE, StoreValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_REMOVE_VALUE, RemoveValueLoggable.class);
-        LogEntryTypes.addEntryType(LOG_REMOVE_PAGE, RemoveEmptyPageLoggable.class);
-        LogEntryTypes.addEntryType(LOG_OVERFLOW_APPEND, OverflowAppendLoggable.class);
-        LogEntryTypes.addEntryType(LOG_OVERFLOW_STORE, OverflowStoreLoggable.class);
-        LogEntryTypes.addEntryType(LOG_OVERFLOW_CREATE, OverflowCreateLoggable.class);
-        LogEntryTypes.addEntryType(LOG_OVERFLOW_MODIFIED, OverflowModifiedLoggable.class);
-        LogEntryTypes.addEntryType(LOG_OVERFLOW_CREATE_PAGE, OverflowCreatePageLoggable.class);
-        LogEntryTypes.addEntryType(LOG_OVERFLOW_REMOVE, OverflowRemoveLoggable.class);
+        LogEntryTypes.addEntryType(LOG_CREATE_PAGE, CreatePageLoggable::new);
+        LogEntryTypes.addEntryType(LOG_STORE_VALUE, StoreValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_REMOVE_VALUE, RemoveValueLoggable::new);
+        LogEntryTypes.addEntryType(LOG_REMOVE_PAGE, RemoveEmptyPageLoggable::new);
+        LogEntryTypes.addEntryType(LOG_OVERFLOW_APPEND, OverflowAppendLoggable::new);
+        LogEntryTypes.addEntryType(LOG_OVERFLOW_STORE, OverflowStoreLoggable::new);
+        LogEntryTypes.addEntryType(LOG_OVERFLOW_CREATE, OverflowCreateLoggable::new);
+        LogEntryTypes.addEntryType(LOG_OVERFLOW_MODIFIED, OverflowModifiedLoggable::new);
+        LogEntryTypes.addEntryType(LOG_OVERFLOW_CREATE_PAGE, OverflowCreatePageLoggable::new);
+        LogEntryTypes.addEntryType(LOG_OVERFLOW_REMOVE, OverflowRemoveLoggable::new);
     }
 
     protected BFileHeader fileHeader;

--- a/src/org/exist/storage/journal/AbstractLoggable.java
+++ b/src/org/exist/storage/journal/AbstractLoggable.java
@@ -1,82 +1,81 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.journal;
 
 /**
  * Abstract implementation of the Loggable interface.
- * 
- * @author wolf
  *
+ * @author wolf
  */
 public abstract class AbstractLoggable implements Loggable {
 
-    protected long transactId;
-    protected byte type;
+    protected final byte type;
+    protected long transactionId;
     protected long lsn;
-    
-    /**
-     * Default constructor: initialize entry type and transaction id.
-     * 
-     * @param type
-     * @param transactionId
-     */
-    public AbstractLoggable(byte type, long transactionId) {
+
+    public AbstractLoggable(final byte type, final long transactionId) {
         this.type = type;
-        this.transactId = transactionId;
+        this.transactionId = transactionId;
     }
-    
-    public void clear(long transactionId) {
-        this.transactId = transactionId;
+
+    public void clear(final long transactionId) {
+        this.transactionId = transactionId;
     }
-    
+
+    @Override
     public byte getLogType() {
         return type;
     }
-    
+
+    @Override
     public long getTransactionId() {
-        return transactId;
+        return transactionId;
     }
-    
+
+    @Override
     public void setLsn(long lsn) {
         this.lsn = lsn;
     }
-    
+
+    @Override
     public long getLsn() {
         return lsn;
     }
-	
+
+    @Override
     public void redo() throws LogException {
         // do nothing
     }
-    
+
+    @Override
     public void undo() throws LogException {
         // do nothing
     }
-    
+
     /**
      * Default implementation returns the current LSN plus the
-     * class name of the Loggable instance. 
+     * class name of the Loggable instance.
      */
-	public String dump() {
-		return '[' + Lsn.dump(getLsn()) + "] " + getClass().getName() + ' ';
-	}
+    @Override
+    public String dump() {
+        return '[' + Lsn.dump(getLsn()) + "] " + getClass().getName() + ' ';
+    }
 }

--- a/src/org/exist/storage/txn/Checkpoint.java
+++ b/src/org/exist/storage/txn/Checkpoint.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.txn;
 
@@ -32,36 +31,30 @@ import org.exist.storage.journal.LogEntryTypes;
 /**
  * @author wolf
  */
-
 public class Checkpoint extends AbstractLoggable {
-
 	private long timestamp;
 	private long storedLsn;
 	
 	private final DateFormat df =
 		DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM);
 	
-    public Checkpoint(long transactionId) {
+    public Checkpoint(final long transactionId) {
         this(null, transactionId);
     }
     
-    public Checkpoint(DBBroker broker, long transactionId) {
+    public Checkpoint(final DBBroker broker, final long transactionId) {
         super(LogEntryTypes.CHECKPOINT, transactionId);
 		timestamp = new Date().getTime();
     }
     
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#write(java.nio.ByteBuffer)
-     */
-    public void write(ByteBuffer out) {
+    @Override
+    public void write(final ByteBuffer out) {
     	out.putLong(lsn);
 		out.putLong(timestamp);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#read(java.nio.ByteBuffer)
-     */
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
     	storedLsn = in.getLong();
 		timestamp = in.getLong();
     }
@@ -70,17 +63,16 @@ public class Checkpoint extends AbstractLoggable {
     	return storedLsn;
     }
     
-    /* (non-Javadoc)
-     * @see org.exist.storage.log.Loggable#getLogSize()
-     */
+    @Override
     public int getLogSize() {
         return 16;
     }
-	
+
     public String getDateString() {
     	return df.format(new Date(timestamp));
     }
-    
+
+    @Override
 	public String dump() {
 		return super.dump() + " - checkpoint at " + df.format(new Date(timestamp));
 	}

--- a/src/org/exist/storage/txn/TxnAbort.java
+++ b/src/org/exist/storage/txn/TxnAbort.java
@@ -1,3 +1,23 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2015 The eXist Team
+ *
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
 package org.exist.storage.txn;
 
 import java.nio.ByteBuffer;
@@ -8,26 +28,29 @@ import org.exist.storage.journal.LogEntryTypes;
 
 public class TxnAbort extends AbstractLoggable {
 
-	public TxnAbort(long transactionId) {
+    public TxnAbort(final long transactionId) {
         this(null, transactionId);
     }
-    
-    public TxnAbort(DBBroker broker, long transactionId) {
+
+    public TxnAbort(final DBBroker broker, final long transactionId) {
         super(LogEntryTypes.TXN_ABORT, transactionId);
     }
-    
-	public void write(ByteBuffer out) {
-	}
 
-	public void read(ByteBuffer in) {
+    @Override
+    public void write(final ByteBuffer out) {
+    }
 
-	}
+    @Override
+    public void read(final ByteBuffer in) {
+    }
 
-	public int getLogSize() {
-		return 0;
-	}
+    @Override
+    public int getLogSize() {
+        return 0;
+    }
 
-	public String dump() {
-		return super.dump() + " - transaction " + transactId + " aborted.";
-	}
+    @Override
+    public String dump() {
+        return super.dump() + " - transaction " + transactionId + " aborted.";
+    }
 }

--- a/src/org/exist/storage/txn/TxnCommit.java
+++ b/src/org/exist/storage/txn/TxnCommit.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.txn;
 
@@ -29,29 +28,32 @@ import org.exist.storage.journal.LogEntryTypes;
 
 /**
  * @author wolf
- *
  */
 public class TxnCommit extends AbstractLoggable {
 
-    public TxnCommit(long transactionId) {
+    public TxnCommit(final long transactionId) {
         this(null, transactionId);
     }
-    
-    public TxnCommit(DBBroker broker, long transactionId) {
+
+    public TxnCommit(final DBBroker broker, final long transactionId) {
         super(LogEntryTypes.TXN_COMMIT, transactionId);
     }
 
-    public void write(ByteBuffer out) {
+    @Override
+    public void write(final ByteBuffer out) {
     }
 
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
     }
 
+    @Override
     public int getLogSize() {
         return 0;
     }
-	
-	public String dump() {
-		return super.dump() + " - transaction " + transactId + " committed.";
-	}
+
+    @Override
+    public String dump() {
+        return super.dump() + " - transaction " + transactionId + " committed.";
+    }
 }

--- a/src/org/exist/storage/txn/TxnStart.java
+++ b/src/org/exist/storage/txn/TxnStart.java
@@ -1,23 +1,22 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2015 The eXist Project
+ *
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.txn;
 
@@ -29,29 +28,32 @@ import org.exist.storage.journal.LogEntryTypes;
 
 /**
  * @author wolf
- *
  */
 public class TxnStart extends AbstractLoggable {
 
-    public TxnStart(long transactionId) {
+    public TxnStart(final long transactionId) {
         this(null, transactionId);
     }
-    
-    public TxnStart(DBBroker broker, long transactionId) {
+
+    public TxnStart(final DBBroker broker, final long transactionId) {
         super(LogEntryTypes.TXN_START, transactionId);
     }
 
-    public void write(ByteBuffer out) {
+    @Override
+    public void write(final ByteBuffer out) {
     }
 
-    public void read(ByteBuffer in) {
+    @Override
+    public void read(final ByteBuffer in) {
     }
 
+    @Override
     public int getLogSize() {
         return 0;
     }
-	
-	public String dump() {
-		return super.dump() + " - transaction " + transactId + " started.";
-	}
+
+    @Override
+    public String dump() {
+        return super.dump() + " - transaction " + transactionId + " started.";
+    }
 }


### PR DESCRIPTION
Java 8 provide method references; As the Enumeration of Loggable sub-classes is statically known and their constructors fixed, we can instead use a method reference to the constructor of each Loggable to avoid the expensive use of reflection at runtime.