### PR TITLE
Retain temp files and directories. Fixes  #1187

### DIFF
--- a/installer/install.xml.tmpl
+++ b/installer/install.xml.tmpl
@@ -179,6 +179,10 @@
                 <exclude name="**/*~"/>
             </fileset>
             <fileset targetdir="$INSTALL_PATH/tools" dir="tools">
+                <include name="jetty/tmp/.DO_NOT_DELETE"/>
+                <include name="yajsw/tmp/.DO_NOT_DELETE"/>
+            </fileset>
+            <fileset targetdir="$INSTALL_PATH/tools" dir="tools">
                 <include name="**/*.jar"/>
                 <include name="yajsw/**"/>
                 <exclude name="yajsw/log/*"/>
@@ -198,6 +202,10 @@
                 <exclude name="ant/lib/svnkit*.jar"/>
                 <include name="jmx/**"/>
                 <exclude name="jmx/classes/**"/>
+            </fileset>
+            <fileset targetdir="$INSTALL_PATH/webapp" dir="webapp">
+                <include name="WEB-INF/data/.DO_NOT_DELETE"/>
+                <include name="WEB-INF/logs/.DO_NOT_DELETE"/>
             </fileset>
             <fileset targetdir="$INSTALL_PATH/webapp" dir="webapp">
                 <exclude name="**/*.dbx"/>


### PR DESCRIPTION
These must be retained, only ( * ) is in the (former) installer
./tools/jetty/tmp/.DO_NOT_DELETE
./tools/yajsw/tmp/.DO_NOT_DELETE
./webapp/WEB-INF/data/.DO_NOT_DELETE (*)
./webapp/WEB-INF/logs/.DO_NOT_DELETE