### PR TITLE
[bugfix] Fix an issue where we were leaking file handles and memory.

### DIFF
--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -3537,27 +3537,35 @@ public class XQueryContext implements BinaryValueManager, Context
     @Override
     public void registerBinaryValueInstance(final BinaryValue binaryValue) {
         if(binaryValueInstances == null) {
-             binaryValueInstances = new ArrayList<BinaryValue>();
-             
-             cleanupTasks.add(new CleanupTask() {
-                 
-                 @Override
-                 public void cleanup(final XQueryContext context) {
-                    if(context.binaryValueInstances != null) {
-                       for(final BinaryValue bv : context.binaryValueInstances) {
-                           try {
-                               bv.close();
-                           } catch (final IOException ioe) {
-                               LOG.error("Unable to close binary value: " + ioe.getMessage(), ioe);
-                           }
-                       }
-                       context.binaryValueInstances.clear();
-                   }
-                 }
-             });
+             binaryValueInstances = new ArrayList<>();
         }
-        
+
+        if(cleanupTasks.isEmpty() || !cleanupTasks.stream().filter(ct -> ct instanceof BinaryValueCleanupTask).findFirst().isPresent()) {
+            cleanupTasks.add(new BinaryValueCleanupTask());
+        }
+
         binaryValueInstances.add(binaryValue);
+    }
+
+    /**
+     * Cleanup Task which is responsible for relasing the streams
+     * of any {@link BinaryValue} which have been used during
+     * query execution
+     */
+    private static class BinaryValueCleanupTask implements CleanupTask {
+        @Override
+        public void cleanup(final XQueryContext context) {
+            if (context.binaryValueInstances != null) {
+                for (final BinaryValue bv : context.binaryValueInstances) {
+                    try {
+                        bv.close();
+                    } catch (final IOException ioe) {
+                        LOG.error("Unable to close binary value: " + ioe.getMessage(), ioe);
+                    }
+                }
+                context.binaryValueInstances.clear();
+            }
+        }
     }
 
     @Override
@@ -3655,14 +3663,14 @@ public class XQueryContext implements BinaryValueManager, Context
 
     }
     
-    private List<CleanupTask> cleanupTasks = new ArrayList<CleanupTask>();
+    private final List<CleanupTask> cleanupTasks = new ArrayList<>();
     
     public void registerCleanupTask(final CleanupTask cleanupTask) {
         cleanupTasks.add(cleanupTask);
     }
     
     public interface CleanupTask {
-        public void cleanup(final XQueryContext context);
+        void cleanup(final XQueryContext context);
     }
     
     @Override

--- a/test/src/org/exist/xquery/XQueryContextTest.java
+++ b/test/src/org/exist/xquery/XQueryContextTest.java
@@ -1,16 +1,40 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2016 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
 package org.exist.xquery;
 
 import org.exist.storage.DBBroker;
 import org.exist.security.Subject;
+import org.exist.xquery.value.BinaryValue;
 import org.junit.Test;
 import org.easymock.EasyMock;
 import org.exist.security.xacml.AccessContext;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
