### PR TITLE
Feature/fix modification time bug

### DIFF
--- a/build/scripts/junit.xml
+++ b/build/scripts/junit.xml
@@ -167,7 +167,8 @@
             <test fork="yes" name="org.exist.security.XMLDBSecurityTest" todir="${junit.reports.dat}"/>
             <test fork="yes" name="org.exist.security.SecurityManagerRoundtripTest" todir="${junit.reports.dat}"/>
             <test fork="yes" name="org.exist.storage.NativeBrokerTest" todir="${junit.reports.dat}"/>
-
+            <test fork="yes" name="org.exist.storage.ModificationTimeTest" todir="${junit.reports.dat}"/>
+            
             <!-- Execute all other tests except those that have to be called manually.   -->
             <batchtest fork="yes" todir="${junit.reports.dat}">
                 <fileset dir="${junit.reports}/src">

--- a/src/org/exist/collections/Collection.java
+++ b/src/org/exist/collections/Collection.java
@@ -1779,8 +1779,7 @@ public class Collection extends Observable implements Comparable<Collection>, Ca
      */
     
     private void updateModificationTime(final DocumentImpl document) {
-        DocumentMetadata metadata = new DocumentMetadata();
-        metadata = document.getMetadata();
+        final DocumentMetadata metadata = document.getMetadata();
         metadata.setLastModified(System.currentTimeMillis());
         document.setMetadata(metadata);
     }

--- a/src/org/exist/collections/Collection.java
+++ b/src/org/exist/collections/Collection.java
@@ -1643,6 +1643,7 @@ public class Collection extends Observable implements Comparable<Collection>, Ca
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("removing old document " + oldDoc.getFileURI());
                 }
