### PR TITLE
Various improvements to XPath 3.1 Map functions

### DIFF
--- a/src/org/exist/xquery/functions/map/AbstractMapType.java
+++ b/src/org/exist/xquery/functions/map/AbstractMapType.java
@@ -44,6 +44,8 @@ public abstract class AbstractMapType extends FunctionReference
 
     public abstract Sequence get(AtomicValue key);
 
+    public abstract AbstractMapType put(AtomicValue key, Sequence value) throws XPathException;
+
     public abstract boolean contains(AtomicValue key);
 
     public abstract Sequence keys();

--- a/src/org/exist/xquery/functions/map/MapFunction.java
+++ b/src/org/exist/xquery/functions/map/MapFunction.java
@@ -10,154 +10,182 @@ import java.util.Map;
  * Implements all functions of the map module.
  */
 public class MapFunction extends BasicFunction {
-    
-    public static final FunctionSignature[] signatures = {
-        new FunctionSignature(
-            new QName("new", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "Constructs and returns an empty map whose collation is the default collation in the static context.",
-            null,
-            new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)),
-        new FunctionSignature(
-            new QName("new", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "Constructs and returns an empty map whose collation is the default collation in the static context.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("maps", Type.MAP, Cardinality.ZERO_OR_MORE, "Existing maps to combine into the new map.")
-            },
-            new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)),
-        new FunctionSignature(
-            new QName("new", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "Constructs and returns an empty map whose collation is given in the second argument.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("maps", Type.MAP, Cardinality.ZERO_OR_MORE, "Existing maps to combine into the new map."),
-                new FunctionParameterSequenceType("collation", Type.STRING, Cardinality.EXACTLY_ONE, "The collation to use for the new map.")
-            },
-            new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)),
-        new FunctionSignature(
-            new QName("entry", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "Creates a map that contains a single entry (a key-value pair).",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key"),
-                new FunctionParameterSequenceType("value", Type.ITEM, Cardinality.ZERO_OR_MORE, "The associated value")
-            },
-            new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)),
-        new FunctionSignature(
-            new QName("get", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "Returns the value associated with a supplied key in a given map.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
-                new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key to look up")
-            },
-            new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)),
-        new FunctionSignature(
-            new QName("contains", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "Tests whether a supplied map contains an entry for a given key.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
-                new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key to look up")
-            },
-            new SequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE)),
-        new FunctionSignature(
-            new QName("keys", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "Returns a sequence containing all the key values present in a map.",
-            new SequenceType[]{new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map")},
-            new SequenceType(Type.ATOMIC, Cardinality.ZERO_OR_MORE)),
-        new FunctionSignature(
-            new QName("remove", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "Constructs a new map by removing an entry from an existing map.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
-                new FunctionParameterSequenceType("key", Type.STRING, Cardinality.EXACTLY_ONE, "The key to remove")
-            },
-            new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)),
-        new FunctionSignature(
-            new QName("for-each", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "takes any map as its $input argument and applies the supplied function to each entry in the map, in implementation-dependent order; the result is the sequence obtained by concatenating the results of these function calls. " +
-            "The function supplied as $action takes two arguments. It is called supplying the key of the map entry as the first argument, and the associated value as the second argument.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("input", Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
-                new FunctionParameterSequenceType("action", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function to be called for each entry")
-            },
-            new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
-        ),
+
+    private static final QName QN_NEW = new QName("new", MapModule.NAMESPACE_URI, MapModule.PREFIX);
+    private static final QName QN_ENTRY = new QName("entry", MapModule.NAMESPACE_URI, MapModule.PREFIX);
+    private static final QName QN_GET = new QName("get", MapModule.NAMESPACE_URI, MapModule.PREFIX);
+    private static final QName QN_CONTAINS = new QName("contains", MapModule.NAMESPACE_URI, MapModule.PREFIX);
+    private static final QName QN_KEYS = new QName("keys", MapModule.NAMESPACE_URI, MapModule.PREFIX);
+    private static final QName QN_REMOVE = new QName("remove", MapModule.NAMESPACE_URI, MapModule.PREFIX);
+    private static final QName QN_FOR_EACH = new QName("for-each", MapModule.NAMESPACE_URI, MapModule.PREFIX);
+
+	@Deprecated private static final QName QN_FOR_EACH_ENTRY = new QName("for-each-entry", MapModule.NAMESPACE_URI, MapModule.PREFIX);
 
 
-        /* Deprecated below */
-        new FunctionSignature(
-            new QName("for-each-entry", MapModule.NAMESPACE_URI, MapModule.PREFIX),
-            "takes any map as its $input argument and applies the supplied function to each entry in the map, in implementation-dependent order; the result is the sequence obtained by concatenating the results of these function calls. " +
-                    "The function supplied as $action takes two arguments. It is called supplying the key of the map entry as the first argument, and the associated value as the second argument.",
-            new SequenceType[] {
-                    new FunctionParameterSequenceType("input", Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
-                    new FunctionParameterSequenceType("action", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function to be called for each entry")
-            },
-            new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE),
-            MapFunction.signatures[8]
-        )
-    };
+    public final static FunctionSignature FNS_NEW_0 = new FunctionSignature(
+        QN_NEW,
+        "Constructs and returns an empty map whose collation is the default collation in the static context.",
+        null,
+        new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
+    );
+
+    public final static FunctionSignature FNS_NEW_N = new FunctionSignature(
+        QN_NEW,
+        "Constructs and returns an empty map whose collation is the default collation in the static context.",
+        new SequenceType[] {
+            new FunctionParameterSequenceType("maps", Type.MAP, Cardinality.ZERO_OR_MORE, "Existing maps to combine into the new map.")
+        },
+        new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
+    );
+
+    public final static FunctionSignature FNS_NEW_N_COLLATION = new FunctionSignature(
+        QN_NEW,
+        "Constructs and returns an empty map whose collation is given in the second argument.",
+        new SequenceType[] {
+            new FunctionParameterSequenceType("maps", Type.MAP, Cardinality.ZERO_OR_MORE, "Existing maps to combine into the new map."),
+            new FunctionParameterSequenceType("collation", Type.STRING, Cardinality.EXACTLY_ONE, "The collation to use for the new map.")
+        },
+        new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
+    );
+
+    public final static FunctionSignature FNS_ENTRY = new FunctionSignature(
+        QN_ENTRY,
+        "Creates a map that contains a single entry (a key-value pair).",
+        new SequenceType[] {
+            new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key"),
+            new FunctionParameterSequenceType("value", Type.ITEM, Cardinality.ZERO_OR_MORE, "The associated value")
+        },
+        new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
+    );
+
+    public final static FunctionSignature FNS_GET = new FunctionSignature(
+        QN_GET,
+        "Returns the value associated with a supplied key in a given map.",
+        new SequenceType[] {
+            new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
+            new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key to look up")
+        },
+        new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
+    );
+
+    public final static FunctionSignature FNS_CONTAINS = new FunctionSignature(
+        QN_CONTAINS,
+        "Tests whether a supplied map contains an entry for a given key.",
+        new SequenceType[] {
+            new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
+            new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key to look up")
+        },
+        new SequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE)
+    );
+
+    public final static FunctionSignature FNS_KEYS = new FunctionSignature(
+        QN_KEYS,
+        "Returns a sequence containing all the key values present in a map.",
+        new SequenceType[]{new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map")},
+        new SequenceType(Type.ATOMIC, Cardinality.ZERO_OR_MORE)
+    );
+
+    public final static FunctionSignature FNS_REMOVE = new FunctionSignature(
+        QN_REMOVE,
+        "Constructs a new map by removing an entry from an existing map.",
+        new SequenceType[] {
+            new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
+            new FunctionParameterSequenceType("key", Type.STRING, Cardinality.EXACTLY_ONE, "The key to remove")
+        },
+        new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
+    );
+
+    public final static FunctionSignature FNS_FOR_EACH = new FunctionSignature(
+        QN_FOR_EACH,
+        "takes any map as its $input argument and applies the supplied function to each entry in the map, in implementation-dependent order; the result is the sequence obtained by concatenating the results of these function calls. " +
+        "The function supplied as $action takes two arguments. It is called supplying the key of the map entry as the first argument, and the associated value as the second argument.",
+        new SequenceType[] {
+            new FunctionParameterSequenceType("input", Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
+            new FunctionParameterSequenceType("action", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function to be called for each entry")
+        },
+        new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
+    );
+
+
+	/* Deprecated below */
+
+	@Deprecated
+    public final static FunctionSignature FNS_FOR_EACH_ENTRY = new FunctionSignature(
+        QN_FOR_EACH_ENTRY,
+        "takes any map as its $input argument and applies the supplied function to each entry in the map, in implementation-dependent order; the result is the sequence obtained by concatenating the results of these function calls. " +
+        "The function supplied as $action takes two arguments. It is called supplying the key of the map entry as the first argument, and the associated value as the second argument.",
+        new SequenceType[] {
+            new FunctionParameterSequenceType("input", Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
+            new FunctionParameterSequenceType("action", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function to be called for each entry")
+        },
+        new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE),
+		FNS_FOR_EACH
+    );
 
     private AnalyzeContextInfo cachedContextInfo;
 
-    public MapFunction(XQueryContext context, FunctionSignature signature) {
+    public MapFunction(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
     @Override
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         cachedContextInfo = new AnalyzeContextInfo(contextInfo);
         super.analyze(contextInfo);
     }
 
-    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-        if (isCalledAs("new"))
-            {return newMap(args);}
-        if (isCalledAs("entry"))
-            {return entry(args);}
-        if (isCalledAs("get"))
-            {return get(args);}
-        if (isCalledAs("contains"))
-            {return contains(args);}
-        if (isCalledAs("keys"))
-            {return keys(args);}
-        if (isCalledAs("remove"))
-            {return remove(args);}
-        if (isCalledAs("for-each") || isCalledAs("for-each-entry")) {
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        if (isCalledAs(QN_NEW.getLocalPart())) {
+            return newMap(args);
+        } else if (isCalledAs(QN_ENTRY.getLocalPart())) {
+            return entry(args);
+        } else if (isCalledAs(QN_GET.getLocalPart())) {
+            return get(args);
+        } else if (isCalledAs(QN_CONTAINS.getLocalPart())) {
+            return contains(args);
+        } else if (isCalledAs(QN_KEYS.getLocalPart())) {
+            return keys(args);
+        } else if (isCalledAs(QN_REMOVE.getLocalPart())) {
+            return remove(args);
+        } else if (isCalledAs(QN_FOR_EACH.getLocalPart()) || isCalledAs(QN_FOR_EACH_ENTRY.getLocalPart())) {
             return forEach(args);
         }
         return null;
     }
 
-    private Sequence remove(Sequence[] args) {
+    private Sequence remove(final Sequence[] args) {
         final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
         return map.remove((AtomicValue) args[1].itemAt(0));
     }
 
-    private Sequence keys(Sequence[] args) {
+    private Sequence keys(final Sequence[] args) {
         final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
         return map.keys();
     }
 
-    private Sequence contains(Sequence[] args) {
+    private Sequence contains(final Sequence[] args) {
         final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
         return BooleanValue.valueOf(map.contains((AtomicValue) args[1].itemAt(0)));
     }
 
-    private Sequence get(Sequence[] args) {
+    private Sequence get(final Sequence[] args) {
         final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
         return map.get((AtomicValue) args[1].itemAt(0));
     }
 
-    private Sequence entry(Sequence[] args) throws XPathException {
+    private Sequence entry(final Sequence[] args) throws XPathException {
         final AtomicValue key = (AtomicValue) args[0].itemAt(0);
         return new SingleKeyMapType(this.context, null, key, args[1]);
     }
 
-    private Sequence newMap(Sequence[] args) throws XPathException {
+    private Sequence newMap(final Sequence[] args) throws XPathException {
         if (args.length == 0) {
             return new MapType(this.context);
         }
         String collation = null;
-        if (args.length == 2)
-            {collation = args[1].getStringValue();}
+        if (args.length == 2) {
+            collation = args[1].getStringValue();
+        }
         final MapType map = new MapType(this.context, collation);
         for (final SequenceIterator i = args[0].unorderedIterator(); i.hasNext(); ) {
             final AbstractMapType m = (AbstractMapType) i.nextItem();
@@ -166,16 +194,13 @@ public class MapFunction extends BasicFunction {
         return map;
     }
 
-    private Sequence forEach(Sequence[] args) throws XPathException {
+    private Sequence forEach(final Sequence[] args) throws XPathException {
         final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
         final FunctionReference ref = (FunctionReference) args[1].itemAt(0);
         ref.analyze(cachedContextInfo);
         final ValueSequence result = new ValueSequence();
-        final Sequence fargs[] = new Sequence[2];
-        for (Map.Entry<AtomicValue, Sequence> entry: map) {
-            fargs[0] = entry.getKey();
-            fargs[1] = entry.getValue();
-            final Sequence s = ref.evalFunction(null, null, fargs);
+        for (final Map.Entry<AtomicValue, Sequence> entry : map) {
+            final Sequence s = ref.evalFunction(null, null, new Sequence[] { entry.getKey(), entry.getValue() });
             result.addAll(s);
         }
         return result;

--- a/src/org/exist/xquery/functions/map/MapFunction.java
+++ b/src/org/exist/xquery/functions/map/MapFunction.java
@@ -15,6 +15,7 @@ public class MapFunction extends BasicFunction {
     private static final QName QN_SIZE = new QName("size", MapModule.NAMESPACE_URI, MapModule.PREFIX);
     private static final QName QN_ENTRY = new QName("entry", MapModule.NAMESPACE_URI, MapModule.PREFIX);
     private static final QName QN_GET = new QName("get", MapModule.NAMESPACE_URI, MapModule.PREFIX);
+    private static final QName QN_PUT = new QName("put", MapModule.NAMESPACE_URI, MapModule.PREFIX);
     private static final QName QN_CONTAINS = new QName("contains", MapModule.NAMESPACE_URI, MapModule.PREFIX);
     private static final QName QN_KEYS = new QName("keys", MapModule.NAMESPACE_URI, MapModule.PREFIX);
     private static final QName QN_REMOVE = new QName("remove", MapModule.NAMESPACE_URI, MapModule.PREFIX);
@@ -68,6 +69,17 @@ public class MapFunction extends BasicFunction {
             new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key to look up")
         },
         new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
+    );
+
+    public final static FunctionSignature FNS_PUT = new FunctionSignature(
+        QN_PUT,
+        "Returns a map containing all the contents of the supplied map, but with an additional entry, which replaces any existing entry for the same key.",
+        new SequenceType[] {
+            new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
+            new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key for the entry to insert"),
+            new FunctionParameterSequenceType("value", Type.ITEM, Cardinality.ZERO_OR_MORE, "The value for the entry to insert")
+        },
+        new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
     );
 
     public final static FunctionSignature FNS_ENTRY = new FunctionSignature(
@@ -174,6 +186,8 @@ public class MapFunction extends BasicFunction {
             return contains(args);
         } else if (isCalledAs(QN_GET.getLocalPart())) {
             return get(args);
+        } else if (isCalledAs(QN_PUT.getLocalPart())) {
+            return put(args);
         } else if (isCalledAs(QN_ENTRY.getLocalPart())) {
             return entry(args);
         } else if (isCalledAs(QN_REMOVE.getLocalPart())) {
@@ -202,6 +216,11 @@ public class MapFunction extends BasicFunction {
     private Sequence get(final Sequence[] args) {
         final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
         return map.get((AtomicValue) args[1].itemAt(0));
+    }
+
+    private Sequence put(final Sequence[] args) throws XPathException {
+        final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
+        return map.put((AtomicValue) args[1].itemAt(0), args[2]);
     }
 
     private Sequence entry(final Sequence[] args) throws XPathException {

--- a/src/org/exist/xquery/functions/map/MapFunction.java
+++ b/src/org/exist/xquery/functions/map/MapFunction.java
@@ -12,6 +12,7 @@ import java.util.Map;
 public class MapFunction extends BasicFunction {
 
     private static final QName QN_MERGE = new QName("merge", MapModule.NAMESPACE_URI, MapModule.PREFIX);
+    private static final QName QN_SIZE = new QName("size", MapModule.NAMESPACE_URI, MapModule.PREFIX);
     private static final QName QN_ENTRY = new QName("entry", MapModule.NAMESPACE_URI, MapModule.PREFIX);
     private static final QName QN_GET = new QName("get", MapModule.NAMESPACE_URI, MapModule.PREFIX);
     private static final QName QN_CONTAINS = new QName("contains", MapModule.NAMESPACE_URI, MapModule.PREFIX);
@@ -29,6 +30,15 @@ public class MapFunction extends BasicFunction {
             new FunctionParameterSequenceType("maps", Type.MAP, Cardinality.ZERO_OR_MORE, "Existing maps to merge to create a new map.")
         },
         new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
+    );
+
+    public final static FunctionSignature FNS_SIZE = new FunctionSignature(
+        QN_SIZE,
+        "Returns the number of entries in the supplied map.",
+        new SequenceType[] {
+                new FunctionParameterSequenceType("input", Type.MAP, Cardinality.EXACTLY_ONE, "Any map to determine the size of.")
+        },
+        new SequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE)
     );
 
     public final static FunctionSignature FNS_ENTRY = new FunctionSignature(
@@ -154,6 +164,8 @@ public class MapFunction extends BasicFunction {
             return newMap(args);
         } else if (isCalledAs(QN_MERGE.getLocalPart())) {
             return merge(args);
+        } else if (isCalledAs(QN_SIZE.getLocalPart())) {
+            return size(args);
         } else if (isCalledAs(QN_ENTRY.getLocalPart())) {
             return entry(args);
         } else if (isCalledAs(QN_GET.getLocalPart())) {
@@ -193,6 +205,11 @@ public class MapFunction extends BasicFunction {
     private Sequence entry(final Sequence[] args) throws XPathException {
         final AtomicValue key = (AtomicValue) args[0].itemAt(0);
         return new SingleKeyMapType(this.context, null, key, args[1]);
+    }
+
+    private Sequence size(final Sequence[] args) throws XPathException {
+        final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
+        return new IntegerValue(map.size(), Type.INTEGER);
     }
 
     private Sequence merge(final Sequence[] args) throws XPathException {

--- a/src/org/exist/xquery/functions/map/MapFunction.java
+++ b/src/org/exist/xquery/functions/map/MapFunction.java
@@ -70,7 +70,7 @@ public class MapFunction extends BasicFunction {
             },
             new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)),
         new FunctionSignature(
-            new QName("for-each-entry", MapModule.NAMESPACE_URI, MapModule.PREFIX),
+            new QName("for-each", MapModule.NAMESPACE_URI, MapModule.PREFIX),
             "takes any map as its $input argument and applies the supplied function to each entry in the map, in implementation-dependent order; the result is the sequence obtained by concatenating the results of these function calls. " +
             "The function supplied as $action takes two arguments. It is called supplying the key of the map entry as the first argument, and the associated value as the second argument.",
             new SequenceType[] {
@@ -78,6 +78,20 @@ public class MapFunction extends BasicFunction {
                 new FunctionParameterSequenceType("action", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function to be called for each entry")
             },
             new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
+        ),
+
+
+        /* Deprecated below */
+        new FunctionSignature(
+            new QName("for-each-entry", MapModule.NAMESPACE_URI, MapModule.PREFIX),
+            "takes any map as its $input argument and applies the supplied function to each entry in the map, in implementation-dependent order; the result is the sequence obtained by concatenating the results of these function calls. " +
+                    "The function supplied as $action takes two arguments. It is called supplying the key of the map entry as the first argument, and the associated value as the second argument.",
+            new SequenceType[] {
+                    new FunctionParameterSequenceType("input", Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
+                    new FunctionParameterSequenceType("action", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function to be called for each entry")
+            },
+            new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE),
+            MapFunction.signatures[8]
         )
     };
 
@@ -106,8 +120,8 @@ public class MapFunction extends BasicFunction {
             {return keys(args);}
         if (isCalledAs("remove"))
             {return remove(args);}
-        if (isCalledAs("for-each-entry")) {
-            return forEachEntry(args);
+        if (isCalledAs("for-each") || isCalledAs("for-each-entry")) {
+            return forEach(args);
         }
         return null;
     }
@@ -152,7 +166,7 @@ public class MapFunction extends BasicFunction {
         return map;
     }
 
-    private Sequence forEachEntry(Sequence[] args) throws XPathException {
+    private Sequence forEach(Sequence[] args) throws XPathException {
         final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
         final FunctionReference ref = (FunctionReference) args[1].itemAt(0);
         ref.analyze(cachedContextInfo);

--- a/src/org/exist/xquery/functions/map/MapFunction.java
+++ b/src/org/exist/xquery/functions/map/MapFunction.java
@@ -36,29 +36,18 @@ public class MapFunction extends BasicFunction {
         QN_SIZE,
         "Returns the number of entries in the supplied map.",
         new SequenceType[] {
-                new FunctionParameterSequenceType("input", Type.MAP, Cardinality.EXACTLY_ONE, "Any map to determine the size of.")
+            new FunctionParameterSequenceType("input", Type.MAP, Cardinality.EXACTLY_ONE, "Any map to determine the size of.")
         },
         new SequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE)
     );
 
-    public final static FunctionSignature FNS_ENTRY = new FunctionSignature(
-        QN_ENTRY,
-        "Creates a map that contains a single entry (a key-value pair).",
-        new SequenceType[] {
-            new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key"),
-            new FunctionParameterSequenceType("value", Type.ITEM, Cardinality.ZERO_OR_MORE, "The associated value")
+    public final static FunctionSignature FNS_KEYS = new FunctionSignature(
+        QN_KEYS,
+        "Returns a sequence containing all the key values present in a map.",
+        new SequenceType[]{
+            new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map")
         },
-        new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
-    );
-
-    public final static FunctionSignature FNS_GET = new FunctionSignature(
-        QN_GET,
-        "Returns the value associated with a supplied key in a given map.",
-        new SequenceType[] {
-            new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
-            new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key to look up")
-        },
-        new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
+        new SequenceType(Type.ATOMIC, Cardinality.ZERO_OR_MORE)
     );
 
     public final static FunctionSignature FNS_CONTAINS = new FunctionSignature(
@@ -71,11 +60,24 @@ public class MapFunction extends BasicFunction {
         new SequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE)
     );
 
-    public final static FunctionSignature FNS_KEYS = new FunctionSignature(
-        QN_KEYS,
-        "Returns a sequence containing all the key values present in a map.",
-        new SequenceType[]{new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map")},
-        new SequenceType(Type.ATOMIC, Cardinality.ZERO_OR_MORE)
+    public final static FunctionSignature FNS_GET = new FunctionSignature(
+        QN_GET,
+        "Returns the value associated with a supplied key in a given map.",
+        new SequenceType[] {
+            new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
+            new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key to look up")
+        },
+        new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
+    );
+
+    public final static FunctionSignature FNS_ENTRY = new FunctionSignature(
+        QN_ENTRY,
+        "Creates a map that contains a single entry (a key-value pair).",
+        new SequenceType[] {
+            new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.EXACTLY_ONE, "The key"),
+            new FunctionParameterSequenceType("value", Type.ITEM, Cardinality.ZERO_OR_MORE, "The associated value")
+        },
+        new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
     );
 
     public final static FunctionSignature FNS_REMOVE = new FunctionSignature(
@@ -166,14 +168,14 @@ public class MapFunction extends BasicFunction {
             return merge(args);
         } else if (isCalledAs(QN_SIZE.getLocalPart())) {
             return size(args);
-        } else if (isCalledAs(QN_ENTRY.getLocalPart())) {
-            return entry(args);
-        } else if (isCalledAs(QN_GET.getLocalPart())) {
-            return get(args);
-        } else if (isCalledAs(QN_CONTAINS.getLocalPart())) {
-            return contains(args);
         } else if (isCalledAs(QN_KEYS.getLocalPart())) {
             return keys(args);
+        } else if (isCalledAs(QN_CONTAINS.getLocalPart())) {
+            return contains(args);
+        } else if (isCalledAs(QN_GET.getLocalPart())) {
+            return get(args);
+        } else if (isCalledAs(QN_ENTRY.getLocalPart())) {
+            return entry(args);
         } else if (isCalledAs(QN_REMOVE.getLocalPart())) {
             return remove(args);
         } else if (isCalledAs(QN_FOR_EACH.getLocalPart()) || isCalledAs(QN_FOR_EACH_ENTRY.getLocalPart())) {

--- a/src/org/exist/xquery/functions/map/MapModule.java
+++ b/src/org/exist/xquery/functions/map/MapModule.java
@@ -17,9 +17,7 @@ public class MapModule extends AbstractInternalModule {
     public static final String PREFIX = "map";
 
     private static final FunctionDef[] functions = {
-            new FunctionDef(MapFunction.FNS_NEW_0, MapFunction.class),
-            new FunctionDef(MapFunction.FNS_NEW_N, MapFunction.class),
-            new FunctionDef(MapFunction.FNS_NEW_N_COLLATION, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_MERGE, MapFunction.class),
             new FunctionDef(MapFunction.FNS_ENTRY, MapFunction.class),
             new FunctionDef(MapFunction.FNS_GET, MapFunction.class),
             new FunctionDef(MapFunction.FNS_CONTAINS, MapFunction.class),
@@ -29,7 +27,9 @@ public class MapModule extends AbstractInternalModule {
 
 
             /* Deprecated below */
-
+            new FunctionDef(MapFunction.FNS_NEW_0, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_NEW_N, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_NEW_N_COLLATION, MapFunction.class),
             new FunctionDef(MapFunction.FNS_FOR_EACH_ENTRY, MapFunction.class)
     };
 

--- a/src/org/exist/xquery/functions/map/MapModule.java
+++ b/src/org/exist/xquery/functions/map/MapModule.java
@@ -19,10 +19,10 @@ public class MapModule extends AbstractInternalModule {
     private static final FunctionDef[] functions = {
             new FunctionDef(MapFunction.FNS_MERGE, MapFunction.class),
             new FunctionDef(MapFunction.FNS_SIZE, MapFunction.class),
-            new FunctionDef(MapFunction.FNS_ENTRY, MapFunction.class),
-            new FunctionDef(MapFunction.FNS_GET, MapFunction.class),
-            new FunctionDef(MapFunction.FNS_CONTAINS, MapFunction.class),
             new FunctionDef(MapFunction.FNS_KEYS, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_CONTAINS, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_GET, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_ENTRY, MapFunction.class),
             new FunctionDef(MapFunction.FNS_REMOVE, MapFunction.class),
             new FunctionDef(MapFunction.FNS_FOR_EACH, MapFunction.class),
 

--- a/src/org/exist/xquery/functions/map/MapModule.java
+++ b/src/org/exist/xquery/functions/map/MapModule.java
@@ -17,18 +17,20 @@ public class MapModule extends AbstractInternalModule {
     public static final String PREFIX = "map";
 
     private static final FunctionDef[] functions = {
-            new FunctionDef(MapFunction.signatures[0], MapFunction.class),
-            new FunctionDef(MapFunction.signatures[1], MapFunction.class),
-            new FunctionDef(MapFunction.signatures[2], MapFunction.class),
-            new FunctionDef(MapFunction.signatures[3], MapFunction.class),
-            new FunctionDef(MapFunction.signatures[4], MapFunction.class),
-            new FunctionDef(MapFunction.signatures[5], MapFunction.class),
-            new FunctionDef(MapFunction.signatures[6], MapFunction.class),
-            new FunctionDef(MapFunction.signatures[7], MapFunction.class),
-            new FunctionDef(MapFunction.signatures[8], MapFunction.class),
+            new FunctionDef(MapFunction.FNS_NEW_0, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_NEW_N, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_NEW_N_COLLATION, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_ENTRY, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_GET, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_CONTAINS, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_KEYS, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_REMOVE, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_FOR_EACH, MapFunction.class),
+
 
             /* Deprecated below */
-            new FunctionDef(MapFunction.signatures[9], MapFunction.class)
+
+            new FunctionDef(MapFunction.FNS_FOR_EACH_ENTRY, MapFunction.class)
     };
 
     public MapModule(Map<String, List<? extends Object>> parameters) {

--- a/src/org/exist/xquery/functions/map/MapModule.java
+++ b/src/org/exist/xquery/functions/map/MapModule.java
@@ -22,6 +22,7 @@ public class MapModule extends AbstractInternalModule {
             new FunctionDef(MapFunction.FNS_KEYS, MapFunction.class),
             new FunctionDef(MapFunction.FNS_CONTAINS, MapFunction.class),
             new FunctionDef(MapFunction.FNS_GET, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_PUT, MapFunction.class),
             new FunctionDef(MapFunction.FNS_ENTRY, MapFunction.class),
             new FunctionDef(MapFunction.FNS_REMOVE, MapFunction.class),
             new FunctionDef(MapFunction.FNS_FOR_EACH, MapFunction.class),

--- a/src/org/exist/xquery/functions/map/MapModule.java
+++ b/src/org/exist/xquery/functions/map/MapModule.java
@@ -18,6 +18,7 @@ public class MapModule extends AbstractInternalModule {
 
     private static final FunctionDef[] functions = {
             new FunctionDef(MapFunction.FNS_MERGE, MapFunction.class),
+            new FunctionDef(MapFunction.FNS_SIZE, MapFunction.class),
             new FunctionDef(MapFunction.FNS_ENTRY, MapFunction.class),
             new FunctionDef(MapFunction.FNS_GET, MapFunction.class),
             new FunctionDef(MapFunction.FNS_CONTAINS, MapFunction.class),

--- a/src/org/exist/xquery/functions/map/MapModule.java
+++ b/src/org/exist/xquery/functions/map/MapModule.java
@@ -25,7 +25,10 @@ public class MapModule extends AbstractInternalModule {
             new FunctionDef(MapFunction.signatures[5], MapFunction.class),
             new FunctionDef(MapFunction.signatures[6], MapFunction.class),
             new FunctionDef(MapFunction.signatures[7], MapFunction.class),
-            new FunctionDef(MapFunction.signatures[8], MapFunction.class)
+            new FunctionDef(MapFunction.signatures[8], MapFunction.class),
+
+            /* Deprecated below */
+            new FunctionDef(MapFunction.signatures[9], MapFunction.class)
     };
 
     public MapModule(Map<String, List<? extends Object>> parameters) {

--- a/src/org/exist/xquery/functions/map/MapType.java
+++ b/src/org/exist/xquery/functions/map/MapType.java
@@ -82,6 +82,11 @@ public class MapType extends AbstractMapType {
         return e == null ? Sequence.EMPTY_SEQUENCE : e.getValue();
     }
 
+    @Override
+    public AbstractMapType put(AtomicValue key, final Sequence value) throws XPathException {
+        return new MapType(this.context, this.map.assoc(key, value), type);
+    }
+
     public boolean contains(AtomicValue key) {
         key = convert(key);
         if (key == null)
@@ -125,9 +130,17 @@ public class MapType extends AbstractMapType {
 
     @Override
     public Sequence getValue() {
-        if (map.count() == 0)
-            {return null;}
-        final Iterator<Map.Entry<AtomicValue,Sequence>> iter = this.map.iterator();
+        return mapToSequence(this.map);
+    }
+
+    /**
+     * Get a Sequence from an internal map representation
+     */
+    private Sequence mapToSequence(final IPersistentMap<AtomicValue, Sequence> map) {
+        if (map.count() == 0) {
+            return null;
+        }
+        final Iterator<Map.Entry<AtomicValue,Sequence>> iter = map.iterator();
         return iter.next().getValue();
     }
 
@@ -150,7 +163,7 @@ public class MapType extends AbstractMapType {
     }
 
     private AtomicValue convert(AtomicValue key) {
-        if (type != Type.ITEM) {
+        if (type != Type.ANY_TYPE && type != Type.ITEM) {
             try {
                 return key.convertTo(type);
             } catch (final XPathException e) {

--- a/src/org/exist/xquery/functions/map/SingleKeyMapType.java
+++ b/src/org/exist/xquery/functions/map/SingleKeyMapType.java
@@ -36,6 +36,13 @@ public class SingleKeyMapType extends AbstractMapType {
     }
 
     @Override
+    public AbstractMapType put(final AtomicValue key, final Sequence value) throws XPathException {
+        final MapType map = new MapType(context);
+        map.add(this);
+        return map.put(key, value);
+    }
+
+    @Override
     public boolean contains(AtomicValue key) {
         return (comparator.compare(this.key, key) == Constants.EQUAL);
     }

--- a/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -603,9 +603,9 @@ declare %private function test:assertXPath($annotation as element(annotation), $
             $output
     let $prolog :=
         if ($result instance of element()*) then
-            let $namespaces := fold-left($result/descendant-or-self::*, map:new(),
+            let $namespaces := fold-left($result/descendant-or-self::*, map {},
                 function ($namespaces as map(*), $xml as element()) {
-                    map:new(($namespaces,
+                    map:merge(($namespaces,
                 	    for $prefix in in-scope-prefixes($xml)
                 	    where $prefix != "" and $prefix != "xml"
                 	    return

--- a/test/src/xquery/maps/maps.xql
+++ b/test/src/xquery/maps/maps.xql
@@ -64,6 +64,36 @@ function mt:size-empty() {
 };
 
 declare
+    %test:assertEquals("Good")
+function mt:put-empty() {
+    let $m := map {}
+    return
+      map:put($m, "Cats", "Good")("Cats")
+};
+
+declare
+    %test:assertEquals("Bad")
+function mt:put-single() {
+    let $m := map {
+        "Cats" : "Good"
+    }
+    return
+      map:put($m, "Dogs", "Bad")("Dogs")
+};
+
+declare
+    %test:assertEquals("Duck")
+function mt:put() {
+    let $m := map {
+        "Cats" : "Good",
+        "Dogs" : "Bad",
+        1 : "Chicken"
+    }
+    return
+      map:put($m, 2, "Duck")(2)
+};
+
+declare
     %test:assertEquals(4)
 function mt:size() {
     let $m := map {

--- a/test/src/xquery/maps/maps.xql
+++ b/test/src/xquery/maps/maps.xql
@@ -55,6 +55,27 @@ function mt:createFromTwoMaps() {
         map:keys($map)
 };
 
+declare
+    %test:assertEquals(0)
+function mt:size-empty() {
+    let $m := map {}
+    return
+      map:size($m)
+};
+
+declare
+    %test:assertEquals(4)
+function mt:size() {
+    let $m := map {
+      "Cats" : "Good",
+      "Dogs" : "Bad",
+      1 : "Chicken",
+      2 : "Duck"
+    }
+    return
+      map:size($m)
+};
+
 declare 
     %test:assertEquals("Sonntag", "Dienstag", "Donnerstag", "Samstag")
 function mt:for-each() {

--- a/test/src/xquery/maps/maps.xql
+++ b/test/src/xquery/maps/maps.xql
@@ -57,10 +57,10 @@ function mt:createFromTwoMaps() {
 
 declare 
     %test:assertEquals("Sonntag", "Dienstag", "Donnerstag", "Samstag")
-function mt:for-each-entry() {
+function mt:for-each() {
     let $week := map{0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag", 5: "Freitag", 6: "Samstag"}
     return
-        map:for-each-entry($week, function($key, $value) {
+        map:for-each($week, function($key, $value) {
             if ($key mod 2 = 0) then
                 $value
             else
@@ -70,8 +70,8 @@ function mt:for-each-entry() {
 
 declare 
     %test:assertEquals(3)
-function mt:for-each-entry2() {
-    let $nm := map:new(map:for-each-entry(map{"a":1, "b":2}, function($k, $v){map:entry($k, $v+1)}))
+function mt:for-each2() {
+    let $nm := map:new(map:for-each(map{"a":1, "b":2}, function($k, $v){map:entry($k, $v+1)}))
     return
         $nm?b
 };

--- a/test/src/xquery/maps/maps.xql
+++ b/test/src/xquery/maps/maps.xql
@@ -42,7 +42,7 @@ declare %test:assertEquals(20) function mt:createWithFunctionValue() {
 
 declare %test:assertEquals("Sunday") function mt:createWithEntry() {
     let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-    let $map := map:new(map(function($day) { map:entry(substring($day, 1, 2), $day) }, $days))
+    let $map := map:merge((map(function($day) { map:entry(substring($day, 1, 2), $day) }, $days)))
     return
         $map("Su")
 };
@@ -50,7 +50,7 @@ declare %test:assertEquals("Sunday") function mt:createWithEntry() {
 declare %test:assertXPath("count($result) = 8") %test:assertXPath("7 = $result") 
 function mt:createFromTwoMaps() {
     let $week := map{0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag", 5: "Freitag", 6: "Samstag"}
-    let $map := map:new(($week, map { 7 : "Sonntag" }))
+    let $map := map:merge(($week, map { 7 : "Sonntag" }))
     return
         map:keys($map)
 };
@@ -71,7 +71,7 @@ function mt:for-each() {
 declare 
     %test:assertEquals(3)
 function mt:for-each2() {
-    let $nm := map:new(map:for-each(map{"a":1, "b":2}, function($k, $v){map:entry($k, $v+1)}))
+    let $nm := map:merge(map:for-each(map{"a":1, "b":2}, function($k, $v){map:entry($k, $v+1)}))
     return
         $nm?b
 };
@@ -84,7 +84,7 @@ declare %test:assertEquals("Sunday") function mt:createWithSingleKey() {
 
 declare %test:assertEquals("Samstag", "Sonnabend") function mt:overwriteKeyInNewMap() {
     let $week := map {0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag", 5: "Freitag", 6: "Samstag"}
-    let $map := map:new(($week, map { 6 :  "Sonnabend" }))
+    let $map := map:merge(($week, map { 6 :  "Sonnabend" }))
     return
         ($week(6), $map(6))
 };
@@ -127,15 +127,9 @@ declare %test:assertTrue function mt:containsOnEmptyValue() {
         map:contains($map, 0)
 };
 
-declare %test:assertEquals("Monday") function mt:createWithCollation() {
-    let $map := map:new(map:entry("Mo", "Monday"), "?strength=primary")
-    return
-        $map("mo")
-};
-
 declare %test:assertEquals("Fr", "Mo", "Sa", "Su", "Th", "Tu", "We") function mt:keys() {
     let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-    let $map := map:new(map(function($day) { map:entry(substring($day, 1, 2), $day) }, $days))
+    let $map := map:merge((map(function($day) { map:entry(substring($day, 1, 2), $day) }, $days)))
     for $day in map:keys($map)
     order by $day ascending
     return
@@ -150,7 +144,7 @@ declare %test:assertEquals("Su") function mt:keysOnMapWithSingleKey() {
 
 declare %test:assertEquals("Fr", "Mo", "Sa", "Su", "Th") function mt:remove() {
     let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-    let $map := map:new(map(function($day) { map:entry(substring($day, 1, 2), $day) }, $days))
+    let $map := map:merge((map(function($day) { map:entry(substring($day, 1, 2), $day) }, $days)))
     for $day in map:keys(map:remove(map:remove($map, "We"), "Tu"))
     order by $day
     return
@@ -159,7 +153,7 @@ declare %test:assertEquals("Fr", "Mo", "Sa", "Su", "Th") function mt:remove() {
 
 declare %test:assertFalse function mt:remove() {
     let $days := ("Monday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-    let $map := map:new(map(function($day) { map:entry(substring($day, 1, 2), $day) }, $days))
+    let $map := map:merge((map(function($day) { map:entry(substring($day, 1, 2), $day) }, $days)))
     return
         map:contains(map:remove($map, "Tu"), "Tu")
 };
@@ -200,7 +194,7 @@ declare %test:assertEquals("false", "true") function mt:immutability() {
         "Th" : "Thursday",
         "Fr" : "Friday"
     }
-    let $map2 := map:new(($map, map:entry("Sa", "Saturday")))
+    let $map2 := map:merge(($map, map:entry("Sa", "Saturday")))
     return
         (map:contains($map, "Sa"), map:contains($map2, "Sa"))
 };
@@ -307,7 +301,7 @@ declare
 function mt:doubleKeys($key as item()) {
     let $map := map { xs:double(1.1) : 1, xs:double(2) : 2 }
     return
-        map:new(($map, map:entry(xs:double(2), 3)))($key)
+        map:merge(($map, map:entry(xs:double(2), 3)))($key)
 };
 
 declare


### PR DESCRIPTION
1. Corrected the function name `map:for-each-entry` to `map:for-each`
2. Removed `map:new` in favour of `map:merge`
3. Implemented missing function `map:size`
4. Implemented missing function `map:put`

We should now have the correct functions from XPath 3.1 for maps.