### PR TITLE
Fixes to query optimizer and range index not being used

### DIFF
--- a/src/org/exist/xquery/BasicExpressionVisitor.java
+++ b/src/org/exist/xquery/BasicExpressionVisitor.java
@@ -230,6 +230,11 @@ public class BasicExpressionVisitor implements ExpressionVisitor {
         //Nothing to do
     }
 
+    @Override
+    public void visitSimpleMapOperator(OpSimpleMap simpleMap) {
+        // Nothing to do
+    }
+
     public static class FirstStepVisitor extends BasicExpressionVisitor {
 
         private LocationStep firstStep = null;

--- a/src/org/exist/xquery/DefaultExpressionVisitor.java
+++ b/src/org/exist/xquery/DefaultExpressionVisitor.java
@@ -162,4 +162,10 @@ public class DefaultExpressionVisitor extends BasicExpressionVisitor {
             clause.getCatchExpr().accept(this);
         }
     }
+
+    @Override
+    public void visitSimpleMapOperator(OpSimpleMap simpleMap) {
+        simpleMap.getLeft().accept(this);
+        simpleMap.getRight().accept(this);
+    }
 }

--- a/src/org/exist/xquery/ExpressionVisitor.java
+++ b/src/org/exist/xquery/ExpressionVisitor.java
@@ -91,4 +91,6 @@ public interface ExpressionVisitor {
     void visitVariableReference(VariableReference ref);
 
     void visitVariableDeclaration(VariableDeclaration decl);
+
+    void visitSimpleMapOperator(OpSimpleMap simpleMap);
 }

--- a/src/org/exist/xquery/FunctionCall.java
+++ b/src/org/exist/xquery/FunctionCall.java
@@ -363,6 +363,7 @@ public class FunctionCall extends Function {
     @Override
     public void resetState(boolean postOptimization) {
         super.resetState(postOptimization);
+        setRecursive(false);
         if(expression.needsReset() || postOptimization) {
             expression.resetState(postOptimization);
         }

--- a/src/org/exist/xquery/OpSimpleMap.java
+++ b/src/org/exist/xquery/OpSimpleMap.java
@@ -22,9 +22,8 @@ public class OpSimpleMap extends AbstractExpression {
 
     @Override
     public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
-        final AnalyzeContextInfo contextCopy = new AnalyzeContextInfo(contextInfo);
-        left.analyze(contextCopy);
-        right.analyze(contextCopy);
+        left.analyze(new AnalyzeContextInfo(contextInfo));
+        right.analyze(new AnalyzeContextInfo(contextInfo));
     }
 
     @Override
@@ -60,5 +59,25 @@ public class OpSimpleMap extends AbstractExpression {
         left.dump(dumper);
         dumper.display(" ! ");
         right.dump(dumper);
+    }
+
+    public Expression getLeft() {
+        return left;
+    }
+
+    public PathExpr getRight() {
+        return right;
+    }
+
+    @Override
+    public void accept(ExpressionVisitor visitor) {
+        visitor.visitSimpleMapOperator(this);
+    }
+
+    @Override
+    public void resetState(boolean postOptimization) {
+        super.resetState(postOptimization);
+        left.resetState(postOptimization);
+        right.resetState(postOptimization);
     }
 }

--- a/src/org/exist/xquery/functions/fn/FunHeadTail.java
+++ b/src/org/exist/xquery/functions/fn/FunHeadTail.java
@@ -61,15 +61,6 @@ public class FunHeadTail extends BasicFunction {
 		} else if (isCalledAs("head")) {
 			tmp = seq.itemAt(0).toSequence();
 		} else {
-            if (seq instanceof NodeSet) {
-                tmp = new ExtArrayNodeSet();
-                ((ExtArrayNodeSet)tmp).keepUnOrdered(unordered);
-            } else {
-                tmp = new ValueSequence();
-                ((ValueSequence)tmp).keepUnOrdered(unordered);
-            }
-            
-            
             tmp = seq.tail();
 		}
 		return tmp;

--- a/src/org/exist/xquery/value/AbstractSequence.java
+++ b/src/org/exist/xquery/value/AbstractSequence.java
@@ -21,10 +21,7 @@
 package org.exist.xquery.value;
 
 import org.exist.collections.Collection;
-import org.exist.dom.persistent.DocumentSet;
-import org.exist.dom.persistent.EmptyNodeSet;
-import org.exist.dom.persistent.NodeHandle;
-import org.exist.dom.persistent.NodeProxy;
+import org.exist.dom.persistent.*;
 import org.exist.numbering.NodeId;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.XPathException;

--- a/test/src/org/exist/xquery/DeferredFunctionCallTest.java
+++ b/test/src/org/exist/xquery/DeferredFunctionCallTest.java
@@ -78,6 +78,8 @@ public class DeferredFunctionCallTest {
         
         expect(mockExpression.eval(mockContextSequence, mockContextItem)).andReturn(Sequence.EMPTY_SEQUENCE);
 
+        mockExpression.resetState(true);
+
         mockContext.stackLeave((Expression)anyObject());
         mockContext.functionEnd();
         mockContext.popDocumentContext();
@@ -98,6 +100,7 @@ public class DeferredFunctionCallTest {
         
         // 1) Call reset, this should set current arguments to null
         functionCall.resetState(true);
+        functionCall.setRecursive(true); //ensure DeferredFunction
         
         // 2) check UserDefinedFunction.currentArguments == null
         assertNull(userDefinedFunction.getCurrentArguments());


### PR DESCRIPTION
1. query optimizer did not descend into simple map operator expressions, so any code called below it would not be optimized. As a consequence, available range index were not used

2. recursive functions were not re-analyzed after optimization, which again results in range indexes not being used properly