### PR TITLE
fix 'x' flag parsing

### DIFF
--- a/src/org/exist/xquery/functions/fn/FunAnalyzeString.java
+++ b/src/org/exist/xquery/functions/fn/FunAnalyzeString.java
@@ -195,7 +195,7 @@ public class FunAnalyzeString extends BasicFunction {
                 break;
                 
             case 'x' :
-                iFlags |= Pattern.CANON_EQ;
+                iFlags |= Pattern.COMMENT;
                 break;
                 
             case 'q' :

--- a/src/org/exist/xquery/functions/fn/FunAnalyzeString.java
+++ b/src/org/exist/xquery/functions/fn/FunAnalyzeString.java
@@ -195,7 +195,7 @@ public class FunAnalyzeString extends BasicFunction {
                 break;
                 
             case 'x' :
-                iFlags |= Pattern.COMMENT;
+                iFlags |= Pattern.COMMENTS;
                 break;
                 
             case 'q' :

--- a/test/src/xquery/xquery3/fn.xql
+++ b/test/src/xquery/xquery3/fn.xql
@@ -3,6 +3,7 @@ xquery version "3.0";
 module namespace fn="http://exist-db.org/xquery/test/fnfunctions";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace xpf = "http://www.w3.org/2005/xpath-functions";
 
 declare
     %test:assertEquals(0, 4, 3, 2, 1)
@@ -14,3 +15,9 @@ return
     })
 };
 
+declare
+    %test:args('test', 't e s t', '') %test:assertFalse
+    %test:args('test', 't e s t', 'x') %test:assertTrue
+function fn:analyze-matches($str, $pat, $flags) {
+	exists(analyze-string($str, $pat, $flags)/xpf:match)
+};


### PR DESCRIPTION
as seen in FunMatches.java#L528, an 'x' flag in regular expressions should be interpreted as Pattern.COMMENTS