### PR TITLE
Windows shutdown issues: launch as service

### DIFF
--- a/build/scripts/build-impl.xml
+++ b/build/scripts/build-impl.xml
@@ -37,20 +37,20 @@
     <property name="jvmarg" value="-Xmx128000k -Xms32000k -Djetty.home=${jetty.dir} -Dexist.home=${basedir}"/>
     <property name="xmldb.src" value="undefined"/>
     <property name="dist.dir" value="${dist}/${project.name}-${project.version}"/>
-        
+
     <!-- import common targets -->
     <!-- <import file="../../build.xml"/> -->
     <import file="git-support.xml"/>
     <import file="./junit.xml"/>
     <import file="./antlr3.xml"/>
-    
+
     <!-- setup conditional properties -->
     <available file="${xmldb.src}" type="dir" property="has.xmldb.src"/>
     <available file="key.store" property="key.store.present"/>
 
     <!-- additional set of ant tasks -->
     <property name="asocat-exist.jar" location="${tools.ant}/lib/asocat-exist.jar"/>
-    
+
     <path id="classpath.external">
         <fileset dir="${lib.core}">
             <include name="*.jar"/>
@@ -61,22 +61,25 @@
         <fileset dir="${lib.endorsed}">
             <include name="*.jar"/>
         </fileset>
-        
+
         <fileset dir="${lib.user}">
             <include name="*.jar"/>
         </fileset>
         <fileset dir="${lib.extensions}" erroronmissingdir="false">
             <include name="*.jar"/>
         </fileset>
-        
+
         <fileset dir="extensions" erroronmissingdir="false">
             <include name="**/lib/*.jar"/>
         </fileset>
         <fileset dir="${tools.ant}/lib">
             <include name="*.jar"/>
         </fileset>
+        <fileset dir="tools/wrapper/lib">
+            <include name="*.jar"/>
+        </fileset>
     </path>
-    
+
     <!-- setup class path -->
     <path id="classpath.core">
         <path refid="classpath.external"/>
@@ -149,7 +152,7 @@
         <copy file="${basedir}/mime-types.xml.tmpl" tofile="${basedir}/mime-types.xml"
             filtering="true"/>
         <copy file="${basedir}/mime-types.xml" tofile="${src}/org/exist/util/mime-types.xml"/>
-        
+
         <copy file="${src.webapp}/WEB-INF/web.xml.tmpl" tofile="${src.webapp}/WEB-INF/web.xml"
             filtering="true" overwrite="true"/>
 
@@ -406,13 +409,13 @@
     <target name="all"
         depends="prepare,jar,wrapper,extension-betterform,extension-modules,extension-xprocxq,extensions-xar,test-compile"
         description="Build all">
-        
+
         <!--  hand over build to extensions build -->
         <ant antfile="${build.scripts}/extensions-build.xml" target="all" inheritAll="false"/>
-        
+
         <!--  this module must be built after the ldap extension -->
         <ant antfile="build.xml" dir="extensions/security/activedirectory" inheritall="false"/>
-        
+
         <antcall target="sign"/>
     </target>
 
@@ -430,7 +433,7 @@
 
         <delete dir="${build.javadoc}"/>
         <mkdir dir="${build.javadoc}"/>
-        
+
         <echo message="Generating Javadocs ..."/>
         <javadoc bottom="Copyright (C) The eXist-db Project. All rights reserved." destdir="${build.javadoc}"
             doctitle="eXist Javadocs" noindex="true" notree="true" access="public" maxmemory="1024M"
@@ -456,7 +459,7 @@
             <classpath>
                 <path refid="classpath.core"/>
                 <path refid="classpath.jetty"/>
-                <path refid="classpath.aspectj"/>                
+                <path refid="classpath.aspectj"/>
             </classpath>
             <link href="http://xmldb.exist-db.org/javadoc/"/>
             <link href="http://java.sun.com/javase/7/docs/api/"/>
@@ -474,18 +477,18 @@
             <link href="http://www.slf4j.org/api/"/>
             <link href="http://nekohtml.sourceforge.net/javadoc/"/>
             <link href="http://www.quartz-scheduler.org/api/1.8.5/"/>
-            <link href="http://sunxacml.sourceforge.net/javadoc/"/>  
+            <link href="http://sunxacml.sourceforge.net/javadoc/"/>
             <link href="http://ws.apache.org/xmlrpc/apidocs/"/>
