### PR TITLE
Range index bug fixes and enhancements

### DIFF
--- a/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
@@ -50,8 +50,10 @@ public class ComplexRangeIndexConfigElement extends RangeIndexConfigElement {
             Node child = children.item(i);
             if (child.getNodeType() == Node.ELEMENT_NODE) {
                 if (FIELD_ELEMENT.equals(child.getLocalName())) {
-                    RangeIndexConfigField field = new RangeIndexConfigField(path, (Element)child, namespaces);
+                    RangeIndexConfigField field = new RangeIndexConfigField(path, (Element) child, namespaces);
                     fields.put(field.getName(), field);
+                } else if (FILTER_ELEMENT.equals(child.getLocalName())) {
+                    analyzer.addFilter((Element) child);
                 } else {
                     LOG.warn("Invalid element encountered for range index configuration: " + child.getLocalName());
                 }

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndex.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndex.java
@@ -44,28 +44,34 @@ public class RangeIndex extends LuceneIndex {
      * Enumeration of supported operators and optimized functions.
      */
     public enum Operator {
-        GT ("gt"),
-        LT ("lt"),
-        EQ ("eq"),
-        GE ("ge"),
-        LE ("le"),
-        NE ("ne"),
-        ENDS_WITH ("ends-with"),
-        STARTS_WITH ("starts-with"),
-        CONTAINS ("contains"),
-        MATCH ("matches");
+        GT ("gt", true),
+        LT ("lt", true),
+        EQ ("eq", true),
+        GE ("ge", true),
+        LE ("le", true),
+        NE ("ne", true),
+        ENDS_WITH ("ends-with", false),
+        STARTS_WITH ("starts-with", false),
+        CONTAINS ("contains", false),
+        MATCH ("matches", false);
 
         private final String name;
+        private final boolean supportsCollation;
 
-        Operator(String name) {
+        Operator(String name, boolean supportsCollation) {
             this.name = name;
+            this.supportsCollation = supportsCollation;
         }
 
         @Override
         public String toString() {
             return name;
         }
-    };
+
+        public boolean supportsCollation() {
+            return supportsCollation;
+        }
+    }
 
     private static final String DIR_NAME = "range";
 

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexAnalyzer.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexAnalyzer.java
@@ -1,0 +1,92 @@
+package org.exist.indexing.range;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.KeywordTokenizer;
+import org.apache.lucene.collation.CollationAttributeFactory;
+import org.apache.lucene.util.AttributeFactory;
+import org.exist.util.Collations;
+import org.exist.util.DatabaseConfigurationException;
+import org.apache.logging.log4j.Logger;
+import org.exist.xquery.XPathException;
+import org.w3c.dom.Element;
+
+import java.io.Reader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Lucene analyzer used by the range index. Based on {@link KeywordTokenizer}, it allows additional
+ * filters to be added to the pipeline through the collection.xconf configuration. A collation may be
+ * specified as well.
+ */
+public class RangeIndexAnalyzer extends Analyzer {
+
+    private final static Logger LOG = LogManager.getLogger(RangeIndexAnalyzer.class);
+
+    private static class FilterConfig {
+        Constructor<?> constructor;
+
+        FilterConfig(Element config) throws DatabaseConfigurationException {
+            final String className = config.getAttribute("class");
+            if (className == null) {
+                throw new DatabaseConfigurationException("No class specified for filter");
+            }
+            try {
+                Class clazz = Class.forName(className);
+                if (!TokenFilter.class.isAssignableFrom(clazz)) {
+                    throw new DatabaseConfigurationException("Filter " + className + " is not a subclass of " +
+                        TokenFilter.class.getName());
+                }
+                constructor = clazz.getConstructor(TokenStream.class);
+            } catch (ClassNotFoundException e) {
+                throw new DatabaseConfigurationException("Filter not found: " + className, e);
+            } catch (NoSuchMethodException e) {
+                throw new DatabaseConfigurationException("Filter class " + className + " has non-default " +
+                        "constructor", e);
+            }
+        }
+    }
+
+    private List<FilterConfig> filterConfigs = new ArrayList<>();
+    private Collator collator = null;
+
+    public RangeIndexAnalyzer() {
+    }
+
+    public void addFilter(Element filter) throws DatabaseConfigurationException {
+        filterConfigs.add(new FilterConfig(filter));
+    }
+
+    public void addCollation(String uri) throws DatabaseConfigurationException {
+        try {
+            collator = Collations.getCollationFromURI(null, uri);
+        } catch (XPathException e) {
+            throw new DatabaseConfigurationException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    protected TokenStreamComponents createComponents(final String fieldName, final Reader reader) {
+        AttributeFactory factory = AttributeFactory.DEFAULT_ATTRIBUTE_FACTORY;
+        if (collator != null) {
+            factory = new CollationAttributeFactory(collator);
+        }
+        Tokenizer src = new KeywordTokenizer(factory, reader, 256);
+        TokenStream tok = src;
+        for (FilterConfig filter: filterConfigs) {
+            try {
+                tok = (TokenStream) filter.constructor.newInstance(tok);
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                LOG.warn(e.getMessage(), e);
+            }
+        }
+        return new TokenStreamComponents(src, tok);
+    }
+}

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeIndexModule.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeIndexModule.java
@@ -21,8 +21,10 @@
  */
 package org.exist.xquery.modules.range;
 
+import org.exist.dom.QName;
 import org.exist.indexing.range.RangeIndex;
 import org.exist.xquery.AbstractInternalModule;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.FunctionDef;
 
 import java.util.HashMap;
@@ -76,6 +78,17 @@ public class RangeIndexModule extends AbstractInternalModule {
         OPERATOR_MAP.put("matches", RangeIndex.Operator.MATCH);
 
     }
+
+    protected final static class RangeIndexErrorCode extends ErrorCodes.ErrorCode {
+
+        public RangeIndexErrorCode(String code, String description) {
+            super(new QName(code, NAMESPACE_URI, PREFIX), description);
+        }
+
+    }
+
+    public final static ErrorCodes.ErrorCode EXXQDYFT0001 = new RangeIndexErrorCode("EXXQDYFT0001", "Collation not " +
+            "supported");
 
     public RangeIndexModule(Map<String, List<? extends Object>> parameters) {
         super(functions, parameters, false);

--- a/extensions/indexes/range/test/src/xquery/optimizer.xql
+++ b/extensions/indexes/range/test/src/xquery/optimizer.xql
@@ -27,12 +27,19 @@ declare variable $ot:COLLECTION_CONFIG :=
                     <field name="type" match="@type" type="xs:string"/>
                     <field name="subtype" match="@subtype" type="xs:string"/>
                 </create>
+                <create qname="tei:orth" type="xs:string" collation="?lang=sr&amp;strength=primary" case="no"/>
                 <create match="//address">
+                    <filter class="org.apache.lucene.analysis.core.LowerCaseFilter"/>
                     <field name="address-city" match="city" type="xs:string"/>
                     <field name="address-street" match="street" type="xs:string"/>
                     <field name="address-email" match="contact/email" type="xs:string"/>
+                    <field name="address-name" match="name3" type="xs:string"/>
                 </create>
                 <create match="/test/address/name"/>
+                <create match="/test/address/name2">
+                    <filter class="org.apache.lucene.analysis.core.LowerCaseFilter"/>
+                    <filter class="org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter"/>
+                </create>
                 <create match="/test/address/city/@code" type="xs:integer"/>
                 <create qname="@id" type="xs:string"/>
             </range>
@@ -63,6 +70,8 @@ declare variable $ot:DATA :=
     <test>
         <address id="muh">
             <name>Berta Muh</name>
+            <name2>Berta Muh</name2>
+            <name3>Berta Muh</name3>
             <street>Wiesenweg 14</street>
             <city code="65463">Almweide</city>
             <contact>
@@ -71,6 +80,8 @@ declare variable $ot:DATA :=
         </address>
         <address id="rüssel">
             <name>Rudi Rüssel</name>
+            <name2>Rudi Rüssel</name2>
+            <name3>Rudi Rüssel</name3>
             <street>Elefantenweg 67</street>
             <city code="65428">Rüsselsheim</city>
             <contact>
@@ -79,6 +90,8 @@ declare variable $ot:DATA :=
         </address>
         <address id="amsel">
             <name>Albert Amsel</name>
+            <name2>Albert Amsel</name2>
+            <name3>Albert Amsel</name3>
             <street>Birkenstraße 77</street>
             <city code="76878">Waldstadt</city>
             <contact>
@@ -87,6 +100,8 @@ declare variable $ot:DATA :=
         </address>
         <address id="reh">
             <name>Pü Reh</name>
+            <name2>Pü Reh</name2>
+            <name3>Pü Reh</name3>
             <street>Am Waldrand 4</street>
             <city code="89283">Wiesental</city>
             <contact>
@@ -95,6 +110,31 @@ declare variable $ot:DATA :=
         </address>
     </test>;
 
+declare variable $ot:DATA_SR_WITH_DIACRITICS :=
+    <TEI xmlns="http://www.tei-c.org/ns/1.0">
+        <teiHeader>
+            <fileDesc>
+                <titleStmt><title>sr with diacritics</title></titleStmt>
+                <publicationStmt><distributor>sr with diacritics</distributor></publicationStmt>
+                <sourceDesc><listOrg><org><name>test</name></org></listOrg></sourceDesc>
+            </fileDesc>
+        </teiHeader>
+        <text>
+            <body>
+                <div>
+                    <entryFree>
+                        <form type="lemma">
+                            <orth>Мла̀тишума</orth>
+                        </form>
+                        <form type="lemma">
+                            <orth>Млатишума</orth>
+                        </form>
+                    </entryFree>
+                </div>
+            </body>
+        </text>
+    </TEI>;
+    
 declare variable $ot:COLLECTION_NAME := "optimizertest";
 declare variable $ot:COLLECTION := "/db/" || $ot:COLLECTION_NAME;
 
@@ -105,15 +145,16 @@ function ot:setup() {
     xmldb:store("/db/system/config/db/" || $ot:COLLECTION_NAME, "collection.xconf", $ot:COLLECTION_CONFIG),
     xmldb:create-collection("/db", $ot:COLLECTION_NAME),
     xmldb:store($ot:COLLECTION, "test.xml", $ot:DATA),
-    xmldb:store($ot:COLLECTION, "nested.xml", $ot:DATA_NESTED)
+    xmldb:store($ot:COLLECTION, "nested.xml", $ot:DATA_NESTED),
+    xmldb:store($ot:COLLECTION, "diacritics.xml", $ot:DATA_SR_WITH_DIACRITICS)
 };
 
-declare
+(: declare
     %test:tearDown
 function ot:cleanup() {
     xmldb:remove($ot:COLLECTION),
     xmldb:remove("/db/system/config/db/" || $ot:COLLECTION_NAME)
-};
+}; :)
 
 declare
     %test:stats
@@ -450,14 +491,14 @@ function ot:optimize-mixed-op-field($city as xs:string, $street as xs:string) {
 };
 
 declare
-    %test:args("Rüsselsheim", "Elefantenweg 67")
+    %test:args("rüsselsheim", "Elefantenweg 67")
     %test:assertEquals(0)
 function ot:mixed-op-field1($city as xs:string, $street as xs:string) {
     count(collection($ot:COLLECTION)//address[city > $city][street = $street])
 };
 
 declare
-    %test:args("Rüsselsheim", "Elefantenweg 67")
+    %test:args("rüsselsheim", "Elefantenweg 67")
     %test:assertEquals(1)
 function ot:mixed-op-field2($city as xs:string, $street as xs:string) {
     count(collection($ot:COLLECTION)//address[city >= $city][street = $street])
@@ -505,3 +546,109 @@ declare
 function ot:optimize-field-self($type as xs:string, $subtype as xs:string, $name as xs:string) {
     //tei:placeName[@type = $type][@subtype = $subtype][. = $name]/text()
 };
+
+(: Filters :)
+
+declare
+    %test:args("rudi russel")
+    %test:assertEquals("Rudi Rüssel")
+    %test:args("rudi rüssel")
+    %test:assertEquals("Rudi Rüssel")
+function ot:eq-string-filtered($name as xs:string) {
+    collection($ot:COLLECTION)//address[name2 = $name]/name2/text()
+};
+
+declare
+    %test:args("Rudi Russel")
+    %test:assertEquals(3)
+function ot:ne-string-filtered($name as xs:string) {
+    count(collection($ot:COLLECTION)//address[name2 != $name])
+};
+
+declare
+    %test:args("russel")
+    %test:assertEquals("Rudi Rüssel")
+function ot:contains-string-filtered($name as xs:string) {
+    collection($ot:COLLECTION)//address[contains(name2, $name)]/name2/text()
+};
+
+declare
+    %test:args("Rudi Rus")
+    %test:assertEquals("Rudi Rüssel")
+function ot:starts-with-string-filtered($name as xs:string) {
+    collection($ot:COLLECTION)//address[starts-with(name2, $name)]/name2/text()
+};
+
+declare
+    %test:args("ussel")
+    %test:assertEquals("Rudi Rüssel")
+function ot:ends-with-string-filtered($name as xs:string) {
+    collection($ot:COLLECTION)//address[ends-with(name2, $name)]/name2/text()
+};
+
+declare
+    %test:args("Rudi rüssel")
+    %test:assertEquals("Rudi Rüssel")
+    %test:args("rudi rüssel")
+    %test:assertEquals("Rudi Rüssel")
+function ot:eq-field-string-filtered($name as xs:string) {
+    collection($ot:COLLECTION)//address[name3 = $name]/name3/text()
+};
+
+declare
+    %test:args("rudi rüssel")
+    %test:assertEquals(3)
+function ot:ne-field-string-filtered($name as xs:string) {
+    count(collection($ot:COLLECTION)//address[name3 != $name])
+};
+
+declare
+    %test:args("rüssel")
+    %test:assertEquals("Rudi Rüssel")
+function ot:contains-field-string-filtered($name as xs:string) {
+    collection($ot:COLLECTION)//address[contains(name3, $name)]/name3/text()
+};
+
+declare
+    %test:args("rudi rüs")
+    %test:assertEquals("Rudi Rüssel")
+function ot:starts-with-field-string-filtered($name as xs:string) {
+    collection($ot:COLLECTION)//address[starts-with(name3, $name)]/name3/text()
+};
+
+declare
+    %test:args("üssel")
+    %test:assertEquals("Rudi Rüssel")
+function ot:ends-with-field-string-filtered($name as xs:string) {
+    collection($ot:COLLECTION)//address[ends-with(name3, $name)]/name3/text()
+};
+
+(: Collations :)
+
+declare
+    %test:args("Мла̀тишума")
+    %test:assertEquals(2)
+    %test:args("Млатишума")
+    %test:assertEquals(2)
+function ot:eq-string-collation-with-diacritics($name) {
+    count(//tei:form[tei:orth = $name])
+};
+
+declare
+    %test:args("Мла̀тишума")
+    %test:assertError("range:EXXQDYFT0001")
+    %test:args("Млатишума")
+    %test:assertError("range:EXXQDYFT0001")
+function ot:contains-string-collation-with-diacritics($name) {
+    count(//tei:form[contains(tei:orth, $name)])
+};
+
+declare
+    %test:args("Мла̀тишума")
+    %test:assertEquals(0)
+    %test:args("Млатишума")
+    %test:assertEquals(0)
+function ot:ne-string-collation-with-diacritics($name) {
+    count(//tei:form[tei:orth != $name])
+};
+


### PR DESCRIPTION
1. fix issue with byte reference becoming invalid; 
2. throw error when using fn:contains, fn:starts-with or fn:ends-with on a collated index. A collated index is not suitable for substring matching.
3. generalize analyzer configuration so arbitrary lucene token filters can be plugged into it via collection.xconf (see test cases). It would also be possible to extend this to pass in optional parameters, but looking at the token filters which might apply to a range index, there are hardly any useful ones for the time being, so I skipped this
4. fix wrong gt, ge, lt, le comparison for analyzed strings
5. extended test cases

Closes #1055, #1098.