### PR TITLE
[bugfix] Close memory leak: cleanupTasks in XQueryContext need to be …

### DIFF
--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -3669,5 +3669,6 @@ public class XQueryContext implements BinaryValueManager, Context
                 LOG.error("Cleaning up XQueryContext: Ignoring: " + t.getMessage(), t);
             }
         }
+        cleanupTasks.clear();
     }
 }


### PR DESCRIPTION
…cleared before query is pushed to pool, otherwise the list will keep growing with every call to the query and resources are not freed. Mainly used from http client.