### PR TITLE
Bump exist version to upcoming RC2

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,8 +4,8 @@
 #
 # $Id$
 project.name = eXist-db
-project.version = 3.0.RC1
-project.version.numeric = 3.0.0
+project.version = 3.0.RC2
+project.version.numeric = 3.0.2
 project.source = develop
 project.codename = Berlin
 


### PR DESCRIPTION
Relabel internal RC2 to 3.0.2 [this is not visible anyway to users] ; this is highly required to get my extensions to work ; there is a long standing conflict with my extensions due to API changes between RC1 and RC2 ;
"3.0.2" helps me/us to continue developing extensions, without over and over again explaining our users that RC2 extension are not perse compatible with RC1. This unclearness + conflict is bad for us!
As discussed in weekly telco. Please pull-in ASAP. And please don't use 'puristic' arguments, this is the best and pragmatic solution.