### PR TITLE
[bugfix] Combination of two descendant axis lookups in an XPath

### DIFF
--- a/src/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/src/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -477,8 +477,30 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
     }
 
     public void updateNoSort() {
-        updateDocs();
-        isSorted = true;
+        if (needsSort()) {
+            sort(false);
+        } else {
+            updateDocs();
+            isSorted = true;
+        }
+    }
+
+
+    /**
+     * Check if this node set is sorted in document order
+     *
+     * @return true if sorted
+     */
+    private boolean needsSort() {
+        if (hasOne) {
+            return false;
+        }
+        for(int i = 1; i < size; i++) {
+            if (nodes[i].compareTo(nodes[i - 1]) < 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void updateDocs() {

--- a/test/src/xquery/axes.xql
+++ b/test/src/xquery/axes.xql
@@ -1,0 +1,74 @@
+xquery version "3.0";
+
+module namespace axes="http://exist-db.org/xquery/test/axes";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $axes:NESTED_DIVS :=
+    <body>
+        <div>
+            <head>1</head>
+            <div>
+                <head>2</head>
+                <div>
+                    <head>3</head>
+                </div>
+            </div>
+            <div>
+                <head>4</head>
+                <div>
+                    <head>5</head>
+                </div>
+                <div>
+                    <head>6</head>
+                    <div>
+                        <head>7</head>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>;
+
+declare 
+    %test:setUp
+function axes:setup() {
+    xmldb:create-collection("/db", "axes-test"),
+    xmldb:store("/db/axes-test", "test.xml", $axes:NESTED_DIVS)
+};
+
+declare 
+    %test:tearDown
+function axes:cleanup() {
+    xmldb:remove("/db/axes-test")
+};
+
+(: ---------------------------------------------------------------
+ : Descendant axis: check if nested elements are handled properly.
+ : Wrong evaluation may lead to duplicate nodes being returned.
+   --------------------------------------------------------------- :)
+
+declare 
+    %test:assertEquals(6, 6)
+function axes:descendant-axis-nested() {
+    let $node := doc("/db/axes-test/test.xml")/body
+    return (
+        count($node/descendant::div/descendant::div),
+        count($node//div//div)
+    )
+};
+
+declare 
+    %test:assertEquals("<head>1</head>")
+function axes:descendant-axis-except-nested1() {
+    let $node := doc("/db/axes-test/test.xml")/body
+    return
+        ($node//div except $node//div//div)/head
+};
+
+declare 
+    %test:assertEquals("<head>2</head>", "<head>4</head>")
+function axes:descendant-axis-except-nested2() {
+    let $node := doc("/db/axes-test/test.xml")/body/div
+    return
+        ($node//div except $node//div//div)/head
+};

--- a/test/src/xquery/suite.xql
+++ b/test/src/xquery/suite.xql
@@ -3,6 +3,7 @@ xquery version "3.0";
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
 
 test:suite((
+    inspect:module-functions(xs:anyURI("axes.xql")),
     inspect:module-functions(xs:anyURI("last.xql")),
     inspect:module-functions(xs:anyURI("namespaces.xql")),
     inspect:module-functions(xs:anyURI("positional.xql")),


### PR DESCRIPTION
returned duplicate nodes in rare cases (if applied to deeply nested elements of same name). Fix by making sure the node set is correctly sorted in document order. 

For performance reasons, node sets returned by a structural index lookup are not sorted automatically, because we can normally assume the nodes are already in document order. However, this needs to be tested for edge cases like the one shown in the test.

Closes https://github.com/eXistSolutions/hsg-shell/issues/133