### PR TITLE
[bugfix] new range index: sequence comparisons produce incorrect …

### DIFF
--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/FieldLookup.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/FieldLookup.java
@@ -294,8 +294,16 @@ public class FieldLookup extends Function implements Optimizable {
                     String field = fieldIter.nextItem().getStringValue();
                     targetType = getType(contextSequence, field);
                 }
-                if (targetType != Type.ITEM) {
-                    keys[i -j] = keys[i - j].convertTo(targetType);
+                if (targetType != Type.ITEM && !Type.subTypeOf(keys[i -j].getItemType(), targetType)) {
+                    if (keys[i - j].hasMany()) {
+                        final Sequence temp = new ValueSequence(keys[i -j].getItemCount());
+                        for (final SequenceIterator iterator = keys[i - j].unorderedIterator(); iterator.hasNext(); ) {
+                            temp.add(iterator.nextItem().convertTo(targetType));
+                        }
+                        keys[i - j] = temp;
+                    } else {
+                        keys[i - j] = keys[i - j].convertTo(targetType);
+                    }
                 }
             }
 

--- a/extensions/indexes/range/test/src/xquery/fields.xql
+++ b/extensions/indexes/range/test/src/xquery/fields.xql
@@ -19,6 +19,10 @@ declare variable $rt:COLLECTION_CONFIG :=
                     <field name="stage" match="tei:stage" type="xs:string"/>
                     <field name="head" match="tei:head" type="xs:string"/>
                 </create>
+                <create match="//tei:sp">
+                    <field name="sp-who" match="@who" type="xs:string"/>
+                    <field name="sp-line-n" match="tei:l/@n" type="xs:int"/>
+                </create>
             </range>
         </index>
     </collection>;
@@ -173,4 +177,16 @@ declare
     %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2]")
 function rt:field-head-ends-with-optimize($head as xs:string) {
     count(collection($rt:COLLECTION)//tei:div[ends-with(tei:head, $head)])
+};
+
+declare
+    %test:assertEquals(2)
+function rt:field-multi-values-lookup() {
+    count(collection($rt:COLLECTION)//tei:sp[@who = ("mac-first-witch.", "mac-sec.-witch.")])
+};
+
+declare
+    %test:assertEquals(2)
+function rt:field-multi-values-lookup-int() {
+    count(collection($rt:COLLECTION)//tei:sp[tei:l/@n = ("1", 3)])
 };


### PR DESCRIPTION
…result as only the first item in a sequence is evaluated.

For example: //a[b = ("c", "d")] returned b="c" only, not b="d" - if a range index was defined on b. See test case.