### PR TITLE
no needs to read db for collection url because it's immutable

### DIFF
--- a/src/org/exist/xmldb/LocalCollection.java
+++ b/src/org/exist/xmldb/LocalCollection.java
@@ -249,7 +249,7 @@ public class LocalCollection extends AbstractLocal implements CollectionImpl {
 
     @Override
     public String getName() throws XMLDBException {
-        return this.<String>read().apply((collection, broker, transaction) -> collection.getURI().toString());
+        return path.toString();
     }
 
     @Override


### PR DESCRIPTION
it also avoid deadlock condition and speedup
