### PR TITLE
[bugfix] Small fixes to Backup/Restore process

### DIFF
--- a/src/org/exist/backup/Backup.java
+++ b/src/org/exist/backup/Backup.java
@@ -233,7 +233,13 @@ public class Backup
         if(FileUtils.fileName(target).endsWith(".zip")) {
             fWriter = currentName -> new ZipWriter(target, encode(URIUtils.urlDecodeUtf8(currentName)));
         } else {
-            fWriter = currentName -> new FileSystemWriter(target.resolve(encode(URIUtils.urlDecodeUtf8(currentName))));
+            fWriter = currentName -> {
+                String child = encode(URIUtils.urlDecodeUtf8(currentName));
+                if(child.charAt(0) == '/') {
+                    child = child.substring(1);
+                }
+                return new FileSystemWriter(target.resolve(child));
+            };
         }
 
         try(final BackupWriter output = fWriter.apply(cname)) {

--- a/src/org/exist/backup/FileSystemBackupDescriptor.java
+++ b/src/org/exist/backup/FileSystemBackupDescriptor.java
@@ -125,11 +125,13 @@ public class FileSystemBackupDescriptor extends AbstractBackupDescriptor
         	dir = dir.getParent();
         	if (dir != null) {
 	        	final Path propFile = dir.resolve(BACKUP_PROPERTIES);
-                final Properties  properties = new Properties();
-                try(final InputStream is = Files.newInputStream(propFile)) {
-                    properties.load(is);
+                if(Files.exists(propFile)) {
+                    final Properties properties = new Properties();
+                    try (final InputStream is = Files.newInputStream(propFile)) {
+                        properties.load(is);
+                    }
+                    return properties;
                 }
-                return properties;
         	}
         }
         return null;


### PR DESCRIPTION
Under some circumstances after the move to NIO.2 the backup/restore process can fail when it is misused in such a way that it resolves absolute paths against relative paths. There were no tests for such behaviour. Anyway here are some improvements to make it even more robust.