### PR TITLE
[bugfix] Fixed URL rewriting for webdav in stand-alone mode.

### DIFF
--- a/tools/jetty/etc/standalone/WEB-INF/controller-config.xml
+++ b/tools/jetty/etc/standalone/WEB-INF/controller-config.xml
@@ -14,7 +14,7 @@
     <!-- XMLRPC servlet -->
 	<forward pattern="/xmlrpc" servlet="org.exist.xmlrpc.RpcServlet"/>
     <!-- WebDAV interface -->
-	<forward pattern="/webdav/" servlet="WebDAVServlet"/>
+	<forward pattern="/webdav/" servlet="milton"/>
     <!-- Atom Publishing Protocol -->
     <forward pattern="/atom/" servlet="AtomServlet"/>
     


### PR DESCRIPTION
"WebDAVServlet" seems to be deprecated since 1.4.1 and is currently disabled in
./web.xml for stand-alone jetty.