+                updateModificationTime(document);
                 oldDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
                 oldDocLocked = true;
                 if (oldDoc.getResourceType() == DocumentImpl.BINARY_FILE) {
@@ -1748,7 +1749,6 @@ public class Collection extends Observable implements Comparable<Collection>, Ca
         if (oldDoc != null) {
             metadata = oldDoc.getMetadata();
             metadata.setCreated(oldDoc.getMetadata().getCreated());
-            metadata.setLastModified(System.currentTimeMillis());
             document.setPermissions(oldDoc.getPermissions());
         } else {
         	//Account user = broker.getCurrentSubject();
@@ -1774,6 +1774,17 @@ public class Collection extends Observable implements Comparable<Collection>, Ca
         document.setMetadata(metadata);
     }
 
+     /** Update the modification time of a document
+     * @param document
+     */
+    
+    private void updateModificationTime(final DocumentImpl document) {
+        DocumentMetadata metadata = new DocumentMetadata();
+        metadata = document.getMetadata();
+        metadata.setLastModified(System.currentTimeMillis());
+        document.setMetadata(metadata);
+    }
+    
     /**
      * Check Permissions about user and document when a document is added to the databse, and throw exceptions if necessary.
      *
@@ -1907,6 +1918,7 @@ public class Collection extends Observable implements Comparable<Collection>, Ca
 
             if (oldDoc != null) {
                 LOG.debug("removing old document " + oldDoc.getFileURI());
+                updateModificationTime(blob);
                 if (oldDoc instanceof BinaryDocument) {
                     broker.removeBinaryResource(transaction, (BinaryDocument) oldDoc);
                 } else {

--- a/test/src/org/exist/TestUtils.java
+++ b/test/src/org/exist/TestUtils.java
@@ -19,6 +19,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.stream.Stream;
+import org.exist.util.ConfigurationHelper;
 
 /**
  * Created by IntelliJ IDEA.
@@ -136,4 +138,16 @@ public class TestUtils {
         Files.move(dataDirPath, lastTestRunDataDir, StandardCopyOption.ATOMIC_MOVE);
 		Files.move(backupDataDirPath, dataDirPath, StandardCopyOption.ATOMIC_MOVE);
 	}
+        
+        
+        public static void cleanupDataDir() throws IOException, DatabaseConfigurationException {
+            Configuration conf = new Configuration();
+            final Path data = (Path) conf.getProperty(BrokerPool.PROPERTY_DATA_DIR);
+
+            try(final Stream<Path> dataFiles  = Files.list(data)) {
+                dataFiles
+                        .filter(path -> !(FileUtils.fileName(path).equals("RECOVERY") || FileUtils.fileName(path).equals("README") || FileUtils.fileName(path).equals(".DO_NOT_DELETE")))
+                        .forEach(FileUtils::deleteQuietly);
+            }
+        }
 }

--- a/test/src/org/exist/storage/AllStorageTests.java
+++ b/test/src/org/exist/storage/AllStorageTests.java
@@ -47,7 +47,8 @@ import org.junit.runners.Suite;
         ResourceTest.class,
         RangeIndexUpdateTest.class,
         LargeValuesTest.class,
-        StoreBinaryTest.class
+        StoreBinaryTest.class,
+        ModificationTimeTest.class
 })
 public class AllStorageTests {
 }

--- a/test/src/org/exist/storage/ModificationTimeTest.java
+++ b/test/src/org/exist/storage/ModificationTimeTest.java
@@ -1,0 +1,209 @@
+package org.exist.storage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.util.LockException;
+import org.junit.BeforeClass;
+import org.exist.dom.persistent.BinaryDocument;
+import org.exist.EXistException;
+import org.exist.xmldb.XmldbURI;
+import org.exist.test.TestConstants;
+import org.exist.collections.Collection;
+import org.exist.Database;
+import org.exist.collections.IndexInfo;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.start.Main;
+import org.exist.storage.txn.TransactionManager;
+import org.exist.storage.txn.Txn;
+import org.exist.util.Configuration;
+import org.exist.util.FileUtils;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.exist.util.ConfigurationHelper;
+import org.exist.util.DatabaseConfigurationException;
+import org.junit.After;
+import org.xml.sax.SAXException;
+
+
+public class ModificationTimeTest {
+
+    protected static String XML_FILENAME = "test.xml";
+    protected static String VALID_XML = "<?xml version=\"1.0\"?>" +
+                                        "<valid/>";
+    protected static String INVALID_XML = "<?xml version=\"1.0\"?>"
+            + "<invalid>";
+
+    
+    @BeforeClass
+    public static void ensureCleanDatabase() throws IOException {
+        final Optional<Path> home = ConfigurationHelper.getExistHome();
+        final Path data = FileUtils.resolve(home, "webapp/WEB-INF/data");
+
+        try(final Stream<Path> dataFiles  = Files.list(data)) {
+            dataFiles
+                    .filter(path -> !(FileUtils.fileName(path).equals("RECOVERY") || FileUtils.fileName(path).equals("README") || FileUtils.fileName(path).equals(".DO_NOT_DELETE")))
+                    .forEach(FileUtils::deleteQuietly);
+        }
+    }
+
+     /**
+     * Store a binary document, wait for a while and then overwrite it 
+     * with another binary document. The document's modification time should
+     * have been updated afterwards.
+     */
+    @Test
+    public void check_if_modification_time_is_updated_binary() throws EXistException, InterruptedException, PermissionDeniedException, LockException, IOException, TriggerException, DatabaseConfigurationException {
+        
+        final String mimeType = "application/octet-stream";
+        final String filename = "data.dat";
+        final String data = "some data";
+
+            BinaryDocument binaryDoc = storeBinary(filename, data, mimeType);
+            assertNotNull(binaryDoc);
+
+            long modificationTimeBefore = binaryDoc.getMetadata().getLastModified();
+            
+            Thread.sleep(500);
+            
+            binaryDoc = storeBinary(filename, data, mimeType);
+            assertNotNull(binaryDoc);
+
+            long modificationTimeAfter = binaryDoc.getMetadata().getLastModified();
+            //check the mimetype has been preserved across database restarts
+            assertNotEquals(modificationTimeBefore, modificationTimeAfter);
+    }
+    
+     /**
+     * Store a valid XML resource, wait for a while and then overwrite it 
+     * with another valid XML resource. The resource's modification time should
+     * have been updated afterwards.
+     */
+    @Test
+    public void check_if_modification_time_is_updated_xml() throws EXistException, InterruptedException, PermissionDeniedException, LockException, IOException, TriggerException, SAXException, DatabaseConfigurationException {
+            
+            IndexInfo info = storeXML(XML_FILENAME, VALID_XML);
+            assertNotNull(info);
+            DocumentImpl doc = info.getDocument();
+            
+            long modificationTimeBefore = doc.getMetadata().getLastModified();
+            Thread.sleep(500);
+            
+            info = storeXML(XML_FILENAME, VALID_XML);
+            assertNotNull(info);
+            doc = info.getDocument();
+            
+            long modificationTimeAfter = doc.getMetadata().getLastModified();
+            
+            assertNotEquals(modificationTimeBefore, modificationTimeAfter);
+    }
+    
+     /**
+     * Store a valid XML resource, wait for a while and then try to overwrite
+     * it with an invalid XML resource. The invalid XML should be rejected and 
+     * the resource's modification time should be the same afterwards.
+     */
+    @Test
+    public void check_if_modification_time_is_not_updated_on_parse_error() throws EXistException, InterruptedException, PermissionDeniedException, LockException, IOException, TriggerException, SAXException, DatabaseConfigurationException {
+        
+            
+            IndexInfo info = storeXML(XML_FILENAME, VALID_XML);
+            assertNotNull(info);
+            DocumentImpl doc = info.getDocument();
+            final XmldbURI docUri = doc.getFileURI();
+            
+            long modificationTimeBefore = doc.getMetadata().getLastModified();
+            
+            Thread.sleep(500);
+            
+            boolean threw = false;
+            info = null;
+            try {
+                info = storeXML(XML_FILENAME, INVALID_XML);
+            } catch (SAXException e) {
+                threw = true;
+            }
+            assertTrue(threw);
+            assertNull(info);
+            
+            doc = getDocument(docUri);
+            assertNotNull(doc);
+            
+            long modificationTimeAfter = doc.getMetadata().getLastModified();
+            assertEquals(modificationTimeBefore, modificationTimeAfter);
+    }
+
+   protected BrokerPool startDB() throws DatabaseConfigurationException, EXistException {
+        final Configuration config = new Configuration();
+        BrokerPool.configure(1, 5, config);
+        return BrokerPool.getInstance();
+    }
+
+    @After
+    public void tearDown() {
+        BrokerPool.stopAll(false);
+    }
+
+    private DocumentImpl getDocument(final XmldbURI uri) throws EXistException, PermissionDeniedException, DatabaseConfigurationException {
+        DocumentImpl doc = null;
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
+
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
+            assertNotNull(broker);
+
+            final Collection root = broker.getCollection(TestConstants.TEST_COLLECTION_URI);
+            assertNotNull(root);
+
+            doc = root.getDocument(broker, uri);
+
+        }
+
+        return doc;
+    }
+
+    private BinaryDocument storeBinary(String name,  String data, String mimeType) throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException, DatabaseConfigurationException {
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
+
+        BinaryDocument binaryDoc = null;
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                final Txn transaction = transact.beginTransaction()) {
+
+            final Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
+    		broker.saveCollection(transaction, root);
+            assertNotNull(root);
+
+            binaryDoc = root.addBinaryResource(transaction, broker, XmldbURI.create(name), data.getBytes(), mimeType);
+
+            transact.commit(transaction);
+        }
+
+        return binaryDoc;
+    }
+    
+    private IndexInfo storeXML(String name, String xml) throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException, SAXException, DatabaseConfigurationException {
+        final BrokerPool pool = startDB();
+        final TransactionManager transact = pool.getTransactionManager();
+
+        IndexInfo info = null;
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                final Txn transaction = transact.beginTransaction()) {
+
+            final Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
+    		broker.saveCollection(transaction, root);
+            assertNotNull(root);
+
+            info = root.validateXMLResource(transaction, broker, XmldbURI.create(name), xml);
+                    
+            transact.commit(transaction);
+        }
+
+        return info;
+    }
+}