-            <link href="http://www.antlr2.org/javadoc/"/>          
+            <link href="http://www.antlr2.org/javadoc/"/>
             <link href="http://xerces.apache.org/xerces2-j/javadocs/api/"/>
             <link href="http://xerces.apache.org/xerces2-j/javadocs/xerces2/"/>
             <link href="http://xerces.apache.org/xerces2-j/javadocs/xni/"/>
             <link href="http://xml.apache.org/commons/components/apidocs/resolver/"/>
             <link href="http://xml.apache.org/xalan-j/apidocs/"/>
             <link href="http://java.sun.com/products/javamail/javadocs/"/>
-            <link href="http://java.sun.com/javase/technologies/desktop/javabeans/glasgow/javadocs"/>   
-            <link href="http://download.eclipse.org/jetty/stable-7/apidocs/"/> 
-            <link href="http://www.saxonica.com/documentation/javadoc"/> 
+            <link href="http://java.sun.com/javase/technologies/desktop/javabeans/glasgow/javadocs"/>
+            <link href="http://download.eclipse.org/jetty/stable-7/apidocs/"/>
+            <link href="http://www.saxonica.com/documentation/javadoc"/>
             <link href="http://lucene.apache.org/java/2_9_4/api/all/"/>
         </javadoc>
 
@@ -545,17 +548,17 @@
             <link href="http://logging.apache.org/log4j/2.x/log4j-api/apidocs/"/>
             <link href="http://nekohtml.sourceforge.net/javadoc/"/>
             <link href="http://www.quartz-scheduler.org/docs/api/"/>
-            <link href="http://sunxacml.sourceforge.net/javadoc/"/>  
+            <link href="http://sunxacml.sourceforge.net/javadoc/"/>
             <link href="http://ws.apache.org/xmlrpc/apidocs/"/>
             <link href="http://www.antlr2.org/javadoc/"/>
-            <link href="http://www.jgroups.org/javagroupsnew/docs/javadoc/"/>          
+            <link href="http://www.jgroups.org/javagroupsnew/docs/javadoc/"/>
             <link href="http://xerces.apache.org/xerces2-j/javadocs/api/"/>
             <link href="http://xerces.apache.org/xerces2-j/javadocs/xerces2/"/>
             <link href="http://xerces.apache.org/xerces2-j/javadocs/xni/"/>
             <link href="http://xml.apache.org/commons/components/apidocs/resolver/"/>
             <link href="http://xml.apache.org/xalan-j/apidocs/"/>
             <link href="http://java.sun.com/products/javamail/javadocs/"/>
-            <link href="http://java.sun.com/javase/technologies/desktop/javabeans/glasgow/javadocs"/>   
+            <link href="http://java.sun.com/javase/technologies/desktop/javabeans/glasgow/javadocs"/>
         </javadoc>
 
         <ant antfile="build.xml" dir="extensions/fluent" target="javadoc"/>
@@ -597,26 +600,26 @@
         </delete>
 
         <delete failonerror="no" dir="${dist}"/>
-        
+
         <!-- XQTS files -->
         <delete failonerror="no">
             <fileset dir="${junit.reports}/external" includes="*.zip"/>
         </delete>
         <delete failonerror="no" dir="cat"/>
-        
+
         <ant antfile="build.xml" dir="extensions/betterform" target="clean" inheritall="false"/>
         <ant antfile="build.xml" dir="extensions/modules" target="clean" inheritall="false"/>
         <ant antfile="build.xml" dir="extensions/security/activedirectory"  target="clean" inheritall="false"/>
         <ant antfile="build.xml" dir="extensions/xprocxq" target="clean" inheritall="false"/>
         <ant antfile="build.xml" dir="tools/wrapper" target="clean" inheritall="false"/>
-        
+
         <ant antfile="${build.scripts}/extensions-build.xml" target="clean" inheritAll="false"/>
-        
+
         <!-- fall back -->
         <delete failonerror="no">
             <fileset dir="${lib.extensions}" includes="*.jar"/>
-        </delete> 
-        
+        </delete>
+
     </target>
 
     <target name="clean-conf" description="Cleanup config file">
@@ -663,7 +666,7 @@
 
         <!-- autodeploy -->
         <delete failonerror="no" dir="autodeploy"/>
-        
+
         <!-- XQTS files -->
         <delete failonerror="no">
             <fileset dir="${junit.reports}/src/org/exist/xquery/xqts" includes="*" excludes="QT3TS_case.java,QT3TS_To_junit.java,XQTS_case.java,XQTS_To_junit.java,config.xml,hacked-tests.xml,xqts.xql"/>