-import static org.easymock.EasyMock.expect;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertEquals;
+
 /**
- *
- * @author aretter
+ * @author Adam Retter <adam.retter@googlemail.com>
  */
 public class XQueryContextTest {
 
@@ -25,9 +49,9 @@ public class XQueryContextTest {
                 .addMockedMethod("getBroker")
                 .createMock();
 
-        DBBroker mockBroker = EasyMock.createMock(DBBroker.class);
+        DBBroker mockBroker = createMock(DBBroker.class);
 
-        Subject mockSubject = EasyMock.createMock(Subject.class);
+        Subject mockSubject = createMock(Subject.class);
 
         //expectations
         expect(context.getUserFromHttpSession()).andReturn(mockSubject);
@@ -40,5 +64,116 @@ public class XQueryContextTest {
         context.prepareForExecution();
 
         verify(context);
+    }
+
+    /**
+     * Test to ensure that BinaryValueInstances are
+     * correctly cleaned up by the XQueryContext
+     * between reuse of the context
+     */
+    @Test
+    public void cleanUp_BinaryValueInstances() throws NoSuchFieldException, IllegalAccessException, IOException {
+        final XQueryContext context = new XQueryContext(AccessContext.TEST);
+        final XQueryWatchDog mockWatchdog = createMock(XQueryWatchDog.class);
+        context.setWatchDog(mockWatchdog);
+
+        final BinaryValue mockBin1 = createMock(BinaryValue.class);
+        final BinaryValue mockBin2 = createMock(BinaryValue.class);
+        final BinaryValue mockBin3 = createMock(BinaryValue.class);
+        final BinaryValue mockBin4 = createMock(BinaryValue.class);
+        final BinaryValue mockBin5 = createMock(BinaryValue.class);
+        final BinaryValue mockBin6 = createMock(BinaryValue.class);
+        final BinaryValue mockBin7 = createMock(BinaryValue.class);
+
+        // expectations on our mocks
+        mockBin1.close();
+        expectLastCall().times(1);
+        mockBin2.close();
+        expectLastCall().times(1);
+        mockBin3.close();
+        expectLastCall().times(1);
+        mockBin4.close();
+        expectLastCall().times(1);
+        mockBin5.close();
+        expectLastCall().times(1);
+        mockBin6.close();
+        expectLastCall().times(1);
+        mockBin7.close();
+        expectLastCall().times(1);
+        mockWatchdog.reset();
+        expectLastCall().times(3);
+
+        // prepare our mocks for our test
+        replay(mockBin1, mockBin2, mockBin3, mockBin4, mockBin5, mockBin6, mockBin7, mockWatchdog);
+
+
+        /* round 1 */
+
+        // use some binary streams
+        context.registerBinaryValueInstance(mockBin1);
+        context.registerBinaryValueInstance(mockBin2);
+        context.registerBinaryValueInstance(mockBin3);
+        assertEquals(3, countBinaryValueInstances(context));
+        assertEquals(1, countCleanupTasks(context));
+
+        // cleanup those streams
+        context.runCleanupTasks();
+        assertEquals(0, countBinaryValueInstances(context));
+
+        //reset the context (for reuse(), just as XQueryPool#returnCompiledXQuery(org.exist.source.Source, CompiledXQuery) would do)
+        context.reset();
+        assertEquals(0, countCleanupTasks(context));
+
+
+        /* round 2, let's reuse the context... */
+
+        // use some more binary streams
+        context.registerBinaryValueInstance(mockBin4);
+        context.registerBinaryValueInstance(mockBin5);
+        assertEquals(2, countBinaryValueInstances(context));
+        assertEquals(1, countCleanupTasks(context));
+
+        // cleanup those streams
+        context.runCleanupTasks();
+        assertEquals(0, countBinaryValueInstances(context));
+
+        //reset the context (for reuse(), just as XQueryPool#returnCompiledXQuery(org.exist.source.Source, CompiledXQuery) would do)
+        context.reset();
+        assertEquals(0, countCleanupTasks(context));
+
+
+        /* round 3, let's reuse the context a second time... */
+
+        // again, use some more binary streams
+        context.registerBinaryValueInstance(mockBin6);
+        context.registerBinaryValueInstance(mockBin7);
+        assertEquals(2, countBinaryValueInstances(context));
+        assertEquals(1, countCleanupTasks(context));
+
+        // cleanup those streams
+        context.runCleanupTasks();
+        assertEquals(0, countBinaryValueInstances(context));
+
+        //reset the context (for reuse(), just as XQueryPool#returnCompiledXQuery(org.exist.source.Source, CompiledXQuery) would do)
+        context.reset();
+        assertEquals(0, countCleanupTasks(context));
+
+
+        // verify the expectations of our mocks
+        verify(mockBin1, mockBin2, mockBin3, mockBin4, mockBin5, mockBin6, mockBin7, mockWatchdog);
+    }
+
+    private int countBinaryValueInstances(final XQueryContext context) throws NoSuchFieldException, IllegalAccessException {
+        final Field fldBinaryValueInstances = context.getClass().getDeclaredField("binaryValueInstances");
+        fldBinaryValueInstances.setAccessible(true);
+        final List<BinaryValue> binaryValueInstances = (List<BinaryValue>)fldBinaryValueInstances.get(context);
+        return binaryValueInstances.size();
+    }
+
+    private int countCleanupTasks(final XQueryContext context) throws NoSuchFieldException, IllegalAccessException {
+        final Field fldCleanupTasks = context.getClass().getDeclaredField("cleanupTasks");
+        fldCleanupTasks.setAccessible(true);
+        final List<XQueryContext.CleanupTask> cleanupTasks = (List<XQueryContext.CleanupTask>)fldCleanupTasks.get(context);
+        return cleanupTasks.size();
     }
 }


### PR DESCRIPTION
BinaryValue's were not closed after an XQuery was executed more than once (i.e. if the XQueryContext was recycled).

I think this one must have been around for quite some time.