### PR TITLE
Separates the concerns of Transactions and Recovery

### DIFF
--- a/extensions/fluent/src/org/exist/fluent/Database.java
+++ b/extensions/fluent/src/org/exist/fluent/Database.java
@@ -171,7 +171,7 @@ public class Database {
 		if (!BrokerPool.isConfigured(dbName)) throw new IllegalStateException("database not started");
 		try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 			broker.flush();
-			broker.sync(Sync.MAJOR_SYNC);
+			broker.sync(Sync.MAJOR);
 		} catch (EXistException e) {
 			throw new DatabaseException(e);
 		}

--- a/extensions/modules/src/org/exist/xquery/modules/image/GetThumbnailsFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/image/GetThumbnailsFunction.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.Iterator;
+import java.util.Optional;
 
 import javax.imageio.ImageIO;
 
@@ -43,6 +44,7 @@ import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.storage.journal.JournalManager;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.xmldb.XmldbURI;
@@ -321,7 +323,10 @@ public class GetThumbnailsFunction extends BasicFunction {
                     throw new XPathException(this, e.getMessage());
                 }
             }
-            transact.getJournal().flushToLog(true);
+            final Optional<JournalManager> journalManager = pool.getJournalManager();
+            if(journalManager.isPresent()) {
+                journalManager.get().flush(true, false);
+            }
             dbbroker.closeDocument();
         }
 		return result;