--- a/test/src/org/exist/storage/ModificationTimeTest.java
+++ b/test/src/org/exist/storage/ModificationTimeTest.java
@@ -16,6 +16,7 @@ import org.exist.xmldb.XmldbURI;
 import org.exist.test.TestConstants;
 import org.exist.collections.Collection;
 import org.exist.Database;
+import static org.exist.TestUtils.cleanupDataDir;
 import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.start.Main;
@@ -41,15 +42,8 @@ public class ModificationTimeTest {
 
     
     @BeforeClass
-    public static void ensureCleanDatabase() throws IOException {
-        final Optional<Path> home = ConfigurationHelper.getExistHome();
-        final Path data = FileUtils.resolve(home, "webapp/WEB-INF/data");
-
-        try(final Stream<Path> dataFiles  = Files.list(data)) {
-            dataFiles
-                    .filter(path -> !(FileUtils.fileName(path).equals("RECOVERY") || FileUtils.fileName(path).equals("README") || FileUtils.fileName(path).equals(".DO_NOT_DELETE")))
-                    .forEach(FileUtils::deleteQuietly);
-        }
+    public static void setup() throws IOException, DatabaseConfigurationException, EXistException {
+        cleanupDataDir();
     }
 
      /**

--- a/test/src/org/exist/storage/StoreBinaryTest.java
+++ b/test/src/org/exist/storage/StoreBinaryTest.java
@@ -16,6 +16,7 @@ import org.exist.xmldb.XmldbURI;
 import org.exist.test.TestConstants;
 import org.exist.collections.Collection;
 import org.exist.Database;
+import static org.exist.TestUtils.cleanupDataDir;
 import org.exist.start.Main;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -23,6 +24,7 @@ import org.exist.util.FileUtils;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.exist.util.ConfigurationHelper;
+import org.exist.util.DatabaseConfigurationException;
 
 /**
  *
@@ -31,15 +33,8 @@ import org.exist.util.ConfigurationHelper;
 public class StoreBinaryTest {
 
     @BeforeClass
-    public static void ensureCleanDatabase() throws IOException {
-        final Optional<Path> home = ConfigurationHelper.getExistHome();
-        final Path data = FileUtils.resolve(home, "webapp/WEB-INF/data");
-
-        try(final Stream<Path> dataFiles  = Files.list(data)) {
-            dataFiles
-                    .filter(path -> !(FileUtils.fileName(path).equals("RECOVERY") || FileUtils.fileName(path).equals("README") || FileUtils.fileName(path).equals(".DO_NOT_DELETE")))
-                    .forEach(FileUtils::deleteQuietly);
-        }
+    public static void setup() throws IOException, DatabaseConfigurationException {
+        cleanupDataDir();
     }
 
     @Test


### PR DESCRIPTION
When trying to overwrite an XML resource with an invalid XML resource, the modification time of the resource would still be updated even if the resource has not been changed. This is due to the method `manageDocumentInformation` in `validatateXMLResource` being called before the document is validated (in Collection.java). 

I have moved the modification time update out of `manageDocumentInformation` into a separate method which will only be called after the document is validated. There's also a test that will fail without the changes in Collection.java and verifies that modification times will still be updated as expected for valid resources.

This fixes the underlying issue for bug  #811.