### PR TITLE
Improve %latest% in start.config

### DIFF
--- a/src/org/exist/client/NewResourceDialog.java
+++ b/src/org/exist/client/NewResourceDialog.java
@@ -267,10 +267,8 @@ public class NewResourceDialog extends JFrame {
     private void createResource(final ResourceType resourceType, final String filename, final String moduleNamespace, final String moduleNamespacePrefix) {
         
         final StringBuilder resourceContentBuilder = new StringBuilder();
-        Reader reader = null;
-        try {
-            final InputStream is = getClass().getResourceAsStream(resourceType.getTemplatePath());
-            reader = new InputStreamReader(is);
+        try(final InputStream is = getClass().getResourceAsStream(resourceType.getTemplatePath());
+                final Reader reader = new InputStreamReader(is)) {
             final char buf[] = new char[1024];
             int read = -1;
             while((read = reader.read(buf)) > -1) {
@@ -278,14 +276,6 @@ public class NewResourceDialog extends JFrame {
             }
         } catch(final IOException ioe) {
             ClientFrame.showErrorMessage(ioe.getMessage(), ioe);
-        } finally {
-            if(reader != null) {
-                try {
-                    reader.close();
-                } catch(final IOException ioe) {
-                    ClientFrame.showErrorMessage(ioe.getMessage(), ioe);
-                }
-            }
         }
         
         final String resourceContent;

--- a/src/org/exist/start/EXistClassLoader.java
+++ b/src/org/exist/start/EXistClassLoader.java
@@ -1,9 +1,9 @@
 package org.exist.start;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 
 /**
  * Root class loader when eXist is started via the bootstrap loader. Extends
@@ -13,14 +13,14 @@ import java.net.URLClassLoader;
  */
 public class EXistClassLoader extends URLClassLoader {
 
-    public EXistClassLoader(URL[] urls, ClassLoader classLoader) {
+    public EXistClassLoader(final URL[] urls, final ClassLoader classLoader) {
         super(urls, classLoader);
     }
 
-    public void addURLs(Classpath cp) {
-        for (final File file : cp) {
+    public void addURLs(final Classpath cp) {
+        for (final Path path : cp) {
             try {
-                addURL(file.toURI().toURL());
+                addURL(path.toUri().toURL());
             } catch (final MalformedURLException e) {
             }
         }

--- a/src/org/exist/start/LatestFileResolver.java
+++ b/src/org/exist/start/LatestFileResolver.java
@@ -78,13 +78,10 @@ public class LatestFileResolver {
 
         final Path containerDir = Paths.get(containerDirName);
 
-        // 0-9 . - and _ are valid chars that can occur where the %latest% token
-        // was (maybe allow letters too?).
-        final String patternString = uptoToken.substring(
-            uptoToken.lastIndexOf(File.separatorChar) + 1
-        ) + "([\\d\\.\\-_]+)" + fileinfo[1];
-        final Pattern pattern = Pattern.compile("^" + patternString + "$");
-
+        final String artifactId = Pattern.quote(uptoToken.substring(uptoToken.lastIndexOf(File.separatorChar) + 1));
+        final String suffix = Pattern.quote(fileinfo[1]);
+        final String patternString = '^' + artifactId + "(?:(?:[0-9]+(?:\\.[0-9]+)*)(?:-SNAPSHOT)?(?:-[0-9a-f]{7})?)" + suffix + '$';
+        final Pattern pattern = Pattern.compile(patternString);
         final Matcher matcher = pattern.matcher("");
 
         List<Path> jars;

--- a/src/org/exist/start/LatestFileResolver.java
+++ b/src/org/exist/start/LatestFileResolver.java
@@ -23,7 +23,11 @@
 package org.exist.start;
 
 import java.io.File;
-import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -58,7 +62,7 @@ public class LatestFileResolver {
      * @param filename Path relative to exist home dir of
      * a jar file that should be added to the classpath.
      */
-    public String getResolvedFileName(String filename) {
+    public String getResolvedFileName(final String filename) {
         final Matcher matches = latestVersionPattern.matcher(filename);
         if (!matches.find()) {
             return filename;
@@ -72,7 +76,7 @@ public class LatestFileResolver {
             0, uptoToken.lastIndexOf(File.separatorChar)
         );
 
-        final File containerDir = new File(containerDirName);
+        final Path containerDir = Paths.get(containerDirName);
 
         // 0-9 . - and _ are valid chars that can occur where the %latest% token
         // was (maybe allow letters too?).
@@ -81,18 +85,22 @@ public class LatestFileResolver {
         ) + "([\\d\\.\\-_]+)" + fileinfo[1];
         final Pattern pattern = Pattern.compile("^" + patternString + "$");
 
-        final File[] jars = containerDir.listFiles(new FilenameFilter() {
-            public boolean accept(File dir, String name) {
-                Matcher matches = pattern.matcher(name);
-                return matches.find();
-            }
-        });
-        
-        if(jars==null){
-            System.err.println("ERROR: No jars found in "+containerDir.getAbsolutePath());
-            
-        } else if (jars.length > 0) {
-            final String actualFileName = jars[0].getAbsolutePath();
+        final Matcher matcher = pattern.matcher("");
+
+        List<Path> jars;
+        try {
+             jars = Main.list(containerDir, p -> {
+                matcher.reset(Main.fileName(p));
+                return matcher.find();
+            });
+        } catch (final IOException e) {
+            System.err.println("ERROR: No jars found in " + containerDir.toAbsolutePath());
+            e.printStackTrace();
+            jars = Collections.emptyList();
+        }
+
+        if (!jars.isEmpty()) {
+            final String actualFileName = jars.get(0).toAbsolutePath().toString();
             if (_debug) {
                 System.err.println(
                     "Found match: " + actualFileName

--- a/src/org/exist/start/ServiceDaemon.java
+++ b/src/org/exist/start/ServiceDaemon.java
@@ -1,7 +1,7 @@
 package org.exist.start;
 
-import java.io.File;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 
 /**
  * An apache commons daemon class to start eXist.
@@ -46,7 +46,7 @@ public class ServiceDaemon {
         /* Dump a message */
         System.err.println("ServiceDaemon: stopping");
         try {
-           final File homeDir = existMain.detectHome();
+           final Path homeDir = existMain.detectHome();
            final String [] noArgs = {};
            final Classpath classpath = existMain.constructClasspath(homeDir,noArgs);
            final ClassLoader cl = classpath.getClassLoader(null);

--- a/src/org/exist/util/function/OptionalUtil.java
+++ b/src/org/exist/util/function/OptionalUtil.java
@@ -1,0 +1,64 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2016 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util.function;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Functional utility methods that are missing from {@link java.util.Optional}
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+public class OptionalUtil {
+
+    /**
+     * Return the left Optional if present, else thr right Optional
+     *
+     * @param left The left of the disjunction
+     * @param right The right of the disjunction
+     *
+     * @return left if present, else right
+     */
+    public static <T> Optional<T> or(final Optional<T> left, final Optional<T> right) {
+        if(left.isPresent()) {
+            return left;
+        } else {
+            return right;
+        }
+    }
+
+    /**
+     * A lazy version of {@link OptionalUtil#or(Optional, Optional)}
+     *
+     * @param left The left of the disjunction
+     * @param right A lazily evaluated supplier of Optional for the right of the disjunction,
+     *              only evaluated if the left is empty
+     *
+     * @param left if present, else the evaluation of the the right
+     */
+    public static <T> Optional<T> or(final Optional<T> left, final Supplier<Optional<T>> right) {
+        if(left.isPresent()) {
+            return left;
+        } else {
+            return right.get();
+        }
+    }
+}

--- a/tools/wrapper/src/org/exist/wrapper/Main.java
+++ b/tools/wrapper/src/org/exist/wrapper/Main.java
@@ -22,8 +22,8 @@
  */
 package org.exist.wrapper;
 
-import java.io.File;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.Observer;
 import java.util.Observable;
 
@@ -71,7 +71,7 @@ public class Main implements WrapperListener, Observer {
 			// use the bootstrap loader to autodetect EXIST_HOME and
 			// construct a correct classpath
 			org.exist.start.Main loader = new org.exist.start.Main(args[0]);
-			File homeDir = loader.detectHome();
+			Path homeDir = loader.detectHome();
 			Classpath classpath = loader.constructClasspath(homeDir, args);
 			ClassLoader cl = classpath.getClassLoader(null);
 			Thread.currentThread().setContextClassLoader(cl);


### PR DESCRIPTION
When running `client`/`jetty` from `org.exist.start.Main` eXist did not recognised the new log4j2 jar files as it's definition of `%latest%` in `org/exist/start/start.config` was too narrow.