### PR TITLE
[performance] Remove two calls to System.gc and excessive logging.

### DIFF
--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -3640,14 +3640,7 @@ public class NativeBroker extends DBBroker {
         if(nodesCountThreshold <= 0) {
             if(nodesCount > DEFAULT_NODES_BEFORE_MEMORY_CHECK) {
                 if(run.totalMemory() >= run.maxMemory() && run.freeMemory() < pool.getReservedMem()) {
-                    final NumberFormat nf = NumberFormat.getNumberInstance();
-                    LOG.info("total memory: " + nf.format(run.totalMemory()) +
-                        "; max: " + nf.format(run.maxMemory()) +
-                        "; free: " + nf.format(run.freeMemory()) +
-                        "; reserved: " + nf.format(pool.getReservedMem()) +
-                        "; used: " + nf.format(pool.getCacheManager().getCurrentSize()));
                     flush();
-                    System.gc();
                 }
                 nodesCount = 0;
             }
@@ -3874,10 +3867,7 @@ public class NativeBroker extends DBBroker {
         private void checkAvailableMemory() {
             if(indexMode != IndexMode.REMOVE && nodesCount > DEFAULT_NODES_BEFORE_MEMORY_CHECK) {
                 if(run.totalMemory() >= run.maxMemory() && run.freeMemory() < pool.getReservedMem()) {
-                    //LOG.info("total memory: " + run.totalMemory() + "; free: " + run.freeMemory());
                     flush();
-                    System.gc();
-                    LOG.info("total memory: " + run.totalMemory() + "; free: " + run.freeMemory());
                 }
                 nodesCount = 0;
             }

--- a/src/org/exist/storage/NativeValueIndex.java
+++ b/src/org/exist/storage/NativeValueIndex.java
@@ -1323,7 +1323,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
                 atomic = new StringValue( value ).convertTo( xpathType );
             }
             catch( final XPathException e ) {
-                LOG.warn( "Node value '" + value + "' cannot be converted to " + Type.getTypeName( xpathType ) );
+                LOG.debug( "Node value '" + value + "' cannot be converted to " + Type.getTypeName( xpathType ) );
                 return( null );
             }
         }


### PR DESCRIPTION
The calls to System.gc date back to the early days and are definitely unnecessary today. They dramatically slow down the reindexing process. Stress testing did not show any negative effects after dropping those calls.