### PR TITLE
Structure index: change lock to MultiReadReentrantLock

### DIFF
--- a/src/org/exist/storage/index/BTreeStore.java
+++ b/src/org/exist/storage/index/BTreeStore.java
@@ -5,7 +5,7 @@ import org.exist.storage.DefaultCacheManager;
 import org.exist.storage.btree.BTree;
 import org.exist.storage.btree.DBException;
 import org.exist.storage.lock.Lock;
-import org.exist.storage.lock.ReentrantReadWriteLock;
+import org.exist.storage.lock.MultiReadReentrantLock;
 import org.exist.util.FileUtils;
 
 import java.nio.file.Path;
@@ -18,7 +18,7 @@ public class BTreeStore extends BTree {
 
     public BTreeStore(BrokerPool pool, byte fileId, boolean transactional, final Path file, DefaultCacheManager cacheManager) throws DBException {
         super(pool, fileId, transactional, cacheManager, file);
-        lock = new ReentrantReadWriteLock(FileUtils.fileName(file));
+        lock = new MultiReadReentrantLock(FileUtils.fileName(file));
 
         if(exists()) {
             open(FILE_FORMAT_VERSION_ID);


### PR DESCRIPTION
BTreeStore used by structure index, but I find no reasons why not switch BTreeStore in general to MultiReadReentrantLock