### PR TITLE
[bugfix] Fix nested try/catch

### DIFF
--- a/src/org/exist/xquery/TryCatchExpression.java
+++ b/src/org/exist/xquery/TryCatchExpression.java
@@ -228,10 +228,13 @@ public class TryCatchExpression extends AbstractExpression {
 
                 // If an error hasn't been caught, throw new one
                 if (!errorMatched) {
-                    LOG.error(throwable);
-                    throw new XPathException(throwable);
+                    if (throwable instanceof XPathException) {
+                        throw throwable;
+                    } else {
+                        LOG.error(throwable);
+                        throw new XPathException(throwable);
+                    }
                 }
-
 
             } finally {
                 context.popLocalVariables(mark0, catchResultSeq);


### PR DESCRIPTION
The inner try/catch shouldn't mess with an XPathException if it doesn't catch it.
Closes https://github.com/eXist-db/exist/issues/745