--- a/src/org/exist/collections/Collection.java
+++ b/src/org/exist/collections/Collection.java
@@ -1562,7 +1562,7 @@ public class Collection extends Observable implements Resource, Comparable<Colle
         //TODO: *resolve* URI against CollectionConfigurationManager.CONFIG_COLLECTION_URI 
         if (getURI().startsWith(XmldbURI.CONFIG_COLLECTION_URI)
                 && docName.endsWith(CollectionConfiguration.COLLECTION_CONFIG_SUFFIX_URI)) {
-            broker.sync(Sync.MAJOR_SYNC);
+            broker.sync(Sync.MAJOR);
             final CollectionConfigurationManager manager = broker.getBrokerPool().getConfigurationManager();
             if(manager != null) {
                 try {

--- a/src/org/exist/collections/CollectionConfigurationManager.java
+++ b/src/org/exist/collections/CollectionConfigurationManager.java
@@ -408,21 +408,16 @@ public class CollectionConfigurationManager {
      */
     private void checkCreateCollection(DBBroker broker, XmldbURI uri) throws EXistException {
         final TransactionManager transact = broker.getDatabase().getTransactionManager();
-        Txn txn = null;
-        try {
+        try(final Txn txn = transact.beginTransaction()) {
             Collection collection = broker.getCollection(uri);
             if (collection == null) {
-                txn = transact.beginTransaction();
                 collection = broker.getOrCreateCollection(txn, uri);
                 SanityCheck.THROW_ASSERT(collection != null);
                 broker.saveCollection(txn, collection);
                 transact.commit(txn);
             }
         } catch (final Exception e) {
-            transact.abort(txn);
             throw new EXistException("Failed to initialize '" + uri + "' : " + e.getMessage());
-        } finally {
-            transact.close(txn);
         }
     }
 

--- a/src/org/exist/config/Configurator.java
+++ b/src/org/exist/config/Configurator.java
@@ -1291,7 +1291,6 @@ public class Configurator {
             collection.store(txn, broker, info, data, false);
             broker.saveCollection(txn, doc.getCollection());
             transact.commit(txn);
-            txn = null;
             saving.remove(fullURI);
             broker.flush();
             broker.sync(Sync.MAJOR);

--- a/src/org/exist/config/Configurator.java
+++ b/src/org/exist/config/Configurator.java
@@ -1294,7 +1294,7 @@ public class Configurator {
             txn = null;
             saving.remove(fullURI);
             broker.flush();
-            broker.sync(Sync.MAJOR_SYNC);
+            broker.sync(Sync.MAJOR);
             return collection.getDocument(broker, uri.lastSegment());
             
         } catch (final Exception e) {

--- a/src/org/exist/management/impl/Database.java
+++ b/src/org/exist/management/impl/Database.java
@@ -23,6 +23,7 @@ package org.exist.management.impl;
 
 import java.io.StringWriter;
 import java.util.Map;
+import java.util.Optional;
 import javax.management.openmbean.*;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
@@ -84,10 +85,7 @@ public class Database implements DatabaseMBean {
                 final Thread thread = entry.getKey();
                 final DBBroker broker = entry.getValue();
                 final String trace = printStackTrace(thread);
-                String watchdogTrace = null;
-                if (pool.getWatchdog() != null) {
-                	watchdogTrace = pool.getWatchdog().get(broker);
-                }
+                final String watchdogTrace = pool.getWatchdog().map(wd -> wd.get(broker)).orElse(null);
                 final Object[] itemValues = { thread.getName(), broker.getReferenceCount(), trace, watchdogTrace };
                 data.put(new CompositeDataSupport(infoType, itemNames, itemValues));
             }

--- a/src/org/exist/storage/BrokerPool.java
+++ b/src/org/exist/storage/BrokerPool.java
@@ -75,7 +75,6 @@ import java.io.StringWriter;
 import java.lang.ref.Reference;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -121,7 +120,7 @@ public class BrokerPool implements Database {
     /**
      * The name of a default database instance for those who are too lazy to provide parameters ;-).
      */
-    public final static String DEFAULT_INSTANCE_NAME = "exist";
+    public static final String DEFAULT_INSTANCE_NAME = "exist";
     public static final String CONFIGURATION_CONNECTION_ELEMENT_NAME = "db-connection";
     public static final String CONFIGURATION_STARTUP_ELEMENT_NAME = "startup";
     public static final String CONFIGURATION_POOL_ELEMENT_NAME = "pool";
@@ -148,7 +147,7 @@ public class BrokerPool implements Database {
     public final static String PROPERTY_MAX_CONNECTIONS = "db-connection.pool.max";
     public final static String PROPERTY_SYNC_PERIOD = "db-connection.pool.sync-period";
     public final static String PROPERTY_SHUTDOWN_DELAY = "wait-before-shutdown";
-    public static final String DISK_SPACE_MIN_PROPERTY = "db-connection.diskSpaceMin";
+    public final static String DISK_SPACE_MIN_PROPERTY = "db-connection.diskSpaceMin";
 
     //TODO : move elsewhere ?
     public final static String PROPERTY_COLLECTION_CACHE_SIZE = "db-connection.collection-cache-size";
@@ -158,8 +157,8 @@ public class BrokerPool implements Database {
     public final static String PROPERTY_RECOVERY_ENABLED = "db-connection.recovery.enabled";
     public final static String PROPERTY_RECOVERY_CHECK = "db-connection.recovery.consistency-check";
     public final static String PROPERTY_SYSTEM_TASK_CONFIG = "db-connection.system-task-config";
-    public static final String PROPERTY_NODES_BUFFER = "db-connection.nodes-buffer";
-    public static final String PROPERTY_EXPORT_ONLY = "db-connection.emergency";
+    public final static String PROPERTY_NODES_BUFFER = "db-connection.nodes-buffer";
+    public final static String PROPERTY_EXPORT_ONLY = "db-connection.emergency";
 
     public static final String DOC_ID_MODE_ATTRIBUTE = "doc-ids";
 
@@ -197,7 +196,7 @@ public class BrokerPool implements Database {
     //TODO : rename as activateShutdownHook ? or registerShutdownHook(Thread aThread)
     // WM: it is probably not necessary to allow users to register their own hook. This method
     // is only used once, by class org.exist.jetty.JettyStart, which registers its own hook.
-    public final static void setRegisterShutdownHook(boolean register) {
+    public final static void setRegisterShutdownHook(final boolean register) {
         /*
          * TODO : call Runtime.getRuntime().removeShutdownHook or Runtime.getRuntime().registerShutdownHook 
          * depending of the value of register
@@ -423,11 +422,8 @@ public class BrokerPool implements Database {
     /**
      * Default values
      */
-    //TODO : make them static when we have 2 classes
-    private final int DEFAULT_MIN_BROKERS = 1;
-    private final int DEFAULT_MAX_BROKERS = 15;
-    public final long DEFAULT_SYNCH_PERIOD = 120000;
-    public final long DEFAULT_MAX_SHUTDOWN_WAIT = 45000;
+    public static final long DEFAULT_SYNCH_PERIOD = 120000;
+    public static final long DEFAULT_MAX_SHUTDOWN_WAIT = 45000;
     //TODO : move this default setting to org.exist.collections.CollectionCache ?
     public final int DEFAULT_COLLECTION_BUFFER_SIZE = 64;
 
@@ -437,20 +433,24 @@ public class BrokerPool implements Database {
     /**
      * <code>true</code> if the database instance is able to handle transactions.
      */
-    private boolean transactionsEnabled;
+    private final boolean transactionsEnabled;
 
     /**
      * The name of the database instance
      */
-    private String instanceName;
+    private final String instanceName;
 
-    //TODO: change 0 = initializing, 1 = operating, -1 = shutdown  (shabanovd)
-    private final static int SHUTDOWN = -1;
-    private final static int INITIALIZING = 0;
-    private final static int OPERATING = 1;
+    /**
+     * State of the BrokerPool instance
+     */
+    private enum State {
+        SHUTDOWN,
+        INITIALIZING,
+        OPERATIONAL
+    }
 
     // volatile so this doesn't get optimized away or into a CPU register in some thread
-    private volatile int status = INITIALIZING;
+    private volatile State status = State.INITIALIZING;
 
     /**
      * The number of brokers for the database instance
@@ -461,18 +461,18 @@ public class BrokerPool implements Database {
      * The minimal number of brokers for the database instance
      */
     @ConfigurationFieldAsAttribute("min")
-    private int minBrokers;
+    private final int minBrokers;
 
     /**
      * The maximal number of brokers for the database instance
      */
     @ConfigurationFieldAsAttribute("max")
-    private int maxBrokers;
+    private final int maxBrokers;
 
     /**
      * The number of inactive brokers for the database instance
      */
-    private final Stack<DBBroker> inactiveBrokers = new Stack<>();
+    private final Deque<DBBroker> inactiveBrokers = new ArrayDeque<>();
 
     /**
      * The number of active brokers for the database instance
@@ -484,13 +484,13 @@ public class BrokerPool implements Database {
      * Used when TRACE level logging is enabled
      * to provide a history of broker leases
      */
-    private Map<String, TraceableStateChanges<TraceableBrokerLeaseChange.BrokerInfo, TraceableBrokerLeaseChange.Change>> brokerLeaseChangeTrace = LOG.isTraceEnabled() ? new HashMap<>() : null;
-    private Map<String, List<TraceableStateChanges<TraceableBrokerLeaseChange.BrokerInfo, TraceableBrokerLeaseChange.Change>>> brokerLeaseChangeTraceHistory = LOG.isTraceEnabled() ? new HashMap<>() : null;
+    private final Map<String, TraceableStateChanges<TraceableBrokerLeaseChange.BrokerInfo, TraceableBrokerLeaseChange.Change>> brokerLeaseChangeTrace = LOG.isTraceEnabled() ? new HashMap<>() : null;
+    private final Map<String, List<TraceableStateChanges<TraceableBrokerLeaseChange.BrokerInfo, TraceableBrokerLeaseChange.Change>>> brokerLeaseChangeTraceHistory = LOG.isTraceEnabled() ? new HashMap<>() : null;
 
     /**
      * The configuration object for the database instance
      */
-    protected Configuration conf = null;
+    protected final Configuration conf;
 
     /**
      * <code>true</code> if a cache synchronization event is scheduled
@@ -501,9 +501,9 @@ public class BrokerPool implements Database {
 
     /**
      * The kind of scheduled cache synchronization event.
-     * One of {@link org.exist.storage.sync.Sync#MAJOR_SYNC} or {@link org.exist.storage.sync.Sync#MINOR_SYNC}
+     * One of {@link org.exist.storage.sync.Sync}
      */
-    private int syncEvent = 0;
+    private Sync syncEvent = Sync.MINOR;
 
     private boolean checkpoint = false;
 
@@ -513,7 +513,7 @@ public class BrokerPool implements Database {
     @GuardedBy("itself") private Boolean readOnly = Boolean.FALSE;
 
     @ConfigurationFieldAsAttribute("pageSize")
-    private int pageSize;
+    private final int pageSize;
 
     private FileLock dataLock;
 
@@ -526,13 +526,13 @@ public class BrokerPool implements Database {
      * Delay (in ms) for running jobs to return when the database instance shuts down.
      */
     @ConfigurationFieldAsAttribute("wait-before-shutdown")
-    private long maxShutdownWait;
+    private final long maxShutdownWait;
 
     /**
      * The scheduler for the database instance.
      */
     @ConfigurationFieldAsAttribute("scheduler")
-    private Scheduler scheduler;
+    private final Scheduler scheduler;
 
     /**
      * Manages pluggable index structures.
@@ -548,10 +548,11 @@ public class BrokerPool implements Database {
      * Cache synchronization on the database instance.
      */
     @ConfigurationFieldAsAttribute("sync-period")
-    private long majorSyncPeriod = DEFAULT_SYNCH_PERIOD;        //the period after which a major sync should occur
+    private final long majorSyncPeriod;        //the period after which a major sync should occur
     private long lastMajorSync = System.currentTimeMillis();    //time the last major sync occurred
 
-    private long diskSpaceMin = 64 * 1024L * 1024L;
+    public static final short DEFAULT_DISK_SPACE_MIN = 64; // 64 MB
+    private final long diskSpaceMin;
 
     /**
      * The listener that is notified when the database instance shuts down.
@@ -617,11 +618,11 @@ public class BrokerPool implements Database {
      */
     protected XMLReaderPool xmlReaderPool;
 
-    private NodeIdFactory nodeFactory = new DLNFactory();
+    private final NodeIdFactory nodeFactory = new DLNFactory();
 
     //TODO : is another value possible ? If no, make it static
     // WM: no, we need one lock per database instance. Otherwise we would lock another database.
-    private Lock globalXUpdateLock = new ReentrantReadWriteLock("xupdate");
+    private final Lock globalXUpdateLock = new ReentrantReadWriteLock("xupdate");
 
     private Subject serviceModeUser = null;
     private boolean inServiceMode = false;
@@ -629,9 +630,9 @@ public class BrokerPool implements Database {
     //the time that the database was started
     private final Calendar startupTime = Calendar.getInstance();
 
-    private BrokerWatchdog watchdog = null;
+    private final Optional<BrokerWatchdog> watchdog;
 
-    private ClassLoader classLoader;
+    private final ClassLoader classLoader;
 
     private Optional<ExistRepository> expathRepo = Optional.empty();
 
@@ -649,9 +650,6 @@ public class BrokerPool implements Database {
     private BrokerPool(final String instanceName, final int minBrokers, final int maxBrokers, final Configuration conf)
         throws EXistException, DatabaseConfigurationException {
 
-        Integer anInteger;
-        Long aLong;
-        Boolean aBoolean;
         final NumberFormat nf = NumberFormat.getNumberInstance();
 
         this.classLoader = Thread.currentThread().getContextClassLoader();
@@ -660,67 +658,33 @@ public class BrokerPool implements Database {
         //WM: needs to be done in the configure method.
         this.instanceName = instanceName;
 
-        //TODO : find a nice way to (re)set the default values
-        //TODO : create static final members for configuration keys
-        this.minBrokers = DEFAULT_MIN_BROKERS;
-        this.maxBrokers = DEFAULT_MAX_BROKERS;
-        this.maxShutdownWait = DEFAULT_MAX_SHUTDOWN_WAIT;
-        //TODO : read from configuration
-        this.transactionsEnabled = true;
+        //TODO : sanity check : the shutdown period should be reasonable
+        this.maxShutdownWait = conf.getProperty(BrokerPool.PROPERTY_SHUTDOWN_DELAY, DEFAULT_MAX_SHUTDOWN_WAIT);
+        LOG.info("database instance '" + instanceName + "' will wait  " + nf.format(this.maxShutdownWait) + " ms during shutdown");
 
-        this.minBrokers = minBrokers;
-        this.maxBrokers = maxBrokers;
-        /*
-		 * strange enough, the settings provided by the constructor may be overridden
-		 * by the ones *explicitly* provided by the constructor
-		 * TODO : consider a private constructor BrokerPool(String instanceName) then configure(int minBrokers, int maxBrokers, Configuration config)
-		 */
-        anInteger = (Integer) conf.getProperty(PROPERTY_MIN_CONNECTIONS);
-        if(anInteger != null) {
-            this.minBrokers = anInteger;
-        }
-        anInteger = (Integer) conf.getProperty(PROPERTY_MAX_CONNECTIONS);
-        if(anInteger != null) {
-            this.maxBrokers = anInteger;
-        }
+        this.transactionsEnabled = conf.getProperty(PROPERTY_RECOVERY_ENABLED, true);
+        LOG.info("database instance '" + instanceName + "' is enabled for transactions : " + this.transactionsEnabled);
+
+        this.minBrokers = conf.getProperty(PROPERTY_MIN_CONNECTIONS, minBrokers);
+        this.maxBrokers = conf.getProperty(PROPERTY_MAX_CONNECTIONS, maxBrokers);
+
         //TODO : sanity check : minBrokers shall be lesser than or equal to maxBrokers
         //TODO : sanity check : minBrokers shall be positive
         LOG.info("database instance '" + instanceName + "' will have between " + nf.format(this.minBrokers) + " and " + nf.format(this.maxBrokers) + " brokers");
 
         //TODO : use the periodicity of a SystemTask (see below)
-        aLong = (Long) conf.getProperty(PROPERTY_SYNC_PERIOD);
-        if(aLong != null)
-			/*this.*/ {
-            majorSyncPeriod = aLong;
-        }
+        this.majorSyncPeriod = conf.getProperty(PROPERTY_SYNC_PERIOD, DEFAULT_SYNCH_PERIOD);
+
         //TODO : sanity check : the synch period should be reasonable
         LOG.info("database instance '" + instanceName + "' will be synchronized every " + nf.format(/*this.*/majorSyncPeriod) + " ms");
 
-        aLong = (Long) conf.getProperty(BrokerPool.PROPERTY_SHUTDOWN_DELAY);
-        if(aLong != null) {
-            this.maxShutdownWait = aLong;
-        }
-        //TODO : sanity check : the shutdown period should be reasonable
-        LOG.info("database instance '" + instanceName + "' will wait  " + nf.format(this.maxShutdownWait) + " ms during shutdown");
+        // convert from bytes to megabytes: 1024 * 1024
+        this.diskSpaceMin = 1024l * 1024l * conf.getProperty(BrokerPool.DISK_SPACE_MIN_PROPERTY, DEFAULT_DISK_SPACE_MIN);
 
-        aBoolean = (Boolean) conf.getProperty(PROPERTY_RECOVERY_ENABLED);
-        if(aBoolean != null) {
-            this.transactionsEnabled = aBoolean;
-        }
-        LOG.info("database instance '" + instanceName + "' is enabled for transactions : " + this.transactionsEnabled);
-
-        final Integer min = (Integer) conf.getProperty(BrokerPool.DISK_SPACE_MIN_PROPERTY);
-        if(min != null) {
-            diskSpaceMin = min * 1024L * 1024L;
-        }
-
-        pageSize = conf.getInteger(PROPERTY_PAGE_SIZE);
-        if(pageSize < 0) {
-            pageSize = DEFAULT_PAGE_SIZE;
-        }
+        this.pageSize = conf.getProperty(PROPERTY_PAGE_SIZE, DEFAULT_PAGE_SIZE);
 
         //TODO : move this to initialize ? (cant as we need it for FileLockHeartBeat)
-        scheduler = new QuartzSchedulerImpl(this, conf);
+        this.scheduler = new QuartzSchedulerImpl(this, conf);
 
         if(!canReadDataDir(conf)) {
             setReadOnly();
@@ -728,6 +692,10 @@ public class BrokerPool implements Database {
 
         //Configuration is valid, save it
         this.conf = conf;
+
+        this.watchdog = Optional.ofNullable(System.getProperty("trace.brokers"))
+                .filter(v -> v.equals("yes"))
+                .map(v -> new BrokerWatchdog());
 
         //TODO : in the future, we should implement an Initializable interface
         try {
@@ -763,10 +731,6 @@ public class BrokerPool implements Database {
             final SyncTask syncTask = new SyncTask();
             syncTask.configure(conf, null);
             scheduler.createPeriodicJob(2500, new SystemTaskJobImpl(SyncTask.getJobName(), syncTask), 2500);
-        }
-
-        if("yes".equals(System.getProperty("trace.brokers", "no"))) {
-            watchdog = new BrokerWatchdog();
         }
     }
 
@@ -820,7 +784,7 @@ public class BrokerPool implements Database {
         }
 
         //Flag to indicate that we are initializing
-        status = INITIALIZING;
+        status = State.INITIALIZING;
 
         // Don't allow two threads to do a race on this. May be irrelevant as this is only called
         // from the constructor right now.
@@ -835,7 +799,7 @@ public class BrokerPool implements Database {
 
                 // statusReporter may have to be terminated or the thread can/will hang.
                 try {
-                    final boolean exportOnly = (Boolean) conf.getProperty(PROPERTY_EXPORT_ONLY, false);
+                    final boolean exportOnly = conf.getProperty(PROPERTY_EXPORT_ONLY, false);
 
                     //create the security manager
                     securityManager = new SecurityManagerImpl(this);
@@ -956,7 +920,7 @@ public class BrokerPool implements Database {
                             // WM: attention: a small change in the sequence of calls can break
                             // either normal startup or recovery.
 
-                            status = OPERATING;
+                            status = State.OPERATIONAL;
 
                             statusReporter.setStatus(SIGNAL_READINESS);
 
@@ -1012,7 +976,7 @@ public class BrokerPool implements Database {
                                 LOG.error(pde.getMessage(), pde);
                             }
 
-                            sync(broker, Sync.MAJOR_SYNC);
+                            sync(broker, Sync.MAJOR);
 
                             //require to allow access by BrokerPool.getInstance();
                             instances.put(instanceName, this);
@@ -1116,7 +1080,7 @@ public class BrokerPool implements Database {
         }
         // trigger a checkpoint after processing all startup triggers
         checkpoint = true;
-        triggerSync(Sync.MAJOR_SYNC);
+        triggerSync(Sync.MAJOR);
     }
 
     /**
@@ -1194,7 +1158,7 @@ public class BrokerPool implements Database {
      */
     //TODO : let's be positive and rename it as isInitialized ? 
     public boolean isInitializing() {
-        return status == INITIALIZING;
+        return status == State.INITIALIZING;
     }
 
     /**
@@ -1625,8 +1589,8 @@ public class BrokerPool implements Database {
                 LOG.trace("+++ " + Thread.currentThread() + Stacktrace.top(Thread.currentThread().getStackTrace(), Stacktrace.DEFAULT_STACK_TOP));
             }
 
-            if(watchdog != null) {
-                watchdog.add(broker);
+            if(watchdog.isPresent()) {
+                watchdog.get().add(broker);
             }
 
             broker.incReferenceCount();
@@ -1718,9 +1682,7 @@ public class BrokerPool implements Database {
             }
 
             inactiveBrokers.push(broker);
-            if(watchdog != null) {
-                watchdog.remove(broker);
-            }
+            watchdog.ifPresent(wd -> wd.remove(broker));
 
             if(LOG.isTraceEnabled()) {
                 if(!brokerLeaseChangeTraceHistory.containsKey(broker.getId())) {
@@ -1775,7 +1737,7 @@ public class BrokerPool implements Database {
         inServiceMode = true;
         final DBBroker broker = inactiveBrokers.peek();
         checkpoint = true;
-        sync(broker, Sync.MAJOR_SYNC);
+        sync(broker, Sync.MAJOR);
         checkpoint = false;
         // Return a broker that can be used to perform system tasks
         return broker;
@@ -1810,7 +1772,7 @@ public class BrokerPool implements Database {
      * Executes a waiting cache synchronization for the database instance.
      *
      * @param broker    A broker responsible for executing the job
-     * @param syncEvent One of {@link org.exist.storage.sync.Sync#MINOR_SYNC} or {@link org.exist.storage.sync.Sync#MINOR_SYNC}
+     * @param syncEvent One of {@link org.exist.storage.sync.Sync}
      */
     //TODO : rename as runSync ? executeSync ?
     //TOUNDERSTAND (pb) : *not* synchronized, so... "executes" or, rather, "schedules" ? "executes" (WM)
@@ -1818,14 +1780,14 @@ public class BrokerPool implements Database {
     // WM: the method will always be under control of the BrokerPool. It is guaranteed that no
     // other brokers are active when it is called. That's why we don't need to synchronize here.
     //TODO : make it protected ?
-    public void sync(final DBBroker broker, final int syncEvent) {
+    public void sync(final DBBroker broker, final Sync syncEvent) {
         broker.sync(syncEvent);
 
         //TODO : strange that it is set *after* the sunc method has been called.
         try {
             broker.pushSubject(securityManager.getSystemSubject());
 
-            if (syncEvent == Sync.MAJOR_SYNC) {
+            if (syncEvent == Sync.MAJOR) {
                 LOG.debug("Major sync");
                 try {
                     if (!FORCE_CORRUPTION) {
@@ -1859,12 +1821,11 @@ public class BrokerPool implements Database {
      * the cache synchronization will be run immediately. Otherwise, the task will be deferred
      * until all running threads have returned.
      *
-     * @param syncEvent One of {@link org.exist.storage.sync.Sync#MINOR_SYNC} or
-     *                  {@link org.exist.storage.sync.Sync#MINOR_SYNC}
+     * @param syncEvent One of {@link org.exist.storage.sync.Sync}
      */
-    public void triggerSync(final int syncEvent) {
+    public void triggerSync(final Sync syncEvent) {
         //TOUNDERSTAND (pb) : synchronized, so... "schedules" or, rather, "executes" ? "schedules" (WM)
-        if(status == SHUTDOWN) {
+        if(status == State.SHUTDOWN) {
             return;
         }
         LOG.debug("Triggering sync: " + syncEvent);
@@ -1916,7 +1877,7 @@ public class BrokerPool implements Database {
     }
 
     public boolean isShuttingDown() {
-        return status == SHUTDOWN;
+        return status == State.SHUTDOWN;
     }
 
     /**
@@ -1925,14 +1886,14 @@ public class BrokerPool implements Database {
      * @param killed <code>true</code> when the JVM is (cleanly) exiting
      */
     public void shutdown(final boolean killed) {
-        if(status == SHUTDOWN) {
+        if(status == State.SHUTDOWN) {
             // we are already shut down
             return;
         }
 
         LOG.info("Database is shutting down ...");
 
-        status = SHUTDOWN;
+        status = State.SHUTDOWN;
 
         processMonitor.stopRunningJobs();
 
@@ -2048,8 +2009,6 @@ public class BrokerPool implements Database {
                 // deregister JMX MBeans
                 AgentFactory.getInstance().closeDBInstance(this);
 
-                //Invalidate the configuration
-                conf = null;
                 //Clear the living instances container
                 instances.remove(instanceName);
 
@@ -2095,7 +2054,6 @@ public class BrokerPool implements Database {
             collectionConfigurationManager = null;
             notificationService = null;
             indexManager = null;
-            scheduler = null;
             xmlReaderPool = null;
             shutdownListener = null;
             securityManager = null;
@@ -2148,7 +2106,7 @@ public class BrokerPool implements Database {
         }
     }
 
-    public BrokerWatchdog getWatchdog() {
+    public Optional<BrokerWatchdog> getWatchdog() {
         return watchdog;
     }
 
@@ -2158,7 +2116,7 @@ public class BrokerPool implements Database {
             return;
         }
         synchronized(this) {
-            syncEvent = Sync.MAJOR_SYNC;
+            syncEvent = Sync.MAJOR;
             syncRequired = true;
             checkpoint = true;
         }
@@ -2181,20 +2139,21 @@ public class BrokerPool implements Database {
     }
 
     public void printSystemInfo() {
-        final StringWriter sout = new StringWriter();
-        final PrintWriter writer = new PrintWriter(sout);
+        try(final StringWriter sout = new StringWriter();
+            final PrintWriter writer = new PrintWriter(sout)) {
 
-        writer.println("SYSTEM INFO");
-        writer.format("Database instance: %s\n", getId());
-        writer.println("-------------------------------------------------------------------");
-        if(watchdog != null) {
-            watchdog.dump(writer);
+            writer.println("SYSTEM INFO");
+            writer.format("Database instance: %s\n", getId());
+            writer.println("-------------------------------------------------------------------");
+            watchdog.ifPresent(wd -> wd.dump(writer));
+            DeadlockDetection.debug(writer);
+
+            final String s = sout.toString();
+            LOG.info(s);
+            System.err.println(s);
+        } catch(final IOException e) {
+            LOG.error(e);
         }
-        DeadlockDetection.debug(writer);
-
-        final String s = sout.toString();
-        LOG.info(s);
-        System.err.println(s);
     }
 
     private static class StatusReporter extends Observable implements Runnable {
@@ -2306,11 +2265,11 @@ public class BrokerPool implements Database {
             return Integer.toString(getState().referenceCount);
         }
 
-        final static TraceableBrokerLeaseChange get(final BrokerInfo brokerInfo) {
+        static TraceableBrokerLeaseChange get(final BrokerInfo brokerInfo) {
             return new TraceableBrokerLeaseChange(Change.GET, brokerInfo);
         }
 
-        final static TraceableBrokerLeaseChange release(final BrokerInfo brokerInfo) {
+        static TraceableBrokerLeaseChange release(final BrokerInfo brokerInfo) {
             return new TraceableBrokerLeaseChange(Change.RELEASE, brokerInfo);
         }
     }

--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -43,6 +43,7 @@ import org.exist.stax.IEmbeddedXMLStreamReader;
 import org.exist.storage.btree.BTreeCallback;
 import org.exist.storage.dom.INodeIterator;
 import org.exist.storage.serializers.Serializer;
+import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.Txn;
 import org.exist.util.*;
 import org.exist.util.function.Tuple2;
@@ -719,13 +720,12 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
 
 	/**
 	 * Sync dom and collection state data (pages) to disk. In case of
-	 * {@link org.exist.storage.sync.Sync#MAJOR_SYNC}, sync all states (dom,
+	 * {@link org.exist.storage.sync.Sync#MAJOR}, sync all states (dom,
 	 * collection, text and element) to disk.
 	 * 
 	 * @param syncEvent
-	 *            Sync.MAJOR_SYNC or Sync.MINOR_SYNC
 	 */
-	public abstract void sync(int syncEvent);
+	public abstract void sync(Sync syncEvent);
 
 	/**
 	 * Update a node's data. To keep nodes in a correct sequential order, it is

--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -3590,7 +3590,7 @@ public class NativeBroker extends DBBroker {
     long nextReportTS = System.currentTimeMillis();
 
     @Override
-    public void sync(final int syncEvent) {
+    public void sync(final Sync syncEvent) {
         if(isReadOnly()) {
             return;
         }
@@ -3606,7 +3606,7 @@ public class NativeBroker extends DBBroker {
                     return null;
                 }
             }.run();
-            if(syncEvent == Sync.MAJOR_SYNC) {
+            if(syncEvent == Sync.MAJOR) {
                 final Lock lock = collectionsDb.getLock();
                 try {
                     lock.acquire(Lock.WRITE_LOCK);
@@ -3641,7 +3641,7 @@ public class NativeBroker extends DBBroker {
     public void shutdown() {
         try {
             flush();
-            sync(Sync.MAJOR_SYNC);
+            sync(Sync.MAJOR);
             domDb.close();
             collectionsDb.close();
             notifyClose();

--- a/src/org/exist/storage/SystemTaskManager.java
+++ b/src/org/exist/storage/SystemTaskManager.java
@@ -61,7 +61,7 @@ public class SystemTaskManager {
                 while (!waitingSystemTasks.isEmpty()) {
                 	final SystemTask task = waitingSystemTasks.pop();
                 	if (task.afterCheckpoint()) {
-                        pool.sync(broker, Sync.MAJOR_SYNC);
+                        pool.sync(broker, Sync.MAJOR);
                     }
                     runSystemTask(task, broker);
                 }

--- a/src/org/exist/storage/index/BTreeStore.java
+++ b/src/org/exist/storage/index/BTreeStore.java
@@ -16,8 +16,8 @@ public class BTreeStore extends BTree {
 
     protected Lock lock = null;
 
-    public BTreeStore(BrokerPool pool, byte fileId, boolean transactional, final Path file, DefaultCacheManager cacheManager) throws DBException {
-        super(pool, fileId, transactional, cacheManager, file);
+    public BTreeStore(final BrokerPool pool, final byte fileId, final boolean recoverEnabled, final Path file, final DefaultCacheManager cacheManager) throws DBException {
+        super(pool, fileId, recoverEnabled, cacheManager, file);
         lock = new ReentrantReadWriteLock(FileUtils.fileName(file));
 
         if(exists()) {

--- a/src/org/exist/storage/journal/JournalException.java
+++ b/src/org/exist/storage/journal/JournalException.java
@@ -1,0 +1,30 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2016 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.storage.journal;
+
+public class JournalException extends Exception {
+    public JournalException(final String message) {
+        super(message);
+    }
+
+    public JournalException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/org/exist/storage/journal/JournalManager.java
+++ b/src/org/exist/storage/journal/JournalManager.java
@@ -1,0 +1,160 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2016 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.storage.journal;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.EXistException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.recovery.RecoveryManager;
+import org.exist.util.ReadOnlyException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+/**
+ * Journal Manager just adds some light-weight
+ * wrapping around {@link Journal}
+ */
+public class JournalManager {
+    private static final Logger LOG = LogManager.getLogger(JournalManager.class);
+
+    private final BrokerPool pool;
+    private final Path journalDir;
+    private final boolean groupCommits;
+
+    private Journal journal;
+    private boolean journallingDisabled = false;
+    private boolean initialized = false;
+
+    public JournalManager(final BrokerPool pool, final Path journalDir, final boolean groupCommits) {
+        this.pool = pool;
+        this.journalDir = journalDir;
+        this.groupCommits = groupCommits;
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("GroupCommits = " + groupCommits);
+        }
+    }
+
+    public void initialize() throws EXistException, ReadOnlyException {
+        if(!journallingDisabled) {
+            this.journal = new Journal(pool, journalDir);
+            this.journal.initialize();
+            this.initialized = true;
+        }
+    }
+
+    public void disableJournalling() {
+        this.journallingDisabled = true;
+    }
+
+    /**
+     * Write a single entry to the journal
+     *
+     * @see Journal#writeToLog(Loggable)
+     *
+     * @param loggable The entry to write in the journal
+     */
+    public synchronized void journal(final Loggable loggable) throws JournalException {
+        if(!journallingDisabled) {
+            journal.writeToLog(loggable);
+        }
+    }
+
+    /**
+     * Write a group of entrys to the journal
+     *
+     * @see Journal#writeToLog(Loggable)
+     * @see Journal#flushToLog(boolean)
+     *
+     * @param loggable The entry to write in the journalGroup
+     */
+    public synchronized void journalGroup(final Loggable loggable) throws JournalException {
+        if(!journallingDisabled) {
+            journal.writeToLog(loggable);
+            if (!groupCommits) {
+                journal.flushToLog(true);
+            }
+        }
+    }
+
+    /**
+     * @see Journal#checkpoint(long, boolean)
+     *
+     * Create a new checkpoint. A checkpoint fixes the current database state. All dirty pages
+     * are written to disk and the journal file is cleaned.
+     *
+     * This method is called from
+     * {@link org.exist.storage.BrokerPool} within pre-defined periods. It
+     * should not be called from somewhere else. The database needs to
+     * be in a stable state (all transactions completed, no operations running).
+     *
+     * @param transactionId The id of the transaction for the checkpoint
+     * @param switchFiles Whether a new journal file should be started
+     *
+     * @throws JournalException
+     */
+    public synchronized void checkpoint(final long transactionId, final boolean switchFiles) throws JournalException {
+        if(!journallingDisabled) {
+            journal.checkpoint(transactionId, switchFiles);
+        }
+    }
+
+    /**
+     * @see Journal#flushToLog(boolean, boolean)
+     */
+    public synchronized void flush(final boolean fsync, final boolean forceSync) {
+        journal.flushToLog(fsync, forceSync);
+    }
+
+
+
+    /**
+     * Shut down the journal. This will write a checkpoint record
+     * to the log, so recovery manager knows the file has been
+     * closed in a clean way.
+     *
+     * @param transactionId The id of the transaction for the shutdown
+     * @param checkpoint Whether to write a checkpoint before shutdown
+     */
+    public synchronized void shutdown(final long transactionId, final boolean checkpoint) {
+        if(initialized) {
+            journal.shutdown(transactionId, checkpoint);
+            initialized = false;
+        }
+    }
+
+    /**
+     * @see Journal#lastWrittenLsn()
+     */
+    public long lastWrittenLsn() {
+        return journal.lastWrittenLsn();
+    }
+
+
+
+    public RecoveryManager.JournalRecoveryAccessor getRecoveryAccessor(final RecoveryManager recoveryManager) {
+        return recoveryManager.new JournalRecoveryAccessor(
+                journal::setInRecovery, journal::getFiles, journal::getFile, journal::setCurrentFileNum,
+                () -> { journal.switchFiles(); return null; }, () -> { journal.clearBackupFiles(); return null; });
+    }
+}

--- a/src/org/exist/storage/recovery/RecoveryManager.java
+++ b/src/org/exist/storage/recovery/RecoveryManager.java
@@ -183,7 +183,7 @@ public class RecoveryManager {
                 cleanDirectory(files.stream());
                 if (recoveryRun) {
                     broker.repairPrimary();
-                    broker.sync(Sync.MAJOR_SYNC);
+                    broker.sync(Sync.MAJOR);
                 }
             }
 		}
@@ -291,7 +291,7 @@ public class RecoveryManager {
                 }
             }
         } finally {
-            broker.sync(Sync.MAJOR_SYNC);
+            broker.sync(Sync.MAJOR);
             logManager.setInRecovery(false);
         }
     }

--- a/src/org/exist/storage/recovery/RecoveryManager.java
+++ b/src/org/exist/storage/recovery/RecoveryManager.java
@@ -24,6 +24,9 @@ package org.exist.storage.recovery;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,16 +34,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.storage.DBBroker;
 import org.exist.storage.BrokerPool;
-import org.exist.storage.journal.Journal;
-import org.exist.storage.journal.JournalReader;
-import org.exist.storage.journal.LogEntryTypes;
-import org.exist.storage.journal.LogException;
-import org.exist.storage.journal.Loggable;
-import org.exist.storage.journal.Lsn;
+import org.exist.storage.journal.*;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.Checkpoint;
 import org.exist.util.FileUtils;
 import org.exist.util.ProgressBar;
+import org.exist.util.function.SupplierE;
 import org.exist.util.hashtable.Long2ObjectHashMap;
 import org.exist.util.sanity.SanityCheck;
 
@@ -55,13 +54,13 @@ public class RecoveryManager {
 	
 	private final static Logger LOG = LogManager.getLogger(RecoveryManager.class);
 
-	private Journal logManager;
-	private DBBroker broker;
-    private boolean restartOnError;
+    private final DBBroker broker;
+    private final JournalRecoveryAccessor journalRecovery;
+    private final boolean restartOnError;
 
-	public RecoveryManager(DBBroker broker, Journal log, boolean restartOnError) {
+    public RecoveryManager(final DBBroker broker, final JournalManager journalManager, final boolean restartOnError) {
         this.broker = broker;
-		this.logManager = log;
+        this.journalRecovery = journalManager.getRecoveryAccessor(this);
         this.restartOnError = restartOnError;
 	}
 
@@ -78,7 +77,7 @@ public class RecoveryManager {
 	public boolean recover() throws LogException {
         boolean recoveryRun = false;
 		final List<Path> files;
-        try(final Stream<Path> fileStream = logManager.getFiles()) {
+        try(final Stream<Path> fileStream = journalRecovery.getFiles.get()) {
             files = fileStream.collect(Collectors.toList());
         } catch(final IOException ioe) {
             throw new LogException("Unable to find journal files in data dir", ioe);
@@ -87,7 +86,7 @@ public class RecoveryManager {
 		final int lastNum = Journal.findLastFile(files.stream());
 		if (-1 < lastNum) {
             // load the last log file
-			final Path last = logManager.getFile(lastNum);
+			final Path last = journalRecovery.getFile.apply(lastNum);
 			// scan the last log file and record the last checkpoint found
 			final JournalReader reader = new JournalReader(broker, last, lastNum);
             try {
@@ -187,12 +186,34 @@ public class RecoveryManager {
                 }
             }
 		}
-        logManager.setCurrentFileNum(lastNum);
-		logManager.switchFiles();
-        logManager.clearBackupFiles();
+        journalRecovery.setCurrentFileNum.accept(lastNum);
+        journalRecovery.switchFiles.get();
+        journalRecovery.clearBackupFiles.get();
 
         return recoveryRun;
 	}
+
+    public class JournalRecoveryAccessor {
+        final Consumer<Boolean> setInRecovery;
+        final SupplierE<Stream<Path>, IOException> getFiles;
+        final Function<Integer, Path> getFile;
+        final Consumer<Integer> setCurrentFileNum;
+        final SupplierE<Void, LogException> switchFiles;
+        final Supplier<Void> clearBackupFiles;
+
+
+        public JournalRecoveryAccessor(final Consumer<Boolean> setInRecovery,
+                final SupplierE<Stream<Path>, IOException> getFiles, final Function<Integer, Path> getFile,
+                final Consumer<Integer> setCurrentFileNum, final SupplierE<Void, LogException> switchFiles,
+                final Supplier<Void> clearBackupFiles) {
+            this.setInRecovery = setInRecovery;
+            this.getFiles = getFiles;
+            this.getFile = getFile;
+            this.setCurrentFileNum = setCurrentFileNum;
+            this.switchFiles = switchFiles;
+            this.clearBackupFiles = clearBackupFiles;
+        }
+    }
 
     /**
      * Called by {@link #recover()} to do the actual recovery.
@@ -208,7 +229,7 @@ public class RecoveryManager {
         if (LOG.isInfoEnabled()) {
             LOG.info("Running recovery ...");
         }
-        logManager.setInRecovery(true);
+        journalRecovery.setInRecovery.accept(true);
 
         try {
             // map to track running transactions
@@ -292,7 +313,7 @@ public class RecoveryManager {
             }
         } finally {
             broker.sync(Sync.MAJOR);
-            logManager.setInRecovery(false);
+            journalRecovery.setInRecovery.accept(false);
         }
     }
     

--- a/src/org/exist/storage/sync/Sync.java
+++ b/src/org/exist/storage/sync/Sync.java
@@ -27,8 +27,7 @@ package org.exist.storage.sync;
  * It will periodically trigger a cache sync to write
  * cached pages to disk. 
  */
-public interface Sync {
-
-    public final static int MINOR_SYNC = 0;
-    public final static int MAJOR_SYNC = 1;
+public enum Sync {
+    MINOR,
+    MAJOR
 }

--- a/src/org/exist/storage/sync/SyncTask.java
+++ b/src/org/exist/storage/sync/SyncTask.java
@@ -46,7 +46,7 @@ public class SyncTask implements SystemTask {
     }
 
     private Path dataDir;
-    private long diskSpaceMin = 64 * 1024L * 1024L;
+    private long diskSpaceMin;
 
     @Override
     public boolean afterCheckpoint() {
@@ -56,9 +56,7 @@ public class SyncTask implements SystemTask {
 
     @Override
     public void configure(Configuration config, Properties properties) throws EXistException {
-        final Integer min = (Integer) config.getProperty(BrokerPool.DISK_SPACE_MIN_PROPERTY);
-        if (min != null)
-            {diskSpaceMin = min * 1024L * 1024L;}
+        this.diskSpaceMin = 1024l * 1024l * config.getProperty(BrokerPool.DISK_SPACE_MIN_PROPERTY, BrokerPool.DEFAULT_DISK_SPACE_MIN);
 
         // fixme! - Shouldn't it be data dir AND journal dir we check
         // rather than EXIST_HOME? /ljo
@@ -79,9 +77,9 @@ public class SyncTask implements SystemTask {
         }
         if(System.currentTimeMillis() - pool.getLastMajorSync() >
                 pool.getMajorSyncPeriod()) {
-            pool.sync(broker, Sync.MAJOR_SYNC);
+            pool.sync(broker, Sync.MAJOR);
         } else {
-            pool.sync(broker, Sync.MINOR_SYNC);
+            pool.sync(broker, Sync.MINOR);
         }
     }
 

--- a/src/org/exist/storage/txn/TransactionException.java
+++ b/src/org/exist/storage/txn/TransactionException.java
@@ -28,17 +28,13 @@ import org.exist.EXistException;
  *
  */
 public class TransactionException extends EXistException {
-
-    /**
-     * 
-     */
     private static final long serialVersionUID = 3617572708582437173L;
 
-    public TransactionException(String message) {
+    public TransactionException(final String message) {
         super(message);
     }
     
-    public TransactionException(String message, Throwable cause) {
+    public TransactionException(final String message, final Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/org/exist/storage/txn/Txn.java
+++ b/src/org/exist/storage/txn/Txn.java
@@ -33,18 +33,13 @@ import org.exist.util.LockException;
 public class Txn implements Transaction {
 
     public enum State { STARTED, ABORTED, COMMITTED, CLOSED }
-
-    private long id;
-
+    
+    private final TransactionManager tm;
+    private final long id;
     private State state;
 
-    private List<LockInfo> locksHeld = new ArrayList<LockInfo>();
-
-    private List<TxnListener> listeners = new ArrayList<TxnListener>();
-    
-    private String originId;
-    
-    private TransactionManager tm;
+    private List<LockInfo> locksHeld = new ArrayList<>();
+    private List<TxnListener> listeners = new ArrayList<>();
 
     public Txn(final TransactionManager tm, final long transactionId) {
         this.tm = tm;
@@ -56,7 +51,7 @@ public class Txn implements Transaction {
         return state;
     }
 
-    protected void setState(State state) {
+    protected void setState(final State state) {
         this.state = state;
     }
 
@@ -64,11 +59,11 @@ public class Txn implements Transaction {
         return id;
     }
     
-    public void registerLock(Lock lock, int lockMode) {
+    public void registerLock(final Lock lock, final int lockMode) {
         locksHeld.add(new LockInfo(lock, lockMode));
     }
     
-    public void acquireLock(Lock lock, int lockMode) throws LockException {
+    public void acquireLock(final Lock lock, final int lockMode) throws LockException {
         lock.acquire(lockMode);
         locksHeld.add(new LockInfo(lock, lockMode));
     }
@@ -81,7 +76,7 @@ public class Txn implements Transaction {
         locksHeld.clear();
     }
 
-    public void registerListener(TxnListener listener) {
+    public void registerListener(final TxnListener listener) {
         listeners.add(listener);
     }
 
@@ -100,31 +95,13 @@ public class Txn implements Transaction {
     }
 
     private static class LockInfo {
-        Lock lock;
-        int lockMode;
+        final Lock lock;
+        final int lockMode;
         
-        public LockInfo(Lock lock, int lockMode) {
+        public LockInfo(final Lock lock, final int lockMode) {
             this.lock = lock;
             this.lockMode = lockMode;
         }
-    }
-    
-    /**
-     * Get origin of transaction
-     * @return Id
-     */
-    public String getOriginId() {
-        return originId;
-    }
-
-    /**
-     *  Set origin of transaction. Purpose is to be able to 
-     * see the origin of the transaction.
-     * 
-     * @param id  Identifier of origin, FQN or URI.
-     */
-    public void setOriginId(String id) {
-        originId = id;
     }
  
     @Override

--- a/src/org/exist/storage/txn/Txn.java
+++ b/src/org/exist/storage/txn/Txn.java
@@ -46,7 +46,7 @@ public class Txn implements Transaction {
     
     private TransactionManager tm;
 
-    public Txn(TransactionManager tm, long transactionId) {
+    public Txn(final TransactionManager tm, final long transactionId) {
         this.tm = tm;
         this.id = transactionId;
         this.state = State.STARTED;

--- a/src/org/exist/util/Configuration.java
+++ b/src/org/exist/util/Configuration.java
@@ -917,7 +917,7 @@ public class Configuration implements ErrorHandler
             }
 
             try {
-                config.put(BrokerPool.DISK_SPACE_MIN_PROPERTY, Integer.valueOf(diskSpace));
+                config.put(BrokerPool.DISK_SPACE_MIN_PROPERTY, Short.valueOf(diskSpace));
             }
             catch( final NumberFormatException nfe ) {
                 LOG.warn( nfe );
@@ -1531,33 +1531,24 @@ public class Configuration implements ErrorHandler
     }
 
 
-    public Object getProperty( String name )
-    {
-        return( config.get( name ) );
+    public Object getProperty(final String name) {
+        return config.get(name);
     }
 
-    public Object getProperty( String name, Object defaultValue )
-    {
-    	final Object value = config.get( name );
-    	
-    	if (value == null)
-    		{return defaultValue;}
-        
-    	return value;
+    public <T> T getProperty(final String name, final T defaultValue) {
+        return Optional.ofNullable((T)config.get(name)).orElse(defaultValue);
     }
 
-    public boolean hasProperty( String name )
-    {
-        return( config.containsKey( name ) );
+    public boolean hasProperty(final String name) {
+        return config.containsKey(name);
     }
 
 
-    public void setProperty( String name, Object obj )
-    {
-        config.put( name, obj );
+    public void setProperty(final String name, final Object obj) {
+        config.put(name, obj);
     }
 
-    public void removeProperty(String name) {
+    public void removeProperty(final String name) {
         config.remove(name);
     }
 
@@ -1570,24 +1561,17 @@ public class Configuration implements ErrorHandler
      *
      * @return  The parsed <code>Boolean</code>
      */
-    public static Boolean parseBoolean(final String value, final boolean defaultValue)
-    {
-        if(value == null) {
-            return Boolean.valueOf(defaultValue);
-        }
-        return Boolean.valueOf("yes".equalsIgnoreCase(value) || "true".equalsIgnoreCase(value));
+    public static boolean parseBoolean(final String value, final boolean defaultValue) {
+        return Optional.ofNullable(value)
+                .map(v -> v.equalsIgnoreCase("yes") || v.equalsIgnoreCase("true"))
+                .orElse(defaultValue);
     }
 
-
-    public int getInteger( String name )
-    {
-        final Object obj = getProperty( name );
-
-        if( ( obj == null ) || !( obj instanceof Integer ) ) {
-            return( -1 );
-        }
-
-        return( ( (Integer)obj ).intValue() );
+    public int getInteger(final String name) {
+        return Optional.ofNullable(getProperty(name))
+                .filter(v -> v instanceof Integer)
+                .map(v -> (int)v)
+                .orElse(-1);
     }
 
 
@@ -1639,17 +1623,20 @@ public class Configuration implements ErrorHandler
     }
     
 
-    public static final class IndexModuleConfig
-    {
-        protected String  id;
-        protected String  className;
-        protected Element config;
+    public static final class IndexModuleConfig {
+        private final String id;
+        private final String className;
+        private final Element config;
 
-        public IndexModuleConfig( String id, String className, Element config )
-        {
-            this.id        = id;
+        public IndexModuleConfig(final String id, final String className, final Element config) {
+            this.id = id;
             this.className = className;
-            this.config    = config;
+            this.config = config;
+        }
+
+        public String getId()
+        {
+            return( id );
         }
 
         public String getClassName()
@@ -1657,16 +1644,9 @@ public class Configuration implements ErrorHandler
             return( className );
         }
 
-
         public Element getConfig()
         {
             return( config );
-        }
-
-
-        public String getId()
-        {
-            return( id );
         }
     }
 

--- a/src/org/exist/util/Configuration.java
+++ b/src/org/exist/util/Configuration.java
@@ -1007,9 +1007,9 @@ public class Configuration implements ErrorHandler
         setProperty( Journal.PROPERTY_RECOVERY_SYNC_ON_COMMIT, parseBoolean( option, true ) );
         LOG.debug( Journal.PROPERTY_RECOVERY_SYNC_ON_COMMIT + ": " + config.get( Journal.PROPERTY_RECOVERY_SYNC_ON_COMMIT ) );
 
-        option = getConfigAttributeValue( recovery, TransactionManager.RECOVERY_GROUP_COMMIT_ATTRIBUTE );
-        setProperty( TransactionManager.PROPERTY_RECOVERY_GROUP_COMMIT, parseBoolean( option, false ) );
-        LOG.debug( TransactionManager.PROPERTY_RECOVERY_GROUP_COMMIT + ": " + config.get( TransactionManager.PROPERTY_RECOVERY_GROUP_COMMIT ) );
+        option = getConfigAttributeValue( recovery, BrokerPool.RECOVERY_GROUP_COMMIT_ATTRIBUTE );
+        setProperty( BrokerPool.PROPERTY_RECOVERY_GROUP_COMMIT, parseBoolean( option, false ) );
+        LOG.debug( BrokerPool.PROPERTY_RECOVERY_GROUP_COMMIT + ": " + config.get( BrokerPool.PROPERTY_RECOVERY_GROUP_COMMIT ) );
 
         option = getConfigAttributeValue( recovery, Journal.RECOVERY_JOURNAL_DIR_ATTRIBUTE );
 
@@ -1042,14 +1042,14 @@ public class Configuration implements ErrorHandler
             }
         }
 
-        option = getConfigAttributeValue( recovery, TransactionManager.RECOVERY_FORCE_RESTART_ATTRIBUTE );
+        option = getConfigAttributeValue( recovery, BrokerPool.RECOVERY_FORCE_RESTART_ATTRIBUTE );
         boolean value = false;
 
         if( option != null ) {
             value = "yes".equals(option);
         }
-        setProperty( TransactionManager.PROPERTY_RECOVERY_FORCE_RESTART, Boolean.valueOf( value ) );
-        LOG.debug( TransactionManager.PROPERTY_RECOVERY_FORCE_RESTART + ": " + config.get( TransactionManager.PROPERTY_RECOVERY_FORCE_RESTART ) );
+        setProperty( BrokerPool.PROPERTY_RECOVERY_FORCE_RESTART, Boolean.valueOf( value ) );
+        LOG.debug( BrokerPool.PROPERTY_RECOVERY_FORCE_RESTART + ": " + config.get( BrokerPool.PROPERTY_RECOVERY_FORCE_RESTART ) );
 
         option = getConfigAttributeValue( recovery, BrokerPool.RECOVERY_POST_RECOVERY_CHECK );
         value  = false;

--- a/src/org/exist/xmldb/LocalCollection.java
+++ b/src/org/exist/xmldb/LocalCollection.java
@@ -145,7 +145,7 @@ public class LocalCollection extends AbstractLocal implements CollectionImpl {
     public void close() throws XMLDBException {
         if (needsSync) {
             withDb((broker, transaction) -> {
-                broker.sync(Sync.MAJOR_SYNC);
+                broker.sync(Sync.MAJOR);
                 return null;
             });
         }

--- a/src/org/exist/xmldb/LocalIndexQueryService.java
+++ b/src/org/exist/xmldb/LocalIndexQueryService.java
@@ -72,7 +72,7 @@ public class LocalIndexQueryService extends AbstractLocalService implements Inde
         final XmldbURI collectionPath = resolve(col);
         withDb((broker, transaction) -> {
             broker.reindexCollection(collectionPath);
-            broker.sync(Sync.MAJOR_SYNC);
+            broker.sync(Sync.MAJOR);
             return null;
         });
     }
@@ -89,7 +89,7 @@ public class LocalIndexQueryService extends AbstractLocalService implements Inde
             try {
                 doc = broker.getXMLResource(collectionPath.append(docName), Lock.READ_LOCK);
                 broker.reindexXMLResource(transaction, doc, DBBroker.IndexMode.STORE);
-                broker.sync(Sync.MAJOR_SYNC);
+                broker.sync(Sync.MAJOR);
                 return null;
             } finally {
                 if(doc != null) {

--- a/src/org/exist/xmlrpc/RpcConnection.java
+++ b/src/org/exist/xmlrpc/RpcConnection.java
@@ -841,7 +841,7 @@ public class RpcConnection implements RpcAPI {
     public boolean sync() {
         try {
             return withDbAsSystem((broker, transaction) -> {
-                broker.sync(Sync.MAJOR_SYNC);
+                broker.sync(Sync.MAJOR);
                 return true;
             });
         } catch(final EXistException | PermissionDeniedException e) {

--- a/test/src/org/exist/storage/AppendTest.java
+++ b/test/src/org/exist/storage/AppendTest.java
@@ -101,7 +101,7 @@ public class AppendTest extends AbstractUpdateTest {
                 proc.reset();
             }
             //DO NOT COMMIT TRANSACTION
-            pool.getTransactionManager().getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
         }
     }
 

--- a/test/src/org/exist/storage/BFileOverflowTest.java
+++ b/test/src/org/exist/storage/BFileOverflowTest.java
@@ -53,7 +53,7 @@ public class BFileOverflowTest {
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             broker.flush();
-            broker.sync(Sync.MAJOR_SYNC);
+            broker.sync(Sync.MAJOR);
 
             final BFile collectionsDb = (BFile) ((NativeBroker) broker).getStorage(NativeBroker.COLLECTIONS_DBX_ID);
             BrokerPool.FORCE_CORRUPTION = true;

--- a/test/src/org/exist/storage/BFileOverflowTest.java
+++ b/test/src/org/exist/storage/BFileOverflowTest.java
@@ -84,8 +84,8 @@ public class BFileOverflowTest {
             }
        
             collectionsDb.remove(txn, key);
-            
-            mgr.getJournal().flushToLog(true);
+
+            pool.getJournalManager().get().flush(true, false);
 
         }
     }

--- a/test/src/org/exist/storage/BFileRecoverTest.java
+++ b/test/src/org/exist/storage/BFileRecoverTest.java
@@ -55,7 +55,7 @@ public class BFileRecoverTest {
         TransactionManager mgr = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             broker.flush();
-            broker.sync(Sync.MAJOR_SYNC);
+            broker.sync(Sync.MAJOR);
 
             final BFile collectionsDb = (BFile) ((NativeBroker) broker).getStorage(NativeBroker.COLLECTIONS_DBX_ID);
             BrokerPool.FORCE_CORRUPTION = true;

--- a/test/src/org/exist/storage/BTreeRecoverTest.java
+++ b/test/src/org/exist/storage/BTreeRecoverTest.java
@@ -96,8 +96,8 @@ public class BTreeRecoverTest {
             
             final IndexQuery idx = new IndexQuery(IndexQuery.GT, new NativeBroker.NodeRef(500, idFact.createInstance(600)));
             domDb.remove(txn, idx, null);
-            
-            mgr.getJournal().flushToLog(true);
+
+            pool.getJournalManager().get().flush(true, false);
             
             Writer writer = new StringWriter();
             domDb.dump(writer);

--- a/test/src/org/exist/storage/ConcurrentStoreTest.java
+++ b/test/src/org/exist/storage/ConcurrentStoreTest.java
@@ -150,7 +150,7 @@ public class ConcurrentStoreTest {
                 transact.commit(transaction);
                 
 //              Don't commit...
-                transact.getJournal().flushToLog(true);
+                pool.getJournalManager().get().flush(true, false);
     	    } catch (Exception e) {
                 e.printStackTrace();
     	        fail(e.getMessage()); 

--- a/test/src/org/exist/storage/CopyCollectionTest.java
+++ b/test/src/org/exist/storage/CopyCollectionTest.java
@@ -161,7 +161,7 @@ public class CopyCollectionTest {
             broker.copyCollection(transaction, test2, dest, XmldbURI.create("test3"));
 
 //DO NOT COMMIT TRANSACTION
-            transact.getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
         }
     }
 

--- a/test/src/org/exist/storage/CopyResourceTest.java
+++ b/test/src/org/exist/storage/CopyResourceTest.java
@@ -182,7 +182,7 @@ public class CopyResourceTest {
 			broker.saveCollection(transaction, testCollection);
 
 //DO NOT COMMIT TRANSACTION
-			pool.getTransactionManager().getJournal().flushToLog(true);
+			pool.getJournalManager().get().flush(true, false);
 		}
 	}
 

--- a/test/src/org/exist/storage/DOMFileRecoverTest.java
+++ b/test/src/org/exist/storage/DOMFileRecoverTest.java
@@ -138,7 +138,7 @@ public class DOMFileRecoverTest {
                 // Don't commit...
                 mgr.commit(txn);
             }
-            mgr.getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
 
             Writer writer = new StringWriter();
             domDb.dump(writer);

--- a/test/src/org/exist/storage/LargeValuesTest.java
+++ b/test/src/org/exist/storage/LargeValuesTest.java
@@ -106,7 +106,7 @@ public class LargeValuesTest {
                 transact.commit(transaction);
             }
 
-            transact.getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
 
             BrokerPool.FORCE_CORRUPTION = true;
 
@@ -121,7 +121,7 @@ public class LargeValuesTest {
                 transact.commit(transaction);
             }
 
-            transact.getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
             file.delete();
         }
     }

--- a/test/src/org/exist/storage/MoveCollectionTest.java
+++ b/test/src/org/exist/storage/MoveCollectionTest.java
@@ -145,7 +145,7 @@ public class MoveCollectionTest {
             broker.moveCollection(transaction, test2, dest, XmldbURI.create("test3"));
 
 //          Don't commit...
-            pool.getTransactionManager().getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
 	    }
     }
 

--- a/test/src/org/exist/storage/MoveResourceTest.java
+++ b/test/src/org/exist/storage/MoveResourceTest.java
@@ -164,7 +164,7 @@ public class MoveResourceTest {
 
             //NOTE: do not commit the transaction
 
-            pool.getTransactionManager().getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
         }
     }
 

--- a/test/src/org/exist/storage/RecoverBinaryTest.java
+++ b/test/src/org/exist/storage/RecoverBinaryTest.java
@@ -96,7 +96,7 @@ public class RecoverBinaryTest {
 //          root.removeBinaryResource(transaction, broker, doc);
             
             //TODO : remove ?
-            transact.getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
 		}
     }
     

--- a/test/src/org/exist/storage/RecoveryTest.java
+++ b/test/src/org/exist/storage/RecoveryTest.java
@@ -154,7 +154,7 @@ public class RecoveryTest {
             test2.removeBinaryResource(transaction, broker, doc);
             
 //DO NOT COMMIT TRANSACTION
-            transact.getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
 
             //DOMFile domDb = ((NativeBroker)broker).getDOMFile();
             //assertNotNull(domDb);

--- a/test/src/org/exist/storage/ReindexTest.java
+++ b/test/src/org/exist/storage/ReindexTest.java
@@ -87,7 +87,7 @@ public class ReindexTest {
             final Txn transaction = transact.beginTransaction();
             broker.reindexCollection(TestConstants.TEST_COLLECTION_URI);
 
-            transact.getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -111,7 +111,7 @@ public class ReindexTest {
             assertNotNull(root);
             transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
             broker.removeCollection(transaction, root);
-            transact.getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
             transact.commit(transaction);
         } catch (Exception e) {
             e.printStackTrace();

--- a/test/src/org/exist/storage/RemoveTest.java
+++ b/test/src/org/exist/storage/RemoveTest.java
@@ -124,7 +124,7 @@ public class RemoveTest extends AbstractUpdateTest {
             }
             
 //DO NOT COMMIT TRANSACTION
-            pool.getTransactionManager().getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
 	    }
     }
 }

--- a/test/src/org/exist/storage/RenameTest.java
+++ b/test/src/org/exist/storage/RenameTest.java
@@ -108,7 +108,7 @@ public class RenameTest extends AbstractUpdateTest {
             proc.reset();
             
 //DO NOT COMMIT TRANSACTION
-            pool.getTransactionManager().getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
         }
     }
 

--- a/test/src/org/exist/storage/ReplaceTest.java
+++ b/test/src/org/exist/storage/ReplaceTest.java
@@ -131,7 +131,7 @@ public class ReplaceTest extends AbstractUpdateTest {
             }
             
 //DO NOT COMMIT TRANSACTION
-            pool.getTransactionManager().getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
 	    } catch (Exception e) {
 	        fail(e.getMessage());             
         }

--- a/test/src/org/exist/storage/UpdateAttributeTest.java
+++ b/test/src/org/exist/storage/UpdateAttributeTest.java
@@ -104,7 +104,7 @@ public class UpdateAttributeTest extends AbstractUpdateTest {
             }
            
 //DO NOT COMMIT TRANSACTION
-            pool.getTransactionManager().getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
         }
     }
 }

--- a/test/src/org/exist/storage/UpdateTest.java
+++ b/test/src/org/exist/storage/UpdateTest.java
@@ -105,7 +105,7 @@ public class UpdateTest extends AbstractUpdateTest {
             }
             
 //DO NOT COMMIT TRANSACTION
-            pool.getTransactionManager().getJournal().flushToLog(true);
+            pool.getJournalManager().get().flush(true, false);
 
         }
     }

--- a/test/src/org/exist/storage/txn/TxnTest.java
+++ b/test/src/org/exist/storage/txn/TxnTest.java
@@ -5,8 +5,10 @@ import org.exist.EXistException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.NativeBroker;
 import org.exist.storage.SystemTaskManager;
-import org.exist.storage.journal.Journal;
+import org.exist.storage.journal.JournalManager;
 import org.junit.Test;
+
+import java.util.Optional;
 
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertEquals;
@@ -191,11 +193,11 @@ public class TxnTest extends EasyMockSupport {
         mockBroker.close();
         expectLastCall().atLeastOnce();
 
-        final Journal mockJournal = createMock(Journal.class);
+        final JournalManager mockJournalManager = createMock(JournalManager.class);
         final SystemTaskManager mockTaskManager = createMock(SystemTaskManager.class);
 
         replay(mockBrokerPool, mockBroker);
 
-        return new TransactionManager(mockBrokerPool, true, mockJournal, false, false, mockTaskManager);
+        return new TransactionManager(mockBrokerPool, Optional.of(mockJournalManager), mockTaskManager);
     }
 }

--- a/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -227,8 +227,8 @@ public class ConstructedNodesRecoveryTest {
 	        //test the child collections exist
 	        testTempChildCollectionExists(broker, transact, "testchild1");
 	        testTempChildCollectionExists(broker, transact, "testchild2");
-	        
-	        transact.getJournal().flushToLog(true);
+
+			pool.getJournalManager().get().flush(true, false);
 	    }
 	}
 	


### PR DESCRIPTION
Until now if you set `<recovery enabled="no"...` in `conf.xml` then eXist would not start up, instead throwing a series of `NullPointerExceptions`.

This occurred because the use of `Txn` has become deeply embedded in eXist, however switching off recovery, would also disable the `TransactionManager` (i.e. set it to `null`).

This patch seperates the concerns of Transactions and Recovery. Enabling eXist still to work in terms of Transactions, yet just disabling the journal (and recovery of which) when recovery is disabled in `conf.xml`.

This PR includes a few pieces of cleanup to related classes, however the main aspect of the change is in the commits:

1. https://github.com/eXist-db/exist/pull/989/commits/5129f36266ec28cb1a59e3cd847b4f720ff77691
2. https://github.com/eXist-db/exist/pull/989/commits/6818ed5a041a7a6e9e85c036122a992ecf33bf8e