### PR TITLE
[refactor] Extract jarsigner props to build.properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -18,6 +18,12 @@ build.compiler=modern
 build.compiler.source=1.8
 build.compiler.target=1.8
 
+# jarsigner settings
+keystore.alias = exist
+keystore.password = secret
+keystore.file = key.store
+keystore.validity = 100000
+
 autodeploy=dashboard,shared,eXide
 autodeploy.repo=http://demo.exist-db.org/exist/apps/public-repo
 use.autodeploy.feature=true

--- a/build/scripts/jarsigner.xml
+++ b/build/scripts/jarsigner.xml
@@ -22,12 +22,6 @@
     
     <description>Sign jarfiles for eXist webstart application</description>
     
-    <!-- Set sign properties -->
-    <property name="keystore.alias" value="exist"/>
-    <property name="keystore.password" value="secret"/>
-    <property name="keystore.file" value="key.store"/>
-    <property name="keystore.validity" value="100000"/>
-    
     <!-- Check wether the keystore already exists -->
     <available file="${keystore.file}" property="keystore.present"/>
     


### PR DESCRIPTION
This allows the jarsigner properties to be overriden in `local.build.properties`.

I would like this so that it makes producing signed jars from on the nightly builds server easier as `local.build.properties` is not under the control of Git and so I can have this point to a keystore outside of `$EXIST_HOME` without worrying about doing a git pull and getting merge conflicts.