### PR TITLE
[bugfix] fixed configuration of log4j2 for WAR distribution

### DIFF
--- a/build/scripts/dist-war-log4j.xsl
+++ b/build/scripts/dist-war-log4j.xsl
@@ -4,6 +4,10 @@
 
     <!-- Convert log4j2.xml for use in war-file -->
     <xsl:output method="xml"/>
+  
+    <xsl:template match="Property[@name='logs']">
+        <Property name="logs">${web:rootDir}/WEB-INF/logs</Property>
+    </xsl:template>
     
     <xsl:template match="category[@name='org.mortbay']">
     </xsl:template>

--- a/build/scripts/dist.xml
+++ b/build/scripts/dist.xml
@@ -25,15 +25,28 @@
 
         <!-- create war specific configuration files -->
         <xslt in="conf.xml"  out="webapp/WEB-INF/conf.xml"  style="${build.scripts}/dist-war-conf.xsl"/>
-        <xslt in="log4j2.xml" out="webapp/WEB-INF/log4j2.xml" style="${build.scripts}/dist-war-log4j.xsl"/>
+        <xslt in="log4j2.xml" out="webapp/WEB-INF/log4j2.xml" style="${build.scripts}/dist-war-log4j.xsl"/>      
         
+        <!-- fetch war specific libs -->
+        <property name="log4j2.version" value="2.6"/>
+        <property name="log4j2.url" value="http://archive.apache.org/dist/logging/log4j/${log4j2.version}/apache-log4j-${log4j2.version}-bin.zip"/>
+        <taskdef name="fetch" classname="nl.ow.dilemma.ant.fetch.FetchTask" classpathref="classpath.core"/>
+        <mkdir dir="webapp/WEB-INF/temp/lib"/>    
+        <fetch classpathref="classpath.core" dest="webapp/WEB-INF/temp/lib"
+        url="${log4j2.url}" usecache="true">
+              <patternset>
+                    <include name="**/log4j-web-*.jar"/>
+                    <exclude name="**/log4j-web-*-javadoc.jar"/>
+                    <exclude name="**/log4j-web-*-sources.jar"/>
+              </patternset>
+        </fetch>
     </target>
 
     <!-- ================================================================== -->
     <!-- Create .war file                                                   -->
     <!-- ================================================================== -->
     <target name="dist-war" depends="git.details,webapps" description="Create war file">
-        <war destfile="${dist}/exist-${project.version}-${git.commit}.war" webxml="webapp/WEB-INF/web.xml">
+      <war destfile="${dist}/exist-${project.version}-${git.commit}.war" webxml="webapp/WEB-INF/web.xml">
                 
             <!-- Add files to WEB-INF/lib -->
             <lib dir=".">
@@ -102,7 +115,9 @@
             <lib dir="extensions/modules/lib">
                 <include name="*.jar"/>
             </lib>
-            
+            <lib dir="webapp/WEB-INF/temp/lib">
+              <include name="*.jar"/>
+            </lib>
 
             <!-- Add configuration files to WEB-INF -->
             <webinf dir=".">
@@ -158,6 +173,7 @@
             </manifest>
 
         </war>
+        <delete dir="webapp/WEB-INF/temp"/>
     </target>
     
     <!-- ================================================================== -->


### PR DESCRIPTION
- download `log4j-web.jar` to a temporary folder; include in WAR; delete temporary folder
  NOTE: since `log4j-web.jar` must have the same release version of the log4j files in the eXist distribution, I've used inline properties for declaring the version number; there are probably better ways
- change path to the log folder in the generated `log4j2.xml` configuration file