### PR TITLE
[refactor] Use TransactionManager#beginTransaction instead of DBBroker#beginTx

### DIFF
--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -852,10 +852,6 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
         pool.release(this);
     }
 
-    public Txn beginTx() {
-        return getDatabase().getTransactionManager().beginTransaction();
-    }
-
     /**
      * Represents a {@link Subject} change
      * made to a broker

--- a/test/src/org/exist/storage/MoveOverwriteCollectionTest.java
+++ b/test/src/org/exist/storage/MoveOverwriteCollectionTest.java
@@ -108,17 +108,17 @@ public class MoveOverwriteCollectionTest {
     }
 
     private void store(final DBBroker broker) throws Exception {
-        try(Txn txn = broker.beginTx()) {
+        try(final Txn transaction = broker.getBrokerPool().getTransactionManager().beginTransaction()) {
 
-            test1 = createCollection(txn, broker, TEST_COLLECTION_URI);
-            test2 = createCollection(txn, broker, SUB_TEST_COLLECTION_URI);
-            test3 = createCollection(txn, broker, TEST3_COLLECTION_URI);
+            test1 = createCollection(transaction, broker, TEST_COLLECTION_URI);
+            test2 = createCollection(transaction, broker, SUB_TEST_COLLECTION_URI);
+            test3 = createCollection(transaction, broker, TEST3_COLLECTION_URI);
 
-            store(txn, broker, test1, doc1Name, XML1);
-            store(txn, broker, test2, doc2Name, XML2);
-            store(txn, broker, test3, doc3Name, XML3);
+            store(transaction, broker, test1, doc1Name, XML1);
+            store(transaction, broker, test2, doc2Name, XML2);
+            store(transaction, broker, test3, doc3Name, XML3);
 
-            txn.commit();
+            transaction.commit();
         }
     }
 
@@ -134,10 +134,10 @@ public class MoveOverwriteCollectionTest {
     }
 
     private void move(final DBBroker broker) throws Exception {
-        try (Txn txn = broker.beginTx()) {
+        try(final Txn transaction = broker.getBrokerPool().getTransactionManager().beginTransaction()) {
             Collection root = broker.getCollection(XmldbURI.ROOT_COLLECTION_URI);
-            broker.moveCollection(txn, test3, root, XmldbURI.create("test"));
-            txn.commit();
+            broker.moveCollection(transaction, test3, root, XmldbURI.create("test"));
+            transaction.commit();
         }
     }
 

--- a/test/src/org/exist/storage/MoveOverwriteResourceTest.java
+++ b/test/src/org/exist/storage/MoveOverwriteResourceTest.java
@@ -107,15 +107,14 @@ public class MoveOverwriteResourceTest {
     }
 
     private void store(final DBBroker broker) throws Exception {
-        try(Txn txn = broker.beginTx()) {
+        try(final Txn transaction = broker.getBrokerPool().getTransactionManager().beginTransaction()) {
+            test1 = createCollection(transaction, broker, TEST_COLLECTION_URI);
+            test2 = createCollection(transaction, broker, SUB_TEST_COLLECTION_URI);
 
-            test1 = createCollection(txn, broker, TEST_COLLECTION_URI);
-            test2 = createCollection(txn, broker, SUB_TEST_COLLECTION_URI);
+            store(transaction, broker, test1, doc1Name, XML1);
+            store(transaction, broker, test2, doc2Name, XML2);
 
-            store(txn, broker, test1, doc1Name, XML1);
-            store(txn, broker, test2, doc2Name, XML2);
-
-            txn.commit();
+            transaction.commit();
         }
     }
 
@@ -142,10 +141,10 @@ public class MoveOverwriteResourceTest {
         //create
         index.expectingDocument.add(test2.getURI().append(doc2Name));
 
-        try(Txn txn = broker.beginTx()) {
+        try(final Txn transaction = broker.getBrokerPool().getTransactionManager().beginTransaction()) {
             final DocumentImpl doc = test1.getDocument(broker, doc1Name);
-            broker.moveResource(txn, doc, test2, doc2Name);
-            txn.commit();
+            broker.moveResource(transaction, doc, test2, doc2Name);
+            transaction.commit();
         }
 
         assertTrue(index.expectingDocument.isEmpty());


### PR DESCRIPTION
Currently > 98.2% of the eXist code base uses `TransactionManager#beginTransaction`, this PR reverts the recent introduction of the 4 calls to `DBBroker#beginTx`, and removes the then unused `DBBroker#beginTx`.

My reasoning is that I would rather not introduce a second way alongside the original. I understand that the current approach could be improved, however if a new approach is decided upon there should be a refactoring commit to completely switch from one to the other; until then I would like us to stick to a single approach. One of the reasons being that I have substantial outstanding work in this area, which starts with https://github.com/adamretter/exist/tree/txn-thread, locally I also have major transaction redesign work and more recently the PR https://github.com/eXist-db/exist/pull/989 which I submitted is also related