### PR TITLE
XInclude issue

### DIFF
--- a/src/org/exist/storage/serializers/XIncludeFilter.java
+++ b/src/org/exist/storage/serializers/XIncludeFilter.java
@@ -517,21 +517,26 @@ public class XIncludeFilter implements Receiver {
         return Optional.empty();
     }
 
-	/** Executes the given compiled XQuery in a separate thread, using a separate DBBroker.
-	 * @param compiled the query to execute
-	 * @param contextSeq the context sequence for the query
+	/**
+	 * Executes the given compiled XQuery in a separate thread, using a separate
+	 * DBBroker.
+	 * 
+	 * @param compiled
+	 *            the query to execute
+	 * @param contextSeq
+	 *            the context sequence for the query
 	 * @return
 	 * @throws InterruptedException
 	 * @throws ExecutionException
 	 */
 	private Sequence executeXQueryInSeparateThread(final CompiledXQuery compiled, final Sequence contextSeq)
-			throws InterruptedException, ExecutionException {
+	        throws InterruptedException, ExecutionException {
 		final Callable<Sequence> toExecute = new Callable<Sequence>() {
-			public Sequence call() throws Exception {
+			public Sequence call() throws EXistException, XPathException, PermissionDeniedException {
 				final XQuery xquery = serializer.broker.getBrokerPool().getXQueryService();
-		        try(final DBBroker newBroker = serializer.broker.getBrokerPool().getBroker()) {
-		        	return xquery.execute(newBroker, compiled, contextSeq);
-		        }
+				try (final DBBroker newBroker = serializer.broker.getBrokerPool().getBroker()) {
+					return xquery.execute(newBroker, compiled, contextSeq);
+				}
 			}
 		};
 		ExecutorService executor = null;
@@ -541,7 +546,7 @@ public class XIncludeFilter implements Receiver {
 			// wait synchronously
 			return taskHandle.get();
 		} finally {
-			if(executor != null)
+			if (executor != null)
 				executor.shutdown();
 		}
 	}

--- a/src/org/exist/storage/serializers/XIncludeFilter.java
+++ b/src/org/exist/storage/serializers/XIncludeFilter.java
@@ -23,6 +23,7 @@ package org.exist.storage.serializers;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.EXistException;
 import org.exist.dom.INodeHandle;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
@@ -34,6 +35,7 @@ import org.exist.security.xacml.AccessContext;
 import org.exist.source.DBSource;
 import org.exist.source.Source;
 import org.exist.source.StringSource;
+import org.exist.storage.DBBroker;
 import org.exist.storage.XQueryPool;
 import org.exist.util.function.Either;
 import org.exist.util.serializer.AttrList;
@@ -73,6 +75,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.StringTokenizer;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * A filter that listens for XInclude elements in the stream
@@ -469,8 +476,9 @@ public class XIncludeFilter implements Receiver {
                 Sequence contextSeq = null;
                 if (memtreeDoc != null)
                     {contextSeq = memtreeDoc;}
-                final Sequence seq = xquery.execute(serializer.broker, compiled, contextSeq);
-
+                
+                final Sequence seq = executeXQueryInSeparateThread(compiled, contextSeq);
+                
                 if(Type.subTypeOf(seq.getItemType(), Type.NODE)) {
                     if (LOG.isDebugEnabled())
                         {LOG.debug("xpointer found: " + seq.getItemCount());}
@@ -491,6 +499,12 @@ public class XIncludeFilter implements Receiver {
             } catch (final XPathException e) {
                 LOG.warn("xpointer error", e);
                 throw new SAXException("Error while processing XInclude expression: " + e.getMessage(), e);
+            } catch (final ExecutionException e) {
+                LOG.warn("eXist error", e);
+                throw new SAXException("Error while processing XInclude expression: " + e.getMessage(), e);
+            } catch (final InterruptedException e) {
+                LOG.warn("eXist error", e);
+                throw new SAXException("Processing of XInclude expression interrupted: " + e.getMessage(), e);
             } catch (final PermissionDeniedException e) {
                 LOG.warn("xpointer error", e);
                 throw new SAXException("Error while processing XInclude expression: " + e.getMessage(), e);
@@ -502,6 +516,35 @@ public class XIncludeFilter implements Receiver {
 
         return Optional.empty();
     }
+
+	/** Executes the given compiled XQuery in a separate thread, using a separate DBBroker.
+	 * @param compiled the query to execute
+	 * @param contextSeq the context sequence for the query
+	 * @return
+	 * @throws InterruptedException
+	 * @throws ExecutionException
+	 */
+	private Sequence executeXQueryInSeparateThread(final CompiledXQuery compiled, final Sequence contextSeq)
+			throws InterruptedException, ExecutionException {
+		final Callable<Sequence> toExecute = new Callable<Sequence>() {
+			public Sequence call() throws Exception {
+				final XQuery xquery = serializer.broker.getBrokerPool().getXQueryService();
+		        try(final DBBroker newBroker = serializer.broker.getBrokerPool().getBroker()) {
+		        	return xquery.execute(newBroker, compiled, contextSeq);
+		        }
+			}
+		};
+		ExecutorService executor = null;
+		try {
+			executor = Executors.newSingleThreadExecutor();
+			final Future<Sequence> taskHandle = executor.submit(toExecute);
+			// wait synchronously
+			return taskHandle.get();
+		} finally {
+			if(executor != null)
+				executor.shutdown();
+		}
+	}
 
     private Either<ResourceError, org.exist.dom.memtree.DocumentImpl> parseExternal(final URI externalUri) throws IOException, PermissionDeniedException, ParserConfigurationException, SAXException {
         final URLConnection con = externalUri.toURL().openConnection();


### PR DESCRIPTION
There was a problem when in the middle of one serialisation process, through an XInclude tag calling a stored XQuery, and xmldb operations inside it, another serialisation process was started. It all ended in a NPE or other errors.
This change enforces to use a separate DBBroker when executing an XQuery from the context of XInclude. I achieved it by executing the XQuery in a separate thread, which definitely IS a cost, but taking into account that calling XQuery from XInclude during serialisation is an unusual case, maybe it is acceptable...