### PR TITLE
Make last-account-id and last-group-id virtual.

### DIFF
--- a/src/org/exist/security/AbstractRealm.java
+++ b/src/org/exist/security/AbstractRealm.java
@@ -1,23 +1,21 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2011 The eXist Project
+ *  Copyright (C) 2001-2016 The eXist Project
  *  http://exist-db.org
- *  
+ *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
  *  as published by the Free Software Foundation; either version 2
  *  of the License, or (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.security;
 
@@ -65,7 +63,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
     protected final PrincipalDbByName<Group> groupsByName = new PrincipalDbByName<>();
     
 
-    private SecurityManager sm;
+    private SecurityManagerImpl sm;
 
     protected Configuration configuration;
 
@@ -75,7 +73,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
     protected Collection collectionRemovedAccounts = null;
     protected Collection collectionRemovedGroups = null;
 	
-    public AbstractRealm(SecurityManager sm, Configuration config) {
+    public AbstractRealm(SecurityManagerImpl sm, Configuration config) {
         this.sm = sm;
         this.configuration = Configurator.configure(this, config);
     }
@@ -86,7 +84,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
     }
 
     @Override
-    public SecurityManager getSecurityManager() {
+    public SecurityManagerImpl getSecurityManager() {
         return sm;
     }
     
@@ -126,7 +124,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
                         //Group group = instantiateGroup(this, conf);
                         final GroupImpl group = new GroupImpl(r, conf);
 
-                        getSecurityManager().addGroup(group.getId(), group);
+                        getSecurityManager().registerGroup(group);
                         principalDb.put(group.getName(), group);
 
                         //set collection
@@ -152,7 +150,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
                     final GroupImpl group = new GroupImpl(this, conf);
                     group.removed = true;
                     
-                    getSecurityManager().addGroup(group.getId(), group);
+                    getSecurityManager().registerGroup(group);
                 }
             }
         }
@@ -180,7 +178,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
                             return;
                         }
 
-                        getSecurityManager().addUser(account.getId(), account);
+                        getSecurityManager().registerAccount(account);
                         principalDb.put(account.getName(), account);
 
                         //set collection
@@ -206,7 +204,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
 	            final AccountImpl account = new AccountImpl( this, conf );
 	            account.removed = true;
 		    
-                    getSecurityManager().addUser(account.getId(), account);
+                    getSecurityManager().registerAccount(account);
                 }
             }
         }

