### PR TITLE
Fixes the installation of systemd for YAJSW

### DIFF
--- a/tools/yajsw/templates/systemd.vm
+++ b/tools/yajsw/templates/systemd.vm
@@ -1,10 +1,11 @@
 [Unit]
 Description=eXist-db – Native XML Database – $w_name
+Documentation=http://exist-db.org/exist/apps/doc/
 After=syslog.target
 
 [Service]
 Type=forking
-User=${USER}
+User=${RUN_AS_USER}
 ExecStart=${JAVA_HOME}/bin/java -Dwrapper.pidfile=$w_wrapper_pid_file -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir=${EXIST_HOME}/tools/yajsw/tmp -jar ${EXIST_HOME}/tools/yajsw/wrapper.jar -tx ${EXIST_HOME}/tools/yajsw/conf/wrapper.conf
 ExecStop=${JAVA_HOME}/bin/java -Dwrapper.pidfile=$w_wrapper_pid_file -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir=${EXIST_HOME}/tools/yajsw/tmp -jar ${EXIST_HOME}/tools/yajsw/wrapper.jar -px ${EXIST_HOME}/tools/yajsw/conf/wrapper.conf
 Restart=on-abort


### PR DESCRIPTION
`systemctl --user` is inhertently insecure (and as such unsupported in RHEL derived distributions); Instead install eXist as a system service

Users should now run `tools/yajsw/bin/installDaemon.sh` as a user that has `sudo` privileges (or as root) and follow the instructions to install eXist with systemd.

...I think when systemd shuts down the service it is not stopping eXist gracefully, there is still possibly something wrong with our YAJSW config. However we can deal with that in a subsequent PR.