### PR TITLE
Add test showing bug in typeswitch - eXist allows invalid "empty()" check

### DIFF
--- a/test/src/xquery/xquery3/typeswitch.xql
+++ b/test/src/xquery/xquery3/typeswitch.xql
@@ -188,3 +188,21 @@ function tsw:atomic-default() {
             case xs:string return "string"
             default return "unknown"
 };
+
+declare 
+    %test:assertEquals("empty() is not a valid itemType as defined at https://www.w3.org/TR/xquery-31/#doc-xquery31-ItemType")
+    %test:pending
+function tsw:item-type() {
+    let $value := <node/>
+    return
+        try 
+            { 
+                typeswitch ($value)
+                    case empty() return "empty?!"
+                    default return "default"
+            }
+        catch *
+            {
+                "empty() is not a valid itemType as defined at https://www.w3.org/TR/xquery-31/#doc-xquery31-ItemType"
+            }
+};


### PR DESCRIPTION
This PR adds a failing test (with `%test:pending` annotation) demonstrating the problem documented at https://github.com/eXist-db/exist/issues/1155.