### PR TITLE
Make sure that URLs inside a FO are correctly resolved

### DIFF
--- a/extensions/modules/src/org/exist/xquery/modules/xslfo/RenderFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/xslfo/RenderFunction.java
@@ -62,7 +62,7 @@ public class RenderFunction extends BasicFunction {
             + "Parameters are specified with the structure: "
             + "<parameters><param name=\"param-name1\" value=\"param-value1\"/>"
             + "</parameters>. "
-            + "Recognised rendering parameters are: author, title, keywords and dpi.",
+            + "Recognised rendering parameters are: author, title, keywords and dpi. URL's in the FO can be resolved from: http, https, file and exist URI schemes. If you wish to access a resource in the local database then the URI 'exist://localhost/db' refers to the root collection.",
             new SequenceType[]{
                 new FunctionParameterSequenceType("document", Type.NODE, Cardinality.EXACTLY_ONE, "FO document"),
                 new FunctionParameterSequenceType("mime-type", Type.STRING, Cardinality.EXACTLY_ONE, ""),
@@ -78,7 +78,7 @@ public class RenderFunction extends BasicFunction {
             + "Parameters are specified with the structure: "
             + "<parameters><param name=\"param-name1\" value=\"param-value1\"/>"
             + "</parameters>. "
-            + "Recognised rendering parameters are: author, title, keywords and dpi.",
+            + "Recognised rendering parameters are: author, title, keywords and dpi. URL's in the FO can be resolved from: http, https, file and exist URI schemes. If you wish to access a resource in the local database then the URI 'exist://localhost/db' refers to the root collection.",
             new SequenceType[]{
                 new FunctionParameterSequenceType("document", Type.NODE, Cardinality.EXACTLY_ONE, "FO document"),
                 new FunctionParameterSequenceType("mime-type", Type.STRING, Cardinality.EXACTLY_ONE, ""),


### PR DESCRIPTION
We now support:

* http
* https
* file
* exist

URL schemes from inside FO. You can use `exist://localhost/db` to refer to the root collection of the local database.

Note, Apache FOP does not seem to respect it's `font-base` config parameter, and so you will need to use absolute paths for each font that you wish to embed, see: http://fop-users.markmail.org/search/?q=#query:+page:1+mid:gmsajwfwr2la7qxu+state:results

Should improve on https://github.com/eXist-db/exist/pull/912 and https://github.com/eXist-db/exist/pull/914.

@hungerburg Any comments on this?