### PR TITLE
[performance] Numeric operators inside filter expression

### DIFF
--- a/src/org/exist/xquery/OpNumeric.java
+++ b/src/org/exist/xquery/OpNumeric.java
@@ -70,8 +70,13 @@ public class OpNumeric extends BinaryOp {
             if (Type.subTypeOf(ltype, Type.NUMBER)) {ltype = Type.NUMBER;}
             if (Type.subTypeOf(rtype, Type.NUMBER)) {rtype = Type.NUMBER;}
             final OpEntry entry = OP_TYPES.get(new OpEntry(operator, ltype, rtype));
-            if (entry != null)
-                {returnType = entry.typeResult;}
+            if (entry != null) {
+                returnType = entry.typeResult;
+            } else if (ltype == Type.NUMBER || rtype == Type.NUMBER) {
+                // if one of both operands returns a number, we can safely assume
+                // the return type of the whole expression will be a number
+                returnType = Type.NUMBER;
+            }
         }
         add(left);
         add(right);
@@ -79,7 +84,7 @@ public class OpNumeric extends BinaryOp {
 
     @Override
     public int getDependencies() {
-        return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
+        return getLeft().getDependencies() | getRight().getDependencies();
     }
 
     public int returnsType() {

--- a/src/org/exist/xquery/Predicate.java
+++ b/src/org/exist/xquery/Predicate.java
@@ -337,7 +337,11 @@ public class Predicate extends PathExpr {
                         Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Positional evaluation");}
                 // In case it hasn't been evaluated above
                 if (innerSeq == null) {
-                    innerSeq = inner.eval(contextSequence);
+                    // for a positional predicate, check if it depends on the context item
+                    // if not, do not pass the context sequence to avoid cardinality errors
+                    context.setContextSequencePosition(0, contextSequence);
+                    innerSeq = inner.eval(Dependency.dependsOn(inner.getDependencies(), Dependency.CONTEXT_ITEM)
+                            ? contextSequence : null);
                 }
                 result = selectByPosition(outerSequence, contextSequence, mode, innerSeq);
                 break;


### PR DESCRIPTION
cause performance loss as the operation is evaluated once per context item, which is completely unnecessary. The performance issue becomes dramatic when running generated XQuery code, e.g. as produced by the REX parser generator. A query took hours instead of a few milliseconds after my fix.

The performance issue was introduced by #86.