--- a/src/org/exist/security/SecurityManager.java
+++ b/src/org/exist/security/SecurityManager.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2015 The eXist Project
+ *  Copyright (C) 2001-2016 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -107,10 +107,6 @@ public interface SecurityManager extends Configurable {
    
    @Deprecated
    Subject getSubjectBySessionId(String sessionid);
-
-   void addGroup(int id, Group group);
-
-   void addUser(int id, Account account);
 
    boolean hasGroup(int id);
 

--- a/src/org/exist/security/internal/RealmImpl.java
+++ b/src/org/exist/security/internal/RealmImpl.java
@@ -1,23 +1,21 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2010-2011 The eXist Project
+ *  Copyright (C) 2001-2016 The eXist Project
  *  http://exist-db.org
- *  
+ *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
  *  as published by the Free Software Foundation; either version 2
  *  of the License, or (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.security.internal;
 
@@ -70,12 +68,10 @@ public class RealmImpl extends AbstractRealm {
     public final static int ADMIN_ACCOUNT_ID = 1048574;
     public final static int GUEST_ACCOUNT_ID = 1048573;
     public final static int UNKNOWN_ACCOUNT_ID = 1048572;
-    public final static int INITIAL_LAST_ACCOUNT_ID = 10;
 
     public final static int DBA_GROUP_ID = 1048575;
     public final static int GUEST_GROUP_ID = 1048574;
     public final static int UNKNOWN_GROUP_ID = 1048573;
-    public final static int INITIAL_LAST_GROUP_ID = 10;
 
     protected final AccountImpl ACCOUNT_SYSTEM;
     protected final AccountImpl ACCOUNT_UNKNOWN;
@@ -94,40 +90,31 @@ public class RealmImpl extends AbstractRealm {
 
     	super(sm, config);
 
-    	sm.lastUserId = INITIAL_LAST_ACCOUNT_ID;     //TODO this is horrible!
-    	sm.lastGroupId = INITIAL_LAST_GROUP_ID;    //TODO this is horrible!
-        
         //DBA group
         GROUP_DBA = new GroupImpl(this, DBA_GROUP_ID, SecurityManager.DBA_GROUP);
         GROUP_DBA.setManagers(new ArrayList<Reference<SecurityManager, Account>>(){
             { add(new ReferenceImpl<>(sm, "getAccount", SecurityManager.DBA_USER)); }
         });
         GROUP_DBA.setMetadataValue(EXistSchemaType.DESCRIPTION, "Database Administrators");
-    	sm.addGroup(GROUP_DBA.getId(), GROUP_DBA);
+        sm.registerGroup(GROUP_DBA);
         registerGroup(GROUP_DBA);
-        //sm.groupsById.put(GROUP_DBA.getId(), GROUP_DBA);
-    	//groupsByName.put(GROUP_DBA.getName(), GROUP_DBA);
-        
+
         //System account
     	ACCOUNT_SYSTEM = new AccountImpl(this, SYSTEM_ACCOUNT_ID, SecurityManager.SYSTEM, "", GROUP_DBA, true);
         ACCOUNT_SYSTEM.setMetadataValue(AXSchemaType.FULLNAME, SecurityManager.SYSTEM);
         ACCOUNT_SYSTEM.setMetadataValue(EXistSchemaType.DESCRIPTION, "System Internals");
-        sm.addUser(ACCOUNT_SYSTEM.getId(), ACCOUNT_SYSTEM);
+        sm.registerAccount(ACCOUNT_SYSTEM);
         registerAccount(ACCOUNT_SYSTEM);
-    	//sm.usersById.put(ACCOUNT_SYSTEM.getId(), ACCOUNT_SYSTEM);
-    	//usersByName.put(ACCOUNT_SYSTEM.getName(), ACCOUNT_SYSTEM);
-        
+
         //guest group
         GROUP_GUEST = new GroupImpl(this, GUEST_GROUP_ID, SecurityManager.GUEST_GROUP);
         GROUP_GUEST.setManagers(new ArrayList<Reference<SecurityManager, Account>>(){
             { add(new ReferenceImpl<>(sm, "getAccount", SecurityManager.DBA_USER)); }
         });
         GROUP_GUEST.setMetadataValue(EXistSchemaType.DESCRIPTION, "Anonymous Users");
-        sm.addGroup(GROUP_GUEST.getId(), GROUP_GUEST);
+        sm.registerGroup(GROUP_GUEST);
         registerGroup(GROUP_GUEST);
-    	//sm.groupsById.put(GROUP_GUEST.getId(), GROUP_GUEST);
-    	//groupsByName.put(GROUP_GUEST.getName(), GROUP_GUEST);
-        
+
         //unknown account and group
         GROUP_UNKNOWN = new GroupImpl(this, UNKNOWN_GROUP_ID, "");
     	ACCOUNT_UNKNOWN = new AccountImpl(this, UNKNOWN_ACCOUNT_ID, "", (String)null, GROUP_UNKNOWN);
@@ -210,7 +197,7 @@ public class RealmImpl extends AbstractRealm {
                     LOG.warn(e.getMessage(), e);
                 }
 
-                getSecurityManager().addUser(remove_account.getId(), remove_account);
+                getSecurityManager().registerAccount(remove_account);
                 principalDb.remove(remove_account.getName());
             }
         });
@@ -246,7 +233,7 @@ public class RealmImpl extends AbstractRealm {
                 LOG.warn(e.getMessage(), e);
             }
 
-            getSecurityManager().addGroup(remove_group.getId(), (Group)remove_group);
+            getSecurityManager().registerGroup((Group)remove_group);
             principalDb.remove(remove_group.getName());
         });
         

