### PR TITLE
Correct mime-type names for JavaScript & Markdown

### DIFF
--- a/mime-types.xml.tmpl
+++ b/mime-types.xml.tmpl
@@ -269,7 +269,7 @@
         <description>Plain text</description>
         <extensions>.txt,.text,.java,.dtd,.rnc,.properties</extensions>
     </mime-type>
-    <mime-type name="text/x-markdown" type="binary">
+    <mime-type name="text/markdown" type="binary">
         <description>Markdown</description>
         <extensions>.md</extensions>
     </mime-type>
@@ -327,7 +327,7 @@
         <description>PostScript Document</description>
         <extensions>.eps,.ps</extensions>
     </mime-type>
-    <mime-type name="application/x-javascript" type="binary">
+    <mime-type name="application/javascript" type="binary">
         <description>JavaScript</description>
         <extensions>.js</extensions>
     </mime-type>


### PR DESCRIPTION
For JavaScript, see https://tools.ietf.org/html/rfc4329 (via http://stackoverflow.com/questions/9664282/difference-between-application-x-javascript-and-text-javascript-content-types)
For Markdown, see https://tools.ietf.org/html/rfc7763 (via http://stackoverflow.com/questions/10701983/what-is-the-mime-type-for-markdown)