### PR TITLE
[refactor] Switch to using JUnit Rule for starting and stopping XML:DB embedded database

### DIFF
--- a/test/src/org/exist/collections/triggers/CollectionTriggerTest.java
+++ b/test/src/org/exist/collections/triggers/CollectionTriggerTest.java
@@ -3,24 +3,23 @@ package org.exist.collections.triggers;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.security.PermissionDeniedException;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.xmldb.api.base.Collection;
 import org.exist.xmldb.CollectionManagementServiceImpl;
-import org.exist.xmldb.DatabaseInstanceManager;
 import org.exist.xmldb.IndexQueryService;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.XMLDBException;
+
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 
 public class CollectionTriggerTest {
 
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
     private final static String TEST_COLLECTION = "testCollectionTrigger";
-    private static Collection root;
     private static Collection testCollection;
     private static CollectionManagementServiceImpl rootSrv;
 
@@ -66,42 +65,15 @@ public class CollectionTriggerTest {
 
     /** just start the DB and create the test collection */
     @BeforeClass
-    public static void startDB() {
-        try {
-            // initialize driver
-            Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-            Database database = (Database) cl.newInstance();
-            database.setProperty("create-database", "true");
-            DatabaseManager.registerDatabase(database);
-
-            root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-            assertNotNull(root);
-
-            rootSrv = (CollectionManagementServiceImpl)root.getService("CollectionManagementService", "1.0");
-        } catch (ClassNotFoundException e) {
-            fail(e.getMessage());
-        } catch (InstantiationException e) {
-            fail(e.getMessage());
-        } catch (IllegalAccessException e) {
-            fail(e.getMessage());
-        } catch (XMLDBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+    public static void startDB() throws XMLDBException {
+        rootSrv = (CollectionManagementServiceImpl)existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
     }
 
     @AfterClass
     public static void shutdownDB() {
         TestUtils.cleanupDB();
-        try {
-            org.xmldb.api.base.Collection root = DatabaseManager.getCollection("xmldb:exist://" + XmldbURI.ROOT_COLLECTION, "admin", "");
-            DatabaseInstanceManager mgr = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-            mgr.shutdown();
-        } catch (XMLDBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
         testCollection = null;
+        rootSrv = null;
     }
 
     private final static String COLLECTION_CONFIG =

--- a/test/src/org/exist/collections/triggers/TriggerConfigTest.java
+++ b/test/src/org/exist/collections/triggers/TriggerConfigTest.java
@@ -21,15 +21,13 @@ package org.exist.collections.triggers;
 
 import java.util.Arrays;
 import org.exist.TestUtils;
-import org.exist.xmldb.DatabaseInstanceManager;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.xmldb.IndexQueryService;
-import org.exist.xmldb.XmldbURI;
-import org.junit.After;
-import org.junit.AfterClass;
+import org.junit.*;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -47,6 +45,9 @@ import org.junit.runners.Parameterized.Parameters;
  */
 @RunWith(Parameterized.class)
 public class TriggerConfigTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     @Parameters(name = "{0}")
     public static java.util.Collection<Object[]> data() {
@@ -194,39 +195,18 @@ public class TriggerConfigTest {
     }
 
     @BeforeClass
-    public static void initDB() {
-        // initialize XML:DB driver
-        try {
-            Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-            Database database = (Database) cl.newInstance();
-            database.setProperty("create-database", "true");
-            DatabaseManager.registerDatabase(database);
+    public static void initDB() throws XMLDBException {
+        CollectionManagementService mgmt = (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
+        Collection testCol = mgmt.createCollection("triggers");
 
-            Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-            CollectionManagementService mgmt = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
-            Collection testCol = mgmt.createCollection("triggers");
-
-            for (int i = 1; i <= 2; i++) {
-                mgmt = (CollectionManagementService) testCol.getService("CollectionManagementService", "1.0");
-                testCol = mgmt.createCollection("sub" + i);
-            }
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        for (int i = 1; i <= 2; i++) {
+            mgmt = (CollectionManagementService) testCol.getService("CollectionManagementService", "1.0");
+            testCol = mgmt.createCollection("sub" + i);
         }
     }
 
     @AfterClass
     public static void closeDB() {
         TestUtils.cleanupDB();
-        try {
-            Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-            DatabaseInstanceManager mgr = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-            mgr.shutdown();
-        } catch (XMLDBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
     }
 }

--- a/test/src/org/exist/dom/memtree/MemtreeInXQuery.java
+++ b/test/src/org/exist/dom/memtree/MemtreeInXQuery.java
@@ -1,14 +1,9 @@
 package org.exist.dom.memtree;
 
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.*;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
-import org.xmldb.api.modules.XPathQueryService;
 
 import static org.junit.Assert.assertEquals;
 
@@ -17,12 +12,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class MemtreeInXQuery {
 
-    private final static String TEST_DB_USER = "guest";
-    private final static String TEST_DB_PWD = "guest";
-
-    private static XPathQueryService service;
-    private static Collection root = null;
-    private static Database database = null;
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(true);
 
     @Test
     public void pi_attributes() throws XMLDBException {
@@ -32,7 +23,7 @@ public class MemtreeInXQuery {
                 "}\n" +
                 "return count($doc//processing-instruction()/@*)";
 
-        final ResourceSet result = service.query(xquery);
+        final ResourceSet result = existEmbeddedServer.executeQuery(xquery);
 
         assertEquals(1, result.getSize());
         assertEquals(0, Integer.parseInt(result.getResource(0).getContent().toString()));
@@ -48,7 +39,7 @@ public class MemtreeInXQuery {
                 "}\n" +
                 "return count($doc//processing-instruction()/node())";
 
-        final ResourceSet result = service.query(xquery);
+        final ResourceSet result = existEmbeddedServer.executeQuery(xquery);
 
         assertEquals(1, result.getSize());
         assertEquals(0, Integer.parseInt(result.getResource(0).getContent().toString()));
@@ -64,7 +55,7 @@ public class MemtreeInXQuery {
                 "}\n" +
                 "return count($doc//processing-instruction()//@*)";
 
-        final ResourceSet result = service.query(xquery);
+        final ResourceSet result = existEmbeddedServer.executeQuery(xquery);
 
         assertEquals(1, result.getSize());
         assertEquals(0, Integer.parseInt(result.getResource(0).getContent().toString()));
@@ -81,7 +72,7 @@ public class MemtreeInXQuery {
                 "} return\n" +
                 "    count($doc/a/@x/@y)";
 
-        final ResourceSet result = service.query(xquery);
+        final ResourceSet result = existEmbeddedServer.executeQuery(xquery);
 
         assertEquals(1, result.getSize());
         assertEquals(0, Integer.parseInt(result.getResource(0).getContent().toString()));
@@ -98,33 +89,11 @@ public class MemtreeInXQuery {
                 "} return\n" +
                 "    count($doc/a/@x/node())";
 
-        final ResourceSet result = service.query(xquery);
+        final ResourceSet result = existEmbeddedServer.executeQuery(xquery);
 
         assertEquals(1, result.getSize());
         assertEquals(0, Integer.parseInt(result.getResource(0).getContent().toString()));
 
         result.clear();
-    }
-
-    @BeforeClass
-    public static void setUp() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        // initialize driver
-        final Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, TEST_DB_USER, TEST_DB_PWD);
-        service = (XPathQueryService) root.getService( "XQueryService", "1.0" );
-    }
-
-    @AfterClass
-    public static void tearDown() throws XMLDBException {
-        DatabaseManager.deregisterDatabase(database);
-        final DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-
-        // clear instance variables
-        service = null;
-        root = null;
     }
 }

--- a/test/src/org/exist/storage/RemoveCollectionTest.java
+++ b/test/src/org/exist/storage/RemoveCollectionTest.java
@@ -45,6 +45,7 @@ import org.xml.sax.SAXException;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Optional;
 
@@ -144,12 +145,12 @@ public class RemoveCollectionTest {
             try(final Txn transaction = transact.beginTransaction()) {
 
                 TestDataGenerator generator = new TestDataGenerator("xdb", COUNT);
-                File[] files = generator.generate(broker, test, generateXQ);
+                final Path[] files = generator.generate(broker, test, generateXQ);
 
                 int j = 0;
                 for (final Iterator<DocumentImpl> i = test.iterator(broker); i.hasNext() && j < files.length; j++) {
                     final DocumentImpl doc = i.next();
-                    final InputSource is = new InputSource(files[j].toURI().toASCIIString());
+                    final InputSource is = new InputSource(files[j].toUri().toASCIIString());
                     assertNotNull(is);
                     final IndexInfo info = test.validateXMLResource(transaction, broker, doc.getURI(), is);
                     assertNotNull(info);
@@ -185,11 +186,11 @@ public class RemoveCollectionTest {
 
         try(final Txn transaction = transact.beginTransaction()) {
             final TestDataGenerator generator = new TestDataGenerator("xdb", COUNT);
-            final File[] files = generator.generate(broker, test, generateXQ);
-            for(final File file : files) {
-                final InputSource is = new InputSource(file.toURI().toASCIIString());
+            final Path[] files = generator.generate(broker, test, generateXQ);
+            for(final Path file : files) {
+                final InputSource is = new InputSource(file.toUri().toASCIIString());
                 assertNotNull(is);
-                final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create(file.getName()), is);
+                final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create(file.getFileName().toString()), is);
                 assertNotNull(info);
                 test.store(transaction, broker, info, is, false);
             }

--- a/test/src/org/exist/storage/lock/DeadlockTest.java
+++ b/test/src/org/exist/storage/lock/DeadlockTest.java
@@ -24,6 +24,7 @@ package org.exist.storage.lock;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -268,10 +269,10 @@ public class DeadlockTest {
                         transact.commit(transaction);
                     }
 
-                    final File[] files = generator.generate(broker, coll, generateXQ);
+                    final Path[] files = generator.generate(broker, coll, generateXQ);
                     for (int j = 0; j < files.length; j++, fileCount++) {
                         try(final Txn transaction = transact.beginTransaction()) {
-                            InputSource is = new InputSource(files[j].toURI()
+                            InputSource is = new InputSource(files[j].toUri()
                                     .toASCIIString());
                             assertNotNull(is);
                             IndexInfo info = coll.validateXMLResource(transaction,

--- a/test/src/org/exist/test/ExistXmldbEmbeddedServer.java
+++ b/test/src/org/exist/test/ExistXmldbEmbeddedServer.java
@@ -1,0 +1,111 @@
+package org.exist.test;
+
+import org.exist.xmldb.DatabaseInstanceManager;
+import org.exist.xmldb.XmldbURI;
+import org.junit.rules.ExternalResource;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.*;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Exist embedded XML:DB Server Rule to JUnit
+ */
+public class ExistXmldbEmbeddedServer extends ExternalResource {
+
+    private final static String ADMIN_DB_USER = "admin";
+    private final static String ADMIN_DB_PWD = "";
+
+    private final static String GUEST_DB_USER = "guest";
+    private final static String GUEST_DB_PWD = "guest";
+    private final boolean asGuest;
+
+    private Database database = null;
+    private Collection root = null;
+    private XQueryService xpathQueryService = null;
+
+    public ExistXmldbEmbeddedServer() {
+        this(false);
+    }
+
+    /**
+     * @param asGuest Use the guest account, default is the admin account
+     */
+    public ExistXmldbEmbeddedServer(final boolean asGuest) {
+        this.asGuest = asGuest;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        startDb();
+        super.before();
+    }
+
+    private void startDb() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
+        if(database == null) {
+            // initialize driver
+            final Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
+            database = (Database) cl.newInstance();
+            database.setProperty("create-database", "true");
+            DatabaseManager.registerDatabase(database);
+            if(asGuest) {
+                root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, GUEST_DB_USER, GUEST_DB_PWD);
+            } else {
+                root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, ADMIN_DB_USER, ADMIN_DB_PWD);
+            }
+            xpathQueryService = (XQueryService) root.getService("XQueryService", "1.0");
+        } else {
+            throw new IllegalStateException("ExistXmldbEmbeddedServer already running");
+        }
+    }
+
+    public ResourceSet executeQuery(final String query) throws XMLDBException {
+        final CompiledExpression compiledQuery = xpathQueryService.compile(query);
+        ResourceSet result = xpathQueryService.execute(compiledQuery);
+        return result;
+    }
+
+    public String executeOneValue(final String query) throws XMLDBException {
+        final ResourceSet results = executeQuery(query);
+        assertEquals(1, results.getSize());
+        return results.getResource(0).getContent().toString();
+    }
+
+    public Collection getRoot() {
+        return root;
+    }
+
+    public void restart() throws ClassNotFoundException, InstantiationException, XMLDBException, IllegalAccessException {
+        stopDb();
+        startDb();
+    }
+
+    @Override
+    protected void after() {
+        try {
+            stopDb();
+        } catch(final XMLDBException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+        super.after();
+    }
+
+    private void stopDb() throws XMLDBException {
+        if(database != null) {
+            DatabaseManager.deregisterDatabase(database);
+            final DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
+            dim.shutdown();
+
+
+            // clear instance variables
+            xpathQueryService = null;
+            root = null;
+            database = null;
+        } else {
+            throw new IllegalStateException("ExistXmldbEmbeddedServer already stopped");
+        }
+    }
+}

--- a/test/src/org/exist/validation/CollectionConfigurationValidationModeTest.java
+++ b/test/src/org/exist/validation/CollectionConfigurationValidationModeTest.java
@@ -23,21 +23,11 @@
 package org.exist.validation;
 
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.exist.xmldb.XmldbURI;
+import org.exist.test.ExistXmldbEmbeddedServer;
 
-import org.xmldb.api.DatabaseManager;
+import org.junit.*;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.XMLDBException;
-import org.xmldb.api.modules.XPathQueryService;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.modules.CollectionManagementService;
@@ -50,48 +40,30 @@ import static org.junit.Assert.*;
  */
 public class CollectionConfigurationValidationModeTest {
 
-    String valid = "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://jmvanel.free.fr/xsd/addressBook\" elementFormDefault=\"qualified\">" + "<xsd:attribute name=\"uselessAttribute\" type=\"xsd:string\"/>" + "<xsd:complexType name=\"record\">" + "<xsd:sequence>" + "<xsd:element name=\"cname\" type=\"xsd:string\"/>" + "<xsd:element name=\"email\" type=\"xsd:string\"/>" + "</xsd:sequence>" + "</xsd:complexType>" + "<xsd:element name=\"addressBook\">" + "<xsd:complexType>" + "<xsd:sequence>" + "<xsd:element name=\"owner\" type=\"record\"/>" + "<xsd:element name=\"person\" type=\"record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>" + "</xsd:sequence>" + "</xsd:complexType>" + "</xsd:element>" + "</xsd:schema>";
-    String invalid = "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://jmvanel.free.fr/xsd/addressBook\" elementFormDefault=\"qualified\">" + "<xsd:attribute name=\"uselessAttribute\" type=\"xsd:string\"/>" + "<xsd:complexType name=\"record\">" + "<xsd:sequence>" + "<xsd:elementa name=\"cname\" type=\"xsd:string\"/>" + "<xsd:elementb name=\"email\" type=\"xsd:string\"/>" + "</xsd:sequence>" + "</xsd:complexType>" + "<xsd:element name=\"addressBook\">" + "<xsd:complexType>" + "<xsd:sequence>" + "<xsd:element name=\"owner\" type=\"record\"/>" + "<xsd:element name=\"person\" type=\"record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>" + "</xsd:sequence>" + "</xsd:complexType>" + "</xsd:element>" + "</xsd:schema>";
-    String anonymous = "<schema elementFormDefault=\"qualified\">" + "<attribute name=\"uselessAttribute\" type=\"string\"/>" + "<complexType name=\"record\">" + "<sequence>" + "<elementa name=\"cname\" type=\"string\"/>" + "<elementb name=\"email\" type=\"string\"/>" + "</sequence>" + "</complexType>" + "<element name=\"addressBook\">" + "<complexType>" + "<sequence>" + "<element name=\"owner\" type=\"record\"/>" + "<element name=\"person\" type=\"record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>" + "</sequence>" + "</complexType>" + "</element>" + "</schema>";
-    String different = "<asd:schema xmlns:asd=\"http://www.w3.org/2001/XMLSchemaschema\" targetNamespace=\"http://jmvanel.free.fr/xsd/addressBookbook\" elementFormDefault=\"qualified\">" + "<asd:attribute name=\"uselessAttribute\" type=\"asd:string\"/>" + "<asd:complexType name=\"record\">" + "<asd:sequence>" + "<asd:element name=\"cname\" type=\"asd:string\"/>" + "<asd:element name=\"email\" type=\"asd:string\"/>" + "</asd:sequence>" + "</asd:complexType>" + "<asd:element name=\"addressBook\">" + "<asd:complexType>" + "<asd:sequence>" + "<asd:element name=\"owner\" type=\"record\"/>" + "<asd:element name=\"person\" type=\"record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>" + "</asd:sequence>" + "</asd:complexType>" + "</asd:element>" + "</asd:schema>";
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
-    String xconf_yes = "<collection xmlns=\"http://exist-db.org/collection-config/1.0\"><validation mode=\"yes\"/></collection>";
-    String xconf_no = "<collection xmlns=\"http://exist-db.org/collection-config/1.0\"><validation mode=\"no\"/></collection>";
-    String xconf_auto = "<collection xmlns=\"http://exist-db.org/collection-config/1.0\"><validation mode=\"auto\"/></collection>";
-    @SuppressWarnings("unused")
-	private static final Logger logger = LogManager.getLogger(CollectionConfigurationValidationModeTest.class);
-    private static XPathQueryService xpqservice;
-    private static Collection root = null;
-    private static Database database = null;
-    private static CollectionManagementService cmservice = null;
+    private static final String valid = "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://jmvanel.free.fr/xsd/addressBook\" elementFormDefault=\"qualified\">" + "<xsd:attribute name=\"uselessAttribute\" type=\"xsd:string\"/>" + "<xsd:complexType name=\"record\">" + "<xsd:sequence>" + "<xsd:element name=\"cname\" type=\"xsd:string\"/>" + "<xsd:element name=\"email\" type=\"xsd:string\"/>" + "</xsd:sequence>" + "</xsd:complexType>" + "<xsd:element name=\"addressBook\">" + "<xsd:complexType>" + "<xsd:sequence>" + "<xsd:element name=\"owner\" type=\"record\"/>" + "<xsd:element name=\"person\" type=\"record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>" + "</xsd:sequence>" + "</xsd:complexType>" + "</xsd:element>" + "</xsd:schema>";
+    private static final String invalid = "<xsd:schema xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://jmvanel.free.fr/xsd/addressBook\" elementFormDefault=\"qualified\">" + "<xsd:attribute name=\"uselessAttribute\" type=\"xsd:string\"/>" + "<xsd:complexType name=\"record\">" + "<xsd:sequence>" + "<xsd:elementa name=\"cname\" type=\"xsd:string\"/>" + "<xsd:elementb name=\"email\" type=\"xsd:string\"/>" + "</xsd:sequence>" + "</xsd:complexType>" + "<xsd:element name=\"addressBook\">" + "<xsd:complexType>" + "<xsd:sequence>" + "<xsd:element name=\"owner\" type=\"record\"/>" + "<xsd:element name=\"person\" type=\"record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>" + "</xsd:sequence>" + "</xsd:complexType>" + "</xsd:element>" + "</xsd:schema>";
+    private static final String anonymous = "<schema elementFormDefault=\"qualified\">" + "<attribute name=\"uselessAttribute\" type=\"string\"/>" + "<complexType name=\"record\">" + "<sequence>" + "<elementa name=\"cname\" type=\"string\"/>" + "<elementb name=\"email\" type=\"string\"/>" + "</sequence>" + "</complexType>" + "<element name=\"addressBook\">" + "<complexType>" + "<sequence>" + "<element name=\"owner\" type=\"record\"/>" + "<element name=\"person\" type=\"record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>" + "</sequence>" + "</complexType>" + "</element>" + "</schema>";
+    private static final String different = "<asd:schema xmlns:asd=\"http://www.w3.org/2001/XMLSchemaschema\" targetNamespace=\"http://jmvanel.free.fr/xsd/addressBookbook\" elementFormDefault=\"qualified\">" + "<asd:attribute name=\"uselessAttribute\" type=\"asd:string\"/>" + "<asd:complexType name=\"record\">" + "<asd:sequence>" + "<asd:element name=\"cname\" type=\"asd:string\"/>" + "<asd:element name=\"email\" type=\"asd:string\"/>" + "</asd:sequence>" + "</asd:complexType>" + "<asd:element name=\"addressBook\">" + "<asd:complexType>" + "<asd:sequence>" + "<asd:element name=\"owner\" type=\"record\"/>" + "<asd:element name=\"person\" type=\"record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>" + "</asd:sequence>" + "</asd:complexType>" + "</asd:element>" + "</asd:schema>";
 
-    public CollectionConfigurationValidationModeTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        xpqservice = (XPathQueryService) root.getService( "XQueryService", "1.0" );
-        cmservice = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
-    }
+    private static final String xconf_yes = "<collection xmlns=\"http://exist-db.org/collection-config/1.0\"><validation mode=\"yes\"/></collection>";
+    private static final String xconf_no = "<collection xmlns=\"http://exist-db.org/collection-config/1.0\"><validation mode=\"no\"/></collection>";
+    private static final String xconf_auto = "<collection xmlns=\"http://exist-db.org/collection-config/1.0\"><validation mode=\"auto\"/></collection>";
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        @SuppressWarnings("unused")
-		ResourceSet result = xpqservice.query("validation:clear-grammar-cache()");
+        existEmbeddedServer.executeQuery("validation:clear-grammar-cache()");
     }
 
     @Before
     public void setUp() throws Exception {
-        @SuppressWarnings("unused")
-		ResourceSet result = xpqservice.query("validation:clear-grammar-cache()");
+        existEmbeddedServer.executeQuery("validation:clear-grammar-cache()");
     }
 
-    private void createCollection(String collection) throws XMLDBException {
+    private void createCollection(final String collection) throws XMLDBException {
+        final CollectionManagementService cmservice = (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
         Collection testCollection = cmservice.createCollection(collection);
         assertNotNull(testCollection);
 
@@ -99,58 +71,43 @@ public class CollectionConfigurationValidationModeTest {
         assertNotNull(testCollection);
     }
 
-    private void storeCollectionXconf(String collection, String document) throws XMLDBException {
-        ResourceSet result = xpqservice.query("xmldb:store(\"" + collection + "\", \"collection.xconf\", " + document + ")");
-        String r = (String) result.getResource(0).getContent();
+    private void storeCollectionXconf(final String collection, final String document) throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery("xmldb:store(\"" + collection + "\", \"collection.xconf\", " + document + ")");
+        final String r = (String) result.getResource(0).getContent();
         assertEquals("Store xconf", collection + "/collection.xconf", r);
     }
 
-    private void storeDocument(String collection, String name, String document) throws XMLDBException {
-        ResourceSet result = xpqservice.query("xmldb:store(\"" + collection + "\", \"" + name + "\", " + document + ")");
-        String r = (String) result.getResource(0).getContent();
+    private void storeDocument(final String collection, final String name, final String document) throws XMLDBException {
+        final ResourceSet result = existEmbeddedServer.executeQuery("xmldb:store(\"" + collection + "\", \"" + name + "\", " + document + ")");
+        final String r = (String) result.getResource(0).getContent();
         assertEquals("Store doc", collection + "/" + name, r);
     }
 
     @Test
-    public void insertModeFalse() {
+    public void insertModeFalse() throws XMLDBException {
+        createCollection("/db/false");
+        storeCollectionXconf("/db/system/config/db/false", xconf_no);
 
-        try {
-            createCollection("/db/false");
-            storeCollectionXconf("/db/system/config/db/false", xconf_no);
-        } catch (XMLDBException ex) {
-            fail(ex.getMessage());
-        }
+        // namespace provided, valid document; should pass
+        storeDocument("/db/false", "valid.xml", valid);
 
-        try {
-            // namespace provided, valid document; should pass
-            storeDocument("/db/false", "valid.xml", valid);
+        // namespace provided, invalid document; should pass
+        storeDocument("/db/false", "invalid.xml", invalid);
 
-            // namespace provided, invalid document; should pass
-            storeDocument("/db/false", "invalid.xml", invalid);
+        // no namespace provided, should pass
+        storeDocument("/db/false", "anonymous.xml", anonymous);
 
-            // no namespace provided, should pass
-            storeDocument("/db/false", "anonymous.xml", anonymous);
-
-            // non resolvable namespace provided, should pass
-            storeDocument("/db/false", "different.xml", different);
-
-        } catch (XMLDBException ex) {
-            fail(ex.getMessage());
-        }
+        // non resolvable namespace provided, should pass
+        storeDocument("/db/false", "different.xml", different);
     }
 
     @Test
-    public void insertModeTrue() {
-
+    public void insertModeTrue() throws XMLDBException {
         // namespace provided, valid document; should pass
-        try {
-            createCollection("/db/true");
-            storeCollectionXconf("/db/system/config/db/true", xconf_yes);
+        createCollection("/db/true");
+        storeCollectionXconf("/db/system/config/db/true", xconf_yes);
 
-            storeDocument("/db/true", "valid.xml", valid);
-        } catch (XMLDBException ex) {
-            fail(ex.getMessage());
-        }
+        storeDocument("/db/true", "valid.xml", valid);
 
         // namespace provided, invalid document; should fail
         try {
@@ -189,17 +146,13 @@ public class CollectionConfigurationValidationModeTest {
     }
 
     @Test
-    public void insertModeAuto() {
-
+    public void insertModeAuto() throws XMLDBException {
         // namespace provided, valid document; should pass
-        try {
-            createCollection("/db/auto");
-            storeCollectionXconf("/db/system/config/db/auto", xconf_auto);
+        createCollection("/db/auto");
+        storeCollectionXconf("/db/system/config/db/auto", xconf_auto);
 
-            storeDocument("/db/auto", "valid.xml", valid);
-        } catch (XMLDBException ex) {
-            fail(ex.getMessage());
-        }
+        storeDocument("/db/auto", "valid.xml", valid);
+
 
         // namespace provided, invalid document, should fail
         try {

--- a/test/src/org/exist/validation/TestTools.java
+++ b/test/src/org/exist/validation/TestTools.java
@@ -48,47 +48,6 @@ public class TestTools {
     public final static String VALIDATION_XSD_COLLECTION = "xsd";
     public final static String VALIDATION_TMP_COLLECTION = "tmp";
     
-
-    /*
-    public static void insertResources(){
-
-        try {
-            String eXistHome = ConfigurationHelper.getExistHome().getAbsolutePath();
-
-            Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-            Database database = (Database) cl.newInstance();
-            database.setProperty("create-database", "true");
-            DatabaseManager.registerDatabase(database);
-            Collection root = DatabaseManager.getCollection("xmldb:exist://" + DBBroker.ROOT_COLLECTION, "admin", "");
-            XPathQueryService service = (XPathQueryService) root.getService("XQueryService", "1.0");
-
-            CollectionManagementService cmservice = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
-            Collection col1 = cmservice.createCollection(TestTools.VALIDATION_HOME);
-            Collection col2 = cmservice.createCollection(TestTools.VALIDATION_XSD);
-
-            Permission permission = PermissionAiderFactory.getPermission("guest", "guest", 999);
-
-            UserManagementService umservice = (UserManagementService) root.getService("UserManagementService", "1.0");
-            umservice.setPermissions(col1, permission);
-            umservice.setPermissions(col2, permission);
-
-            String addressbook = eXistHome + "/samples/validation/addressbook";
-
-            TestTools.insertDocumentToURL(addressbook + "/addressbook.xsd",
-                    "xmldb:exist://" + TestTools.VALIDATION_XSD + "/addressbook.xsd");
-            TestTools.insertDocumentToURL(addressbook + "/catalog.xml",
-                    "xmldb:exist://" + TestTools.VALIDATION_XSD + "/catalog.xml");
-
-            TestTools.insertDocumentToURL(addressbook + "/addressbook_valid.xml",
-                    "xmldb:exist://" + TestTools.VALIDATION_HOME + "/addressbook_valid.xml");
-            TestTools.insertDocumentToURL(addressbook + "/addressbook_invalid.xml",
-                    "xmldb:exist://" + TestTools.VALIDATION_HOME + "/addressbook_invalid.xml");
-
-        } catch (Throwable ex) {
-            ex.printStackTrace();
-        }
-    }*/
-    
     // Transfer bytes from in to out
     public static void copyStream(InputStream is, OutputStream os) throws IOException {
         byte[] buf = new byte[1024];

--- a/test/src/org/exist/validation/ValidationFunctions_DTD_Test.java
+++ b/test/src/org/exist/validation/ValidationFunctions_DTD_Test.java
@@ -276,8 +276,8 @@ public class ValidationFunctions_DTD_Test {
         final BrokerPool pool = BrokerPool.getInstance();
         final TransactionManager transact = pool.getTransactionManager();
 
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD)));
-            final Txn txn = transact.beginTransaction()) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD)));
+             final Txn txn = transact.beginTransaction()) {
 
             org.exist.collections.Collection testCollection = broker.getOrCreateCollection(txn, XmldbURI.create(VALIDATION_HOME_COLLECTION_URI));
             broker.removeCollection(txn, testCollection);
@@ -285,83 +285,4 @@ public class ValidationFunctions_DTD_Test {
             transact.commit(txn);
         }
     }
-    /*
-
-    @Before
-    public void setUp() throws Exception {
-
-        logger.info("setUp");
-
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection("xmldb:exist://" + DBBroker.ROOT_COLLECTION, "admin", "");
-        service = (XPathQueryService) root.getService( "XQueryService", "1.0" );
-
-        try {
-            File file = new File(eXistHome, "samples/shakespeare/hamlet.xml");
-            InputStream fis = new FileInputStream(file);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            TestTools.copyStream(fis, baos);
-            fis.close();
-
-            String sb = new String(baos.toByteArray());
-            sb=sb.replaceAll("\\Q<!\\E.*DOCTYPE.*\\Q-->\\E",
-                "<!DOCTYPE PLAY PUBLIC \"-//PLAY//EN\" \"play.dtd\">" );
-            InputStream is = new ByteArrayInputStream(sb.getBytes());
-
-            // -----
-
-            URL url = new URL("xmldb:exist://" + TestTools.VALIDATION_TMP + "/hamlet_valid.xml");
-            URLConnection connection = url.openConnection();
-            OutputStream os = connection.getOutputStream();
-
-            TestTools.copyStream(is, os);
-
-            is.close();
-            os.close();
-
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            logger.error(ex);
-            fail(ex.getMessage());
-        }
-
-        try{
-            config.setProperty(XMLReaderObjectFactory.PROPERTY_VALIDATION_MODE, "no");
-
-            String hamlet = eXistHome + "/samples/validation/dtd";
-
-            TestTools.insertDocumentToURL(hamlet+"/hamlet.dtd",
-                "xmldb:exist://"+TestTools.VALIDATION_DTD+"/hamlet.dtd");
-            TestTools.insertDocumentToURL(hamlet+"/catalog.xml",
-                "xmldb:exist://"+TestTools.VALIDATION_DTD+"/catalog.xml");
-
-            TestTools.insertDocumentToURL(hamlet+"/hamlet_valid.xml",
-                "xmldb:exist://"+TestTools.VALIDATION_HOME+"/hamlet_valid.xml");
-            TestTools.insertDocumentToURL(hamlet+"/hamlet_invalid.xml",
-                "xmldb:exist://"+TestTools.VALIDATION_HOME+"/hamlet_invalid.xml");
-
-            config.setProperty(XMLReaderObjectFactory.PROPERTY_VALIDATION_MODE, "yes");
-
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            logger.error(ex);
-            fail(ex.getMessage());
-        }
-    }
-
-    @AfterClass
-    public static void shutdownDB() throws Exception {
-
-        logger.info("shutdownDB");
-        
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim =
-            (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdownDB();
-        
-    }*/
-    
 }

--- a/test/src/org/exist/xmldb/CollectionConfigurationTest.java
+++ b/test/src/org/exist/xmldb/CollectionConfigurationTest.java
@@ -21,11 +21,10 @@
  */
 package org.exist.xmldb;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.*;
 import org.exist.security.Account;
-import org.junit.After;
-import org.junit.Before;
+
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -35,7 +34,6 @@ import org.exist.test.TestConstants;
 import org.exist.xquery.Constants;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
@@ -46,6 +44,8 @@ import static org.exist.xmldb.XmldbLocalTests.*;
 
 public class CollectionConfigurationTest {
 
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     private final static String TEST_COLLECTION = "testIndexConfiguration";
     
@@ -157,24 +157,16 @@ public class CollectionConfigurationTest {
 
     @Before
     public void setUp() throws Exception {
-        
-        // initialize driver
-        Class<?> cl = Class.forName(DRIVER);
-        Database database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        
-        Collection root = DatabaseManager.getCollection(ROOT_URI, ADMIN_UID, ADMIN_PWD);
-        CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        final CollectionManagementService service = (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
 
-        Collection testCollection = service.createCollection(TEST_COLLECTION);
+        final Collection testCollection = service.createCollection(TEST_COLLECTION);
         UserManagementService ums = (UserManagementService) testCollection.getService("UserManagementService", "1.0");
         // change ownership to guest
-        Account guest = ums.getAccount(GUEST_UID);
+        final Account guest = ums.getAccount(GUEST_UID);
         ums.chown(guest, guest.getPrimaryGroup());
         ums.chmod("rwxr-xr-x");
 
-        Collection testConfCollection = service.createCollection(CONF_COLL_URI.toString());
+        final Collection testConfCollection = service.createCollection(CONF_COLL_URI.toString());
         ums = (UserManagementService) testConfCollection.getService("UserManagementService", "1.0");
         // change ownership to guest
         ums.chown(guest, guest.getPrimaryGroup());
@@ -185,13 +177,9 @@ public class CollectionConfigurationTest {
 
     @After
     public void tearDown() throws XMLDBException {
-        Collection root = DatabaseManager.getCollection(ROOT_URI, ADMIN_UID, ADMIN_PWD);
-        CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        final CollectionManagementService service = (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
         service.removeCollection(TEST_COLLECTION.toString());
         service.removeCollection(CONF_COLL_URI.toString()); //Removes the collection config collection *manually*
-
-        DatabaseInstanceManager mgr = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        mgr.shutdown();
     }
 
     @Test

--- a/test/src/org/exist/xmldb/CollectionTest.java
+++ b/test/src/org/exist/xmldb/CollectionTest.java
@@ -21,52 +21,37 @@
  */
 package org.exist.xmldb;
 
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import static org.junit.Assert.assertNotNull;
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.CollectionManagementService;
-import static org.exist.xmldb.XmldbLocalTests.*;
 
 public class CollectionTest {
 
-    @Test
-    public void create() throws XMLDBException {
-        Collection root = DatabaseManager.getCollection(ROOT_URI, ADMIN_UID, ADMIN_PWD);
-        CollectionManagementService service = (CollectionManagementService)root.getService("CollectionManagementService", "1.0");
-        Collection testCollection = service.createCollection(TestConstants.SPECIAL_NAME);
-        assertNotNull(testCollection);
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
+    @Before
+    public void setup() throws XMLDBException {
+        final CollectionManagementService service = (CollectionManagementService)existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
+        service.createCollection(TestConstants.SPECIAL_NAME);
+    }
+
+    @After
+    public void cleanup() throws XMLDBException {
+        final CollectionManagementService service = (CollectionManagementService)existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
+        service.removeCollection(TestConstants.SPECIAL_NAME);
     }
 
     @Test
     public void testRead() throws XMLDBException {
-        Collection test = DatabaseManager.getCollection(ROOT_URI, ADMIN_UID, ADMIN_PWD);
+        final Collection test = existEmbeddedServer.getRoot().getChildCollection(TestConstants.SPECIAL_NAME);
         assertNotNull(test);
-        Collection root = DatabaseManager.getCollection(ROOT_URI, ADMIN_UID, ADMIN_PWD);
-        test = root.getChildCollection(TestConstants.SPECIAL_NAME);
-        assertNotNull(test);
-        CollectionManagementService service = (CollectionManagementService)root.getService("CollectionManagementService", "1.0");
-        service.removeCollection(TestConstants.SPECIAL_NAME);
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        // initialize driver
-        Class<?> cl = Class.forName(DRIVER);
-        Database database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-    }
-
-    @After
-    public void tearDown() throws XMLDBException {
-        Collection root = DatabaseManager.getCollection(ROOT_URI, ADMIN_UID, ADMIN_PWD);
-        DatabaseInstanceManager mgr = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        mgr.shutdown();
     }
 }

--- a/test/src/org/exist/xmldb/CopyMoveTest.java
+++ b/test/src/org/exist/xmldb/CopyMoveTest.java
@@ -1,9 +1,11 @@
 package org.exist.xmldb;
 
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.After;
 import org.exist.security.Account;
 import org.exist.security.Permission;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -15,6 +17,9 @@ import static org.exist.xmldb.XmldbLocalTests.*;
 
 
 public class CopyMoveTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     private final static String TEST_COLLECTION = "testCopyMove";
 
@@ -97,17 +102,11 @@ public class CopyMoveTest {
 
     @Before
     public void setUp() throws Exception {
-        // initialize driver
-        Database database = (Database) Class.forName(DRIVER).newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-
-        Collection root = DatabaseManager.getCollection(ROOT_URI, ADMIN_UID, ADMIN_PWD);
-        CollectionManagementService cms = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
-        Collection testCollection = cms.createCollection(TEST_COLLECTION);
-        UserManagementService ums = (UserManagementService) testCollection.getService("UserManagementService", "1.0");
+        final CollectionManagementService cms = (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
+        final Collection testCollection = cms.createCollection(TEST_COLLECTION);
+        final UserManagementService ums = (UserManagementService) testCollection.getService("UserManagementService", "1.0");
         // change ownership to guest
-        Account guest = ums.getAccount(GUEST_UID);
+        final Account guest = ums.getAccount(GUEST_UID);
         ums.chown(guest, guest.getPrimaryGroup());
         ums.chmod("rwxr-xr-x");
     }
@@ -115,12 +114,7 @@ public class CopyMoveTest {
     @After
     public void tearDown() throws XMLDBException {
         //delete the test collection
-        Collection root = DatabaseManager.getCollection(ROOT_URI, ADMIN_UID, ADMIN_PWD);
-        CollectionManagementService cms = (CollectionManagementService)root.getService("CollectionManagementService", "1.0");
+        final CollectionManagementService cms = (CollectionManagementService)existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
         cms.removeCollection(TEST_COLLECTION);
-
-        //shutdownDB the db
-        DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
     }
 }

--- a/test/src/org/exist/xmldb/SerializationTest.java
+++ b/test/src/org/exist/xmldb/SerializationTest.java
@@ -1,13 +1,13 @@
 package org.exist.xmldb;
 
 import org.exist.Namespaces;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.xml.sax.SAXException;
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertNotNull;
 
 public class SerializationTest {
 
+	@ClassRule
+	public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
 	private static final String TEST_COLLECTION_NAME = "test";
 
 	private static final String XML =
@@ -29,26 +32,25 @@ public class SerializationTest {
 		"	<entry>1</entry>" +
 		"	<entry>2</entry>" +
 		"</root>";
-	
+
 	private static final String XML_EXPECTED1 =
-		"<exist:result xmlns:exist=\"" + Namespaces.EXIST_NS + "\" hitCount=\"2\">\n" + 
-		"    <entry xmlns=\"http://foo.com\">1</entry>\n" + 
-		"    <entry xmlns=\"http://foo.com\">2</entry>\n" + 
+		"<exist:result xmlns:exist=\"" + Namespaces.EXIST_NS + "\" hitCount=\"2\">\n" +
+		"    <entry xmlns=\"http://foo.com\">1</entry>\n" +
+		"    <entry xmlns=\"http://foo.com\">2</entry>\n" +
 		"</exist:result>";
-	
+
 	private static final String XML_EXPECTED2 =
 		"<exist:result xmlns:exist=\"" + Namespaces.EXIST_NS + "\" hitCount=\"1\">\n" +
 		"    <c:Site xmlns:c=\"urn:content\" xmlns=\"urn:content\">\n"+
 		//BUG : we should have
 		//<config xmlns="urn:config">123</config>
         "        <config>123</config>\n" +
-        //BUG : we should have 
+        //BUG : we should have
         //<serverconfig xmlns="urn:config">123</serverconfig>
         "        <serverconfig>123</serverconfig>\n" +
 		"    </c:Site>\n" +
 		"</exist:result>";
 
-	private Database database;
 	private Collection testCollection;
 
 	@Test
@@ -74,16 +76,8 @@ public class SerializationTest {
 
     @Before
 	public void setUp() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-
-        Collection root =
-            DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        CollectionManagementService service =
-            (CollectionManagementService) root.getService(
+        final CollectionManagementService service =
+            (CollectionManagementService) existEmbeddedServer.getRoot().getService(
                 "CollectionManagementService",
                 "1.0");
         testCollection = service.createCollection(TEST_COLLECTION_NAME);
@@ -97,20 +91,11 @@ public class SerializationTest {
 
     @After
     public void tearDown() throws XMLDBException {
-        Collection root =
-            DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        CollectionManagementService service =
-            (CollectionManagementService) root.getService(
+        final CollectionManagementService service =
+            (CollectionManagementService) existEmbeddedServer.getRoot().getService(
                 "CollectionManagementService",
                 "1.0");
         service.removeCollection(TEST_COLLECTION_NAME);
-
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim =
-            (DatabaseInstanceManager) testCollection.getService(
-                "DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-        database = null;
         testCollection = null;
     }
 }

--- a/test/src/org/exist/xmldb/XmldbLocalTests.java
+++ b/test/src/org/exist/xmldb/XmldbLocalTests.java
@@ -22,6 +22,9 @@
 package org.exist.xmldb;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -30,7 +33,7 @@ import org.junit.runners.Suite;
     CreateCollectionsTest.class,
     ResourceTest.class,
     BinaryResourceUpdateTest.class,
-    /* ResourceSetTest.class */
+    ResourceSetTest.class,
     TestEXistXMLSerialize.class,
     CopyMoveTest.class,
     ContentAsDOMTest.class,
@@ -42,20 +45,19 @@ import org.junit.runners.Suite;
 public class XmldbLocalTests {
 
     public final static String ROOT_URI = XmldbURI.LOCAL_DB;
-    public final static String DRIVER = "org.exist.xmldb.DatabaseImpl";
 
     public final static String ADMIN_UID = "admin";
     public final static String ADMIN_PWD = "";
 
     public final static String GUEST_UID = "guest";
 
-    public static File getExistDir() {
+    public static Path getExistDir() {
         final String existHome = System.getProperty("exist.home");
-        return existHome == null ? new File(".") : new File(existHome);
+        return existHome == null ? Paths.get(".").normalize() : Paths.get(existHome).normalize();
     }
 
-    public static File getShakespeareSamplesDirectory() {
+    public static Path getShakespeareSamplesDirectory() {
         final String directory = "samples/shakespeare";
-        return new File(getExistDir(), directory);
+        return getExistDir().resolve(directory).normalize();
     }
 }

--- a/test/src/org/exist/xmlrpc/QuerySessionTest.java
+++ b/test/src/org/exist/xmlrpc/QuerySessionTest.java
@@ -10,6 +10,7 @@ import org.xmldb.api.modules.CollectionManagementService;
 import org.xmldb.api.modules.XQueryService;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -136,10 +137,10 @@ public class QuerySessionTest {
         test.storeResource(resource);
         
         TestDataGenerator generator = new TestDataGenerator("xdb", DOC_COUNT);
-        File[] files = generator.generate(test, generateXQ);
+        final Path[] files = generator.generate(test, generateXQ);
         for (int i = 0; i < files.length; i++) {
-            resource = test.createResource(files[i].getName(), "XMLResource");
-            resource.setContent(files[i]);
+            resource = test.createResource(files[i].getFileName().toString(), "XMLResource");
+            resource.setContent(files[i].toFile());
             test.storeResource(resource);
         }
         generator.releaseAll();

--- a/test/src/org/exist/xquery/AbstractDescendantOrSelfNodeKindTest.java
+++ b/test/src/org/exist/xquery/AbstractDescendantOrSelfNodeKindTest.java
@@ -1,13 +1,8 @@
 package org.exist.xquery;
 
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 
@@ -17,6 +12,9 @@ import static org.junit.Assert.assertEquals;
  * @author Adam Retter <adam.retter@googlemail.com>
  */
 public abstract class AbstractDescendantOrSelfNodeKindTest {
+
+    @ClassRule
+    public final static ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     protected final static String TEST_DOCUMENT = "<doc xml:id=\"x\">\n"+
         "<?xml-stylesheet type=\"text/xsl\" href=\"test\"?>\n"+
@@ -30,7 +28,6 @@ public abstract class AbstractDescendantOrSelfNodeKindTest {
         "    </a>\n"+
         "</doc>";
 
-    protected static Collection root = null;
 
     protected abstract ResourceSet executeQueryOnDoc(final String docQuery) throws XMLDBException;
 
@@ -82,22 +79,4 @@ public abstract class AbstractDescendantOrSelfNodeKindTest {
         assertEquals(1, result.getSize());
         assertEquals(1, Integer.parseInt((String)result.getResource(0).getContent()));
     }
-
-    @BeforeClass
-    public static void startDbAndCreateTestCollection() throws Exception {
-        // initialize driver
-        final Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        final Database database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        final DatabaseInstanceManager dim = (DatabaseInstanceManager)root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-        root = null;
-    }
-
 }

--- a/test/src/org/exist/xquery/AnnotationsTest.java
+++ b/test/src/org/exist/xquery/AnnotationsTest.java
@@ -22,15 +22,15 @@
 package org.exist.xquery;
 
 import org.exist.TestUtils;
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import static org.junit.Assert.*;
+
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
@@ -39,21 +39,15 @@ import org.xmldb.api.modules.XPathQueryService;
 
 public class AnnotationsTest {
 
-    private static Database database;
+    @ClassRule
+    public final static ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     public AnnotationsTest() {
     }
 
     @BeforeClass
     public static void setUp() throws XMLDBException, ClassNotFoundException, InstantiationException, IllegalAccessException {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-
-        Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        CollectionManagementService service = (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
         Collection testCollection = service.createCollection("test");
         assertNotNull(testCollection);
     }
@@ -62,11 +56,6 @@ public class AnnotationsTest {
     public static void tearDown() throws Exception {
         // testCollection.removeResource( testCollection .getResource(file_name));
         TestUtils.cleanupDB();
-        DatabaseInstanceManager dim =
-                (DatabaseInstanceManager) DatabaseManager.getCollection("xmldb:exist:///db", "admin", "").getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-        DatabaseManager.deregisterDatabase(database);
-        database = null;
     }
 
     private Collection getTestCollection() throws XMLDBException {

--- a/test/src/org/exist/xquery/ConversionsTest.java
+++ b/test/src/org/exist/xquery/ConversionsTest.java
@@ -3,17 +3,11 @@
  */
 package org.exist.xquery;
 
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
-import org.junit.After;
-import org.junit.Before;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
-import org.xmldb.api.modules.XPathQueryService;
 
 import static org.junit.Assert.assertEquals;
 
@@ -22,51 +16,25 @@ import static org.junit.Assert.assertEquals;
  */
 public class ConversionsTest {
 
-	private XPathQueryService service;
-	private Collection root = null;
-	private Database database = null;
-	
+	@ClassRule
+	public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
-/** test conversion from QName to string */
+	/** test conversion from QName to string */
 	@Test
 	public void qname2string() throws XMLDBException {
-		ResourceSet result 	= null;
-		String		r		= "";
-		String		query	= null;
-
-        query = "declare namespace foo = 'http://foo'; \n" +
+        final String query = "declare namespace foo = 'http://foo'; \n" +
                 "let $a := ( xs:QName('foo:bar'), xs:QName('foo:john'), xs:QName('foo:doe') )\n" +
                     "for $b in $a \n" +
                         "return \n" +
                             "<blah>{string($b)}</blah>" ;
-        result 	= service.query( query );
+        final ResourceSet result = existEmbeddedServer.executeQuery( query );
         /* which returns :
             <blah>foo:bar</blah>
             <blah>foo:john</blah>
             <blah>foo:doe</blah>"
         */
-        r = (String) result.getResource(0).getContent();
+        final String r = (String) result.getResource(0).getContent();
         assertEquals( "<blah>foo:bar</blah>", r );
         assertEquals( "XQuery: " + query, 3, result.getSize() );
-	}
-
-	
-	@Before
-	public void setUp() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        service = (XPathQueryService) root.getService( "XQueryService", "1.0" );
-	}
-
-	@After
-	public void tearDown() throws XMLDBException {
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim =
-            (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
 	}
 }

--- a/test/src/org/exist/xquery/DocumentUpdateTest.java
+++ b/test/src/org/exist/xquery/DocumentUpdateTest.java
@@ -1,13 +1,11 @@
 package org.exist.xquery;
 
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.CollectionManagementService;
@@ -18,9 +16,10 @@ import static org.junit.Assert.assertNotNull;
 
 public class DocumentUpdateTest {
 
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
 	private static final String TEST_COLLECTION_NAME = "testup";
-    
-    private Database database;
     private Collection testCollection;
     
     /**
@@ -140,16 +139,8 @@ public class DocumentUpdateTest {
 
     @Before
     public void setUp() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-
-        Collection root =
-            DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
         CollectionManagementService service =
-            (CollectionManagementService) root.getService(
+            (CollectionManagementService) existEmbeddedServer.getRoot().getService(
                 "CollectionManagementService",
                 "1.0");
         testCollection = service.createCollection(TEST_COLLECTION_NAME);
@@ -158,20 +149,11 @@ public class DocumentUpdateTest {
 
     @After
     public void tearDown() throws XMLDBException {
-        Collection root =
-            DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
         CollectionManagementService service =
-            (CollectionManagementService) root.getService(
+            (CollectionManagementService) existEmbeddedServer.getRoot().getService(
                 "CollectionManagementService",
                 "1.0");
         service.removeCollection(TEST_COLLECTION_NAME);
-
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim =
-            (DatabaseInstanceManager) testCollection.getService(
-                "DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-        database = null;
         testCollection = null;
     }
 }

--- a/test/src/org/exist/xquery/EntitiesTest.java
+++ b/test/src/org/exist/xquery/EntitiesTest.java
@@ -1,13 +1,10 @@
 package org.exist.xquery;
 
-import org.exist.jetty.JettyStart;
-import org.exist.xmldb.CollectionImpl;
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.*;
 import org.xmldb.api.modules.CollectionManagementService;
 import org.xmldb.api.modules.XMLResource;
@@ -17,59 +14,31 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class EntitiesTest {
-    
-    private static String uri = XmldbURI.LOCAL_DB;
-    
-    public static void setURI(String collectionURI) {
-        uri = collectionURI;
-    }
-    
-    private static JettyStart server = null;
-    
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
     private Collection testCollection;
     @SuppressWarnings("unused")
 	private String query;
 
     @Before
     public void setUp() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        if (uri.startsWith("xmldb:exist://localhost")) {
-            initServer();
-        }
-
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        Database database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-
-        Collection root =
-                DatabaseManager.getCollection(
-                uri,
-                "admin",
-                null);
-        CollectionManagementService service =
-                (CollectionManagementService) root.getService(
+        final CollectionManagementService service =
+                (CollectionManagementService) existEmbeddedServer.getRoot().getService(
                 "CollectionManagementService",
                 "1.0");
         testCollection = service.createCollection("test");
         assertNotNull(testCollection);
     }
-    
-	private void initServer() {
-        if (server == null) {
-            server = new JettyStart();
-            server.run();
-        }
-    }
 
     @After
     public void tearDown() throws Exception {
-        if (!((CollectionImpl) testCollection).isRemoteCollection()) {
-            DatabaseInstanceManager dim =
-                    (DatabaseInstanceManager) testCollection.getService(
-                    "DatabaseInstanceManager", "1.0");
-            dim.shutdown();
-        }
+        final CollectionManagementService service =
+                (CollectionManagementService) existEmbeddedServer.getRoot().getService(
+                        "CollectionManagementService",
+                        "1.0");
+        service.removeCollection("test");
         testCollection = null;
     }
     

--- a/test/src/org/exist/xquery/JavaFunctionsTest.java
+++ b/test/src/org/exist/xquery/JavaFunctionsTest.java
@@ -3,11 +3,13 @@
  */
 package org.exist.xquery;
 
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.Configuration;
 import org.exist.xmldb.DatabaseInstanceManager;
 import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
@@ -26,9 +28,8 @@ import static org.junit.Assert.fail;
  */
 public class JavaFunctionsTest {
 
-    private XPathQueryService service;
-    private Collection root = null;
-    private Database database = null;
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     private boolean javabindingenabled = false;
 
@@ -43,7 +44,7 @@ public class JavaFunctionsTest {
                     "let $list := list:new() " +
                     "let $actions := (list:add($list,'a'),list:add($list,'b'),list:add($list,'c')) " +
                     "return list:get($list,1)";
-            ResourceSet result = service.query(query);
+            ResourceSet result = existEmbeddedServer.executeQuery(query);
             String r = (String) result.getResource(0).getContent();
             assertEquals("b", r);
         } catch (XMLDBException e) {
@@ -59,14 +60,6 @@ public class JavaFunctionsTest {
 
     @Before
     public void setUp() throws Exception {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        service = (XPathQueryService) root.getService("XQueryService", "1.0");
-
         //Check the configuration file to see if Java binding is enabled
         //if it is not enabled then we expect an exception when trying to
         //perform Java binding.
@@ -78,13 +71,4 @@ public class JavaFunctionsTest {
             }
         }
     }
-
-    @After
-    public void tearDown() throws Exception {
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim =
-                (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-    }
-
 }

--- a/test/src/org/exist/xquery/MemtreeDescendantOrSelfNodeKindTest.java
+++ b/test/src/org/exist/xquery/MemtreeDescendantOrSelfNodeKindTest.java
@@ -2,7 +2,6 @@ package org.exist.xquery;
 
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
-import org.xmldb.api.modules.XQueryService;
 
 /**
  * @author Adam Retter <adam.retter@googlemail.com>
@@ -21,8 +20,6 @@ public class MemtreeDescendantOrSelfNodeKindTest extends AbstractDescendantOrSel
     @Override
     protected ResourceSet executeQueryOnDoc(final String docQuery) throws XMLDBException {
         final String query = getInMemoryQuery(docQuery);
-
-        final XQueryService service = (XQueryService) root.getService("XPathQueryService", "1.0");
-        return service.query(query);
+        return existEmbeddedServer.executeQuery(query);
     }
 }

--- a/test/src/org/exist/xquery/NamespaceUpdateTest.java
+++ b/test/src/org/exist/xquery/NamespaceUpdateTest.java
@@ -1,11 +1,11 @@
 package org.exist.xquery;
 
-import org.exist.xmldb.XmldbURI;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.CollectionManagementService;
@@ -17,15 +17,16 @@ import static org.junit.Assert.assertNotNull;
 
 public class NamespaceUpdateTest {
 
-	private final static String URI = XmldbURI.LOCAL_DB;
-	
+	@ClassRule
+	public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
 	private final static String namespaces =
-		"<test xmlns='http://www.foo.com'>"
-			+ "<section>"
-			+ "<title>Test Document</title>"
-			+ "<c:comment xmlns:c='http://www.other.com'>This is my comment</c:comment>"
-			+ "</section>"
-			+ "</test>";
+			"<test xmlns='http://www.foo.com'>"
+					+ "<section>"
+					+ "<title>Test Document</title>"
+					+ "<c:comment xmlns:c='http://www.other.com'>This is my comment</c:comment>"
+					+ "</section>"
+					+ "</test>";
 
 	private Collection testCollection;
 
@@ -33,45 +34,45 @@ public class NamespaceUpdateTest {
 	public void updateAttribute() throws XMLDBException {
 		XQueryService service = (XQueryService) testCollection.getService("XQueryService", "1.0");
 		String query =
-			"declare namespace t='http://www.foo.com';\n" +
-			"<test xmlns='http://www.foo.com'>\n" +
-			"{\n" +
-			"	update insert attribute { 'ID' } { 'myid' } into /t:test\n" +
-			"}\n" +
-			"</test>";
+				"declare namespace t='http://www.foo.com';\n" +
+						"<test xmlns='http://www.foo.com'>\n" +
+						"{\n" +
+						"	update insert attribute { 'ID' } { 'myid' } into /t:test\n" +
+						"}\n" +
+						"</test>";
 		service.query(query);
 
 		query =
-			"declare namespace t='http://www.foo.com';\n" +
-			"/t:test/@ID";
+				"declare namespace t='http://www.foo.com';\n" +
+						"/t:test/@ID";
 		ResourceSet result = service.query(query);
 		assertEquals(1, result.getSize());
 		assertEquals("myid", result.getResource(0).getContent().toString());
 	}
 
-    @Before
+	@Before
 	public void setUp() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        Database database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
+		// initialize driver
+		final CollectionManagementService service =
+				(CollectionManagementService) existEmbeddedServer.getRoot().getService(
+						"CollectionManagementService",
+						"1.0");
+		testCollection = service.createCollection("test");
+		assertNotNull(testCollection);
 
-        Collection root =
-            DatabaseManager.getCollection(
-                URI,
-                "admin",
-                null);
-        CollectionManagementService service =
-            (CollectionManagementService) root.getService(
-                "CollectionManagementService",
-                "1.0");
-        testCollection = service.createCollection("test");
-        assertNotNull(testCollection);
+		final XMLResource doc =
+				(XMLResource) testCollection.createResource("namespace-updates.xml", "XMLResource");
+		doc.setContent(namespaces);
+		testCollection.storeResource(doc);
+	}
 
-        XMLResource doc =
-            (XMLResource) root.createResource("namespace-updates.xml", "XMLResource");
-        doc.setContent(namespaces);
-        testCollection.storeResource(doc);
+	@After
+	public void tearDown() throws Exception {
+		final CollectionManagementService service =
+				(CollectionManagementService) existEmbeddedServer.getRoot().getService(
+						"CollectionManagementService",
+						"1.0");
+		service.removeCollection("test");
+		testCollection = null;
 	}
 }

--- a/test/src/org/exist/xquery/PersistentDescendantOrSelfNodeKindTest.java
+++ b/test/src/org/exist/xquery/PersistentDescendantOrSelfNodeKindTest.java
@@ -2,11 +2,11 @@ package org.exist.xquery;
 
 import org.junit.After;
 import org.junit.Before;
+import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.XMLResource;
-import org.xmldb.api.modules.XQueryService;
 
 /**
  * @author Adam Retter <adam.retter@googlemail.com>
@@ -23,12 +23,12 @@ public class PersistentDescendantOrSelfNodeKindTest extends AbstractDescendantOr
 
     @Override
     protected ResourceSet executeQueryOnDoc(final String docQuery) throws XMLDBException {
-        final XQueryService service = (XQueryService) root.getService("XPathQueryService", "1.0");
-        return service.query(getDbQuery(docQuery));
+        return  existEmbeddedServer.executeQuery(getDbQuery(docQuery));
     }
 
     @Before
     public void storeTestDoc() throws XMLDBException {
+        final Collection root =  existEmbeddedServer.getRoot();
         final XMLResource res = (XMLResource)root.createResource(TEST_DOCUMENT_NAME, "XMLResource");
         res.setContent(TEST_DOCUMENT);
         root.storeResource(res);
@@ -36,6 +36,7 @@ public class PersistentDescendantOrSelfNodeKindTest extends AbstractDescendantOr
 
     @After
     public void removeTestDoc() throws XMLDBException {
+        final Collection root =  existEmbeddedServer.getRoot();
         final Resource res = root.getResource(TEST_DOCUMENT_NAME);
         root.removeResource(res);
     }

--- a/test/src/org/exist/xquery/TestXPathOpOrSpecialCase.java
+++ b/test/src/org/exist/xquery/TestXPathOpOrSpecialCase.java
@@ -1,23 +1,13 @@
 package org.exist.xquery;
 
-import org.junit.Before;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.*;
 
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.CollectionManagementService;
 import org.xmldb.api.modules.XMLResource;
-import org.xmldb.api.modules.XQueryService;
 
-import org.exist.TestUtils;
-import org.exist.jetty.JettyStart;
-import org.exist.xmldb.CollectionImpl;
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
 
 /**
  * This is the simplest test that demonstrates the <tt>Predicate</tt>/<tt>OpOr</tt>
@@ -25,80 +15,30 @@ import org.exist.xmldb.XmldbURI;
  * source code. 
  * @author Jason Smith
  */
-public class TestXPathOpOrSpecialCase extends Assert
-{
-	/** The local database getUri. */
-	private static final String uri = XmldbURI.LOCAL_DB;
-	/** The test Jetty server. */
-	private JettyStart server = null;
-	
-	/** Database root collection. */
-	private Collection rootCollection;
+public class TestXPathOpOrSpecialCase extends Assert {
+
+	@ClassRule
+	public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
 	/** Database test collection (<tt>/db/blah</tt>). */
 	private Collection testCollection;
 	
 	@Before
 	public void setUp() throws Exception 
 	{
-        if (server == null) 
-		{
-			server = new JettyStart();
-			server.run();
-		}
-        
-        final Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        final Database database = (Database)cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-
-        rootCollection = DatabaseManager.getCollection(uri, "admin", "");
-        final CollectionManagementService service = (CollectionManagementService)rootCollection.getService("CollectionManagementService", "1.0");
+        final CollectionManagementService service = (CollectionManagementService)existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
         testCollection = service.createCollection("blah");
         assertNotNull(testCollection);
     }
-    
-    @After
-    public void tearDown() throws Exception 
-    {
-		try 
-		{
-			TestUtils.cleanupDB();
-            if (!((CollectionImpl)testCollection).isRemoteCollection()) 
-            {
-                DatabaseInstanceManager dim = (DatabaseInstanceManager)testCollection.getService("DatabaseInstanceManager", "1.0");
-                dim.shutdown();
-            }
-            testCollection = null;
-        } 
-        catch(final XMLDBException e) 
-        {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
-    }
 
-	/** 
-	 * Store the XML string into the specified collection and document.
-	 * @param The target collection.
-     * @param documentName The target document name.
-     * @param content The XML content to be stored.
-     * @throws XMLDBException See {@link XMLDBException}.
-     */
-    private void storeXML(final Collection collection, final String documentName, final String content) throws XMLDBException 
-    {
-        final XMLResource doc = (XMLResource)collection.createResource(documentName, "XMLResource");
-        doc.setContent(content);
-        collection.storeResource(doc);
-    }
-    
-    /**
-     * Get the XQuery service.
-     * @param collection The target collection.
-     * @throws XMLDBException See {@link XMLDBException}.
-     */
-    private XQueryService getXQueryService(final Collection collection) throws XMLDBException
-    {
-		return (XQueryService)collection.getService("XPathQueryService", "1.0");
+	@After
+	public void tearDown() throws Exception {
+		final CollectionManagementService service =
+				(CollectionManagementService) existEmbeddedServer.getRoot().getService(
+						"CollectionManagementService",
+						"1.0");
+		service.removeCollection("blah");
+		testCollection = null;
 	}
 
 	/**
@@ -110,14 +50,28 @@ public class TestXPathOpOrSpecialCase extends Assert
 	public void verifyOpOrInPredicate() throws Exception
 	{
 		try
-		{	
+		{
 			storeXML(testCollection, "blah.xml", "<blah>No element content.</blah>");
-			getXQueryService(rootCollection).query("/blah[a='A' or b='B']");
+			existEmbeddedServer.executeQuery("/blah[a='A' or b='B']");
 		}
 		catch(final XMLDBException e)
 		{
 			e.printStackTrace();
 			throw e;
-		}	
+		}
 	}
+
+	/** 
+	 * Store the XML string into the specified collection and document.
+	 * @param collection The target collection.
+     * @param documentName The target document name.
+     * @param content The XML content to be stored.
+     * @throws XMLDBException See {@link XMLDBException}.
+     */
+    private void storeXML(final Collection collection, final String documentName, final String content) throws XMLDBException 
+    {
+        final XMLResource doc = (XMLResource)collection.createResource(documentName, "XMLResource");
+        doc.setContent(content);
+        collection.storeResource(doc);
+    }
 }

--- a/test/src/org/exist/xquery/TransformTest.java
+++ b/test/src/org/exist/xquery/TransformTest.java
@@ -1,14 +1,14 @@
 package org.exist.xquery;
 
-import org.exist.xmldb.DatabaseInstanceManager;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.xmldb.EXistResource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
@@ -21,9 +21,11 @@ import static org.junit.Assert.assertNotNull;
 
 
 public class TransformTest {
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
 	private static final String TEST_COLLECTION_NAME = "transform-test";
-    
-    private Database database;
+
     private Collection testCollection;
     
     /**
@@ -70,16 +72,8 @@ public class TransformTest {
 
     @Before
     public void setUp() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-
-        Collection root =
-            DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
         CollectionManagementService service =
-            (CollectionManagementService) root.getService(
+            (CollectionManagementService) existEmbeddedServer.getRoot().getService(
                 "CollectionManagementService",
                 "1.0");
         testCollection = service.createCollection(TEST_COLLECTION_NAME);
@@ -149,13 +143,6 @@ public class TransformTest {
                 "CollectionManagementService",
                 "1.0");
         service.removeCollection(TEST_COLLECTION_NAME);
-
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim =
-            (DatabaseInstanceManager) testCollection.getService(
-                "DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-        database = null;
         testCollection = null;
     }
 }

--- a/test/src/org/exist/xquery/UnionTest.java
+++ b/test/src/org/exist/xquery/UnionTest.java
@@ -1,17 +1,12 @@
 package org.exist.xquery;
 
-import org.exist.TestUtils;
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
-import org.junit.AfterClass;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.*;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.xmldb.api.DatabaseManager;
+
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.CollectionManagementService;
@@ -25,7 +20,10 @@ import org.xmldb.api.modules.XQueryService;
  * @author Adam Retter <adam.retter@googlemail.com>
  */
 public class UnionTest {
-    
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
     private final static String TEST_COLLECTION_NAME = "test-pubmed";
     
     private final static String PUBMED_DOC_NAME = "pubmed.xml";
@@ -171,28 +169,21 @@ public class UnionTest {
             service.removeCollection(TEST_COLLECTION_NAME);
         }
     }
-    
-    @BeforeClass
-    public static void startDbAndCreateTestCollection() throws Exception {
-        
-        // initialize driver
-        final Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        final Database database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
 
-        final Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        final CollectionManagementService service = (CollectionManagementService)root.getService("CollectionManagementService", "1.0");
+    @BeforeClass
+    public static void createTestCollection() throws Exception {
+        final CollectionManagementService service = (CollectionManagementService)existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
         testCollection = service.createCollection(TEST_COLLECTION_NAME);
         assertNotNull(testCollection);
     }
-    
+
     @AfterClass
     public static void tearDown() throws Exception {
-        TestUtils.cleanupDB();
-
-        final DatabaseInstanceManager dim = (DatabaseInstanceManager)testCollection.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
+        final CollectionManagementService service =
+                (CollectionManagementService) existEmbeddedServer.getRoot().getService(
+                        "CollectionManagementService",
+                        "1.0");
+        service.removeCollection(TEST_COLLECTION_NAME);
         testCollection = null;
     }
 }

--- a/test/src/org/exist/xquery/ValueIndexTest.java
+++ b/test/src/org/exist/xquery/ValueIndexTest.java
@@ -23,15 +23,13 @@ package org.exist.xquery;
 
 import java.io.File;
 
-import org.exist.xmldb.DatabaseInstanceManager;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.xmldb.IndexQueryService;
-import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceIterator;
 import org.xmldb.api.base.ResourceSet;
@@ -49,7 +47,8 @@ import static org.junit.Assert.assertNotNull;
  */
 public class ValueIndexTest {
 
-    private final static String URI = XmldbURI.LOCAL_DB;
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     private String CONFIG =
     	"<collection xmlns=\"http://exist-db.org/collection-config/1.0\">" + 
@@ -99,14 +98,7 @@ public class ValueIndexTest {
 
     @Before
     public void setUp() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        Database database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-
-        Collection root = DatabaseManager.getCollection(URI, "admin", "");
-        CollectionManagementService service = (CollectionManagementService) root
+        final CollectionManagementService service = (CollectionManagementService) existEmbeddedServer.getRoot()
                 .getService("CollectionManagementService", "1.0");
         testCollection = service.createCollection("test");
         assertNotNull(testCollection);
@@ -114,17 +106,10 @@ public class ValueIndexTest {
 
     @After
     public void tearDown() throws Exception {
-        try {
-            Collection root = DatabaseManager.getCollection(URI, "admin", "");
-            CollectionManagementService service = (CollectionManagementService) root
-                    .getService("CollectionManagementService", "1.0");
-            service.removeCollection("test");
-        } finally {
-            DatabaseInstanceManager dim =
-                    (DatabaseInstanceManager) testCollection.getService("DatabaseInstanceManager", "1.0");
-            dim.shutdown();
-            testCollection = null;
-        }
+        final CollectionManagementService service = (CollectionManagementService) existEmbeddedServer.getRoot()
+                .getService("CollectionManagementService", "1.0");
+        service.removeCollection("test");
+        testCollection = null;
     }
     
 	/**

--- a/test/src/org/exist/xquery/XQueryFunctionsTest.java
+++ b/test/src/org/exist/xquery/XQueryFunctionsTest.java
@@ -27,19 +27,16 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Optional;
 
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.ConfigurationHelper;
 import org.exist.util.FileUtils;
-import org.exist.xmldb.DatabaseInstanceManager;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.BinaryResource;
 import org.xmldb.api.modules.CollectionManagementService;
-import org.xmldb.api.modules.XPathQueryService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -62,14 +59,14 @@ import static org.junit.Assert.assertTrue;
  */
 public class XQueryFunctionsTest {
 
-    private static XPathQueryService service;
-    private static Collection root = null;
-    private static Database database = null;
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+    
     private final static String ROOT_COLLECTION_URI = "xmldb:exist:///db";
 
     @Test
     public void arguments() throws XPathException, XMLDBException {
-        ResourceSet result = service.query("declare function local:testAnyURI($uri as xs:string) as xs:string { " +
+        ResourceSet result = existEmbeddedServer.executeQuery("declare function local:testAnyURI($uri as xs:string) as xs:string { " +
                 "concat('Successfully processed as xs:string : ',$uri) " +
                 "}; " +
                 "let $a := xs:anyURI('http://exist.sourceforge.net/') " +
@@ -79,7 +76,7 @@ public class XQueryFunctionsTest {
         assertEquals("Successfully processed as xs:string : http://exist.sourceforge.net/", r);
 
 
-        result = service.query("declare function local:testEmpty($blah as xs:string)  as element()* { " +
+        result = existEmbeddedServer.executeQuery("declare function local:testEmpty($blah as xs:string)  as element()* { " +
                 "for $a in (1,2,3) order by $a " +
                 "return () " +
                 "}; " +
@@ -94,17 +91,17 @@ public class XQueryFunctionsTest {
     @Test
     public void roundHtE_INTEGER() throws XPathException, XMLDBException {
         String query = "fn:round-half-to-even( xs:integer('1'), 0 )";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         String r = (String) result.getResource(0).getContent();
         assertEquals("1", r);
 
         query = "fn:round-half-to-even( xs:integer('6'), -1 )";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals("10", r);
 
         query = "fn:round-half-to-even( xs:integer('5'), -1 )";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals("0", r);
     }
@@ -123,10 +120,9 @@ public class XQueryFunctionsTest {
         int[] precision =
                 {0, 0, 0, 2, 2, -2};
 
-        XPathQueryService service = (XPathQueryService) root.getService("XQueryService", "1.0");
         for (int i = 0; i < testvalues.length; i++) {
             String query = "fn:round-half-to-even( xs:double('" + testvalues[i] + "'), " + precision[i] + " )";
-            ResourceSet result = service.query(query);
+            ResourceSet result = existEmbeddedServer.executeQuery(query);
             String r = (String) result.getResource(0).getContent();
             assertEquals(resultvalues[i], r);
         }
@@ -137,19 +133,19 @@ public class XQueryFunctionsTest {
      */
     @Test
     public void tokenize() throws XPathException, XMLDBException {
-        ResourceSet result = service.query("count ( tokenize('a/b' , '/') )");
+        ResourceSet result = existEmbeddedServer.executeQuery("count ( tokenize('a/b' , '/') )");
         String r = (String) result.getResource(0).getContent();
         assertEquals("2", r);
 
-        result = service.query("count ( tokenize('a/b/' , '/') )");
+        result = existEmbeddedServer.executeQuery("count ( tokenize('a/b/' , '/') )");
         r = (String) result.getResource(0).getContent();
         assertEquals("3", r);
 
-        result = service.query("count ( tokenize('' , '/') )");
+        result = existEmbeddedServer.executeQuery("count ( tokenize('' , '/') )");
         r = (String) result.getResource(0).getContent();
         assertEquals("0", r);
 
-        result = service.query(
+        result = existEmbeddedServer.executeQuery(
                 "let $res := fn:tokenize('abracadabra', '(ab)|(a)')" +
                         "let $reference := ('', 'r', 'c', 'd', 'r', '')" +
                         "return fn:deep-equal($res, $reference)");
@@ -159,7 +155,7 @@ public class XQueryFunctionsTest {
 
     @Test
     public void deepEqual() throws XPathException, XMLDBException {
-        ResourceSet result = service.query(
+        ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $res := ('a', 'b')" +
                         "let $reference := ('a', 'b')" +
                         "return fn:deep-equal($res, $reference)");
@@ -169,119 +165,119 @@ public class XQueryFunctionsTest {
 
     @Test
     public void compare() throws XPathException, XMLDBException {
-        ResourceSet result = service.query("fn:compare(\"Strasse\", \"Stra\u00DFe\")");
+        ResourceSet result = existEmbeddedServer.executeQuery("fn:compare(\"Strasse\", \"Stra\u00DFe\")");
         String r = (String) result.getResource(0).getContent();
         assertEquals("-1", r);
-        //result 	= service.query("fn:compare(\"Strasse\", \"Stra\u00DFe\", \"java:GermanCollator\")");
+        //result 	= existEmbeddedServer.executeQuery("fn:compare(\"Strasse\", \"Stra\u00DFe\", \"java:GermanCollator\")");
         //r 		= (String) result.getResource(0).getContent();
         //assertEquals( "0", r );
 
         String query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "return $a/b[compare(., '+') gt 0]";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
     @Test
     public void distinctValues() throws XPathException, XMLDBException {
-        ResourceSet result = service.query("declare variable $c { distinct-values(('a', 'a')) }; $c");
+        ResourceSet result = existEmbeddedServer.executeQuery("declare variable $c { distinct-values(('a', 'a')) }; $c");
         String r = (String) result.getResource(0).getContent();
         assertEquals("a", r);
 
-        result = service.query("declare variable $c { distinct-values((<a>a</a>, <b>a</b>)) }; $c");
+        result = existEmbeddedServer.executeQuery("declare variable $c { distinct-values((<a>a</a>, <b>a</b>)) }; $c");
         r = (String) result.getResource(0).getContent();
         assertEquals("a", r);
 
-        result = service.query("let $seq := ('A', 2, 'B', 2) return distinct-values($seq) ");
+        result = existEmbeddedServer.executeQuery("let $seq := ('A', 2, 'B', 2) return distinct-values($seq) ");
         assertEquals(3, result.getSize());
 
         String query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "return $a/b[distinct-values(.)]";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
     @Test
     public void sum() throws XPathException, XMLDBException {
-        ResourceSet result = service.query("declare variable $c { sum((1, 2)) }; $c");
+        ResourceSet result = existEmbeddedServer.executeQuery("declare variable $c { sum((1, 2)) }; $c");
         String r = (String) result.getResource(0).getContent();
         assertEquals("3", r);
 
-        result = service.query("declare variable $c { sum((<a>1</a>, <b>2</b>)) }; $c");
+        result = existEmbeddedServer.executeQuery("declare variable $c { sum((<a>1</a>, <b>2</b>)) }; $c");
         r = (String) result.getResource(0).getContent();
         //Any untyped atomic values in the sequence are converted to xs:double values ([MK Xpath 2.0], p. 432)
         assertEquals("3", r);
 
-        result = service.query("declare variable $c { sum((), 3) }; $c");
+        result = existEmbeddedServer.executeQuery("declare variable $c { sum((), 3) }; $c");
         r = (String) result.getResource(0).getContent();
         assertEquals("3", r);
     }
 
     @Test
     public void avg() throws XPathException, XMLDBException {
-        ResourceSet result = service.query("avg((2, 2))");
+        ResourceSet result = existEmbeddedServer.executeQuery("avg((2, 2))");
         String r = (String) result.getResource(0).getContent();
         assertEquals("2", r);
 
-        result = service.query("avg((<a>2</a>, <b>2</b>))");
+        result = existEmbeddedServer.executeQuery("avg((<a>2</a>, <b>2</b>))");
         r = (String) result.getResource(0).getContent();
         //Any untyped atomic values in the resulting sequence
         //(typically, values extracted from nodes in a schemaless document)
         //are converted to xs:double values ([MK Xpath 2.0], p. 301)
         assertEquals("2", r);
 
-        result = service.query("avg((3, 4, 5))");
+        result = existEmbeddedServer.executeQuery("avg((3, 4, 5))");
         r = (String) result.getResource(0).getContent();
         assertEquals("4", r);
 
-        result = service.query("avg((xdt:yearMonthDuration('P20Y'), xdt:yearMonthDuration('P10M')))");
+        result = existEmbeddedServer.executeQuery("avg((xdt:yearMonthDuration('P20Y'), xdt:yearMonthDuration('P10M')))");
         r = (String) result.getResource(0).getContent();
         assertEquals("P10Y5M", r);
 
         String message = "";
         try {
-            result = service.query("avg((xdt:yearMonthDuration('P20Y') , (3, 4, 5)))");
+            result = existEmbeddedServer.executeQuery("avg((xdt:yearMonthDuration('P20Y') , (3, 4, 5)))");
         } catch (XMLDBException e) {
             message = e.getMessage();
         }
         assertTrue(message.indexOf("FORG0006") > -1);
 
-        result = service.query("avg(())");
+        result = existEmbeddedServer.executeQuery("avg(())");
         assertEquals(0, result.getSize());
 
-        result = service.query("avg(((xs:float('INF')), xs:float('-INF')))");
+        result = existEmbeddedServer.executeQuery("avg(((xs:float('INF')), xs:float('-INF')))");
         r = (String) result.getResource(0).getContent();
         assertEquals("NaN", r);
 
-        result = service.query("avg(((3, 4, 5), xs:float('NaN')))");
+        result = existEmbeddedServer.executeQuery("avg(((3, 4, 5), xs:float('NaN')))");
         r = (String) result.getResource(0).getContent();
         assertEquals("NaN", r);
     }
 
     @Test
     public void min() throws XPathException, XMLDBException {
-        ResourceSet result = service.query("min((1, 2))");
+        ResourceSet result = existEmbeddedServer.executeQuery("min((1, 2))");
         String r = (String) result.getResource(0).getContent();
         assertEquals("1", r);
 
-        result = service.query("min((<a>1</a>, <b>2</b>))");
+        result = existEmbeddedServer.executeQuery("min((<a>1</a>, <b>2</b>))");
         r = (String) result.getResource(0).getContent();
         assertEquals("1", r);
 
-        result = service.query("min(())");
+        result = existEmbeddedServer.executeQuery("min(())");
         assertEquals(0, result.getSize());
 
-        result = service.query("min((xs:dateTime('2005-12-19T16:22:40.006+01:00'), xs:dateTime('2005-12-19T16:29:40.321+01:00')))");
+        result = existEmbeddedServer.executeQuery("min((xs:dateTime('2005-12-19T16:22:40.006+01:00'), xs:dateTime('2005-12-19T16:29:40.321+01:00')))");
         r = (String) result.getResource(0).getContent();
         assertEquals("2005-12-19T16:22:40.006+01:00", r);
 
-        result = service.query("min(('a', 'b'))");
+        result = existEmbeddedServer.executeQuery("min(('a', 'b'))");
         r = (String) result.getResource(0).getContent();
         assertEquals("a", r);
 
         String message = "";
         try {
-            result = service.query("min((xs:dateTime('2005-12-19T16:22:40.006+01:00'), 'a'))");
+            result = existEmbeddedServer.executeQuery("min((xs:dateTime('2005-12-19T16:22:40.006+01:00'), 'a'))");
         } catch (XMLDBException e) {
             message = e.getMessage();
         }
@@ -289,7 +285,7 @@ public class XQueryFunctionsTest {
 
         try {
             message = "";
-            result = service.query("min(1, 2)");
+            result = existEmbeddedServer.executeQuery("min(1, 2)");
         } catch (XMLDBException e) {
             message = e.getMessage();
         }
@@ -298,28 +294,28 @@ public class XQueryFunctionsTest {
     }
 
     public void max() throws XPathException, XMLDBException {
-        ResourceSet result = service.query("max((1, 2))");
+        ResourceSet result = existEmbeddedServer.executeQuery("max((1, 2))");
         String r = (String) result.getResource(0).getContent();
         assertEquals("2", r);
 
-        result = service.query("max((<a>1</a>, <b>2</b>))");
+        result = existEmbeddedServer.executeQuery("max((<a>1</a>, <b>2</b>))");
         r = (String) result.getResource(0).getContent();
         assertEquals("2", r);
 
-        result = service.query("max(())");
+        result = existEmbeddedServer.executeQuery("max(())");
         assertEquals(0, result.getSize());
 
-        result = service.query("max((xs:dateTime('2005-12-19T16:22:40.006+01:00'), xs:dateTime('2005-12-19T16:29:40.321+01:00')))");
+        result = existEmbeddedServer.executeQuery("max((xs:dateTime('2005-12-19T16:22:40.006+01:00'), xs:dateTime('2005-12-19T16:29:40.321+01:00')))");
         r = (String) result.getResource(0).getContent();
         assertEquals("2005-12-19T16:29:40.321+01:00", r);
 
-        result = service.query("max(('a', 'b'))");
+        result = existEmbeddedServer.executeQuery("max(('a', 'b'))");
         r = (String) result.getResource(0).getContent();
         assertEquals("b", r);
 
         String message = "";
         try {
-            result = service.query("max((xs:dateTime('2005-12-19T16:22:40.006+01:00'), 'a'))");
+            result = existEmbeddedServer.executeQuery("max((xs:dateTime('2005-12-19T16:22:40.006+01:00'), 'a'))");
         } catch (XMLDBException e) {
             message = e.getMessage();
         }
@@ -327,7 +323,7 @@ public class XQueryFunctionsTest {
 
         try {
             message = "";
-            result = service.query("max(1, 2)");
+            result = existEmbeddedServer.executeQuery("max(1, 2)");
         } catch (XMLDBException e) {
             message = e.getMessage();
         }
@@ -341,7 +337,7 @@ public class XQueryFunctionsTest {
                 "let $query2 := (2, 3)\n" +
                 "let $a := util:exclusive-lock(//*,($query1, $query2))\n" +
                 "return $a";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(3, result.getSize());
         String r = (String) result.getResource(0).getContent();
         assertEquals("<a/>", r);
@@ -354,7 +350,7 @@ public class XQueryFunctionsTest {
                 "let $query2 := (2, 3)\n" +
                 "let $a := util:exclusive-lock((),($query1, $query2))\n" +
                 "return $a";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(3, result.getSize());
         r = (String) result.getResource(0).getContent();
         assertEquals("<a/>", r);
@@ -367,7 +363,7 @@ public class XQueryFunctionsTest {
                 "let $query2 := (2, 3)\n" +
                 "let $a := util:exclusive-lock((),($query1, $query2))\n" +
                 "return $a";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(3, result.getSize());
         r = (String) result.getResource(0).getContent();
         assertEquals("<a/>", r);
@@ -378,7 +374,7 @@ public class XQueryFunctionsTest {
 
         query = "let $a := util:exclusive-lock(//*,<root/>)\n" +
                 "return $a";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals("<root/>", r);
     }
@@ -387,7 +383,7 @@ public class XQueryFunctionsTest {
     @Test
     public void utilEval1() throws XPathException, XMLDBException {
         String query = "<a><b/></a>/util:eval('*')";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(1, result.getSize());
     }
 
@@ -399,7 +395,7 @@ public class XQueryFunctionsTest {
         String query = "let $context := <item/> " +
                 "return util:eval(\"<result>{$context}</result>\")";
         // TODO check result
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(1, result.getSize());
     }
 
@@ -412,7 +408,7 @@ public class XQueryFunctionsTest {
                 + "};\n"
                 + "util:eval(\"local:home()\")\n";
 
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(1, result.getSize());
     }
 
@@ -422,7 +418,7 @@ public class XQueryFunctionsTest {
                 "let $query2 := (2, 3)\n" +
                 "let $a := util:shared-lock(//*,($query1, $query2))\n" +
                 "return $a";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(3, result.getSize());
         String r = (String) result.getResource(0).getContent();
         assertEquals("<a/>", r);
@@ -435,7 +431,7 @@ public class XQueryFunctionsTest {
                 "let $query2 := (2, 3)\n" +
                 "let $a := util:shared-lock((),($query1, $query2))\n" +
                 "return $a";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(3, result.getSize());
         r = (String) result.getResource(0).getContent();
         assertEquals("<a/>", r);
@@ -448,7 +444,7 @@ public class XQueryFunctionsTest {
                 "let $query2 := (2, 3)\n" +
                 "let $a := util:shared-lock((),($query1, $query2))\n" +
                 "return $a";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(3, result.getSize());
         r = (String) result.getResource(0).getContent();
         assertEquals("<a/>", r);
@@ -459,7 +455,7 @@ public class XQueryFunctionsTest {
 
         query = "let $a := util:shared-lock(//*,<root/>)\n" +
                 "return $a";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals("<root/>", r);
     }
@@ -469,28 +465,28 @@ public class XQueryFunctionsTest {
         String string = "http://www.example.com/00/Weather/CA/Los%20Angeles#ocean";
         String expected = "http%3A%2F%2Fwww.example.com%2F00%2FWeather%2FCA%2FLos%2520Angeles%23ocean";
         String query = "encode-for-uri(\"" + string + "\")";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         String r = (String) result.getResource(0).getContent();
         assertEquals(expected, r);
 
         string = "~b\u00e9b\u00e9";
         expected = "~b%C3%A9b%C3%A9";
         query = "encode-for-uri(\"" + string + "\")";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals(expected, r);
 
         string = "100% organic";
         expected = "100%25%20organic";
         query = "encode-for-uri(\"" + string + "\")";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals(expected, r);
 
 
         query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "return $a/b[encode-for-uri(.) ne '']";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
@@ -499,7 +495,7 @@ public class XQueryFunctionsTest {
         String string = "http://www.example.com/00/Weather/CA/Los%20Angeles#ocean";
         String expected = "http://www.example.com/00/Weather/CA/Los%20Angeles#ocean";
         String query = "iri-to-uri(\"" + string + "\")";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         String r = (String) result.getResource(0).getContent();
         assertEquals(expected, r);
 
@@ -507,14 +503,14 @@ public class XQueryFunctionsTest {
         string = "http://www.example.com/~b\u00e9b\u00e9";
         expected = "http://www.example.com/~b%C3%A9b%C3%A9";
         query = "iri-to-uri(\"" + string + "\")";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals(expected, r);
 
         string = "$";
         expected = "$";
         query = "iri-to-uri(\"" + string + "\")";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals(expected, r);
     }
@@ -524,31 +520,31 @@ public class XQueryFunctionsTest {
         String string = "http://www.example.com/00/Weather/CA/Los Angeles#ocean";
         String expected = "http://www.example.com/00/Weather/CA/Los Angeles#ocean";
         String query = "escape-html-uri(\"" + string + "\")";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         String r = (String) result.getResource(0).getContent();
         assertEquals(expected, r);
 
         string = "javascript:if (navigator.browserLanguage == 'fr') window.open('http://www.example.com/~b\u00e9b\u00e9');";
         expected = "javascript:if (navigator.browserLanguage == 'fr') window.open('http://www.example.com/~b%C3%A9b%C3%A9');";
         query = "escape-html-uri(\"" + string + "\")";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals(expected, r);
 
         query = "escape-html-uri('$')";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals("$", r);
 
         query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "return $a/b[escape-html-uri(.) ne '']";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
     @Test
     public void localName() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $a := <a><b></b></a>" +
                         "return fn:local-name($a)");
         String r = (String) result.getResource(0).getContent();
@@ -557,7 +553,7 @@ public class XQueryFunctionsTest {
 
     @Test
     public void localName_empty() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "fn:local-name(())");
         final String r = (String) result.getResource(0).getContent();
         assertEquals("", r);
@@ -565,7 +561,7 @@ public class XQueryFunctionsTest {
 
     @Test
     public void localName_emptyElement() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "<a>b</a>/fn:local-name(c)");
         final String r = (String) result.getResource(0).getContent();
         assertEquals("", r);
@@ -573,7 +569,7 @@ public class XQueryFunctionsTest {
 
     @Test
     public void localName_emptyText() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "<a>b</a>/fn:local-name(text())");
         final String r = (String) result.getResource(0).getContent();
         assertEquals("", r);
@@ -581,7 +577,7 @@ public class XQueryFunctionsTest {
 
     @Test
     public void name() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $a := <a><b></b></a>" +
                         "return fn:name($a)");
         String r = (String) result.getResource(0).getContent();
@@ -590,7 +586,7 @@ public class XQueryFunctionsTest {
 
     @Test
     public void name_empty() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "fn:name(())");
         final String r = (String) result.getResource(0).getContent();
         assertEquals("", r);
@@ -598,7 +594,7 @@ public class XQueryFunctionsTest {
 
     @Test
     public void name_emptyElement() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "<a>b</a>/fn:name(c)");
         final String r = (String) result.getResource(0).getContent();
         assertEquals("", r);
@@ -606,7 +602,7 @@ public class XQueryFunctionsTest {
 
     @Test
     public void name_emptyText() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "<a>b</a>/fn:local-name(text())");
         final String r = (String) result.getResource(0).getContent();
         assertEquals("", r);
@@ -614,7 +610,7 @@ public class XQueryFunctionsTest {
 
     @Test
     public void dateTimeConstructor() throws XPathException, XMLDBException {
-        ResourceSet result = service.query(
+        ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $date := xs:date('2007-05-02+02:00') " +
                         "return dateTime($date, xs:time('15:12:52.421+02:00'))"
         );
@@ -625,7 +621,7 @@ public class XQueryFunctionsTest {
     @Test
     public void currentDateTime() throws XPathException, XMLDBException {
         //Do not use this test around midnight on the last day of a month ;-)
-        ResourceSet result = service.query(
+        ResourceSet result = existEmbeddedServer.executeQuery(
                 "('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', " +
                         "'Oct', 'Nov', 'Dec')[month-from-dateTime(current-dateTime())]");
         String r = (String) result.getResource(0).getContent();
@@ -635,7 +631,7 @@ public class XQueryFunctionsTest {
 
         String query = "declare option exist:current-dateTime '2007-08-23T00:01:02.062+02:00';" +
                 "current-dateTime()";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(1, result.getSize());
         r = (String) result.getResource(0).getContent();
         assertEquals("2007-08-23T00:01:02.062+02:00", r);
@@ -651,11 +647,11 @@ public class XQueryFunctionsTest {
      */
     @Test
     public void secondsFromDateTime() throws XMLDBException {
-        ResourceSet result = service.query("seconds-from-dateTime(xs:dateTime(\"2005-12-22T13:35:21.000\") )");
+        ResourceSet result = existEmbeddedServer.executeQuery("seconds-from-dateTime(xs:dateTime(\"2005-12-22T13:35:21.000\") )");
         String r = (String) result.getResource(0).getContent();
         assertEquals("21", r);
 
-        result = service.query("seconds-from-dateTime(xs:dateTime(\"2005-12-22T13:35:21\") )");
+        result = existEmbeddedServer.executeQuery("seconds-from-dateTime(xs:dateTime(\"2005-12-22T13:35:21\") )");
         r = (String) result.getResource(0).getContent();
         assertEquals("21", r);
     }
@@ -669,7 +665,7 @@ public class XQueryFunctionsTest {
                 "for $e in $d/d " +
                 "return fn:resolve-QName($e/text(), $e)";
 
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         String r = (String) result.getResource(0).getContent();
         assertEquals("x:test", r);
 
@@ -678,7 +674,7 @@ public class XQueryFunctionsTest {
                 "declare variable $d := <c xmlns:x=\"ns1\"><d xmlns:y=\"ns1\">y:test</d></c>; " +
                 "for $e in $d/d " +
                 "return fn:resolve-QName($e/text(), $e)";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals("y:test", r);
     }
@@ -688,13 +684,13 @@ public class XQueryFunctionsTest {
         String query = "let $var := <a xmlns='aaa'/> " +
                 "return " +
                 "$var[fn:namespace-uri() = 'aaa']/fn:namespace-uri()";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         String r = (String) result.getResource(0).getContent();
         assertEquals("aaa", r);
 
         query = "for $a in <test><a xmlns=\"aaa\"><b><c/></b></a></test>//* " +
                 "return namespace-uri($a)";
-        result = service.query(query);
+        result = existEmbeddedServer.executeQuery(query);
         assertEquals(result.getSize(), 3);
         r = (String) result.getResource(0).getContent();
         assertEquals("aaa", r);
@@ -709,7 +705,7 @@ public class XQueryFunctionsTest {
         String query = "declare namespace foo = \"http://example.org\"; " +
                 "declare namespace FOO = \"http://example.org\"; " +
                 "fn:prefix-from-QName(xs:QName(\"foo:bar\"))";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         String r = (String) result.getResource(0).getContent();
         assertEquals("foo", r);
     }
@@ -718,7 +714,7 @@ public class XQueryFunctionsTest {
     public void stringJoin() throws XMLDBException {
         String query = "let $s := ('','a','b','') " +
                 "return string-join($s,'/')";
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         String r = (String) result.getResource(0).getContent();
         assertEquals("/a/b/", r);
     }
@@ -727,27 +723,28 @@ public class XQueryFunctionsTest {
     public void nodeName() throws XMLDBException {
         final String query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "for $b in $a/b[fn:node-name(.) = xs:QName('b')] return $b";
-        final ResourceSet result = service.query(query);
+
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
     @Test
     public void noeName_empty() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "fn:node-name(())");
         assertEquals(0, result.getSize());
     }
 
     @Test
     public void nodeName_emptyElement() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "<a>b</a>/fn:node-name(c)");
         assertEquals(0, result.getSize());
     }
 
     @Test
     public void nodeName_emptyText() throws XPathException, XMLDBException {
-        final ResourceSet result = service.query(
+        final ResourceSet result = existEmbeddedServer.executeQuery(
                 "<a>b</a>/fn:node-name(text())");
         assertEquals(0, result.getSize());
     }
@@ -757,7 +754,7 @@ public class XQueryFunctionsTest {
         final String query = "let $a := <a><b>1</b><b>1</b></a> " +
                 "for $b in $a/b[data() = '1'] return $b";
 
-        final ResourceSet result = service.query(query);
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
@@ -765,7 +762,7 @@ public class XQueryFunctionsTest {
     public void data0_atomization() throws XMLDBException {
         final String query = "(<a>1<b>2</b>three</a>, <four>4</four>)/data()";
 
-        final ResourceSet result = service.query(query);
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
         assertEquals("12three", result.getResource(0).getContent().toString());
         assertEquals("4", result.getResource(1).getContent());
@@ -776,7 +773,7 @@ public class XQueryFunctionsTest {
         final String query = "let $a := <a><b>1</b><b>1</b></a> " +
                 "for $b in $a/b[data() = '1'] return $b";
 
-        final ResourceSet result = service.query(query);
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
@@ -784,7 +781,7 @@ public class XQueryFunctionsTest {
     public void data1_atomization() throws XMLDBException {
         final String query = "data((<a>1<b>2</b>three</a>, <four>4</four>, xs:integer(5)))";
 
-        final ResourceSet result = service.query(query);
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(3, result.getSize());
         assertEquals("12three", result.getResource(0).getContent().toString());
         assertEquals("4", result.getResource(1).getContent());
@@ -796,7 +793,7 @@ public class XQueryFunctionsTest {
         String query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "return $a/b[abs(ceiling(.))]";
 
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
@@ -805,7 +802,7 @@ public class XQueryFunctionsTest {
         String query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "return $a/b[concat('+', ., '+') = '+-2+']";
 
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(1, result.getSize());
     }
 
@@ -814,7 +811,7 @@ public class XQueryFunctionsTest {
         String query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "return $a/b[empty(document-uri(.))]";
 
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
@@ -823,7 +820,7 @@ public class XQueryFunctionsTest {
         String query = "declare option exist:implicit-timezone 'PT3H';" +
                 "implicit-timezone()";
 
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(1, result.getSize());
         String r = (String) result.getResource(0).getContent();
         assertEquals("PT3H", r);
@@ -834,7 +831,7 @@ public class XQueryFunctionsTest {
         String query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "return $a/b[exists(.)]";
 
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
 
     }
@@ -844,7 +841,7 @@ public class XQueryFunctionsTest {
         String query = "let $a := <a><b>-1</b><b>-2</b></a> " +
                 "return $a/b[abs(floor(.))]";
 
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertEquals(2, result.getSize());
     }
 
@@ -859,9 +856,9 @@ public class XQueryFunctionsTest {
         String collectionPath = XmldbURI.ROOT_COLLECTION + "/" + collectionName;
         String collectionURI = ROOT_COLLECTION_URI + "/" + collectionName;
 
-        Collection testCollection = root.getChildCollection(collectionName);
+        Collection testCollection = existEmbeddedServer.getRoot().getChildCollection(collectionName);
         if (testCollection != null) {
-            CollectionManagementService cms = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+            CollectionManagementService cms = (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
             cms.removeCollection(collectionPath);
         }
 
@@ -880,9 +877,9 @@ public class XQueryFunctionsTest {
         String collectionPath = XmldbURI.ROOT_COLLECTION + "/" + collectionName;
         String collectionURI = ROOT_COLLECTION_URI + "/" + collectionName;
 
-        Collection testCollection = root.getChildCollection(collectionName);
+        Collection testCollection = existEmbeddedServer.getRoot().getChildCollection(collectionName);
         if (testCollection == null) {
-            CollectionManagementService cms = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+            CollectionManagementService cms = (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
             cms.createCollection(collectionPath);
         }
 
@@ -895,7 +892,7 @@ public class XQueryFunctionsTest {
         String importXMLDB = "import module namespace xdb=\"http://exist-db.org/xquery/xmldb\";\n";
         String collectionAvailable = "xdb:collection-available('" + collectionPath + "')";
         String query = importXMLDB + collectionAvailable;
-        ResourceSet result = service.query(query);
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
         assertNotNull(result);
         assertTrue(result.getSize() == 1);
         assertNotNull(result.getResource(0));
@@ -912,7 +909,7 @@ public class XQueryFunctionsTest {
         final String XML_RESOURCE_FILENAME = "logo.xml";
 
         //create a test collection
-        CollectionManagementService colService = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        CollectionManagementService colService = (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
         Collection testCollection = colService.createCollection(TEST_BINARY_COLLECTION);
         assertNotNull(testCollection);
 
@@ -929,7 +926,7 @@ public class XQueryFunctionsTest {
                 + "let $embedded := <logo><image>{util:binary-doc(\"" + TEST_COLLECTION + "/" + BINARY_RESOURCE_FILENAME + "\")}</image></logo> return\n"
                 + "xmldb:store(\"" + TEST_COLLECTION + "\", \"" + XML_RESOURCE_FILENAME + "\", $embedded)";
 
-        ResourceSet resultStore = service.query(queryStore);
+        ResourceSet resultStore = existEmbeddedServer.executeQuery(queryStore);
         assertEquals("store, Expect single result", 1, resultStore.getSize());
         assertEquals("Expect stored filename as result", TEST_COLLECTION + "/" + XML_RESOURCE_FILENAME, resultStore.getResource(0).getContent().toString());
 
@@ -938,31 +935,7 @@ public class XQueryFunctionsTest {
                 + "let $image := doc(\"" + TEST_COLLECTION + "/" + XML_RESOURCE_FILENAME + "\")/logo/image return\n"
                 + "$image/text() cast as xs:base64Binary";
 
-        ResourceSet resultRetreive = service.query(queryRetreive);
+        ResourceSet resultRetreive = existEmbeddedServer.executeQuery(queryRetreive);
         assertEquals("retreive, Expect single result", 1, resultRetreive.getSize());
-    }
-
-
-    @BeforeClass
-    public static void setUp() throws Exception {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        service = (XPathQueryService) root.getService("XQueryService", "1.0");
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim =
-                (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-
-        // clear instance variables
-        service = null;
-        root = null;
     }
 }

--- a/test/src/org/exist/xquery/XQueryProcessingInstruction.java
+++ b/test/src/org/exist/xquery/XQueryProcessingInstruction.java
@@ -1,19 +1,12 @@
 package org.exist.xquery;
 
 import java.io.IOException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.*;
 
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 import org.xml.sax.SAXException;
-import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.modules.XPathQueryService;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 
@@ -24,61 +17,19 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
  */
 public class XQueryProcessingInstruction {
 
-    private XPathQueryService service;
-    private Collection root = null;
-    private Database database = null;
-
-    public XQueryProcessingInstruction() {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        service = (XPathQueryService) root.getService("XQueryService", "1.0");
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-
-        // clear instance variables
-        service = null;
-        root = null;
-    }
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     @Test
-    public void testPI() throws XPathException, SAXException, IOException {
-
-        ResourceSet result = null;
-        String r = "";
-        try {
-            String query = "let $xml := <doc>"+
-                                "<?pi test?>"+
-                                "<p>This is a p.</p>"+
-                                "</doc>" +
-                    "return\n" +
-                    "$xml";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertXMLEqual(r,"<doc><?pi test?><p>This is a p.</p></doc>");
-
-        } catch (IOException ioe) {
-                fail(ioe.getMessage());
-        } catch (SAXException sae) {
-                fail(sae.getMessage());
-        } catch (XMLDBException e) {
-            fail(e.getMessage());
-        }
-
+    public void testPI() throws XPathException, SAXException, IOException, XMLDBException {
+        final String query = "let $xml := <doc>" +
+                "<?pi test?>" +
+                "<p>This is a p.</p>" +
+                "</doc>" +
+                "return\n" +
+                "$xml";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertXMLEqual(r, "<doc><?pi test?><p>This is a p.</p></doc>");
     }
-
-
-   
 }

--- a/test/src/org/exist/xquery/XQueryTest.java
+++ b/test/src/org/exist/xquery/XQueryTest.java
@@ -22,8 +22,7 @@
 package org.exist.xquery;
 
 import org.custommonkey.xmlunit.DetailedDiff;
-import org.exist.TestUtils;
-import org.exist.xmldb.DatabaseInstanceManager;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.xmldb.EXistResource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
@@ -32,7 +31,6 @@ import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
@@ -61,6 +59,9 @@ import static org.junit.Assert.*;
  * TODO maybe move the various eXist XQuery extensions in another class ...
  */
 public class XQueryTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     private static final String NUMBERS_XML = "numbers.xml";
     private static final String BOWLING_XML = "bowling.xml";
@@ -142,39 +143,19 @@ public class XQueryTest {
     private static int nbElem = 1;
     private String file_name = "detail_xml.xml";
     private String xml;
-    private static Database database;
-
-    @BeforeClass
-    public static void setUpOnce() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-    }
 
     @Before
     public void setup() throws XMLDBException {
-        Collection root =
-                DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        CollectionManagementService service =
-                (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
-        Collection testCollection = service.createCollection("test");
-        assertNotNull(testCollection);
+        final CollectionManagementService service =
+                (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
+        service.createCollection("test");
     }
 
     @After
-    public void tearDown() {
-        TestUtils.cleanupDB();
-    }
-
-    @AfterClass
-    public static void tearDownOnce() throws XMLDBException {
-        DatabaseInstanceManager dim =
-                (DatabaseInstanceManager) DatabaseManager.getCollection("xmldb:exist:///db", "admin", "").getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-        DatabaseManager.deregisterDatabase(database);
-        database = null;
+    public void tearDown() throws XMLDBException {
+        final CollectionManagementService service =
+                (CollectionManagementService) existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
+        service.removeCollection("test");
     }
 
     private Collection getTestCollection() throws XMLDBException {

--- a/test/src/org/exist/xquery/XQueryUseCase.java
+++ b/test/src/org/exist/xquery/XQueryUseCase.java
@@ -30,13 +30,13 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.xmldb.XQueryService;
 import org.exist.xmldb.XmldbURI;
 
 import org.junit.Before;
-import org.xmldb.api.DatabaseManager;
+import org.junit.ClassRule;
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.modules.CollectionManagementService;
 import org.xmldb.api.modules.XMLResource;
@@ -46,18 +46,16 @@ import org.xmldb.api.modules.XMLResource;
  */
 public class XQueryUseCase {
 
+	@ClassRule
+	public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
 	private final static String baseDir = "samples/xquery/use-cases";
 
 	private Collection root = null;
 
 	@Before
 	protected void setUp() throws Exception {
-		// initialize driver
-		Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-		Database database = (Database) cl.newInstance();
-		database.setProperty("create-database", "true");
-		DatabaseManager.registerDatabase(database);
-		root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
+		root = existEmbeddedServer.getRoot();
 	}
 
 	public void doTest(String useCase) throws Exception {

--- a/test/src/org/exist/xquery/functions/fn/DocTest.java
+++ b/test/src/org/exist/xquery/functions/fn/DocTest.java
@@ -21,30 +21,19 @@
  */
 package org.exist.xquery.functions.fn;
 
-import java.io.IOException;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.*;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 import static org.junit.Assert.*;
 
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.methods.PostMethod;
-import org.exist.xmldb.DatabaseInstanceManager;
 import org.exist.xmldb.EXistResource;
 import org.exist.xmldb.LocalXMLResource;
-import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.w3c.dom.Node;
 
 import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.modules.CollectionManagementService;
-import org.xmldb.api.modules.XPathQueryService;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 
@@ -55,31 +44,15 @@ import org.xmldb.api.base.XMLDBException;
  */
 public class DocTest {
 
-    private XPathQueryService service;
-    private Collection root = null;
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
     private Collection test = null;
 
-    private Database database = null;
-    private org.exist.start.Main runner = null;
-
-    public DocTest() {
-    }
-
     @Before
-    public void setUp() throws Exception {
-        runner = new org.exist.start.Main("jetty");
-		runner.run(new String[]{"jetty"});
-
-		// initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        service = (XPathQueryService) root.getService("XQueryService", "1.0");
-
-        CollectionManagementService cms = (CollectionManagementService) 
-        	root.getService("CollectionManagementService", "1.0");
+    public void setUp() throws XMLDBException {
+        final CollectionManagementService cms = (CollectionManagementService)
+        	existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
         //Creates the 'test' collection
         test = cms.createCollection("test");
         assertNotNull(test);
@@ -87,71 +60,49 @@ public class DocTest {
         storeResource(test, "test.xq", "BinaryResource", "application/xquery", "doc('test.xml')");
         storeResource(test, "test1.xq", "BinaryResource", "application/xquery", "doc('/test.xml')");
 
-        storeResource(root, "test.xml", "XMLResource", null, "<x/>");
+        storeResource(existEmbeddedServer.getRoot(), "test.xml", "XMLResource", null, "<x/>");
         storeResource(test, "test.xml", "XMLResource", null, "<y/>");
 
     }
+
+    @After
+    public void tearDown() throws XMLDBException {
+        final CollectionManagementService cms = (CollectionManagementService)
+                existEmbeddedServer.getRoot().getService("CollectionManagementService", "1.0");
+        //Creates the 'test' collection
+        cms.removeCollection("test");
+        test = null;
+
+        existEmbeddedServer.getRoot().removeResource(existEmbeddedServer.getRoot().getResource("test.xml"));
+    }
     
-    private void storeResource(Collection col, String fileName, String type, String mimeType, String content) throws XMLDBException {
+    private void storeResource(final Collection col, final String fileName, final String type, final String mimeType, final String content) throws XMLDBException {
     	Resource res = col.createResource(fileName, type);
     	res.setContent(content);
     	
-    	if (mimeType != null)
-    		((EXistResource) res).setMimeType(mimeType);
+    	if (mimeType != null) {
+            ((EXistResource) res).setMimeType(mimeType);
+        }
         
     	col.storeResource(res);
     }
 
-    @After
-    public void tearDown() throws Exception {
-
-        //root.removeResource(invokableQuery);
-
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-        
-        runner.shutdown();
-
-        // clear instance variables
-        service = null;
-        root = null;
-    }
-
     @Test
-    public void testURIResolveWithEval() throws XPathException {
-        ResourceSet result = null;
-        try {
-            String query = "util:eval(xs:anyURI('/db/test/test.xq'), false(), ())";
-            result = service.query(query);
+    public void testURIResolveWithEval() throws XPathException, XMLDBException {
+        String query = "util:eval(xs:anyURI('/db/test/test.xq'), false(), ())";
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
 
-            LocalXMLResource res = (LocalXMLResource)result.getResource(0);
-            assertNotNull(res);
-            Node n = res.getContentAsDOM();
-            assertEquals("y", n.getLocalName());
+        LocalXMLResource res = (LocalXMLResource)result.getResource(0);
+        assertNotNull(res);
+        Node n = res.getContentAsDOM();
+        assertEquals("y", n.getLocalName());
 
-            query = "util:eval(xs:anyURI('/db/test/test1.xq'), false(), ())";
-            result = service.query(query);
+        query = "util:eval(xs:anyURI('/db/test/test1.xq'), false(), ())";
+        result = existEmbeddedServer.executeQuery(query);
 
-            res = (LocalXMLResource)result.getResource(0);
-            assertNotNull(res);
-            n = res.getContentAsDOM();
-            assertEquals("x", n.getLocalName());
-        } catch (XMLDBException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    @Ignore
-    @Test
-    public void testURLRewriter() throws XPathException, HttpException, IOException {
-
-		HttpClient client = new HttpClient();
-
-		// connect to a login page to retrieve session ID
-		PostMethod method = new PostMethod("http://localhost:" + System.getProperty("jetty.port") + "/exist/rest/test/text.xq");
-
-    	client.executeMethod(method);
-
+        res = (LocalXMLResource)result.getResource(0);
+        assertNotNull(res);
+        n = res.getContentAsDOM();
+        assertEquals("x", n.getLocalName());
     }
 }

--- a/test/src/org/exist/xquery/functions/fn/FunLangTest.java
+++ b/test/src/org/exist/xquery/functions/fn/FunLangTest.java
@@ -1,34 +1,24 @@
 package org.exist.xquery.functions.fn;
 
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
-import org.junit.After;
-import org.junit.Before;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
-import org.xmldb.api.modules.XPathQueryService;
 
 /**
  *
  * @author ljo
  */
 public class FunLangTest {
-    
-    private final static String TEST_DB_USER = "admin";
-    private final static String TEST_DB_PWD = "";
-	
-    private XPathQueryService service;
-    private Collection root = null;
-    private Database database = null;
-    
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
     @Test
     public void testFnLangWithContext() throws XMLDBException {
-        ResourceSet resourceSet = service.query(
+        final ResourceSet resourceSet = existEmbeddedServer.executeQuery(
             "let $doc-frag := " +
 	    "<desclist xml:lang=\"en\">" +
 	       "<desc xml:lang=\"en-US\" n=\"1\">" +
@@ -47,7 +37,7 @@ public class FunLangTest {
 
         @Test
     public void testFnLangWithArgument() throws XMLDBException {
-        ResourceSet resourceSet = service.query(
+		final ResourceSet resourceSet = existEmbeddedServer.executeQuery(
             "let $doc-frag := " +
 	    "<desclist xml:lang=\"en\">" +
 	       "<desc xml:lang=\"en-US\" n=\"1\">" +
@@ -66,7 +56,7 @@ public class FunLangTest {
     
     @Test
     public void testFnLangWithAttributeArgument() throws XMLDBException {
-        ResourceSet resourceSet = service.query(
+		final ResourceSet resourceSet = existEmbeddedServer.executeQuery(
             "let $doc-frag := " +
 	    "<desclist xml:lang=\"en\">" +
 	       "<desc xml:lang=\"en-US\" n=\"1\">" +
@@ -81,27 +71,5 @@ public class FunLangTest {
         
         assertEquals(1, resourceSet.getSize());
         assertEquals("true", resourceSet.getResource(0).getContent());
-    }
-    
-    @Before
-    public void setUp() throws Exception {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, TEST_DB_USER, TEST_DB_PWD);
-        service = (XPathQueryService) root.getService( "XQueryService", "1.0" );
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-
-        // clear instance variables
-        service = null;
-        root = null;
     }
 }

--- a/test/src/org/exist/xquery/functions/fn/FunNumberTest.java
+++ b/test/src/org/exist/xquery/functions/fn/FunNumberTest.java
@@ -1,34 +1,24 @@
 package org.exist.xquery.functions.fn;
 
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
-import org.junit.After;
-import org.junit.Before;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
-import org.xmldb.api.modules.XPathQueryService;
 
 /**
  *
  * @author aretter
  */
 public class FunNumberTest {
-    
-    private final static String TEST_DB_USER = "admin";
-    private final static String TEST_DB_PWD = "";
-	
-    private XPathQueryService service;
-    private Collection root = null;
-    private Database database = null;
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
     
     @Test
     public void testFnNumberWithContext() throws XMLDBException {
-        ResourceSet resourceSet = service.query(
+        final ResourceSet resourceSet = existEmbeddedServer.executeQuery(
             "let $errors := " +
                 "<report>" +
                     "<message level=\"Error\" line=\"1191\" column=\"49\" repeat=\"96\"></message>" +
@@ -46,7 +36,7 @@ public class FunNumberTest {
     
     @Test
     public void testFnNumberWithArgument() throws XMLDBException {
-        ResourceSet resourceSet = service.query(
+        final ResourceSet resourceSet = existEmbeddedServer.executeQuery(
             "let $errors := " +
                 "<report>" +
                     "<message level=\"Error\" line=\"1191\" column=\"49\" repeat=\"96\"></message>" +
@@ -60,27 +50,5 @@ public class FunNumberTest {
         
         assertEquals(1, resourceSet.getSize());
         assertEquals("NaN", resourceSet.getResource(0).getContent());
-    }
-    
-    @Before
-    public void setUp() throws Exception {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, TEST_DB_USER, TEST_DB_PWD);
-        service = (XPathQueryService) root.getService( "XQueryService", "1.0" );
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-
-        // clear instance variables
-        service = null;
-        root = null;
     }
 }

--- a/test/src/org/exist/xquery/functions/util/CounterTest.java
+++ b/test/src/org/exist/xquery/functions/util/CounterTest.java
@@ -1,113 +1,66 @@
 package org.exist.xquery.functions.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.modules.counter.CounterModule;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
-import org.xmldb.api.modules.XPathQueryService;
 
 /**
  * @author Jasper Linthorst (jasper.linthorst@gmail.com)
  */
 public class CounterTest {
 
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
+
     private final static String IMPORT = "import module namespace counter=\"" + CounterModule.NAMESPACE_URI + "\" " +
         "at \"java:org.exist.xquery.modules.counter.CounterModule\"; ";
     
-    private XPathQueryService service;
-    private Collection root = null;
-    private Database database = null;
+    @Test
+    public void testCreateAndDestroyCounter() throws XPathException, XMLDBException {
+        String query = IMPORT + "counter:create('jasper1')";
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
+        String r = (String) result.getResource(0).getContent();
+        assertEquals("0", r);
 
-    public CounterTest() {
-    }
+        query = IMPORT +"counter:next-value('jasper1')";
+        result = existEmbeddedServer.executeQuery(query);
+        r = (String) result.getResource(0).getContent();
+        assertEquals("1", r);
 
-    @Before
-    public void setUp() throws Exception {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        service = (XPathQueryService) root.getService("XQueryService", "1.0");
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-        
-        // clear instance variables
-        service = null;
-        root = null;
+        query = IMPORT +"counter:destroy('jasper1')";
+        result = existEmbeddedServer.executeQuery(query);
+        r = (String) result.getResource(0).getContent();
+        assertEquals("true", r);
     }
     
     @Test
-    public void testCreateAndDestroyCounter() throws XPathException {
-        ResourceSet result = null;
-        String r = "";
-        try {
-        	String query = IMPORT + "counter:create('jasper1')";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertEquals("0", r);
-            
-            query = IMPORT +"counter:next-value('jasper1')";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertEquals("1", r);
-            
-            query = IMPORT +"counter:destroy('jasper1')";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertEquals("true", r);
-        } catch (XMLDBException e) {
-            fail(e.getMessage());
-        }
-    }
-    
-    @Test
-    public void testCreateAndInitAndDestroyCounter() throws XPathException {
-        ResourceSet result = null;
-        String r = "";
-        try {
-        	String query = IMPORT +"counter:create('jasper3',xs:long(1200))";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertEquals("1200", r);
-            
-            query = IMPORT +"counter:next-value('jasper3')";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertEquals("1201", r);
-            
-            query = IMPORT +"counter:destroy('jasper3')";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertEquals("true", r);
-        } catch (XMLDBException e) {
-            fail(e.getMessage());
-        }
+    public void testCreateAndInitAndDestroyCounter() throws XPathException, XMLDBException {
+        String query = IMPORT +"counter:create('jasper3',xs:long(1200))";
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
+        String r = (String) result.getResource(0).getContent();
+        assertEquals("1200", r);
+
+        query = IMPORT +"counter:next-value('jasper3')";
+        result = existEmbeddedServer.executeQuery(query);
+        r = (String) result.getResource(0).getContent();
+        assertEquals("1201", r);
+
+        query = IMPORT +"counter:destroy('jasper3')";
+        result = existEmbeddedServer.executeQuery(query);
+        r = (String) result.getResource(0).getContent();
+        assertEquals("true", r);
     }
     
     @Test
     public void threadedIncrementTest() throws XPathException, InterruptedException, XMLDBException {
-		service = (XPathQueryService) root.getService("XQueryService", "1.0");
-		
 		String query = IMPORT +"counter:create('jasper2')";
-		ResourceSet result = service.query(query);
+		ResourceSet result = existEmbeddedServer.executeQuery(query);
 		
 		assertEquals("0", result.getResource(0).getContent());
 		
@@ -123,26 +76,21 @@ public class CounterTest {
 		c.join();
 		
 		query = IMPORT +"counter:next-value('jasper2')";
-		ResourceSet valueAfter = service.query(query);
+		ResourceSet valueAfter = existEmbeddedServer.executeQuery(query);
 		
 		query = IMPORT +"counter:destroy('jasper2')";
-		result = service.query(query);
+		result = existEmbeddedServer.executeQuery(query);
 		
 		assertEquals("601", (String)valueAfter.getResource(0).getContent());
     }
     
-    class IncrementThread extends Thread {
+    static class IncrementThread extends Thread {
     	
         public void run() {
-        	
-        	ResourceSet result = null;
-        	String query="";
         	try {
-        		service = (XPathQueryService) root.getService("XQueryService", "1.0");
-	        	
 	        	for (int i=0; i<200; i++) {
-	        		query = IMPORT +"counter:next-value('jasper2')";
-	                result = service.query(query);
+	        		final String query = IMPORT +"counter:next-value('jasper2')";
+	                final ResourceSet result = existEmbeddedServer.executeQuery(query);
 	                result.getResource(0).getContent();
 	        	}
         	} catch (XMLDBException e) {

--- a/test/src/org/exist/xquery/functions/util/ExpandTest.java
+++ b/test/src/org/exist/xquery/functions/util/ExpandTest.java
@@ -23,16 +23,10 @@ package org.exist.xquery.functions.util;
 
 import static org.junit.Assert.*;
 
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XQueryService;
-import org.exist.xmldb.XmldbURI;
+import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.xquery.XPathException;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 
@@ -43,65 +37,33 @@ import org.xmldb.api.base.XMLDBException;
  */
 public class ExpandTest {
 
-    private XQueryService service;
-    private Collection root = null;
-    private Database database = null;
-
-    @Before
-    public void setUp() throws Exception {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        service = (XQueryService) root.getService("XQueryService", "1.0");
-    }
-
-    @After
-    public void tearDown() throws Exception {
-
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-
-        // clear instance variables
-        service = null;
-        root = null;
-    }
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
     @Test
-    public void testExpandWithDefaultNS() throws XPathException {
+    public void testExpandWithDefaultNS() throws XPathException, XMLDBException {
+    	final String expected = "<ok xmlns=\"some\">\n    <concept xmlns=\"\"/>\n</ok>";
 
-    	String expected = "<ok xmlns=\"some\">\n    <concept xmlns=\"\"/>\n</ok>";
-    	
-        ResourceSet result = null;
-        String r = null;
-        try {
-            String query = "" +
-            		"let $doc-path := xmldb:store('/db', 'test.xml', <concept/>)\n" +
-                    "let $doc := doc($doc-path)\n" +
-                    "return\n" +
-                    "<ok xmlns='some'>\n" +
-                    "{util:expand($doc)}\n" +
-            		"</ok>";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertEquals(expected, r);
+        String query = "" +
+                "let $doc-path := xmldb:store('/db', 'test.xml', <concept/>)\n" +
+                "let $doc := doc($doc-path)\n" +
+                "return\n" +
+                "<ok xmlns='some'>\n" +
+                "{util:expand($doc)}\n" +
+                "</ok>";
+        ResourceSet result = existEmbeddedServer.executeQuery(query);
+        String r = (String) result.getResource(0).getContent();
+        assertEquals(expected, r);
 
-            query = "" +
-            		"let $doc-path := xmldb:store('/db', 'test.xml', <concept/>)\n" +
-                    "let $doc := doc($doc-path)\n" +
-                    "return\n" +
-                    "<ok xmlns='some'>\n" +
-                    "{$doc}\n" +
-            		"</ok>";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertEquals(expected, r);
-
-        } catch (XMLDBException e) {
-            fail(e.getMessage());
-        }
+        query = "" +
+                "let $doc-path := xmldb:store('/db', 'test.xml', <concept/>)\n" +
+                "let $doc := doc($doc-path)\n" +
+                "return\n" +
+                "<ok xmlns='some'>\n" +
+                "{$doc}\n" +
+                "</ok>";
+        result = existEmbeddedServer.executeQuery(query);
+        r = (String) result.getResource(0).getContent();
+        assertEquals(expected, r);
     }
 }

--- a/test/src/org/exist/xquery/functions/util/SerializeTest.java
+++ b/test/src/org/exist/xquery/functions/util/SerializeTest.java
@@ -1,25 +1,20 @@
 package org.exist.xquery.functions.util;
 
 import org.custommonkey.xmlunit.exceptions.XpathException;
-import org.junit.After;
-import org.junit.Before;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
 import org.junit.Test;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.junit.Assert.*;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import org.xml.sax.SAXException;
 import java.io.IOException;
 
 import org.custommonkey.xmlunit.XMLUnit;
-import org.exist.xmldb.DatabaseInstanceManager;
-import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 
-import org.xmldb.api.base.Collection;
-import org.xmldb.api.base.Database;
-import org.xmldb.api.DatabaseManager;
-import org.xmldb.api.modules.XPathQueryService;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 
@@ -29,151 +24,61 @@ import org.xmldb.api.base.XMLDBException;
  */
 public class SerializeTest {
 
-    private XPathQueryService service;
-    private Collection root = null;
-    private Database database = null;
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
-    public SerializeTest() {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        // initialize driver
-        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-        root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-        service = (XPathQueryService) root.getService("XQueryService", "1.0");
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        DatabaseManager.deregisterDatabase(database);
-        DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-
-        // clear instance variables
-        service = null;
-        root = null;
-    }
-
- 
     @Test
-    public void testSerialize() throws XPathException {
-
-        ResourceSet result = null;
-        String r = "";
-        try {
-            String query = "let $xml := <test/>\n" +
-                    "return\n" +
-                    "util:serialize($xml,'method=xml')";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertXMLEqual(r,"<test/>");
-
-        } catch (IOException ioe) {
-                fail(ioe.getMessage());
-        } catch (SAXException sae) {
-                fail(sae.getMessage());
-        } catch (XMLDBException e) {
-            fail(e.getMessage());
-        }
-
-    }
-    
-    @Test
-    public void testSerialize2() throws XPathException {
-
-        ResourceSet result = null;
-        String r = "";
-        try {
-            String query = "let $xml := <test><a/><b/></test>\n" +
-                    "return\n" +
-                    "util:serialize($xml,'method=xml indent=no')";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertXMLEqual(r,"<test><a/><b/></test>");
-
-        } catch (IOException ioe) {
-                fail(ioe.getMessage());
-        } catch (SAXException sae) {
-                fail(sae.getMessage());
-        } catch (XMLDBException e) {
-            fail(e.getMessage());
-        }
-
+    public void testSerialize() throws XPathException, XMLDBException, IOException, SAXException {
+        final String query = "let $xml := <test/>\n" +
+                "return\n" +
+                "util:serialize($xml,'method=xml')";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertXMLEqual(r,"<test/>");
     }
 
     @Test
-    public void testSerializeText() throws XPathException {
+    public void testSerialize2() throws XPathException, XMLDBException, IOException, SAXException {
+        final String query = "let $xml := <test><a/><b/></test>\n" +
+                "return\n" +
+                "util:serialize($xml,'method=xml indent=no')";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertXMLEqual(r,"<test><a/><b/></test>");
+    }
 
-        ResourceSet result = null;
-        String r = "";
-        try {
-            String query = "let $xml := <test><a>test</a></test>\n" +
-                    "return\n" +
-                    "util:serialize($xml,'method=text indent=no')";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            assertEquals(r,"test");
-
-        } catch (XMLDBException e) {
-            fail(e.getMessage());
-        }
-
+    @Test
+    public void testSerializeText() throws XPathException, XMLDBException, IOException, SAXException {
+        final String query = "let $xml := <test><a>test</a></test>\n" +
+                "return\n" +
+                "util:serialize($xml,'method=text indent=no')";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertEquals(r,"test");
     } 
 
     @Test
-    public void testSerializeIndent() throws XPathException {
-
-        ResourceSet result = null;
-        String r = "";
-        try {
-            String query = "let $xml := <test><a/><b/></test>\n" +
-                    "return\n" +
-                    "util:serialize($xml,'method=xml indent=yes')";
-            result = service.query(query);
-            r = (String) result.getResource(0).getContent();
-            XMLUnit.setIgnoreWhitespace(true);
-            assertXMLEqual(r,"<test><a/><b/></test>");
-
-        } catch (IOException ioe) {
-                fail(ioe.getMessage());
-        } catch (SAXException sae) {
-                fail(sae.getMessage());
-        } catch (XMLDBException e) {
-            fail(e.getMessage());
-        }
-
+    public void testSerializeIndent() throws XPathException, XMLDBException, IOException, SAXException {
+        final String query = "let $xml := <test><a/><b/></test>\n" +
+                "return\n" +
+                "util:serialize($xml,'method=xml indent=yes')";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        XMLUnit.setIgnoreWhitespace(true);
+        assertXMLEqual(r,"<test><a/><b/></test>");
     }
-    
+
     @Test
-    public void testSerializeXincludes() throws XPathException, XpathException {
-                        
-        ResourceSet result = null;
-        String r = "";
-        try {
-                                
-            String query = "let $xml := " +
-            		"<test xmlns:xi='http://www.w3.org/2001/XInclude'>" +
-            		"	<xi:include href='/db/system/security/config.xml'/>" +
-            		"</test>\n" +
-                    "return\n" +
-                    "util:serialize($xml,'enable-xincludes=yes')";
+    public void testSerializeXincludes() throws XPathException, XMLDBException, IOException, SAXException, XpathException {
+        final String query = "let $xml := " +
+                "<test xmlns:xi='http://www.w3.org/2001/XInclude'>" +
+                "	<xi:include href='/db/system/security/config.xml'/>" +
+                "</test>\n" +
+                "return\n" +
+                "util:serialize($xml,'enable-xincludes=yes')";
 
-           result = service.query(query);
-           r = (String) result.getResource(0).getContent();
-           assertXpathEvaluatesTo("2.0","/test//@version",r);
-
-        } catch (IOException ioe) {
-                fail(ioe.getMessage());
-        } catch (SAXException sae) {
-                fail(sae.getMessage());
-        } catch (XMLDBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
-
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertXpathEvaluatesTo("2.0","/test//@version",r);
     }    
 }


### PR DESCRIPTION
This removes an unnecessary huge amount of code duplication in the Unit tests by introducing a Rule for Starting/Stopping an embedded XML:DB API database:

```java
@ClassRule
public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
```