### PR TITLE
Remove asm.jar from download

### DIFF
--- a/extensions/contentextraction/ivy.xml
+++ b/extensions/contentextraction/ivy.xml
@@ -1,55 +1,47 @@
-<!-- Ivy module to retrieve the tika jar, including dependancies, excluding duplicate jars $Id$ -->
+<!-- 
+ Ivy module to retrieve the tika jars, including dependencies, 
+ excluding jars that are provided by eXist-db already
+-->
 <ivy-module version="2.0">
-	<info organisation="org.exist" module="tika" />
-	<dependencies>
-		<dependency org="org.apache.tika" name="tika-parsers" rev="1.12" conf="*->*,!sources,!javadoc">
-            <!-- 
-            <exclude module="poi" />
-            <exclude module="poi-scratchpad" />
-            <exclude module="poi-ooxml" />    
-             -->		
-		</dependency>
-        
-        <!-- 
-        <dependency org="org.apache.poi" name="poi" rev="3.10-FINAL" conf="*->*,!sources,!javadoc"/>
-        <dependency org="org.apache.poi" name="poi-scratchpad" rev="3.10-FINAL" conf="*->*,!sources,!javadoc" />
-        <dependency org="org.apache.poi" name="poi-ooxml" rev="3.10-FINAL" conf="*->*,!sources,!javadoc"/>
-        <dependency org="org.tukaani" name="xz" rev="1.5" conf="*->*,!sources,!javadoc" /> 
-        -->
-        
-        <!-- identified as provided by eXist-db -->
-		<exclude module="asm-all" />
-		<exclude module="asm-debug-all" />
-		<exclude module="aspectjrt" />
-		<exclude module="commons-codec" />
-		<exclude module="commons-compress" />
-		<exclude module="commons-httpclient" />
-		<exclude module="commons-io" />
-		<exclude module="commons-logging" />
-		<exclude module="geronimo-stax-api_1.0_spec" />
-		<exclude module="jdom" />
-		<exclude module="log4j" />
-		<exclude module="servlet-api" />
-		<exclude module="slf4j-api" />
-		<exclude module="stax" />
-		<exclude module="stax-api" />
-		<exclude module="xercesImpl" />
-		<exclude module="xml-apis" />
-        <exclude module="commons-logging-api" />
-        <exclude module="ehcache-core" />
-        <exclude module="quartz" />
-        <exclude org="org.apache.httpcomponents" />
-        <exclude org="org.apache.lucene" />
+ 
+ <info organisation="org.exist" module="tika"/>
+ 
+ <dependencies>
+  
+  <dependency org="org.apache.tika" name="tika-parsers" rev="1.12" conf="*->*,!sources,!javadoc"/>
 
-        <!-- identified as not needed for pure parsing -->
-        <exclude module="junit" />
-        <exclude module="sqlite-jdbc" />      
-        <exclude org="javax.annotation" />
-        <exclude org="javax.ws.rs" />
-        <exclude org="org.apache.cxf" />
-        <exclude org="org.apache.felix" />
-        <exclude org="org.apache.maven.scm" />      
-        <exclude org="org.osgi" /> 
+  <!-- identified as provided by eXist-db -->
+  <exclude module="asm"/>
+  <exclude module="aspectjrt"/>
+  <exclude module="commons-codec"/>
+  <exclude module="commons-compress"/>
+  <exclude module="commons-httpclient"/>
+  <exclude module="commons-io"/>
+  <exclude module="commons-logging"/>
+  <exclude module="geronimo-stax-api_1.0_spec"/>
+  <exclude module="jdom"/>
+  <exclude module="log4j"/>
+  <exclude module="servlet-api"/>
+  <exclude module="slf4j-api"/>
+  <exclude module="stax"/>
+  <exclude module="stax-api"/>
+  <exclude module="xercesImpl"/>
+  <exclude module="xml-apis"/>
+  <exclude module="commons-logging-api"/>
+  <exclude module="ehcache-core"/>
+  <exclude module="quartz"/>
+  <exclude org="org.apache.httpcomponents"/>
+  <exclude org="org.apache.lucene"/>
 
-	</dependencies>
+  <!-- identified as not needed for pure parsing -->
+  <exclude module="junit"/>
+  <exclude module="sqlite-jdbc"/>
+  <exclude org="javax.annotation"/>
+  <exclude org="javax.ws.rs"/>
+  <exclude org="org.apache.cxf"/>
+  <exclude org="org.apache.felix"/>
+  <exclude org="org.apache.maven.scm"/>
+  <exclude org="org.osgi"/>
+
+ </dependencies>
 </ivy-module>


### PR DESCRIPTION
Accidentally asm.jar appeared again ; this jar file conflicts with jetty8 and should thus not be downloaded; as a bonus the file has been reformatted