### PR TITLE
java.net.URI picky about what is absolute

### DIFF
--- a/extensions/modules/src/org/exist/xquery/modules/xslfo/ApacheFopProcessorAdapter.java
+++ b/extensions/modules/src/org/exist/xquery/modules/xslfo/ApacheFopProcessorAdapter.java
@@ -35,7 +35,7 @@ public class ApacheFopProcessorAdapter implements ProcessorAdapter {
                 final EnvironmentProfile environment = EnvironmentalProfileFactory.createDefault(defaultBaseURI, null);
                 builder = new FopFactoryBuilder(environment).setConfiguration(cfg);
             } else {
-                builder = new FopFactoryBuilder(new URI("xmldb:exist:///db"));
+                builder = new FopFactoryBuilder(new URI("file:///db"));
             }
 
             final FopFactory fopFactory = builder.build();


### PR DESCRIPTION
Schema "xmldb:exist:" does not do it, "file:" does -- should be fine, as it seems to be dropped anyways.