### PR TITLE
Small fix to jetty configuration

### DIFF
--- a/tools/jetty/webapps/exist-webapp-context.xml
+++ b/tools/jetty/webapps/exist-webapp-context.xml
@@ -19,6 +19,6 @@
     </Set>
     <Call name="setAttribute">
         <Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
-        <Arg>.*/[^/]*servlet-api-[^/]*\.jar$|.*/javax.servlet.jsp.jstl-.*\.jar$|.*/org.apache.taglibs.taglibs-standard-impl-.*\.jar$</Arg>
+        <Arg>.*/[^/]*servlet-api-[^/]*\.jar$|.*/javax.servlet.jsp.jstl-.*\.jar$|.*/org.apache.taglibs.taglibs-standard-impl-.*\.jar$|.*/content/.*\.jar$</Arg>
     </Call>
 </Configure>


### PR DESCRIPTION
Jetty should scan jars provided by installed expath packages, so they can provide additional servlets without modifying eXist core. This used to work previously but failed after the Jetty 9 update.