### PR TITLE
Support for resources in repo.xml (replaces PR #727)

### DIFF
--- a/src/org/exist/repo/Deployment.java
+++ b/src/org/exist/repo/Deployment.java
@@ -27,10 +27,10 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.exist.SystemProperties;
+import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.InMemoryNodeSet;
 import org.exist.dom.memtree.DocumentImpl;
@@ -98,6 +98,8 @@ public class Deployment {
     private static final QName CLEANUP_ELEMENT = new QName("cleanup", REPO_NAMESPACE);
     private static final QName DEPLOYED_ELEMENT = new QName("deployed", REPO_NAMESPACE);
     private static final QName DEPENDENCY_ELEMENT = new QName("dependency", PKG_NAMESPACE);
+    private static final QName RESOURCES_ELEMENT = new QName("resources", REPO_NAMESPACE);
+    private static final String RESOURCES_PATH_ATTRIBUTE = "path";
 
     private final DBBroker broker;
 
@@ -405,8 +407,11 @@ public class Deployment {
                 // check for invalid users now.
                 checkUserSettings();
 
+                // check for resourcepath elements
+                InMemoryNodeSet resources = findElements(repoXML,RESOURCES_ELEMENT);
+
                 // install
-                scanDirectory(packageDir, targetCollection, true);
+                scanDirectory(packageDir, targetCollection,resources, true,false);
 
                 // run the post-setup query if present
                 final ElementImpl postSetup = findElement(repoXML, POST_SETUP_ELEMENT);
@@ -634,8 +639,10 @@ public class Deployment {
      *
      * @param directory
      * @param target
+     * @param resources set of resource elements being present in repo.xml
      */
-    private void scanDirectory(final Path directory, final XmldbURI target, final boolean inRootDir) {
+
+    private void scanDirectory(final Path directory, final XmldbURI target, InMemoryNodeSet resources, boolean inRootDir, boolean isResourcesDir) {
         final TransactionManager mgr = broker.getBrokerPool().getTransactionManager();
         Collection collection = null;
         try(final Txn txn = mgr.beginTransaction()) {
@@ -647,14 +654,36 @@ public class Deployment {
             LOG.warn(e);
         }
 
-        storeFiles(directory, collection, inRootDir);
+        isResourcesDir = isResourcesDir || isResourceDir(target, resources);
+
+        // the root dir is not allowed to be a resources directory
+        if(!inRootDir && isResourcesDir){
+            try {
+                storeBinaryResources(directory, collection);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }else{
+            storeFiles(directory, collection, inRootDir);
+        }
 
         // scan sub directories
         try(final Stream<Path> subDirs = Files.find(directory, 1, (path, attrs) -> (!path.equals(directory)) && attrs.isDirectory())) {
-            subDirs.forEach(path -> scanDirectory(path, target.append(FileUtils.fileName(path)), false));
+            subDirs.forEach(path -> scanDirectory(path, target.append(FileUtils.fileName(path)), resources, false, isResourcesDir));
         } catch(final IOException ioe) {
             LOG.warn("Unable to scan sub-directories", ioe);
+    }
+
+    private boolean isResourceDir(XmldbURI target, InMemoryNodeSet resources) throws XPathException {
+        // iterate here or pass into scandirectory directly or even save as class property???
+        for (final SequenceIterator i = resources.iterate(); i.hasNext();) {
+            final ElementImpl child = (ElementImpl) i.nextItem();
+            final String resourcePath = child.getAttribute(RESOURCES_PATH_ATTRIBUTE);
+            if (target.toString().endsWith(resourcePath)){
+                return true;
+            }
         }
+        return false;
     }
 
     /**
@@ -688,24 +717,22 @@ public class Deployment {
 
                 try(final Txn txn = mgr.beginTransaction()) {
                     if (mime.isXMLType()) {
-                        final InputSource is = new InputSource(file.toUri().toASCIIString());
-                        final IndexInfo info = targetCollection.validateXMLResource(txn, broker, name, is);
-                        info.getDocument().getMetadata().setMimeType(mime.getName());
-                        final Permission permission = info.getDocument().getPermissions();
-                        setPermissions(false, mime, permission);
-
-                        targetCollection.store(txn, broker, info, is, false);
-                    } else {
-                        final long size = Files.size(file);
-                        try(final InputStream is = Files.newInputStream(file)) {
-                            final BinaryDocument doc =
-                                    targetCollection.addBinaryResource(txn, broker, name, is, mime.getName(), size);
-
-                            final Permission permission = doc.getPermissions();
+                        try {
+                            final InputSource is = new InputSource(file.toURI().toASCIIString());
+                            final IndexInfo info = targetCollection.validateXMLResource(txn, broker, name, is);
+                            info.getDocument().getMetadata().setMimeType(mime.getName());
+                            final Permission permission = info.getDocument().getPermissions();
                             setPermissions(false, mime, permission);
-                            doc.getMetadata().setMimeType(mime.getName());
-                            broker.storeXMLResource(txn, doc);
+                            targetCollection.store(txn, broker, info, is, false);
+                        } catch (final Exception e) {
+                            //check for .html ending
+                            if(mime.getName().equals(MimeType.HTML_TYPE.getName())){
+                                //store it
+                                storeBinary(targetCollection, file, mime, name, txn);
+                            }
                         }
+                    } else {
+                        storeBinary(targetCollection, file, mime, name, txn);
                     }
                     mgr.commit(txn);
                 } catch (final Exception e) {
@@ -714,6 +741,37 @@ public class Deployment {
             }
         }
     }
+
+    private void storeBinary(Collection targetCollection, File file, MimeType mime, XmldbURI name, Txn txn) throws IOException, EXistException, PermissionDeniedException, LockException, TriggerException {
+        final long size = file.length();
+        try (final FileInputStream is = new FileInputStream(file)) {
+            final BinaryDocument doc =
+                    targetCollection.addBinaryResource(txn, broker, name, is, mime.getName(), size);
+
+            final Permission permission = doc.getPermissions();
+            setPermissions(false, mime, permission);
+            doc.getMetadata().setMimeType(mime.getName());
+            broker.storeXMLResource(txn, doc);
+        }
+    }
+
+    private void storeBinaryResources(File directory, Collection targetCollection) throws IOException, EXistException, PermissionDeniedException, LockException, TriggerException {
+
+        final File[] files = directory.listFiles();
+        final TransactionManager mgr = broker.getBrokerPool().getTransactionManager();
+        for (final File file : files) {
+            if (!file.isDirectory()) {
+                final XmldbURI name = XmldbURI.create(file.getName());
+                try(final Txn txn = mgr.beginTransaction()) {
+                    storeBinary(targetCollection, file, MimeType.BINARY_TYPE, name, txn);
+                    mgr.commit(txn);
+                } catch (final Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
 
     /**
      * Set owner, group and permissions. For XQuery resources, always set the executable flag.

--- a/src/org/exist/xquery/functions/xmldb/XMLDBModule.java
+++ b/src/org/exist/xquery/functions/xmldb/XMLDBModule.java
@@ -35,100 +35,101 @@ import org.exist.xquery.FunctionDef;
  * @author ljo
  */
 public class XMLDBModule extends AbstractInternalModule {
-    
+
     public final static String NAMESPACE_URI = "http://exist-db.org/xquery/xmldb";
-    
+
     public final static String PREFIX = "xmldb";
     public final static String INCLUSION_DATE = "2004-09-12";
     public final static String RELEASED_IN_VERSION = "pre eXist-1.0";
-    
+
     public final static String NEED_PRIV_USER = "The XQuery owner must have appropriate privileges to do this, e.g. having DBA role.";
     public final static String NEED_PRIV_USER_NOT_CURRENT = "The XQuery owner must have appropriate privileges to do this, e.g. having DBA role, and not being the owner of the currently running XQuery.";
     public final static String REMEMBER_OCTAL_CALC = "PLEASE REMEMBER that octal number 0755 is 7*64+5*8+5 i.e. 493 in decimal NOT 755. You can use util:base-to-integer(0755, 8) as argument for convenience.";
     public final static String COLLECTION_URI = "Collection URIs can be specified either as a simple collection path or an XMLDB URI.";
     public final static String ANY_URI = "Resource URIs can be specified either as a simple collection path, an XMLDB URI or any URI.";
 
-    public final static FunctionDef[] functions = {        
-        new FunctionDef(XMLDBCreateCollection.signature, XMLDBCreateCollection.class),
-        new FunctionDef(XMLDBRegisterDatabase.signature, XMLDBRegisterDatabase.class),
-        new FunctionDef(XMLDBStore.signatures[0], XMLDBStore.class),
-        new FunctionDef(XMLDBStore.signatures[1], XMLDBStore.class),
-        new FunctionDef(XMLDBLoadFromPattern.signatures[0], XMLDBLoadFromPattern.class),
-        new FunctionDef(XMLDBLoadFromPattern.signatures[1], XMLDBLoadFromPattern.class),
-        new FunctionDef(XMLDBLoadFromPattern.signatures[2], XMLDBLoadFromPattern.class),
-        new FunctionDef(XMLDBLoadFromPattern.signatures[3], XMLDBLoadFromPattern.class),
-        new FunctionDef(XMLDBXUpdate.signature, XMLDBXUpdate.class),
-        new FunctionDef(XMLDBCopy.signatures[0], XMLDBCopy.class),
-        new FunctionDef(XMLDBCopy.signatures[1], XMLDBCopy.class),
-        new FunctionDef(XMLDBMove.signatures[0], XMLDBMove.class),
-        new FunctionDef(XMLDBMove.signatures[1], XMLDBMove.class),
-        new FunctionDef(XMLDBRename.signatures[0], XMLDBRename.class),
-        new FunctionDef(XMLDBRename.signatures[1], XMLDBRename.class),
-        new FunctionDef(XMLDBRemove.signatures[0], XMLDBRemove.class),
-        new FunctionDef(XMLDBRemove.signatures[1], XMLDBRemove.class),
-        new FunctionDef(XMLDBHasLock.signature[0], XMLDBHasLock.class),
-        new FunctionDef(XMLDBHasLock.signature[1], XMLDBHasLock.class),
-        new FunctionDef(XMLDBCreated.lastModifiedSignature, XMLDBCreated.class),
-        new FunctionDef(XMLDBCreated.createdSignatures[0], XMLDBCreated.class),
-        new FunctionDef(XMLDBCreated.createdSignatures[1], XMLDBCreated.class),
-        new FunctionDef(XMLDBSize.signature, XMLDBSize.class),
-        new FunctionDef(XMLDBGetChildCollections.signature, XMLDBGetChildCollections.class),
-        new FunctionDef(XMLDBGetChildResources.signature, XMLDBGetChildResources.class),
-        new FunctionDef(XMLDBCollectionAvailable.signatures[0], XMLDBCollectionAvailable.class),
-        new FunctionDef(XMLDBURIFunctions.signatures[0], XMLDBURIFunctions.class),
-        new FunctionDef(XMLDBURIFunctions.signatures[1], XMLDBURIFunctions.class),
-        new FunctionDef(XMLDBURIFunctions.signatures[2], XMLDBURIFunctions.class),
-        new FunctionDef(XMLDBURIFunctions.signatures[3], XMLDBURIFunctions.class),
-        new FunctionDef(XMLDBGetMimeType.signature, XMLDBGetMimeType.class),
-        new FunctionDef(XMLDBSetMimeType.signature, XMLDBSetMimeType.class),
-        new FunctionDef(XMLDBDocument.signature, XMLDBDocument.class),
-        new FunctionDef(FunXCollection.signature, FunXCollection.class),
-        new FunctionDef(XMLDBReindex.signature, XMLDBReindex.class),
-        new FunctionDef(XMLDBDefragment.signatures[0], XMLDBDefragment.class),
-        new FunctionDef(XMLDBDefragment.signatures[1], XMLDBDefragment.class),
-        new FunctionDef(FindLastModifiedSince.signature, FindLastModifiedSince.class),
-        new FunctionDef(XMLDBMatchCollection.signature, XMLDBMatchCollection.class),
-        new FunctionDef(XMLDBTouch.FNS_TOUCH_DOCUMENT_NOW, XMLDBTouch.class),
-        new FunctionDef(XMLDBTouch.FNS_TOUCH_DOCUMENT, XMLDBTouch.class),
+    public final static FunctionDef[] functions = {
+            new FunctionDef(XMLDBCreateCollection.signature, XMLDBCreateCollection.class),
+            new FunctionDef(XMLDBRegisterDatabase.signature, XMLDBRegisterDatabase.class),
+            new FunctionDef(XMLDBStore.signatures[0], XMLDBStore.class),
+            new FunctionDef(XMLDBStore.signatures[1], XMLDBStore.class),
+            new FunctionDef(XMLDBStore.signatures[2], XMLDBStore.class),
+            new FunctionDef(XMLDBLoadFromPattern.signatures[0], XMLDBLoadFromPattern.class),
+            new FunctionDef(XMLDBLoadFromPattern.signatures[1], XMLDBLoadFromPattern.class),
+            new FunctionDef(XMLDBLoadFromPattern.signatures[2], XMLDBLoadFromPattern.class),
+            new FunctionDef(XMLDBLoadFromPattern.signatures[3], XMLDBLoadFromPattern.class),
+            new FunctionDef(XMLDBXUpdate.signature, XMLDBXUpdate.class),
+            new FunctionDef(XMLDBCopy.signatures[0], XMLDBCopy.class),
+            new FunctionDef(XMLDBCopy.signatures[1], XMLDBCopy.class),
+            new FunctionDef(XMLDBMove.signatures[0], XMLDBMove.class),
+            new FunctionDef(XMLDBMove.signatures[1], XMLDBMove.class),
+            new FunctionDef(XMLDBRename.signatures[0], XMLDBRename.class),
+            new FunctionDef(XMLDBRename.signatures[1], XMLDBRename.class),
+            new FunctionDef(XMLDBRemove.signatures[0], XMLDBRemove.class),
+            new FunctionDef(XMLDBRemove.signatures[1], XMLDBRemove.class),
+            new FunctionDef(XMLDBHasLock.signature[0], XMLDBHasLock.class),
+            new FunctionDef(XMLDBHasLock.signature[1], XMLDBHasLock.class),
+            new FunctionDef(XMLDBCreated.lastModifiedSignature, XMLDBCreated.class),
+            new FunctionDef(XMLDBCreated.createdSignatures[0], XMLDBCreated.class),
+            new FunctionDef(XMLDBCreated.createdSignatures[1], XMLDBCreated.class),
+            new FunctionDef(XMLDBSize.signature, XMLDBSize.class),
+            new FunctionDef(XMLDBGetChildCollections.signature, XMLDBGetChildCollections.class),
+            new FunctionDef(XMLDBGetChildResources.signature, XMLDBGetChildResources.class),
+            new FunctionDef(XMLDBCollectionAvailable.signatures[0], XMLDBCollectionAvailable.class),
+            new FunctionDef(XMLDBURIFunctions.signatures[0], XMLDBURIFunctions.class),
+            new FunctionDef(XMLDBURIFunctions.signatures[1], XMLDBURIFunctions.class),
+            new FunctionDef(XMLDBURIFunctions.signatures[2], XMLDBURIFunctions.class),
+            new FunctionDef(XMLDBURIFunctions.signatures[3], XMLDBURIFunctions.class),
+            new FunctionDef(XMLDBGetMimeType.signature, XMLDBGetMimeType.class),
+            new FunctionDef(XMLDBSetMimeType.signature, XMLDBSetMimeType.class),
+            new FunctionDef(XMLDBDocument.signature, XMLDBDocument.class),
+            new FunctionDef(FunXCollection.signature, FunXCollection.class),
+            new FunctionDef(XMLDBReindex.signature, XMLDBReindex.class),
+            new FunctionDef(XMLDBDefragment.signatures[0], XMLDBDefragment.class),
+            new FunctionDef(XMLDBDefragment.signatures[1], XMLDBDefragment.class),
+            new FunctionDef(FindLastModifiedSince.signature, FindLastModifiedSince.class),
+            new FunctionDef(XMLDBMatchCollection.signature, XMLDBMatchCollection.class),
+            new FunctionDef(XMLDBTouch.FNS_TOUCH_DOCUMENT_NOW, XMLDBTouch.class),
+            new FunctionDef(XMLDBTouch.FNS_TOUCH_DOCUMENT, XMLDBTouch.class),
 
         /* TODO these functions for login/logout etc need to be re-engineered and added to the SecurityManagerModule (deprecating these) */
-        new FunctionDef(XMLDBAuthenticate.authenticateSignature, XMLDBAuthenticate.class),
-        new FunctionDef(XMLDBAuthenticate.loginSignatures[0], XMLDBAuthenticate.class),
-        new FunctionDef(XMLDBAuthenticate.loginSignatures[1], XMLDBAuthenticate.class),
-        new FunctionDef(XMLDBGetCurrentUser.signature, XMLDBGetCurrentUser.class),
-        
-        /** security functions, deprecated by those in SecurityManagerModule **/
-        new FunctionDef(XMLDBSetCollectionPermissions.signature, XMLDBSetCollectionPermissions.class),
-        new FunctionDef(XMLDBSetResourcePermissions.signature, XMLDBSetResourcePermissions.class),
-        new FunctionDef(XMLDBUserAccess.fnExistsUser, XMLDBUserAccess.class),
-        new FunctionDef(XMLDBUserAccess.fnUserGroups, XMLDBUserAccess.class),
-        new FunctionDef(XMLDBUserAccess.fnUserPrimaryGroup, XMLDBUserAccess.class),
-        new FunctionDef(XMLDBUserAccess.fnUserHome, XMLDBUserAccess.class),
-        new FunctionDef(XMLDBCreateUser.signatures[0], XMLDBCreateUser.class),
-        new FunctionDef(XMLDBCreateUser.signatures[1], XMLDBCreateUser.class),
-        new FunctionDef(XMLDBDeleteUser.signature, XMLDBDeleteUser.class),
-        new FunctionDef(XMLDBChangeUser.signatures[0], XMLDBChangeUser.class),
-        new FunctionDef(XMLDBChangeUser.signatures[1], XMLDBChangeUser.class),
-        new FunctionDef(XMLDBCreateGroup.signatures[0], XMLDBCreateGroup.class),
-        new FunctionDef(XMLDBCreateGroup.signatures[1], XMLDBCreateGroup.class),
-        new FunctionDef(XMLDBAddUserToGroup.signature, XMLDBAddUserToGroup.class),
-        new FunctionDef(XMLDBRemoveUserFromGroup.signature, XMLDBRemoveUserFromGroup.class),
-        new FunctionDef(XMLDBGroupExists.signatures[0], XMLDBGroupExists.class),
-        new FunctionDef(XMLDBChmodCollection.signature, XMLDBChmodCollection.class),
-        new FunctionDef(XMLDBChmodResource.signature, XMLDBChmodResource.class),
-        new FunctionDef(XMLDBPermissions.signatures[0], XMLDBPermissions.class),
-        new FunctionDef(XMLDBPermissions.signatures[1], XMLDBPermissions.class),
-        new FunctionDef(XMLDBPermissionsToString.signatures[0], XMLDBPermissionsToString.class),
-        new FunctionDef(XMLDBPermissionsToString.signatures[1], XMLDBPermissionsToString.class),
-        new FunctionDef(XMLDBIsAdmin.signature, XMLDBIsAdmin.class),
-        new FunctionDef(XMLDBIsAuthenticated.signature, XMLDBIsAuthenticated.class),
-        new FunctionDef(XMLDBGetUsers.signature, XMLDBGetUsers.class),
-        new FunctionDef(XMLDBGetUserOrGroup.getGroupSignatures[0], XMLDBGetUserOrGroup.class),
-        new FunctionDef(XMLDBGetUserOrGroup.getGroupSignatures[1], XMLDBGetUserOrGroup.class),
-        new FunctionDef(XMLDBGetUserOrGroup.getOwnerSignatures[0], XMLDBGetUserOrGroup.class),
-        new FunctionDef(XMLDBGetUserOrGroup.getOwnerSignatures[1], XMLDBGetUserOrGroup.class),
-        new FunctionDef(XMLDBGetCurrentUserAttribute.signature, XMLDBGetCurrentUserAttribute.class),
-        new FunctionDef(XMLDBGetCurrentUserAttributeNames.signature, XMLDBGetCurrentUserAttributeNames.class)
+            new FunctionDef(XMLDBAuthenticate.authenticateSignature, XMLDBAuthenticate.class),
+            new FunctionDef(XMLDBAuthenticate.loginSignatures[0], XMLDBAuthenticate.class),
+            new FunctionDef(XMLDBAuthenticate.loginSignatures[1], XMLDBAuthenticate.class),
+            new FunctionDef(XMLDBGetCurrentUser.signature, XMLDBGetCurrentUser.class),
+
+            /** security functions, deprecated by those in SecurityManagerModule **/
+            new FunctionDef(XMLDBSetCollectionPermissions.signature, XMLDBSetCollectionPermissions.class),
+            new FunctionDef(XMLDBSetResourcePermissions.signature, XMLDBSetResourcePermissions.class),
+            new FunctionDef(XMLDBUserAccess.fnExistsUser, XMLDBUserAccess.class),
+            new FunctionDef(XMLDBUserAccess.fnUserGroups, XMLDBUserAccess.class),
+            new FunctionDef(XMLDBUserAccess.fnUserPrimaryGroup, XMLDBUserAccess.class),
+            new FunctionDef(XMLDBUserAccess.fnUserHome, XMLDBUserAccess.class),
+            new FunctionDef(XMLDBCreateUser.signatures[0], XMLDBCreateUser.class),
+            new FunctionDef(XMLDBCreateUser.signatures[1], XMLDBCreateUser.class),
+            new FunctionDef(XMLDBDeleteUser.signature, XMLDBDeleteUser.class),
+            new FunctionDef(XMLDBChangeUser.signatures[0], XMLDBChangeUser.class),
+            new FunctionDef(XMLDBChangeUser.signatures[1], XMLDBChangeUser.class),
+            new FunctionDef(XMLDBCreateGroup.signatures[0], XMLDBCreateGroup.class),
+            new FunctionDef(XMLDBCreateGroup.signatures[1], XMLDBCreateGroup.class),
+            new FunctionDef(XMLDBAddUserToGroup.signature, XMLDBAddUserToGroup.class),
+            new FunctionDef(XMLDBRemoveUserFromGroup.signature, XMLDBRemoveUserFromGroup.class),
+            new FunctionDef(XMLDBGroupExists.signatures[0], XMLDBGroupExists.class),
+            new FunctionDef(XMLDBChmodCollection.signature, XMLDBChmodCollection.class),
+            new FunctionDef(XMLDBChmodResource.signature, XMLDBChmodResource.class),
+            new FunctionDef(XMLDBPermissions.signatures[0], XMLDBPermissions.class),
+            new FunctionDef(XMLDBPermissions.signatures[1], XMLDBPermissions.class),
+            new FunctionDef(XMLDBPermissionsToString.signatures[0], XMLDBPermissionsToString.class),
+            new FunctionDef(XMLDBPermissionsToString.signatures[1], XMLDBPermissionsToString.class),
+            new FunctionDef(XMLDBIsAdmin.signature, XMLDBIsAdmin.class),
+            new FunctionDef(XMLDBIsAuthenticated.signature, XMLDBIsAuthenticated.class),
+            new FunctionDef(XMLDBGetUsers.signature, XMLDBGetUsers.class),
+            new FunctionDef(XMLDBGetUserOrGroup.getGroupSignatures[0], XMLDBGetUserOrGroup.class),
+            new FunctionDef(XMLDBGetUserOrGroup.getGroupSignatures[1], XMLDBGetUserOrGroup.class),
+            new FunctionDef(XMLDBGetUserOrGroup.getOwnerSignatures[0], XMLDBGetUserOrGroup.class),
+            new FunctionDef(XMLDBGetUserOrGroup.getOwnerSignatures[1], XMLDBGetUserOrGroup.class),
+            new FunctionDef(XMLDBGetCurrentUserAttribute.signature, XMLDBGetCurrentUserAttribute.class),
+            new FunctionDef(XMLDBGetCurrentUserAttributeNames.signature, XMLDBGetCurrentUserAttributeNames.class)
     };
 
     static {
@@ -138,26 +139,26 @@ public class XMLDBModule extends AbstractInternalModule {
     public XMLDBModule(Map<String, List<? extends Object>> parameters) {
         super(functions, parameters, true);
     }
-    
-        /* (non-Javadoc)
-         * @see org.exist.xquery.Module#getDescription()
-         */
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.Module#getDescription()
+     */
     @Override
     public String getDescription() {
         return "A module for database manipulation functions.";
     }
-    
-        /* (non-Javadoc)
-         * @see org.exist.xquery.Module#getNamespaceURI()
-         */
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.Module#getNamespaceURI()
+     */
     @Override
     public String getNamespaceURI() {
         return NAMESPACE_URI;
     }
-    
-        /* (non-Javadoc)
-         * @see org.exist.xquery.Module#getDefaultPrefix()
-         */
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.Module#getDefaultPrefix()
+     */
     @Override
     public String getDefaultPrefix() {
         return PREFIX;
@@ -167,5 +168,5 @@ public class XMLDBModule extends AbstractInternalModule {
     public String getReleaseVersion() {
         return RELEASED_IN_VERSION;
     }
-    
+
 }

--- a/src/org/exist/xquery/functions/xmldb/XMLDBStore.java
+++ b/src/org/exist/xquery/functions/xmldb/XMLDBStore.java
@@ -66,61 +66,79 @@ import org.xmldb.api.modules.XMLResource;
  * @author wolf
  */
 public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
-	
+
 	protected static final Logger logger = LogManager.getLogger(XMLDBStore.class);
 
 	protected static final FunctionParameterSequenceType ARG_COLLECTION = new FunctionParameterSequenceType("collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collection URI");
 	protected static final FunctionParameterSequenceType ARG_RESOURCE_NAME = new FunctionParameterSequenceType("resource-name", Type.STRING, Cardinality.ZERO_OR_ONE, "The resource name");
 	protected static final FunctionParameterSequenceType ARG_CONTENTS = new FunctionParameterSequenceType("contents", Type.ITEM, Cardinality.EXACTLY_ONE, "The contents");
 	protected static final FunctionParameterSequenceType ARG_MIME_TYPE = new FunctionParameterSequenceType("mime-type", Type.STRING, Cardinality.EXACTLY_ONE, "The mime type");
-	
+
 	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the path to new resource if sucessfully stored, otherwise the emtpty sequence");
 
-    protected static final Properties SERIALIZATION_PROPERTIES = new Properties();
-    static {
-        SERIALIZATION_PROPERTIES.setProperty(EXistOutputKeys.EXPAND_XINCLUDES, "no");
-    }
+	protected static final Properties SERIALIZATION_PROPERTIES = new Properties();
+
+	static {
+		SERIALIZATION_PROPERTIES.setProperty(EXistOutputKeys.EXPAND_XINCLUDES, "no");
+	}
 
 	public final static FunctionSignature signatures[] = {
-		new FunctionSignature(
-			new QName("store", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
-			"Stores a new resource into the database. The resource is stored  " +
-			"in the collection $collection-uri with the name $resource-name. " +
-            XMLDBModule.COLLECTION_URI + 
-            // fixit! - security -  if URI and possibly also file object
-            // DBA role should be required/ljo
-            // Of course we need to think of the node case too but it has at 
-            // least been passed throught fn:doc() but since the retrieval
-            // happens firstly who knows ... 
-			" The contents $contents, is either a node, an xs:string, a Java file object or an xs:anyURI. " +
-			"A node will be serialized to SAX. It becomes the root node of the new " +
-			"document. If $contents is of type xs:anyURI, the resource is loaded " +
-			"from that URI. " + 
-            "Returns the path to the new document if successfully stored, " + 
-            "otherwise an XPathException is thrown.",
-			new SequenceType[] { ARG_COLLECTION, ARG_RESOURCE_NAME, ARG_CONTENTS },
-			RETURN_TYPE),
-		new FunctionSignature(
-			new QName("store", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
-			"Stores a new resource into the database. The resource is stored  " +
-			"in the collection $collection-uri with the name $resource-name. " +
-            XMLDBModule.COLLECTION_URI + 
-            // fixit! - security -  if URI and possibly also file object 
-            // DBA role should be required/ljo
-            // Of course we need to think of the node case too but it has at 
-            // least been passed through fn:doc() but since the retrieval
-            // happens firstly who knows ... 
-
-            " The contents $contents, is either a node, an xs:string, a Java file object or an xs:anyURI. " +
-			"A node will be serialized to SAX. It becomes the root node of the new " +
-			"document. If $contents is of type xs:anyURI, the resource is loaded " +
-			"from that URI. The final argument $mime-type is used to specify " +
-            "a mime type.  If the mime-type is not a xml based type, the " +
-            "resource will be stored as a binary resource." +
-            "Returns the path to the new document if successfully stored, " + 
-		    "otherwise an XPathException is thrown.",
-			new SequenceType[] { ARG_COLLECTION, ARG_RESOURCE_NAME, ARG_CONTENTS, ARG_MIME_TYPE },
-			RETURN_TYPE)
+			new FunctionSignature(
+					new QName("store", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
+					"Stores a new resource into the database. The resource is stored  "
+							+ "in the collection $collection-uri with the name $resource-name. "
+							+ XMLDBModule.COLLECTION_URI
+							// fixit! - security -  if URI and possibly also file object
+							// DBA role should be required/ljo
+							// Of course we need to think of the node case too but it has at
+							// least been passed throught fn:doc() but since the retrieval
+							// happens firstly who knows ...
+							+ " The contents $contents, is either a node, an xs:string, a Java file object or an xs:anyURI. "
+							+ "A node will be serialized to SAX. It becomes the root node of the new "
+							+ "document. If $contents is of type xs:anyURI, the resource is loaded "
+							+ "from that URI. "
+							+ "Returns the path to the new document if successfully stored, "
+							+ "otherwise an XPathException is thrown.",
+					new SequenceType[]{ARG_COLLECTION, ARG_RESOURCE_NAME, ARG_CONTENTS},
+					RETURN_TYPE),
+			new FunctionSignature(
+					new QName("store", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
+					"Stores a new resource into the database. The resource is stored  "
+							+ "in the collection $collection-uri with the name $resource-name. "
+							+ XMLDBModule.COLLECTION_URI
+							// fixit! - security -  if URI and possibly also file object
+							// DBA role should be required/ljo
+							// Of course we need to think of the node case too but it has at
+							// least been passed through fn:doc() but since the retrieval
+							// happens firstly who knows ...
+							+ " The contents $contents, is either a node, an xs:string, a Java file object or an xs:anyURI. "
+							+ "A node will be serialized to SAX. It becomes the root node of the new "
+							+ "document. If $contents is of type xs:anyURI, the resource is loaded "
+							+ "from that URI. The final argument $mime-type is used to specify "
+							+ "a mime type.  If the mime-type is not a xml based type, the "
+							+ "resource will be stored as a binary resource."
+							+ "Returns the path to the new document if successfully stored, "
+							+ "otherwise an XPathException is thrown.",
+					new SequenceType[]{ARG_COLLECTION, ARG_RESOURCE_NAME, ARG_CONTENTS, ARG_MIME_TYPE},
+					RETURN_TYPE),
+			new FunctionSignature(
+					new QName("store-as-binary", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
+					"Stores a new resource into the database. The resource is stored  "
+							+ "in the collection $collection-uri with the name $resource-name. "
+							+ XMLDBModule.COLLECTION_URI
+							// fixit! - security -  if URI and possibly also file object
+							// DBA role should be required/ljo
+							// Of course we need to think of the node case too but it has at
+							// least been passed throught fn:doc() but since the retrieval
+							// happens firstly who knows ...
+							+ " The contents $contents, is either a node, an xs:string, a Java file object or an xs:anyURI. "
+							+ "A node will be serialized to SAX. It becomes the root node of the new "
+							+ "document. If $contents is of type xs:anyURI, the resource is loaded "
+							+ "from that URI. "
+							+ "Returns the path to the new document if successfully stored, "
+							+ "otherwise an XPathException is thrown.",
+					new SequenceType[]{ARG_COLLECTION, ARG_RESOURCE_NAME, ARG_CONTENTS},
+					RETURN_TYPE)
 	};
 
 	/**
@@ -132,127 +150,134 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
 	}
 
 	/* (non-Javadoc)
-	 * @see org.exist.xquery.Expression#eval(org.exist.dom.persistent.DocumentSet, org.exist.xquery.value.Sequence, org.exist.xquery.value.Item)
-	 */
-	public Sequence evalWithCollection(Collection collection, Sequence args[],
-		Sequence contextSequence)
-		throws XPathException {
+     * @see org.exist.xquery.Expression#eval(org.exist.dom.persistent.DocumentSet, org.exist.xquery.value.Sequence, org.exist.xquery.value.Item)
+     */
+	public Sequence evalWithCollection(Collection collection, Sequence args[],Sequence contextSequence) throws XPathException {
+
 		String docName = args[1].isEmpty() ? null : args[1].getStringValue();
-		if(docName != null && docName.length() == 0)
-			{docName = null;}
-		else if(docName != null)
-			{docName = new AnyURIValue(docName).toXmldbURI().toString();}
-		
+		if (docName != null && docName.length() == 0) {
+			docName = null;
+		} else if (docName != null) {
+			docName = new AnyURIValue(docName).toXmldbURI().toString();
+		}
+
 		final Item item = args[2].itemAt(0);
-        String mimeType = MimeType.XML_TYPE.getName();
+		String mimeType = MimeType.XML_TYPE.getName();
 		boolean binary = !Type.subTypeOf(item.getType(), Type.NODE);
-		
-		if(getSignature().getArgumentCount() == 4) {
-		    mimeType = args[3].getStringValue();
-		    final MimeType mime = MimeTable.getInstance().getContentType(mimeType);
-		    if (mime != null)
-			{binary = !mime.isXMLType();}
-            
-		} else if (docName != null){
-		    final MimeType mime = MimeTable.getInstance().getContentTypeFor(docName);
-            if (mime != null) {
-                mimeType = mime.getName();
-                binary = !mime.isXMLType();
-            }
-        }
-		
+
+		if (getSignature().getArgumentCount() == 4) {
+			mimeType = args[3].getStringValue();
+			final MimeType mime = MimeTable.getInstance().getContentType(mimeType);
+			if (mime != null) {
+				binary = !mime.isXMLType();
+			}
+
+		} else if (docName != null) {
+			final MimeType mime = MimeTable.getInstance().getContentTypeFor(docName);
+			if (mime != null) {
+				mimeType = mime.getName();
+				binary = !mime.isXMLType();
+			}
+		}
+
+		if(getSignature().getName().getLocalPart().equals("store-as-binary")) {
+			binary = true;
+		}
+
 		Resource resource;
 		try {
-			if(Type.subTypeOf(item.getType(), Type.JAVA_OBJECT)) {
-				final Object obj = ((JavaObjectValue)item).getObject();
-				if(!(obj instanceof File)) {
-                    logger.error("Passed java object should be a File");
+			if (Type.subTypeOf(item.getType(), Type.JAVA_OBJECT)) {
+				final Object obj = ((JavaObjectValue) item).getObject();
+				if (!(obj instanceof File)) {
+					logger.error("Passed java object should be a File");
 					throw new XPathException(this, "Passed java object should be a File");
-                }
-				resource = loadFromFile(collection, (File)obj, docName, binary, mimeType);
+				}
+				resource = loadFromFile(collection, (File) obj, docName, binary, mimeType);
 
-			} else if(Type.subTypeOf(item.getType(), Type.ANY_URI)) {
+			} else if (Type.subTypeOf(item.getType(), Type.ANY_URI)) {
 				try {
 					final URI uri = new URI(item.getStringValue());
 					resource = loadFromURI(collection, uri, docName, binary, mimeType);
 
 				} catch (final URISyntaxException e) {
-                    logger.error("Invalid URI: " + item.getStringValue());
+					logger.error("Invalid URI: " + item.getStringValue());
 					throw new XPathException(this, "Invalid URI: " + item.getStringValue(), e);
 				}
 
 			} else {
-				if(binary) {
+				if (binary) {
 					resource = collection.createResource(docName, "BinaryResource");
-                } else {
+				} else {
 					resource = collection.createResource(docName, "XMLResource");
-                }
+				}
 
-				if(Type.subTypeOf(item.getType(), Type.STRING)) {
+				if (Type.subTypeOf(item.getType(), Type.STRING)) {
 					resource.setContent(item.getStringValue());
 
-				} else if(item.getType() == Type.BASE64_BINARY) {
-					resource.setContent(((BinaryValue)item).toJavaObject());
+				} else if (item.getType() == Type.BASE64_BINARY) {
+					resource.setContent(((BinaryValue) item).toJavaObject());
 
-				} else if(Type.subTypeOf(item.getType(), Type.NODE)) {
-					if(binary) {
+				} else if (Type.subTypeOf(item.getType(), Type.NODE)) {
+					if (binary) {
 						final StringWriter writer = new StringWriter();
 						final SAXSerializer serializer = new SAXSerializer();
 						serializer.setOutput(writer, null);
 						item.toSAX(context.getBroker(), serializer, SERIALIZATION_PROPERTIES);
 						resource.setContent(writer.toString());
 					} else {
-						final ContentHandler handler = ((XMLResource)resource).setContentAsSAX();
+						final ContentHandler handler = ((XMLResource) resource).setContentAsSAX();
 						handler.startDocument();
 
 						item.toSAX(context.getBroker(), handler, SERIALIZATION_PROPERTIES);
 						handler.endDocument();
 					}
 				} else {
-                    logger.error("Data should be either a node or a string");
+					logger.error("Data should be either a node or a string");
 					throw new XPathException(this, "Data should be either a node or a string");
-                }
+				}
 
-                ((EXistResource) resource).setMimeType(mimeType);
+				((EXistResource) resource).setMimeType(mimeType);
 				collection.storeResource(resource);
 			}
-            
+
 		} catch (final XMLDBException e) {
-                        logger.error(e.getMessage(), e);
+			logger.error(e.getMessage(), e);
 			throw new XPathException(this,
-				"XMLDB reported an exception while storing document" + e, e);
+					"XMLDB reported an exception while storing document" + e, e);
 
 		} catch (final SAXException e) {
-            logger.error(e.getMessage());
-			throw new XPathException(this, "SAX reported an exception while storing document",	e);
+			logger.error(e.getMessage());
+			throw new XPathException(this, "SAX reported an exception while storing document", e);
 		}
 
 		if (resource == null) {
 			return Sequence.EMPTY_SEQUENCE;
 
-        } else {
+		} else {
 			try {
-                //TODO : use dedicated function in XmldbURI
+				//TODO : use dedicated function in XmldbURI
 				return new StringValue(collection.getName() + "/" + resource.getId());
 			} catch (final XMLDBException e) {
-                logger.error(e.getMessage());
-				throw new XPathException(this, "XMLDB reported an exception while retrieving the " +
-						"stored document", e);
+				logger.error(e.getMessage());
+				throw new XPathException(this, "XMLDB reported an exception while retrieving the "
+						+ "stored document", e);
 			}
 
-        }
+		}
 	}
-	
-	private Resource loadFromURI(Collection collection, URI uri, String docName, boolean binary, String mimeType) 
-	throws XPathException {
+
+	private Resource loadFromURI(Collection collection, URI uri, String docName, boolean binary, String mimeType)
+			throws XPathException {
 		Resource resource;
-		if("file".equals(uri.getScheme())) {
+		if ("file".equals(uri.getScheme())) {
 			final String path = uri.getPath();
-            if(path == null)
-                {throw new XPathException(this, "Cannot read from URI: " + uri.toASCIIString());}
+			if (path == null) {
+				throw new XPathException(this, "Cannot read from URI: " + uri.toASCIIString());
+			}
 			final File file = new File(path);
-			if(!file.canRead())
-				{throw new XPathException(this, "Cannot read path: " + path);}
+			if (!file.canRead()) {
+				throw new XPathException(this, "Cannot read path: " + path);
+			}
 			resource = loadFromFile(collection, file, docName, binary, mimeType);
 
 		} else {
@@ -265,7 +290,7 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
 				final InputStream is = uri.toURL().openStream();
 				final byte[] data = new byte[1024];
 				int read = 0;
-				while((read = is.read(data)) > -1) {
+				while ((read = is.read(data)) > -1) {
 					os.write(data, 0, read);
 				}
 				is.close();
@@ -277,38 +302,42 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
 				throw new XPathException(this, "Malformed URL: " + uri.toString(), e);
 
 			} catch (final IOException e) {
-				throw new XPathException(this, "IOException while reading from URL: " +
-						uri.toString(), e);
+				throw new XPathException(this, "IOException while reading from URL: "
+						+ uri.toString(), e);
 			} finally {
-				if(temp!=null)
-					{temp.delete();}
+				if (temp != null) {
+					temp.delete();
+				}
 			}
 		}
 		return resource;
 	}
-	
-	private Resource loadFromFile(Collection collection, File file, String docName, boolean binary, String mimeType) 
-	throws XPathException {
-		if(file.isFile()) {
-			if(docName == null)
-				{docName = file.getName();}
+
+	private Resource loadFromFile(Collection collection, File file, String docName, boolean binary, String mimeType)
+			throws XPathException {
+		if (file.isFile()) {
+			if (docName == null) {
+				docName = file.getName();
+			}
 			try {
 				Resource resource;
-				if(binary) {
+				if (binary) {
 					resource = collection.createResource(docName, "BinaryResource");
-                } else
-					{resource = collection.createResource(docName, "XMLResource");}
-                ((EXistResource)resource).setMimeType(mimeType);
+				} else {
+					resource = collection.createResource(docName, "XMLResource");
+				}
+				((EXistResource) resource).setMimeType(mimeType);
 				resource.setContent(file);
 				collection.storeResource(resource);
 				return resource;
 
 			} catch (final XMLDBException e) {
-				throw new XPathException(this, "Could not store file " + file.getAbsolutePath() +
-						": " + e.getMessage(), e);
+				throw new XPathException(this, "Could not store file " + file.getAbsolutePath()
+						+ ": " + e.getMessage(), e);
 			}
-            
-		} else
-			{throw new XPathException(this, file.getAbsolutePath() + " does not point to a file");}
+
+		} else {
+			throw new XPathException(this, file.getAbsolutePath() + " does not point to a file");
+		}
 	}
 }


### PR DESCRIPTION
support for resources directories in repo.xml, if storing html fails try as binary in deployment.


**Cherry picked version of https://github.com/eXist-db/exist/pull/727 with current develop:**

repo.xml sample:
```
<?xml version="1.0" encoding="UTF-8"?>
<meta xmlns="http://exist-db.org/xquery/repo">
    <description>eXistdb some app</description>
    <author>eXist Solutions</author>
    <website/>
    <status>alpha</status>
    <license>BSD-2-Clause</license>
    <copyright>true</copyright>
    <type>application</type>
    <target>someapp</target>
    <resources path="bower_components" type="binary"/>
    <resources path="app/elements" type="binary"/>
</meta>
```
