### PR TITLE
[bugfix] Make sure to normalize exist.home

### DIFF
--- a/bin/functions.d/eXist-settings.sh
+++ b/bin/functions.d/eXist-settings.sh
@@ -14,10 +14,14 @@ get_exist_home() {
 		(cd $(/usr/bin/dirname "$p") ; /bin/pwd)
 }
 
+resolve_dir() {
+    (builtin cd `dirname "${1/#~/$HOME}"`'/'`basename "${1/#~/$HOME}"` 2>/dev/null; if [ $? -eq 0 ]; then pwd; fi)
+}
+
 check_exist_home() {
     if [ -z "${EXIST_HOME}" ]; then
 	EXIST_HOME_1=$(get_exist_home "$1");
-	EXIST_HOME="$EXIST_HOME_1/..";
+	EXIST_HOME=`resolve_dir "$EXIST_HOME_1/.."`;
     fi
 
     if [ ! -f "${EXIST_HOME}/start.jar" ]; then

--- a/src/org/exist/jetty/JettyStart.java
+++ b/src/org/exist/jetty/JettyStart.java
@@ -129,13 +129,12 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
 
         logger.info("Running as user '" 
                 + System.getProperty("user.name", "(unknown user.name)") + "'");
-
+        logger.info("[eXist Home : "
+                + System.getProperty("exist.home", "unknown") + "]");
         logger.info("[eXist Version : " 
                 + SystemProperties.getInstance().getSystemProperty("product-version", "unknown") + "]");
         logger.info("[eXist Build : " 
                 + SystemProperties.getInstance().getSystemProperty("product-build", "unknown") + "]");
-        logger.info("[eXist Home : " 
-                + SystemProperties.getInstance().getSystemProperty("exist.home", "unknown") + "]");
         logger.info("[Git commmit : " 
                 + SystemProperties.getInstance().getSystemProperty("git-commit", "unknown") + "]");
         

--- a/src/org/exist/start/Main.java
+++ b/src/org/exist/start/Main.java
@@ -89,7 +89,7 @@ public class Main {
     static Path getDirectory(final String name) {
         try {
             if (name != null) {
-                final Path dir = Paths.get(name).toAbsolutePath();
+                final Path dir = Paths.get(name).normalize().toAbsolutePath();
                 if (Files.isDirectory(dir)) {
                     return dir;
                 }


### PR DESCRIPTION
Previously `EXIST_HOME` / `exist.home`, and subsequently `jetty.home` and could look like for example:

```bash
[eXist Home : /Users/aretter/code/exist-git/bin/..] 
[jetty.home : /Users/aretter/code/exist-git/bin/../tools/jetty]
```

these changes ensure the paths are normalized, so the paths now correctly look like:

```bash
[eXist Home : /Users/aretter/code/exist-git] 
[jetty.home : /Users/aretter/code/exist-git/tools/jetty]
```