### PR TITLE
Fix path to yajsw in dist build target

### DIFF
--- a/build/scripts/dist.xml
+++ b/build/scripts/dist.xml
@@ -329,7 +329,7 @@
             </fileset>
         </chmod>
         <chmod perm="+x">
-            <fileset dir="${dist.dir}/yajsw/bin">
+            <fileset dir="${dist.dir}/tools/yajsw/bin">
                 <include name="*.sh"/>
             </fileset>
         </chmod>


### PR DESCRIPTION
The build was failing on the dist step:

> BUILD FAILED
> /Users/joe/workspace/exist/build/scripts/dist.xml:331: /Users/joe/workspace/exist/dist/eXist-db-3.0.RC2/yajsw/bin does not exist.

This fixes the path to yajsw, allowing the build to complete successfully