### PR TITLE
Fix recursive calls to group by and order by.

### DIFF
--- a/src/org/exist/xquery/AbstractFLWORClause.java
+++ b/src/org/exist/xquery/AbstractFLWORClause.java
@@ -20,18 +20,16 @@ public abstract class AbstractFLWORClause extends AbstractExpression implements 
 
     public LocalVariable createVariable(String name) throws XPathException {
         final LocalVariable var = new LocalVariable(QName.parse(context, name, null));
-        if (firstVar == null) {
-            firstVar = var;
-        }
+        firstVar = var;
         return var;
     }
 
     @Override
     public Sequence preEval(Sequence seq) throws XPathException {
-        // just return the input sequence by default
         if (returnExpr instanceof FLWORClause) {
             return ((FLWORClause)returnExpr).preEval(seq);
         }
+        // just return the input sequence by default
         return seq;
     }
 

--- a/src/org/exist/xquery/FunctionCall.java
+++ b/src/org/exist/xquery/FunctionCall.java
@@ -154,13 +154,6 @@ public class FunctionCall extends Function {
 			context.functionEnd();
 		}
 
-        context.functionStart(functionDef.getSignature());
-        try {
-            expression.analyze(newContextInfo);
-        } finally {
-            context.functionEnd();
-        }
-
         varDeps = new VariableReference[getArgumentCount()];
         for(int i = 0; i < getArgumentCount(); i++) {
             final Expression arg = getArgument(i);

--- a/src/org/exist/xquery/GroupByClause.java
+++ b/src/org/exist/xquery/GroupByClause.java
@@ -1,6 +1,5 @@
 package org.exist.xquery;
 
-import org.apache.xerces.impl.xpath.XPath;
 import org.exist.dom.QName;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.*;

--- a/src/org/exist/xquery/GroupByClause.java
+++ b/src/org/exist/xquery/GroupByClause.java
@@ -1,5 +1,6 @@
 package org.exist.xquery;
 
+import org.apache.xerces.impl.xpath.XPath;
 import org.exist.dom.QName;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.*;
@@ -17,9 +18,34 @@ public class GroupByClause extends AbstractFLWORClause {
 
     protected FLWORClause rootClause = null;
     private GroupSpec[] groupSpecs;
-    private Map<List<AtomicValue>, Tuple> groupedMap = null;
-    private Map<QName, LocalVariable> variables = null;
-    private List<LocalVariable> groupingVars = null;
+    private Stack<GroupByData> stack = new Stack<>();
+
+    /**
+     * Collect tuples and grouping vars. Because GroupByClause needs to keep
+     * state across calls to preEval/eval/postEval, we have to track state data
+     * in a separate object and push it to a stack, otherwise recursive calls
+     * would overwrite data.
+     */
+    private class GroupByData {
+
+        private Map<List<AtomicValue>, Tuple> groupedMap = null;
+        private Map<QName, LocalVariable> variables = null;
+        private List<LocalVariable> groupingVars = null;
+
+        private boolean initialized = false;
+
+        public GroupByData() {
+            // check if we can use a hash map
+            if (usesDefaultCollator()) {
+                groupedMap = new HashMap<>();
+            } else {
+                // non-default collation: must use tree map
+                groupedMap = new TreeMap<>(GroupByClause.this::compareKeys);
+            }
+            variables = new HashMap<>();
+            groupingVars = new ArrayList<>();
+        }
+    }
 
     public GroupByClause(XQueryContext context) {
         super(context);
@@ -31,19 +57,14 @@ public class GroupByClause extends AbstractFLWORClause {
     }
 
     @Override
+    public Sequence preEval(Sequence seq) throws XPathException {
+        stack.push(new GroupByData());
+        return super.preEval(seq);
+    }
+
+    @Override
     public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
-        final boolean init = groupedMap == null;
-        if (init) {
-            // check if we can use a hash map
-            if (usesDefaultCollator()) {
-                groupedMap = new HashMap<>();
-            } else {
-                // non-default collation: must use tree map
-                groupedMap = new TreeMap<>(this::compareKeys);
-            }
-            variables = new HashMap<>();
-            groupingVars = new ArrayList<>();
-        }
+        final GroupByData data = stack.peek();
 
         // Evaluate group spec to create grouping key sequence
         final List<Sequence> groupingValues = new ArrayList<>();
@@ -56,60 +77,62 @@ public class GroupByClause extends AbstractFLWORClause {
             }
             final AtomicValue groupingValue = groupingSeq.isEmpty() ? AtomicValue.EMPTY_VALUE : groupingSeq.itemAt(0)
                     .atomize();
-            if (init) {
+            if (!data.initialized) {
                 final LocalVariable groupingVar = new LocalVariable(spec.getKeyVarName());
                 groupingVar.setSequenceType(new SequenceType(Type.ATOMIC, groupingValue.isEmpty() ? Cardinality
                         .EMPTY : Cardinality.EXACTLY_ONE));
                 groupingVar.setStaticType(groupingValue.getType());
-                groupingVars.add(groupingVar);
+                data.groupingVars.add(groupingVar);
             }
             groupingValues.add(groupingSeq);
             groupingKeys.add(groupingValue);
         }
 
         // collect the current tuples into the grouping map
-        final Tuple tuple = groupedMap.computeIfAbsent(groupingKeys, ks -> new Tuple(groupingValues));
+        final Tuple tuple = data.groupedMap.computeIfAbsent(groupingKeys, ks -> new Tuple(groupingValues));
 
         // scan in-scope variables to collect tuples
         LocalVariable nextVar = rootClause.getStartVariable();
         Objects.requireNonNull(nextVar);
         while(nextVar != null) {
             tuple.add(nextVar.getQName(), nextVar.getValue());
-            if (init) {
+            if (!data.initialized) {
                 // on first call: initialize non-grouping variable for later use
                 final LocalVariable var = new LocalVariable(nextVar.getQName());
                 var.setSequenceType(nextVar.getSequenceType());
                 var.setStaticType(nextVar.getStaticType());
                 var.setContextDocs(nextVar.getContextDocs());
-                variables.put(var.getQName(), var);
+                data.variables.put(var.getQName(), var);
             }
             nextVar = nextVar.after;
         }
 
+        data.initialized = true;
         return contextSequence;
     }
 
     @Override
     public Sequence postEval(final Sequence seq) throws XPathException {
-        if (groupedMap != null) {
+        if (!stack.empty()) {
+            final GroupByData data = stack.peek();
             Sequence result = new ValueSequence();
             final LocalVariable mark = context.markLocalVariables(false);
             try {
                 // declare non-grouping variables
-                for (LocalVariable var: variables.values()) {
+                for (LocalVariable var : data.variables.values()) {
                     context.declareVariableBinding(var);
                 }
                 // declare grouping variables
-                for (LocalVariable var: groupingVars) {
+                for (LocalVariable var : data.groupingVars) {
                     context.declareVariableBinding(var);
                 }
                 // iterate over each group
-                for (Tuple tuple: groupedMap.values()) {
+                for (Tuple tuple : data.groupedMap.values()) {
                     context.proceed();
 
                     // set grouping variable values
                     final Iterator<Sequence> siter = tuple.groupingValues.iterator();
-                    for (LocalVariable var : groupingVars) {
+                    for (LocalVariable var : data.groupingVars) {
                         if (siter.hasNext()) {
                             Sequence val = siter.next();
                             var.setValue(val);
@@ -119,17 +142,17 @@ public class GroupByClause extends AbstractFLWORClause {
                     }
                     // set values of non-grouping variables
                     for (Map.Entry<QName, Sequence> entry : tuple.entrySet()) {
-                        final LocalVariable var = variables.get(entry.getKey());
+                        final LocalVariable var = data.variables.get(entry.getKey());
                         var.setValue(entry.getValue());
                     }
-                    result.addAll(returnExpr.eval(null));
+                    final Sequence r = returnExpr.eval(null);
+                    result.addAll(r);
                 }
             } finally {
+                stack.pop();
                 context.popLocalVariables(mark, result);
             }
-            groupedMap = null;
-            groupingVars = null;
-            variables = null;
+
             if (returnExpr instanceof FLWORClause) {
                 result = ((FLWORClause) returnExpr).postEval(result);
             }
@@ -210,9 +233,7 @@ public class GroupByClause extends AbstractFLWORClause {
     @Override
     public void resetState(boolean postOptimization) {
         super.resetState(postOptimization);
-        groupedMap = null;
-        groupingVars = null;
-        variables = null;
+        stack.clear();
         returnExpr.resetState(postOptimization);
         for (GroupSpec spec: groupSpecs) {
             spec.resetState(postOptimization);

--- a/src/org/exist/xquery/OrderByClause.java
+++ b/src/org/exist/xquery/OrderByClause.java
@@ -6,6 +6,7 @@ import org.exist.xquery.value.OrderedValueSequence;
 import org.exist.xquery.value.Sequence;
 
 import java.util.List;
+import java.util.Stack;
 
 /**
  * Represents an "order by" clause within a FLWOR expression.
@@ -13,7 +14,10 @@ import java.util.List;
 public class OrderByClause extends AbstractFLWORClause {
 
     protected OrderSpec[] orderSpecs = null;
-    protected OrderedValueSequence orderedResult = null;
+
+    /*  OrderByClause needs to keep state between calls to eval and postEval. We thus need
+        to track state in a stack to avoid overwrites if we're called recursively. */
+    Stack<OrderedValueSequence> stack = new Stack<>();
 
     public OrderByClause(XQueryContext context, List<OrderSpec> orderSpecs) {
         super(context);
@@ -45,25 +49,28 @@ public class OrderByClause extends AbstractFLWORClause {
 
     @Override
     public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
-        if (orderedResult == null) {
+        final OrderedValueSequence orderedResult;
+        if (stack.empty()) {
             orderedResult = new OrderedValueSequence(orderSpecs, 100);
+        } else {
+            orderedResult = stack.pop();
         }
         final Sequence result = getReturnExpression().eval(contextSequence, contextItem);
         if (result != null) {
             orderedResult.addAll(result);
         }
+        stack.push(orderedResult);
         return result;
     }
 
     @Override
     public Sequence postEval(Sequence seq) throws XPathException {
-        if (orderedResult == null) {
+        if (stack.empty()) {
             return seq;
         }
+        final OrderedValueSequence orderedResult = stack.pop();
         orderedResult.sort();
         Sequence result = orderedResult;
-        // reset to prepare for next iteration of outer loop
-        orderedResult = null;
 
         if (getReturnExpression() instanceof FLWORClause) {
             result = ((FLWORClause) getReturnExpression()).postEval(result);
@@ -90,6 +97,6 @@ public class OrderByClause extends AbstractFLWORClause {
     @Override
     public void resetState(boolean postOptimization) {
         super.resetState(postOptimization);
-        orderedResult = null;
+        stack.clear();
     }
 }


### PR DESCRIPTION
Both clauses need to maintain state between calls to eval() because they are collecting tuples. When used inside a recursive function, state may get overwritten (see the included tests). We thus need to keep state information in separate objects and push them to a stack between calls.

Closes issue #845