### PR TITLE
Adding jcip annotations library to netbeans project too.

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -6,6 +6,7 @@ auxiliary.de-markiewb-netbeans-plugins-eclipse-formatter.preserveBreakPoints=tru
 auxiliary.de-markiewb-netbeans-plugins-eclipse-formatter.showNotifications=true
 auxiliary.de-markiewb-netbeans-plugins-eclipse-formatter.useProjectSettings=false
 file.reference.apache-mime4j-0.6.jar=extensions/expath/lib/apache-mime4j-0.6.jar
+file.reference.jcip-annotations-1.0.jar=lib/core/jcip-annotations-1.0.jar
 file.reference.cglib-nodep-3.1.jar=lib/core/cglib-nodep-3.1.jar
 file.reference.easymock-3.4.jar=lib/test/easymock-3.4.jar
 file.reference.gnu-crypto-2.0.1.jar=lib/core/gnu-crypto-2.0.1.jar
@@ -270,6 +271,7 @@ javac.classpath=\
     ${file.reference.jackson-core-2.5.0.jar}:\
     ${file.reference.gnu-crypto-2.0.1.jar}:\
     ${file.reference.cglib-nodep-3.1.jar}:\
+    ${file.reference.jcip-annotations-1.0.jar}:\
     ${file.reference.commons-compress-1.10.jar}:\
     ${file.reference.commons-discovery-0.5.jar}:\
     ${file.reference.commons-fileupload-1.3.1.jar}:\


### PR DESCRIPTION
Makes netbeans compile without errors on the annotations.