### PR TITLE
Utilities for trace logging the history of broker leases and broker subject changes

### DIFF
--- a/src/org/exist/util/Stacktrace.java
+++ b/src/org/exist/util/Stacktrace.java
@@ -19,16 +19,20 @@
  */
 package org.exist.util;
 
+import java.util.Arrays;
+
 /**
- * Utility methods for dealing with stacktraces
+ * Utility methods for dealing with stack traces
  *
  * @author Adam Retter <adam.retter@googlemail.com>
  */
 public class Stacktrace {
 
+    public final static int DEFAULT_STACK_TOP = 10;
+
     /**
-     * Gets the top N frames from the stack returns
-     * them as a string
+     * Gets the top N frames from the stack trace and
+     * returns them as a string
      *
      * Excludes the callee and self stack frames
      *
@@ -38,15 +42,48 @@ public class Stacktrace {
      * @return String representation of the top frames of the stack
      */
     public static String top(final StackTraceElement[] stack, final int top) {
-        final StringBuilder builder = new StringBuilder();
-        final int start = 2;
+        final int from = 2;
+        final int until = stack.length - from < top ? stack.length - from : top + from;
+        return asString(stack, from, until);
+    }
 
-        for(int i = start; i < start + top && i < stack.length; i++) {
+    /**
+     * Formats the stack trace as a String
+     *
+     * @return A formatted string showing the stack trace
+     */
+    public static String asString(final StackTraceElement[] stack) {
+        return asString(stack, 0, stack.length);
+    }
+
+    /**
+     * Formats the stack trace as a String
+     *
+     * @param from The most recent frame to start from
+     * @param until The least recent frame to format until
+     * @return A formatted string showing the stack trace
+     */
+    public static String asString(final StackTraceElement[] stack, final int from, final int until) {
+        final StringBuilder builder = new StringBuilder();
+        for(int i = from; i < until; i++) {
             builder
                     .append(" <- ")
                     .append(stack[i]);
         }
-
         return builder.toString();
+    }
+
+    /**
+     * Get a subset of the StackTraceElements
+     *
+     * @param stack The stack trace
+     * @param from Starting from HEAD
+     * @param max The maximum number of elements to take
+     *
+     * @return The stack trace elements between from and from+max (or less)
+     */
+    public static StackTraceElement[] substack(final StackTraceElement[] stack, final int from, final int max) {
+        final int to = stack.length - from  < max ? stack.length - from : from + max;
+        return Arrays.copyOfRange(stack, from, to);
     }
 }

--- a/src/org/exist/util/TraceableStateChange.java
+++ b/src/org/exist/util/TraceableStateChange.java
@@ -1,0 +1,64 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2016 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.util;
+
+/**
+ * Represents a traceable change of state
+ *
+ * @param <S> Information about the state which was modified
+ * @param <C> the change which was applied to the state
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+public abstract class TraceableStateChange<S, C> {
+    private final C change;
+    private final StackTraceElement trace[];
+    private final S state;
+    private final Thread thread;
+
+    public TraceableStateChange(final C change, final S subject) {
+        this.change = change;
+        this.trace = Stacktrace.substack(Thread.currentThread().getStackTrace(), 2, Stacktrace.DEFAULT_STACK_TOP);
+        this.state = subject;
+        this.thread = Thread.currentThread();
+    }
+
+    public abstract String getId();
+
+    public C getChange() {
+        return change;
+    }
+
+    public S getState() {
+        return state;
+    }
+
+    public String describeState() {
+        return state.toString();
+    }
+
+    public StackTraceElement[] getTrace() {
+        return trace;
+    }
+
+    public Thread getThread() {
+        return thread;
+    }
+}

--- a/src/org/exist/util/TraceableStateChanges.java
+++ b/src/org/exist/util/TraceableStateChanges.java
@@ -1,0 +1,81 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2016 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.util;
+
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a traceable history of state changes
+ *
+ * @param <S> Information about the state which was modified
+ * @param <C> the change which was applied to the state
+ *
+ * @author Adam Retter <adam.retter@googlemail.com>
+ */
+public class TraceableStateChanges<S, C> {
+    private List<TraceableStateChange<S, C>> stateChangeTrace = new ArrayList<>();
+
+    /**
+     * Add a state change to the tail
+     */
+    public void add(final TraceableStateChange<S, C> stateChange) {
+        stateChangeTrace.add(stateChange);
+    }
+
+    /**
+     * Clear all state changes
+     */
+    public void clear() {
+        stateChangeTrace.clear();
+    }
+
+    /**
+     * Makes a copy of the list of state changes
+     * useful for archival purposes
+     *
+     * @return A copy of the state changes
+     */
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        final TraceableStateChanges<S, C> copy = new TraceableStateChanges<>();
+        copy.stateChangeTrace = new ArrayList<>(stateChangeTrace);
+        return copy;
+    }
+
+    /**
+     * Writes the history fo state changes to the
+     * provided logger at TRACE level
+     *
+     * @param logger The logger to write the changes to
+     */
+    public final void logTrace(final Logger logger) {
+        if (!logger.isTraceEnabled()) {
+            throw new IllegalStateException("This is only enabled at TRACE level logging");
+        }
+
+        for (int i = 0; i < stateChangeTrace.size(); i++) {
+            final TraceableStateChange<S, C> traceableStateChange = stateChangeTrace.get(i);
+            logger.trace(String.format("%d: %s: %s(%s) from: %s(%s)", i + 1, traceableStateChange.getId(), traceableStateChange.getChange(), traceableStateChange.describeState(), traceableStateChange.getThread(), Stacktrace.asString(traceableStateChange.getTrace())));
+        }
+    }
+}

--- a/src/org/exist/util/function/Either.java
+++ b/src/org/exist/util/function/Either.java
@@ -55,6 +55,45 @@ public abstract class Either<L, R> {
     }
 
     /**
+     * Map on the right-hand-side of the disjunction
+     *
+     * @param f The function to map with
+     */
+    public final <T> Either<L, T> map(final Function<R, T> f) {
+        if(isLeft()) {
+            return (Left<L, T>)this;
+        } else {
+            return Right(f.apply(((Right<L, R>)this).value));
+        }
+    }
+
+    /**
+     * Bind through on the right-hand-side of this disjunction
+     *
+     * @param f the function to bind through
+     */
+    public final <LL extends L, T> Either<LL, T> flatMap(final Function<R, Either<LL, T>> f) {
+        if(isLeft) {
+            return (Left<LL, T>)this;
+        } else {
+            return f.apply(((Right<L, R>)this).value);
+        }
+    }
+
+    /**
+     * Map on the left-hand-side of the disjunction
+     *
+     * @param f The function to map with
+     */
+    public final <T> Either<T, R> leftMap(final Function<L, T> f) {
+        if(isLeft) {
+            return Left(f.apply(((Left<L, R>)this).value));
+        } else {
+            return (Right<T, R>)this;
+        }
+    }
+
+    /**
      * Catamorphism. Run the first given function if left,
      * otherwise the second given function
      *


### PR DESCRIPTION
Note - These utilities are only ever enabled when the logging level is set to TRACE