### PR TITLE
Fix BC dates in the range index DateConverter

### DIFF
--- a/extensions/indexes/range/src/org/exist/indexing/range/conversion/DateConverter.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/conversion/DateConverter.java
@@ -42,13 +42,13 @@ public class DateConverter implements TypeConverter {
 
     protected static final Logger LOG = LogManager.getLogger(DateConverter.class);
 
-    private final static Pattern DATE_REGEX = Pattern.compile("(\\d+)-(\\d+)-(\\d+)");
+    private final static Pattern DATE_REGEX = Pattern.compile("(-?\\d+)-(\\d+)-(\\d+)");
 
     @Override
     public Field toField(String fieldName, String content) {
         try {
             DateValue dv;
-            if (content.indexOf('-') < 0) {
+            if (content.indexOf('-') < 1) {
                 // just year
                 int year = Integer.parseInt(content);
                 XMLGregorianCalendar calendar = TimeUtils.getInstance().newXMLGregorianCalendar();
@@ -61,7 +61,8 @@ public class DateConverter implements TypeConverter {
                 Matcher matcher = DATE_REGEX.matcher(content);
                 if (matcher.matches()) {
                     try {
-                        content = String.format("%04d-%02d-%02d", Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2)), Integer.parseInt(matcher.group(3)));
+                        int year = Integer.parseInt(matcher.group(1));
+                        content = (year < 0 ? "-" : "") + String.format("%04d-%02d-%02d", Math.abs(year), Integer.parseInt(matcher.group(2)), Integer.parseInt(matcher.group(3)));
                     } catch (NumberFormatException e) {
                         // invalid content: ignore
                     }

--- a/extensions/indexes/range/test/src/xquery/types.xql
+++ b/extensions/indexes/range/test/src/xquery/types.xql
@@ -17,6 +17,8 @@ declare variable $tt:COLLECTION_CONFIG :=
                     <field name="date" match="date2" type="xs:date"/>
                     <field name="int2" match="int2" type="xs:integer"/>
                     <field name="date3" match="date3" type="xs:date" converter="org.exist.indexing.range.conversion.DateConverter"/>
+                    <field name="date5" match="date5" type="xs:date" converter="org.exist.indexing.range.conversion.DateConverter"/>
+                    <field name="date6" match="date6" type="xs:date" converter="org.exist.indexing.range.conversion.DateConverter"/>
                 </create>
                 <create qname="string-lc" type="xs:string" case="no"/>
                 <create qname="string" type="xs:string"/>
@@ -33,6 +35,8 @@ declare variable $tt:XML :=
             <date2>1918-02-11</date2>
             <date3>1918</date3>
             <date4>1918</date4>
+            <date5>-800-02-11</date5>
+            <date6>-800</date6>
             <time>09:00:00Z</time>
             <dateTime>1918-02-11T09:00:00Z</dateTime>
             <string-lc>UPPERCASE</string-lc>
@@ -499,4 +503,18 @@ declare
     %test:assertEquals("E2")
 function tt:date-field-normalized($date as xs:date) {
     collection($tt:COLLECTION)//entry[date4 = $date]/id/string()
+};
+
+declare 
+    %test:args("-0800-02-11")
+    %test:assertEquals("E1")
+function tt:date-field-normalized-bc($date as xs:date) {
+    collection($tt:COLLECTION)//entry[date5 = $date]/id/string()
+};
+
+declare 
+    %test:args("-0800-01-01")
+    %test:assertEquals("E1")
+function tt:date-field-normalized-bc($date as xs:date) {
+    collection($tt:COLLECTION)//entry[date6 = $date]/id/string()
 };


### PR DESCRIPTION
In our project we have to deal with dates BC, like "-300" or "-0004-03-29" that, when indexed, have to be normalized using the DateConverter (which should definitely be documented somewhere... utter happiness ensued when I stumbled upon this while digging through the sources 😄 )

These changes make the converter work correctly with negative (BC) dates. Would be excellent if this could go into 3.0.   