### PR TITLE
Function classes must have `public` visibility

### DIFF
--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/UriFunctions.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/UriFunctions.java
@@ -44,7 +44,7 @@ import org.exquery.restxq.RestXqErrorCodes;
  *
  * @author Adam Retter <adam.retter@googlemail.com>
  */
-class UriFunctions extends BasicFunction {
+public class UriFunctions extends BasicFunction {
     
     public final static FunctionSignature signatures[] = {
 		

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/exist/RegistryFunctions.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/exist/RegistryFunctions.java
@@ -58,7 +58,7 @@ import org.exquery.restxq.RestXqServiceRegistry;
  *
  * @author Adam Retter <adam.retter@googlemail.com>
  */
-class RegistryFunctions extends BasicFunction {
+public class RegistryFunctions extends BasicFunction {
     
     private final static QName qnFindResourceFunctions = new QName("find-resource-functions", ExistRestXqModule.NAMESPACE_URI, ExistRestXqModule.PREFIX);
     private final static QName qnRegisterModule = new QName("register-module", ExistRestXqModule.NAMESPACE_URI, ExistRestXqModule.PREFIX);


### PR DESCRIPTION
 The `inspect` module uses reflection to enumerate or access function modules. eXide expects all function modules to be publicly enumerable, and so this change fixes that issue.