@@ -671,7 +674,7 @@
         </delete>
         <delete failonerror="no">
             <fileset dir="${jetty.dir}/tmp" includes="*"/>
-        </delete> 
+        </delete>
         <mkdir dir="${jetty.dir}/tmp"/>
 		<ant antfile="build.xml" dir="extensions/modules" target="clean-all" inheritall="false"/>
     </target>
@@ -687,11 +690,11 @@
     <target name="extension-modules" depends="jar">
         <ant antfile="build.xml" dir="extensions/modules" inheritall="false"/>
     </target>
-    
+
     <target name="extension-xprocxq" depends="jar">
         <ant antfile="build.xml" dir="extensions/xprocxq" inheritall="false"/>
     </target>
-    
+
     <target name="samples" depends="jar" description="Build samples">
         <ant antfile="build.xml" dir="samples"/>
     </target>
@@ -699,7 +702,7 @@
     <target name="extensions-xar" depends="jar" if="${use.autodeploy.feature}" >
         <ant antfile="build/scripts/setup.xml" dir="." inheritall="false"/>
     </target>
-    
+
     <target name="cleandocs">
         <replaceregexp>
             <regexp pattern="/\*.*Description of the Method.*\*/"/>
@@ -733,7 +736,7 @@
         <!-- the jars are some how locked by ant (classpath.core)-->
 
     </target>
-    
+
 
     <!-- ============================================================================ -->
     <!-- Download additional files                                                    -->
@@ -750,5 +753,5 @@
     </target>
 
 
-    
+
 </project>

--- a/installer/vm.properties
+++ b/installer/vm.properties
@@ -11,3 +11,5 @@ vmoptions=-Dfile.encoding=UTF-8
 
 # Mac specific properties
 vmoptions.mac=-Xdock:name="eXist-db" -Xdock:icon="icon.png" -Dapple.laf.useScreenMenuBar="true"
+
+vmoptions.win=-Djava.library.path=tools/wrapper/lib -Djava.security.manager -Djava.security.policy=tools/wrapper/conf/java.policy

--- a/src/org/exist/launcher/LauncherWrapper.java
+++ b/src/org/exist/launcher/LauncherWrapper.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.Properties;
 