--- a/src/org/exist/security/internal/SecurityManagerImpl.java
+++ b/src/org/exist/security/internal/SecurityManagerImpl.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2015 The eXist Project
+ *  Copyright (C) 2001-2016 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
@@ -96,14 +97,14 @@ public class SecurityManagerImpl implements SecurityManager {
     private final PrincipalLocks<Account> accountLocks = new PrincipalLocks<>();
     private final PrincipalLocks<Group> groupLocks = new PrincipalLocks<>();
 
-    //TODO: validate & remove if session timeout
     private SessionDb sessions = new SessionDb();
 
-    @ConfigurationFieldAsAttribute("last-account-id")
-    protected int lastUserId = 0;
+    public final static int INITIAL_LAST_ACCOUNT_ID = 10;
+    public final static int INITIAL_LAST_GROUP_ID = 10;
 
-    @ConfigurationFieldAsAttribute("last-group-id")
-    protected int lastGroupId = 0;
+    //calculated runtime
+    protected int lastAccountId = INITIAL_LAST_ACCOUNT_ID;
+    protected int lastGroupId = INITIAL_LAST_GROUP_ID;
 
     @ConfigurationFieldAsAttribute("version")
     private String version = "2.0";
@@ -483,18 +484,29 @@ public class SecurityManagerImpl implements SecurityManager {
         return db;
     }
 
-    private synchronized int getNextGroupId() {
-        if(lastGroupId + 1 == MAX_GROUP_ID) {
-            throw new RuntimeException("System has no more group-ids available");            
-        }
-        return ++lastGroupId;
+    private int getNextGroupId() {
+        AtomicInteger nextId = new AtomicInteger();
+        groupsById.modify(principalDb -> {
+            if(lastGroupId + 1 >= MAX_GROUP_ID) {
+                throw new RuntimeException("System has no more group-ids available");
+            }
+            nextId.set(++lastGroupId);
+        });
+
+        return nextId.get();
+
     }
 
-    private synchronized int getNextAccountId() {
-        if(lastUserId +1 == MAX_USER_ID) {
-            throw new RuntimeException("System has no more user-ids available");
-        }
-        return ++lastUserId;
+    private int getNextAccountId() {
+        AtomicInteger nextId = new AtomicInteger();
+        usersById.modify(principalDb -> {
+            if(lastAccountId +1 >= MAX_USER_ID) {
+                throw new RuntimeException("System has no more user-ids available");
+            }
+            nextId.set(++lastAccountId);
+        });
+
+        return nextId.get();
     }
 
     @Override
@@ -568,11 +580,9 @@ public class SecurityManagerImpl implements SecurityManager {
         final Lock lock = groupLocks.getWriteLock(newGroup);
         lock.lock();
         try {
-            groupsById.modify(principalDb -> principalDb.put(id, newGroup));
-            
+            registerGroup(newGroup);
             registeredRealm.registerGroup(newGroup);
 
-            save();
             newGroup.save();
 
             return newGroup;
@@ -606,12 +616,9 @@ public class SecurityManagerImpl implements SecurityManager {
         final Lock lock = accountLocks.getWriteLock(newAccount);
         lock.lock();
         try {
-            usersById.modify(principalDb -> principalDb.put(id, newAccount));
-            
+            registerAccount(newAccount);
             registeredRealm.registerAccount(newAccount);
 
-            //XXX: one transaction?
-            save();
             newAccount.save();
 
             return newAccount;
@@ -643,29 +650,14 @@ public class SecurityManagerImpl implements SecurityManager {
         final Lock lock = accountLocks.getWriteLock(newAccount);
         lock.lock();
         try {
-            usersById.modify(principalDb -> principalDb.put(id, newAccount));
-            
+            registerAccount(newAccount);
             registeredRealm.registerAccount(newAccount);
 
-            //XXX: one transaction?
-            save(broker);
             newAccount.save(broker);
 
             return newAccount;
         } finally {
             lock.unlock();
-        }
-    }
-
-    private void save() throws PermissionDeniedException, EXistException {
-        if (configuration != null) {
-            configuration.save();
-        }
-    }
-        
-    private void save(final DBBroker broker) throws PermissionDeniedException, EXistException {
-        if (configuration != null) {
-            configuration.save(broker);
         }
     }
 
@@ -753,15 +745,41 @@ public class SecurityManagerImpl implements SecurityManager {
         }
         throw new ConfigurationException("Realm id = '" + realmId + "' not found.");
     }
-    
-    @Override
-    public void addGroup(final int id, final Group group) {
-        groupsById.modify(principalDb -> principalDb.put(id, group));
+
+    /**
+     * Register mapping id to group.
+     *
+     * @param group
+     */
+    public void registerGroup(final Group group) {
+        groupsById.modify(principalDb -> {
+
+            final int id = group.getId();
+
+            principalDb.put(id, group);
+
+            if (id < MAX_GROUP_ID) {
+                lastGroupId = Math.max(lastGroupId, id);
+            }
+        });
     }
 
-    @Override
-    public void addUser(final int id, final Account account) {
-        usersById.modify(principalDb -> principalDb.put(id, account));
+    /**
+     * Register mapping id to account.
+     *
+     * @param account
+     */
+    public void registerAccount(final Account account) {
+        usersById.modify(principalDb -> {
+
+            final int id = account.getId();
+
+            principalDb.put(id, account);
+
+            if (id < MAX_USER_ID) {
+                lastAccountId = Math.max(lastAccountId, id);
+            }
+        });
     }
 
     @Override
@@ -895,7 +913,7 @@ public class SecurityManagerImpl implements SecurityManager {
                 if (isRemoved && id > 2 && !hasUser(id)) {
                     final AccountImpl account = new AccountImpl( realm, conf );
                     account.removed = true;
-                    addUser(account.getId(), account);
+                    registerAccount(account);
                 } else if(name != null) {
                 	if (realm.hasAccount(name)) {
                 		final Integer oldId = saving.get(document.getURI());
@@ -918,7 +936,7 @@ public class SecurityManagerImpl implements SecurityManager {
             			}
                 	} else {
                 		final Account account = new AccountImpl( realm, conf );
-                		addUser(account.getId(), account);
+                        registerAccount(account);
                 		realm.registerAccount(account);
                 	}
                 } else {
@@ -930,10 +948,10 @@ public class SecurityManagerImpl implements SecurityManager {
                 if (isRemoved && id > 2 && !hasGroup(id)) {
                     final GroupImpl group = new GroupImpl( realm, conf );
                     group.removed = true;
-                    addGroup(group.getId(), group);
+                    registerGroup(group);
                 } else if (name != null && !realm.hasGroup(name)) {
                     final GroupImpl group = new GroupImpl( realm, conf );
-                    addGroup(group.getId(), group);
+                    registerGroup(group);
                     realm.registerGroup(group);
                 } else {
                     //this can't be! log any way
@@ -1043,16 +1061,12 @@ public class SecurityManagerImpl implements SecurityManager {
     }
 
     @Override
-    public final synchronized void preAllocateAccountId(final PrincipalIdReceiver receiver) throws PermissionDeniedException, EXistException {
-        final int id = getNextAccountId();
-        save();
-        receiver.allocate(id);
+    public final void preAllocateAccountId(final PrincipalIdReceiver receiver) throws PermissionDeniedException, EXistException {
+        receiver.allocate(getNextAccountId());
     }
 
     @Override
-    public final synchronized void preAllocateGroupId(final PrincipalIdReceiver receiver) throws PermissionDeniedException, EXistException {
-        final int id = getNextGroupId();
-        save();
-        receiver.allocate(id);
+    public final void preAllocateGroupId(final PrincipalIdReceiver receiver) throws PermissionDeniedException, EXistException {
+        receiver.allocate(getNextGroupId());
     }
 }

--- a/test/src/org/exist/security/internal/BackupRestoreSecurityPrincipalsTest.java
+++ b/test/src/org/exist/security/internal/BackupRestoreSecurityPrincipalsTest.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2014 The eXist Project
+ *  Copyright (C) 2001-2016 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -16,18 +16,17 @@
  *  You should have received a copy of the GNU Lesser General Public
  *  License along with this library; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
  */
-package org.exist.backup;
+package org.exist.security.internal;
 
 import org.exist.EXistException;
+import org.exist.backup.Backup;
+import org.exist.backup.Restore;
 import org.exist.backup.restore.listener.RestoreListener;
 import org.exist.jetty.JettyStart;
 import static org.exist.repo.AutoDeploymentTrigger.AUTODEPLOY_PROPERTY;
 import org.exist.security.*;
 import org.exist.security.SecurityManager;
-import org.exist.security.internal.RealmImpl;
 import org.exist.security.internal.aider.GroupAider;
 import org.exist.security.internal.aider.UserAider;
 import org.exist.storage.BrokerPool;
@@ -90,9 +89,11 @@ public class BackupRestoreSecurityPrincipalsTest {
     @Before
     public void setup() throws PermissionDeniedException, EXistException, XMLDBException, SAXException, IOException, DatabaseConfigurationException, AuthenticationException {
         //we need to temporarily disable the auto-deploy trigger, as deploying eXide creates user accounts which interferes with this test
-	autodeploy = System.getProperty(AUTODEPLOY_PROPERTY, "off");
-	System.setProperty(AUTODEPLOY_PROPERTY, "off");
+        autodeploy = System.getProperty(AUTODEPLOY_PROPERTY, "off");
+        System.setProperty(AUTODEPLOY_PROPERTY, "off");
 
+        //make sure that data folder is empty
+        deleteDatabaseFiles();
         startupDatabase();
 
         createUser(FRANK_USER, FRANK_USER);   //should have id RealmImpl.INITIAL_LAST_ACCOUNT_ID + 1
@@ -181,6 +182,8 @@ public class BackupRestoreSecurityPrincipalsTest {
         final Collection root = DatabaseManager.getCollection("xmldb:exist:///db", "admin", "");
         final XPathQueryService xqs = (XPathQueryService) root.getService("XPathQueryService", "1.0");
 
+        final SecurityManagerImpl sm = (SecurityManagerImpl) BrokerPool.getInstance().getSecurityManager();
+
         //create new users: 'frank' and 'jack'
         createUser(FRANK_USER, FRANK_USER);   // should have id RealmImpl.INITIAL_LAST_ACCOUNT_ID + 1
         createUser(JACK_USER, JACK_USER);     // should have id RealmImpl.INITIAL_LAST_ACCOUNT_ID + 2
@@ -194,14 +197,11 @@ public class BackupRestoreSecurityPrincipalsTest {
         ResourceSet result = xqs.query(accountQuery);
         assertUser(RealmImpl.ADMIN_ACCOUNT_ID, SecurityManager.DBA_USER, ((XMLResource) result.getResource(0)).getContentAsDOM());
         assertUser(RealmImpl.GUEST_ACCOUNT_ID, SecurityManager.GUEST_USER, ((XMLResource) result.getResource(1)).getContentAsDOM());
-        assertUser(RealmImpl.INITIAL_LAST_ACCOUNT_ID + 1, "frank", ((XMLResource) result.getResource(2)).getContentAsDOM());
-        assertUser(RealmImpl.INITIAL_LAST_ACCOUNT_ID + 2, "jack", ((XMLResource) result.getResource(3)).getContentAsDOM());
+        assertUser(SecurityManagerImpl.INITIAL_LAST_ACCOUNT_ID + 1, "frank", ((XMLResource) result.getResource(2)).getContentAsDOM());
+        assertUser(SecurityManagerImpl.INITIAL_LAST_ACCOUNT_ID + 2, "jack", ((XMLResource) result.getResource(3)).getContentAsDOM());
 
         //check the last user id
-        final String lastAccountIdQuery = "declare namespace c = 'http://exist-db.org/Configuration';\n" +
-            "//c:security-manager/string(@last-account-id)";
-        result = xqs.query(lastAccountIdQuery);
-        assertEquals(RealmImpl.INITIAL_LAST_ACCOUNT_ID + 2, Integer.parseInt(result.getResource(0).getContent().toString())); //last account id should be that of 'jack'
+        assertEquals(SecurityManagerImpl.INITIAL_LAST_ACCOUNT_ID + 2, sm.lastAccountId); //last account id should be that of 'jack'
 
         //create a test collection and give everyone access
         final CollectionManagementService cms = (CollectionManagementService)root.getService("CollectionManagementService", "1.0");
@@ -232,13 +232,12 @@ public class BackupRestoreSecurityPrincipalsTest {
         result = xqs.query(accountQuery);
         assertUser(RealmImpl.ADMIN_ACCOUNT_ID, SecurityManager.DBA_USER, ((XMLResource) result.getResource(0)).getContentAsDOM());
         assertUser(RealmImpl.GUEST_ACCOUNT_ID, SecurityManager.GUEST_USER, ((XMLResource) result.getResource(1)).getContentAsDOM());
-        assertUser(RealmImpl.INITIAL_LAST_ACCOUNT_ID + 1, "frank", ((XMLResource) result.getResource(2)).getContentAsDOM());
-        assertUser(RealmImpl.INITIAL_LAST_ACCOUNT_ID + 2, "jack", ((XMLResource) result.getResource(3)).getContentAsDOM());
-        assertUser(RealmImpl.INITIAL_LAST_ACCOUNT_ID + 4, "joe", ((XMLResource) result.getResource(4)).getContentAsDOM()); //this is `+ 4` because pre-allocating an id skips one
+        assertUser(SecurityManagerImpl.INITIAL_LAST_ACCOUNT_ID + 1, FRANK_USER, ((XMLResource) result.getResource(2)).getContentAsDOM());
+        assertUser(SecurityManagerImpl.INITIAL_LAST_ACCOUNT_ID + 2, JACK_USER, ((XMLResource) result.getResource(3)).getContentAsDOM());
+        assertUser(SecurityManagerImpl.INITIAL_LAST_ACCOUNT_ID + 3, JOE_USER, ((XMLResource) result.getResource(4)).getContentAsDOM());
 
         //check the last user id after the restore
-        result = xqs.query(lastAccountIdQuery);
-        assertEquals(RealmImpl.INITIAL_LAST_ACCOUNT_ID + 4, Integer.parseInt(result.getResource(0).getContent().toString())); //last account id should be that of 'joe'
+        assertEquals(SecurityManagerImpl.INITIAL_LAST_ACCOUNT_ID + 3, sm.lastAccountId); //last account id should be that of 'joe'
 
         //check the owner of frank's document after restore
         final Resource fDoc = test.getResource(FRANKS_DOCUMENT);


### PR DESCRIPTION
Fields last-account-id and last-group-id did keep state of last id. That bring in few problems. For example, that state go to backup and restore to none empty database lead to state corruption.

That PR make it virtual and calculate it runtime. Next PR will fix ids conflict.
