### PR TITLE
[bugfix] NPE when removing a library package

### DIFF
--- a/src/org/exist/repo/Deployment.java
+++ b/src/org/exist/repo/Deployment.java
@@ -306,6 +306,12 @@ public class Deployment {
                 if (pkg.isPresent()) {
                     uninstall(pkg.get(), target);
                 }
+                if (target == null) {
+                    // a library package does not have a target collection, but we still return
+                    // the temporary location of the package in /db/system
+                    final String pkgColl = pkg.get().getAbbrev() + "-" + pkg.get().getVersion();
+                    return Optional.of(XmldbURI.SYSTEM.append("repo/" + pkgColl).getCollectionPath());
+                }
                 return Optional.ofNullable(target.getStringValue());
             } catch (final XPathException e) {
                 throw new PackageException("Error found while processing repo.xml: " + e.getMessage(), e);


### PR DESCRIPTION
A library package does not have a target collection. Avoid NPE in this case.