### PR TITLE
[bugfix] Fix the reported error location for functions called dynamic…

### DIFF
--- a/src/org/exist/xquery/DynamicFunctionCall.java
+++ b/src/org/exist/xquery/DynamicFunctionCall.java
@@ -18,7 +18,7 @@ public class DynamicFunctionCall extends AbstractExpression {
 
     public DynamicFunctionCall(XQueryContext context, Expression fun, List<Expression> args, boolean partial) {
         super(context);
-
+        setLocation(fun.getLine(), fun.getColumn());
         this.functionExpr = fun;
         this.arguments = args;
         this.isPartial = partial;
@@ -72,9 +72,16 @@ public class DynamicFunctionCall extends AbstractExpression {
             // cachedContextInfo will stay in memory
 	        ref.analyze(new AnalyzeContextInfo(cachedContextInfo));
 	        // Evaluate the function
-	        final Sequence result = ref.eval(contextSequence);
-            ref.resetState(false);
-            return result;
+            try {
+                final Sequence result = ref.eval(contextSequence);
+                ref.resetState(false);
+                return result;
+            } catch (XPathException e) {
+                if (e.getLine() <= 0) {
+                    e.setLocation(getLine(), getColumn(), getSource());
+                }
+                throw e;
+            }
         }
     }
 

--- a/src/org/exist/xquery/FunctionCall.java
+++ b/src/org/exist/xquery/FunctionCall.java
@@ -349,7 +349,7 @@ public class FunctionCall extends Function {
             } catch(final XPathException e) {
                 // append location of the function call to the exception message:
                 if(e.getLine() <= 0) {
-                    e.setLocation(line, column);
+                    e.setLocation(expression.getLine(), expression.getColumn());
                 }
     			
                 e.addFunctionCall(functionDef, this);

--- a/src/org/exist/xquery/LocationStep.java
+++ b/src/org/exist/xquery/LocationStep.java
@@ -397,60 +397,68 @@ public class LocationStep extends Step {
 				{throw new XPathException(this,
 						ErrorCodes.XPDY0002, "Undefined context sequence for '"
 								+ this.toString() + "'");}
-			switch (axis) {
-			case Constants.DESCENDANT_AXIS:
-			case Constants.DESCENDANT_SELF_AXIS:
-				result = getDescendants(context, contextSequence);
-				break;
-			case Constants.CHILD_AXIS:
-				// VirtualNodeSets may have modified the axis ; checking the
-				// type
-				// TODO : further checks ?
+            try {
+                switch (axis) {
+                    case Constants.DESCENDANT_AXIS:
+                    case Constants.DESCENDANT_SELF_AXIS:
+                        result = getDescendants(context, contextSequence);
+                        break;
+                    case Constants.CHILD_AXIS:
+                        // VirtualNodeSets may have modified the axis ; checking the
+                        // type
+                        // TODO : further checks ?
 //				if (this.test.getType() == Type.ATTRIBUTE) {
 //					this.axis = Constants.ATTRIBUTE_AXIS;
 //					result = getAttributes(context, contextSequence);
 //				} else {
-					result = getChildren(context, contextSequence);
+                        result = getChildren(context, contextSequence);
 //				}
-				break;
-			case Constants.ANCESTOR_SELF_AXIS:
-			case Constants.ANCESTOR_AXIS:
-				result = getAncestors(context, contextSequence);
-				break;
-			case Constants.PARENT_AXIS:
-				result = getParents(context, contextSequence);
-				break;
-			case Constants.SELF_AXIS:
-				if (!(contextSequence instanceof VirtualNodeSet)
-						&& Type.subTypeOf(contextSequence.getItemType(),
-								Type.ATOMIC)) {
-					// This test is copied from the legacy method
-					// getSelfAtomic()
-					if (!test.isWildcardTest())
-						{throw new XPathException(this, test.toString()
-								+ " cannot be applied to an atomic value.");}
-					result = contextSequence;
-				} else {
-					result = getSelf(context, contextSequence);
-				}
-				break;
-			case Constants.ATTRIBUTE_AXIS:
-			case Constants.DESCENDANT_ATTRIBUTE_AXIS:
-				result = getAttributes(context, contextSequence);
-				break;
-			case Constants.PRECEDING_AXIS:
-				result = getPreceding(context, contextSequence);
-				break;
-			case Constants.FOLLOWING_AXIS:
-				result = getFollowing(context, contextSequence);
-				break;
-			case Constants.PRECEDING_SIBLING_AXIS:
-			case Constants.FOLLOWING_SIBLING_AXIS:
-				result = getSiblings(context, contextSequence);
-				break;
-			default:
-				throw new IllegalArgumentException("Unsupported axis specified");
-			}
+                        break;
+                    case Constants.ANCESTOR_SELF_AXIS:
+                    case Constants.ANCESTOR_AXIS:
+                        result = getAncestors(context, contextSequence);
+                        break;
+                    case Constants.PARENT_AXIS:
+                        result = getParents(context, contextSequence);
+                        break;
+                    case Constants.SELF_AXIS:
+                        if (!(contextSequence instanceof VirtualNodeSet)
+                                && Type.subTypeOf(contextSequence.getItemType(),
+                                Type.ATOMIC)) {
+                            // This test is copied from the legacy method
+                            // getSelfAtomic()
+                            if (!test.isWildcardTest()) {
+                                throw new XPathException(this, test.toString()
+                                        + " cannot be applied to an atomic value.");
+                            }
+                            result = contextSequence;
+                        } else {
+                            result = getSelf(context, contextSequence);
+                        }
+                        break;
+                    case Constants.ATTRIBUTE_AXIS:
+                    case Constants.DESCENDANT_ATTRIBUTE_AXIS:
+                        result = getAttributes(context, contextSequence);
+                        break;
+                    case Constants.PRECEDING_AXIS:
+                        result = getPreceding(context, contextSequence);
+                        break;
+                    case Constants.FOLLOWING_AXIS:
+                        result = getFollowing(context, contextSequence);
+                        break;
+                    case Constants.PRECEDING_SIBLING_AXIS:
+                    case Constants.FOLLOWING_SIBLING_AXIS:
+                        result = getSiblings(context, contextSequence);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported axis specified");
+                }
+            } catch (XPathException e) {
+                if (e.getLine() <= 0) {
+                    e.setLocation(getLine(), getColumn(), getSource());
+                }
+                throw e;
+            }
 		} else {
 			result = NodeSet.EMPTY_SET;
 		}

--- a/src/org/exist/xquery/NamedFunctionReference.java
+++ b/src/org/exist/xquery/NamedFunctionReference.java
@@ -48,14 +48,17 @@ public class NamedFunctionReference extends AbstractExpression {
             return null;
         }
         if (fun instanceof FunctionCall) {
+            // clear line and column as it will be misleading. should be set later to point
+            // to the location from where the function is called.
+            fun.setLocation(-1, -1);
             return (FunctionCall) fun;
         } else if (fun instanceof Function) {
         	final InternalFunctionCall funcCall = new InternalFunctionCall((Function)fun);
-	        funcCall.setLocation(self.getLine(), self.getColumn());
+            funcCall.setLocation(-1, -1);
 	        return FunctionFactory.wrap(context, funcCall);
         } else if (fun instanceof CastExpression) {
             final InternalFunctionCall funcCall = new InternalFunctionCall(((CastExpression)fun).toFunction());
-            funcCall.setLocation(self.getLine(), self.getColumn());
+            funcCall.setLocation(-1, -1);
             return FunctionFactory.wrap(context, funcCall);
         } else
         	{throw new XPathException(self, ErrorCodes.XPST0017, "Named function reference should point to a function; found: " +

--- a/test/src/xquery/errors.xql
+++ b/test/src/xquery/errors.xql
@@ -1,0 +1,71 @@
+xquery version "3.0";
+
+(:~
+ : Tests to check if the reported line numbers for errors are correct
+ : if a function is called dynamically. In previous eXist versions, the
+ : line number always pointed to the place where the function item was created,
+ : not the actual function body.
+ :)
+module namespace et="http://exist-db.org/xquery/test/error-test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+(: Causes an error when called :)
+declare function et:test($a) {
+    $a + "bla"
+};
+
+(: May cause an error when called :)
+declare function et:test2($a) {
+    $a/foo
+};
+
+declare
+    %test:assertEquals(15)
+function et:dynamically-called-function() {
+    let $fn := function-lookup(xs:QName("et:test"), 1)
+    return
+        try {
+            $fn(1)
+        } catch * {
+            $err:line-number
+        }
+};
+
+declare
+    %test:assertEquals(20)
+function et:dynamically-called-function-path-expr() {
+    let $fn := function-lookup(xs:QName("et:test2"), 1)
+    return
+        try {
+            $fn(1)
+        } catch * {
+            $err:line-number
+        }
+};
+
+declare
+    %test:assertEquals(51)
+function et:inline-function-call() {
+    let $fn := function($a) {
+        $a + "bla"
+    }
+    return
+        try {
+            $fn(1)
+        } catch * {
+            $err:line-number
+        }
+};
+
+declare
+    %test:assertEquals(15)
+function et:function-reference-call() {
+    let $fn := et:test#1
+    return
+        try {
+            $fn(1)
+        } catch * {
+            $err:line-number
+        }
+};

--- a/test/src/xquery/suite.xql
+++ b/test/src/xquery/suite.xql
@@ -10,5 +10,6 @@ test:suite((
     inspect:module-functions(xs:anyURI("count.xql")),
     inspect:module-functions(xs:anyURI("serializer.xql")),
     inspect:module-functions(xs:anyURI("comments.xql")),
-    inspect:module-functions(xs:anyURI("fn.xql"))
+    inspect:module-functions(xs:anyURI("fn.xql")),
+    inspect:module-functions(xs:anyURI("errors.xql"))
 ))


### PR DESCRIPTION
…ally. The line/column indicated in the exception were misleading when using dynamic function calls. For example, if the function item was retrieved by calling fn:lookup-function, the error message would point to where lookup-function was evaluated, not the actual dynamic function call.

This makes it hard to work with libraries relying on dynamic function calls.