@@ -76,6 +75,7 @@ public class LauncherWrapper {
         final Java java = new Java();
         java.setFork(true);
         java.setSpawn(spawn);
+        java.setJvmargs("-Dwrapper.java.library.path=" + home + "tools/wrapper/");
         //java.setClassname(org.exist.start.Main.class.getName());
         java.setProject(project);
         java.setJar(new File(home, "start.jar"));
@@ -136,7 +136,7 @@ public class LauncherWrapper {
 
     public static Properties getVMProperties() {
         final Properties vmProperties = new Properties();
-        final Path propFile = ConfigurationHelper.lookup("vm.properties");
+        final java.nio.file.Path propFile = ConfigurationHelper.lookup("vm.properties");
         InputStream is = null;
         try {
             if (Files.isReadable(propFile)) {

--- a/src/org/exist/launcher/SplashScreen.java
+++ b/src/org/exist/launcher/SplashScreen.java
@@ -107,10 +107,9 @@ public class SplashScreen extends JFrame implements Observer {
 
     public void update(Observable o, Object arg) {
         if (JettyStart.SIGNAL_STARTED.equals(arg)) {
-            launcher.signalStarted();
-
             setStatus("Server started!");
             setVisible(false);
+            launcher.signalStarted();
         } else if (BrokerPool.SIGNAL_STARTUP.equals(arg)) {
             setStatus("Starting eXist-db ...");
         } else if (BrokerPool.SIGNAL_ABORTED.equals(arg)) {

--- a/src/org/exist/launcher/UtilityPanel.java
+++ b/src/org/exist/launcher/UtilityPanel.java
@@ -103,7 +103,7 @@ public class UtilityPanel extends JFrame implements Observer {
         });
         toolbar.add(button);
 
-        button = createButton(toolbar, "shutdown.png", "Shut Down");
+        button = createButton(toolbar, "shutdown.png", "Quit");
         button.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {

--- a/src/org/exist/start/start.config
+++ b/src/org/exist/start/start.config
@@ -9,12 +9,12 @@
 # Format of line:
 #
 #  <subject> [ <space> <condition> ]*
-# 
-# where <subject> 
+#
+# where <subject>
 #   ends with ".class" is the Main class to run.
 #   ends with ".xml" is a configuration file for the command line
-#   ends with "/" is a directory from which add all jar and zip files from. 
-#   ends with "/*" is a directory from which add all unconsidered jar and zip files from. 
+#   ends with "/" is a directory from which add all jar and zip files from.
+#   ends with "/*" is a directory from which add all unconsidered jar and zip files from.
 #   all other subjects are treated as files to be added to the classpath.
 # Files starting with "/" are considered absolute, all others are relative to
 # the home directory.
@@ -104,3 +104,4 @@ tools/jetty/lib/*                                  mode == standalone
 tools/jetty/lib/*                                  mode == other
 tools/ircbot/lib/*                                 mode == jetty
 tools/aspectj/lib/*                                always
+tools/wrapper/lib/*                                mode == other

--- a/tools/wrapper/bin/control.bat
+++ b/tools/wrapper/bin/control.bat
@@ -21,15 +21,15 @@ rem The base name for the Wrapper binary.
 set _WRAPPER_BASE=wrapper
 
 rem The directory where the Wrapper binary (.exe) file is located, this can be
-rem either a absolute or relative path. If the path contains any special characters, 
-rem please make sure to quote the variable. 
+rem either a absolute or relative path. If the path contains any special characters,
+rem please make sure to quote the variable.
 set _WRAPPER_DIR=
 
 rem The name and location of the Wrapper configuration file.   This will be used
 rem  if the user does not specify a configuration file as the first parameter to
 rem  this script.  It will not be possible to specify a configuration file on the
-rem  command line if _PASS_THROUGH is set. 
-rem If a relative path is specified, please note that the location is based on the 
+rem  command line if _PASS_THROUGH is set.
+rem If a relative path is specified, please note that the location is based on the
 rem location.
 set _WRAPPER_CONF_DEFAULT="../conf/%_WRAPPER_BASE%.conf"
 
@@ -125,11 +125,9 @@ shift
 if not [%1]==[] goto :parameters
 
 if [%_PASS_THROUGH%]==[] (
-    %_WRAPPER_EXE% -it %_WRAPPER_CONF%
+    %_WRAPPER_EXE% -i %_WRAPPER_CONF%
 ) else (
-    %_WRAPPER_EXE% -it %_WRAPPER_CONF% -- %_PARAMETERS%
+    %_WRAPPER_EXE% %_PARAMETERS% %_WRAPPER_CONF%
 )
 if not errorlevel 1 goto :eof
 pause
-
-

--- a/tools/wrapper/conf/java.policy
+++ b/tools/wrapper/conf/java.policy
@@ -1,0 +1,13 @@
+// Windows only: using wrapper to start/stop eXist requires special permissions
+
+// Give Wrapper classes full permissions
+grant codeBase "file:tools/wrapper/lib/wrapper.jar" {
+        permission java.security.AllPermission;
+};
+
+// Grant various permissions to a specific service.
+grant codeBase "file:-" {
+        permission java.security.AllPermission;
+
+        permission org.tanukisoftware.wrapper.security.WrapperServicePermission "eXist*", "interrogate,start,stop";
+};

--- a/vm.properties
+++ b/vm.properties
@@ -11,3 +11,5 @@ vmoptions=-Dfile.encoding=UTF-8
 
 # Mac specific properties
 vmoptions.mac=-Xdock:name="eXist-db" -Xdock:icon="icon.png" -Dapple.laf.useScreenMenuBar="true"
+
+vmoptions.win=-Djava.library.path=tools/wrapper/lib -Djava.security.manager -Djava.security.policy=tools/wrapper/conf/java.policy


### PR DESCRIPTION
With recent Java and Windows versions, the OS is no longer sending a signal to eXist before shutting down, thus causing a crash and a recovery run. The only really reliable method to avoid this is to register eXist as a service. Most new users won't be aware of it though (or do not read the documentation), and get a bad impression.

I have thus extended the desktop launcher to automatically check on startup if eXist has already been installed as a service. If not, the launcher will ask if it should do so. After installation, the service can be controlled from the system tray menu. Advanced users which do not start eXist via the launcher can be expected to know how to install a service.

Tested on win8 and 10. Other operating systems are not affected. Java service wrapper is used to interact with the OS.

Closes #713 