### PR TITLE
Avoid storage corruption 

### DIFF
--- a/src/org/exist/xmldb/XmldbURI.java
+++ b/src/org/exist/xmldb/XmldbURI.java
@@ -801,15 +801,21 @@ public class XmldbURI implements Comparable<Object>, Serializable {
         return getXmldbURI().toURL();
     }
 
-    //TODO: add unit test for this
-    //TODO : come on ! use a URI method name.
-    //resolve() is a must here
-    public boolean startsWith(final XmldbURI xmldbUri) {
-        return xmldbUri == null ? false : toString().startsWith(xmldbUri.toString());
+    public boolean startsWith(final XmldbURI prefix) {
+        if (prefix == null) return false;
+
+        XmldbURI[] segments = getPathSegments();
+        XmldbURI[] prefix_segments = prefix.getPathSegments();
+
+        if (prefix_segments.length > segments.length) return false;
+
+        for (int i = 0; i < prefix_segments.length; i++) {
+            if (!prefix_segments[i].equalsInternal(segments[i])) return false;
+        }
+
+        return true;
     }
 
-    //TODO : come on ! use a URI method name.
-    //resolve() is a must here
     public boolean startsWith(final String string) throws URISyntaxException {
         return startsWith(XmldbURI.xmldbUriFor(string));
     }

--- a/src/org/exist/xmldb/XmldbURI.java
+++ b/src/org/exist/xmldb/XmldbURI.java
@@ -544,10 +544,14 @@ public class XmldbURI implements Comparable<Object>, Serializable {
     public XmldbURI[] getPathSegments() {
         final String name = getRawCollectionPath();
 
-        if ((name == null) || name.isEmpty()) return NO_SEGMENTS;
+        if ((name == null) || name.isEmpty()) {
+            return NO_SEGMENTS;
+        }
         
         final String[] split = name.split("/");
-        if (split.length == 0) return NO_SEGMENTS;
+        if (split.length == 0) {
+            return NO_SEGMENTS;
+        }
 
         final int fix = ("".equals(split[0])) ? 1 : 0;
         final XmldbURI[] segments = new XmldbURI[split.length - fix];
@@ -805,10 +809,12 @@ public class XmldbURI implements Comparable<Object>, Serializable {
     }
 
     public boolean startsWith(final XmldbURI prefix) {
-        if (prefix == null) return false;
+        if (prefix == null) {
+            return false;
+        }
 
-        XmldbURI[] segments = getPathSegments();
-        XmldbURI[] prefix_segments = prefix.getPathSegments();
+        final XmldbURI[] segments = getPathSegments();
+        final XmldbURI[] prefix_segments = prefix.getPathSegments();
 
         if (prefix_segments.length > segments.length) return false;
 

--- a/src/org/exist/xmldb/XmldbURI.java
+++ b/src/org/exist/xmldb/XmldbURI.java
@@ -123,6 +123,8 @@ public class XmldbURI implements Comparable<Object>, Serializable {
     public final static String API_REST = "rest-style";
     public final static String API_LOCAL = "local";
 
+    public final static XmldbURI[] NO_SEGMENTS = new XmldbURI[0];
+
     private String encodedCollectionPath;
     protected boolean hadXmldbPrefix = false;
 
@@ -546,6 +548,8 @@ public class XmldbURI implements Comparable<Object>, Serializable {
             return new XmldbURI[0];
         }
         final String[] split = name.split("/");
+        if (split.length == 0) return NO_SEGMENTS;
+
         final int fix = ("".equals(split[0])) ? 1 : 0;
         final XmldbURI[] segments = new XmldbURI[split.length - fix];
 

--- a/src/org/exist/xmldb/XmldbURI.java
+++ b/src/org/exist/xmldb/XmldbURI.java
@@ -123,7 +123,7 @@ public class XmldbURI implements Comparable<Object>, Serializable {
     public final static String API_REST = "rest-style";
     public final static String API_LOCAL = "local";
 
-    public final static XmldbURI[] NO_SEGMENTS = new XmldbURI[0];
+    private final static XmldbURI[] NO_SEGMENTS = new XmldbURI[0];
 
     private String encodedCollectionPath;
     protected boolean hadXmldbPrefix = false;
@@ -544,9 +544,8 @@ public class XmldbURI implements Comparable<Object>, Serializable {
     public XmldbURI[] getPathSegments() {
         final String name = getRawCollectionPath();
 
-        if ((name == null) || name.isEmpty()) {
-            return new XmldbURI[0];
-        }
+        if ((name == null) || name.isEmpty()) return NO_SEGMENTS;
+        
         final String[] split = name.split("/");
         if (split.length == 0) return NO_SEGMENTS;
 

--- a/test/src/org/exist/storage/CopyCollectionTest.java
+++ b/test/src/org/exist/storage/CopyCollectionTest.java
@@ -94,7 +94,7 @@ public class CopyCollectionTest {
 
             fail("expect PermissionDeniedException: Cannot copy collection '/db/test' to it child collection '/db/test/test2'");
 
-            transact.commit(transaction);
+            transaction.commit();
         }
     }
 

--- a/test/src/org/exist/xmldb/XmldbURITest.java
+++ b/test/src/org/exist/xmldb/XmldbURITest.java
@@ -832,4 +832,17 @@ public class XmldbURITest {
 
         assertEquals("xmldb:something%201.xml", uri.lastSegment().toString());
     }
+
+    @Test
+    public void startsWith() {
+
+        assertTrue(XmldbURI.create("/db/test").startsWith(XmldbURI.create("/db/test")));
+
+        assertFalse(XmldbURI.create("/db/test").startsWith(XmldbURI.create("/db/test2")));
+
+        assertTrue(XmldbURI.create("/db/test/db").startsWith(XmldbURI.create("/db/test")));
+        assertTrue(XmldbURI.create("/db/test/db").startsWith(XmldbURI.create("/db/test/")));
+
+        assertFalse(XmldbURI.create("/db/test_db").startsWith(XmldbURI.create("/db/test")));
+    }
 }


### PR DESCRIPTION
Copy or move collection to it child subcollection lead recursion and storage corruption as result of it. To avoid such situation this PR add check for destination to do not be a subcollection (any level) of source and raise exception if so.