### PR TITLE
Unifying the asocat lib handling. 

### DIFF
--- a/build/scripts/build-impl.xml
+++ b/build/scripts/build-impl.xml
@@ -49,7 +49,7 @@
     <available file="key.store" property="key.store.present"/>
 
     <!-- additional set of ant tasks -->
-    <property name="asocat-exist.jar" location="${tools.ant}/lib/asocat-exist.jar"/>
+    <property name="asocat-exist.jar" location="${tools.ant}/lib/asocat-exist-1.0.jar"/>
 
     <path id="classpath.external">
         <fileset dir="${lib.core}">

--- a/build/scripts/installer.xml
+++ b/build/scripts/installer.xml
@@ -84,7 +84,7 @@
         
         <taskdef name="fetch" classname="nl.ow.dilemma.ant.fetch.FetchTask">
             <classpath>
-                <pathelement location="tools/ant/lib/asocat-exist.jar"/>
+                <pathelement location="${asocat-exist.jar}"/>
             </classpath>
         </taskdef>
         <fetch dest="${apps.dir}" url="${apps.repo}/pkg.zip?abbrev=${xar}&amp;zip=yes"

--- a/build/scripts/macosx.xml
+++ b/build/scripts/macosx.xml
@@ -30,7 +30,7 @@
     <target name="install-appbundler" unless="appbundler.available">
         <taskdef name="fetch" classname="nl.ow.dilemma.ant.fetch.FetchTask">
             <classpath>
-                <pathelement location="${tools.ant}/lib/asocat-exist.jar"/>
+                <pathelement location="${asocat-exist.jar}"/>
             </classpath>
         </taskdef>
         

--- a/build/scripts/setup.xml
+++ b/build/scripts/setup.xml
@@ -7,8 +7,10 @@
 <!-- $Id$ -->
 
 <project basedir="../.." name="Setup" default="setup">
-
   <description>Package setup tasks</description>
+
+  <!-- import common targets -->
+  <import file="../../build.xml"/>
   
   <!-- Additional task defs  -->
   <taskdef resource="net/sf/antcontrib/antcontrib.properties">
@@ -60,7 +62,7 @@
       
     <taskdef name="fetch" classname="nl.ow.dilemma.ant.fetch.FetchTask">
         <classpath>
-          <pathelement location="tools/ant/lib/asocat-exist.jar"/>
+          <pathelement location="${asocat-exist.jar}"/>
         </classpath>
     </taskdef>
     <fetch dest="${autostart-dir}" url="${autodeploy.repo}/pkg.zip?abbrev=${xar}&amp;zip=yes"


### PR DESCRIPTION
Changing to correct name for jar file, now only in one place. Makes ant only builds happy.