### PR TITLE
XQuery profiler should track location of function call, not called class

### DIFF
--- a/src/org/exist/xquery/Profiler.java
+++ b/src/org/exist/xquery/Profiler.java
@@ -181,7 +181,8 @@ public class Profiler {
 
     public final void traceFunctionEnd(Function function, long elapsed) {
         if (stats.isEnabled()) {
-            final String source = String.format("%s [%d:%d]", function.getContext().getXacmlSource().getKey(), function
+            final String source = String.format("%s [%d:%d]", function.getContext().getSource().getKey(),
+                    function
                     .getLine(), function.getColumn());
             stats.recordFunctionCall(function.getSignature().getName(), source, elapsed);
         }

--- a/src/org/exist/xquery/Profiler.java
+++ b/src/org/exist/xquery/Profiler.java
@@ -181,13 +181,8 @@ public class Profiler {
 
     public final void traceFunctionEnd(Function function, long elapsed) {
         if (stats.isEnabled()) {
-            String source;
-            if (function instanceof InternalFunctionCall) {
-                source = ((InternalFunctionCall) function).getFunction().getClass().getName();
-            } else {
-                source = function.getContext().getSource().path();
-            }
-            source = String.format("%s [%d:%d]", source, function.getLine(), function.getColumn());
+            final String source = String.format("%s [%d:%d]", function.getContext().getXacmlSource().getKey(), function
+                    .getLine(), function.getColumn());
             stats.recordFunctionCall(function.getSignature().getName(), source, elapsed);
         }
         if (isLogEnabled()) {

--- a/src/org/exist/xquery/functions/util/Compile.java
+++ b/src/org/exist/xquery/functions/util/Compile.java
@@ -153,6 +153,7 @@ public class Compile extends BasicFunction {
 			error = e.getMessage();
 		} finally {
 			context.popNamespaceContext();
+            pContext.reset(false);
 		}
 		
 		if (isCalledAs("compile")) {


### PR DESCRIPTION
Profiling stats only included the name of the called class for built-in functions. This is useless for profiling: instead you want to see the source location from where the function was called.

Also includes a small memory leak fix for function util:compile.