### PR TITLE
Refactor Collection and Lock

### DIFF
--- a/extensions/debuggee/src/org/exist/debuggee/dbgp/packets/Source.java
+++ b/extensions/debuggee/src/org/exist/debuggee/dbgp/packets/Source.java
@@ -29,7 +29,7 @@ import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.Base64Encoder;
 import org.exist.xmldb.XmldbURI;
 
@@ -108,7 +108,7 @@ public class Source extends Command {
 	
 	        		Database db = getJoint().getContext().getDatabase();
 	        		try(final DBBroker broker = db.getBroker()) {
-		    			DocumentImpl resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+		    			DocumentImpl resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
 		
 		    			if (resource.getResourceType() == DocumentImpl.BINARY_FILE) {
 		    				is = broker.getBinaryResource((BinaryDocument) resource);

--- a/extensions/exiftool/src/org/exist/exiftool/xquery/MetadataFunctions.java
+++ b/extensions/exiftool/src/org/exist/exiftool/xquery/MetadataFunctions.java
@@ -18,7 +18,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.source.Source;
 import org.exist.source.SourceFactory;
 import org.exist.storage.NativeBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -94,7 +94,7 @@ public class MetadataFunctions extends BasicFunction {
     private Sequence extractMetadataFromLocalResource(XmldbURI docUri) throws XPathException {
         DocumentImpl doc = null;
         try {
-            doc = context.getBroker().getXMLResource(docUri, Lock.READ_LOCK);
+            doc = context.getBroker().getXMLResource(docUri, LockMode.READ_LOCK);
             if (doc instanceof BinaryDocument) {
                 //resolve real filesystem path of binary file
                 final Path binaryFile = ((NativeBroker) context.getBroker()).getCollectionBinaryFileFsPath(docUri);
@@ -109,7 +109,7 @@ public class MetadataFunctions extends BasicFunction {
             throw new XPathException("Could not access binary document: " + pde.getMessage(), pde);
         } finally {
             if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
     }

--- a/extensions/expath/src/org/expath/exist/ZipEntryFunctions.java
+++ b/extensions/expath/src/org/expath/exist/ZipEntryFunctions.java
@@ -33,7 +33,7 @@ import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -242,13 +242,13 @@ public class ZipEntryFunctions extends BasicFunction {
         @Override
         public void close() {
             if(binaryDoc != null) {
-               binaryDoc.getUpdateLock().release(Lock.READ_LOCK);
+               binaryDoc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
 
         private BinaryDocument getDoc() throws PermissionDeniedException {
 
-            DocumentImpl doc = context.getBroker().getXMLResource(uri, Lock.READ_LOCK);
+            DocumentImpl doc = context.getBroker().getXMLResource(uri, LockMode.READ_LOCK);
             if(doc == null || doc.getResourceType() != DocumentImpl.BINARY_FILE) {
                 return null;
             }

--- a/extensions/expath/src/org/expath/exist/ZipFileFunctions.java
+++ b/extensions/expath/src/org/expath/exist/ZipFileFunctions.java
@@ -11,7 +11,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -260,13 +260,13 @@ public class ZipFileFunctions extends BasicFunction {
         @Override
         public void close() {
             if (binaryDoc != null) {
-                binaryDoc.getUpdateLock().release(Lock.READ_LOCK);
+                binaryDoc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
 
         private BinaryDocument getDoc() throws PermissionDeniedException {
 
-            DocumentImpl doc = context.getBroker().getXMLResource(uri, Lock.READ_LOCK);
+            DocumentImpl doc = context.getBroker().getXMLResource(uri, LockMode.READ_LOCK);
             if (doc == null || doc.getResourceType() != DocumentImpl.BINARY_FILE) {
                 return null;
             }

--- a/extensions/fluent/src/org/exist/fluent/Database.java
+++ b/extensions/fluent/src/org/exist/fluent/Database.java
@@ -16,6 +16,7 @@ import org.exist.dom.persistent.TextImpl;
 import org.exist.security.*;
 import org.exist.storage.*;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.util.*;
@@ -382,7 +383,7 @@ public class Database {
                     if (broker.getCollection(XmldbURI.create(path)) != null) return true;
                     String folderPath = path.substring(0, i);
                     String name = path.substring(i+1);			
-                    Collection collection = broker.openCollection(XmldbURI.create(folderPath), Lock.NO_LOCK);
+                    Collection collection = broker.openCollection(XmldbURI.create(folderPath), LockMode.NO_LOCK);
                     if (collection == null) return false;
                     return collection.getDocument(broker, XmldbURI.create(name)) != null;
                 } catch(PermissionDeniedException pde) {
@@ -603,7 +604,7 @@ public class Database {
 							it.remove();
 						} else {
 							// Must hold write lock on doc before checking stale map to avoid race condition
-							if (doc.getUpdateLock().attempt(Lock.WRITE_LOCK)) try {
+							if (doc.getUpdateLock().attempt(LockMode.WRITE_LOCK)) try {
 								String docPath = normalizePath(doc.getURI().getCollectionPath());
 								if (!staleMap.containsKey(docPath)) {
 									LOG.debug("defragmenting " + docPath);
@@ -618,7 +619,7 @@ public class Database {
 									}
 								}
 							} finally {
-								doc.getUpdateLock().release(Lock.WRITE_LOCK);
+								doc.getUpdateLock().release(LockMode.WRITE_LOCK);
 							}
 						}
 					}

--- a/extensions/fluent/src/org/exist/fluent/Folder.java
+++ b/extensions/fluent/src/org/exist/fluent/Folder.java
@@ -16,6 +16,7 @@ import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
@@ -346,11 +347,11 @@ public class Folder extends NamedResource implements Cloneable {
 				public XMLDocument completed(Node[] nodes) {
 					assert nodes.length == 1;
 					Node node = nodes[0];
-					transact(Lock.WRITE_LOCK);
+					transact(LockMode.WRITE_LOCK);
 					try {
 						name.setContext(handle);
 						IndexInfo info = handle.validateXMLResource(tx.tx, broker, XmldbURI.create(name.get()), node);
-						changeLock(Lock.NO_LOCK);
+						changeLock(LockMode.NO_LOCK);
 						handle.store(tx.tx, broker, info, node);
 						commit();
 					} catch (EXistException e) {
@@ -409,12 +410,12 @@ public class Folder extends NamedResource implements Cloneable {
 			Folder target = name.stripPathPrefix(Folder.this);
 			if (target != Folder.this) return target.documents().load(name, source);
 			
-			transact(Lock.WRITE_LOCK);
+			transact(LockMode.WRITE_LOCK);
 			try {
 				source.applyOldName(name);
 				name.setContext(handle);
 				IndexInfo info = handle.validateXMLResource(tx.tx, broker, XmldbURI.create(name.get()), source.toInputSource());
-				changeLock(Lock.NO_LOCK);
+				changeLock(LockMode.NO_LOCK);
 				handle.store(tx.tx, broker, info, source.toInputSource());
 				commit();
 			} catch (EXistException e) {
@@ -447,7 +448,7 @@ public class Folder extends NamedResource implements Cloneable {
 			Folder target = name.stripPathPrefix(Folder.this);
 			if (target != Folder.this) return target.documents().load(name, source);
 			
-			transact(Lock.WRITE_LOCK);
+			transact(LockMode.WRITE_LOCK);
 			try {
 				source.applyOldName(name);
 				name.setContext(handle);
@@ -553,7 +554,7 @@ public class Folder extends NamedResource implements Cloneable {
 			return new QueryService(Folder.this) {
 				@Override
 				protected void prepareContext(DBBroker broker_) {
-					acquire(Lock.READ_LOCK, broker_);
+					acquire(LockMode.READ_LOCK, broker_);
 					try {
 						docs = handle.allDocs(broker_, new DefaultDocumentSet(), false);
 						baseUri = new AnyURIValue(handle.getURI());
@@ -577,7 +578,7 @@ public class Folder extends NamedResource implements Cloneable {
 				private Iterator<DocumentImpl> delegate;
 				private Document last;
 				{
-					acquire(Lock.READ_LOCK);
+					acquire(LockMode.READ_LOCK);
 					try {
 						delegate = handle.iterator(broker);
 					} catch(PermissionDeniedException | LockException e) {
@@ -667,7 +668,7 @@ public class Folder extends NamedResource implements Cloneable {
 	private DBBroker broker;
 	private Collection handle;
 	private Transaction tx;
-	private int lockMode;
+	private LockMode lockMode;
 	private boolean ownBroker;
 	
 	/**
@@ -792,7 +793,7 @@ public class Folder extends NamedResource implements Cloneable {
 		}
 	}
 	
-	void transact(int _lockMode) {
+	void transact(LockMode _lockMode) {
 		if (tx != null) throw new IllegalStateException("transaction already in progress");
 		tx = Database.requireTransaction();
 		acquire(_lockMode);
@@ -803,7 +804,7 @@ public class Folder extends NamedResource implements Cloneable {
 		tx.commit();		// later aborts will do nothing
 	}
 	
-	void acquire(int _lockMode) {
+	void acquire(LockMode _lockMode) {
 		DBBroker _broker = db.acquireBroker();
 		ownBroker = true;
 		try {
@@ -815,7 +816,7 @@ public class Folder extends NamedResource implements Cloneable {
 		}
 	}
 	
-	void acquire(int _lockMode, DBBroker _broker) {
+	void acquire(LockMode _lockMode, DBBroker _broker) {
 		staleMarker.check();
 		if(broker != null || handle != null) throw new IllegalStateException("broker already acquired");
 		broker = _broker;
@@ -839,7 +840,7 @@ public class Folder extends NamedResource implements Cloneable {
 	void release() {
 		if (broker == null || handle == null) throw new IllegalStateException("broker not acquired");
 		if (tx != null) tx.abortIfIncomplete();
-		if (lockMode != Lock.NO_LOCK) handle.getLock().release(lockMode);
+		if (lockMode != LockMode.NO_LOCK) handle.getLock().release(lockMode);
 		if (ownBroker) db.releaseBroker(broker);
 		ownBroker = false;
 		broker = null;
@@ -847,10 +848,10 @@ public class Folder extends NamedResource implements Cloneable {
 		tx = null;
 	}
 	
-	void changeLock(int newLockMode) {
+	void changeLock(LockMode newLockMode) {
 		if (broker == null || handle == null) throw new IllegalStateException("broker not acquired");
 		if (lockMode == newLockMode) return;
-		if (lockMode == Lock.NO_LOCK) {
+		if (lockMode == LockMode.NO_LOCK) {
 			try {
 				handle.getLock().acquire(newLockMode);
 				lockMode = newLockMode;
@@ -858,14 +859,14 @@ public class Folder extends NamedResource implements Cloneable {
 				throw new DatabaseException(e);
 			}
 		} else {
-			if (newLockMode != Lock.NO_LOCK) throw new IllegalStateException("cannot change between read and write lock modes");
+			if (newLockMode != LockMode.NO_LOCK) throw new IllegalStateException("cannot change between read and write lock modes");
 			handle.getLock().release(lockMode);
 			lockMode = newLockMode;
 		}
 	}
 	
 	private Collection getQuickHandle() {
-		acquire(Lock.NO_LOCK);
+		acquire(LockMode.NO_LOCK);
 		try {
 			return handle;
 		} finally {
@@ -879,7 +880,7 @@ public class Folder extends NamedResource implements Cloneable {
 	 * @return whether this folder is empty
 	 */
 	public boolean isEmpty() {
-		acquire(Lock.NO_LOCK);
+		acquire(LockMode.NO_LOCK);
 		try {
 			return handle.getDocumentCount(broker) == 0 && handle.getChildCollectionCount(broker) == 0;
                 } catch (PermissionDeniedException pde) {
@@ -894,7 +895,7 @@ public class Folder extends NamedResource implements Cloneable {
 	 * Remove all resources and subfolders from this folder, but keep the folder itself.
 	 */
 	public void clear() {
-		transact(Lock.READ_LOCK);
+		transact(LockMode.READ_LOCK);
 		try {
 			if (handle.getDocumentCount(broker) == 0 && handle.getChildCollectionCount(broker) == 0) return;
 			broker.removeCollection(tx.tx, handle);
@@ -917,7 +918,7 @@ public class Folder extends NamedResource implements Cloneable {
 	 * deletes all documents and descendants but does not delete the root folder itself.
 	 */
 	@Override public void delete() {
-		transact(Lock.NO_LOCK);
+		transact(LockMode.NO_LOCK);
 		try {
 			// TODO: temporary hack, remove once removing root collection works in eXist
 			if (path.equals("/")) {
@@ -973,9 +974,9 @@ public class Folder extends NamedResource implements Cloneable {
 	
 	private String moveOrCopyThisFolder(Folder destination, Name name, boolean copy) {
 		db.checkSame(destination);
-		transact(Lock.WRITE_LOCK);
+		transact(LockMode.WRITE_LOCK);
 		try {
-			destination.acquire(Lock.WRITE_LOCK, broker);
+			destination.acquire(LockMode.WRITE_LOCK, broker);
 			try {
 				name.setOldName(name());
 				name.setContext(handle);
@@ -1106,7 +1107,7 @@ public class Folder extends NamedResource implements Cloneable {
 	private Sequence getDocsSequence(boolean recursive) {
 		try {
 			DocumentSet docs;
-			acquire(Lock.READ_LOCK);
+			acquire(LockMode.READ_LOCK);
 			try {
 				docs = handle.allDocs(broker, new DefaultDocumentSet(), recursive);
                         } catch(PermissionDeniedException pde) {
@@ -1139,7 +1140,7 @@ public class Folder extends NamedResource implements Cloneable {
 	@Override QueryService createQueryService() {
 		return new QueryService(this) {
 			@Override void prepareContext(DBBroker broker_) {
-				acquire(Lock.READ_LOCK, broker_);
+				acquire(LockMode.READ_LOCK, broker_);
 				try {
 					docs = handle.allDocs(broker_, new DefaultDocumentSet(), true);
 					baseUri = new AnyURIValue(handle.getURI());
@@ -1153,7 +1154,7 @@ public class Folder extends NamedResource implements Cloneable {
 	}
 	
 	void removeDocument(DocumentImpl dimpl) {
-		transact(Lock.WRITE_LOCK);
+		transact(LockMode.WRITE_LOCK);
 		try {
 			if (dimpl instanceof BinaryDocument) {
 				handle.removeBinaryResource(tx.tx, broker, dimpl.getFileURI());
@@ -1170,7 +1171,7 @@ public class Folder extends NamedResource implements Cloneable {
 	
 	DocumentImpl moveOrCopyDocument(DocumentImpl doc, Name name, boolean copy) {
 		XmldbURI uri;
-		transact(Lock.WRITE_LOCK);
+		transact(LockMode.WRITE_LOCK);
 		try {
 			name.setContext(handle);
 			uri = XmldbURI.create(name.get());

--- a/extensions/fluent/src/org/exist/fluent/Folder.java
+++ b/extensions/fluent/src/org/exist/fluent/Folder.java
@@ -207,8 +207,8 @@ public class Folder extends NamedResource implements Cloneable {
                             try {
                                 broker = db.acquireBroker();
                                 delegate = getQuickHandle().collectionIterator(broker);
-                            } catch(PermissionDeniedException pde) {
-                                throw new IllegalStateException(pde.getMessage(), pde);
+                            } catch(final PermissionDeniedException | LockException e) {
+                                throw new IllegalStateException(e.getMessage(), e);
                             }
                         }
                         
@@ -351,7 +351,7 @@ public class Folder extends NamedResource implements Cloneable {
 						name.setContext(handle);
 						IndexInfo info = handle.validateXMLResource(tx.tx, broker, XmldbURI.create(name.get()), node);
 						changeLock(Lock.NO_LOCK);
-						handle.store(tx.tx, broker, info, node, false);
+						handle.store(tx.tx, broker, info, node);
 						commit();
 					} catch (EXistException e) {
 						throw new DatabaseException(e);
@@ -415,7 +415,7 @@ public class Folder extends NamedResource implements Cloneable {
 				name.setContext(handle);
 				IndexInfo info = handle.validateXMLResource(tx.tx, broker, XmldbURI.create(name.get()), source.toInputSource());
 				changeLock(Lock.NO_LOCK);
-				handle.store(tx.tx, broker, info, source.toInputSource(), false);
+				handle.store(tx.tx, broker, info, source.toInputSource());
 				commit();
 			} catch (EXistException e) {
 				throw new DatabaseException("failed to create document '" + name + "' from source " + source, e);
@@ -580,8 +580,8 @@ public class Folder extends NamedResource implements Cloneable {
 					acquire(Lock.READ_LOCK);
 					try {
 						delegate = handle.iterator(broker);
-                                        } catch(PermissionDeniedException pde) {
-                                            throw new DatabaseException(pde.getMessage(), pde);
+					} catch(PermissionDeniedException | LockException e) {
+						throw new DatabaseException(e.getMessage(), e);
 					} finally {
 						release();
 					}

--- a/extensions/fluent/src/org/exist/fluent/Name.java
+++ b/extensions/fluent/src/org/exist/fluent/Name.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 import org.exist.collections.Collection;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
+import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 
 /**
@@ -81,9 +82,9 @@ public abstract class Name {
                 DBBroker _broker = null;
                 try {
                     _broker = db.acquireBroker();
-                    return context.hasDocument(_broker, proposedUri) || context.hasSubcollection(_broker, proposedUri);
-                } catch(PermissionDeniedException pde) {
-                    throw new DatabaseException(pde.getMessage(), pde);
+                    return context.hasDocument(_broker, proposedUri) || context.hasChildCollection(_broker, proposedUri);
+                } catch(final PermissionDeniedException | LockException e) {
+                    throw new DatabaseException(e.getMessage(), e);
                 } finally {
                     if(_broker != null) {
                         db.releaseBroker(_broker);

--- a/extensions/fluent/src/org/exist/fluent/Transaction.java
+++ b/extensions/fluent/src/org/exist/fluent/Transaction.java
@@ -3,6 +3,7 @@ package org.exist.fluent;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.*;
 import org.exist.util.LockException;
 
@@ -71,7 +72,7 @@ class Transaction {
 	
 	void lockWrite(DocumentImpl doc) {
 		try {
-			tx.acquireLock(doc.getUpdateLock(), Lock.WRITE_LOCK);
+			tx.acquireLock(doc.getUpdateLock(), LockMode.WRITE_LOCK);
 		} catch (LockException e) {
 			throw new DatabaseException(e);
 		}
@@ -79,7 +80,7 @@ class Transaction {
 	
 	void lockRead(DocumentImpl doc) {
 		try {
-			tx.acquireLock(doc.getUpdateLock(), Lock.READ_LOCK);
+			tx.acquireLock(doc.getUpdateLock(), LockMode.READ_LOCK);
 		} catch (LockException e) {
 			throw new DatabaseException(e);
 		}		

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -57,7 +57,7 @@ import org.exist.numbering.NodeId;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.*;
 import org.exist.storage.btree.DBException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import org.exist.util.ByteConversion;
 import org.exist.util.DatabaseConfigurationException;
@@ -721,7 +721,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                         DocumentImpl storedDoc = null;
                         try {
                             // try to read document to check if user is allowed to access it
-                            storedDoc = context.getBroker().getXMLResource(XmldbURI.createInternal(fDocUri), Lock.READ_LOCK);
+                            storedDoc = context.getBroker().getXMLResource(XmldbURI.createInternal(fDocUri), LockMode.READ_LOCK);
                             if (storedDoc == null) {
                                 return;
                             }
@@ -756,7 +756,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                             // not allowed to read the document: ignore the match.
                         } finally {
                             if (storedDoc != null) {
-                                storedDoc.getUpdateLock().release(Lock.READ_LOCK);
+                                storedDoc.getUpdateLock().release(LockMode.READ_LOCK);
                             }
                         }
                     }

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -61,6 +61,7 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.util.ByteConversion;
 import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.LockException;
 import org.exist.util.Occurrences;
 import org.exist.util.pool.NodePool;
 import org.exist.xmldb.XmldbURI;
@@ -353,7 +354,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 Term dt = new Term(FIELD_DOC_ID, bytes.toBytesRef());
                 writer.deleteDocuments(dt);
             }
-        } catch (IOException | PermissionDeniedException e) {
+        } catch (IOException | PermissionDeniedException | LockException e) {
             LOG.error("Error while removing lucene index: " + e.getMessage(), e);
         } finally {
             index.releaseWriter(writer);

--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/GetField.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/GetField.java
@@ -26,7 +26,7 @@ import org.exist.dom.QName;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -67,7 +67,7 @@ public class GetField extends BasicFunction {
 		
 		DocumentImpl doc = null;
 		try {
-			doc = context.getBroker().getXMLResource(uri, Lock.READ_LOCK);
+			doc = context.getBroker().getXMLResource(uri, LockMode.READ_LOCK);
 			if (doc == null) {
                 return Sequence.EMPTY_SEQUENCE;
             }
@@ -81,7 +81,7 @@ public class GetField extends BasicFunction {
 			throw new XPathException(this, LuceneModule.EXXQDYFT0002, "IO error while reading document " + args[0].getStringValue());
 		} finally {
 			if (doc != null)
-				doc.getUpdateLock().release(Lock.READ_LOCK);
+				doc.getUpdateLock().release(LockMode.READ_LOCK);
 		}
 	}
 

--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/Index.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/Index.java
@@ -29,7 +29,7 @@ import org.exist.indexing.StreamListener.ReindexMode;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
 
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 
 import org.exist.xquery.BasicFunction;
@@ -109,7 +109,7 @@ public class Index extends BasicFunction {
 	            String path = args[0].itemAt(0).getStringValue();
 	
 	            // Retrieve document from database
-	            doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), Lock.READ_LOCK);
+	            doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), LockMode.READ_LOCK);
 	
 	            // Verify the document actually exists
 	            if (doc == null) {
@@ -143,7 +143,7 @@ public class Index extends BasicFunction {
 
         } finally {
             if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
 

--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/InspectIndex.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/InspectIndex.java
@@ -27,7 +27,7 @@ import org.exist.dom.QName;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -68,7 +68,7 @@ public class InspectIndex extends BasicFunction {
 		
         try {
 			// Retrieve document from database
-			DocumentImpl doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), Lock.READ_LOCK);
+			DocumentImpl doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), LockMode.READ_LOCK);
 
 			// Verify the document actually exists
 			if (doc == null) {

--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/RemoveIndex.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/RemoveIndex.java
@@ -21,11 +21,10 @@ package org.exist.xquery.modules.lucene;
 
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.QName;
-import org.exist.indexing.StreamListener;
 import org.exist.indexing.StreamListener.ReindexMode;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -67,7 +66,7 @@ public class RemoveIndex extends BasicFunction {
             String path = args[0].itemAt(0).getStringValue();
 
             // Retrieve document from database
-            doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), Lock.READ_LOCK);
+            doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), LockMode.READ_LOCK);
 
             // Verify the document actually exists
             if (doc == null) {
@@ -88,7 +87,7 @@ public class RemoveIndex extends BasicFunction {
 
         } finally {
             if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
 

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -1163,7 +1163,7 @@ public class LuceneIndexTest {
 
             final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(docName), data);
             assertNotNull(info);
-            root.store(transaction, broker, info, data, false);
+            root.store(transaction, broker, info, data);
 
             docs.add(info.getDocument());
             transact.commit(transaction);
@@ -1195,7 +1195,7 @@ public class LuceneIndexTest {
                     final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), is);
                     assertNotNull(info);
                     is = new FileInputSource(f);
-                    root.store(transaction, broker, info, is, false);
+                    root.store(transaction, broker, info, is);
                     docs.add(info.getDocument());
                 }
             }

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneMatchListenerTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneMatchListenerTest.java
@@ -383,7 +383,7 @@ public class LuceneMatchListenerTest {
 
             final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_matches.xml"), XML);
             assertNotNull(info);
-            root.store(transaction, broker, info, data, false);
+            root.store(transaction, broker, info, data);
 
             transact.commit(transaction);
         }

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/SerializeAttrMatchesTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/SerializeAttrMatchesTest.java
@@ -111,7 +111,7 @@ public class SerializeAttrMatchesTest {
 
             final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create(docName), data);
             assertNotNull(info);
-            test.store(transaction, broker, info, data, false);
+            test.store(transaction, broker, info, data);
 
             docs.add(info.getDocument());
             transact.commit(transaction);

--- a/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndexWorker.java
+++ b/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndexWorker.java
@@ -72,6 +72,7 @@ import org.exist.storage.index.BFile;
 import org.exist.storage.io.VariableByteInput;
 import org.exist.storage.io.VariableByteOutputStream;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import org.exist.util.*;
 import org.exist.util.serializer.AttrList;
@@ -211,7 +212,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 continue;
             Lock lock = index.db.getLock();
             try {
-                lock.acquire(Lock.WRITE_LOCK);
+                lock.acquire(LockMode.WRITE_LOCK);
 
                 NGramQNameKey value = new NGramQNameKey(currentDoc.getCollection().getId(), key.qname,
                         index.getBrokerPool().getSymbols(), key.term);
@@ -223,7 +224,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             } catch (ReadOnlyException e) {
                 LOG.warn("Read-only error for file " + FileUtils.fileName(index.db.getFile()), e);
             } finally {
-                lock.release(Lock.WRITE_LOCK);
+                lock.release(LockMode.WRITE_LOCK);
                 os.clear();
             }
         }
@@ -241,7 +242,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
 
             Lock lock = index.db.getLock();
             try {
-                lock.acquire(Lock.WRITE_LOCK);
+                lock.acquire(LockMode.WRITE_LOCK);
 
                 NGramQNameKey value = new NGramQNameKey(currentDoc.getCollection().getId(), key.qname,
                         index.getBrokerPool().getSymbols(), key.term);
@@ -336,7 +337,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             } catch (ReadOnlyException e) {
                 LOG.warn("Read-only error for file " + FileUtils.fileName(index.db.getFile()), e);
             } finally {
-                lock.release(Lock.WRITE_LOCK);
+                lock.release(LockMode.WRITE_LOCK);
                 os.clear();
             }
         }
@@ -349,7 +350,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             LOG.debug("Dropping NGram index for collection " + collection.getURI());
         final Lock lock = index.db.getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
             // remove generic index
             Value value = new NGramQNameKey(collection.getId());
             index.db.removeAll(null, new IndexQuery(IndexQuery.TRUNC_RIGHT, value));
@@ -360,7 +361,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         } catch (IOException e) {
             LOG.error(e.getMessage(), e);
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 
@@ -376,7 +377,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 NGramQNameKey key = new NGramQNameKey(collectionId, qname, index.getBrokerPool().getSymbols(), query);
                 final Lock lock = index.db.getLock();
                 try {
-                    lock.acquire(Lock.READ_LOCK);
+                    lock.acquire(LockMode.READ_LOCK);
                     SearchCallback cb = new SearchCallback(contextId, query, ngram, docs, contextSet, context, result, axis == NodeSet.ANCESTOR);
                     int op = query.codePointCount(0, query.length()) < getN() ? IndexQuery.TRUNC_RIGHT : IndexQuery.EQ;
                     index.db.query(new IndexQuery(op, key), cb);
@@ -387,7 +388,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 } catch (BTreeException e) {
                     LOG.error(e.getMessage() + " in '" + FileUtils.fileName(index.db.getFile()) + "'", e);
                 } finally {
-                    lock.release(Lock.READ_LOCK);
+                    lock.release(LockMode.READ_LOCK);
                 }
             }
         }
@@ -459,7 +460,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                     query = new IndexQuery(IndexQuery.BW, startRef, endRef);
                 }
                 try {
-                    lock.acquire(Lock.READ_LOCK);
+                    lock.acquire(LockMode.READ_LOCK);
                     index.db.query(query, cb);
                 } catch (LockException e) {
                     LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(index.db.getFile()) + "'", e);
@@ -470,7 +471,7 @@ public class NGramIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 } catch (TerminatedException e) {
                     LOG.warn(e.getMessage(), e);
                 } finally {
-                    lock.release(Lock.READ_LOCK);
+                    lock.release(LockMode.READ_LOCK);
                 }
             }
         }

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
@@ -31,7 +31,7 @@ import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
@@ -492,7 +492,7 @@ public class CustomIndexTest {
             checkIndex(broker, docs, "cha", 1);
             checkIndex(broker, docs, "le8", 1);
 
-            Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
+            Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
             assertNotNull(root);
 
             root.removeXMLResource(transaction, broker, XmldbURI.create("test_string.xml"));

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
@@ -624,13 +624,13 @@ public class CustomIndexTest {
 
             IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_string.xml"), XML);
             assertNotNull(info);
-            root.store(transaction, broker, info, XML, false);
+            root.store(transaction, broker, info, XML);
 
             docs.add(info.getDocument());
 
             info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_string2.xml"), XML2);
             assertNotNull(info);
-            root.store(transaction, broker, info, XML2, false);
+            root.store(transaction, broker, info, XML2);
 
             docs.add(info.getDocument());
 

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
@@ -558,7 +558,7 @@ public class MatchListenerTest {
 
             final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_matches.xml"), xml);
             assertNotNull(info);
-            root.store(transaction, broker, info, xml, false);
+            root.store(transaction, broker, info, xml);
             
             transact.commit(transaction);
         }

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexWorker.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexWorker.java
@@ -60,6 +60,7 @@ import org.exist.storage.btree.DBException;
 import org.exist.storage.txn.Txn;
 import org.exist.util.ByteConversion;
 import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.LockException;
 import org.exist.util.Occurrences;
 import org.exist.xquery.*;
 import org.exist.xquery.modules.range.RangeQueryRewriter;
@@ -363,9 +364,7 @@ public class RangeIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 Term dt = new Term(FIELD_DOC_ID, bytes.toBytesRef());
                 writer.deleteDocuments(dt);
             }
-        } catch (IOException e) {
-            LOG.error("Error while removing lucene index: " + e.getMessage(), e);
-        } catch (PermissionDeniedException e) {
+        } catch (IOException | PermissionDeniedException | LockException e) {
             LOG.error("Error while removing lucene index: " + e.getMessage(), e);
         } finally {
             index.releaseWriter(writer);

--- a/extensions/indexes/sort/src/org/exist/indexing/sort/SortIndex.java
+++ b/extensions/indexes/sort/src/org/exist/indexing/sort/SortIndex.java
@@ -10,6 +10,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.btree.DBException;
 import org.exist.storage.index.BTreeStore;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
@@ -65,7 +66,7 @@ public class SortIndex extends AbstractIndex implements RawBackupSupport {
             return;
         final Lock lock = btree.getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
             btree.flush();
         } catch (final LockException e) {
             LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(btree.getFile()) + "'", e);
@@ -74,7 +75,7 @@ public class SortIndex extends AbstractIndex implements RawBackupSupport {
             LOG.error(e.getMessage(), e);
             //TODO : throw an exception ? -pb
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 

--- a/extensions/indexes/sort/src/org/exist/indexing/sort/SortIndexWorker.java
+++ b/extensions/indexes/sort/src/org/exist/indexing/sort/SortIndexWorker.java
@@ -15,6 +15,7 @@ import org.exist.storage.btree.BTreeException;
 import org.exist.storage.btree.IndexQuery;
 import org.exist.storage.btree.Value;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.*;
 import org.exist.xquery.QueryRewriter;
 import org.exist.xquery.TerminatedException;
@@ -77,7 +78,7 @@ public class SortIndexWorker implements IndexWorker {
         final short id = getOrRegisterId(name);
         final Lock lock = index.btree.getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
             long idx = 0;
             for (final SortItem item : items) {
                 final byte[] key = computeKey(id, item.getNode());
@@ -86,7 +87,7 @@ public class SortIndexWorker implements IndexWorker {
         } catch (final LockException | IOException | BTreeException e) {
             throw new EXistException("Exception caught while creating sort index: " + e.getMessage(), e);
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 
@@ -108,13 +109,13 @@ public class SortIndexWorker implements IndexWorker {
         final short id = getId(name);
         final Lock lock = index.btree.getLock();
         try {
-            lock.acquire(Lock.READ_LOCK);
+            lock.acquire(LockMode.READ_LOCK);
             final byte[] key = computeKey(id, proxy);
             return index.btree.findValue(new Value(key));
         } catch (final LockException | IOException | BTreeException e) {
             throw new EXistException("Exception caught while reading sort index: " + e.getMessage(), e);
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
     }
 
@@ -129,7 +130,7 @@ public class SortIndexWorker implements IndexWorker {
         final short id = getId(name);
         final Lock lock = index.btree.getLock();
         try {
-            lock.acquire(Lock.READ_LOCK);
+            lock.acquire(LockMode.READ_LOCK);
             final byte[] fromKey = computeKey(id);
             final byte[] toKey = computeKey((short) (id + 1));
             final IndexQuery query = new IndexQuery(IndexQuery.RANGE, new Value(fromKey), new Value(toKey));
@@ -139,7 +140,7 @@ public class SortIndexWorker implements IndexWorker {
         } catch (final BTreeException | TerminatedException | IOException e) {
             throw new EXistException("Exception caught while deleting sort index: " + e.getMessage(), e);
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
     }
 
@@ -151,7 +152,7 @@ public class SortIndexWorker implements IndexWorker {
     private void remove(final DocumentImpl doc, final short id) throws LockException, EXistException {
         final Lock lock = index.btree.getLock();
         try {
-            lock.acquire(Lock.READ_LOCK);
+            lock.acquire(LockMode.READ_LOCK);
             final byte[] fromKey = computeKey(id, doc.getDocId());
             final byte[] toKey = computeKey(id, doc.getDocId() + 1);
             final IndexQuery query = new IndexQuery(IndexQuery.RANGE, new Value(fromKey), new Value(toKey));
@@ -159,7 +160,7 @@ public class SortIndexWorker implements IndexWorker {
         } catch (final BTreeException | TerminatedException | IOException e) {
             throw new EXistException("Exception caught while deleting sort index: " + e.getMessage(), e);
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
     }
 
@@ -171,7 +172,7 @@ public class SortIndexWorker implements IndexWorker {
 
         final Lock lock = index.btree.getLock();
         try {
-            lock.acquire(Lock.READ_LOCK);
+            lock.acquire(LockMode.READ_LOCK);
             final IndexQuery query = new IndexQuery(IndexQuery.RANGE, new Value(fromKey), new Value(endKey));
             final FindIdCallback callback = new FindIdCallback(true);
             index.btree.query(query, callback);
@@ -183,7 +184,7 @@ public class SortIndexWorker implements IndexWorker {
         } catch (final BTreeException | EXistException | LockException | TerminatedException | IOException e) {
             SortIndex.LOG.debug("Exception caught while reading sort index: " + e.getMessage(), e);
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
     }
 
@@ -203,7 +204,7 @@ public class SortIndexWorker implements IndexWorker {
             final IndexQuery query = new IndexQuery(IndexQuery.RANGE, new Value(fromKey), new Value(endKey));
             final Lock lock = index.btree.getLock();
             try {
-                lock.acquire(Lock.READ_LOCK);
+                lock.acquire(LockMode.READ_LOCK);
                 final FindIdCallback callback = new FindIdCallback(false);
                 index.btree.query(query, callback);
                 id = (short) (callback.max + 1);
@@ -211,7 +212,7 @@ public class SortIndexWorker implements IndexWorker {
             } catch (final IOException | TerminatedException | BTreeException e) {
                 throw new EXistException("Exception caught while reading sort index: " + e.getMessage(), e);
             } finally {
-                lock.release(Lock.READ_LOCK);
+                lock.release(LockMode.READ_LOCK);
             }
         }
         return id;
@@ -223,12 +224,12 @@ public class SortIndexWorker implements IndexWorker {
         UTF8.encode(name, key, 1);
         final Lock lock = index.btree.getLock();
         try {
-            lock.acquire(Lock.READ_LOCK);
+            lock.acquire(LockMode.READ_LOCK);
             index.btree.addValue(new Value(key), id);
         } catch (final LockException | IOException | BTreeException e) {
             throw new EXistException("Exception caught while reading sort index: " + e.getMessage(), e);
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
     }
 
@@ -238,12 +239,12 @@ public class SortIndexWorker implements IndexWorker {
         UTF8.encode(name, key, 1);
         final Lock lock = index.btree.getLock();
         try {
-            lock.acquire(Lock.READ_LOCK);
+            lock.acquire(LockMode.READ_LOCK);
             index.btree.removeValue(new Value(key));
         } catch (final LockException | IOException | BTreeException e) {
             throw new EXistException("Exception caught while reading sort index: " + e.getMessage(), e);
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
     }
 
@@ -253,12 +254,12 @@ public class SortIndexWorker implements IndexWorker {
         UTF8.encode(name, key, 1);
         final Lock lock = index.btree.getLock();
         try {
-            lock.acquire(Lock.READ_LOCK);
+            lock.acquire(LockMode.READ_LOCK);
             return (short) index.btree.findValue(new Value(key));
         } catch (final BTreeException | IOException e) {
             throw new EXistException("Exception caught while reading sort index: " + e.getMessage(), e);
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
     }
 

--- a/extensions/metadata/interface/src/main/java/org/exist/storage/md/CollectionEvents.java
+++ b/extensions/metadata/interface/src/main/java/org/exist/storage/md/CollectionEvents.java
@@ -29,7 +29,7 @@ import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import org.exist.xmldb.XmldbURI;
 import org.exist.util.LockException;
@@ -106,14 +106,14 @@ public class CollectionEvents implements CollectionTrigger {
 		for(Iterator<XmldbURI> i = collection.collectionIterator(broker); i.hasNext(); ) {
             final XmldbURI childName = i.next();
             //TODO : resolve URIs !!! name.resolve(childName)
-            final Collection child = broker.openCollection(uri.append(childName), Lock.NO_LOCK);
+            final Collection child = broker.openCollection(uri.append(childName), LockMode.NO_LOCK);
             if(child == null) {
 //                LOG.warn("Child collection " + childName + " not found");
             } else {
                 try {
                 	deleteCollectionRecursive(broker, child);
                 } finally {
-                    child.release(Lock.NO_LOCK);
+                    child.release(LockMode.NO_LOCK);
                 }
             }
         }

--- a/extensions/metadata/interface/src/main/java/org/exist/storage/md/CollectionEvents.java
+++ b/extensions/metadata/interface/src/main/java/org/exist/storage/md/CollectionEvents.java
@@ -32,6 +32,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.xmldb.XmldbURI;
+import org.exist.util.LockException;
 
 /**
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
@@ -83,7 +84,7 @@ public class CollectionEvents implements CollectionTrigger {
             		newUri.append(doc.getFileURI())
         		);
 	        }
-		} catch (PermissionDeniedException e) {
+		} catch (PermissionDeniedException | LockException e) {
 			throw new TriggerException(e);
 		}
 	}
@@ -94,7 +95,7 @@ public class CollectionEvents implements CollectionTrigger {
 		MDStorageManager.inst.md.moveMetas(oldUri, collection.getURI());
 	}
 	
-	private void deleteCollectionRecursive(DBBroker broker, Collection collection) throws PermissionDeniedException {
+	private void deleteCollectionRecursive(DBBroker broker, Collection collection) throws PermissionDeniedException, LockException {
         for(Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
             DocumentImpl doc = i.next();
             MDStorageManager.inst.md.delMetas(doc.getURI());
@@ -124,7 +125,7 @@ public class CollectionEvents implements CollectionTrigger {
 //		System.out.println("beforeDeleteCollection "+collection.getURI());
 		try {
 			deleteCollectionRecursive(broker, collection);
-		} catch (PermissionDeniedException e) {
+		} catch (PermissionDeniedException | LockException e) {
 			throw new TriggerException(e);
 		}
 	}

--- a/extensions/metadata/interface/src/main/java/org/exist/storage/md/xquery/Check.java
+++ b/extensions/metadata/interface/src/main/java/org/exist/storage/md/xquery/Check.java
@@ -32,7 +32,7 @@ import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.LockedDocumentMap;
 import org.exist.storage.md.MetaData;
 import org.exist.storage.md.MDStorageManager;
@@ -101,7 +101,7 @@ public class Check extends BasicFunction {
 		
 		MutableDocumentSet childDocs = new DefaultDocumentSet();
 		LockedDocumentMap lockedDocuments = new LockedDocumentMap();
-		col.getDocuments(broker, childDocs, lockedDocuments, Lock.WRITE_LOCK);
+		col.getDocuments(broker, childDocs, lockedDocuments, LockMode.WRITE_LOCK);
 		
 		for (Iterator<DocumentImpl> itChildDocs = childDocs.getDocumentIterator(); itChildDocs.hasNext();) {
 			DocumentImpl childDoc = itChildDocs.next();

--- a/extensions/metadata/interface/src/main/java/org/exist/storage/md/xquery/Reindex.java
+++ b/extensions/metadata/interface/src/main/java/org/exist/storage/md/xquery/Reindex.java
@@ -33,7 +33,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.LockedDocumentMap;
 import org.exist.storage.md.MetaData;
 import org.exist.storage.md.Metas;
@@ -101,7 +101,7 @@ public class Reindex extends BasicFunction {
 		
 		MutableDocumentSet childDocs = new DefaultDocumentSet();
 		LockedDocumentMap lockedDocuments = new LockedDocumentMap();
-		col.getDocuments(broker, childDocs, lockedDocuments, Lock.WRITE_LOCK);
+		col.getDocuments(broker, childDocs, lockedDocuments, LockMode.WRITE_LOCK);
 		
 		for (Iterator<DocumentImpl> itChildDocs = childDocs.getDocumentIterator(); itChildDocs.hasNext();) {
 			DocumentImpl childDoc = itChildDocs.next();

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/BackupRestoreMDTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/BackupRestoreMDTest.java
@@ -230,7 +230,7 @@ public class BackupRestoreMDTest extends TestCase {
 
             IndexInfo info = root.validateXMLResource(transaction, broker, doc1uri.lastSegment(), XML);
             assertNotNull(info);
-            root.store(transaction, broker, info, XML, false);
+            root.store(transaction, broker, info, XML);
 
             BinaryDocument doc = root.addBinaryResource(transaction, broker, doc2uri.lastSegment(), BINARY.getBytes(), null);
             assertNotNull(doc);

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/DocumentAsValueTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/DocumentAsValueTest.java
@@ -144,14 +144,14 @@ public class DocumentAsValueTest {
 
             IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
             assertNotNull(info);
-            root.store(txn, broker, info, XML1, false);
+            root.store(txn, broker, info, XML1);
             assertNotNull(info.getDocument());
 
             doc1 = info.getDocument();
 
             info = root.validateXMLResource(txn, broker, doc2uri.lastSegment(), XML2);
             assertNotNull(info);
-            root.store(txn, broker, info, XML2, false);
+            root.store(txn, broker, info, XML2);
 
             doc2 = info.getDocument();
 

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/MatchDocumentsTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/MatchDocumentsTest.java
@@ -32,7 +32,7 @@ import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
@@ -98,7 +98,7 @@ public class MatchDocumentsTest {
 
         Collection col1 = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            col1 = broker.openCollection(col1uri, Lock.READ_LOCK);
+            col1 = broker.openCollection(col1uri, LockMode.READ_LOCK);
 
             final DocumentImpl doc2 = col1.getDocument(broker, doc2uri.lastSegment());
 
@@ -138,7 +138,7 @@ public class MatchDocumentsTest {
 
         } finally {
             if(col1 != null) {
-                col1.release(Lock.READ_LOCK);
+                col1.release(LockMode.READ_LOCK);
             }
         }
     }
@@ -157,8 +157,8 @@ public class MatchDocumentsTest {
         Collection col1 = null;
         Collection parentCol = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            col1 = broker.openCollection(col1uri, Lock.WRITE_LOCK);
-            parentCol = broker.openCollection(col2uri.removeLastSegment(), Lock.WRITE_LOCK);
+            col1 = broker.openCollection(col1uri, LockMode.WRITE_LOCK);
+            parentCol = broker.openCollection(col2uri.removeLastSegment(), LockMode.WRITE_LOCK);
 
             final DocumentImpl doc2 = col1.getDocument(broker, doc2uri.lastSegment());
 
@@ -197,10 +197,10 @@ public class MatchDocumentsTest {
 
         } finally {
             if(parentCol != null) {
-                parentCol.release(Lock.WRITE_LOCK);
+                parentCol.release(LockMode.WRITE_LOCK);
             }
             if(col1 != null) {
-                col1.release(Lock.WRITE_LOCK);
+                col1.release(LockMode.WRITE_LOCK);
             }
         }
     }
@@ -215,7 +215,7 @@ public class MatchDocumentsTest {
 
         Collection col1 = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            col1 = broker.openCollection(col1uri, Lock.WRITE_LOCK);
+            col1 = broker.openCollection(col1uri, LockMode.WRITE_LOCK);
 
             final DocumentImpl doc2 = col1.getDocument(broker, doc2uri.lastSegment());
 
@@ -248,7 +248,7 @@ public class MatchDocumentsTest {
 
         } finally {
             if(col1 != null) {
-                col1.release(Lock.WRITE_LOCK);
+                col1.release(LockMode.WRITE_LOCK);
             }
         }
     }
@@ -263,7 +263,7 @@ public class MatchDocumentsTest {
 
         Collection col1 = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            col1 = broker.openCollection(col1uri, Lock.WRITE_LOCK);
+            col1 = broker.openCollection(col1uri, LockMode.WRITE_LOCK);
 
             DocumentImpl doc2 = col1.getDocument(broker, doc2uri.lastSegment());
 
@@ -297,7 +297,7 @@ public class MatchDocumentsTest {
 
         } finally {
             if(col1 != null) {
-                col1.release(Lock.WRITE_LOCK);
+                col1.release(LockMode.WRITE_LOCK);
             }
         }
     }
@@ -321,7 +321,7 @@ public class MatchDocumentsTest {
         //add some test key-values to metadata of doc1
         Collection col1 = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            col1 = broker.openCollection(col1uri, Lock.WRITE_LOCK);
+            col1 = broker.openCollection(col1uri, LockMode.WRITE_LOCK);
 
             final DocumentImpl doc2 = col1.getDocument(broker, doc2uri.lastSegment());
 
@@ -352,7 +352,7 @@ public class MatchDocumentsTest {
 
         } finally {
             if(col1 != null) {
-                col1.release(Lock.WRITE_LOCK);
+                col1.release(LockMode.WRITE_LOCK);
             }
         }
     }
@@ -367,7 +367,7 @@ public class MatchDocumentsTest {
 
         Collection col1 = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            col1 = broker.openCollection(col1uri, Lock.WRITE_LOCK);
+            col1 = broker.openCollection(col1uri, LockMode.WRITE_LOCK);
 
             DocumentImpl doc2 = col1.getDocument(broker, doc2uri.lastSegment());
 	    	//add first key-value
@@ -400,7 +400,7 @@ public class MatchDocumentsTest {
 
         } finally {
             if(col1 != null) {
-                col1.release(Lock.WRITE_LOCK);
+                col1.release(LockMode.WRITE_LOCK);
             }
         }
     }
@@ -415,7 +415,7 @@ public class MatchDocumentsTest {
 
         Collection col1 = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            col1 = broker.openCollection(col1uri, Lock.WRITE_LOCK);
+            col1 = broker.openCollection(col1uri, LockMode.WRITE_LOCK);
 
             DocumentImpl doc2 = col1.getDocument(broker, doc2uri.lastSegment());
 
@@ -449,7 +449,7 @@ public class MatchDocumentsTest {
 
         } finally {
             if(col1 != null) {
-                col1.release(Lock.WRITE_LOCK);
+                col1.release(LockMode.WRITE_LOCK);
             }
         }
     }
@@ -465,7 +465,7 @@ public class MatchDocumentsTest {
         Collection col1 = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
-            col1 = broker.openCollection(col1uri, Lock.WRITE_LOCK);
+            col1 = broker.openCollection(col1uri, LockMode.WRITE_LOCK);
 
             DocumentImpl doc2 = col1.getDocument(broker, doc2uri.lastSegment());
 
@@ -495,7 +495,7 @@ public class MatchDocumentsTest {
 
         } finally {
             if(col1 != null) {
-                col1.release(Lock.WRITE_LOCK);
+                col1.release(LockMode.WRITE_LOCK);
             }
         }
     }
@@ -553,12 +553,12 @@ public class MatchDocumentsTest {
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn txn = txnManager.beginTransaction()) {
 
-            col1 = broker.openCollection(col1uri, Lock.WRITE_LOCK);
+            col1 = broker.openCollection(col1uri, LockMode.WRITE_LOCK);
             if(col1 != null) {
             	broker.removeCollection(txn, col1);
             }
 
-            col2 = broker.openCollection(col2uri, Lock.WRITE_LOCK);
+            col2 = broker.openCollection(col2uri, LockMode.WRITE_LOCK);
             if(col2 != null) {
             	broker.removeCollection(txn, col2);
             }
@@ -569,10 +569,10 @@ public class MatchDocumentsTest {
             fail(e.getMessage());
         } finally {
             if(col2 != null) {
-                col2.release(Lock.WRITE_LOCK);
+                col2.release(LockMode.WRITE_LOCK);
             }
             if(col1 != null) {
-                col1.release(Lock.WRITE_LOCK);
+                col1.release(LockMode.WRITE_LOCK);
             }
         }
     }

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/MatchDocumentsTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/MatchDocumentsTest.java
@@ -522,9 +522,9 @@ public class MatchDocumentsTest {
 
             //store test data
             IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
-            root.store(txn, broker, info, XML1, false);
+            root.store(txn, broker, info, XML1);
             info = root.validateXMLResource(txn, broker, doc2uri.lastSegment(), XML2);
-            root.store(txn, broker, info, XML2, false);
+            root.store(txn, broker, info, XML2);
             root.addBinaryResource(txn, broker, doc3uri.lastSegment(), BINARY.getBytes(), null);
 
             txnManager.commit(txn);

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/SearchTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/SearchTest.java
@@ -212,7 +212,7 @@ public class SearchTest {
 	private static DocumentImpl storeDocument(Txn txn, DBBroker broker, Collection col, XmldbURI uri, String data) throws TriggerException, EXistException, PermissionDeniedException, SAXException, LockException, IOException {
         IndexInfo info = col.validateXMLResource(txn, broker, uri.lastSegment(), data);
         assertNotNull(info);
-        col.store(txn, broker, info, data, false);
+        col.store(txn, broker, info, data);
         assertNotNull(info.getDocument());
 
         return info.getDocument();

--- a/extensions/metadata/interface/src/test/java/org/exist/storage/md/SimpleMDTest.java
+++ b/extensions/metadata/interface/src/test/java/org/exist/storage/md/SimpleMDTest.java
@@ -266,7 +266,7 @@ public class SimpleMDTest {
 
 		    	IndexInfo info = col.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
 	            assertNotNull(info);
-	            col.store(txn, broker, info, XML1, false);
+	            col.store(txn, broker, info, XML1);
 	            
 	            //XXX: need to simulate unfinished transaction & crash
 	            txnManager.commit(txn);
@@ -294,7 +294,7 @@ public class SimpleMDTest {
 
 		    	IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
 	            assertNotNull(info);
-	            root.store(txn, broker, info, XML1, false);
+	            root.store(txn, broker, info, XML1);
 
 	            txnManager.commit(txn);
 	            
@@ -715,7 +715,7 @@ public class SimpleMDTest {
 
                     final IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), XML1);
                     assertNotNull(info);
-                    root.store(txn, broker, info, XML1, false);
+                    root.store(txn, broker, info, XML1);
 
                     txnManager.commit(txn);
                 } catch (Exception e) {
@@ -739,7 +739,7 @@ public class SimpleMDTest {
 
                     final IndexInfo info = root.validateXMLResource(txn, broker, doc1uri.lastSegment(), wrongXML);
                     assertNotNull(info);
-                    root.store(txn, broker, info, wrongXML, false);
+                    root.store(txn, broker, info, wrongXML);
 
                     txnManager.commit(txn);
                 } catch (Exception e) {
@@ -772,7 +772,7 @@ public class SimpleMDTest {
 	private static DocumentImpl storeDocument(Txn txn, DBBroker broker, Collection col, XmldbURI uri, String data) throws TriggerException, EXistException, PermissionDeniedException, SAXException, LockException, IOException {
         IndexInfo info = col.validateXMLResource(txn, broker, uri.lastSegment(), data);
         assertNotNull(info);
-        col.store(txn, broker, info, data, false);
+        col.store(txn, broker, info, data);
         assertNotNull(info.getDocument());
 
         return info.getDocument();

--- a/extensions/modules/src/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -30,7 +30,7 @@ import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.Base64Decoder;
 import org.exist.util.LockException;
@@ -165,7 +165,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                     try
                     {
                         XmldbURI xmldburi = XmldbURI.create(uri);
-                        doc = context.getBroker().getXMLResource(xmldburi, Lock.READ_LOCK);
+                        doc = context.getBroker().getXMLResource(xmldburi, LockMode.READ_LOCK);
 
                         if(doc == null)
                         {
@@ -195,7 +195,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                     } finally
                     {
                         if(doc != null)
-                            doc.getUpdateLock().release(Lock.READ_LOCK);
+                            doc.getUpdateLock().release(LockMode.READ_LOCK);
                     }
                 }
 
@@ -479,11 +479,11 @@ public abstract class AbstractCompressFunction extends BasicFunction
 		col.getDocuments(context.getBroker(), childDocs);
 		for (Iterator<DocumentImpl> itChildDocs = childDocs.getDocumentIterator(); itChildDocs.hasNext();) {
 			DocumentImpl childDoc = itChildDocs.next();
-			childDoc.getUpdateLock().acquire(Lock.READ_LOCK);
+			childDoc.getUpdateLock().acquire(LockMode.READ_LOCK);
 			try {
 				compressResource(os, childDoc, useHierarchy, stripOffset, "", null);
 			} finally {
-				childDoc.getUpdateLock().release(Lock.READ_LOCK);
+				childDoc.getUpdateLock().release(LockMode.READ_LOCK);
 			}
 		}
 		// iterate over child collections

--- a/extensions/modules/src/org/exist/xquery/modules/expathrepo/Deploy.java
+++ b/extensions/modules/src/org/exist/xquery/modules/expathrepo/Deploy.java
@@ -38,7 +38,7 @@ import org.exist.repo.Deployment;
 import org.exist.repo.PackageLoader;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.NativeBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
@@ -200,7 +200,7 @@ public class Deploy extends BasicFunction {
         final XmldbURI docPath = XmldbURI.createInternal(path);
         DocumentImpl doc = null;
         try {
-            doc = context.getBroker().getXMLResource(docPath, Lock.READ_LOCK);
+            doc = context.getBroker().getXMLResource(docPath, LockMode.READ_LOCK);
             if (doc.getResourceType() != DocumentImpl.BINARY_FILE)
                 throw new XPathException(this, EXPathErrorCode.EXPDY001, path + " is not a valid .xar", new StringValue(path));
 
@@ -216,7 +216,7 @@ public class Deploy extends BasicFunction {
             throw new XPathException(this, EXPathErrorCode.EXPDY007, e.getMessage());
         } finally {
             if (doc != null)
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
         }
     }
 

--- a/extensions/modules/src/org/exist/xquery/modules/expathrepo/InstallFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/expathrepo/InstallFunction.java
@@ -35,7 +35,7 @@ import org.exist.repo.ExistRepository;
 import org.exist.security.PermissionDeniedException;
 import org.exist.repo.ClasspathHelper;
 import org.exist.storage.NativeBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -110,7 +110,7 @@ public class InstallFunction extends BasicFunction {
 			    repo.get().reportAction(ExistRepository.Action.INSTALL, pkg.getName());
 			} finally {
 			    if (doc != null)
-				doc.getUpdateLock().release(Lock.READ_LOCK);
+				doc.getUpdateLock().release(LockMode.READ_LOCK);
 			}
 		    }
 		    ExistPkgInfo info = (ExistPkgInfo) pkg.getInfo("exist");
@@ -153,7 +153,7 @@ public class InstallFunction extends BasicFunction {
     private BinaryDocument _getDocument(String path) throws XPathException {
     	try {
 			XmldbURI uri = XmldbURI.createInternal(path);
-			DocumentImpl doc = context.getBroker().getXMLResource(uri, Lock.READ_LOCK);
+			DocumentImpl doc = context.getBroker().getXMLResource(uri, LockMode.READ_LOCK);
 			if (doc.getResourceType() != DocumentImpl.BINARY_FILE)
 				throw new XPathException(this, EXPathErrorCode.EXPDY001, path + " is not a valid .xar", new StringValue(path));
 			return (BinaryDocument) doc;

--- a/extensions/modules/src/org/exist/xquery/modules/file/Sync.java
+++ b/extensions/modules/src/org/exist/xquery/modules/file/Sync.java
@@ -25,7 +25,7 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.FileUtils;
@@ -139,7 +139,7 @@ public class Sync extends BasicFunction {
 		List<XmldbURI> subcollections = null;
 		Collection collection = null;
 		try {
-			collection = context.getBroker().openCollection(collectionPath, Lock.READ_LOCK);
+			collection = context.getBroker().openCollection(collectionPath, LockMode.READ_LOCK);
 			if (collection == null) {
 				reportError(output, "Collection not found: " + collectionPath);
 				return;
@@ -161,7 +161,7 @@ public class Sync extends BasicFunction {
 			}
 		} finally {
 			if (collection != null)
-				collection.getLock().release(Lock.READ_LOCK);
+				collection.getLock().release(LockMode.READ_LOCK);
 		}
 		
 		for (final XmldbURI childURI : subcollections) {

--- a/extensions/modules/src/org/exist/xquery/modules/file/Sync.java
+++ b/extensions/modules/src/org/exist/xquery/modules/file/Sync.java
@@ -29,6 +29,7 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.FileUtils;
+import org.exist.util.LockException;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.serializer.SerializerPool;
 import org.exist.xmldb.XmldbURI;
@@ -113,15 +114,15 @@ public class Sync extends BasicFunction {
 			
 			output.endElement();
 			output.endDocument();
-        } catch(final PermissionDeniedException pde) {
-            throw new XPathException(this, pde);
+        } catch(final PermissionDeniedException | LockException e) {
+            throw new XPathException(this, e);
 		} finally {
 			context.popDocumentContext();
 		}
 		return output.getDocument();
 	}
 
-	private void saveCollection(final XmldbURI collectionPath, Path targetDir, final Date startDate, final MemTreeBuilder output) throws PermissionDeniedException {
+	private void saveCollection(final XmldbURI collectionPath, Path targetDir, final Date startDate, final MemTreeBuilder output) throws PermissionDeniedException, LockException {
 		try {
 			targetDir = Files.createDirectories(targetDir);
 		} catch(final IOException ioe) {

--- a/extensions/modules/src/org/exist/xquery/modules/image/GetThumbnailsFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/image/GetThumbnailsFunction.java
@@ -50,6 +50,7 @@ import org.exist.storage.journal.JournalManager;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.util.FileUtils;
+import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -316,8 +317,8 @@ public class GetThumbnailsFunction extends BasicFunction {
                             result.add(new StringValue(docImage.getFileURI().toString()));
                         }
                     }
-                } catch (PermissionDeniedException pde) {
-                    throw new XPathException(this, pde.getMessage(), pde);
+                } catch (final PermissionDeniedException | LockException e) {
+                    throw new XPathException(this, e.getMessage(), e);
                 }
                 try {
                     transact.commit(transaction);

--- a/extensions/security/openid/src/org/exist/security/realm/openid/OpenIDUtility.java
+++ b/extensions/security/openid/src/org/exist/security/realm/openid/OpenIDUtility.java
@@ -31,7 +31,7 @@ import org.exist.source.Source;
 import org.exist.source.DBSource;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XQuery;
@@ -104,7 +104,7 @@ public class OpenIDUtility {
                 XmldbURI pathUri = XmldbURI.create(xqueryResourcePath);
 
 
-                resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+                resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
 
                 if (resource != null) {
                     LOG.info("Resource " + xqueryResourcePath + " exists.");

--- a/extensions/webdav/src/org/exist/webdav/ExistCollection.java
+++ b/extensions/webdav/src/org/exist/webdav/ExistCollection.java
@@ -44,7 +44,7 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.LockException;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
@@ -101,7 +101,7 @@ public class ExistCollection extends ExistResource {
             // Get access to collection
             Collection collection = null;
             try {
-                collection = broker.openCollection(xmldbUri, Lock.READ_LOCK);
+                collection = broker.openCollection(xmldbUri, LockMode.READ_LOCK);
 
                 if (collection == null) {
                     LOG.error(String.format("Collection for %s cannot be opened for metadata", xmldbUri));
@@ -122,7 +122,7 @@ public class ExistCollection extends ExistResource {
             } finally {
                 // Clean up collection
                 if (collection != null) {
-                    collection.release(Lock.READ_LOCK);
+                    collection.release(LockMode.READ_LOCK);
                 }
             }
         } catch (final PermissionDeniedException | EXistException pde) {
@@ -143,7 +143,7 @@ public class ExistCollection extends ExistResource {
             // Try to read as specified subject
             Collection collection = null;
             try {
-                collection = broker.openCollection(xmldbUri, Lock.READ_LOCK);
+                collection = broker.openCollection(xmldbUri, LockMode.READ_LOCK);
                 // Get all collections
                 final Iterator<XmldbURI> collections = collection.collectionIteratorNoLock(broker); // QQ: use collectionIterator ?
                 while (collections.hasNext()) {
@@ -152,7 +152,7 @@ public class ExistCollection extends ExistResource {
                 }
             } finally {
                 if (collection != null) {
-                    collection.release(Lock.READ_LOCK);
+                    collection.release(LockMode.READ_LOCK);
                 }
             }
         } catch (final EXistException | PermissionDeniedException e) {
@@ -174,7 +174,7 @@ public class ExistCollection extends ExistResource {
             Collection collection = null;
             try {
                 // Try to read as specified subject
-                collection = broker.openCollection(xmldbUri, Lock.READ_LOCK);
+                collection = broker.openCollection(xmldbUri, LockMode.READ_LOCK);
 
                 // Get all documents
                 final Iterator<DocumentImpl> documents = collection.iteratorNoLock(broker); // QQ: use 'iterator'
@@ -184,7 +184,7 @@ public class ExistCollection extends ExistResource {
             } finally {
                 // Clean up resources
                 if (collection != null) {
-                    collection.release(Lock.READ_LOCK);
+                    collection.release(LockMode.READ_LOCK);
                 }
             }
         } catch (final PermissionDeniedException | EXistException e) {
@@ -213,7 +213,7 @@ public class ExistCollection extends ExistResource {
             final Txn txn = txnManager.beginTransaction()) {
 
             // Open collection if possible, else abort
-            collection = broker.openCollection(xmldbUri, Lock.WRITE_LOCK);
+            collection = broker.openCollection(xmldbUri, LockMode.WRITE_LOCK);
             if (collection == null) {
                 txnManager.abort(txn);
                 return;
@@ -234,7 +234,7 @@ public class ExistCollection extends ExistResource {
 
             // TODO: check if can be done earlier
             if (collection != null) {
-                collection.release(Lock.WRITE_LOCK);
+                collection.release(LockMode.WRITE_LOCK);
             }
 
             if(LOG.isDebugEnabled()) {
@@ -259,7 +259,7 @@ public class ExistCollection extends ExistResource {
 
             // Check if collection exists. not likely to happen since availability is
             // checked by ResourceFactory
-            collection = broker.openCollection(newCollection, Lock.WRITE_LOCK);
+            collection = broker.openCollection(newCollection, LockMode.WRITE_LOCK);
             if (collection != null) {
                 final String msg = "Collection already exists";
 
@@ -296,7 +296,7 @@ public class ExistCollection extends ExistResource {
 
             // TODO: check if can be done earlier
             if (collection != null) {
-                collection.release(Lock.WRITE_LOCK);
+                collection.release(LockMode.WRITE_LOCK);
             }
 
             if(LOG.isDebugEnabled()) {
@@ -353,7 +353,7 @@ public class ExistCollection extends ExistResource {
 
             // Check if collection exists. not likely to happen since availability is checked
             // by ResourceFactory
-            collection = broker.openCollection(xmldbUri, Lock.WRITE_LOCK);
+            collection = broker.openCollection(xmldbUri, LockMode.WRITE_LOCK);
             if (collection == null) {
                 LOG.debug(String.format("Collection %s does not exist", xmldbUri));
                 txnManager.abort(txn);
@@ -414,7 +414,7 @@ public class ExistCollection extends ExistResource {
 
             // TODO: check if can be done earlier
             if (collection != null) {
-                collection.release(Lock.WRITE_LOCK);
+                collection.release(LockMode.WRITE_LOCK);
             }
 
             if(LOG.isDebugEnabled()) {
@@ -454,7 +454,7 @@ public class ExistCollection extends ExistResource {
             XmldbURI srcCollectionUri = xmldbUri;
 
             // Open collection if possible, else abort
-            srcCollection = broker.openCollection(srcCollectionUri, Lock.WRITE_LOCK);
+            srcCollection = broker.openCollection(srcCollectionUri, LockMode.WRITE_LOCK);
             if (srcCollection == null) {
                 txnManager.abort(txn);
                 return; // TODO throw
@@ -462,7 +462,7 @@ public class ExistCollection extends ExistResource {
 
 
             // Open collection if possible, else abort
-            destCollection = broker.openCollection(destCollectionUri, Lock.WRITE_LOCK);
+            destCollection = broker.openCollection(destCollectionUri, LockMode.WRITE_LOCK);
             if (destCollection == null) {
                 LOG.debug(String.format("Destination collection %s does not exist.", xmldbUri));
                 txnManager.abort(txn);
@@ -496,11 +496,11 @@ public class ExistCollection extends ExistResource {
         } finally {
 
             if (destCollection != null) {
-                destCollection.release(Lock.WRITE_LOCK);
+                destCollection.release(LockMode.WRITE_LOCK);
             }
 
             if (srcCollection != null) {
-                srcCollection.release(Lock.WRITE_LOCK);
+                srcCollection.release(LockMode.WRITE_LOCK);
             }
 
             if (LOG.isDebugEnabled()) {

--- a/extensions/webdav/src/org/exist/webdav/ExistCollection.java
+++ b/extensions/webdav/src/org/exist/webdav/ExistCollection.java
@@ -371,7 +371,7 @@ public class ExistCollection extends ExistResource {
                     IndexInfo info = collection.validateXMLResource(txn, broker, newNameUri, vtfis);
                     DocumentImpl doc = info.getDocument();
                     doc.getMetadata().setMimeType(mime.getName());
-                    collection.store(txn, broker, info, vtfis, false);
+                    collection.store(txn, broker, info, vtfis);
                 }
 
             } else {

--- a/extensions/webdav/src/org/exist/webdav/ExistDocument.java
+++ b/extensions/webdav/src/org/exist/webdav/ExistDocument.java
@@ -39,7 +39,7 @@ import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -95,7 +95,7 @@ public class ExistDocument extends ExistResource {
             DocumentImpl document = null;
             try {
                 // If it is not a collection, check if it is a document
-                document = broker.getXMLResource(xmldbUri, Lock.READ_LOCK);
+                document = broker.getXMLResource(xmldbUri, LockMode.READ_LOCK);
 
                 if (document.getResourceType() == DocumentImpl.XML_FILE) {
                     isXmlDocument = true;
@@ -121,7 +121,7 @@ public class ExistDocument extends ExistResource {
             }  finally {
                 // Cleanup resources
                 if (document != null) {
-                    document.getUpdateLock().release(Lock.READ_LOCK);
+                    document.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
         } catch (final EXistException | PermissionDeniedException e) {
@@ -164,7 +164,7 @@ public class ExistDocument extends ExistResource {
             DocumentImpl document = null;
             try {
                 // If it is not a collection, check if it is a document
-                document = broker.getXMLResource(xmldbUri, Lock.READ_LOCK);
+                document = broker.getXMLResource(xmldbUri, LockMode.READ_LOCK);
 
                 if (document.getResourceType() == DocumentImpl.XML_FILE) {
                     // Stream XML document
@@ -197,7 +197,7 @@ public class ExistDocument extends ExistResource {
                 }
             } finally {
                 if (document != null) {
-                    document.getUpdateLock().release(Lock.READ_LOCK);
+                    document.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
         } catch (EXistException e) {
@@ -238,7 +238,7 @@ public class ExistDocument extends ExistResource {
             XmldbURI docName = xmldbUri.lastSegment();
 
             // Open collection if possible, else abort
-            collection = broker.openCollection(collName, Lock.WRITE_LOCK);
+            collection = broker.openCollection(collName, LockMode.WRITE_LOCK);
             if (collection == null) {
                 LOG.debug("Collection does not exist");
                 txnManager.abort(txn);
@@ -275,7 +275,7 @@ public class ExistDocument extends ExistResource {
 
             // TODO: check if can be done earlier
             if (collection != null) {
-                collection.release(Lock.WRITE_LOCK);
+                collection.release(LockMode.WRITE_LOCK);
             }
 
             if (LOG.isDebugEnabled()) {
@@ -298,7 +298,7 @@ public class ExistDocument extends ExistResource {
         try(final DBBroker broker = brokerPool.get(Optional.ofNullable(subject))) {
 
             // If it is not a collection, check if it is a document
-            document = broker.getXMLResource(xmldbUri, Lock.READ_LOCK);
+            document = broker.getXMLResource(xmldbUri, LockMode.READ_LOCK);
 
             if (document == null) {
                 LOG.debug("No resource found for path: " + xmldbUri);
@@ -340,7 +340,7 @@ public class ExistDocument extends ExistResource {
         } finally {
 
             if (document != null) {
-                document.getUpdateLock().release(Lock.READ_LOCK);
+                document.getUpdateLock().release(LockMode.READ_LOCK);
             }
 
             if (LOG.isDebugEnabled()) {
@@ -364,7 +364,7 @@ public class ExistDocument extends ExistResource {
         try(final DBBroker broker = brokerPool.get(Optional.ofNullable(subject))) {
 
             // Try to get document (add catch?)
-            document = broker.getXMLResource(xmldbUri, Lock.WRITE_LOCK);
+            document = broker.getXMLResource(xmldbUri, LockMode.WRITE_LOCK);
 
             if (document == null) {
 
@@ -437,7 +437,7 @@ public class ExistDocument extends ExistResource {
 
             // TODO: check if can be done earlier
             if (document != null) {
-                document.getUpdateLock().release(Lock.WRITE_LOCK);
+                document.getUpdateLock().release(LockMode.WRITE_LOCK);
             }
 
             if (LOG.isDebugEnabled()) {
@@ -464,7 +464,7 @@ public class ExistDocument extends ExistResource {
 
 
             // Try to get document (add catch?)
-            document = broker.getXMLResource(xmldbUri, Lock.WRITE_LOCK);
+            document = broker.getXMLResource(xmldbUri, LockMode.WRITE_LOCK);
 
             if (document == null) {
                 final String msg = String.format("No resource found for path: %s", xmldbUri);
@@ -504,7 +504,7 @@ public class ExistDocument extends ExistResource {
             throw new EXistException(e);
 		} finally {
             if (document != null) {
-                document.getUpdateLock().release(Lock.WRITE_LOCK);
+                document.getUpdateLock().release(LockMode.WRITE_LOCK);
             }
 
             if (LOG.isDebugEnabled()) {
@@ -546,7 +546,7 @@ public class ExistDocument extends ExistResource {
             XmldbURI srdDocumentUri = xmldbUri.lastSegment();
 
             // Open collection if possible, else abort
-            srcCollection = broker.openCollection(srcCollectionUri, Lock.WRITE_LOCK);
+            srcCollection = broker.openCollection(srcCollectionUri, LockMode.WRITE_LOCK);
             if (srcCollection == null) {
                 txnManager.abort(txn);
                 return; // TODO throw
@@ -561,7 +561,7 @@ public class ExistDocument extends ExistResource {
             }
 
             // Open collection if possible, else abort
-            destCollection = broker.openCollection(destCollectionUri, Lock.WRITE_LOCK);
+            destCollection = broker.openCollection(destCollectionUri, LockMode.WRITE_LOCK);
             if (destCollection == null) {
                 LOG.debug(String.format("Destination collection %s does not exist.", xmldbUri));
                 txnManager.abort(txn);
@@ -601,11 +601,11 @@ public class ExistDocument extends ExistResource {
 
             // TODO: check if can be done earlier
             if (destCollection != null) {
-                destCollection.release(Lock.WRITE_LOCK);
+                destCollection.release(LockMode.WRITE_LOCK);
             }
 
             if (srcCollection != null) {
-                srcCollection.release(Lock.WRITE_LOCK);
+                srcCollection.release(LockMode.WRITE_LOCK);
             }
 
             if (LOG.isDebugEnabled()) {
@@ -633,7 +633,7 @@ public class ExistDocument extends ExistResource {
         try(final DBBroker broker = brokerPool.get(Optional.ofNullable(subject))) {
 
             // Try to get document (add catch?)
-            document = broker.getXMLResource(xmldbUri, Lock.WRITE_LOCK);
+            document = broker.getXMLResource(xmldbUri, LockMode.WRITE_LOCK);
 
             if (document == null) {
                 if (LOG.isDebugEnabled()) {
@@ -694,7 +694,7 @@ public class ExistDocument extends ExistResource {
 
             // TODO: check if can be done earlier
             if (document != null) {
-                document.getUpdateLock().release(Lock.WRITE_LOCK);
+                document.getUpdateLock().release(LockMode.WRITE_LOCK);
             }
 
             if (LOG.isDebugEnabled()) {

--- a/extensions/webdav/src/org/exist/webdav/ExistResourceFactory.java
+++ b/extensions/webdav/src/org/exist/webdav/ExistResourceFactory.java
@@ -41,7 +41,7 @@ import org.exist.collections.Collection;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.util.FileUtils;
 import org.exist.xmldb.XmldbURI;
@@ -210,20 +210,20 @@ public class ExistResourceFactory implements ResourceFactory {
             }
             
             // First check if resource is a collection
-            collection = broker.openCollection(xmldbUri, Lock.READ_LOCK);
+            collection = broker.openCollection(xmldbUri, LockMode.READ_LOCK);
             if (collection != null) {
                 type = ResourceType.COLLECTION;
-                collection.release(Lock.READ_LOCK);
+                collection.release(LockMode.READ_LOCK);
                 collection = null;
 
             } else {
                 // If it is not a collection, check if it is a document
-                document = broker.getXMLResource(xmldbUri, Lock.READ_LOCK);
+                document = broker.getXMLResource(xmldbUri, LockMode.READ_LOCK);
 
                 if (document != null) {
                     // Document is found
                     type = ResourceType.DOCUMENT;
-                    document.getUpdateLock().release(Lock.READ_LOCK);
+                    document.getUpdateLock().release(LockMode.READ_LOCK);
                     document = null;
 
                 } else {
@@ -241,12 +241,12 @@ public class ExistResourceFactory implements ResourceFactory {
 
             // Clean-up, just in case
             if (collection != null) {
-                collection.release(Lock.READ_LOCK);
+                collection.release(LockMode.READ_LOCK);
             }
 
             // Clean-up, just in case
             if (document != null) {
-                document.getUpdateLock().release(Lock.READ_LOCK);
+                document.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
 

--- a/extensions/xqdoc/src/org/exist/xqdoc/xquery/Scan.java
+++ b/extensions/xqdoc/src/org/exist/xqdoc/xquery/Scan.java
@@ -11,7 +11,7 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
 import org.exist.source.*;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xqdoc.XQDocHelper;
@@ -93,12 +93,12 @@ public class Scan extends BasicFunction {
                 DocumentImpl doc = null;
                 try {
                     XmldbURI resourceURI = XmldbURI.xmldbUriFor(uri);
-                    collection = context.getBroker().openCollection(resourceURI.removeLastSegment(), Lock.READ_LOCK);
+                    collection = context.getBroker().openCollection(resourceURI.removeLastSegment(), LockMode.READ_LOCK);
                     if (collection == null) {
                         LOG.warn("collection not found: " + resourceURI.getCollectionPath());
                         return Sequence.EMPTY_SEQUENCE;
                     }
-                    doc = collection.getDocumentWithLock(context.getBroker(), resourceURI.lastSegment(), Lock.READ_LOCK);
+                    doc = collection.getDocumentWithLock(context.getBroker(), resourceURI.lastSegment(), LockMode.READ_LOCK);
                     if (doc == null)
                         return Sequence.EMPTY_SEQUENCE;
                     if (doc.getResourceType() != DocumentImpl.BINARY_FILE ||
@@ -116,9 +116,9 @@ public class Scan extends BasicFunction {
                     throw new XPathException(this, pde.getMessage(), pde);
                 } finally {
                     if (doc != null)
-                        doc.getUpdateLock().release(Lock.READ_LOCK);
+                        doc.getUpdateLock().release(LockMode.READ_LOCK);
                     if(collection != null)
-                        collection.release(Lock.READ_LOCK);
+                        collection.release(LockMode.READ_LOCK);
                 }
             } else {
                 // first check if the URI points to a registered module

--- a/samples/src/org/exist/examples/triggers/ExampleTrigger.java
+++ b/samples/src/org/exist/examples/triggers/ExampleTrigger.java
@@ -93,7 +93,7 @@ public class ExampleTrigger extends FilteringTrigger implements DocumentTrigger 
                 parent.setTriggersEnabled(false);
                 IndexInfo info = parent.validateXMLResource(null, broker, contentsFile, "<?xml version=\"1.0\"?><contents></contents>");
                 //TODO : unlock the collection here ?
-                parent.store(null, broker, info, "<?xml version=\"1.0\"?><contents></contents>", false);
+                parent.store(null, broker, info, "<?xml version=\"1.0\"?><contents></contents>");
                 this.doc = info.getDocument();
             } catch (Exception e) {
                 throw new TriggerException(e.getMessage(), e);

--- a/src/org/exist/atom/modules/AtomFeeds.java
+++ b/src/org/exist/atom/modules/AtomFeeds.java
@@ -44,7 +44,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.source.URLSource;
 import org.exist.storage.DBBroker;
 import org.exist.storage.XQueryPool;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.serializer.SerializerPool;
@@ -98,7 +98,7 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 		final XmldbURI pathUri = XmldbURI.create(request.getPath());
 		try {
 
-			resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+			resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
 
 			if (resource == null) {
 
@@ -209,7 +209,7 @@ public class AtomFeeds extends AtomModuleBase implements Atom {
 
 		} finally {
 			if (resource != null) {
-				resource.getUpdateLock().release(Lock.READ_LOCK);
+				resource.getUpdateLock().release(LockMode.READ_LOCK);
 			}
 		}
 	}

--- a/src/org/exist/atom/modules/AtomProtocol.java
+++ b/src/org/exist/atom/modules/AtomProtocol.java
@@ -207,7 +207,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					final IndexInfo info = collection.validateXMLResource(transaction, broker, FEED_DOCUMENT_URI, doc);
 					setPermissions(broker, root, info.getDocument());
 					// TODO : We should probably unlock the collection here
-					collection.store(transaction, broker, info, doc, false);
+					collection.store(transaction, broker, info, doc);
 					transact.commit(transaction);
 					response.setStatusCode(204);
 					response.setHeader("Location", request.getModuleBase() + request.getPath());
@@ -283,7 +283,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
                         final IndexInfo info = collection.validateXMLResource(transaction, broker, entryURI, doc);
                         setPermissions(broker, root, info.getDocument());
                         // TODO : We should probably unlock the collection here
-                        collection.store(transaction, broker, info, doc, false);
+                        collection.store(transaction, broker, info, doc);
 
                         // Update the updated element
                         DOMDB.replaceTextElement(transaction, feedRoot,
@@ -386,7 +386,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					info.getDocument().getMetadata().setMimeType(contentType);
 
 					try(final Reader reader = new InputStreamReader(new FileInputStream(tempFile), charset)) {
-                        collection.store(transaction, broker, info, new InputSource(reader), false);
+                        collection.store(transaction, broker, info, new InputSource(reader));
                     }
 				} else {
 					try(final FileInputStream is = new FileInputStream(tempFile)) {
@@ -419,7 +419,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 
 					final IndexInfo info = collection.validateXMLResource(transaction, broker, entryURI, mediaEntry);
 					// TODO : We should probably unlock the collection here
-					collection.store(transaction, broker, info, mediaEntry, false);
+					collection.store(transaction, broker, info, mediaEntry);
 					// Update the updated element
 					DOMDB.replaceTextElement(
 							transaction, feedRoot, Atom.NAMESPACE_STRING, "updated", 
@@ -713,7 +713,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 
                     try(final Reader reader = new InputStreamReader(new FileInputStream(tempFile), charset)) {
                         collection.store(transaction, broker, info,
-                                new InputSource(reader), false);
+                                new InputSource(reader));
                     }
 				} else {
 					final FileInputStream is = new FileInputStream(tempFile);

--- a/src/org/exist/atom/modules/AtomProtocol.java
+++ b/src/org/exist/atom/modules/AtomProtocol.java
@@ -59,7 +59,7 @@ import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.security.UUIDGenerator;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.util.LockException;
@@ -268,7 +268,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
                         final ElementImpl feedRoot = (ElementImpl) feedDoc.getDocumentElement();
 
                         // Lock the feed
-                        feedDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+                        feedDoc.getUpdateLock().acquire(LockMode.WRITE_LOCK);
 
                         // Append the entry
                         collection = broker.getOrCreateCollection(transaction, pathUri.append(ENTRY_COLLECTION_URI));
@@ -329,7 +329,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					 */
                     } finally {
                         if (feedDoc != null) {
-                            feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                            feedDoc.getUpdateLock().release(LockMode.WRITE_LOCK);
                         }
                     }
                 }
@@ -396,7 +396,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 
 				try {
 					LOG.debug("Acquiring lock on feed document...");
-					feedDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+					feedDoc.getUpdateLock().acquire(LockMode.WRITE_LOCK);
 					
 					String title = request.getHeader("Title");
 					if (title == null)
@@ -449,7 +449,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					throw new EXistException("Cannot acquire write lock.", ex);
 				} finally {
 					if (feedDoc != null) {
-                        feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                        feedDoc.getUpdateLock().release(LockMode.WRITE_LOCK);
                     }
 				}
 
@@ -562,7 +562,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 
 				final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
 				try(final Txn transaction = transact.beginTransaction()) {
-					feedDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+					feedDoc.getUpdateLock().acquire(LockMode.WRITE_LOCK);
 					final ElementImpl feedRoot = (ElementImpl) feedDoc.getDocumentElement();
 
 					// Modify the feed by merging the new feed-level elements
@@ -579,7 +579,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					throw ex;
 				} finally {
 					if (feedDoc != null) {
-                        feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                        feedDoc.getUpdateLock().release(LockMode.WRITE_LOCK);
                     }
 				}
 
@@ -606,7 +606,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 								"Permission denied to update feed "
 										+ collection.getURI());}
 					
-					feedDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+					feedDoc.getUpdateLock().acquire(LockMode.WRITE_LOCK);
 
 					// Find the entry
 					final String uuid = id.substring(9);
@@ -618,7 +618,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 								"Cannot find entry with id " + id);}
 
 					// Lock the entry
-					entryDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+					entryDoc.getUpdateLock().acquire(LockMode.WRITE_LOCK);
 
 					final Element entry = entryDoc.getDocumentElement();
 
@@ -659,11 +659,11 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 					 */
 				} finally {
 					if (feedDoc != null) {
-                        feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                        feedDoc.getUpdateLock().release(LockMode.WRITE_LOCK);
                     }
 
 					if (entryDoc != null) {
-                        entryDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+                        entryDoc.getUpdateLock().release(LockMode.WRITE_LOCK);
                     }
 				}
 
@@ -783,7 +783,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 				{throw new PermissionDeniedException(
 						"Permission denied to update feed "
 								+ collection.getURI());}
-			feedDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+			feedDoc.getUpdateLock().acquire(LockMode.WRITE_LOCK);
 
 			// Find the entry
 			final String uuid = id.substring(9);
@@ -836,7 +836,7 @@ public class AtomProtocol extends AtomFeeds implements Atom {
 			throw new EXistException("Cannot acquire write lock.", ex);
 		} finally {
 			if (feedDoc != null) {
-				feedDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+				feedDoc.getUpdateLock().release(LockMode.WRITE_LOCK);
 			}
 		}
 

--- a/src/org/exist/backup/ConsistencyCheck.java
+++ b/src/org/exist/backup/ConsistencyCheck.java
@@ -45,7 +45,7 @@ import org.exist.storage.dom.DOMFile;
 import org.exist.storage.dom.DOMTransaction;
 import org.exist.storage.index.CollectionStore;
 import org.exist.storage.io.VariableByteInput;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.TerminatedException;
 
@@ -283,7 +283,7 @@ public class ConsistencyCheck
      */
     public ErrorReport checkDocument(final DocumentImpl doc) {
         final DOMFile domDb = ( (NativeBroker)broker ).getDOMFile();
-        return (ErrorReport)new DOMTransaction( this, domDb, Lock.WRITE_LOCK, doc ) {
+        return (ErrorReport)new DOMTransaction( this, domDb, LockMode.WRITE_LOCK, doc ) {
             public Object start() {
                 EmbeddedXMLStreamReader reader = null;
                 try {
@@ -319,7 +319,7 @@ public class ConsistencyCheck
     public ErrorReport checkXMLTree( final DocumentImpl doc )
     {
         final DOMFile domDb = ( (NativeBroker)broker ).getDOMFile();
-        return( (ErrorReport)new DOMTransaction( this, domDb, Lock.WRITE_LOCK, doc ) {
+        return( (ErrorReport)new DOMTransaction( this, domDb, LockMode.WRITE_LOCK, doc ) {
                     public Object start() {
                         EmbeddedXMLStreamReader reader = null;
                         try {

--- a/src/org/exist/backup/SystemExport.java
+++ b/src/org/exist/backup/SystemExport.java
@@ -19,6 +19,7 @@
  */
 package org.exist.backup;
 
+import org.exist.collections.MutableCollection;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.DocumentMetadata;
 import org.exist.dom.persistent.DocumentSet;
@@ -764,9 +765,10 @@ public class SystemExport {
                     if (callback != null) {
                         callback.startCollection(uri);
                     }
-                    final Collection collection = new Collection(broker, XmldbURI.createInternal(uri));
+
                     final VariableByteInput istream = store.getAsStream(pointer);
-                    collection.read(broker, istream);
+                    final Collection collection = MutableCollection.load(broker, XmldbURI.createInternal(uri), istream);
+
                     BackupDescriptor bd = null;
 
                     if (prevBackup != null) {

--- a/src/org/exist/backup/restore/SystemImportHandler.java
+++ b/src/org/exist/backup/restore/SystemImportHandler.java
@@ -47,7 +47,6 @@ import org.exist.xquery.value.DateTimeValue;
 import java.net.URISyntaxException;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Observable;
 import java.util.Stack;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -62,7 +61,7 @@ import org.exist.security.ACLPermission.ACE_ACCESS_TYPE;
 import org.exist.security.ACLPermission.ACE_TARGET;
 import org.exist.security.internal.aider.ACEAider;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.xml.sax.XMLReader;
@@ -422,7 +421,7 @@ public class SystemImportHandler extends DefaultHandler {
 				throw new IOException(e);
 			} finally {
 //				if (resource != null)
-//					resource.getUpdateLock().release(Lock.READ_LOCK);
+//					resource.getUpdateLock().release(LockMode.READ_LOCK);
 			}
 
         } catch(final Exception e) {
@@ -542,7 +541,7 @@ public class SystemImportHandler extends DefaultHandler {
         @Override
         public void apply() {
             try {
-            	getTarget().getLock().acquire(Lock.WRITE_LOCK);
+            	getTarget().getLock().acquire(LockMode.WRITE_LOCK);
 
                 final TransactionManager txnManager = broker.getDatabase().getTransactionManager();
                 try(final Txn txn = txnManager.beginTransaction()) {
@@ -561,7 +560,7 @@ public class SystemImportHandler extends DefaultHandler {
 	                
 	                txnManager.commit(txn);
             	} finally {
-                	getTarget().release(Lock.WRITE_LOCK);
+                	getTarget().release(LockMode.WRITE_LOCK);
                 }
                 
             } catch (final Exception xe) {
@@ -581,7 +580,7 @@ public class SystemImportHandler extends DefaultHandler {
         @Override
         public void apply() {
             try {
-            	getTarget().getUpdateLock().acquire(Lock.WRITE_LOCK);
+            	getTarget().getUpdateLock().acquire(LockMode.WRITE_LOCK);
 
             	final TransactionManager txnManager = broker.getDatabase().getTransactionManager();
 
@@ -602,7 +601,7 @@ public class SystemImportHandler extends DefaultHandler {
 	                txnManager.commit(txn);
 	            	
 	            } finally {
-	                getTarget().getUpdateLock().release(Lock.WRITE_LOCK);
+	                getTarget().getUpdateLock().release(LockMode.WRITE_LOCK);
 	            }
             
             } catch (final Exception xe) {

--- a/src/org/exist/backup/restore/SystemImportHandler.java
+++ b/src/org/exist/backup/restore/SystemImportHandler.java
@@ -367,7 +367,7 @@ public class SystemImportHandler extends DefaultHandler {
             
             listener.setCurrentResource(name);
             if(currentCollection != null) {
-                listener.observe(currentCollection);
+                listener.observe(currentCollection.getObservable());
             }
 
 			final TransactionManager txnManager = broker.getDatabase().getTransactionManager();
@@ -392,11 +392,11 @@ public class SystemImportHandler extends DefaultHandler {
 
 					rh.startDocumentRestore(resource, atts);
 
-					currentCollection.store(txn, broker, info, is, false);
+					currentCollection.store(txn, broker, info, is);
 	
 				} else {
 					// store as binary resource
-					resource = currentCollection.validateBinaryResource(txn, broker, docUri, is.getByteStream(), mimetype, is.getByteStreamLength() , date_created, date_modified);
+					resource = currentCollection.validateBinaryResource(txn, broker, docUri);
 					
 					rh.startDocumentRestore(resource, atts);
 

--- a/src/org/exist/collections/Collection.java
+++ b/src/org/exist/collections/Collection.java
@@ -15,6 +15,7 @@ import org.exist.storage.cache.Cacheable;
 import org.exist.storage.io.VariableByteInput;
 import org.exist.storage.io.VariableByteOutputStream;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.LockedDocumentMap;
 import org.exist.storage.txn.Txn;
 import org.exist.util.LockException;
@@ -37,8 +38,8 @@ import java.util.Observable;
  * child Collections and documents, and provides the methods to store/remove resources.
  *
  * Collections are shared between {@link org.exist.storage.DBBroker} instances. The caller
- * is responsible to lock/unlock the collection. Call {@link DBBroker#openCollection(XmldbURI, int)}
- * to get a collection with a read or write lock and {@link #release(int)} to release the lock.
+ * is responsible to lock/unlock the collection. Call {@link DBBroker#openCollection(XmldbURI, LockMode)}
+ * to get a collection with a read or write lock and {@link #release(LockMode)} to release the lock.
  */
 public interface Collection extends Resource, Comparable<Collection>, Cacheable {
 
@@ -56,7 +57,7 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
      * Get's the lock for this Collection
      * <p>
      * Note - this does not actually acquire the lock
-     * for that you must subsequently call {@link Lock#acquire(int)}
+     * for that you must subsequently call {@link Lock#acquire(LockMode)}
      *
      * @return The lock for the Collection
      */
@@ -66,11 +67,11 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
      * Closes the Collection, i.e. releases the lock held by
      * the current thread.
      * <p>
-     * This is a shortcut for {@code getLock().release(int)}
+     * This is a shortcut for {@code getLock().release(LockMode)}
      *
      * @param mode The mode of the Lock to release
      */
-    void release(int mode);
+    void release(LockMode mode);
 
     /**
      * Get the internal id.
@@ -496,7 +497,7 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
      * @return The mutable document set provided in {@param docs}
      */
     DocumentSet allDocs(DBBroker broker, MutableDocumentSet docs, boolean recursive, LockedDocumentMap lockMap,
-                        int lockType) throws LockException, PermissionDeniedException;
+                        LockMode lockType) throws LockException, PermissionDeniedException;
 
     /**
      * Gets all of the documents from the Collection
@@ -530,7 +531,7 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
      * @param lockType The type of lock to acquire on the documents
      * @return The mutable document set provided in {@param docs}
      */
-    DocumentSet getDocuments(DBBroker broker, MutableDocumentSet docs, LockedDocumentMap lockMap, int lockType)
+    DocumentSet getDocuments(DBBroker broker, MutableDocumentSet docs, LockedDocumentMap lockMap, LockMode lockType)
             throws LockException, PermissionDeniedException;
 
     /**
@@ -566,7 +567,7 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
      * @param lockMode The mode of the lock to acquire
      * @return The locked document or null if it doesn't exist
      */
-    DocumentImpl getDocumentWithLock(DBBroker broker, XmldbURI name, int lockMode)
+    DocumentImpl getDocumentWithLock(DBBroker broker, XmldbURI name, LockMode lockMode)
             throws LockException, PermissionDeniedException;
 
     /**
@@ -586,7 +587,7 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
      * Release any locks held on the document
      *
      * @param doc The document to release locks on
-     * @deprecated Use {@link #releaseDocument(DocumentImpl, int)} instead
+     * @deprecated Use {@link #releaseDocument(DocumentImpl, LockMode)} instead
      */
     @Deprecated
     void releaseDocument(DocumentImpl doc);
@@ -597,7 +598,7 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
      * @param doc  The document to release locks on
      * @param mode The lock mode to release
      */
-    void releaseDocument(DocumentImpl doc, int mode);
+    void releaseDocument(DocumentImpl doc, LockMode mode);
 
     /**
      * Remove the specified child Collection

--- a/src/org/exist/collections/Collection.java
+++ b/src/org/exist/collections/Collection.java
@@ -1,202 +1,888 @@
-/*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2015 The eXist Project
- *  http://exist-db.org
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- */
 package org.exist.collections;
 
-import net.jcip.annotations.GuardedBy;
-import org.exist.Resource;
-import org.exist.dom.QName;
-import org.exist.dom.persistent.DocumentMetadata;
-import org.exist.dom.persistent.DocumentSet;
-import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.MutableDocumentSet;
-import org.exist.dom.persistent.BinaryDocument;
-import org.exist.dom.persistent.DefaultDocumentSet;
-import java.io.*;
-import java.util.*;
-
-import org.apache.commons.io.input.CloseShieldInputStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.exist.Database;
 import org.exist.EXistException;
-import org.exist.Indexer;
-import org.exist.collections.triggers.*;
-import org.exist.indexing.IndexController;
-import org.exist.indexing.StreamListener;
-import org.exist.security.Account;
-import org.exist.security.Permission;
-import org.exist.security.PermissionDeniedException;
-import org.exist.security.PermissionFactory;
+import org.exist.Resource;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.QName;
+import org.exist.dom.persistent.BinaryDocument;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.DocumentSet;
+import org.exist.dom.persistent.MutableDocumentSet;
+import org.exist.security.*;
 import org.exist.security.SecurityManager;
-import org.exist.security.Subject;
 import org.exist.storage.*;
 import org.exist.storage.cache.Cacheable;
-import org.exist.storage.index.BFile;
 import org.exist.storage.io.VariableByteInput;
 import org.exist.storage.io.VariableByteOutputStream;
-import org.exist.storage.lock.*;
-import org.exist.storage.sync.Sync;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.LockedDocumentMap;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
 import org.exist.util.LockException;
-import org.exist.util.MimeType;
 import org.exist.util.SyntaxException;
-import org.exist.util.XMLReaderObjectFactory;
-import org.exist.util.XMLReaderObjectFactory.VALIDATION_SETTING;
-import org.exist.util.hashtable.ObjectHashSet;
-import org.exist.util.serializer.DOMStreamer;
 import org.exist.xmldb.XmldbURI;
-import org.exist.xquery.Constants;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Observable;
+
 /**
- * This class represents a collection in the database. A collection maintains a list of
- * sub-collections and documents, and provides the methods to store/remove resources.
+ * Represents a Collection in the database. A collection maintains a list of
+ * child Collections and documents, and provides the methods to store/remove resources.
  *
  * Collections are shared between {@link org.exist.storage.DBBroker} instances. The caller
  * is responsible to lock/unlock the collection. Call {@link DBBroker#openCollection(XmldbURI, int)}
  * to get a collection with a read or write lock and {@link #release(int)} to release the lock.
- *
- * @author wolf
  */
-public class Collection extends Observable implements Resource, Comparable<Collection>, Cacheable {
-
-    public static final int LENGTH_COLLECTION_ID = 4; //sizeof int
-
-    public static final int POOL_PARSER_THRESHOLD = 500;
-
-    private final static int SHALLOW_SIZE = 550;
-
-    private final static int DOCUMENT_SIZE = 450;
-    
-    private final static Logger LOG = LogManager.getLogger(Collection.class);
-    
-    public final static int UNKNOWN_COLLECTION_ID = -1;
-    
-    // Internal id
-    private int collectionId = UNKNOWN_COLLECTION_ID;
-    
-    // the path of this collection
-    private XmldbURI path;
-
-    private final Lock lock;
-
-    // the documents contained in this collection
-    @GuardedBy("lock")
-    private final Map<String, DocumentImpl> documents = new TreeMap<>();
-
-    // stores child-collections with their storage address
-    @GuardedBy("lock")
-    private ObjectHashSet<XmldbURI> subCollections = new ObjectHashSet<>(19);
-    
-    // Storage address of the collection in the BFile
-    private long address = BFile.UNKNOWN_ADDRESS;
-    
-    // creation time
-    private long created = 0;
-    
-    private Observer[] observers = null;
-    
-    private volatile boolean collectionConfigEnabled = true;
-    private boolean triggersEnabled = true;
-    
-    // fields required by the collections cache
-    private int refCount;
-    private int timestamp;
-
-    /** user-defined Reader */
-    private XMLReader userReader;
-    
-    /** is this a temporary collection? */
-    private boolean isTempCollection;
-
-    private Permission permissions;
-
-    private final CollectionMetadata collectionMetadata;
-
-    public Collection(final DBBroker broker, final XmldbURI path) {
-        //The permissions assigned to this collection
-        permissions = PermissionFactory.getDefaultCollectionPermission(broker.getBrokerPool().getSecurityManager());
-
-        setPath(path);
-        lock = new ReentrantReadWriteLock(path);
-        this.collectionMetadata = new CollectionMetadata(this);
-    }
-
-    public boolean isTriggersEnabled() {
-        return triggersEnabled;
-    }
-
-    public final void setPath(XmldbURI path) {
-        path = path.toCollectionPathURI();
-        //TODO : see if the URI resolves against DBBroker.TEMP_COLLECTION
-        isTempCollection = path.getRawCollectionPath().equals(XmldbURI.TEMP_COLLECTION);
-        this.path=path;
-    }
-
-    public Lock getLock() {
-        return lock;
-    }
+public interface Collection extends Resource, Comparable<Collection>, Cacheable {
 
     /**
-     *  Add a new sub-collection to the collection.
-     *
+     * The length in bytes of the Collection ID
      */
-    public void addCollection(final DBBroker broker, final Collection child, final boolean isNew) throws PermissionDeniedException, LockException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-            throw new PermissionDeniedException("Permission to write to Collection denied for " + this.getURI());
-        }
-        
-        final XmldbURI childName = child.getURI().lastSegment();
+    int LENGTH_COLLECTION_ID = 4; //sizeof int
 
-        getLock().acquire(Lock.WRITE_LOCK);
-        try {
-            if (!subCollections.contains(childName)) {
-                subCollections.add(childName);
-            }
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
+    /**
+     * The ID of an unknown Collection
+     */
+    int UNKNOWN_COLLECTION_ID = -1;
 
-        if(isNew) {
-            child.setCreationTime(System.currentTimeMillis());
-        }
+    /**
+     * Get's the lock for this Collection
+     * <p>
+     * Note - this does not actually acquire the lock
+     * for that you must subsequently call {@link Lock#acquire(int)}
+     *
+     * @return The lock for the Collection
+     */
+    Lock getLock();
+
+    /**
+     * Closes the Collection, i.e. releases the lock held by
+     * the current thread.
+     * <p>
+     * This is a shortcut for {@code getLock().release(int)}
+     *
+     * @param mode The mode of the Lock to release
+     */
+    void release(int mode);
+
+    /**
+     * Get the internal id.
+     *
+     * @return The id of the Collection
+     */
+    int getId();
+
+    /**
+     * Set the internal id
+     *
+     * @param id The id of the Collection
+     */
+    void setId(int id);
+
+    /**
+     * Set the internal storage address of the Collection data
+     *
+     * @param address The internal storage address
+     */
+    void setAddress(long address);
+
+    /**
+     * Gets the internal storage address of the Collection data
+     *
+     * @return The internal storage address
+     */
+    long getAddress();
+
+    /**
+     * Get the URI path of the Collection
+     *
+     * @return The URI path of the Collection
+     */
+    XmldbURI getURI();
+
+    /**
+     * Set the URI path of the Collection
+     *
+     * @param path The URI path of the Collection
+     */
+    void setPath(XmldbURI path);
+
+    /**
+     * Get the metadata of the Collection
+     *
+     * @return The Collection metadata
+     */
+    CollectionMetadata getMetadata();
+
+    /**
+     * Get the Collection permissions
+     *
+     * @return The permissions of this Collection
+     */
+    Permission getPermissions();
+
+    /**
+     * Get the Collection permissions (without locking)
+     *
+     * @return The permissions of this Collection
+     */
+    Permission getPermissionsNoLock();
+
+    /**
+     * Get the mode of the Collection permissions
+     *
+     * @param mode The unix like mode of the Collection permissions
+     */
+    void setPermissions(int mode) throws LockException, PermissionDeniedException;
+
+    /**
+     * Set the mode of the Collection permissions
+     *
+     * @param mode The unix like mode of the Collection permissions
+     */
+    @Deprecated
+    void setPermissions(String mode) throws SyntaxException, LockException, PermissionDeniedException;
+
+    /**
+     * Set permissions for the collection.
+     *
+     * @param permissions the permissions to set on the Collection
+     *
+     * @deprecated This function is considered a security problem
+     * and should be removed, move code to copyOf or Constructor
+     */
+    @Deprecated
+    void setPermissions(Permission permissions) throws LockException;
+
+    /**
+     * Gets the creation timestamp of this Collection
+     *
+     * @return timestamp the creation timestamp in milliseconds
+     *
+     * @deprecated Use {@link #getMetadata()} {@link CollectionMetadata#getCreated()}
+     */
+    @Deprecated
+    long getCreationTime();
+
+    /**
+     * Sets the creation timestamp of this Collection
+     *
+     * @param timestamp the creation timestamp in milliseconds
+     */
+    void setCreationTime(long timestamp);
+
+    /**
+     * Is the Collection Configuration enabled for this Collection
+     *
+     * @return true if the Collection Configuration is enabled
+     */
+    boolean isCollectionConfigEnabled();
+
+    /**
+     * Enables/disables the Should the collection configuration for this Collection.
+     *
+     * Called by {@link org.exist.storage.NativeBroker} before doing a re-index.
+     *
+     * @param collectionConfigEnabled true if the Collection Configuration should be enabled, false otherwise
+     */
+    void setCollectionConfigEnabled(boolean collectionConfigEnabled);
+
+    /**
+     * Get the Collection Configuration of this Collection
+     *
+     * @param broker The database broker
+     */
+    CollectionConfiguration getConfiguration(DBBroker broker);
+
+    /**
+     * Get the index configuration for this collection
+     *
+     * @param broker The database broker
+     */
+    IndexSpec getIndexConfiguration(DBBroker broker);
+
+    /**
+     * Get the index configuration for a node path of this collection
+     *
+     * @param broker The database broker
+     * @param nodePath The node path to get the index configuration for
+     *
+     * @return The index configuration
+     */
+    GeneralRangeIndexSpec getIndexByPathConfiguration(DBBroker broker, NodePath nodePath);
+
+    /**
+     * Get the index configuration for a node name of this collection
+     *
+     * @param broker The database broker
+     * @param nodeName The node name to get the index configuration for
+     *
+     * @return The index configuration
+     */
+    QNameRangeIndexSpec getIndexByQNameConfiguration(final DBBroker broker, final QName nodeName);
+
+    /**
+     * Returns true if this is a temporary collection. By default,
+     * the temporary collection is in /db/system/temp.
+     *
+     * @return true if the collection is temporary, false otherwise
+     */
+    boolean isTempCollection();
+
+    /**
+     * Are Triggers enabled for this Collection
+     *
+     * @return true of Triggers are enabled
+     */
+    boolean isTriggersEnabled();
+
+    /**
+     * Enables/Disables Triggers for this collection
+     *
+     * @param enabled true if Triggers should be enabled for this Collection
+     */
+    void setTriggersEnabled(final boolean enabled);
+
+    /**
+     * Returns the estimated amount of memory used by this collection
+     * and its documents. This information is required by the
+     * {@link org.exist.storage.CollectionCacheManager} to be able
+     * to resize the caches.
+     *
+     * @return estimated amount of memory in bytes
+     */
+    int getMemorySize();
+
+    /**
+     * Get the parent Collection.
+     *
+     * @return The parent Collection of this Collection
+     * or null if this is the root Collection (i.e. /db).
+     */
+    XmldbURI getParentURI();
+
+    /**
+     * Set user-defined Reader
+     *
+     * @param reader The XML reader
+     */
+    void setReader(XMLReader reader);
+
+    /**
+     * Determines if this Collection has any documents, or child Collections
+     *
+     * @param broker The database broker
+     * @return true if the collection is empty, false otherwise
+     */
+    boolean isEmpty(DBBroker broker) throws PermissionDeniedException;
+
+    /**
+     * Returns the number of documents in this Collection
+     *
+     * @param broker The database broker
+     * @return The number of documents in the Collection, or -1 if the collection could not be locked
+     */
+    int getDocumentCount(DBBroker broker) throws PermissionDeniedException;
+
+    /**
+     * Returns the number of documents in this Collection
+     *
+     * @param broker The database broker
+     * @return The number of documents in the Collection
+     * @deprecated Use {@link #getDocumentCount(DBBroker)}
+     */
+    @Deprecated
+    int getDocumentCountNoLock(DBBroker broker) throws PermissionDeniedException;
+
+    /**
+     * Return the number of child Collections within this Collection.
+     *
+     * @param broker The database broker
+     * @return The childCollectionCount value
+     */
+    int getChildCollectionCount(DBBroker broker) throws PermissionDeniedException;
+
+    /**
+     * Check if the Collection has a child document
+     *
+     * @param broker The database broker
+     * @param name   the name (without path) of the document
+     * @return true when the collection has the document, false otherwise
+     */
+    boolean hasDocument(DBBroker broker, XmldbURI name) throws PermissionDeniedException;
+
+    /**
+     * Check if the collection has a child Collection
+     *
+     * @param broker The database broker
+     * @param name   the name of the child Collection (without path)
+     * @return true if the child Collection exists, false otherwise
+     */
+    boolean hasChildCollection(DBBroker broker, XmldbURI name) throws PermissionDeniedException, LockException;
+
+    /**
+     * Check if the collection has a child Collection
+     *
+     * @param broker The database broker
+     * @param name   the name of the child Collection (without path)
+     * @return true if the child Collection exists, false otherwise
+     * @deprecated Use {@link #hasChildCollection(DBBroker, XmldbURI)} instead
+     */
+    @Deprecated
+    boolean hasChildCollectionNoLock(DBBroker broker, XmldbURI name) throws PermissionDeniedException;
+
+    /**
+     * Add a new child Collection to this Collection
+     *
+     * @param broker The database broker
+     * @param child  The child Collection to add to this Collection
+     * @param isNew  Whether the Child Collection is a newly created Collection
+     */
+    void addCollection(DBBroker broker, Collection child, boolean isNew)
+            throws PermissionDeniedException, LockException;
+
+    /**
+     * Get the Document and child Collection
+     * entries of this Collection
+     *
+     * @param broker The database broker
+     * @return A list of entries in this Collection
+     */
+    List<CollectionEntry> getEntries(DBBroker broker)
+            throws PermissionDeniedException, LockException;
+
+    /**
+     * Get the entry for a child Collection
+     *
+     * @param broker The database broker
+     * @param name   The name of the child Collection
+     * @return The child Collection entry
+     */
+    CollectionEntry getChildCollectionEntry(DBBroker broker, String name) throws PermissionDeniedException;
+
+    /**
+     * Get the entry for a resource
+     *
+     * @param broker The database broker
+     * @param name   The name of the resource
+     * @return The resource entry
+     */
+    CollectionEntry getResourceEntry(DBBroker broker, String name)
+            throws PermissionDeniedException, LockException;
+
+    /**
+     * Update the specified child Collection
+     *
+     * @param broker The database broker
+     * @param child  The child Collection to update
+     */
+    void update(DBBroker broker, Collection child) throws PermissionDeniedException, LockException;
+
+    /**
+     * Add a document to the collection
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param doc         The document to add to the Collection
+     */
+    void addDocument(Txn transaction, DBBroker broker, DocumentImpl doc)
+            throws PermissionDeniedException, LockException;
+
+    /**
+     * Removes the document from the internal list of resources, but
+     * doesn't delete the document object itself.
+     *
+     * @param broker The database broker
+     * @param doc    The document to unlink from the Collection
+     */
+    void unlinkDocument(DBBroker broker, DocumentImpl doc) throws PermissionDeniedException, LockException;
+
+    /**
+     * Return an iterator over all child Collections
+     * <p>
+     * The list of child Collections is copied first, so modifications
+     * via the iterator have no effect.
+     *
+     * @param broker The database broker
+     * @return An iterator over the child Collections
+     */
+    Iterator<XmldbURI> collectionIterator(DBBroker broker) throws PermissionDeniedException, LockException;
+
+    /**
+     * Return an iterator over all child Collections.
+     * <p>
+     * The list of child Collections is copied first, so modifications
+     * via the iterator have no effect.
+     *
+     * @param broker The database broker
+     * @return An iterator over the child Collections
+     * @deprecated The creation of the stable iterator may
+     * throw an {@link java.lang.IndexOutOfBoundsException},
+     * use {@link #collectionIterator(DBBroker)} instead
+     */
+    @Deprecated
+    Iterator<XmldbURI> collectionIteratorNoLock(DBBroker broker) throws PermissionDeniedException;
+
+    /**
+     * Returns an iterator on the documents in this Collection
+     *
+     * @param broker The database broker
+     * @return A iterator of all the documents in the Collection.
+     */
+    Iterator<DocumentImpl> iterator(DBBroker broker) throws PermissionDeniedException, LockException;
+
+    /**
+     * Returns an iterator on the documents in this Collection
+     *
+     * @param broker The database broker
+     * @return A iterator of all the documents in the Collection.
+     * @deprecated This is not an atomic operation and
+     * so there are no guarantees about which docs will be available to
+     * the iterator. Use {@link #iterator(DBBroker)} instead
+     */
+    @Deprecated
+    Iterator<DocumentImpl> iteratorNoLock(DBBroker broker) throws PermissionDeniedException;
+
+
+    //TODO(AR) it is unlikely we need to pass the user as a parameter, fix this...
+
+    /**
+     * Return the Collections below this Collection
+     *
+     * @param broker The database broker
+     * @param user   The user that is performing the operation
+     * @return The List of descendant Collections
+     */
+    List<Collection> getDescendants(DBBroker broker, Subject user) throws PermissionDeniedException;
+
+    /**
+     * Gets all of the documents from the Collection
+     *
+     * @param broker    The database broker
+     * @param docs      A mutable document set which receives the documents
+     * @param recursive true if we should get all descendants, false just retrieves the children
+     * @return The mutable document set provided in {@param docs}
+     */
+    MutableDocumentSet allDocs(DBBroker broker, MutableDocumentSet docs, boolean recursive)
+            throws PermissionDeniedException;
+
+    /**
+     * Gets all of the documents from the Collection
+     *
+     * @param broker    The database broker
+     * @param docs      A mutable document set which receives the documents
+     * @param recursive true if we should get all descendants, false just retrieves the children
+     * @param lockMap   A map that receives the locks we have taken on documents
+     * @return The mutable document set provided in {@param docs}
+     */
+    MutableDocumentSet allDocs(DBBroker broker, MutableDocumentSet docs, boolean recursive,
+                               LockedDocumentMap lockMap) throws PermissionDeniedException;
+
+    /**
+     * Gets all of the documents from the Collection
+     *
+     * @param broker    The database broker
+     * @param docs      A mutable document set which receives the documents
+     * @param recursive true if we should get all descendants, false just retrieves the children
+     * @param lockMap   A map that receives the locks we have taken on documents
+     * @param lockType  The type of lock to acquire on the documents
+     * @return The mutable document set provided in {@param docs}
+     */
+    DocumentSet allDocs(DBBroker broker, MutableDocumentSet docs, boolean recursive, LockedDocumentMap lockMap,
+                        int lockType) throws LockException, PermissionDeniedException;
+
+    /**
+     * Gets all of the documents from the Collection
+     *
+     * @param broker The database broker
+     * @param docs   A mutable document set which receives the documents
+     * @return The mutable document set provided in {@param docs}
+     */
+    DocumentSet getDocuments(DBBroker broker, MutableDocumentSet docs) throws PermissionDeniedException, LockException;
+
+    /**
+     * Gets all of the documents from the Collection (without locking)
+     *
+     * @param broker The database broker
+     * @param docs   A mutable document set which receives the documents
+     * @return The mutable document set provided in {@param docs}
+     * @deprecated This is not an atomic operation and
+     * so there are no guarantees about which docs will be added to
+     * the document set. Use {@link #getDocuments(DBBroker, MutableDocumentSet)}
+     * instead
+     */
+    @Deprecated
+    DocumentSet getDocumentsNoLock(DBBroker broker, MutableDocumentSet docs);
+
+    /**
+     * Gets all of the documents from the Collection
+     *
+     * @param broker   The database broker
+     * @param docs     A mutable document set which receives the documents
+     * @param lockMap  A map that receives the locks we have taken on documents
+     * @param lockType The type of lock to acquire on the documents
+     * @return The mutable document set provided in {@param docs}
+     */
+    DocumentSet getDocuments(DBBroker broker, MutableDocumentSet docs, LockedDocumentMap lockMap, int lockType)
+            throws LockException, PermissionDeniedException;
+
+    /**
+     * Get a child resource as identified by name. This method doesn't put
+     * a lock on the document nor does it recognize locks held by other threads.
+     * There's no guarantee that the document still exists when accessing it.
+     *
+     * @param broker The database broker
+     * @param name   The name of the document (without collection path)
+     * @return the document or null if it doesn't exist
+     */
+    DocumentImpl getDocument(DBBroker broker, XmldbURI name) throws PermissionDeniedException;
+
+    /**
+     * Retrieve a child resource after putting a read lock on it.
+     * With this method, access to the received document object is safe.
+     *
+     * @param broker The database broker
+     * @param name   The name of the document (without collection path)
+     * @return The locked document or null if it doesn't exist
+     * @deprecated Use getDocumentWithLock(DBBroker broker, XmldbURI uri, int lockMode)
+     */
+    @Deprecated
+    DocumentImpl getDocumentWithLock(DBBroker broker, XmldbURI name)
+            throws LockException, PermissionDeniedException;
+
+    /**
+     * Retrieve a child resource after putting a lock on it.
+     * With this method, access to the received document object is safe.
+     *
+     * @param broker   The database broker
+     * @param name     The name of the document (without collection path)
+     * @param lockMode The mode of the lock to acquire
+     * @return The locked document or null if it doesn't exist
+     */
+    DocumentImpl getDocumentWithLock(DBBroker broker, XmldbURI name, int lockMode)
+            throws LockException, PermissionDeniedException;
+
+    /**
+     * Get a child resource as identified by path. This method doesn't put
+     * a lock on the document nor does it recognize locks held by other threads.
+     * There's no guarantee that the document still exists when accessing it.
+     *
+     * @param broker  The database broker
+     * @param rawPath The path of the document
+     * @return the document or null if it doesn't exist
+     * @deprecated Use {@link #getDocument(DBBroker, XmldbURI)} instead
+     */
+    @Deprecated
+    DocumentImpl getDocumentNoLock(DBBroker broker, String rawPath) throws PermissionDeniedException;
+
+    /**
+     * Release any locks held on the document
+     *
+     * @param doc The document to release locks on
+     * @deprecated Use {@link #releaseDocument(DocumentImpl, int)} instead
+     */
+    @Deprecated
+    void releaseDocument(DocumentImpl doc);
+
+    /**
+     * Release any locks held on the document
+     *
+     * @param doc  The document to release locks on
+     * @param mode The lock mode to release
+     */
+    void releaseDocument(DocumentImpl doc, int mode);
+
+    /**
+     * Remove the specified child Collection
+     *
+     * @param broker The database broker
+     * @param name   the name of the child Collection (without path)
+     */
+    void removeCollection(DBBroker broker, XmldbURI name) throws LockException, PermissionDeniedException;
+
+    /**
+     * Removes a document from this Collection
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param doc         The document to remove
+     */
+    void removeResource(Txn transaction, DBBroker broker, DocumentImpl doc)
+            throws PermissionDeniedException, LockException, IOException, TriggerException;
+
+    /**
+     * Remove an XML document from this Collection
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     */
+    void removeXMLResource(Txn transaction, DBBroker broker, XmldbURI name)
+            throws PermissionDeniedException, TriggerException, LockException, IOException;
+
+    /**
+     * Remove a Binary document from this Collection
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     */
+    void removeBinaryResource(Txn transaction, DBBroker broker, XmldbURI name)
+            throws PermissionDeniedException, LockException, TriggerException;
+
+    /**
+     * Remove a Binary document from this Collection
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param doc         the document to remove
+     */
+    void removeBinaryResource(Txn transaction, DBBroker broker, DocumentImpl doc)
+            throws PermissionDeniedException, LockException, TriggerException;
+
+    /**
+     * Validates an XML document and prepares it for further storage.
+     * Launches prepare and postValidate triggers.
+     * Since the process is dependent from the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     * @param source      The source of the document to store
+     * @return An {@link IndexInfo} with a write lock on the document
+     */
+    IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, InputSource source)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
+     * Validates an XML document and prepares it for further storage.
+     * Launches prepare and postValidate triggers.
+     * Since the process is dependent from the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     * @param data        The data of the document to store
+     * @return An {@link IndexInfo} with a write lock on the document
+     */
+    IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, String data)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
+     * Validates an XML document and prepares it for further storage.
+     * Launches prepare and postValidate triggers.
+     * Since the process is dependent from the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     * @param node        The document node of the document to store
+     * @return An {@link IndexInfo} with a write lock on the document
+     */
+    IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, Node node)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
+     * Stores an XML document into the Collection
+     * <p>
+     * {@link #validateXMLResource(Txn, DBBroker, XmldbURI, InputSource)} should have been called previously in order
+     * to acquire a write lock for the document. Launches the finish trigger.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param info        Tracks information between validate and store phases
+     * @param source      The source of the document to store
+     */
+    void store(Txn transaction, DBBroker broker, IndexInfo info, InputSource source)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException;
+
+    /**
+     * Stores an XML document into the Collection
+     * <p>
+     * {@link #validateXMLResource(Txn, DBBroker, XmldbURI, String)} should have been called previously in order to
+     * acquire a write lock for the document. Launches the finish trigger.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param info        Tracks information between validate and store phases
+     * @param data        The data of the document to store
+     */
+    void store(Txn transaction, DBBroker broker, IndexInfo info, String data)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException;
+
+    /**
+     * Stores an XML document into the Collection
+     * <p>
+     * {@link #validateXMLResource(Txn, DBBroker, XmldbURI, Node)} should have been called previously in order to
+     * acquire a write lock for the document. Launches the finish trigger.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param info        Tracks information between validate and store phases
+     * @param node        The document node of the document to store
+     */
+    void store(Txn transaction, DBBroker broker, IndexInfo info, Node node)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException;
+
+    /**
+     * Creates a Binary Document object
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     *
+     * @return The Binary Document object
+     */
+    BinaryDocument validateBinaryResource(Txn transaction, DBBroker broker, XmldbURI name)
+            throws PermissionDeniedException, LockException, TriggerException, IOException;
+
+    /**
+     * Store a binary document into the Collection (streaming)
+     *
+     * Locks the collection while the resource is being saved. Triggers will be called after the collection
+     * has been unlocked while keeping a lock on the resource to prevent modification.
+     *
+     * Callers should not lock the collection before calling this method as this may lead to deadlocks.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     * @param is          The content for the document
+     * @param mimeType    The Internet Media Type of the document
+     * @param size        The size in bytes of the document
+     * @param created     The created timestamp of the document
+     * @param modified    The modified timestamp of the document
+     *
+     * @return The stored Binary Document object
+     */
+    BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, InputStream is, String mimeType,
+            long size, Date created, Date modified) throws EXistException, PermissionDeniedException, LockException,
+            TriggerException, IOException;
+
+    /**
+     * Store a binary document into the Collection
+     *
+     * Locks the collection while the resource is being saved. Triggers will be called after the collection
+     * has been unlocked while keeping a lock on the resource to prevent modification.
+     *
+     * Callers should not lock the collection before calling this method as this may lead to deadlocks.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     * @param data        The content for the document
+     * @param mimeType    The Internet Media Type of the document
+     *
+     * @return The stored Binary Document object
+     *
+     * @deprecated Use {@link #addBinaryResource(Txn, DBBroker, XmldbURI, InputStream, String, long)}
+     */
+    @Deprecated
+    BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, byte[] data, String mimeType)
+            throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException;
+
+    /**
+     * Store a binary document into the Collection
+     *
+     * Locks the collection while the resource is being saved. Triggers will be called after the collection
+     * has been unlocked while keeping a lock on the resource to prevent modification.
+     *
+     * Callers should not lock the collection before calling this method as this may lead to deadlocks.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     * @param data        The content for the document
+     * @param mimeType    The Internet Media Type of the document
+     * @param created     The created timestamp of the document
+     * @param modified    The modified timestamp of the document
+     *
+     * @return The stored Binary Document object
+     *
+     * @deprecated Use {@link #addBinaryResource(Txn, DBBroker, BinaryDocument, InputStream, String, long, Date, Date)}
+     */
+    @Deprecated
+    BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, byte[] data, String mimeType,
+            Date created, Date modified) throws EXistException, PermissionDeniedException, LockException,
+            TriggerException, IOException;
+
+    /**
+     * Store a binary document into the Collection (streaming)
+     *
+     * Locks the collection while the resource is being saved. Triggers will be called after the collection
+     * has been unlocked while keeping a lock on the resource to prevent modification.
+     *
+     * Callers should not lock the collection before calling this method as this may lead to deadlocks.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     * @param is          The content for the document
+     * @param mimeType    The Internet Media Type of the document
+     * @param size        The size in bytes of the document
+     *
+     * @return The stored Binary Document object
+     */
+    BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, InputStream is,
+            String mimeType, long size) throws EXistException, PermissionDeniedException, LockException,
+            TriggerException, IOException;
+
+    /**
+     * Store a binary document into the Collection (streaming)
+     *
+     * Locks the collection while the resource is being saved. Triggers will be called after the collection
+     * has been unlocked while keeping a lock on the resource to prevent modification.
+     *
+     * Callers should not lock the collection before calling this method as this may lead to deadlocks.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param blob        the binary resource to store the data into
+     * @param is          The content for the document
+     * @param mimeType    The Internet Media Type of the document
+     * @param size        The size in bytes of the document
+     * @param created     The created timestamp of the document
+     * @param modified    The modified timestamp of the document
+     *
+     * @return The stored Binary Document object
+     */
+    BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, BinaryDocument blob, InputStream is,
+            String mimeType, long size, Date created, Date modified) throws EXistException, PermissionDeniedException,
+            LockException, TriggerException, IOException;
+
+    /**
+     * Gets an Observable object for this Collection
+     *
+     * @return An observable of this Collection, or null if the Collection is not Observable
+     */
+    Observable getObservable();
+
+    /**
+     * Serializes the Collection to a variable byte representation
+     *
+     * @param outputStream The output stream to write the collection contents to
+     */
+    void serialize(final VariableByteOutputStream outputStream) throws IOException, LockException;
+
+    //TODO(AR) consider a better separation between Broker and Collection, possibly introduce a CollectionManager object
+    interface InternalAccess {
+        void addDocument(DocumentImpl doc) throws EXistException;
+        int getId();
     }
 
-    public boolean hasChildCollection(final DBBroker broker, final XmldbURI path) throws PermissionDeniedException, LockException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
 
-        getLock().acquire(Lock.READ_LOCK);
-        try {
-            return subCollections.contains(path);
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-    }
-
-    public abstract class CollectionEntry {
+    //TODO(AR) remove specific implementation details from below - i.e. the read functions etc;
+    abstract class CollectionEntry {
         private final XmldbURI uri;
         private Permission permissions;
         private long created = -1;
@@ -205,8 +891,9 @@ public class Collection extends Observable implements Resource, Comparable<Colle
             this.uri = uri;
             this.permissions = permissions;
         }
-        
+
         public abstract void readMetadata(DBBroker broker);
+
         public abstract void read(VariableByteInput is) throws IOException;
 
         public XmldbURI getUri() {
@@ -228,11 +915,9 @@ public class Collection extends Observable implements Resource, Comparable<Colle
         protected void setPermissions(final Permission permissions) {
             this.permissions = permissions;
         }
-
     }
 
-    public class SubCollectionEntry extends CollectionEntry {
-
+    class SubCollectionEntry extends CollectionEntry {
         public SubCollectionEntry(final SecurityManager sm, final XmldbURI uri) {
             super(uri, PermissionFactory.getDefaultCollectionPermission(sm));
         }
@@ -246,7 +931,7 @@ public class Collection extends Observable implements Resource, Comparable<Colle
         public void read(final VariableByteInput is) throws IOException {
             is.skip(1);
             final int collLen = is.readInt();
-            for(int i = 0; i < collLen; i++) {
+            for (int i = 0; i < collLen; i++) {
                 is.readUTF();
             }
             getPermissions().read(is);
@@ -259,8 +944,7 @@ public class Collection extends Observable implements Resource, Comparable<Colle
         }
     }
 
-    public class DocumentEntry extends CollectionEntry {
-
+    class DocumentEntry extends CollectionEntry {
         public DocumentEntry(final DocumentImpl document) {
             super(document.getURI(), document.getPermissions());
             setCreated(document.getMetadata().getCreated());
@@ -273,2180 +957,5 @@ public class Collection extends Observable implements Resource, Comparable<Colle
         @Override
         public void read(final VariableByteInput is) throws IOException {
         }
-    }
-
-    public List<CollectionEntry> getEntries(final DBBroker broker) throws PermissionDeniedException, LockException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-        final List<CollectionEntry> list = new ArrayList<>();
-
-        final Iterator<XmldbURI> subCollectionIterator;
-        getLock().acquire(Lock.READ_LOCK);
-        try {
-            subCollectionIterator = subCollections.stableIterator();
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-        while(subCollectionIterator.hasNext()) {
-            final XmldbURI subCollectionURI = subCollectionIterator.next();
-            final CollectionEntry entry = new SubCollectionEntry(broker.getBrokerPool().getSecurityManager(), subCollectionURI);
-            entry.readMetadata(broker);
-            list.add(entry);
-        }
-
-        for(final DocumentImpl document : copyOfDocs()) {
-            final CollectionEntry entry = new DocumentEntry(document);
-            entry.readMetadata(broker);
-            list.add(entry);
-        }
-        return list;
-    }
-
-    public CollectionEntry getSubCollectionEntry(final DBBroker broker, final String name) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-        final XmldbURI subCollectionURI = getURI().append(name);
-        final CollectionEntry entry = new SubCollectionEntry(broker.getBrokerPool().getSecurityManager(), subCollectionURI);
-        entry.readMetadata(broker);
-        return entry;
-    }
-
-    public CollectionEntry getResourceEntry(final DBBroker broker, final String name) throws PermissionDeniedException, LockException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-
-        final CollectionEntry entry;
-        getLock().acquire(Lock.READ_LOCK);
-        try {
-            entry = new DocumentEntry(documents.get(name));
-        }  finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-
-        entry.readMetadata(broker);
-        return entry;
-    }
-
-    /**
-     * Returns true if this is a temporary collection. By default,
-     * the temporary collection is in /db/system/temp.
-     *
-     * @return A boolean where true means the collection is temporary.
-     */
-    public boolean isTempCollection() {
-        return isTempCollection;
-    }
-
-    /**
-     * Closes the collection, i.e. releases the lock held by
-     * the current thread. This is a shortcut for getLock().release().
-     */
-    public void release(final int mode) {
-        getLock().release(mode);
-    }
-
-    /**
-     * Update the specified child-collection.
-     *
-     * @param child
-     */
-    public void update(final DBBroker broker, final Collection child) throws PermissionDeniedException, LockException {
-        final XmldbURI childName = child.getURI().lastSegment();
-        getLock().acquire(Lock.WRITE_LOCK);
-        try {
-            subCollections.remove(childName);
-            subCollections.add(childName);
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    /**
-     * Add a document to the collection.
-     *
-     * @param  doc
-     */
-    public void addDocument(final Txn transaction, final DBBroker broker, final DocumentImpl doc) throws PermissionDeniedException, LockException {
-        addDocument(transaction, broker, doc, null);
-    }
-    
-    /**
-     * @param oldDoc if not null, then this document is replacing another and so WRITE access on the collection is not required,
-     * just WRITE access on the old document
-     */
-    private void addDocument(final Txn transaction, final DBBroker broker, final DocumentImpl doc, final DocumentImpl oldDoc) throws PermissionDeniedException, LockException {
-        if(oldDoc == null) {
-            
-            /* create */
-            if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-                throw new PermissionDeniedException("Permission to write to Collection denied for " + this.getURI());
-            }
-        } else {
-            
-            /* update-replace */
-            if(!oldDoc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-                throw new PermissionDeniedException("Permission to write to overwrite document: " +  oldDoc.getURI());
-            }
-        }
-        
-        if (doc.getDocId() == DocumentImpl.UNKNOWN_DOCUMENT_ID) {
-            try {
-                doc.setDocId(broker.getNextResourceId(transaction, this));
-            } catch(final EXistException e) {
-                LOG.error("Collection error " + e.getMessage(), e);
-                // TODO : re-raise the exception ? -pb
-                return;
-            }
-        }
-
-        getLock().acquire(Lock.WRITE_LOCK);
-        try {
-            documents.put(doc.getFileURI().getRawCollectionPath(), doc);
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    /**
-     * Removes the document from the internal list of resources, but
-     * doesn't delete the document object itself.
-     *
-     * @param doc
-     */
-    public void unlinkDocument(final DBBroker broker, final DocumentImpl doc) throws PermissionDeniedException, LockException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-            throw new PermissionDeniedException("Permission denied to remove document from collection: " + path);
-        }
-
-        getLock().acquire(Lock.WRITE_LOCK);
-        try {
-            documents.remove(doc.getFileURI().getRawCollectionPath());
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    /**
-     *  Return an iterator over all sub-collections.
-     *
-     * The list of sub-collections is copied first, so modifications
-     * via the iterator have no effect.
-     *
-     * @return An iterator over the collections
-     */
-    public Iterator<XmldbURI> collectionIterator(final DBBroker broker) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission to list sub-collections denied on " + this.getURI());
-        }
-
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                return subCollections.stableIterator();
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch (final LockException e) {
-            LOG.error(e.getMessage(), e);
-            return null;
-        }
-    }
-
-    /**
-     *  Return an iterator over all sub-collections.
-     *
-     * The list of sub-collections is copied first, so modifications
-     * via the iterator have no effect.
-     *
-     * @return An iterator over the collections
-     *
-     * @deprecated The creation of the stable iterator may
-     * throw an {@link java.lang.IndexOutOfBoundsException},
-     * use {@link #collectionIterator(DBBroker)} instead
-     */
-    @Deprecated
-    public Iterator<XmldbURI> collectionIteratorNoLock(final DBBroker broker) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission to list sub-collections denied on " + this.getURI());
-        }
-        return subCollections.stableIterator();
-    }
-
-    /**
-     * Return the collections below this collection
-     *
-     * @return List
-     */
-    public List<Collection> getDescendants(final DBBroker broker, final Subject user) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission to list sub-collections denied on " + this.getURI());
-        }
-
-        final ArrayList<Collection> collectionList;
-        final Iterator<XmldbURI> i;
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                collectionList = new ArrayList<>(subCollections.size());
-                i = subCollections.stableIterator();
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.error(e.getMessage(), e);
-            return Collections.EMPTY_LIST;
-        }
-
-        while(i.hasNext()) {
-            final XmldbURI childName = i.next();
-            //TODO : resolve URI !
-            final Collection child = broker.getCollection(path.append(childName));
-            if(getPermissionsNoLock().validate(user, Permission.READ)) {
-                collectionList.add(child);
-                if(child.getChildCollectionCount(broker) > 0) {
-                    //Recursive call
-                    collectionList.addAll(child.getDescendants(broker, user));
-                }
-            }
-        }
-
-        return collectionList;
-    }
-
-    public MutableDocumentSet allDocs(final DBBroker broker, final MutableDocumentSet docs, final boolean recursive) throws PermissionDeniedException {
-        return allDocs(broker, docs, recursive, null);
-    }
-
-    /**
-     * Retrieve all documents contained in this collections.
-     *
-     * If recursive is true, documents from sub-collections are
-     * included.
-     *
-     * @return The set of documents
-     */
-    public MutableDocumentSet allDocs(final DBBroker broker, final MutableDocumentSet docs, final boolean recursive, final LockedDocumentMap protectedDocs) throws PermissionDeniedException {
-        List<XmldbURI> subColls = null;
-        if(getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            try {
-                getLock().acquire(Lock.READ_LOCK);
-                try {
-                    //Add all docs in this collection to the returned set
-                    getDocuments(broker, docs);
-                    //Get a list of sub-collection URIs. We will process them
-                    //after unlocking this collection. otherwise we may deadlock ourselves
-                    subColls = subCollections.keys();
-                } finally {
-                    getLock().release(Lock.READ_LOCK);
-                }
-            } catch(final LockException e) {
-                LOG.error(e.getMessage(), e);
-            }
-        }
-
-        if(recursive && subColls != null) {
-            // process the child collections
-            for(final XmldbURI childName : subColls) {
-                //TODO : resolve URI !
-                try {
-                    final Collection child = broker.openCollection(path.appendInternal(childName), Lock.NO_LOCK);
-                    //A collection may have been removed in the meantime, so check first
-                    if(child != null) {
-                        child.allDocs(broker, docs, recursive, protectedDocs);
-                    }
-                } catch(final PermissionDeniedException pde) {
-                    //SKIP to next collection
-                    //TODO create an audit log??!
-                }
-            }
-        }
-        return docs;
-    }
-
-    public DocumentSet allDocs(final DBBroker broker, final MutableDocumentSet docs, final boolean recursive, final LockedDocumentMap lockMap, final int lockType) throws LockException, PermissionDeniedException {
-        
-        XmldbURI uris[] = null;
-        if(getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                //Add all documents in this collection to the returned set
-                getDocuments(broker, docs, lockMap, lockType);
-                //Get a list of sub-collection URIs. We will process them
-                //after unlocking this collection.
-                //otherwise we may deadlock ourselves
-                final List<XmldbURI> subColls = subCollections.keys();
-                if (subColls != null) {
-                    uris = new XmldbURI[subColls.size()];
-                    for(int i = 0; i < subColls.size(); i++) {
-                        uris[i] = path.appendInternal(subColls.get(i));
-                    }
-                }
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        }
-        
-        if(recursive && uris != null) {
-            //Process the child collections
-            for (XmldbURI uri : uris) {
-                //TODO : resolve URI !
-                try {
-                    final Collection child = broker.openCollection(uri, Lock.NO_LOCK);
-                    // a collection may have been removed in the meantime, so check first
-                    if (child != null) {
-                        child.allDocs(broker, docs, recursive, lockMap, lockType);
-                    }
-                } catch (final PermissionDeniedException pde) {
-                    //SKIP to next collection
-                    //TODO create an audit log??!
-                }
-            }
-        }
-        return docs;
-    }
-
-    /**
-     * Add all documents to the specified document set.
-     *
-     * @param docs
-     */
-    public DocumentSet getDocuments(final DBBroker broker, final MutableDocumentSet docs) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-        
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            docs.addCollection(this);
-            addDocumentsToSet(broker, docs);
-        } catch(final LockException le) {
-            //TODO this should not be caught - it should be thrown - lock errors are bad!!!
-            LOG.error(le.getMessage(), le);
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-        
-        return docs;
-    }
-
-    /**
-     * @deprecated This is not an atomic operation and
-     * so there are no guarantees about which docs will be added to
-     * the document set. Use {@link #getDocuments(DBBroker, MutableDocumentSet)}
-     * instead
-     */
-    @Deprecated
-    public DocumentSet getDocumentsNoLock(final DBBroker broker, final MutableDocumentSet docs) {
-        docs.addCollection(this);
-        addDocumentsToSet(broker, docs);
-        return docs;
-    }
-
-    public DocumentSet getDocuments(final DBBroker broker, final MutableDocumentSet docs, final LockedDocumentMap lockMap, final int lockType) throws LockException, PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-        
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            docs.addCollection(this);
-            addDocumentsToSet(broker, docs, lockMap, lockType);
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-        return docs;
-    }
-
-    /**
-     * Gets a stable list of the document objects
-     * from {@link #documents}
-     *
-     * @return A stable list of the document objects
-     */
-    private List<DocumentImpl> copyOfDocs() throws LockException {
-        getLock().acquire(Lock.READ_LOCK);
-        try {
-            return new ArrayList<>(documents.values());
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-    }
-
-    /**
-     * Gets a stable set of the the document object
-     * names from {@link #documents}
-     */
-    private Set<String> copyOfDocNames() throws LockException {
-        getLock().acquire(Lock.READ_LOCK);
-        try {
-            return new TreeSet<>(documents.keySet());
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-    }
-
-    private void addDocumentsToSet(final DBBroker broker, final MutableDocumentSet docs, final LockedDocumentMap lockMap, final int lockType) throws LockException {
-    	for(final DocumentImpl doc : copyOfDocs()) {
-            if(doc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-                doc.getUpdateLock().acquire(Lock.WRITE_LOCK);
-
-                docs.add(doc);
-                lockMap.add(doc);
-            }
-    	}
-    }
-    
-    private void addDocumentsToSet(final DBBroker broker, final MutableDocumentSet docs) {
-    	try {
-            for (final DocumentImpl doc : copyOfDocs()) {
-                if (doc.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
-                    docs.add(doc);
-                }
-            }
-        } catch(final LockException e) {
-            LOG.error(e);
-        }
-    }
-
-    /**
-     * Check if this collection may be safely removed from the
-     * cache. Returns false if there are ongoing write operations,
-     * i.e. one or more of the documents is locked for write.
-     *
-     * @return A boolean value where true indicates it may be unloaded.
-     */
-    @Override
-    public boolean allowUnload() {
-        if (getURI().startsWith(CollectionConfigurationManager.ROOT_COLLECTION_CONFIG_URI)) {
-            return false;
-        }
-
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                for (final DocumentImpl doc : documents.values()) {
-                    if (doc.isLockedForWrite()) {
-                        return false;
-                    }
-                }
-                return true;
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.error(e);
-            return false;
-        }
-    }
-
-    @Override
-    public int compareTo(final Collection other) {
-        if(collectionId == other.collectionId) {
-            return Constants.EQUAL;
-        } else if(collectionId < other.collectionId) {
-            return Constants.INFERIOR;
-        } else {
-            return Constants.SUPERIOR;
-        }
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if(!(obj instanceof Collection)) {
-            return false;
-        }
-        
-        return ((Collection) obj).collectionId == collectionId;
-    }
-
-    /**
-     * Returns the estimated amount of memory used by this collection
-     * and its documents. This information is required by the
-     * {@link org.exist.storage.CollectionCacheManager} to be able
-     * to resize the caches.
-     *
-     * @return estimated amount of memory in bytes
-     */
-    public int getMemorySize() {
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                return SHALLOW_SIZE + documents.size() * DOCUMENT_SIZE;
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.error(e);
-            return -1;
-        }
-    }
-
-    /**
-     * Return the number of child-collections managed by this collection.
-     *
-     * @return The childCollectionCount value
-     */
-    public int getChildCollectionCount(final DBBroker broker) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                return subCollections.size();
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.error(e.getMessage(), e);
-            return 0;
-        }
-    }
-    
-    /**
-     * Determines if this Collection has any documents, or sub-collections
-     */
-    public boolean isEmpty(final DBBroker broker) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                return documents.isEmpty() && subCollections.isEmpty();
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.error(e.getMessage(), e);
-            return false;
-        }
-    }
-
-   /**
-     * Get a child resource as identified by path. This method doesn't put
-     * a lock on the document nor does it recognize locks held by other threads.
-     * There's no guarantee that the document still exists when accessing it.
-     *
-     * @param  broker
-     * @param  path  The name of the document (without collection path)
-     * @return the document
-     */
-    public DocumentImpl getDocument(final DBBroker broker, final XmldbURI path) throws PermissionDeniedException {
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                final DocumentImpl doc = documents.get(path.getRawCollectionPath());
-                if (doc != null) {
-                    if (!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
-                        throw new PermissionDeniedException("Permission denied to read document: " + path.toString());
-                    }
-                } else {
-                    LOG.debug("Document " + path + " not found!");
-                }
-
-                return doc;
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.error(e.getMessage(), e);
-            return null;
-        }
-    }
-
-    /**
-     * Retrieve a child resource after putting a read lock on it. With this method,
-     * access to the received document object is safe.
-     *
-     * @deprecated Use getDocumentWithLock(DBBroker broker, XmldbURI uri, int lockMode)
-     * @param broker
-     * @param name
-     * @return The document that was locked.
-     * @throws LockException
-     */
-    @Deprecated
-    public DocumentImpl getDocumentWithLock(final DBBroker broker, final XmldbURI name) throws LockException, PermissionDeniedException {
-    	return getDocumentWithLock(broker,name,Lock.READ_LOCK);
-    }
-
-    /**
-     * Retrieve a child resource after putting a read lock on it. With this method,
-     * access to the received document object is safe.
-     *
-     * @param broker
-     * @param uri
-     * @param lockMode
-     * @return The document that was locked.
-     * @throws LockException
-     */
-    public DocumentImpl getDocumentWithLock(final DBBroker broker, final XmldbURI uri, final int lockMode) throws LockException, PermissionDeniedException {
-        getLock().acquire(Lock.READ_LOCK);
-        try {
-            final DocumentImpl doc = documents.get(uri.getRawCollectionPath());
-            if(doc != null) {
-                if(!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
-                    throw new PermissionDeniedException("Permission denied to read document: " + uri.toString());
-                }
-            	doc.getUpdateLock().acquire(lockMode);
-            }
-            return doc;
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-    }
-
-    /**
-     * @deprecated Use {@link #getDocument(DBBroker, XmldbURI)} instead
-     */
-    @Deprecated
-    public DocumentImpl getDocumentNoLock(final DBBroker broker, final String rawPath) throws PermissionDeniedException {
-        final DocumentImpl doc = documents.get(rawPath);
-        if(doc != null) {
-            if(!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
-                throw new PermissionDeniedException("Permission denied to read document: " + rawPath);
-            }
-        }
-        return doc;
-    }
-
-    /**
-     * Release any locks held on the document.
-     * @deprecated Use {@link #releaseDocument(DocumentImpl, int)} instead
-     * @param doc
-     */
-    @Deprecated
-    public void releaseDocument(final DocumentImpl doc) {
-        if(doc != null) {
-            doc.getUpdateLock().release(Lock.READ_LOCK);
-        }
-    }
-
-    /**
-     * Release any locks held on the document.
-     *
-     * @param doc
-     */
-    public void releaseDocument(final DocumentImpl doc, final int mode) {
-        if(doc != null) {
-            doc.getUpdateLock().release(mode);
-        }
-    }
-
-    /**
-     * Returns the number of documents in this collection.
-     *
-     * @return The documentCount value, or -1 if the collection could not be locked
-     */
-    public int getDocumentCount(final DBBroker broker) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                return documents.size();
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.warn(e.getMessage(), e);
-            return -1;
-        }
-    }
-
-    /**
-     * @deprecated Use {@link #getDocumentCount(DBBroker)}
-     */
-    @Deprecated
-    public int getDocumentCountNoLock(final DBBroker broker) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-        return documents.size();
-    }
-
-    /**
-     * Get the internal id.
-     *
-     * @return    The id value
-     */
-    public int getId() {
-        return collectionId;
-    }
-
-    @Override
-    public XmldbURI getURI() {
-        return path;
-    }
-
-    /**
-     * Returns the parent-collection.
-     *
-     * @return The parent-collection or null if this is the root collection.
-     */
-    public XmldbURI getParentURI() {
-        if(path.equals(XmldbURI.ROOT_COLLECTION_URI)) {
-            return null;
-        }
-        //TODO : resolve URI against ".." !
-         return path.removeLastSegment();
-    }
-
-    @Override
-    final public Permission getPermissions() {
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            return permissions;
-        } catch(final LockException e) {
-            LOG.error(e.getMessage(), e);
-            return permissions;
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-    }
-
-    public Permission getPermissionsNoLock() {
-        return permissions;
-    }
-
-    @Override
-    public CollectionMetadata getMetadata() {
-        return collectionMetadata;
-    }
-
-    /**
-     * Check if the collection has a child document.
-     *
-     * @param  uri  the name (without path) of the document
-     * @return A value of true when the collection has the document identified.
-     */
-    public boolean hasDocument(final DBBroker broker, final XmldbURI uri) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                return documents.containsKey(uri.getRawCollectionPath());
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.warn(e.getMessage(), e);
-            //TODO : ouch ! Should we return at any price ? Xithout even logging ? -pb
-            return documents.containsKey(uri.getRawCollectionPath());
-        }
-    }
-
-    /**
-     * Check if the collection has a sub-collection.
-     *
-     * @param  name  the name of the subcollection (without path).
-     * @return A value of true when the subcollection exists.
-     */
-    public boolean hasSubcollection(final DBBroker broker, final XmldbURI name) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            try {
-                return subCollections.contains(name);
-            } finally {
-                getLock().release(Lock.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.warn(e.getMessage(), e);
-            //TODO : ouch ! Should we return at any price ? Xithout even logging ? -pb
-            return hasSubcollectionNoLock(broker, name);
-        }
-    }
-
-    /**
-     * @deprecated Use {@link #hasSubcollection(DBBroker, XmldbURI)} instead
-     */
-    @Deprecated
-    public boolean hasSubcollectionNoLock(final DBBroker broker, final XmldbURI name) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-
-        return subCollections.contains(name);
-    }
-
-    /**
-     * Returns an iterator on the child-documents in this collection.
-     *
-     * @return A iterator of all the documents in the collection.
-     */
-    public Iterator<DocumentImpl> iterator(final DBBroker broker) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-        
-        return getDocuments(broker, new DefaultDocumentSet()).getDocumentIterator();
-    }
-
-    /**
-     * @deprecated This is not an atomic operation and
-     * so there are no guarantees about which docs will be available to
-     * the iterator. Use {@link #iterator(DBBroker)} instead
-     */
-    @Deprecated
-    public Iterator<DocumentImpl> iteratorNoLock(final DBBroker broker) throws PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-        
-        return getDocumentsNoLock(broker, new DefaultDocumentSet()).getDocumentIterator();
-    }
-
-    /**
-     * Write collection contents to stream.
-     *
-     * @param ostream
-     * @throws IOException
-     */
-    public void write(final DBBroker broker, final VariableByteOutputStream ostream) throws IOException, LockException {
-        ostream.writeInt(collectionId);
-
-        final int size;
-        final Iterator<XmldbURI> i;
-
-        getLock().acquire(Lock.READ_LOCK);
-        try {
-            size = subCollections.size();
-            i = subCollections.stableIterator();
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-
-        ostream.writeInt(size);
-        while(i.hasNext()) {
-            final XmldbURI childCollectionURI = i.next();
-            ostream.writeUTF(childCollectionURI.toString());
-        }
-        permissions.write(ostream);
-        ostream.writeLong(created);
-    }
-    
-    public interface InternalAccess {
-        public void addDocument(DocumentImpl doc) throws EXistException;
-        public int getId();
-    }
-    
-    /**
-     * Read collection contents from the stream.
-     *
-     * @param istream
-     * @throws IOException
-     */
-    public void read(final DBBroker broker, final VariableByteInput istream) throws IOException, PermissionDeniedException, LockException {
-        collectionId = istream.readInt();
-        if (collectionId < 0) {
-            throw new PermissionDeniedException("Internal error reading collection: invalid collection id");
-        }
-        final int collLen = istream.readInt();
-
-        getLock().acquire(Lock.WRITE_LOCK);
-        try {
-            subCollections = new ObjectHashSet<>(collLen == 0 ? 19 : collLen); //TODO what is this number 19?
-            for (int i = 0; i < collLen; i++) {
-                subCollections.add(XmldbURI.create(istream.readUTF()));
-            }
-
-            permissions.read(istream);
-
-            created = istream.readLong();
-
-            if (!permissions.validate(broker.getCurrentSubject(), Permission.EXECUTE)) {
-                throw new PermissionDeniedException("Permission denied to open the Collection " + path);
-            }
-
-            final Collection col = this;
-
-            broker.getCollectionResources(new InternalAccess() {
-                @Override
-                public void addDocument(final DocumentImpl doc) throws EXistException {
-                    doc.setCollection(col);
-
-                    if (doc.getDocId() == DocumentImpl.UNKNOWN_DOCUMENT_ID) {
-                        LOG.error("Document must have ID. [" + doc + "]");
-                        throw new EXistException("Document must have ID.");
-                    }
-
-                    documents.put(doc.getFileURI().getRawCollectionPath(), doc);
-                }
-
-                @Override
-                public int getId() {
-                    return col.getId();
-                }
-            });
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    /**
-     * Remove the specified sub-collection.
-     *
-     * @param  name  Description of the Parameter
-     */
-    public void removeCollection(final DBBroker broker, final XmldbURI name) throws LockException, PermissionDeniedException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-            throw new PermissionDeniedException("Permission denied to read collection: " + path);
-        }
-
-        getLock().acquire(Lock.WRITE_LOCK);
-        try {
-            subCollections.remove(name);
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    public void removeResource(final Txn transaction, final DBBroker broker, final DocumentImpl doc) throws PermissionDeniedException, LockException, IOException, TriggerException {
-        if (doc.getCollection() != this) {
-            throw new IOException("Document '" + doc.getURI() + "' does not belong to Collection '" + getURI() + "'.");
-        }
-
-        if(doc.getResourceType() == DocumentImpl.BINARY_FILE) {
-            removeBinaryResource(transaction, broker, doc);
-        } else {
-            removeXMLResource(transaction, broker, doc.getFileURI());
-        }
-    }
-
-    /**
-     * Remove the specified document from the collection.
-     *
-     * @param  transaction
-     * @param  broker
-     * @param  docUri
-     */
-    public void removeXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI docUri) throws PermissionDeniedException, TriggerException, LockException, IOException {
-        
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-            throw new PermissionDeniedException("Permission denied to write collection: " + path);
-        }
-        
-        DocumentImpl doc = null;
-        
-        final BrokerPool db = broker.getBrokerPool();
-
-        db.getProcessMonitor().startJob(ProcessMonitor.ACTION_REMOVE_XML, docUri);
-        getLock().acquire(Lock.WRITE_LOCK);
-
-        try {
-            doc = documents.get(docUri.getRawCollectionPath());
-            
-            if (doc == null) {
-                return; //TODO should throw an exception!!! Otherwise we dont know if the document was removed
-            }
-            
-            doc.getUpdateLock().acquire(Lock.WRITE_LOCK);
-            
-            boolean useTriggers = isTriggersEnabled();
-            if (CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI.equals(docUri)) {
-                // we remove a collection.xconf configuration file: tell the configuration manager to
-                // reload the configuration.
-                useTriggers = false;
-                final CollectionConfigurationManager confMgr = broker.getBrokerPool().getConfigurationManager();
-                if (confMgr != null) {
-                    confMgr.invalidate(getURI(), broker.getBrokerPool());
-                }
-            }
-            
-            DocumentTriggers trigger = new DocumentTriggers(broker, null, this, useTriggers ? getConfiguration(broker) : null);
-            
-            trigger.beforeDeleteDocument(broker, transaction, doc);
-            
-            broker.removeXMLResource(transaction, doc);
-            documents.remove(docUri.getRawCollectionPath());
-            
-            trigger.afterDeleteDocument(broker, transaction, getURI().append(docUri));
-            
-            broker.getBrokerPool().getNotificationService().notifyUpdate(doc, UpdateListener.REMOVE);
-        } finally {
-            broker.getBrokerPool().getProcessMonitor().endJob();
-            if(doc != null) {
-                doc.getUpdateLock().release(Lock.WRITE_LOCK);
-            }
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    public void removeBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI uri) throws PermissionDeniedException, LockException, TriggerException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-            throw new PermissionDeniedException("Permission denied to write collection: " + path);
-        }
-        
-        try {
-            getLock().acquire(Lock.READ_LOCK);
-            final DocumentImpl doc = getDocument(broker, uri);
-            
-            if(doc.isLockedForWrite()) {
-                throw new PermissionDeniedException("Document " + doc.getFileURI() + " is locked for write");
-            }
-            
-            removeBinaryResource(transaction, broker, doc);
-        } finally {
-            getLock().release(Lock.READ_LOCK);
-        }
-    }
-
-    public void removeBinaryResource(final Txn transaction, final DBBroker broker, final DocumentImpl doc) throws PermissionDeniedException, LockException, TriggerException {
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-            throw new PermissionDeniedException("Permission denied to write collection: " + path);
-        }
-        
-        if(doc == null) {
-            return;  //TODO should throw an exception!!! Otherwise we dont know if the document was removed
-        }
-
-        broker.getBrokerPool().getProcessMonitor().startJob(ProcessMonitor.ACTION_REMOVE_BINARY, doc.getFileURI());
-        getLock().acquire(Lock.WRITE_LOCK);
-
-        try {
-            
-            if(doc.getResourceType() != DocumentImpl.BINARY_FILE) {
-                throw new PermissionDeniedException("document " + doc.getFileURI() + " is not a binary object");
-            }
-            
-            if(doc.isLockedForWrite()) {
-                throw new PermissionDeniedException("Document " + doc.getFileURI() + " is locked for write");
-            }
-            
-            doc.getUpdateLock().acquire(Lock.WRITE_LOCK);
-            
-            DocumentTriggers trigger = new DocumentTriggers(broker, null, this, isTriggersEnabled() ? getConfiguration(broker) : null);
-
-            trigger.beforeDeleteDocument(broker, transaction, doc);
-
-            final IndexController indexController = broker.getIndexController();
-            final StreamListener listener = indexController.getStreamListener(doc, StreamListener.ReindexMode.REMOVE_BINARY);
-            try {
-                indexController.startIndexDocument(transaction, listener);
-
-                try {
-                    broker.removeBinaryResource(transaction, (BinaryDocument) doc);
-                } catch (final IOException ex) {
-                    throw new PermissionDeniedException("Cannot delete file: " + doc.getURI().toString() + ": " + ex.getMessage(), ex);
-                }
-                documents.remove(doc.getFileURI().getRawCollectionPath());
-            } finally {
-                indexController.endIndexDocument(transaction, listener);
-            }
-
-            trigger.afterDeleteDocument(broker, transaction, doc.getURI());
-
-        } finally {
-            broker.getBrokerPool().getProcessMonitor().endJob();
-            doc.getUpdateLock().release(Lock.WRITE_LOCK);
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    /** Stores an XML document in the database. {@link #validateXMLResourceInternal(org.exist.storage.txn.Txn,
-     * org.exist.storage.DBBroker, org.exist.xmldb.XmldbURI, CollectionConfiguration, org.exist.collections.Collection.ValidateBlock)} 
-     * should have been called previously in order to acquire a write lock for the document. Launches the finish trigger.
-     * 
-     * @param transaction
-     * @param broker
-     * @param info
-     * @param source
-     * @param privileged
-     * 
-     * @throws EXistException
-     * @throws PermissionDeniedException
-     * @throws TriggerException
-     * @throws SAXException
-     * @throws LockException
-     */
-    public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final InputSource source, boolean privileged) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
-        
-        storeXMLInternal(transaction, broker, info, privileged, new StoreBlock() {
-            @Override
-            public void run() throws EXistException, SAXException {
-                try {
-                    final InputStream is = source.getByteStream();
-                    if(is != null && is.markSupported()) {
-                        is.reset();
-                    } else {
-                        final Reader cs = source.getCharacterStream();
-                        if(cs != null && cs.markSupported()) {
-                            cs.reset();
-                        }
-                    }
-                } catch(final IOException e) {
-                    // mark is not supported: exception is expected, do nothing
-                    LOG.debug("InputStream or CharacterStream underlying the InputSource does not support marking and therefore cannot be re-read.");
-                }
-                final XMLReader reader = getReader(broker, false, info.getCollectionConfig());
-                info.setReader(reader, null);
-                try {
-                    reader.parse(source);
-                } catch(final IOException e) {
-                    throw new EXistException(e);
-                } finally {
-                    releaseReader(broker, info, reader);
-                }
-            }
-        });
-    }
-    
-    /** 
-     * Stores an XML document in the database. {@link #validateXMLResourceInternal(org.exist.storage.txn.Txn,
-     * org.exist.storage.DBBroker, org.exist.xmldb.XmldbURI, CollectionConfiguration, org.exist.collections.Collection.ValidateBlock)} 
-     * should have been called previously in order to acquire a write lock for the document. Launches the finish trigger.
-     * 
-     * @param transaction
-     * @param broker
-     * @param info
-     * @param data
-     * @param privileged
-     * 
-     * @throws EXistException
-     * @throws PermissionDeniedException
-     * @throws TriggerException
-     * @throws SAXException
-     * @throws LockException
-     */
-    public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final String data, boolean privileged) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
-        
-        storeXMLInternal(transaction, broker, info, privileged, new StoreBlock() {
-            @Override
-            public void run() throws SAXException, EXistException {
-                final CollectionConfiguration colconf = info.getDocument().getCollection().getConfiguration(broker);
-                final XMLReader reader = getReader(broker, false, colconf);
-                info.setReader(reader, null);
-                try {
-                    reader.parse(new InputSource(new StringReader(data)));
-                } catch(final IOException e) {
-                    throw new EXistException(e);
-                } finally {
-                    releaseReader(broker, info, reader);
-                }
-            }
-        });
-    }
-
-    /** 
-     * Stores an XML document in the database. {@link #validateXMLResourceInternal(org.exist.storage.txn.Txn,
-     * org.exist.storage.DBBroker, org.exist.xmldb.XmldbURI, CollectionConfiguration, org.exist.collections.Collection.ValidateBlock)} 
-     * should have been called previously in order to acquire a write lock for the document. Launches the finish trigger.
-     * 
-     * @param transaction
-     * @param broker
-     * @param info
-     * @param node
-     * @param privileged
-     * 
-     * @throws EXistException
-     * @throws PermissionDeniedException
-     * @throws TriggerException
-     * @throws SAXException
-     * @throws LockException
-     */  
-    public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final Node node, boolean privileged) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
-        
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-            throw new PermissionDeniedException("Permission denied to write collection: " + path);
-        }
-        
-        storeXMLInternal(transaction, broker, info, privileged, new StoreBlock() {
-            @Override
-            public void run() throws EXistException, SAXException {
-                info.getDOMStreamer().serialize(node, true);
-            }
-        });
-    }
-
-    private interface StoreBlock {
-        public void run() throws EXistException, SAXException;
-    }
-
-    /** 
-     * Stores an XML document in the database. {@link #validateXMLResourceInternal(org.exist.storage.txn.Txn,
-     * org.exist.storage.DBBroker, org.exist.xmldb.XmldbURI, CollectionConfiguration, org.exist.collections.Collection.ValidateBlock)} 
-     * should have been called previously in order to acquire a write lock for the document. Launches the finish trigger.
-     * 
-     * @param transaction
-     * @param broker
-     * @param info
-     * @param privileged
-     * @param doParse
-     * 
-     * @throws EXistException
-     * @throws SAXException
-     */
-    private void storeXMLInternal(final Txn transaction, final DBBroker broker, final IndexInfo info, final boolean privileged, final StoreBlock doParse) throws EXistException, SAXException, PermissionDeniedException {
-        
-        final DocumentImpl document = info.getIndexer().getDocument();
-        
-        final Database db = broker.getBrokerPool();
-        
-        try {
-            /* TODO
-             * 
-             * These security checks are temporarily disabled because throwing an exception
-             * here may cause the database to corrupt.
-             * Why would the database corrupt? Because validateXMLInternal that is typically
-             * called before this method actually modifies the database and this collection,
-             * so throwing an exception here leaves the database in an inconsistent state
-             * with data 1/2 added/updated.
-             * 
-             * The downside of disabling these checks here is that: this collection is not locked
-             * between the call to validateXmlInternal and storeXMLInternal, which means that if
-             * UserA in ThreadA calls validateXmlInternal and is permitted access to store a resource,
-             * and then UserB in ThreadB modifies the permissions of this collection to prevent UserA
-             * from storing the document, when UserA reaches here (storeXMLInternal) they will still
-             * be allowed to store their document. However the next document that UserA attempts to store
-             * will be forbidden by validateXmlInternal and so the security transgression whilst not ideal
-             * is short-lived.
-             * 
-             * To fix the issue we need to refactor validateXMLInternal and move any document/database/collection
-             * modification code into storeXMLInternal after the commented out permissions checks below.
-             * 
-             * Noted by Adam Retter 2012-02-01T19:18
-             */
-            
-            /*
-            if(info.isCreating()) {
-                // create
-                * 
-                if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-                    throw new PermissionDeniedException("Permission denied to write collection: " + path);
-                }
-            } else {
-                // update
-
-                final Permission oldDocPermissions = info.getOldDocPermissions();
-                if(!((oldDocPermissions.getOwner().getId() != broker.getCurrentSubject().getId()) | (oldDocPermissions.validate(broker.getCurrentSubject(), Permission.WRITE)))) {
-                    throw new PermissionDeniedException("A resource with the same name already exists in the target collection '" + path + "', and you do not have write access on that resource.");
-                }
-            }
-            */
-
-            if(LOG.isDebugEnabled()) {
-                LOG.debug("storing document " + document.getDocId() + " ...");
-            }
-
-            //Sanity check
-            if(!document.getUpdateLock().isLockedForWrite()) {
-                LOG.warn("document is not locked for write !");
-            }
-            
-            db.getProcessMonitor().startJob(ProcessMonitor.ACTION_STORE_DOC, document.getFileURI());
-            doParse.run();
-            broker.storeXMLResource(transaction, document);
-            broker.flush();
-            broker.closeDocument();
-            //broker.checkTree(document);
-            LOG.debug("document stored.");
-        } finally {
-            //This lock has been acquired in validateXMLResourceInternal()
-            document.getUpdateLock().release(Lock.WRITE_LOCK);
-            broker.getBrokerPool().getProcessMonitor().endJob();
-        }
-        setCollectionConfigEnabled(true);
-        broker.deleteObservers();
-        
-        if(info.isCreating()) {
-            info.getTriggers().afterCreateDocument(broker, transaction, document);
-        } else {
-            info.getTriggers().afterUpdateDocument(broker, transaction, document);
-        }
-        
-        db.getNotificationService().notifyUpdate(document, (info.isCreating() ? UpdateListener.ADD : UpdateListener.UPDATE));
-        //Is it a collection configuration file ?
-        final XmldbURI docName = document.getFileURI();
-        //WARNING : there is no reason to lock the collection since setPath() is normally called in a safe way
-        //TODO: *resolve* URI against CollectionConfigurationManager.CONFIG_COLLECTION_URI 
-        if (getURI().startsWith(XmldbURI.CONFIG_COLLECTION_URI)
-                && docName.endsWith(CollectionConfiguration.COLLECTION_CONFIG_SUFFIX_URI)) {
-            broker.sync(Sync.MAJOR);
-            final CollectionConfigurationManager manager = broker.getBrokerPool().getConfigurationManager();
-            if(manager != null) {
-                try {
-                    manager.invalidate(getURI(), broker.getBrokerPool());
-                    manager.loadConfiguration(broker, this);
-                } catch(final PermissionDeniedException pde) {
-                    throw new EXistException(pde.getMessage(), pde);
-                } catch(final LockException le) {
-                    throw new EXistException(le.getMessage(), le);
-                } catch(final CollectionConfigurationException e) { 
-                    // DIZ: should this exception really been thrown? bugid=1807744
-                    throw new EXistException("Error while reading new collection configuration: " + e.getMessage(), e);
-                }
-            }
-        }
-    }
-
-    private interface ValidateBlock {
-        public void run(IndexInfo info) throws SAXException, EXistException;
-    }
-
-    /** 
-     * Validates an XML document and prepares it for further storage.
-     * Launches prepare and postValidate triggers.
-     * Since the process is dependent from the collection configuration, 
-     * the collection acquires a write lock during the process.
-     * 
-     * @param transaction
-     * @param broker
-     * @param docUri   
-     * @param data  
-     * 
-     * @return An {@link IndexInfo} with a write lock on the document. 
-     * 
-     * @throws EXistException
-     * @throws PermissionDeniedException
-     * @throws TriggerException
-     * @throws SAXException
-     * @throws LockException
-     */    
-    public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI docUri, final String data) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
-        return validateXMLResource(transaction, broker, docUri, new InputSource(new StringReader(data)));
-    }
-
-    /** 
-     * Validates an XML document et prepares it for further storage. Launches prepare and postValidate triggers.
-     * Since the process is dependant from the collection configuration, the collection acquires a write lock during the process.
-     * 
-     * @param transaction
-     * @param broker
-     * @param docUri
-     * @param source
-     * 
-     * @return An {@link IndexInfo} with a write lock on the document. 
-     * 
-     * @throws EXistException
-     * @throws PermissionDeniedException
-     * @throws TriggerException
-     * @throws SAXException
-     * @throws LockException
-     */    
-    public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI docUri, final InputSource source) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
-        final CollectionConfiguration colconf = getConfiguration(broker);
-        
-        return validateXMLResourceInternal(transaction, broker, docUri, colconf, new ValidateBlock() {
-            @Override
-            public void run(final IndexInfo info) throws SAXException, EXistException {
-                final XMLReader reader = getReader(broker, true, colconf);
-                info.setReader(reader, null);
-                try {
-                    
-                    /*
-                     * Note - we must close shield the input source,
-                     * else it can be closed by the Reader, so subsequently
-                     * when we try and read it in storeXmlInternal we will get
-                     * an exception.
-                     */
-                    final InputSource closeShieldedInputSource = closeShieldInputSource(source);
-                    
-                    reader.parse(closeShieldedInputSource);
-                } catch(final SAXException e) {
-                    throw new SAXException("The XML parser reported a problem: " + e.getMessage(), e);
-                } catch(final IOException e) {
-                    throw new EXistException(e);
-                } finally {
-                    releaseReader(broker, info, reader);
-                }
-            }
-        });
-    }
-    
-    //stops streams on the input source from being closed
-    private InputSource closeShieldInputSource(final InputSource source) {
-        
-        final InputSource protectedInputSource = new InputSource();
-        protectedInputSource.setEncoding(source.getEncoding());
-        protectedInputSource.setSystemId(source.getSystemId());
-        protectedInputSource.setPublicId(source.getPublicId());
-        
-        if(source.getByteStream() != null) {
-            //TODO consider AutoCloseInputStream
-            final InputStream closeShieldByteStream = new CloseShieldInputStream(source.getByteStream());
-            protectedInputSource.setByteStream(closeShieldByteStream);
-        }
-        
-        if(source.getCharacterStream() != null) {
-            //TODO consider AutoCloseReader
-            final Reader closeShieldReader = new CloseShieldReader(source.getCharacterStream());
-            protectedInputSource.setCharacterStream(closeShieldReader);
-        }
-        
-        return protectedInputSource;
-    }
-    
-    private static class CloseShieldReader extends Reader {
-        private final Reader reader;
-        public CloseShieldReader(final Reader reader) {
-            this.reader = reader;
-        }
-
-        @Override
-        public int read(final char[] cbuf, final int off, final int len) throws IOException {
-            return reader.read(cbuf, off, len);
-        }
-
-        @Override
-        public void close() throws IOException {
-            //do nothing as we are close shield
-        }
-    }
-
-    /** 
-     * Validates an XML document et prepares it for further storage. Launches prepare and postValidate triggers.
-     * Since the process is dependant from the collection configuration, the collection acquires a write lock during the process.
-     * 
-     * @param transaction
-     * @param broker
-     * @param docUri
-     * @param node
-     * 
-     * @return An {@link IndexInfo} with a write lock on the document. 
-     * 
-     * @throws EXistException
-     * @throws PermissionDeniedException
-     * @throws TriggerException
-     * @throws SAXException
-     * @throws LockException
-     */    
-    public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI docUri, final Node node) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
-    	
-        return validateXMLResourceInternal(transaction, broker, docUri, getConfiguration(broker), new ValidateBlock() {
-            @Override
-            public void run(final IndexInfo info) throws SAXException {
-                info.setDOMStreamer(new DOMStreamer());
-                info.getDOMStreamer().serialize(node, true);
-            }
-        });
-    }
-
-    /** 
-     * Validates an XML document et prepares it for further storage. Launches prepare and postValidate triggers.
-     * Since the process is dependant from the collection configuration, the collection acquires a write lock during the process.
-     * 
-     * @param transaction
-     * @param broker
-     * @param docUri
-     * @param doValidate
-     * 
-     * @return An {@link IndexInfo} with a write lock on the document. 
-     * 
-     * @throws EXistException
-     * @throws PermissionDeniedException
-     * @throws TriggerException
-     * @throws SAXException
-     * @throws LockException
-     */
-    private IndexInfo validateXMLResourceInternal(final Txn transaction, final DBBroker broker, final XmldbURI docUri, final CollectionConfiguration config, final ValidateBlock doValidate) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
-        //Make the necessary operations if we process a collection configuration document
-        checkConfigurationDocument(transaction, broker, docUri);
-        
-        final Database db = broker.getBrokerPool();
-        
-        if (db.isReadOnly()) {
-            throw new IOException("Database is read-only");
-        }
-        
-        DocumentImpl oldDoc = null;
-        boolean oldDocLocked = false;
-
-        db.getProcessMonitor().startJob(ProcessMonitor.ACTION_VALIDATE_DOC, docUri);
-        getLock().acquire(Lock.WRITE_LOCK);
-        try {
-            DocumentImpl document = new DocumentImpl((BrokerPool) db, this, docUri);
-            oldDoc = documents.get(docUri.getRawCollectionPath());
-            checkPermissionsForAddDocument(broker, oldDoc);
-            checkCollectionConflict(docUri);
-            manageDocumentInformation(oldDoc, document);
-            final Indexer indexer = new Indexer(broker, transaction);
-            
-            final IndexInfo info = new IndexInfo(indexer, config);
-            info.setCreating(oldDoc == null);
-            info.setOldDocPermissions(oldDoc != null ? oldDoc.getPermissions() : null);
-            indexer.setDocument(document, config);
-            addObserversToIndexer(broker, indexer);
-            indexer.setValidating(true);
-            
-            if(CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI.equals(docUri)) {
-                // we are updating collection.xconf. Notify configuration manager
-                //CollectionConfigurationManager confMgr = broker.getBrokerPool().getConfigurationManager();
-                //confMgr.invalidateAll(getURI());
-                setCollectionConfigEnabled(false);
-            }
-            
-            final DocumentTriggers trigger = new DocumentTriggers(broker, indexer, this, isTriggersEnabled() ? config : null);
-            trigger.setValidating(true);
-            
-            info.setTriggers(trigger);
-
-            if(oldDoc == null) {
-                trigger.beforeCreateDocument(broker, transaction, getURI().append(docUri));
-            } else {
-                trigger.beforeUpdateDocument(broker, transaction, oldDoc);
-            }
-
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Scanning document " + getURI().append(docUri));
-            }
-            
-            doValidate.run(info);
-            // new document is valid: remove old document
-            if (oldDoc != null) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("removing old document " + oldDoc.getFileURI());
-                }
-                updateModificationTime(document);
-                oldDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
-                oldDocLocked = true;
-                if (oldDoc.getResourceType() == DocumentImpl.BINARY_FILE) {
-                    //TODO : use a more elaborated method ? No triggers...
-                    broker.removeBinaryResource(transaction, (BinaryDocument) oldDoc);
-                    documents.remove(oldDoc.getFileURI().getRawCollectionPath());
-                    //This lock is released in storeXMLInternal()
-                    //TODO : check that we go until there to ensure the lock is released
-//                    if (transaction != null)
-//                    	transaction.acquireLock(document.getUpdateLock(), Lock.WRITE_LOCK);
-//                	else
-                    document.getUpdateLock().acquire(Lock.WRITE_LOCK);
-                    
-                    document.setDocId(broker.getNextResourceId(transaction, this));
-                    addDocument(transaction, broker, document);
-                } else {
-                    //TODO : use a more elaborated method ? No triggers...
-                    broker.removeXMLResource(transaction, oldDoc, false);
-                    oldDoc.copyOf(document, true);
-                    indexer.setDocumentObject(oldDoc);
-                    //old has become new at this point
-                    document = oldDoc;
-                    oldDocLocked = false;		
-                }
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("removed old document " + oldDoc.getFileURI());
-                }
-            } else {
-                //This lock is released in storeXMLInternal()
-                //TODO : check that we go until there to ensure the lock is released
-//            	if (transaction != null)
-//                	transaction.acquireLock(document.getUpdateLock(), Lock.WRITE_LOCK);
-//            	else
-                document.getUpdateLock().acquire(Lock.WRITE_LOCK);
-            	
-                document.setDocId(broker.getNextResourceId(transaction, this));
-                addDocument(transaction, broker, document);
-            }
-            
-            trigger.setValidating(false);
-
-            return info;
-        } finally {
-            if (oldDoc != null && oldDocLocked) {
-                oldDoc.getUpdateLock().release(Lock.WRITE_LOCK);
-            }
-            getLock().release(Lock.WRITE_LOCK);
-            
-            db.getProcessMonitor().endJob();
-        }
-    }
-
-    private void checkConfigurationDocument(final Txn transaction, final DBBroker broker, final XmldbURI docUri) throws EXistException, PermissionDeniedException, LockException {
-        //Is it a collection configuration file ?
-        //TODO : use XmldbURI.resolve() !
-        if (!getURI().startsWith(XmldbURI.CONFIG_COLLECTION_URI)) {
-            return;
-        }
-        if(!docUri.endsWith(CollectionConfiguration.COLLECTION_CONFIG_SUFFIX_URI)) {
-            return;
-        }
-        //Allow just one configuration document per collection
-        //TODO : do not throw the exception if a system property allows several ones -pb
-        for(final Iterator<DocumentImpl> i = iterator(broker); i.hasNext(); ) {
-            final DocumentImpl confDoc = i.next();
-            final XmldbURI currentConfDocName = confDoc.getFileURI();
-            if(currentConfDocName != null && !currentConfDocName.equals(docUri)) {
-                throw new EXistException("Could not store configuration '" + docUri + "': A configuration document with a different name ("
-                    + currentConfDocName + ") already exists in this collection (" + getURI() + ")");
-            }
-        }
-        //broker.saveCollection(transaction, this);
-        //CollectionConfigurationManager confMgr = broker.getBrokerPool().getConfigurationManager();
-        //if(confMgr != null)
-            //try {
-                //confMgr.reload(broker, this);
-            // catch (CollectionConfigurationException e) {
-                //throw new EXistException("An error occurred while reloading the updated collection configuration: " + e.getMessage(), e);
-        //}
-    }
-
-    /** add observers to the indexer
-     * @param broker
-     * @param indexer
-     */
-    private void addObserversToIndexer(final DBBroker broker, final Indexer indexer) {
-        broker.deleteObservers();
-        if(observers != null) {
-            for (Observer observer : observers) {
-                indexer.addObserver(observer);
-                broker.addObserver(observer);
-            }
-        }
-    }
-
-
-    /** If an old document exists, keep information  about  the document.
-     * @param oldDoc
-     * @param document
-     */
-    private void manageDocumentInformation(final DocumentImpl oldDoc, final DocumentImpl document) {
-        DocumentMetadata metadata = new DocumentMetadata();
-        if (oldDoc != null) {
-            metadata = oldDoc.getMetadata();
-            metadata.setCreated(oldDoc.getMetadata().getCreated());
-            document.setPermissions(oldDoc.getPermissions());
-        } else {
-        	//Account user = broker.getCurrentSubject();
-                metadata.setCreated(System.currentTimeMillis());
-
-                /*
-            if(!document.getPermissions().getOwner().equals(user)) {
-                document.getPermissions().setOwner(broker.getCurrentSubject(), user);
-            }
-
-            CollectionConfiguration config = getConfiguration(broker);
-            if (config != null) {
-                document.getPermissions().setMode(config.getDefResPermissions());
-                group = config.getDefResGroup(user);
-            } else {
-                group = user.getPrimaryGroup();
-            }
-
-            if(!document.getPermissions().getGroup().equals(group)) {
-                document.getPermissions().setGroup(broker.getCurrentSubject(), group);
-            }*/
-        }
-        document.setMetadata(metadata);
-    }
-
-     /** Update the modification time of a document
-     * @param document
-     */
-    
-    private void updateModificationTime(final DocumentImpl document) {
-        final DocumentMetadata metadata = document.getMetadata();
-        metadata.setLastModified(System.currentTimeMillis());
-        document.setMetadata(metadata);
-    }
-    
-    /**
-     * Check Permissions about user and document when a document is added to the databse, and throw exceptions if necessary.
-     *
-     * @param broker
-     * @param oldDoc old Document existing in database prior to adding a new one with same name, or null if none exists
-     * @throws LockException
-     * @throws PermissionDeniedException
-     */
-    private void checkPermissionsForAddDocument(final DBBroker broker, final DocumentImpl oldDoc) throws LockException, PermissionDeniedException {
-        
-        // do we have execute permission on the collection?
-        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.EXECUTE)) {
-            throw new PermissionDeniedException("Execute permission is not granted on the Collection.");
-        }
-            
-        if(oldDoc != null) {   
-            
-            /* update document */
-            
-            LOG.debug("Found old doc " + oldDoc.getDocId());
-            
-            // check if the document is locked by another user
-            final Account lockUser = oldDoc.getUserLock();
-            if(lockUser != null && !lockUser.equals(broker.getCurrentSubject())) {
-                throw new PermissionDeniedException("The document is locked by user '" + lockUser.getName() + "'.");
-            }
-            
-            // do we have write permission on the old document or are we the owner of the old document?
-            if (!((oldDoc.getPermissions().getOwner().getId() == broker.getCurrentSubject().getId()) || (oldDoc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)))) {
-                throw new PermissionDeniedException("A resource with the same name already exists in the target collection '" + path + "', and you do not have write access on that resource.");
-            }
-        } else {
-            
-            /* create document */
-            
-            if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-                throw new PermissionDeniedException("Write permission is not granted on the Collection.");
-            }
-        }
-    }
-    
-    private void checkCollectionConflict(final XmldbURI docUri) throws EXistException, PermissionDeniedException {
-        if(subCollections.contains(docUri.lastSegment())) {
-            throw new EXistException(
-                "The collection '" + getURI() + "' already has a sub-collection named '" + docUri.lastSegment() + "', you cannot create a Document with the same name as an existing collection."
-            );
-        }
-    }
-
-    // Blob
-    @Deprecated
-    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI docUri, final byte[] data, final String mimeType) throws EXistException, PermissionDeniedException, LockException, TriggerException,IOException {
-        return addBinaryResource(transaction, broker, docUri, data, mimeType, null, null);
-    }
-
-    // Blob
-    @Deprecated
-    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI docUri, final byte[] data, final String mimeType, final Date created, final Date modified) throws EXistException, PermissionDeniedException, LockException, TriggerException,IOException {
-        return addBinaryResource(transaction, broker, docUri, new ByteArrayInputStream(data), mimeType, data.length, created, modified);
-    }
-
-    // Streaming
-    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI docUri, final InputStream is, final String mimeType, final long size) throws EXistException, PermissionDeniedException, LockException, TriggerException,IOException {
-        return addBinaryResource(transaction, broker, docUri, is, mimeType, size, null, null);
-    }
-
-    // Streaming
-    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI docUri, final InputStream is, final String mimeType, final long size, final Date created, final Date modified) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
-        final BinaryDocument blob = new BinaryDocument(broker.getBrokerPool(), this, docUri);
-        
-        return addBinaryResource(transaction, broker, blob, is, mimeType, size, created, modified);
-    }
-
-    public BinaryDocument validateBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI docUri, final InputStream is, final String mimeType, final long size, final Date created, final Date modified) throws PermissionDeniedException, LockException, TriggerException, IOException {
-        return new BinaryDocument(broker.getBrokerPool(), this, docUri);
-    }
-
-    /**
-     * Store a binary resource by reading the given InputStream.
-     *
-     * Locks the collection while the resource is being saved. Triggers will be called after the collection
-     * has been unlocked while keeping a lock on the resource to prevent modification.
-     *
-     * Callers should not lock the collection before calling this method as this may lead to deadlocks.
-     *
-     * @param transaction the transaction to use
-     * @param broker current broker
-     * @param blob the binary resource to store the data into
-     * @param is the input stream to read data from
-     * @param mimeType mime-type for the data
-     * @param size size hint to be stored with metadata
-     * @param created creation timestamp
-     * @param modified last modified timestamp
-     * @return the updated binary document
-     * @throws EXistException
-     * @throws PermissionDeniedException
-     * @throws LockException
-     * @throws TriggerException
-     * @throws IOException
-     */
-    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final BinaryDocument blob, final InputStream is, final String mimeType, final long size, final Date created, final Date modified) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
-        final Database db = broker.getBrokerPool();
-        if (db.isReadOnly()) {
-            throw new IOException("Database is read-only");
-        }
-        final XmldbURI docUri = blob.getFileURI();
-        //TODO : move later, i.e. after the collection lock is acquired ?
-        final DocumentImpl oldDoc = getDocument(broker, docUri);
-        final DocumentTriggers trigger = new DocumentTriggers(broker, null, this, isTriggersEnabled() ? getConfiguration(broker) : null);
-
-        getLock().acquire(Lock.WRITE_LOCK);
-        try {
-            db.getProcessMonitor().startJob(ProcessMonitor.ACTION_STORE_BINARY, docUri);
-            checkPermissionsForAddDocument(broker, oldDoc);
-            checkCollectionConflict(docUri);
-            manageDocumentInformation(oldDoc, blob);
-            final DocumentMetadata metadata = blob.getMetadata();
-            metadata.setMimeType(mimeType == null ? MimeType.BINARY_TYPE.getName() : mimeType);
-            if (created != null) {
-                metadata.setCreated(created.getTime());
-            }
-            if (modified != null) {
-                metadata.setLastModified(modified.getTime());
-            }
-            blob.setContentLength(size);
-            
-            if (oldDoc == null) {
-                trigger.beforeCreateDocument(broker, transaction, blob.getURI());
-            } else {
-                trigger.beforeUpdateDocument(broker, transaction, oldDoc);
-            }
-
-            if (oldDoc != null) {
-                LOG.debug("removing old document " + oldDoc.getFileURI());
-                updateModificationTime(blob);
-                broker.removeResource(transaction, oldDoc);
-            }
-
-            broker.storeBinaryResource(transaction, blob, is);
-            addDocument(transaction, broker, blob, oldDoc);
-
-            final IndexController indexController = broker.getIndexController();
-            final StreamListener listener = indexController.getStreamListener(blob, StreamListener.ReindexMode.STORE);
-            indexController.startIndexDocument(transaction, listener);
-            try {
-                broker.storeXMLResource(transaction, blob);
-            } finally {
-                indexController.endIndexDocument(transaction, listener);
-            }
-
-            blob.getUpdateLock().acquire(Lock.READ_LOCK);
-        } finally {
-            broker.getBrokerPool().getProcessMonitor().endJob();
-            getLock().release(Lock.WRITE_LOCK);
-        }
-        try {
-            if (oldDoc == null) {
-                trigger.afterCreateDocument(broker, transaction, blob);
-            } else {
-                trigger.afterUpdateDocument(broker, transaction, blob);
-            }
-        } finally {
-            blob.getUpdateLock().release(Lock.READ_LOCK);
-        }
-        return blob;
-    }
-
-    public void setId(int id) {
-        this.collectionId = id;
-    }
-
-    public void setPermissions(final int mode) throws LockException, PermissionDeniedException {
-        try {
-            getLock().acquire(Lock.WRITE_LOCK);
-            permissions.setMode(mode);
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    @Deprecated
-    public void setPermissions(final String mode) throws SyntaxException, LockException, PermissionDeniedException {
-        try {
-            getLock().acquire(Lock.WRITE_LOCK);
-            permissions.setMode(mode);
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    /**
-     * Set permissions for the collection.
-     *
-     * @param permissions
-     *
-     * @deprecated This function is considered a security problem
-     * and should be removed, move code to copyOf or Constructor
-     */
-    @Deprecated
-    public void setPermissions(final Permission permissions) throws LockException {
-        try {
-            getLock().acquire(Lock.WRITE_LOCK);
-            this.permissions = permissions;
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    public CollectionConfiguration getConfiguration(final DBBroker broker) {
-        if(!isCollectionConfigEnabled()) {
-            return null;
-        }
-        
-        final CollectionConfigurationManager manager = broker.getBrokerPool().getConfigurationManager();
-        if(manager == null) {
-            return null;
-        }
-        //Attempt to get configuration
-        CollectionConfiguration configuration = null;
-        try {
-            //TODO: AR: if a Trigger throws CollectionConfigurationException
-            //from its configure() method, is the rest of the collection 
-            //configuration (indexes etc.) ignored even though they might be fine?
-            configuration = manager.getConfiguration(broker, this);
-            setCollectionConfigEnabled(true);
-        } catch(final CollectionConfigurationException e) {
-            setCollectionConfigEnabled(false);
-            LOG.warn("Failed to load collection configuration for '" + getURI() + "'", e);
-        }
-        return configuration;
-    }
-
-    /**
-     * Should the collection configuration document be enabled
-     * for this collection? Called by {@link org.exist.storage.NativeBroker}
-     * before doing a re-index.
-     *
-     * @param collectionConfigEnabled
-     */
-    public void setCollectionConfigEnabled(final boolean collectionConfigEnabled) {
-        this.collectionConfigEnabled = collectionConfigEnabled;
-    }
-
-    public boolean isCollectionConfigEnabled() {
-        return collectionConfigEnabled;
-    }
-
-    /**
-     * Set the internal storage address of the collection data.
-     *
-     * @param addr
-     */
-    public void setAddress(final long addr) {
-        this.address = addr;
-    }
-
-    public long getAddress() {
-        return this.address;
-    }
-
-    public void setCreationTime(final long ms) {
-        created = ms;
-    }
-
-    /**
-     * @deprecated Use {@link #getMetadata()} {@link CollectionMetadata#getCreated()}
-     */
-    @Deprecated
-    public long getCreationTime() {
-        return created;
-    }
-
-    /*** TODO why do we need this? is it just for the versioning trigger?
-     * If so we need to enable/disable specific triggers!
-     ***/
-    public void setTriggersEnabled(final boolean enabled) {
-        try {
-            getLock().acquire(Lock.WRITE_LOCK);
-            this.triggersEnabled = enabled;
-        } catch(final LockException e) {
-            LOG.warn(e.getMessage(), e);
-            //Ouch ! -pb
-            this.triggersEnabled = enabled;
-        } finally {
-            getLock().release(Lock.WRITE_LOCK);
-        }
-    }
-
-    /** set user-defined Reader */
-    public void setReader(final XMLReader reader){
-        userReader = reader;
-    }
-
-    /** 
-     * Get xml reader from readerpool and setup validation when needed.
-     */
-    private XMLReader getReader(final DBBroker broker, final boolean validation, final CollectionConfiguration colconfig) {
-        // If user-defined Reader is set, return it;
-        if (userReader != null) {
-            return userReader;
-        }
-        // Get reader from readerpool.
-        final XMLReader reader = broker.getBrokerPool().getParserPool().borrowXMLReader();
-        
-        // If Collection configuration exists (try to) get validation mode
-        // and setup reader with this information.
-        if (!validation) {
-            XMLReaderObjectFactory.setReaderValidationMode(XMLReaderObjectFactory.VALIDATION_SETTING.DISABLED, reader);
-            
-        } else if( colconfig!=null ) {
-            final VALIDATION_SETTING mode = colconfig.getValidationMode();
-            XMLReaderObjectFactory.setReaderValidationMode(mode, reader);
-        }
-        // Return configured reader.
-        return reader;
-    }
-
-    /**
-     * Reset validation mode of reader and return reader to reader pool.
-     */    
-    private void releaseReader(final DBBroker broker, final IndexInfo info, final XMLReader reader) {
-        if(userReader != null){
-            return;
-        }
-        
-        if(info.getIndexer().getDocSize() > POOL_PARSER_THRESHOLD) {
-            return;
-        }
-        
-        // Get validation mode from static configuration
-        final Configuration config = broker.getConfiguration();
-        final String optionValue = (String) config.getProperty(XMLReaderObjectFactory.PROPERTY_VALIDATION_MODE);
-        final VALIDATION_SETTING validationMode = XMLReaderObjectFactory.convertValidationMode(optionValue);
-        
-        // Restore default validation mode
-        XMLReaderObjectFactory.setReaderValidationMode(validationMode, reader);
-        
-        // Return reader
-        broker.getBrokerPool().getParserPool().returnXMLReader(reader);
-    }
-
-    /* (non-Javadoc)
-     * @see java.util.Observable#addObserver(java.util.Observer)
-     */
-    @Override
-    public synchronized void addObserver(final Observer o) {
-        if(hasObserver(o)) {
-            return;
-        }
-        if(observers == null) {
-            observers = new Observer[1];
-            observers[0] = o;
-        } else {
-            final Observer n[] = new Observer[observers.length + 1];
-            System.arraycopy(observers, 0, n, 0, observers.length);
-            n[observers.length] = o;
-            observers = n;
-        }
-    }
-
-    private boolean hasObserver(final Observer o) {
-        if(observers == null) {
-            return false;
-        }
-        for (Observer observer : observers) {
-            if (observer == o) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /* (non-Javadoc)
-     * @see java.util.Observable#deleteObservers()
-     */
-    @Override
-    public synchronized void deleteObservers() {
-        if(observers != null) {
-            observers = null;
-        }
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.storage.cache.Cacheable#getKey()
-     */
-    @Override
-    public long getKey() {
-        return collectionId;
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.storage.cache.Cacheable#getReferenceCount()
-     */
-    @Override
-    public int getReferenceCount() {
-        return refCount;
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.storage.cache.Cacheable#incReferenceCount()
-     */
-    @Override
-    public int incReferenceCount() {
-        return ++refCount;
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.storage.cache.Cacheable#decReferenceCount()
-     */
-    @Override
-    public int decReferenceCount() {
-        return refCount > 0 ? --refCount : 0;
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.storage.cache.Cacheable#setReferenceCount(int)
-     */
-    @Override
-    public void setReferenceCount(final int count) {
-        refCount = count;
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.storage.cache.Cacheable#setTimestamp(int)
-     */
-    @Override
-    public void setTimestamp(final int timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.storage.cache.Cacheable#getTimestamp()
-     */
-    @Override
-    public int getTimestamp() {
-        return timestamp;
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.storage.cache.Cacheable#release()
-     */
-    @Override
-    public boolean sync(final boolean syncJournal) {
-        return false;
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.storage.cache.Cacheable#isDirty()
-     */
-    @Override
-    public boolean isDirty() {
-        return false;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder buf = new StringBuilder();
-        buf.append( getURI() );
-        buf.append("[");
-
-        try {
-            for (final Iterator<String> i = copyOfDocNames().iterator(); i.hasNext(); ) {
-                buf.append(i.next());
-                if (i.hasNext()) {
-                    buf.append(", ");
-                }
-            }
-        } catch(final LockException e) {
-            LOG.error(e);
-            throw new IllegalStateException(e);
-        }
-        buf.append("]");
-        return buf.toString();
-    }
-
-    /**
-     * (Make private?)
-     * @param broker
-     */
-    public IndexSpec getIndexConfiguration(final DBBroker broker) {
-        final CollectionConfiguration conf = getConfiguration(broker);
-        //If the collection has its own config...
-        if (conf == null) {
-            return broker.getIndexConfiguration();
-        }
-        //... otherwise return the general config (the broker's one)
-        return conf.getIndexConfiguration();
-    }
-
-    public GeneralRangeIndexSpec getIndexByPathConfiguration(final DBBroker broker, final NodePath path) {
-        final IndexSpec idxSpec = getIndexConfiguration(broker);
-        return (idxSpec == null) ? null : idxSpec.getIndexByPath(path);
-    }
-
-    public QNameRangeIndexSpec getIndexByQNameConfiguration(final DBBroker broker, final QName qname) {
-        final IndexSpec idxSpec = getIndexConfiguration(broker);
-        return (idxSpec == null) ? null : idxSpec.getIndexByQName(qname);
     }
 }

--- a/src/org/exist/collections/CollectionCache.java
+++ b/src/org/exist/collections/CollectionCache.java
@@ -29,6 +29,7 @@ import org.exist.storage.BrokerPoolService;
 import org.exist.storage.CacheManager;
 import org.exist.storage.cache.LRUCache;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.hashtable.Object2LongHashMap;
 import org.exist.util.hashtable.SequencedLongHashMap;
 import org.exist.xmldb.XmldbURI;
@@ -97,7 +98,7 @@ public class CollectionCache extends LRUCache<Collection> implements BrokerPoolS
             final Collection cached = next.getValue();
             if(cached.getKey() != item.getKey()) {
                 final Lock lock = cached.getLock();
-                if (lock.attempt(Lock.READ_LOCK)) {
+                if (lock.attempt(LockMode.READ_LOCK)) {
                     try {
                         if (cached.allowUnload()) {
                             if(pool.getConfigurationManager() != null) { // might be null during db initialization
@@ -109,7 +110,7 @@ public class CollectionCache extends LRUCache<Collection> implements BrokerPoolS
                             removed = true;
                         }
                     } finally {
-                        lock.release(Lock.READ_LOCK);
+                        lock.release(LockMode.READ_LOCK);
                     }
                 }
             }

--- a/src/org/exist/collections/CollectionConfigurationManager.java
+++ b/src/org/exist/collections/CollectionConfigurationManager.java
@@ -24,10 +24,9 @@ import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.memtree.SAXAdapter;
-import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.*;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.Locked;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -447,7 +446,7 @@ public class CollectionConfigurationManager implements BrokerPoolService {
         try(final Txn txn = transact.beginTransaction()) {
             Collection collection = null;
             try {
-                collection = broker.openCollection(XmldbURI.ROOT_COLLECTION_URI, Lock.READ_LOCK);
+                collection = broker.openCollection(XmldbURI.ROOT_COLLECTION_URI, LockMode.READ_LOCK);
                 if (collection == null) {
                     transact.abort(txn);
                     throw new EXistException("collection " + XmldbURI.ROOT_COLLECTION_URI + " not found!");
@@ -463,7 +462,7 @@ public class CollectionConfigurationManager implements BrokerPoolService {
                 }
             } finally {
                 if (collection != null) {
-                    collection.release(Lock.READ_LOCK);
+                    collection.release(LockMode.READ_LOCK);
                 }
             }
             // Configure the root collection

--- a/src/org/exist/collections/CollectionConfigurationManager.java
+++ b/src/org/exist/collections/CollectionConfigurationManager.java
@@ -132,7 +132,7 @@ public class CollectionConfigurationManager implements BrokerPoolService {
             broker.saveCollection(txn, confCol);
             final IndexInfo info = confCol.validateXMLResource(txn, broker, configurationDocumentName, config);
             // TODO : unlock the collection here ?
-            confCol.store(txn, broker, info, config, false);
+            confCol.store(txn, broker, info, config);
             // broker.sync(Sync.MAJOR_SYNC);
         } catch (final CollectionConfigurationException e) {
             throw e;

--- a/src/org/exist/collections/MutableCollection.java
+++ b/src/org/exist/collections/MutableCollection.java
@@ -1,0 +1,2016 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2015 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.collections;
+
+import com.evolvedbinary.j8fu.function.Consumer2E;
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.NotThreadSafe;
+import org.exist.dom.QName;
+import org.exist.dom.persistent.DocumentMetadata;
+import org.exist.dom.persistent.DocumentSet;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.MutableDocumentSet;
+import org.exist.dom.persistent.BinaryDocument;
+import org.exist.dom.persistent.DefaultDocumentSet;
+import java.io.*;
+import java.util.*;
+import java.util.function.Consumer;
+
+import org.apache.commons.io.input.CloseShieldInputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.Database;
+import org.exist.EXistException;
+import org.exist.Indexer;
+import org.exist.collections.triggers.*;
+import org.exist.indexing.IndexController;
+import org.exist.indexing.StreamListener;
+import org.exist.security.Account;
+import org.exist.security.Permission;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.PermissionFactory;
+import org.exist.security.Subject;
+import org.exist.storage.*;
+import org.exist.storage.index.BFile;
+import org.exist.storage.io.VariableByteInput;
+import org.exist.storage.io.VariableByteOutputStream;
+import org.exist.storage.lock.*;
+import org.exist.storage.sync.Sync;
+import org.exist.storage.txn.Txn;
+import org.exist.util.Configuration;
+import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.SyntaxException;
+import org.exist.util.XMLReaderObjectFactory;
+import org.exist.util.XMLReaderObjectFactory.VALIDATION_SETTING;
+import org.exist.util.hashtable.ObjectHashSet;
+import org.exist.util.serializer.DOMStreamer;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.Constants;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+/**
+ * An implementation of {@link Collection} that allows
+ * mutations to be made to the Collection object
+ *
+ * Locks should be taken appropriately for any mutation
+ */
+@NotThreadSafe
+public class MutableCollection implements Collection {
+
+    private static final Logger LOG = LogManager.getLogger(Collection.class);
+    private static final int SHALLOW_SIZE = 550;
+    private static final int DOCUMENT_SIZE = 450;
+    private static final int POOL_PARSER_THRESHOLD = 500;
+
+    private int collectionId = UNKNOWN_COLLECTION_ID;
+    private XmldbURI path;
+    private final Lock lock;
+    @GuardedBy("lock") private final Map<String, DocumentImpl> documents = new TreeMap<>();
+    @GuardedBy("lock") private ObjectHashSet<XmldbURI> subCollections = new ObjectHashSet<>(19);
+    private long address = BFile.UNKNOWN_ADDRESS;  // Storage address of the collection in the BFile
+    private long created = 0;
+    private volatile boolean collectionConfigEnabled = true;
+    private boolean triggersEnabled = true;
+    private XMLReader userReader;
+    private boolean isTempCollection;
+    private Permission permissions;
+    private final CollectionMetadata collectionMetadata;
+    private final ObservaleMutableCollection observable = new ObservaleMutableCollection();
+
+    // fields required by the collections cache
+    private int refCount;
+    private int timestamp;
+
+    /**
+     * Constructs a Collection Object (not yet persisted)
+     *
+     * @param broker The database broker
+     * @param path The path of the Collection
+     */
+    public MutableCollection(final DBBroker broker, final XmldbURI path) {
+        //The permissions assigned to this collection
+        permissions = PermissionFactory.getDefaultCollectionPermission(broker.getBrokerPool().getSecurityManager());
+
+        setPath(path);
+        lock = new ReentrantReadWriteLock(path);
+        this.collectionMetadata = new CollectionMetadata(this);
+    }
+
+    /**
+     * Deserializes a Collection object
+     *
+     * Counterpart method to {@link #serialize(VariableByteOutputStream)}
+     *
+     * @param broker The database broker
+     * @param path The path of the Collection
+     * @param inputStream The input stream to deserialize the Collection from
+     *
+     * @return The Collection Object
+     */
+    public static MutableCollection load(final DBBroker broker, final XmldbURI path, final VariableByteInput inputStream)
+            throws PermissionDeniedException, IOException, LockException {
+        final MutableCollection collection = new MutableCollection(broker, path);
+        collection.deserialize(broker, inputStream);
+        return collection;
+    }
+
+    @Override
+    public boolean isTriggersEnabled() {
+        return triggersEnabled;
+    }
+
+    @Override
+    public final void setPath(XmldbURI path) {
+        path = path.toCollectionPathURI();
+        //TODO : see if the URI resolves against DBBroker.TEMP_COLLECTION
+        isTempCollection = path.getRawCollectionPath().equals(XmldbURI.TEMP_COLLECTION);
+        this.path=path;
+    }
+
+    @Override
+    public Lock getLock() {
+        return lock;
+    }
+
+    @Override
+    public void addCollection(final DBBroker broker, final Collection child, final boolean isNew)
+            throws PermissionDeniedException, LockException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+            throw new PermissionDeniedException("Permission to write to Collection denied for " + this.getURI());
+        }
+        
+        final XmldbURI childName = child.getURI().lastSegment();
+
+        getLock().acquire(Lock.WRITE_LOCK);
+        try {
+            if (!subCollections.contains(childName)) {
+                subCollections.add(childName);
+            }
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+
+        if(isNew) {
+            child.setCreationTime(System.currentTimeMillis());
+        }
+    }
+
+    @Override
+    public List<CollectionEntry> getEntries(final DBBroker broker) throws PermissionDeniedException, LockException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+        final List<CollectionEntry> list = new ArrayList<>();
+
+        final Iterator<XmldbURI> subCollectionIterator;
+        getLock().acquire(Lock.READ_LOCK);
+        try {
+            subCollectionIterator = subCollections.stableIterator();
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+        while(subCollectionIterator.hasNext()) {
+            final XmldbURI subCollectionURI = subCollectionIterator.next();
+            final CollectionEntry entry = new SubCollectionEntry(broker.getBrokerPool().getSecurityManager(),
+                    subCollectionURI);
+            entry.readMetadata(broker);
+            list.add(entry);
+        }
+
+        for(final DocumentImpl document : copyOfDocs()) {
+            final CollectionEntry entry = new DocumentEntry(document);
+            entry.readMetadata(broker);
+            list.add(entry);
+        }
+        return list;
+    }
+
+    @Override
+    public CollectionEntry getChildCollectionEntry(final DBBroker broker, final String name)
+            throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+        final XmldbURI subCollectionURI = getURI().append(name);
+        final CollectionEntry entry = new SubCollectionEntry(broker.getBrokerPool().getSecurityManager(),
+                subCollectionURI);
+        entry.readMetadata(broker);
+        return entry;
+    }
+
+    @Override
+    public CollectionEntry getResourceEntry(final DBBroker broker, final String name)
+            throws PermissionDeniedException, LockException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+
+        final CollectionEntry entry;
+        getLock().acquire(Lock.READ_LOCK);
+        try {
+            entry = new DocumentEntry(documents.get(name));
+        }  finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+
+        entry.readMetadata(broker);
+        return entry;
+    }
+
+    @Override
+    public boolean isTempCollection() {
+        return isTempCollection;
+    }
+
+    @Override
+    public void release(final int mode) {
+        getLock().release(mode);
+    }
+
+    @Override
+    public void update(final DBBroker broker, final Collection child) throws PermissionDeniedException, LockException {
+        final XmldbURI childName = child.getURI().lastSegment();
+        getLock().acquire(Lock.WRITE_LOCK);
+        try {
+            subCollections.remove(childName);
+            subCollections.add(childName);
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public void addDocument(final Txn transaction, final DBBroker broker, final DocumentImpl doc)
+            throws PermissionDeniedException, LockException {
+        addDocument(transaction, broker, doc, null);
+    }
+    
+    /**
+     * @param oldDoc if not null, then this document is replacing another and so WRITE access on the collection is not required,
+     * just WRITE access on the old document
+     */
+    private void addDocument(final Txn transaction, final DBBroker broker, final DocumentImpl doc,
+            final DocumentImpl oldDoc) throws PermissionDeniedException, LockException {
+        if(oldDoc == null) {
+            
+            /* create */
+            if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+                throw new PermissionDeniedException("Permission to write to Collection denied for " + this.getURI());
+            }
+        } else {
+            
+            /* update-replace */
+            if(!oldDoc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+                throw new PermissionDeniedException("Permission to write to overwrite document: " +  oldDoc.getURI());
+            }
+        }
+        
+        if (doc.getDocId() == DocumentImpl.UNKNOWN_DOCUMENT_ID) {
+            try {
+                doc.setDocId(broker.getNextResourceId(transaction, this));
+            } catch(final EXistException e) {
+                LOG.error("Collection error " + e.getMessage(), e);
+                // TODO : re-raise the exception ? -pb
+                return;
+            }
+        }
+
+        getLock().acquire(Lock.WRITE_LOCK);
+        try {
+            documents.put(doc.getFileURI().getRawCollectionPath(), doc);
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public void unlinkDocument(final DBBroker broker, final DocumentImpl doc) throws PermissionDeniedException,
+            LockException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+            throw new PermissionDeniedException("Permission denied to remove document from collection: " + path);
+        }
+
+        getLock().acquire(Lock.WRITE_LOCK);
+        try {
+            documents.remove(doc.getFileURI().getRawCollectionPath());
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public Iterator<XmldbURI> collectionIterator(final DBBroker broker) throws PermissionDeniedException, LockException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission to list sub-collections denied on " + this.getURI());
+        }
+
+        getLock().acquire(Lock.READ_LOCK);
+        try {
+            return subCollections.stableIterator();
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+    }
+
+    @Override
+    public Iterator<XmldbURI> collectionIteratorNoLock(final DBBroker broker) throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission to list sub-collections denied on " + this.getURI());
+        }
+        return subCollections.stableIterator();
+    }
+
+    @Override
+    public List<Collection> getDescendants(final DBBroker broker, final Subject user) throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission to list sub-collections denied on " + this.getURI());
+        }
+
+        final ArrayList<Collection> collectionList;
+        final Iterator<XmldbURI> i;
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            try {
+                collectionList = new ArrayList<>(subCollections.size());
+                i = subCollections.stableIterator();
+            } finally {
+                getLock().release(Lock.READ_LOCK);
+            }
+        } catch(final LockException e) {
+            LOG.error(e.getMessage(), e);
+            return Collections.emptyList();
+        }
+
+        while(i.hasNext()) {
+            final XmldbURI childName = i.next();
+            //TODO : resolve URI !
+            final Collection child = broker.getCollection(path.append(childName));
+            if(getPermissionsNoLock().validate(user, Permission.READ)) {
+                collectionList.add(child);
+                if(child.getChildCollectionCount(broker) > 0) {
+                    //Recursive call
+                    collectionList.addAll(child.getDescendants(broker, user));
+                }
+            }
+        }
+
+        return collectionList;
+    }
+
+    @Override
+    public MutableDocumentSet allDocs(final DBBroker broker, final MutableDocumentSet docs, final boolean recursive)
+            throws PermissionDeniedException {
+        return allDocs(broker, docs, recursive, null);
+    }
+
+    @Override
+    public MutableDocumentSet allDocs(final DBBroker broker, final MutableDocumentSet docs, final boolean recursive,
+            final LockedDocumentMap lockMap) throws PermissionDeniedException {
+        List<XmldbURI> subColls = null;
+        if(getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            try {
+                getLock().acquire(Lock.READ_LOCK);
+                try {
+                    //Add all docs in this collection to the returned set
+                    getDocuments(broker, docs);
+                    //Get a list of sub-collection URIs. We will process them
+                    //after unlocking this collection. otherwise we may deadlock ourselves
+                    subColls = subCollections.keys();
+                } finally {
+                    getLock().release(Lock.READ_LOCK);
+                }
+            } catch(final LockException e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+
+        if(recursive && subColls != null) {
+            // process the child collections
+            for(final XmldbURI childName : subColls) {
+                //TODO : resolve URI !
+                try {
+                    final Collection child = broker.openCollection(path.appendInternal(childName), Lock.NO_LOCK);
+                    //A collection may have been removed in the meantime, so check first
+                    if(child != null) {
+                        child.allDocs(broker, docs, recursive, lockMap);
+                    }
+                } catch(final PermissionDeniedException pde) {
+                    //SKIP to next collection
+                    //TODO create an audit log??!
+                }
+            }
+        }
+        return docs;
+    }
+
+    @Override
+    public DocumentSet allDocs(final DBBroker broker, final MutableDocumentSet docs, final boolean recursive,
+            final LockedDocumentMap lockMap, final int lockType) throws LockException, PermissionDeniedException {
+        
+        XmldbURI uris[] = null;
+        if(getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            getLock().acquire(Lock.READ_LOCK);
+            try {
+                //Add all documents in this collection to the returned set
+                getDocuments(broker, docs, lockMap, lockType);
+                //Get a list of sub-collection URIs. We will process them
+                //after unlocking this collection.
+                //otherwise we may deadlock ourselves
+                final List<XmldbURI> subColls = subCollections.keys();
+                if (subColls != null) {
+                    uris = new XmldbURI[subColls.size()];
+                    for(int i = 0; i < subColls.size(); i++) {
+                        uris[i] = path.appendInternal(subColls.get(i));
+                    }
+                }
+            } finally {
+                getLock().release(Lock.READ_LOCK);
+            }
+        }
+
+        if(recursive && uris != null) {
+            //Process the child collections
+            for (XmldbURI uri : uris) {
+                //TODO : resolve URI !
+                try {
+                    final Collection child = broker.openCollection(uri, Lock.NO_LOCK);
+                    // a collection may have been removed in the meantime, so check first
+                    if (child != null) {
+                        child.allDocs(broker, docs, recursive, lockMap, lockType);
+                    }
+                } catch (final PermissionDeniedException pde) {
+                    //SKIP to next collection
+                    //TODO create an audit log??!
+                }
+            }
+        }
+        return docs;
+    }
+
+    @Override
+    public DocumentSet
+    getDocuments(final DBBroker broker, final MutableDocumentSet docs)
+            throws PermissionDeniedException, LockException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+        
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            docs.addCollection(this);
+            addDocumentsToSet(broker, docs);
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+        
+        return docs;
+    }
+
+    @Override
+    public DocumentSet getDocumentsNoLock(final DBBroker broker, final MutableDocumentSet docs) {
+        docs.addCollection(this);
+        addDocumentsToSet(broker, docs);
+        return docs;
+    }
+
+    @Override
+    public DocumentSet getDocuments(final DBBroker broker, final MutableDocumentSet docs,
+            final LockedDocumentMap lockMap, final int lockType) throws LockException, PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+        
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            docs.addCollection(this);
+            addDocumentsToSet(broker, docs, lockMap, lockType);
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+        return docs;
+    }
+
+    /**
+     * Gets a stable list of the document objects
+     * from {@link #documents}
+     *
+     * @return A stable list of the document objects
+     */
+    private List<DocumentImpl> copyOfDocs() throws LockException {
+        getLock().acquire(Lock.READ_LOCK);
+        try {
+            return new ArrayList<>(documents.values());
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+    }
+
+    /**
+     * Gets a stable set of the the document object
+     * names from {@link #documents}
+     *
+     * @return A stable set of the document names
+     */
+    private Set<String> copyOfDocNames() throws LockException {
+        getLock().acquire(Lock.READ_LOCK);
+        try {
+            return new TreeSet<>(documents.keySet());
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+    }
+
+    private void addDocumentsToSet(final DBBroker broker, final MutableDocumentSet docs, final LockedDocumentMap lockMap, final int lockType) throws LockException {
+    	for(final DocumentImpl doc : copyOfDocs()) {
+            if(doc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+                doc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+
+                docs.add(doc);
+                lockMap.add(doc);
+            }
+    	}
+    }
+    
+    private void addDocumentsToSet(final DBBroker broker, final MutableDocumentSet docs) {
+    	try {
+            for (final DocumentImpl doc : copyOfDocs()) {
+                if (doc.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
+                    docs.add(doc);
+                }
+            }
+        } catch(final LockException e) {
+            LOG.error(e);
+        }
+    }
+
+    @Override
+    public boolean allowUnload() {
+        if (getURI().startsWith(CollectionConfigurationManager.ROOT_COLLECTION_CONFIG_URI)) {
+            return false;
+        }
+
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            try {
+                for (final DocumentImpl doc : documents.values()) {
+                    if (doc.isLockedForWrite()) {
+                        return false;
+                    }
+                }
+                return true;
+            } finally {
+                getLock().release(Lock.READ_LOCK);
+            }
+        } catch(final LockException e) {
+            LOG.error(e);
+            return false;
+        }
+    }
+
+    @Override
+    public int compareTo(final Collection other) {
+        Objects.requireNonNull(other);
+
+        if(collectionId == other.getId()) {
+            return Constants.EQUAL;
+        } else if(collectionId < other.getId()) {
+            return Constants.INFERIOR;
+        } else {
+            return Constants.SUPERIOR;
+        }
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if(obj == null || !(obj instanceof Collection)) {
+            return false;
+        }
+
+        return ((Collection) obj).getId() == collectionId;
+    }
+
+    @Override
+    public int getMemorySize() {
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            try {
+                return SHALLOW_SIZE + documents.size() * DOCUMENT_SIZE;
+            } finally {
+                getLock().release(Lock.READ_LOCK);
+            }
+        } catch(final LockException e) {
+            LOG.error(e);
+            return -1;
+        }
+    }
+
+    @Override
+    public int getChildCollectionCount(final DBBroker broker) throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            try {
+                return subCollections.size();
+            } finally {
+                getLock().release(Lock.READ_LOCK);
+            }
+        } catch(final LockException e) {
+            LOG.error(e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    @Override
+    public boolean isEmpty(final DBBroker broker) throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            try {
+                return documents.isEmpty() && subCollections.isEmpty();
+            } finally {
+                getLock().release(Lock.READ_LOCK);
+            }
+        } catch(final LockException e) {
+            LOG.error(e.getMessage(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public DocumentImpl getDocument(final DBBroker broker, final XmldbURI name) throws PermissionDeniedException {
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            try {
+                final DocumentImpl doc = documents.get(name.getRawCollectionPath());
+                if (doc != null) {
+                    if (!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
+                        throw new PermissionDeniedException("Permission denied to read document: " + name.toString());
+                    }
+                } else {
+                    LOG.debug("Document " + name + " not found!");
+                }
+
+                return doc;
+            } finally {
+                getLock().release(Lock.READ_LOCK);
+            }
+        } catch(final LockException e) {
+            LOG.error(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    @Override
+    public DocumentImpl getDocumentWithLock(final DBBroker broker, final XmldbURI name) throws LockException, PermissionDeniedException {
+    	return getDocumentWithLock(broker, name, Lock.READ_LOCK);
+    }
+
+    @Override
+    public DocumentImpl getDocumentWithLock(final DBBroker broker, final XmldbURI name, final int lockMode) throws LockException, PermissionDeniedException {
+        getLock().acquire(Lock.READ_LOCK);
+        try {
+            final DocumentImpl doc = documents.get(name.getRawCollectionPath());
+            if(doc != null) {
+                if(!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
+                    throw new PermissionDeniedException("Permission denied to read document: " + name.toString());
+                }
+            	doc.getUpdateLock().acquire(lockMode);
+            }
+            return doc;
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+    }
+
+    @Override
+    public DocumentImpl getDocumentNoLock(final DBBroker broker, final String rawPath) throws PermissionDeniedException {
+        final DocumentImpl doc = documents.get(rawPath);
+        if(doc != null) {
+            if(!doc.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
+                throw new PermissionDeniedException("Permission denied to read document: " + rawPath);
+            }
+        }
+        return doc;
+    }
+
+    @Override
+    public void releaseDocument(final DocumentImpl doc) {
+        if(doc != null) {
+            doc.getUpdateLock().release(Lock.READ_LOCK);
+        }
+    }
+
+    @Override
+    public void releaseDocument(final DocumentImpl doc, final int mode) {
+        if(doc != null) {
+            doc.getUpdateLock().release(mode);
+        }
+    }
+
+    @Override
+    public int getDocumentCount(final DBBroker broker) throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            try {
+                return documents.size();
+            } finally {
+                getLock().release(Lock.READ_LOCK);
+            }
+        } catch(final LockException e) {
+            LOG.warn(e.getMessage(), e);
+            return -1;
+        }
+    }
+
+    @Override
+    public int getDocumentCountNoLock(final DBBroker broker) throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+        return documents.size();
+    }
+
+    @Override
+    public int getId() {
+        return collectionId;
+    }
+
+    @Override
+    public XmldbURI getURI() {
+        return path;
+    }
+
+    /**
+     * Returns the parent-collection.
+     *
+     * @return The parent-collection or null if this is the root collection.
+     */
+    @Override
+    public XmldbURI getParentURI() {
+        if(path.equals(XmldbURI.ROOT_COLLECTION_URI)) {
+            return null;
+        }
+        //TODO : resolve URI against ".." !
+         return path.removeLastSegment();
+    }
+
+    @Override
+    final public Permission getPermissions() {
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            return permissions;
+        } catch(final LockException e) {
+            LOG.error(e.getMessage(), e);
+            return permissions;
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+    }
+
+    @Override
+    public Permission getPermissionsNoLock() {
+        return permissions;
+    }
+
+    @Override
+    public CollectionMetadata getMetadata() {
+        return collectionMetadata;
+    }
+
+    @Override
+    public boolean hasDocument(final DBBroker broker, final XmldbURI name) throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            try {
+                return documents.containsKey(name.getRawCollectionPath());
+            } finally {
+                getLock().release(Lock.READ_LOCK);
+            }
+        } catch(final LockException e) {
+            LOG.warn(e.getMessage(), e);
+            //TODO : ouch ! Should we return at any price ? Xithout even logging ? -pb
+            return documents.containsKey(name.getRawCollectionPath());
+        }
+    }
+
+    @Override
+    public boolean hasChildCollection(final DBBroker broker, final XmldbURI name) throws PermissionDeniedException, LockException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+
+        getLock().acquire(Lock.READ_LOCK);
+        try {
+            return subCollections.contains(name);
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+    }
+
+    @Override
+    public boolean hasChildCollectionNoLock(final DBBroker broker, final XmldbURI name) throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+
+        return subCollections.contains(name);
+    }
+
+    @Override
+    public Iterator<DocumentImpl> iterator(final DBBroker broker) throws PermissionDeniedException, LockException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+        
+        return getDocuments(broker, new DefaultDocumentSet()).getDocumentIterator();
+    }
+
+    @Override
+    public Iterator<DocumentImpl> iteratorNoLock(final DBBroker broker) throws PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+        
+        return getDocumentsNoLock(broker, new DefaultDocumentSet()).getDocumentIterator();
+    }
+
+    /**
+     * Serializes the Collection to a byte representation
+     *
+     * Counterpart method to {@link #deserialize(DBBroker, VariableByteInput)}
+     *
+     * @param outputStream The output stream to write the collection contents to
+     */
+    @Override
+    public void serialize(final VariableByteOutputStream outputStream) throws IOException, LockException {
+        outputStream.writeInt(collectionId);
+
+        final int size;
+        final Iterator<XmldbURI> i;
+
+        getLock().acquire(Lock.READ_LOCK);
+        try {
+            size = subCollections.size();
+            i = subCollections.stableIterator();
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+
+        outputStream.writeInt(size);
+        while(i.hasNext()) {
+            final XmldbURI childCollectionURI = i.next();
+            outputStream.writeUTF(childCollectionURI.toString());
+        }
+        permissions.write(outputStream);
+        outputStream.writeLong(created);
+    }
+    
+    /**
+     * Read collection contents from the stream
+     *
+     * Counterpart method to {@link #serialize(VariableByteOutputStream)}
+     *
+     * @param broker the database broker
+     * @param istream The input data
+     */
+    private void deserialize(final DBBroker broker, final VariableByteInput istream)
+            throws IOException, PermissionDeniedException, LockException {
+        collectionId = istream.readInt();
+        if (collectionId < 0) {
+            throw new PermissionDeniedException("Internal error reading collection: invalid collection id");
+        }
+        final int collLen = istream.readInt();
+
+        getLock().acquire(Lock.WRITE_LOCK);
+        try {
+            subCollections = new ObjectHashSet<>(collLen == 0 ? 19 : collLen); //TODO(AR) why is this number 19?
+            for (int i = 0; i < collLen; i++) {
+                subCollections.add(XmldbURI.create(istream.readUTF()));
+            }
+
+            permissions.read(istream);
+
+            created = istream.readLong();
+
+            if (!permissions.validate(broker.getCurrentSubject(), Permission.EXECUTE)) {
+                throw new PermissionDeniedException("Permission denied to open the Collection " + path);
+            }
+
+            final Collection col = this;
+
+            broker.getCollectionResources(new InternalAccess() {
+                @Override
+                public void addDocument(final DocumentImpl doc) throws EXistException {
+                    doc.setCollection(col);
+
+                    if (doc.getDocId() == DocumentImpl.UNKNOWN_DOCUMENT_ID) {
+                        LOG.error("Document must have ID. [" + doc + "]");
+                        throw new EXistException("Document must have ID.");
+                    }
+
+                    documents.put(doc.getFileURI().getRawCollectionPath(), doc);
+                }
+
+                @Override
+                public int getId() {
+                    return col.getId();
+                }
+            });
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public void removeCollection(final DBBroker broker, final XmldbURI name)
+            throws LockException, PermissionDeniedException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+            throw new PermissionDeniedException("Permission denied to read collection: " + path);
+        }
+
+        getLock().acquire(Lock.WRITE_LOCK);
+        try {
+            subCollections.remove(name);
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public void removeResource(final Txn transaction, final DBBroker broker, final DocumentImpl doc)
+            throws PermissionDeniedException, LockException, IOException, TriggerException {
+        if (doc.getCollection() != this) {
+            throw new IOException("Document '" + doc.getURI() + "' does not belong to Collection '" + getURI() + "'.");
+        }
+
+        if(doc.getResourceType() == DocumentImpl.BINARY_FILE) {
+            removeBinaryResource(transaction, broker, doc);
+        } else {
+            removeXMLResource(transaction, broker, doc.getFileURI());
+        }
+    }
+
+    @Override
+    public void removeXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name)
+            throws PermissionDeniedException, TriggerException, LockException, IOException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+            throw new PermissionDeniedException("Permission denied to write collection: " + path);
+        }
+        
+        DocumentImpl doc = null;
+        
+        final BrokerPool db = broker.getBrokerPool();
+
+        db.getProcessMonitor().startJob(ProcessMonitor.ACTION_REMOVE_XML, name);
+        getLock().acquire(Lock.WRITE_LOCK);
+
+        try {
+            doc = documents.get(name.getRawCollectionPath());
+            
+            if (doc == null) {
+                return; //TODO should throw an exception!!! Otherwise we dont know if the document was removed
+            }
+            
+            doc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+            
+            boolean useTriggers = isTriggersEnabled();
+            if (CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI.equals(name)) {
+                // we remove a collection.xconf configuration file: tell the configuration manager to
+                // reload the configuration.
+                useTriggers = false;
+                final CollectionConfigurationManager confMgr = broker.getBrokerPool().getConfigurationManager();
+                if (confMgr != null) {
+                    confMgr.invalidate(getURI(), broker.getBrokerPool());
+                }
+            }
+            
+            DocumentTriggers trigger = new DocumentTriggers(broker, null, this, useTriggers ? getConfiguration(broker) : null);
+            
+            trigger.beforeDeleteDocument(broker, transaction, doc);
+            
+            broker.removeXMLResource(transaction, doc);
+            documents.remove(name.getRawCollectionPath());
+            
+            trigger.afterDeleteDocument(broker, transaction, getURI().append(name));
+            
+            broker.getBrokerPool().getNotificationService().notifyUpdate(doc, UpdateListener.REMOVE);
+        } finally {
+            broker.getBrokerPool().getProcessMonitor().endJob();
+            if(doc != null) {
+                doc.getUpdateLock().release(Lock.WRITE_LOCK);
+            }
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public void removeBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name)
+            throws PermissionDeniedException, LockException, TriggerException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+            throw new PermissionDeniedException("Permission denied to write collection: " + path);
+        }
+        
+        try {
+            getLock().acquire(Lock.READ_LOCK);
+            final DocumentImpl doc = getDocument(broker, name);
+            
+            if(doc.isLockedForWrite()) {
+                throw new PermissionDeniedException("Document " + doc.getFileURI() + " is locked for write");
+            }
+            
+            removeBinaryResource(transaction, broker, doc);
+        } finally {
+            getLock().release(Lock.READ_LOCK);
+        }
+    }
+
+    @Override
+    public void removeBinaryResource(final Txn transaction, final DBBroker broker, final DocumentImpl doc)
+            throws PermissionDeniedException, LockException, TriggerException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+            throw new PermissionDeniedException("Permission denied to write collection: " + path);
+        }
+        
+        if(doc == null) {
+            return;  //TODO should throw an exception!!! Otherwise we dont know if the document was removed
+        }
+
+        broker.getBrokerPool().getProcessMonitor().startJob(ProcessMonitor.ACTION_REMOVE_BINARY, doc.getFileURI());
+        getLock().acquire(Lock.WRITE_LOCK);
+
+        try {
+            
+            if(doc.getResourceType() != DocumentImpl.BINARY_FILE) {
+                throw new PermissionDeniedException("document " + doc.getFileURI() + " is not a binary object");
+            }
+            
+            if(doc.isLockedForWrite()) {
+                throw new PermissionDeniedException("Document " + doc.getFileURI() + " is locked for write");
+            }
+            
+            doc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+            
+            DocumentTriggers trigger = new DocumentTriggers(broker, null, this, isTriggersEnabled() ? getConfiguration(broker) : null);
+
+            trigger.beforeDeleteDocument(broker, transaction, doc);
+
+            final IndexController indexController = broker.getIndexController();
+            final StreamListener listener = indexController.getStreamListener(doc, StreamListener.ReindexMode.REMOVE_BINARY);
+            try {
+                indexController.startIndexDocument(transaction, listener);
+
+                try {
+                    broker.removeBinaryResource(transaction, (BinaryDocument) doc);
+                } catch (final IOException ex) {
+                    throw new PermissionDeniedException("Cannot delete file: " + doc.getURI().toString() + ": " + ex.getMessage(), ex);
+                }
+                documents.remove(doc.getFileURI().getRawCollectionPath());
+            } finally {
+                indexController.endIndexDocument(transaction, listener);
+            }
+
+            trigger.afterDeleteDocument(broker, transaction, doc.getURI());
+
+        } finally {
+            broker.getBrokerPool().getProcessMonitor().endJob();
+            doc.getUpdateLock().release(Lock.WRITE_LOCK);
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final InputSource source)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
+        storeXMLInternal(transaction, broker, info, storeInfo -> {
+            try {
+                final InputStream is = source.getByteStream();
+                if(is != null && is.markSupported()) {
+                    is.reset();
+                } else {
+                    final Reader cs = source.getCharacterStream();
+                    if(cs != null && cs.markSupported()) {
+                        cs.reset();
+                    }
+                }
+            } catch(final IOException e) {
+                // mark is not supported: exception is expected, do nothing
+                LOG.debug("InputStream or CharacterStream underlying the InputSource does not support marking and therefore cannot be re-read.");
+            }
+            final XMLReader reader = getReader(broker, false, storeInfo.getCollectionConfig());
+            storeInfo.setReader(reader, null);
+            try {
+                reader.parse(source);
+            } catch(final IOException e) {
+                throw new EXistException(e);
+            } finally {
+                releaseReader(broker, storeInfo, reader);
+            }
+        });
+    }
+
+    @Override
+    public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final String data)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
+        storeXMLInternal(transaction, broker, info, storeInfo -> {
+            final CollectionConfiguration colconf = storeInfo.getDocument().getCollection().getConfiguration(broker);
+            final XMLReader reader = getReader(broker, false, colconf);
+            storeInfo.setReader(reader, null);
+            try {
+                reader.parse(new InputSource(new StringReader(data)));
+            } catch(final IOException e) {
+                throw new EXistException(e);
+            } finally {
+                releaseReader(broker, storeInfo, reader);
+            }
+        });
+    }
+
+    @Override
+    public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final Node node)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+            throw new PermissionDeniedException("Permission denied to write collection: " + path);
+        }
+
+        storeXMLInternal(transaction, broker, info, storeInfo -> storeInfo.getDOMStreamer().serialize(node, true));
+    }
+
+    /** 
+     * Stores an XML document in the database. {@link #validateXMLResourceInternal(Txn, DBBroker, XmldbURI,
+     * CollectionConfiguration, Consumer2E)}should have been called previously in order to acquire a write lock
+     * for the document. Launches the finish trigger.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param info        Tracks information between validate and store phases
+     * @param parserFn    A function which parses the XML document
+     */
+    private void storeXMLInternal(final Txn transaction, final DBBroker broker, final IndexInfo info,
+            final Consumer2E<IndexInfo, EXistException, SAXException> parserFn)
+            throws EXistException, SAXException, PermissionDeniedException {
+        
+        final DocumentImpl document = info.getIndexer().getDocument();
+        
+        final Database db = broker.getBrokerPool();
+        
+        try {
+            /* TODO
+             * 
+             * These security checks are temporarily disabled because throwing an exception
+             * here may cause the database to corrupt.
+             * Why would the database corrupt? Because validateXMLInternal that is typically
+             * called before this method actually modifies the database and this collection,
+             * so throwing an exception here leaves the database in an inconsistent state
+             * with data 1/2 added/updated.
+             * 
+             * The downside of disabling these checks here is that: this collection is not locked
+             * between the call to validateXmlInternal and storeXMLInternal, which means that if
+             * UserA in ThreadA calls validateXmlInternal and is permitted access to store a resource,
+             * and then UserB in ThreadB modifies the permissions of this collection to prevent UserA
+             * from storing the document, when UserA reaches here (storeXMLInternal) they will still
+             * be allowed to store their document. However the next document that UserA attempts to store
+             * will be forbidden by validateXmlInternal and so the security transgression whilst not ideal
+             * is short-lived.
+             * 
+             * To fix the issue we need to refactor validateXMLInternal and move any document/database/collection
+             * modification code into storeXMLInternal after the commented out permissions checks below.
+             * 
+             * Noted by Adam Retter 2012-02-01T19:18
+             */
+            
+            /*
+            if(info.isCreating()) {
+                // create
+                * 
+                if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+                    throw new PermissionDeniedException("Permission denied to write collection: " + path);
+                }
+            } else {
+                // update
+
+                final Permission oldDocPermissions = info.getOldDocPermissions();
+                if(!((oldDocPermissions.getOwner().getId() != broker.getCurrentSubject().getId()) | (oldDocPermissions.validate(broker.getCurrentSubject(), Permission.WRITE)))) {
+                    throw new PermissionDeniedException("A resource with the same name already exists in the target collection '" + path + "', and you do not have write access on that resource.");
+                }
+            }
+            */
+
+            if(LOG.isDebugEnabled()) {
+                LOG.debug("storing document " + document.getDocId() + " ...");
+            }
+
+            //Sanity check
+            if(!document.getUpdateLock().isLockedForWrite()) {
+                LOG.warn("document is not locked for write !");
+            }
+            
+            db.getProcessMonitor().startJob(ProcessMonitor.ACTION_STORE_DOC, document.getFileURI());
+            parserFn.accept(info);
+            broker.storeXMLResource(transaction, document);
+            broker.flush();
+            broker.closeDocument();
+            //broker.checkTree(document);
+            LOG.debug("document stored.");
+        } finally {
+            //This lock has been acquired in validateXMLResourceInternal()
+            document.getUpdateLock().release(Lock.WRITE_LOCK);
+            broker.getBrokerPool().getProcessMonitor().endJob();
+        }
+        setCollectionConfigEnabled(true);
+        broker.deleteObservers();
+        
+        if(info.isCreating()) {
+            info.getTriggers().afterCreateDocument(broker, transaction, document);
+        } else {
+            info.getTriggers().afterUpdateDocument(broker, transaction, document);
+        }
+        
+        db.getNotificationService().notifyUpdate(document, (info.isCreating() ? UpdateListener.ADD : UpdateListener.UPDATE));
+        //Is it a collection configuration file ?
+        final XmldbURI docName = document.getFileURI();
+        //WARNING : there is no reason to lock the collection since setPath() is normally called in a safe way
+        //TODO: *resolve* URI against CollectionConfigurationManager.CONFIG_COLLECTION_URI 
+        if (getURI().startsWith(XmldbURI.CONFIG_COLLECTION_URI)
+                && docName.endsWith(CollectionConfiguration.COLLECTION_CONFIG_SUFFIX_URI)) {
+            broker.sync(Sync.MAJOR);
+            final CollectionConfigurationManager manager = broker.getBrokerPool().getConfigurationManager();
+            if(manager != null) {
+                try {
+                    manager.invalidate(getURI(), broker.getBrokerPool());
+                    manager.loadConfiguration(broker, this);
+                } catch(final PermissionDeniedException | LockException pde) {
+                    throw new EXistException(pde.getMessage(), pde);
+                } catch(final CollectionConfigurationException e) {
+                    // DIZ: should this exception really been thrown? bugid=1807744
+                    throw new EXistException("Error while reading new collection configuration: " + e.getMessage(), e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final String data) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        return validateXMLResource(transaction, broker, name, new InputSource(new StringReader(data)));
+    }
+
+    @Override
+    public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputSource source) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        final CollectionConfiguration colconf = getConfiguration(broker);
+        
+        return validateXMLResourceInternal(transaction, broker, name, colconf, (info) -> {
+            final XMLReader reader = getReader(broker, true, colconf);
+            info.setReader(reader, null);
+            try {
+
+                /*
+                 * Note - we must close shield the input source,
+                 * else it can be closed by the Reader, so subsequently
+                 * when we try and read it in storeXmlInternal we will get
+                 * an exception.
+                 */
+                final InputSource closeShieldedInputSource = closeShieldInputSource(source);
+
+                reader.parse(closeShieldedInputSource);
+            } catch(final SAXException e) {
+                throw new SAXException("The XML parser reported a problem: " + e.getMessage(), e);
+            } catch(final IOException e) {
+                throw new EXistException(e);
+            } finally {
+                releaseReader(broker, info, reader);
+            }
+        });
+    }
+    
+    //stops streams on the input source from being closed
+    private InputSource closeShieldInputSource(final InputSource source) {
+        final InputSource protectedInputSource = new InputSource();
+        protectedInputSource.setEncoding(source.getEncoding());
+        protectedInputSource.setSystemId(source.getSystemId());
+        protectedInputSource.setPublicId(source.getPublicId());
+        
+        if(source.getByteStream() != null) {
+            //TODO consider AutoCloseInputStream
+            final InputStream closeShieldByteStream = new CloseShieldInputStream(source.getByteStream());
+            protectedInputSource.setByteStream(closeShieldByteStream);
+        }
+        
+        if(source.getCharacterStream() != null) {
+            //TODO consider AutoCloseReader
+            final Reader closeShieldReader = new CloseShieldReader(source.getCharacterStream());
+            protectedInputSource.setCharacterStream(closeShieldReader);
+        }
+        
+        return protectedInputSource;
+    }
+    
+    private static class CloseShieldReader extends Reader {
+        private final Reader reader;
+        public CloseShieldReader(final Reader reader) {
+            this.reader = reader;
+        }
+
+        @Override
+        public int read(final char[] cbuf, final int off, final int len) throws IOException {
+            return reader.read(cbuf, off, len);
+        }
+
+        @Override
+        public void close() throws IOException {
+            //do nothing as we are close shield
+        }
+    }
+
+    @Override
+    public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final Node node) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        return validateXMLResourceInternal(transaction, broker, name, getConfiguration(broker), (info) -> {
+                info.setDOMStreamer(new DOMStreamer());
+                info.getDOMStreamer().serialize(node, true);
+        });
+    }
+
+    /** 
+     * Validates an XML document et prepares it for further storage. Launches prepare and postValidate triggers.
+     * Since the process is dependant from the collection configuration, the collection acquires a write lock during
+     * the process.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     * @param validator   A function which validates the document of throws an Exception
+     * 
+     * @return An {@link IndexInfo} with a write lock on the document.
+     */
+    private IndexInfo validateXMLResourceInternal(final Txn transaction, final DBBroker broker, final XmldbURI name,
+            final CollectionConfiguration config, final Consumer2E<IndexInfo, SAXException, EXistException> validator)
+            throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException,
+            IOException {
+
+        //Make the necessary operations if we process a collection configuration document
+        checkConfigurationDocument(transaction, broker, name);
+        
+        final Database db = broker.getBrokerPool();
+        
+        if (db.isReadOnly()) {
+            throw new IOException("Database is read-only");
+        }
+        
+        DocumentImpl oldDoc = null;
+        boolean oldDocLocked = false;
+
+        db.getProcessMonitor().startJob(ProcessMonitor.ACTION_VALIDATE_DOC, name);
+        getLock().acquire(Lock.WRITE_LOCK);
+        try {
+            DocumentImpl document = new DocumentImpl((BrokerPool) db, this, name);
+            oldDoc = documents.get(name.getRawCollectionPath());
+            checkPermissionsForAddDocument(broker, oldDoc);
+            checkCollectionConflict(name);
+            manageDocumentInformation(oldDoc, document);
+            final Indexer indexer = new Indexer(broker, transaction);
+            
+            final IndexInfo info = new IndexInfo(indexer, config);
+            info.setCreating(oldDoc == null);
+            info.setOldDocPermissions(oldDoc != null ? oldDoc.getPermissions() : null);
+            indexer.setDocument(document, config);
+            addObserversToIndexer(broker, indexer);
+            indexer.setValidating(true);
+            
+            if(CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI.equals(name)) {
+                // we are updating collection.xconf. Notify configuration manager
+                //CollectionConfigurationManager confMgr = broker.getBrokerPool().getConfigurationManager();
+                //confMgr.invalidateAll(getURI());
+                setCollectionConfigEnabled(false);
+            }
+            
+            final DocumentTriggers trigger = new DocumentTriggers(broker, indexer, this, isTriggersEnabled() ? config : null);
+            trigger.setValidating(true);
+            
+            info.setTriggers(trigger);
+
+            if(oldDoc == null) {
+                trigger.beforeCreateDocument(broker, transaction, getURI().append(name));
+            } else {
+                trigger.beforeUpdateDocument(broker, transaction, oldDoc);
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Scanning document " + getURI().append(name));
+            }
+            
+            validator.accept(info);
+            // new document is valid: remove old document
+            if (oldDoc != null) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("removing old document " + oldDoc.getFileURI());
+                }
+                updateModificationTime(document);
+                oldDoc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+                oldDocLocked = true;
+                if (oldDoc.getResourceType() == DocumentImpl.BINARY_FILE) {
+                    //TODO : use a more elaborated method ? No triggers...
+                    broker.removeBinaryResource(transaction, (BinaryDocument) oldDoc);
+                    documents.remove(oldDoc.getFileURI().getRawCollectionPath());
+                    //This lock is released in storeXMLInternal()
+                    //TODO : check that we go until there to ensure the lock is released
+//                    if (transaction != null)
+//                    	transaction.acquireLock(document.getUpdateLock(), Lock.WRITE_LOCK);
+//                	else
+                    document.getUpdateLock().acquire(Lock.WRITE_LOCK);
+                    
+                    document.setDocId(broker.getNextResourceId(transaction, this));
+                    addDocument(transaction, broker, document);
+                } else {
+                    //TODO : use a more elaborated method ? No triggers...
+                    broker.removeXMLResource(transaction, oldDoc, false);
+                    oldDoc.copyOf(document, true);
+                    indexer.setDocumentObject(oldDoc);
+                    //old has become new at this point
+                    document = oldDoc;
+                    oldDocLocked = false;		
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("removed old document " + oldDoc.getFileURI());
+                }
+            } else {
+                //This lock is released in storeXMLInternal()
+                //TODO : check that we go until there to ensure the lock is released
+//            	if (transaction != null)
+//                	transaction.acquireLock(document.getUpdateLock(), Lock.WRITE_LOCK);
+//            	else
+                document.getUpdateLock().acquire(Lock.WRITE_LOCK);
+            	
+                document.setDocId(broker.getNextResourceId(transaction, this));
+                addDocument(transaction, broker, document);
+            }
+            
+            trigger.setValidating(false);
+
+            return info;
+        } finally {
+            if (oldDoc != null && oldDocLocked) {
+                oldDoc.getUpdateLock().release(Lock.WRITE_LOCK);
+            }
+            getLock().release(Lock.WRITE_LOCK);
+            
+            db.getProcessMonitor().endJob();
+        }
+    }
+
+    private void checkConfigurationDocument(final Txn transaction, final DBBroker broker, final XmldbURI docUri) throws EXistException, PermissionDeniedException, LockException {
+        //Is it a collection configuration file ?
+        //TODO : use XmldbURI.resolve() !
+        if (!getURI().startsWith(XmldbURI.CONFIG_COLLECTION_URI)) {
+            return;
+        }
+        if(!docUri.endsWith(CollectionConfiguration.COLLECTION_CONFIG_SUFFIX_URI)) {
+            return;
+        }
+        //Allow just one configuration document per collection
+        //TODO : do not throw the exception if a system property allows several ones -pb
+        for(final Iterator<DocumentImpl> i = iterator(broker); i.hasNext(); ) {
+            final DocumentImpl confDoc = i.next();
+            final XmldbURI currentConfDocName = confDoc.getFileURI();
+            if(currentConfDocName != null && !currentConfDocName.equals(docUri)) {
+                throw new EXistException("Could not store configuration '" + docUri + "': A configuration document with a different name ("
+                    + currentConfDocName + ") already exists in this collection (" + getURI() + ")");
+            }
+        }
+        //broker.saveCollection(transaction, this);
+        //CollectionConfigurationManager confMgr = broker.getBrokerPool().getConfigurationManager();
+        //if(confMgr != null)
+            //try {
+                //confMgr.reload(broker, this);
+            // catch (CollectionConfigurationException e) {
+                //throw new EXistException("An error occurred while reloading the updated collection configuration: " + e.getMessage(), e);
+        //}
+    }
+
+    /**
+     * Add observers to the indexer
+     *
+     * @param broker    The database broker
+     * @param indexer   The indexer to add observers to
+     */
+    private void addObserversToIndexer(final DBBroker broker, final Indexer indexer) {
+        broker.deleteObservers();
+        observable.forEachObserver(observer -> {
+            indexer.addObserver(observer);
+            broker.addObserver(observer);
+        });
+    }
+
+
+    /**
+     * If an old document exists, keep information about  the document.
+     *
+     * @param oldDoc The old document
+     * @param document The current/new document
+     */
+    private void manageDocumentInformation(final DocumentImpl oldDoc, final DocumentImpl document) {
+        DocumentMetadata metadata = new DocumentMetadata();
+        if (oldDoc != null) {
+            metadata = oldDoc.getMetadata();
+            metadata.setCreated(oldDoc.getMetadata().getCreated());
+            document.setPermissions(oldDoc.getPermissions());
+        } else {
+            metadata.setCreated(System.currentTimeMillis());
+        }
+        document.setMetadata(metadata);
+    }
+
+     /**
+      * Update the modification time of a document
+      *
+      * @param document The document whose modification time should be updated
+      */
+    private void updateModificationTime(final DocumentImpl document) {
+        final DocumentMetadata metadata = document.getMetadata();
+        metadata.setLastModified(System.currentTimeMillis());
+        document.setMetadata(metadata);
+    }
+    
+    /**
+     * Check Permissions about user and document when a document is added to the database,
+     * and throw exceptions if necessary.
+     *
+     * @param broker The database broker
+     * @param oldDoc old Document existing in database prior to adding a new one with same name, or null if none exists
+     */
+    private void checkPermissionsForAddDocument(final DBBroker broker, final DocumentImpl oldDoc)
+            throws LockException, PermissionDeniedException {
+        
+        // do we have execute permission on the collection?
+        if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.EXECUTE)) {
+            throw new PermissionDeniedException("Execute permission is not granted on the Collection.");
+        }
+            
+        if(oldDoc != null) {   
+            
+            /* update document */
+            
+            LOG.debug("Found old doc " + oldDoc.getDocId());
+            
+            // check if the document is locked by another user
+            final Account lockUser = oldDoc.getUserLock();
+            if(lockUser != null && !lockUser.equals(broker.getCurrentSubject())) {
+                throw new PermissionDeniedException("The document is locked by user '" + lockUser.getName() + "'.");
+            }
+            
+            // do we have write permission on the old document or are we the owner of the old document?
+            if (!((oldDoc.getPermissions().getOwner().getId() == broker.getCurrentSubject().getId()) || (oldDoc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)))) {
+                throw new PermissionDeniedException("A resource with the same name already exists in the target collection '" + path + "', and you do not have write access on that resource.");
+            }
+        } else {
+            
+            /* create document */
+            
+            if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.WRITE)) {
+                throw new PermissionDeniedException("Write permission is not granted on the Collection.");
+            }
+        }
+    }
+    
+    private void checkCollectionConflict(final XmldbURI docUri) throws EXistException, PermissionDeniedException {
+        if(subCollections.contains(docUri.lastSegment())) {
+            throw new EXistException(
+                "The collection '" + getURI() + "' already has a sub-collection named '" + docUri.lastSegment() + "', you cannot create a Document with the same name as an existing collection."
+            );
+        }
+    }
+
+    @Override
+    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final byte[] data, final String mimeType) throws EXistException, PermissionDeniedException, LockException, TriggerException,IOException {
+        return addBinaryResource(transaction, broker, name, data, mimeType, null, null);
+    }
+
+    @Override
+    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final byte[] data, final String mimeType, final Date created, final Date modified) throws EXistException, PermissionDeniedException, LockException, TriggerException,IOException {
+        return addBinaryResource(transaction, broker, name, new ByteArrayInputStream(data), mimeType, data.length, created, modified);
+    }
+
+    @Override
+    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputStream is, final String mimeType, final long size) throws EXistException, PermissionDeniedException, LockException, TriggerException,IOException {
+        return addBinaryResource(transaction, broker, name, is, mimeType, size, null, null);
+    }
+
+    @Override
+    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputStream is, final String mimeType, final long size, final Date created, final Date modified) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
+        final BinaryDocument blob = new BinaryDocument(broker.getBrokerPool(), this, name);
+        return addBinaryResource(transaction, broker, blob, is, mimeType, size, created, modified);
+    }
+
+    @Override
+    public BinaryDocument validateBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name) throws PermissionDeniedException, LockException, TriggerException, IOException {
+        return new BinaryDocument(broker.getBrokerPool(), this, name);
+    }
+
+    @Override
+    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final BinaryDocument blob, final InputStream is, final String mimeType, final long size, final Date created, final Date modified) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
+        final Database db = broker.getBrokerPool();
+        if (db.isReadOnly()) {
+            throw new IOException("Database is read-only");
+        }
+        final XmldbURI docUri = blob.getFileURI();
+        //TODO : move later, i.e. after the collection lock is acquired ?
+        final DocumentImpl oldDoc = getDocument(broker, docUri);
+        final DocumentTriggers trigger = new DocumentTriggers(broker, null, this, isTriggersEnabled() ? getConfiguration(broker) : null);
+
+        getLock().acquire(Lock.WRITE_LOCK);
+        try {
+            db.getProcessMonitor().startJob(ProcessMonitor.ACTION_STORE_BINARY, docUri);
+            checkPermissionsForAddDocument(broker, oldDoc);
+            checkCollectionConflict(docUri);
+            manageDocumentInformation(oldDoc, blob);
+            final DocumentMetadata metadata = blob.getMetadata();
+            metadata.setMimeType(mimeType == null ? MimeType.BINARY_TYPE.getName() : mimeType);
+            if (created != null) {
+                metadata.setCreated(created.getTime());
+            }
+            if (modified != null) {
+                metadata.setLastModified(modified.getTime());
+            }
+            blob.setContentLength(size);
+            
+            if (oldDoc == null) {
+                trigger.beforeCreateDocument(broker, transaction, blob.getURI());
+            } else {
+                trigger.beforeUpdateDocument(broker, transaction, oldDoc);
+            }
+
+            if (oldDoc != null) {
+                LOG.debug("removing old document " + oldDoc.getFileURI());
+                updateModificationTime(blob);
+                broker.removeResource(transaction, oldDoc);
+            }
+
+            broker.storeBinaryResource(transaction, blob, is);
+            addDocument(transaction, broker, blob, oldDoc);
+
+            final IndexController indexController = broker.getIndexController();
+            final StreamListener listener = indexController.getStreamListener(blob, StreamListener.ReindexMode.STORE);
+            indexController.startIndexDocument(transaction, listener);
+            try {
+                broker.storeXMLResource(transaction, blob);
+            } finally {
+                indexController.endIndexDocument(transaction, listener);
+            }
+
+            blob.getUpdateLock().acquire(Lock.READ_LOCK);
+        } finally {
+            broker.getBrokerPool().getProcessMonitor().endJob();
+            getLock().release(Lock.WRITE_LOCK);
+        }
+        try {
+            if (oldDoc == null) {
+                trigger.afterCreateDocument(broker, transaction, blob);
+            } else {
+                trigger.afterUpdateDocument(broker, transaction, blob);
+            }
+        } finally {
+            blob.getUpdateLock().release(Lock.READ_LOCK);
+        }
+        return blob;
+    }
+
+    @Override
+    public void setId(final int id) {
+        this.collectionId = id;
+    }
+
+    @Override
+    public void setPermissions(final int mode) throws LockException, PermissionDeniedException {
+        try {
+            getLock().acquire(Lock.WRITE_LOCK);
+            permissions.setMode(mode);
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public void setPermissions(final String mode) throws SyntaxException, LockException, PermissionDeniedException {
+        try {
+            getLock().acquire(Lock.WRITE_LOCK);
+            permissions.setMode(mode);
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public void setPermissions(final Permission permissions) throws LockException {
+        try {
+            getLock().acquire(Lock.WRITE_LOCK);
+            this.permissions = permissions;
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public CollectionConfiguration getConfiguration(final DBBroker broker) {
+        if(!isCollectionConfigEnabled()) {
+            return null;
+        }
+        
+        final CollectionConfigurationManager manager = broker.getBrokerPool().getConfigurationManager();
+        if(manager == null) {
+            return null;
+        }
+        //Attempt to get configuration
+        CollectionConfiguration configuration = null;
+        try {
+            //TODO: AR: if a Trigger throws CollectionConfigurationException
+            //from its configure() method, is the rest of the collection 
+            //configuration (indexes etc.) ignored even though they might be fine?
+            configuration = manager.getConfiguration(broker, this);
+            setCollectionConfigEnabled(true);
+        } catch(final CollectionConfigurationException e) {
+            setCollectionConfigEnabled(false);
+            LOG.warn("Failed to load collection configuration for '" + getURI() + "'", e);
+        }
+        return configuration;
+    }
+
+    @Override
+    public void setCollectionConfigEnabled(final boolean collectionConfigEnabled) {
+        this.collectionConfigEnabled = collectionConfigEnabled;
+    }
+
+    @Override
+    public boolean isCollectionConfigEnabled() {
+        return collectionConfigEnabled;
+    }
+
+    @Override
+    public void setAddress(final long addr) {
+        this.address = addr;
+    }
+
+    @Override
+    public long getAddress() {
+        return this.address;
+    }
+
+    @Override
+    public void setCreationTime(final long ms) {
+        created = ms;
+    }
+
+    @Override
+    public long getCreationTime() {
+        return created;
+    }
+
+    @Override
+    public void setTriggersEnabled(final boolean enabled) {
+        try {
+            getLock().acquire(Lock.WRITE_LOCK);
+            this.triggersEnabled = enabled;
+        } catch(final LockException e) {
+            LOG.warn(e.getMessage(), e);
+            //Ouch ! -pb
+            this.triggersEnabled = enabled;
+        } finally {
+            getLock().release(Lock.WRITE_LOCK);
+        }
+    }
+
+    @Override
+    public void setReader(final XMLReader reader){
+        userReader = reader;
+    }
+
+    /** 
+     * Get XML Reader from ReaderPool and setup validation when needed.
+     *
+     * @param broker The database broker
+     * @param validation true if validation should be enabled
+     * @param collectionConf The configuration of the Collection
+     *
+     * @return An XML Reader
+     */
+    private XMLReader getReader(final DBBroker broker, final boolean validation, final CollectionConfiguration collectionConf) {
+        // If user-defined Reader is set, return it;
+        if (userReader != null) {
+            return userReader;
+        }
+        // Get reader from readerpool.
+        final XMLReader reader = broker.getBrokerPool().getParserPool().borrowXMLReader();
+        
+        // If Collection configuration exists (try to) get validation mode
+        // and setup reader with this information.
+        if (!validation) {
+            XMLReaderObjectFactory.setReaderValidationMode(XMLReaderObjectFactory.VALIDATION_SETTING.DISABLED, reader);
+            
+        } else if( collectionConf!=null ) {
+            final VALIDATION_SETTING mode = collectionConf.getValidationMode();
+            XMLReaderObjectFactory.setReaderValidationMode(mode, reader);
+        }
+        // Return configured reader.
+        return reader;
+    }
+
+    /**
+     * Reset validation mode of reader and return reader to reader pool.
+     *
+     * @param broker The database broker
+     * @param info The indexing info
+     * @param reader The XML Reader to release
+     */    
+    private void releaseReader(final DBBroker broker, final IndexInfo info, final XMLReader reader) {
+        if(userReader != null){
+            return;
+        }
+        
+        if(info.getIndexer().getDocSize() > POOL_PARSER_THRESHOLD) {
+            return;
+        }
+        
+        // Get validation mode from static configuration
+        final Configuration config = broker.getConfiguration();
+        final String optionValue = (String) config.getProperty(XMLReaderObjectFactory.PROPERTY_VALIDATION_MODE);
+        final VALIDATION_SETTING validationMode = XMLReaderObjectFactory.convertValidationMode(optionValue);
+        
+        // Restore default validation mode
+        XMLReaderObjectFactory.setReaderValidationMode(validationMode, reader);
+        
+        // Return reader
+        broker.getBrokerPool().getParserPool().returnXMLReader(reader);
+    }
+
+    @Override
+    public IndexSpec getIndexConfiguration(final DBBroker broker) {
+        final CollectionConfiguration conf = getConfiguration(broker);
+        //If the collection has its own config...
+        if (conf == null) {
+            return broker.getIndexConfiguration();
+        }
+        //... otherwise return the general config (the broker's one)
+        return conf.getIndexConfiguration();
+    }
+
+    @Override
+    public GeneralRangeIndexSpec getIndexByPathConfiguration(final DBBroker broker, final NodePath nodePath) {
+        final IndexSpec idxSpec = getIndexConfiguration(broker);
+        return (idxSpec == null) ? null : idxSpec.getIndexByPath(nodePath);
+    }
+
+    @Override
+    public QNameRangeIndexSpec getIndexByQNameConfiguration(final DBBroker broker, final QName nodeName) {
+        final IndexSpec idxSpec = getIndexConfiguration(broker);
+        return (idxSpec == null) ? null : idxSpec.getIndexByQName(nodeName);
+    }
+
+    @Override
+    public Observable getObservable() {
+        return observable;
+    }
+
+    @Override
+    public long getKey() {
+        return collectionId;
+    }
+
+    @Override
+    public int getReferenceCount() {
+        return refCount;
+    }
+
+    @Override
+    public int incReferenceCount() {
+        return ++refCount;
+    }
+
+    @Override
+    public int decReferenceCount() {
+        return refCount > 0 ? --refCount : 0;
+    }
+
+    @Override
+    public void setReferenceCount(final int count) {
+        refCount = count;
+    }
+
+    @Override
+    public void setTimestamp(final int timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public int getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public boolean sync(final boolean syncJournal) {
+        return false;
+    }
+
+    @Override
+    public boolean isDirty() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append( getURI() );
+        buf.append("[");
+
+        try {
+            for (final Iterator<String> i = copyOfDocNames().iterator(); i.hasNext(); ) {
+                buf.append(i.next());
+                if (i.hasNext()) {
+                    buf.append(", ");
+                }
+            }
+        } catch(final LockException e) {
+            LOG.error(e);
+            throw new IllegalStateException(e);
+        }
+        buf.append("]");
+        return buf.toString();
+    }
+
+    private static class ObservaleMutableCollection extends Observable {
+        private Observer[] observers = null;
+
+        @Override
+        public synchronized void addObserver(final Observer o) {
+            if(hasObserver(o)) {
+                return;
+            }
+            if(observers == null) {
+                observers = new Observer[1];
+                observers[0] = o;
+            } else {
+                final Observer n[] = new Observer[observers.length + 1];
+                System.arraycopy(observers, 0, n, 0, observers.length);
+                n[observers.length] = o;
+                observers = n;
+            }
+        }
+
+        private boolean hasObserver(final Observer o) {
+            if(observers == null) {
+                return false;
+            }
+            for (Observer observer : observers) {
+                if (observer == o) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void forEachObserver(final Consumer<Observer> consumer) {
+            if(observers != null) {
+                for(final Observer observer : observers) {
+                    consumer.accept(observer);
+                }
+            }
+        }
+
+        @Override
+        public synchronized void deleteObservers() {
+            if(observers != null) {
+                observers = null;
+            }
+        }
+    }
+}

--- a/src/org/exist/collections/MutableCollection.java
+++ b/src/org/exist/collections/MutableCollection.java
@@ -544,7 +544,7 @@ public class MutableCollection implements Collection {
     private void addDocumentsToSet(final DBBroker broker, final MutableDocumentSet docs, final LockedDocumentMap lockMap, final int lockType) throws LockException {
     	for(final DocumentImpl doc : copyOfDocs()) {
             if(doc.getPermissions().validate(broker.getCurrentSubject(), Permission.WRITE)) {
-                doc.getUpdateLock().acquire(Lock.WRITE_LOCK);
+                doc.getUpdateLock().acquire(lockType);
 
                 docs.add(doc);
                 lockMap.add(doc);

--- a/src/org/exist/collections/triggers/Dumper.java
+++ b/src/org/exist/collections/triggers/Dumper.java
@@ -27,6 +27,7 @@ import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.Txn;
+import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 
 import java.util.Iterator;
@@ -63,8 +64,8 @@ public class Dumper extends FilteringTrigger implements DocumentTrigger {
         
         try {
             getCollection().getDocuments(broker, docs);
-        } catch (final PermissionDeniedException pde) {
-            throw new TriggerException(pde.getMessage(), pde);
+        } catch (final PermissionDeniedException | LockException e) {
+            throw new TriggerException(e.getMessage(), e);
         }
         
         for (final Iterator<DocumentImpl> i = docs.getDocumentIterator(); i.hasNext(); ) {

--- a/src/org/exist/collections/triggers/XQueryStartupTrigger.java
+++ b/src/org/exist/collections/triggers/XQueryStartupTrigger.java
@@ -36,7 +36,7 @@ import org.exist.source.Source;
 import org.exist.source.SourceFactory;
 import org.exist.storage.DBBroker;
 import org.exist.storage.StartupTrigger;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.xmldb.XmldbURI;
@@ -109,7 +109,7 @@ public class XQueryStartupTrigger implements StartupTrigger {
         Collection collection = null;
 
         try {
-            collection = broker.openCollection(uri, Lock.READ_LOCK);
+            collection = broker.openCollection(uri, LockMode.READ_LOCK);
 
             if (collection == null) {
                 LOG.debug(String.format("Collection '%s' not found.", AUTOSTART_COLLECTION));
@@ -155,7 +155,7 @@ public class XQueryStartupTrigger implements StartupTrigger {
         } finally {
             // Clean up resources
             if (collection != null) {
-                collection.release(Lock.READ_LOCK);
+                collection.release(LockMode.READ_LOCK);
             }
         }
 

--- a/src/org/exist/config/Configurator.java
+++ b/src/org/exist/config/Configurator.java
@@ -1289,7 +1289,7 @@ public class Configurator {
             doc.getPermissions().setMode(Permission.DEFAULT_SYSTSEM_RESOURCE_PERM);
             fullURI = getFullURI(pool, doc.getURI());
             saving.add(fullURI);
-            collection.store(txn, broker, info, data, false);
+            collection.store(txn, broker, info, data);
             broker.saveCollection(txn, doc.getCollection());
             transact.commit(txn);
             saving.remove(fullURI);

--- a/src/org/exist/config/Configurator.java
+++ b/src/org/exist/config/Configurator.java
@@ -62,7 +62,7 @@ import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -1282,7 +1282,7 @@ public class Configurator {
         try {
             broker.pushSubject(pool.getSecurityManager().getSystemSubject());
             txn = transact.beginTransaction();
-            txn.acquireLock(collection.getLock(), Lock.WRITE_LOCK);
+            txn.acquireLock(collection.getLock(), LockMode.WRITE_LOCK);
             final IndexInfo info = collection.validateXMLResource(txn, broker, uri, data);
             final DocumentImpl doc = info.getDocument();
             doc.getMetadata().setMimeType(MimeType.XML_TYPE.getName());

--- a/src/org/exist/dom/persistent/DefaultDocumentSet.java
+++ b/src/org/exist/dom/persistent/DefaultDocumentSet.java
@@ -26,6 +26,7 @@ import org.exist.collections.Collection;
 import org.exist.numbering.NodeId;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.LockException;
 import org.exist.util.hashtable.Int2ObjectHashMap;
 import org.exist.xmldb.XmldbURI;
@@ -274,9 +275,9 @@ public class DefaultDocumentSet extends Int2ObjectHashMap implements MutableDocu
             //if (checkExisting && dlock.hasLock(thread))
             //continue;
             if (exclusive) {
-                dlock.acquire(Lock.WRITE_LOCK);
+                dlock.acquire(LockMode.WRITE_LOCK);
             } else {
-                dlock.acquire(Lock.READ_LOCK);
+                dlock.acquire(LockMode.READ_LOCK);
             }
         }
     }
@@ -291,9 +292,9 @@ public class DefaultDocumentSet extends Int2ObjectHashMap implements MutableDocu
             final DocumentImpl d = (DocumentImpl)values[idx];
             final Lock dlock = d.getUpdateLock();
             if (exclusive) {
-                dlock.release(Lock.WRITE_LOCK);
+                dlock.release(LockMode.WRITE_LOCK);
             } else if (dlock.isLockedForRead(thread)) {
-                dlock.release(Lock.READ_LOCK);
+                dlock.release(LockMode.READ_LOCK);
             }
         }
     }

--- a/src/org/exist/dom/persistent/ExtArrayNodeSet.java
+++ b/src/org/exist/dom/persistent/ExtArrayNodeSet.java
@@ -25,6 +25,7 @@ import org.exist.collections.Collection;
 import org.exist.numbering.NodeId;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.ArrayUtils;
 import org.exist.util.FastQSort;
 import org.exist.util.LockException;
@@ -460,7 +461,7 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
         for (int i = 0; i < partCount; i++) {
             final DocumentImpl doc = parts[i].getOwnerDocument();
             final Lock docLock = doc.getUpdateLock();
-            docLock.acquire(exclusive ? Lock.WRITE_LOCK : Lock.READ_LOCK);
+            docLock.acquire(exclusive ? LockMode.WRITE_LOCK : LockMode.READ_LOCK);
         }
     }
 
@@ -471,9 +472,9 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
             final DocumentImpl doc = parts[i].getOwnerDocument();
             final Lock docLock = doc.getUpdateLock();
             if(exclusive) {
-                docLock.release(Lock.WRITE_LOCK);
+                docLock.release(LockMode.WRITE_LOCK);
             } else if(docLock.isLockedForRead(thread)) {
-                docLock.release(Lock.READ_LOCK);
+                docLock.release(LockMode.READ_LOCK);
             }
         }
     }

--- a/src/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/src/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -25,6 +25,7 @@ import org.exist.collections.Collection;
 import org.exist.numbering.NodeId;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.FastQSort;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
@@ -1053,7 +1054,7 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
         for(int idx = 0; idx < documentCount; idx++) {
             final DocumentImpl doc = nodes[documentOffsets[idx]].getOwnerDocument();
             final Lock docLock = doc.getUpdateLock();
-            docLock.acquire(exclusive ? Lock.WRITE_LOCK : Lock.READ_LOCK);
+            docLock.acquire(exclusive ? LockMode.WRITE_LOCK : LockMode.READ_LOCK);
         }
     }
 
@@ -1065,9 +1066,9 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
             final DocumentImpl doc = nodes[documentOffsets[idx]].getOwnerDocument();
             final Lock docLock = doc.getUpdateLock();
             if(exclusive) {
-                docLock.release(Lock.WRITE_LOCK);
+                docLock.release(LockMode.WRITE_LOCK);
             } else if(docLock.isLockedForRead(thread)) {
-                docLock.release(Lock.READ_LOCK);
+                docLock.release(LockMode.READ_LOCK);
             }
         }
     }

--- a/src/org/exist/dom/persistent/NodeProxy.java
+++ b/src/org/exist/dom/persistent/NodeProxy.java
@@ -29,6 +29,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.RangeIndexSpec;
 import org.exist.storage.StorageAddress;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
@@ -1421,16 +1422,16 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     @Override
     public void lock(final DBBroker broker, final boolean exclusive, final boolean checkExisting) throws LockException {
         final Lock docLock = doc.getUpdateLock();
-        docLock.acquire(exclusive ? Lock.WRITE_LOCK : Lock.READ_LOCK);
+        docLock.acquire(exclusive ? LockMode.WRITE_LOCK : LockMode.READ_LOCK);
     }
 
     @Override
     public void unlock(final boolean exclusive) {
         final Lock docLock = doc.getUpdateLock();
         if(exclusive) {
-            docLock.release(Lock.WRITE_LOCK);
+            docLock.release(LockMode.WRITE_LOCK);
         } else if(docLock.isLockedForRead(Thread.currentThread())) {
-            docLock.release(Lock.READ_LOCK);
+            docLock.release(LockMode.READ_LOCK);
         }
     }
 

--- a/src/org/exist/http/AuditTrailSessionListener.java
+++ b/src/org/exist/http/AuditTrailSessionListener.java
@@ -31,7 +31,7 @@ import org.exist.source.Source;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.XQueryPool;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XQuery;
@@ -114,7 +114,7 @@ public class AuditTrailSessionListener implements HttpSessionListener {
                     final XmldbURI pathUri = XmldbURI.create(xqueryResourcePath);
 
 
-                    resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+                    resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
 
                     if (resource != null) {
                         LOG.info("Resource [" + xqueryResourcePath + "] exists.");

--- a/src/org/exist/http/RESTServer.java
+++ b/src/org/exist/http/RESTServer.java
@@ -1071,7 +1071,7 @@ public class RESTServer {
                 try(final VirtualTempFileInputSource vtfis = new VirtualTempFileInputSource(vtempFile, charset)) {
                     final IndexInfo info = collection.validateXMLResource(transaction, broker, docUri, vtfis);
                     info.getDocument().getMetadata().setMimeType(contentType);
-                    collection.store(transaction, broker, info, vtfis, false);
+                    collection.store(transaction, broker, info, vtfis);
                     response.setStatus(HttpServletResponse.SC_CREATED);
                 }
             } else {

--- a/src/org/exist/http/RESTServer.java
+++ b/src/org/exist/http/RESTServer.java
@@ -78,7 +78,7 @@ import org.exist.source.URLSource;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.XQueryPool;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.serializers.Serializer.HttpContext;
@@ -391,7 +391,7 @@ public class RESTServer {
             // check if path leads to an XQuery resource
             final String xquery_mime_type = MimeType.XQUERY_TYPE.getName();
             final String xproc_mime_type = MimeType.XPROC_TYPE.getName();
-            resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+            resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
 
             if (null != resource && !isExecutableType(resource)) {
                 // return regular resource that is not an xquery and not is xproc
@@ -437,7 +437,7 @@ public class RESTServer {
                     break;
                 }
 
-                resource = broker.getXMLResource(servletPath, Lock.READ_LOCK);
+                resource = broker.getXMLResource(servletPath, LockMode.READ_LOCK);
                 if (null != resource && isExecutableType(resource)) {
                     break;
 
@@ -525,7 +525,7 @@ public class RESTServer {
             }
         } finally {
             if (resource != null) {
-                resource.getUpdateLock().release(Lock.READ_LOCK);
+                resource.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
     }
@@ -551,7 +551,7 @@ public class RESTServer {
 
         DocumentImpl resource = null;
         try {
-            resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+            resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
 
             if (resource != null) {
                 if (!resource.getPermissions().validate(broker.getCurrentSubject(), Permission.READ)) {
@@ -585,7 +585,7 @@ public class RESTServer {
             }
         } finally {
             if (resource != null) {
-                resource.getUpdateLock().release(Lock.READ_LOCK);
+                resource.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
     }
@@ -625,7 +625,7 @@ public class RESTServer {
             // if yes, the resource is loaded and the XQuery executed.
             final String xquery_mime_type = MimeType.XQUERY_TYPE.getName();
             final String xproc_mime_type = MimeType.XPROC_TYPE.getName();
-            resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+            resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
 
             XmldbURI servletPath = pathUri;
 
@@ -638,7 +638,7 @@ public class RESTServer {
                     break;
                 }
 
-                resource = broker.getXMLResource(servletPath, Lock.READ_LOCK);
+                resource = broker.getXMLResource(servletPath, LockMode.READ_LOCK);
                 if (null != resource
                         && (resource.getResourceType() == DocumentImpl.BINARY_FILE
                         && xquery_mime_type.equals(resource.getMetadata().getMimeType())
@@ -650,7 +650,7 @@ public class RESTServer {
                     // not an xquery or xproc resource. This means we have a path
                     // that cannot contain an xquery or xproc object even if we keep
                     // moving up the path, so bail out now
-                    resource.getUpdateLock().release(Lock.READ_LOCK);
+                    resource.getUpdateLock().release(LockMode.READ_LOCK);
                     resource = null;
                     break;
                 }
@@ -690,7 +690,7 @@ public class RESTServer {
 
         } finally {
             if (resource != null) {
-                resource.getUpdateLock().release(Lock.READ_LOCK);
+                resource.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
 
@@ -1175,7 +1175,7 @@ public class RESTServer {
             while (null == resource) {
                 // traverse up the path looking for xquery objects
 
-                resource = broker.getXMLResource(servletPath, Lock.READ_LOCK);
+                resource = broker.getXMLResource(servletPath, LockMode.READ_LOCK);
                 if (null != resource
                         && (resource.getResourceType() == DocumentImpl.BINARY_FILE
                         && xqueryType.equals(resource.getMetadata().getMimeType()))) {
@@ -1184,7 +1184,7 @@ public class RESTServer {
                     // not an xquery or xproc resource. This means we have a path
                     // that cannot contain an xquery or xproc object even if we keep
                     // moving up the path, so bail out now
-                    resource.getUpdateLock().release(Lock.READ_LOCK);
+                    resource.getUpdateLock().release(LockMode.READ_LOCK);
                     resource = null;
                     break;
                 }
@@ -1205,7 +1205,7 @@ public class RESTServer {
                 } catch (final XPathException e) {
                     writeXPathExceptionHtml(response, HttpServletResponse.SC_BAD_REQUEST, "UTF-8", null, path.toString(), e);
                 } finally {
-                    resource.getUpdateLock().release(Lock.READ_LOCK);
+                    resource.getUpdateLock().release(LockMode.READ_LOCK);
                 }
                 return true;
             }

--- a/src/org/exist/http/servlets/XSLTServlet.java
+++ b/src/org/exist/http/servlets/XSLTServlet.java
@@ -34,7 +34,7 @@ import org.exist.security.Subject;
 import org.exist.security.internal.web.HttpAccount;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.serializers.XIncludeFilter;
 import org.exist.util.serializer.Receiver;
@@ -456,7 +456,7 @@ public class XSLTServlet extends HttpServlet {
                 try (final DBBroker broker = pool.get(Optional.of(user))) {
                     DocumentImpl doc = null;
                     try {
-                        doc = broker.getXMLResource(XmldbURI.create(docPath), Lock.READ_LOCK);
+                        doc = broker.getXMLResource(XmldbURI.create(docPath), LockMode.READ_LOCK);
                         if (doc == null) {
                             throw new ServletException("Stylesheet not found: " + docPath);
                         }
@@ -469,7 +469,7 @@ public class XSLTServlet extends HttpServlet {
                         lastModified = doc.getMetadata().getLastModified();
                     } finally {
                         if (doc != null) {
-                            doc.getUpdateLock().release(Lock.READ_LOCK);
+                            doc.getUpdateLock().release(LockMode.READ_LOCK);
                         }
                     }
                 } catch (final PermissionDeniedException e) {

--- a/src/org/exist/http/urlrewrite/RewriteConfig.java
+++ b/src/org/exist/http/urlrewrite/RewriteConfig.java
@@ -8,7 +8,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.xmldb.XmldbURI;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.dom.memtree.SAXAdapter;
 import org.exist.xquery.regex.JDK15RegexTranslator;
 import org.exist.xquery.regex.RegexSyntaxException;
@@ -193,13 +193,13 @@ public class RewriteConfig {
             try (final DBBroker broker = urlRewrite.pool.get(Optional.ofNullable(urlRewrite.defaultUser))) {
                 DocumentImpl doc = null;
                 try {
-                    doc = broker.getXMLResource(XmldbURI.create(controllerConfig), Lock.READ_LOCK);
+                    doc = broker.getXMLResource(XmldbURI.create(controllerConfig), LockMode.READ_LOCK);
                     if (doc != null) {
                         parse(doc);
                     }
                 } finally {
                     if (doc != null) {
-                        doc.getUpdateLock().release(Lock.READ_LOCK);
+                        doc.getUpdateLock().release(LockMode.READ_LOCK);
                     }
                 }
             } catch (final EXistException e) {

--- a/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -59,7 +59,7 @@ import org.exist.security.*;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.XQueryPool;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.MimeType;
 import org.exist.http.servlets.HttpRequestWrapper;
@@ -739,7 +739,7 @@ public class XQueryURLRewrite extends HttpServlet {
         	}
             try {
                 final XmldbURI locationUri = XmldbURI.xmldbUriFor(basePath);
-                final Collection collection = broker.openCollection(locationUri, Lock.READ_LOCK);
+                final Collection collection = broker.openCollection(locationUri, LockMode.READ_LOCK);
                 if (collection == null) {
                     LOG.warn("Controller base collection not found: " + basePath);
                     return null;
@@ -755,16 +755,16 @@ public class XQueryURLRewrite extends HttpServlet {
                             if (LOG.isTraceEnabled()) {
                             	LOG.trace("Inspecting sub-collection: " + newSubCollURI);
                             }
-                            subColl = broker.openCollection(newSubCollURI, Lock.READ_LOCK);
+                            subColl = broker.openCollection(newSubCollURI, LockMode.READ_LOCK);
                             if (subColl != null) {
                                 if (LOG.isTraceEnabled()) {
                                 	LOG.trace("Looking for controller.xql in " + subColl.getURI());
                                 }
                                 final XmldbURI docUri = subColl.getURI().append("controller.xql");
-                                doc = broker.getXMLResource(docUri, Lock.READ_LOCK);
+                                doc = broker.getXMLResource(docUri, LockMode.READ_LOCK);
                                 if (doc != null) {
                                 	if (controllerDoc != null) {
-                                		controllerDoc.getUpdateLock().release(Lock.READ_LOCK);
+                                		controllerDoc.getUpdateLock().release(LockMode.READ_LOCK);
                                 	}
                                     controllerDoc = doc;
                                 }
@@ -784,19 +784,19 @@ public class XQueryURLRewrite extends HttpServlet {
                     
                     } finally {
                         if (doc != null && controllerDoc == null) {
-                            doc.getUpdateLock().release(Lock.READ_LOCK);
+                            doc.getUpdateLock().release(LockMode.READ_LOCK);
                         }
                         
                         if (subColl != null && subColl != collection) {
-                            subColl.getLock().release(Lock.READ_LOCK);
+                            subColl.getLock().release(LockMode.READ_LOCK);
                         }
                     }
                 }
-                collection.getLock().release(Lock.READ_LOCK);
+                collection.getLock().release(LockMode.READ_LOCK);
                 if (controllerDoc == null) {
                     try {
                         final XmldbURI docUri = collection.getURI().append("controller.xql");
-                        controllerDoc = broker.getXMLResource(docUri, Lock.READ_LOCK);
+                        controllerDoc = broker.getXMLResource(docUri, LockMode.READ_LOCK);
                     } catch (final PermissionDeniedException e) {
                         LOG.debug("Permission denied while scanning for XQueryURLRewrite controllers: " +
                             e.getMessage(), e);
@@ -825,7 +825,7 @@ public class XQueryURLRewrite extends HttpServlet {
                     return sourceInfo;
                 } finally {
                     if (controllerDoc != null) {
-                        controllerDoc.getUpdateLock().release(Lock.READ_LOCK);
+                        controllerDoc.getUpdateLock().release(LockMode.READ_LOCK);
                     }
                 }
             } catch (final URISyntaxException e) {
@@ -892,7 +892,7 @@ public class XQueryURLRewrite extends HttpServlet {
                 final XmldbURI locationUri = XmldbURI.xmldbUriFor(query);
                 DocumentImpl sourceDoc = null;
                 try {
-                    sourceDoc = broker.getXMLResource(locationUri.toCollectionPathURI(), Lock.READ_LOCK);
+                    sourceDoc = broker.getXMLResource(locationUri.toCollectionPathURI(), LockMode.READ_LOCK);
                     if (sourceDoc == null)
                         {throw new ServletException("XQuery resource: " + query + " not found in database");}
                     if (sourceDoc.getResourceType() != DocumentImpl.BINARY_FILE ||
@@ -905,7 +905,7 @@ public class XQueryURLRewrite extends HttpServlet {
                     throw new ServletException("permission denied to read module source from " + query);
                 } finally {
                     if(sourceDoc != null)
-                        {sourceDoc.getUpdateLock().release(Lock.READ_LOCK);}
+                        {sourceDoc.getUpdateLock().release(LockMode.READ_LOCK);}
                 }
             } catch(final URISyntaxException e) {
                 throw new ServletException(e.getMessage(), e);

--- a/src/org/exist/protocolhandler/embedded/EmbeddedDownload.java
+++ b/src/org/exist/protocolhandler/embedded/EmbeddedDownload.java
@@ -38,7 +38,7 @@ import org.exist.protocolhandler.xmldb.XmldbURL;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.xmldb.XmldbURI;
@@ -110,10 +110,10 @@ public class EmbeddedDownload {
                 DocumentImpl resource = null;
                 Collection collection = null;
                 try {
-                    resource = broker.getXMLResource(path, Lock.READ_LOCK);
+                    resource = broker.getXMLResource(path, LockMode.READ_LOCK);
                     if (resource == null) {
                         // Test for collection
-                        collection = broker.openCollection(path, Lock.READ_LOCK);
+                        collection = broker.openCollection(path, LockMode.READ_LOCK);
                         if (collection == null) {
                             // No collection, no document
                             throw new IOException("Resource " + xmldbURL.getPath() + " not found.");
@@ -140,11 +140,11 @@ public class EmbeddedDownload {
                     }
                 } finally {
                     if(resource != null){
-                        resource.getUpdateLock().release(Lock.READ_LOCK);
+                        resource.getUpdateLock().release(LockMode.READ_LOCK);
                     }
 
                     if(collection != null){
-                        collection.release(Lock.READ_LOCK);
+                        collection.release(LockMode.READ_LOCK);
                     }
                     LOG.debug("End document download");
                 }

--- a/src/org/exist/protocolhandler/embedded/EmbeddedUpload.java
+++ b/src/org/exist/protocolhandler/embedded/EmbeddedUpload.java
@@ -173,7 +173,7 @@ public class EmbeddedUpload {
                         doc.getMetadata().setMimeType(contentType);
                         collection.release(Lock.READ_LOCK);
                         collectionLocked = false;
-                        collection.store(txn, broker, info, inputsource, false);
+                        collection.store(txn, broker, info, inputsource);
                         LOG.debug("done");
 
                     } else {

--- a/src/org/exist/protocolhandler/embedded/EmbeddedUpload.java
+++ b/src/org/exist/protocolhandler/embedded/EmbeddedUpload.java
@@ -37,7 +37,7 @@ import org.exist.protocolhandler.xmldb.XmldbURL;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.util.MimeTable;
@@ -144,7 +144,7 @@ public class EmbeddedUpload {
                 final XmldbURI collectionUri = XmldbURI.create(xmldbURL.getCollection());
                 final XmldbURI documentUri = XmldbURI.create(xmldbURL.getDocumentName());
 
-                collection = broker.openCollection(collectionUri, Lock.READ_LOCK);
+                collection = broker.openCollection(collectionUri, LockMode.READ_LOCK);
 
                 if (collection == null) {
                     throw new IOException("Resource " + collectionUri.toString() + " is not a collection.");
@@ -171,7 +171,7 @@ public class EmbeddedUpload {
                         final IndexInfo info = collection.validateXMLResource(txn, broker, documentUri, inputsource);
                         final DocumentImpl doc = info.getDocument();
                         doc.getMetadata().setMimeType(contentType);
-                        collection.release(Lock.READ_LOCK);
+                        collection.release(LockMode.READ_LOCK);
                         collectionLocked = false;
                         collection.store(txn, broker, info, inputsource);
                         LOG.debug("done");
@@ -200,7 +200,7 @@ public class EmbeddedUpload {
         } finally {
             LOG.debug("Done.");
             if(collectionLocked && collection != null){
-                collection.release(Lock.READ_LOCK);
+                collection.release(LockMode.READ_LOCK);
             }
         }
     }

--- a/src/org/exist/repo/Deployment.java
+++ b/src/org/exist/repo/Deployment.java
@@ -611,7 +611,7 @@ public class Deployment {
             final Permission permission = info.getDocument().getPermissions();
             setPermissions(requestedPerms, false, MimeType.XML_TYPE, permission);
 
-            collection.store(transaction, broker, info, updatedXML, false);
+            collection.store(transaction, broker, info, updatedXML);
 
             mgr.commit(transaction);
         } catch (final Exception e) {
@@ -769,7 +769,7 @@ public class Deployment {
                             final Permission permission = info.getDocument().getPermissions();
                             setPermissions(requestedPerms, false, mime, permission);
 
-                            targetCollection.store(transaction, broker, info, is, false);
+                            targetCollection.store(transaction, broker, info, is);
                         } catch (Exception e) {
                             //check for .html ending
                             if(mime.getName().equals(MimeType.HTML_TYPE.getName())){

--- a/src/org/exist/repo/RepoBackup.java
+++ b/src/org/exist/repo/RepoBackup.java
@@ -4,7 +4,7 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
 import org.exist.storage.NativeBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.FileUtils;
 import org.exist.xmldb.XmldbURI;
 
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -38,7 +37,7 @@ public class RepoBackup {
         final XmldbURI docPath = XmldbURI.createInternal(XmldbURI.ROOT_COLLECTION + "/" + REPO_ARCHIVE);
         DocumentImpl doc = null;
         try {
-            doc = broker.getXMLResource(docPath, Lock.READ_LOCK);
+            doc = broker.getXMLResource(docPath, LockMode.READ_LOCK);
             if (doc == null)
                 {return;}
             if (doc.getResourceType() != DocumentImpl.BINARY_FILE)
@@ -49,7 +48,7 @@ public class RepoBackup {
             unzip(file, directory);
         } finally {
             if (doc != null)
-                {doc.getUpdateLock().release(Lock.READ_LOCK);}
+                {doc.getUpdateLock().release(LockMode.READ_LOCK);}
         }
     }
 

--- a/src/org/exist/scheduler/UserXQueryJob.java
+++ b/src/org/exist/scheduler/UserXQueryJob.java
@@ -36,7 +36,7 @@ import org.exist.source.SourceFactory;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.XQueryPool;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XPathException;
@@ -158,7 +158,7 @@ public class UserXQueryJob extends UserJob {
                 source = SourceFactory.getSource(broker, "", xqueryresource, true);
             } else {
                 final XmldbURI pathUri = XmldbURI.create(xqueryresource);
-                resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+                resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
 
                 if(resource != null) {
                     source = new DBSource(broker, (BinaryDocument)resource, true);
@@ -240,7 +240,7 @@ public class UserXQueryJob extends UserJob {
 
             //release the lock on the xquery resource
             if(resource != null) {
-                resource.getUpdateLock().release(Lock.READ_LOCK);
+                resource.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
     }

--- a/src/org/exist/security/PermissionFactory.java
+++ b/src/org/exist/security/PermissionFactory.java
@@ -29,7 +29,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionException;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -113,9 +113,9 @@ public class PermissionFactory {
         DocumentImpl doc = null;
         final TransactionManager transact = broker.getBrokerPool().getTransactionManager();
         try(final Txn transaction = transact.beginTransaction()) {
-            final Collection collection = broker.openCollection(pathUri, Lock.WRITE_LOCK);
+            final Collection collection = broker.openCollection(pathUri, LockMode.WRITE_LOCK);
             if (collection == null) {
-                doc = broker.getXMLResource(pathUri, Lock.WRITE_LOCK);
+                doc = broker.getXMLResource(pathUri, LockMode.WRITE_LOCK);
                 if(doc == null) {
                     transact.abort(transaction);
                     throw new XPathException("Resource or collection '" + pathUri.toString() + "' does not exist.");
@@ -129,7 +129,7 @@ public class PermissionFactory {
                 broker.flush();
             } else {
                 // keep the write lock in the transaction
-                transaction.registerLock(collection.getLock(), Lock.WRITE_LOCK);
+                transaction.registerLock(collection.getLock(), LockMode.WRITE_LOCK);
 
                 final Permission permissions = collection.getPermissionsNoLock();
                 permissionModifier.accept(permissions);
@@ -142,7 +142,7 @@ public class PermissionFactory {
             throw new PermissionDeniedException("Permission to modify permissions is denied for user '" + broker.getCurrentSubject().getName() + "' on '" + pathUri.toString() + "': " + e.getMessage(), e);
         } finally {
             if(doc != null) {
-                doc.getUpdateLock().release(Lock.WRITE_LOCK);
+                doc.getUpdateLock().release(LockMode.WRITE_LOCK);
             }
         }
     }

--- a/src/org/exist/security/internal/SMEvents.java
+++ b/src/org/exist/security/internal/SMEvents.java
@@ -43,7 +43,7 @@ import org.exist.source.Source;
 import org.exist.source.StringSource;
 import org.exist.storage.DBBroker;
 import org.exist.storage.ProcessMonitor;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.AnalyzeContextInfo;
 import org.exist.xquery.CompiledXQuery;
@@ -153,7 +153,7 @@ public class SMEvents implements Configurable {
         	try {
 				final XmldbURI pathUri = XmldbURI.create(scriptURI);
 				
-				resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+				resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
 				if (resource != null)
 					{return new DBSource(broker, (BinaryDocument)resource, true);}
 				
@@ -162,7 +162,7 @@ public class SMEvents implements Configurable {
 				e.printStackTrace();
 			} finally {
 				if(resource != null)
-					{resource.getUpdateLock().release(Lock.READ_LOCK);}
+					{resource.getUpdateLock().release(LockMode.READ_LOCK);}
 			}
 
 //			try {

--- a/src/org/exist/source/DBSource.java
+++ b/src/org/exist/source/DBSource.java
@@ -36,7 +36,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.security.internal.aider.UnixStylePermissionAider;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 
 /**
@@ -96,7 +96,7 @@ public class DBSource extends AbstractSource {
         DocumentImpl d = null;
         int result;
         try {
-            d = broker.getXMLResource(key, Lock.READ_LOCK);
+            d = broker.getXMLResource(key, LockMode.READ_LOCK);
             
             if(d == null) {
                 result = INVALID;
@@ -109,7 +109,7 @@ public class DBSource extends AbstractSource {
             result = INVALID;
         } finally {
             if(d != null) {
-                d.getUpdateLock().release(Lock.READ_LOCK);
+                d.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
         

--- a/src/org/exist/source/SourceFactory.java
+++ b/src/org/exist/source/SourceFactory.java
@@ -37,7 +37,7 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.FileUtils;
 import org.exist.xmldb.XmldbURI;
 
@@ -158,7 +158,7 @@ public class SourceFactory {
             DocumentImpl resource = null;
             try {
                 final XmldbURI pathUri = XmldbURI.create(location);
-                resource = broker.getXMLResource(pathUri, Lock.READ_LOCK);
+                resource = broker.getXMLResource(pathUri, LockMode.READ_LOCK);
                 if (resource != null) {
                     source = new DBSource(broker, (BinaryDocument) resource, true);
                 }
@@ -166,7 +166,7 @@ public class SourceFactory {
                 //TODO: this is nasty!!! as we are unlocking the resource whilst there
                 //is still a source
                 if (resource != null) {
-                    resource.getUpdateLock().release(Lock.READ_LOCK);
+                    resource.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
         }

--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -42,6 +42,7 @@ import org.exist.security.Subject;
 import org.exist.stax.IEmbeddedXMLStreamReader;
 import org.exist.storage.btree.BTreeCallback;
 import org.exist.storage.dom.INodeIterator;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.Txn;
@@ -293,7 +294,7 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
      * 
      * deprecated Use XmldbURI instead!
      * 
-     * public abstract Collection openCollection(String name, int lockMode);
+     * public abstract Collection openCollection(String name, LockMode lockMode);
      */
 
     /**
@@ -311,7 +312,7 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
      * @return collection or null if no collection matches the path
      * 
      */
-    public abstract Collection openCollection(XmldbURI uri, int lockMode) throws PermissionDeniedException;
+    public abstract Collection openCollection(XmldbURI uri, LockMode lockMode) throws PermissionDeniedException;
 
     public abstract List<String> findCollectionsMatching(String regexp);
     
@@ -392,7 +393,7 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
     /**
      * deprecated Use XmldbURI instead!
      * 
-     * public abstract DocumentImpl getXMLResource(String docPath, int lockMode)
+     * public abstract DocumentImpl getXMLResource(String docPath, LockMode lockMode)
      * throws PermissionDeniedException;
      */
 
@@ -403,7 +404,7 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
      * @return the document or null if no document could be found at the
      *         specified location.
      */
-    public abstract DocumentImpl getXMLResource(XmldbURI docURI, int lockMode)
+    public abstract DocumentImpl getXMLResource(XmldbURI docURI, LockMode lockMode)
         throws PermissionDeniedException;
 
     /**

--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -376,15 +376,16 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
      * public abstract Document getXMLResource(String path) throws
      * PermissionDeniedException;
      */
-
     public abstract Document getXMLResource(XmldbURI docURI) throws PermissionDeniedException;
-    
+
     /**
-     * Return the document stored at the specified path. The path should be
-     * absolute, e.g. /db/shakespeare/plays/hamlet.xml.
-     * 
-     * @return the document or null if no document could be found at the
-     *         specified location.
+     * Get a document by its file name. The document's file name is used to
+     * identify a document.
+     *
+     * @param docURI absolute file name in the database;
+     *                 name can be given with or without the leading path /db/shakespeare.
+     * @param accessType The access mode for the resource e.g. {@link org.exist.security.Permission#READ}
+     * @return The document value or null if no document could be found
      */
     public abstract DocumentImpl getResource(XmldbURI docURI, int accessType) throws PermissionDeniedException;
 

--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -2171,19 +2171,11 @@ public class NativeBroker extends DBBroker {
         }
     }
 
+    @Override
     public Document getXMLResource(final XmldbURI fileName) throws PermissionDeniedException {
         return getResource(fileName, Permission.READ);
     }
 
-    /**
-     * get a document by its file name. The document's file name is used to
-     * identify a document.
-     *
-     * @param fileName absolute file name in the database;
-     *                 name can be given with or without the leading path /db/shakespeare.
-     * @return The document value
-     * @throws PermissionDeniedException
-     */
     @Override
     public DocumentImpl getResource(XmldbURI fileName, final int accessType) throws PermissionDeniedException {
         fileName = prepend(fileName.toCollectionPathURI());

--- a/src/org/exist/storage/NativeValueIndex.java
+++ b/src/org/exist/storage/NativeValueIndex.java
@@ -48,6 +48,7 @@ import org.exist.storage.io.VariableByteArrayInput;
 import org.exist.storage.io.VariableByteInput;
 import org.exist.storage.io.VariableByteOutputStream;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
@@ -359,7 +360,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
         final Lock lock = dbValues.getLock();
 
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
             dbValues.flush();
         } catch (final LockException e) {
             LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
@@ -368,7 +369,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
             LOG.error(e.getMessage(), e);
             //TODO : throw an exception ? -pb
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 
@@ -418,7 +419,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
             os.writeFixedInt(nodeIDsLength, os.position() - nodeIDsLength - LENGTH_NODE_IDS);
             final Lock lock = dbValues.getLock();
             try {
-                lock.acquire(Lock.WRITE_LOCK);
+                lock.acquire(LockMode.WRITE_LOCK);
 
                 final Value v = dbKeyFn.apply(key);
 
@@ -437,7 +438,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
                 //Return without clearing the pending entries
                 return;
             } finally {
-                lock.release(Lock.WRITE_LOCK);
+                lock.release(LockMode.WRITE_LOCK);
                 os.clear();
             }
         }
@@ -465,7 +466,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
 
             final Lock lock = dbValues.getLock();
             try {
-                lock.acquire(Lock.WRITE_LOCK);
+                lock.acquire(LockMode.WRITE_LOCK);
 
                 //Compute a key for the value
                 final Value searchKey = dbKeyFn.apply(key);
@@ -559,7 +560,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
             } catch (final ReadOnlyException e) {
                 LOG.warn("Read-only error on '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
             } finally {
-                lock.release(Lock.WRITE_LOCK);
+                lock.release(LockMode.WRITE_LOCK);
                 os.clear();
             }
         }
@@ -575,7 +576,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
         final Lock lock = dbValues.getLock();
 
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
 
             flush();
 
@@ -591,7 +592,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
         } catch (final BTreeException | IOException e) {
             LOG.error(e.getMessage(), e);
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 
@@ -600,7 +601,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
         final int collectionId = document.getCollection().getId();
         final Lock lock = dbValues.getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
 
             dropIndex(document.getDocId(), pendingGeneric, key -> new SimpleValue(collectionId, (Indexable) key));
             dropIndex(document.getDocId(), pendingQName, key -> new QNameValue(collectionId, key.qname, key.value, broker.getBrokerPool().getSymbols()));
@@ -612,7 +613,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
             LOG.warn("Exception while removing range index: " + e.getMessage(), e);
         } finally {
             os.clear();
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 
@@ -729,7 +730,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
 
             if (qnames == null) {
                 try {
-                    lock.acquire(Lock.READ_LOCK);
+                    lock.acquire(LockMode.READ_LOCK);
                     final Value searchKey = new SimpleValue(collectionId, value);
                     final IndexQuery query = new IndexQuery(idxOp, searchKey);
 
@@ -744,12 +745,12 @@ public class NativeValueIndex implements ContentLoadingObserver {
                 } catch (final LockException e) {
                     LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
                 } finally {
-                    lock.release(Lock.READ_LOCK);
+                    lock.release(LockMode.READ_LOCK);
                 }
             } else {
                 for (final QName qname : qnames) {
                     try {
-                        lock.acquire(Lock.READ_LOCK);
+                        lock.acquire(LockMode.READ_LOCK);
 
                         //Compute a key for the value in the collection
                         final Value searchKey = new QNameValue(collectionId, qname, value, broker.getBrokerPool().getSymbols());
@@ -766,7 +767,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
                     } catch (final LockException e) {
                         LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
                     } finally {
-                        lock.release(Lock.READ_LOCK);
+                        lock.release(LockMode.READ_LOCK);
                     }
                 }
             }
@@ -892,7 +893,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
             watchDog.proceed(null);
             if (qnames == null) {
                 try {
-                    lock.acquire(Lock.READ_LOCK);
+                    lock.acquire(LockMode.READ_LOCK);
 
                     final Value searchKey;
                     if (startTerm != null) {
@@ -909,12 +910,12 @@ public class NativeValueIndex implements ContentLoadingObserver {
                 } catch (final LockException e) {
                     LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
                 } finally {
-                    lock.release(Lock.READ_LOCK);
+                    lock.release(LockMode.READ_LOCK);
                 }
             } else {
                 for (final QName qname : qnames) {
                     try {
-                        lock.acquire(Lock.READ_LOCK);
+                        lock.acquire(LockMode.READ_LOCK);
 
                         final Value searchKey;
                         if (startTerm != null) {
@@ -930,7 +931,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
                     } catch (final LockException e) {
                         LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
                     } finally {
-                        lock.release(Lock.READ_LOCK);
+                        lock.release(LockMode.READ_LOCK);
                     }
                 }
             }
@@ -947,7 +948,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
         for (final Iterator<Collection> i = docs.getCollectionIterator(); i.hasNext(); ) {
 
             try {
-                lock.acquire(Lock.READ_LOCK);
+                lock.acquire(LockMode.READ_LOCK);
                 final Collection c = i.next();
                 final int collectionId = c.getId();
 
@@ -966,7 +967,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
             } catch (final LockException e) {
                 LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
             } finally {
-                lock.release(Lock.READ_LOCK);
+                lock.release(LockMode.READ_LOCK);
             }
         }
         final Map<AtomicValue, ValueOccurrences> map = cb.map;
@@ -1001,7 +1002,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
 
             for (final Iterator<Collection> i = docs.getCollectionIterator(); i.hasNext(); ) {
                 try {
-                    lock.acquire(Lock.READ_LOCK);
+                    lock.acquire(LockMode.READ_LOCK);
                     final int collectionId = i.next().getId();
 
                     //Compute a key for the start value in the collection
@@ -1019,7 +1020,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
                 } catch (final LockException e) {
                     LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
                 } finally {
-                    lock.release(Lock.READ_LOCK);
+                    lock.release(LockMode.READ_LOCK);
                 }
             }
         }
@@ -1107,13 +1108,13 @@ public class NativeValueIndex implements ContentLoadingObserver {
     public void closeAndRemove() {
         final Lock lock = dbValues.getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
             config.setProperty(getConfigKeyForFile(), null);
             dbValues.closeAndRemove();
         } catch (final LockException e) {
             LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 
@@ -1121,13 +1122,13 @@ public class NativeValueIndex implements ContentLoadingObserver {
     public void close() throws DBException {
         final Lock lock = dbValues.getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
             config.setProperty(getConfigKeyForFile(), null);
             dbValues.close();
         } catch (final LockException e) {
             LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(dbValues.getFile()) + "'", e);
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 

--- a/src/org/exist/storage/btree/Repair.java
+++ b/src/org/exist/storage/btree/Repair.java
@@ -7,6 +7,7 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.NativeBroker;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.structural.NativeStructuralIndexWorker;
 import org.exist.util.Configuration;
 import org.exist.util.DatabaseConfigurationException;
@@ -54,13 +55,13 @@ public class Repair {
             }
             final Lock lock = btree.getLock();
             try {
-                lock.acquire(Lock.WRITE_LOCK);
+                lock.acquire(LockMode.WRITE_LOCK);
 
                 System.console().printf("Rebuilding %15s ...", FileUtils.fileName(btree.getFile()));
                 btree.rebuild();
                 System.out.println("Done");
             } finally {
-                lock.release(Lock.WRITE_LOCK);
+                lock.release(LockMode.WRITE_LOCK);
             }
 
         } catch (Exception e) {

--- a/src/org/exist/storage/dom/DOMTransaction.java
+++ b/src/org/exist/storage/dom/DOMTransaction.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
 import org.exist.util.ReadOnlyException;
@@ -41,20 +42,18 @@ import org.exist.util.ReadOnlyException;
  */
 public abstract class DOMTransaction {
 
-    private final static Logger LOG = LogManager.getLogger(DOMTransaction.class);
+    private static final Logger LOG = LogManager.getLogger(DOMTransaction.class);
 
-    private Object ownerObject;
-    private DOMFile file;
-    private DocumentImpl document = null;
-    private int mode;
+    private final Object ownerObject;
+    private final DOMFile file;
+    private final LockMode mode;
+    private final DocumentImpl document;
 
     /**
      * @deprecated : use other constructors
      */
-    public DOMTransaction(Object owner, DOMFile file) {
-        this.ownerObject = owner;
-        this.file = file;
-        this.mode = Lock.READ_LOCK;
+    public DOMTransaction(final Object owner, final DOMFile file) {
+        this(owner, file, LockMode.READ_LOCK);
     }
 
     /**
@@ -64,9 +63,8 @@ public abstract class DOMTransaction {
      * @param file a <code>DOMFile</code> value
      * @param mode an <code>int</code> value
      */
-    public DOMTransaction(Object owner, DOMFile file, int mode) {
-        this(owner, file);
-        this.mode = mode;
+    public DOMTransaction(final Object owner, final DOMFile file, final LockMode mode) {
+        this(owner, file, mode, null);
     }
 
     /**
@@ -77,8 +75,10 @@ public abstract class DOMTransaction {
      * @param mode an <code>int</code> value
      * @param doc a <code>DocumentImpl</code> value
      */
-    public DOMTransaction(Object owner, DOMFile file, int mode, DocumentImpl doc) {
-        this(owner, file, mode);
+    public DOMTransaction(final Object owner, final DOMFile file, final LockMode mode, final DocumentImpl doc) {
+        this.ownerObject = owner;
+        this.file = file;
+        this.mode = mode;
         this.document = doc;
     }
 

--- a/src/org/exist/storage/dom/NodeIterator.java
+++ b/src/org/exist/storage/dom/NodeIterator.java
@@ -12,6 +12,7 @@ import org.exist.storage.btree.BTree;
 import org.exist.storage.btree.BTreeException;
 import org.exist.storage.btree.Paged.Page;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.ByteConversion;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
@@ -72,7 +73,7 @@ public final class NodeIterator implements INodeIterator {
         final Lock lock = db.getLock();
         try {
             try {
-                lock.acquire(Lock.READ_LOCK);
+                lock.acquire(LockMode.READ_LOCK);
             } catch (final LockException e) {
                 LOG.warn("Failed to acquire read lock on " + FileUtils.fileName(db.getFile()));
                 //TODO : throw exception here ? -pb
@@ -97,7 +98,7 @@ public final class NodeIterator implements INodeIterator {
             LOG.warn(e);
             //TODO : throw exception here ? -pb
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
         return false;
     }
@@ -110,7 +111,7 @@ public final class NodeIterator implements INodeIterator {
         final Lock lock = db.getLock();
         try {
             try {
-                lock.acquire(Lock.READ_LOCK);
+                lock.acquire(LockMode.READ_LOCK);
             } catch (final LockException e) {
                 LOG.warn("Failed to acquire read lock on " + FileUtils.fileName(db.getFile()));
                 //TODO : throw exception here ? -pb
@@ -217,7 +218,7 @@ public final class NodeIterator implements INodeIterator {
             LOG.error(e.getMessage(), e);
             //TODO : re-throw exception ? -pb
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
         return null;
     }

--- a/src/org/exist/storage/dom/RawNodeIterator.java
+++ b/src/org/exist/storage/dom/RawNodeIterator.java
@@ -32,6 +32,7 @@ import org.exist.storage.btree.BTreeException;
 import org.exist.storage.btree.Paged;
 import org.exist.storage.btree.Value;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.ByteConversion;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
@@ -76,7 +77,7 @@ public class RawNodeIterator implements IRawNodeIterator {
     public final void seek(final NodeHandle node) throws IOException {
         final Lock lock = db.getLock();
         try {
-            lock.acquire(Lock.READ_LOCK);
+            lock.acquire(LockMode.READ_LOCK);
             RecordPos rec = null;
             if (StorageAddress.hasAddress(node.getInternalAddress()))
                 {rec = db.findRecord(node.getInternalAddress());}
@@ -97,7 +98,7 @@ public class RawNodeIterator implements IRawNodeIterator {
         } catch (final LockException e) {
             throw new IOException("Exception while scanning document: " + e.getMessage());
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
     }
 
@@ -107,7 +108,7 @@ public class RawNodeIterator implements IRawNodeIterator {
         final Lock lock = db.getLock();
         try {
             try {
-                lock.acquire(Lock.READ_LOCK);
+                lock.acquire(LockMode.READ_LOCK);
             } catch (final LockException e) {
                 LOG.error("Failed to acquire read lock on " + FileUtils.fileName(db.getFile()));
                 //TODO : throw exception here ? -pb
@@ -199,7 +200,7 @@ public class RawNodeIterator implements IRawNodeIterator {
             } while (nextValue == null);
             return nextValue;
         } finally {
-            lock.release(Lock.READ_LOCK);
+            lock.release(LockMode.READ_LOCK);
         }
     }
 

--- a/src/org/exist/storage/index/BFile.java
+++ b/src/org/exist/storage/index/BFile.java
@@ -46,6 +46,7 @@ import org.exist.storage.journal.LogEntryTypes;
 import org.exist.storage.journal.Loggable;
 import org.exist.storage.journal.Lsn;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.ReentrantReadWriteLock;
 import org.exist.storage.txn.Txn;
 import org.exist.util.*;
@@ -2336,7 +2337,7 @@ public class BFile extends BTree {
             }
 
             try {
-                lock.acquire(Lock.READ_LOCK);
+                lock.acquire(LockMode.READ_LOCK);
                 nextPage = (SinglePage) getDataPage(next, false);
                 pageLen = nextPage.ph.getDataLength();
                 offset = 0;
@@ -2345,7 +2346,7 @@ public class BFile extends BTree {
                 throw new IOException("failed to acquire a read lock on "
                         + FileUtils.fileName(getFile()));
             } finally {
-                lock.release(Lock.READ_LOCK);
+                lock.release(LockMode.READ_LOCK);
             }
         }
 
@@ -2457,7 +2458,7 @@ public class BFile extends BTree {
             final int newPage = StorageAddress.pageFromPointer(position);
             final short newOffset = StorageAddress.tidFromPointer(position);
             try {
-                lock.acquire(Lock.READ_LOCK);
+                lock.acquire(LockMode.READ_LOCK);
                 nextPage = getSinglePage(newPage);
                 pageLen = nextPage.ph.getDataLength();
                 if (pageLen > fileHeader.getWorkSize()) {
@@ -2468,7 +2469,7 @@ public class BFile extends BTree {
             } catch (final LockException e) {
                 throw new IOException("Failed to acquire a read lock on " + FileUtils.fileName(getFile()));
             } finally {
-                lock.release(Lock.READ_LOCK);
+                lock.release(LockMode.READ_LOCK);
             }
         }
     }

--- a/src/org/exist/storage/index/CollectionStore.java
+++ b/src/org/exist/storage/index/CollectionStore.java
@@ -11,6 +11,7 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.btree.DBException;
 import org.exist.storage.btree.Value;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.*;
 
 import java.io.IOException;
@@ -81,13 +82,13 @@ public class CollectionStore extends BFile {
     public void freeResourceId(int id) {
         final Lock lock = getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
 
             freeResourceIds.push(id);
         } catch (LockException e) {
             LOG.warn("Failed to acquire lock on " + FileUtils.fileName(getFile()), e);
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 
@@ -95,7 +96,7 @@ public class CollectionStore extends BFile {
         int freeDocId = DocumentImpl.UNKNOWN_DOCUMENT_ID;
         final Lock lock = getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
 
             if (!freeResourceIds.isEmpty()) {
                 freeDocId = freeResourceIds.pop();
@@ -105,7 +106,7 @@ public class CollectionStore extends BFile {
             return DocumentImpl.UNKNOWN_DOCUMENT_ID;
             //TODO : rethrow ? -pb
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
         return freeDocId;
     }
@@ -113,13 +114,13 @@ public class CollectionStore extends BFile {
     public void freeCollectionId(int id) {
         final Lock lock = getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
 
             freeCollectionIds.push(id);
         } catch (LockException e) {
             LOG.warn("Failed to acquire lock on " + FileUtils.fileName(getFile()), e);
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 
@@ -127,7 +128,7 @@ public class CollectionStore extends BFile {
         int freeCollectionId = Collection.UNKNOWN_COLLECTION_ID;
         final Lock lock = getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
 
             if (!freeCollectionIds.isEmpty()) {
                 freeCollectionId = freeCollectionIds.pop();
@@ -137,7 +138,7 @@ public class CollectionStore extends BFile {
             return Collection.UNKNOWN_COLLECTION_ID;
             //TODO : rethrow ? -pb
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
         return freeCollectionId;
     }

--- a/src/org/exist/storage/lock/Lock.java
+++ b/src/org/exist/storage/lock/Lock.java
@@ -1,24 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-06 Wolfgang M. Meier
- *  wolfgang@exist-db.org
- *  http://exist.sourceforge.net
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- * $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2016 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.lock;
 
@@ -27,49 +24,77 @@ import org.exist.util.LockException;
 
 public interface Lock extends Debuggable {
 
-	public final static int READ_LOCK = 0;
-	public final static int WRITE_LOCK = 1;
-	public final static int NO_LOCK = -1;
-	
+    /**
+     * The modes of a {@link Lock}
+     */
+    enum LockMode {
+        NO_LOCK,
+        READ_LOCK,
+        WRITE_LOCK
+    }
+
+    /**
+     * Get the id of the lock
+     */
+    String getId();
+
+    /**
+     * Create a LockInfo entry for the given lock.
+     *
+     * @return the lock info
+     */
+    LockInfo getLockInfo();
+
 	/**
 	 * Acquire a lock for read.
 	 * 
 	 * @throws LockException
+     *
+     * @deprecated Use {@link #acquire(LockMode)}
 	 */
-    public boolean acquire( ) throws LockException;
+	@Deprecated
+    boolean acquire() throws LockException;
     
     /**
      * Acquire a lock for read or write.
-     * mode is one of {@link #READ_LOCK} or
-     * {@link #WRITE_LOCK}.
+     * mode is one of {@link LockMode#READ_LOCK} or
+     * {@link LockMode#WRITE_LOCK}.
      * 
-     * @param mode
+     * @param mode The mode of the lock to acquire
      * @throws LockException
      */
-	public boolean acquire( int mode ) throws LockException;
+	boolean acquire(LockMode mode) throws LockException;
 	
 	/**
 	 * Attempt to acquire a lock for read or write. This method
 	 * will fail immediately if the lock cannot be acquired.
-	 *  
-	 * @param mode
+	 *
+     * @param mode The mode of the lock to attempt to acquire
 	 */
-	public boolean attempt( int mode );
+	boolean attempt(LockMode mode);
 	
     /**
      * Release a lock of the specified type.
-     * 
-     * @param mode
+     *
+     * @param mode The mode of the lock to release
      */
-    public void release( int mode );
-    
-    public void release(int mode, int count);
+    void release(LockMode mode);
+
+    /**
+     * Release a number of references of the specified lock mode
+     *
+     * @param mode The mode of the lock to release
+     * @param count The number of references to release
+     */
+    void release(LockMode mode, int count);
 
     /**
      * Returns true if there are active or pending
      * write locks.
+     *
+     * @return true if the lock is locked for write
      */
-    public boolean isLockedForWrite();
+    boolean isLockedForWrite();
 
     /**
      * Check if the specified thread does currently hold a read lock.
@@ -77,14 +102,14 @@ public interface Lock extends Debuggable {
      * @param owner the thread to search for
      * @return true if the thread holds a read lock
      */
-    public boolean isLockedForRead(Thread owner);
+    boolean isLockedForRead(Thread owner);
 
     /**
      * Check if the lock is currently locked by someone.
      *
      * @return true if there's an active read or write lock
      */
-    public boolean hasLock();
+    boolean hasLock();
 
     /**
      * Check if the specified thread holds either a write or a read lock
@@ -93,20 +118,11 @@ public interface Lock extends Debuggable {
      * @param owner the thread
      * @return true if owner has a lock
      */
-    public boolean hasLock(Thread owner);
+    boolean hasLock(Thread owner);
 
     /**
      * Wake up waiting threads and recompute dependencies.
      * Currently used to rerun deadlock detection.
      */
-    public void wakeUp();
-
-    public String getId();
-
-    /**
-     * Create a LockInfo entry for the given lock.
-     * 
-     * @return the lock info
-     */
-    public LockInfo getLockInfo();
+    void wakeUp();
 }

--- a/src/org/exist/storage/lock/LockInfo.java
+++ b/src/org/exist/storage/lock/LockInfo.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import org.exist.Debuggable;
 
 /**
- * Encapsulates debug information about a log. This information can be exported
+ * Encapsulates debug information about a lock. This information can be exported
  * via the JMX management interface, if enabled.
  */
 public class LockInfo implements Debuggable {

--- a/src/org/exist/storage/lock/LockListener.java
+++ b/src/org/exist/storage/lock/LockListener.java
@@ -4,6 +4,5 @@ package org.exist.storage.lock;
  * Notify a listener that a lock has been released.
  */
 public interface LockListener {
-
     void lockReleased();
 }

--- a/src/org/exist/storage/lock/LockedDocumentMap.java
+++ b/src/org/exist/storage/lock/LockedDocumentMap.java
@@ -27,6 +27,7 @@ import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.MutableDocumentSet;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.hashtable.Int2ObjectHashMap;
 
 /**
@@ -106,7 +107,7 @@ public class LockedDocumentMap extends Int2ObjectHashMap<Object> {
 
     private void unlockDocument(final LockedDocument lockedDocument) {
         final Lock documentLock = lockedDocument.document.getUpdateLock();
-        documentLock.release(Lock.WRITE_LOCK, lockedDocument.locksAcquired);
+        documentLock.release(LockMode.WRITE_LOCK, lockedDocument.locksAcquired);
     }
 
     private static class LockedDocument {

--- a/src/org/exist/storage/lock/MultiReadReentrantLock.java
+++ b/src/org/exist/storage/lock/MultiReadReentrantLock.java
@@ -57,7 +57,7 @@ public class MultiReadReentrantLock implements Lock {
 
     private final static Logger LOG = LogManager.getLogger(MultiReadReentrantLock.class);
 
-    private Object id;
+    private final Object id;
 
     /**
      * Number of threads waiting to read.
@@ -67,7 +67,7 @@ public class MultiReadReentrantLock implements Lock {
     /**
      * Number of threads reading.
      */
-    private List<LockOwner> outstandingReadLocks = new ArrayList<LockOwner>(4);
+    private final List<LockOwner> outstandingReadLocks = new ArrayList<>(4);
 
     /**
      * The thread that has the write lock or null.
@@ -84,49 +84,62 @@ public class MultiReadReentrantLock implements Lock {
      * Threads waiting to get a write lock are tracked in this ArrayList to
      * ensure that write locks are issued in the same order they are requested.
      */
-    private List<WaitingThread> waitingForWriteLock = null;
+    private final List<WaitingThread> waitingForWriteLock = new ArrayList<>(3);
 
     /**
      * Default constructor.
      */
-    public MultiReadReentrantLock(Object id) {
+    public MultiReadReentrantLock(final Object id) {
         this.id = id;
     }
 
+    @Override
     public String getId() {
         return id.toString();
     }
 
-    /* @deprecated Use other method
-    * @see org.exist.storage.lock.Lock#acquire()
-    */
-    public boolean acquire() throws LockException {
-        return acquire(Lock.READ_LOCK);
-    }
-
-    public boolean acquire(int mode) throws LockException {
-        if (mode == Lock.NO_LOCK) {
-            LOG.warn("acquired with no lock !");
-            return true;
-        }
-        switch (mode) {
-            case Lock.WRITE_LOCK:
-                return writeLock(true);
-            default:
-                return readLock(true);
-        }
-    }
-
-    /* (non-Javadoc)
-     * @see org.exist.util.Lock#attempt(int)
+    /**
+     * @deprecated Use {@link #acquire(LockMode)}
      */
-    public boolean attempt(int mode) {
+    @Override
+    public boolean acquire() throws LockException {
+        return acquire(LockMode.READ_LOCK);
+    }
+
+    @Override
+    public boolean acquire(final LockMode mode) throws LockException {
+        switch (mode) {
+            case NO_LOCK:
+                LOG.warn("Acquired with LockMode.NO_LOCK!");
+                return true;
+
+            case READ_LOCK:
+                return readLock(true);
+
+            case WRITE_LOCK:
+                return writeLock(true);
+
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    @Override
+    public boolean attempt(final LockMode mode) {
         try {
             switch (mode) {
-            case Lock.WRITE_LOCK:
-                return writeLock(false);
-            default:
-                return readLock(false);
+                case NO_LOCK:
+                    LOG.warn("Attempted acquire with LockMode.NO_LOCK!");
+                    return true;
+
+                case READ_LOCK:
+                    return readLock(false);
+
+                case WRITE_LOCK:
+                    return writeLock(false);
+
+                default:
+                    throw new IllegalStateException();
             }
         } catch (final LockException e) {
             return false;
@@ -151,7 +164,7 @@ public class MultiReadReentrantLock implements Lock {
         waitingForReadLock++;
         if (writeLockedThread != null) {
            if (!waitIfNecessary) {return false;}
-            final WaitingThread waiter = new WaitingThread(thisThread, this, this, Lock.READ_LOCK);
+            final WaitingThread waiter = new WaitingThread(thisThread, this, this, LockMode.READ_LOCK);
             DeadlockDetection.addResourceWaiter(thisThread, waiter);
             while (writeLockedThread != null) {
                 //LOG.debug("readLock wait by " + thisThread.getName() + " for " + getId());
@@ -184,12 +197,11 @@ public class MultiReadReentrantLock implements Lock {
                 outstandingWriteLocks++;
                 return true;
             }
-            if (!waitIfNecessary)
-                {return false;}
+            if (!waitIfNecessary) {
+                return false;
+            }
             deadlockCheck();
-            if (waitingForWriteLock == null)
-                {waitingForWriteLock = new ArrayList<WaitingThread>(3);}
-            waiter = new WaitingThread(thisThread, thisThread, this, Lock.WRITE_LOCK);
+            waiter = new WaitingThread(thisThread, thisThread, this, LockMode.WRITE_LOCK);
             addWaitingWrite(waiter);
             DeadlockDetection.addResourceWaiter(thisThread, waiter);
         }
@@ -219,8 +231,9 @@ public class MultiReadReentrantLock implements Lock {
                     }
                 }
             }
-            if (deadlockedThreads == null && exceptionCaught == null)
-                {outstandingWriteLocks++;}
+            if (deadlockedThreads == null && exceptionCaught == null) {
+                outstandingWriteLocks++;
+            }
         }
         synchronized (this) {
             DeadlockDetection.clearResourceWaiter(thisThread);
@@ -251,36 +264,49 @@ public class MultiReadReentrantLock implements Lock {
         }
     }
 
-    /* @deprecated : use other method
-     * @see org.exist.storage.lock.Lock#release()
+    /**
+     * @deprecated Use {@link #release(LockMode)}
      */
     public void release() {
-        release(Lock.READ_LOCK);
+        release(LockMode.READ_LOCK);
     }
 
-    public void release(int mode) {
+    @Override
+    public void release(final LockMode mode) {
         switch (mode) {
-        case Lock.NO_LOCK:
-            break;
-        case Lock.WRITE_LOCK:
-            releaseWrite(1);
-            break;
-        //TODO : use READ_LOCK ? -pb
-        default:
-            releaseRead(1);
-            break;
+            case NO_LOCK:
+                LOG.warn("Released with LockMode.NO_LOCK!");
+                break;
+
+            case READ_LOCK:
+                releaseRead(1);
+                break;
+
+            case WRITE_LOCK:
+                releaseWrite(1);
+                break;
+
+            default:
+                throw new IllegalStateException();
         }
     }
 
-    public void release(int mode, int count) {
+    @Override
+    public void release(final LockMode mode, final int count) {
         switch (mode) {
-        case Lock.WRITE_LOCK:
-            releaseWrite(count);
-            break;
-        //TODO : use READ_LOCK ? -pb
-        default:
-            releaseRead(count);
-            break;
+            case NO_LOCK:
+                LOG.warn("Released with LockMode.NO_LOCK and count=" + count + "!");
+
+            case READ_LOCK:
+                releaseRead(count);
+                break;
+
+            case WRITE_LOCK:
+                releaseWrite(count);
+                break;
+
+            default:
+                throw new IllegalStateException();
         }
     }
 
@@ -341,24 +367,29 @@ public class MultiReadReentrantLock implements Lock {
                     "thread was interrupted or it never acquired the lock. " +
                     "Write lock: " + (writeLockedThread != null ? writeLockedThread.getName() : "null"),
                     new Throwable());
-            if (LockOwner.DEBUG)
-                {debugReadLocks("ILLEGAL RELEASE");}
+            if (LockOwner.DEBUG) {
+                debugReadLocks("ILLEGAL RELEASE");
+            }
             //TODO : throw exception ? -pb
         }
     }
 
+    @Override
     public synchronized boolean isLockedForWrite() {
         return writeLockedThread != null || (waitingForWriteLock != null && waitingForWriteLock.size() > 0);
     }
 
+    @Override
     public synchronized boolean hasLock() {
         return !outstandingReadLocks.isEmpty() || isLockedForWrite();
     }
 
+    @Override
     public synchronized boolean isLockedForRead(Thread owner) {
         for (int i = outstandingReadLocks.size() - 1; i > -1; i--) {
-            if ((outstandingReadLocks.get(i)).getOwner() == owner)
-                {return true;}
+            if ((outstandingReadLocks.get(i)).getOwner() == owner) {
+                return true;
+            }
         }
         return false;
     }
@@ -456,10 +487,11 @@ public class MultiReadReentrantLock implements Lock {
      * @param owner the thread
      * @return true if owner has a read lock
      */
-    private boolean hasReadLock(Thread owner) {
+    private boolean hasReadLock(final Thread owner) {
         for (final LockOwner next : outstandingReadLocks) {
-            if (next.getOwner() == owner)
-                {return true;}
+            if (next.getOwner() == owner) {
+                return true;
+            }
         }
         return false;
     }
@@ -475,12 +507,15 @@ public class MultiReadReentrantLock implements Lock {
      * @param owner the thread
      * @return true if owner has a lock
      */
-    public boolean hasLock(Thread owner) {
-        if (writeLockedThread == owner)
-            {return true;}
+    @Override
+    public boolean hasLock(final Thread owner) {
+        if (writeLockedThread == owner) {
+            return true;
+        }
         return hasReadLock(owner);
     }
 
+    @Override
     public void wakeUp() {
         //Nothing to do
     }
@@ -495,7 +530,7 @@ public class MultiReadReentrantLock implements Lock {
      * @return true if the lock request is compatible with all other requests and the
      * lock can be granted.
      */
-    private boolean isCompatible(Thread waiting) {
+    private boolean isCompatible(final Thread waiting) {
         for (final LockOwner next : outstandingReadLocks) {
             //If the read lock is owned by the current thread, all is OK and we continue
             if (next.getOwner() != waiting) {
@@ -510,6 +545,7 @@ public class MultiReadReentrantLock implements Lock {
         return true;
     }
 
+    @Override
     public synchronized LockInfo getLockInfo() {
         LockInfo info;
         String[] readers = new String[0];
@@ -544,7 +580,7 @@ public class MultiReadReentrantLock implements Lock {
     }
 
     @Override
-    public void debug(PrintStream out) {
+    public void debug(final PrintStream out) {
         getLockInfo().debug(out);
     }
 }

--- a/src/org/exist/storage/lock/ReentrantReadWriteLock.java
+++ b/src/org/exist/storage/lock/ReentrantReadWriteLock.java
@@ -31,7 +31,8 @@
 package org.exist.storage.lock;
 
 import java.io.PrintStream;
-import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -68,20 +69,23 @@ public class ReentrantReadWriteLock implements Lock {
 
     private final Object id_;
 	private Thread owner_ = null;
-    private final Stack<SuspendedWaiter> suspendedThreads = new Stack<>();
+    private final Deque<SuspendedWaiter> suspendedThreads = new ArrayDeque<>();
 
     private int holds_ = 0;
     private LockMode mode_ = LockMode.NO_LOCK;
-    private Stack<LockMode> modeStack = new Stack<>();
+    private final Deque<LockMode> modeStack = new ArrayDeque<>();
     private int writeLocks = 0;
-    private boolean DEBUG = false;
-    private Stack<StackTraceElement[]> seStack;
     private LockListener listener = null;
+
+    private final boolean DEBUG = false;
+    private final Deque<StackTraceElement[]> seStack;
 
     public ReentrantReadWriteLock(final Object id) {
         this.id_ = id;
         if (DEBUG) {
-            seStack = new Stack<>();
+            seStack = new ArrayDeque<>();
+        } else {
+            seStack = null;
         }
     }
 

--- a/src/org/exist/storage/lock/ReentrantReadWriteLock.java
+++ b/src/org/exist/storage/lock/ReentrantReadWriteLock.java
@@ -53,11 +53,11 @@ public class ReentrantReadWriteLock implements Lock {
     private static final int WAIT_CHECK_PERIOD = 200;
 
     private static class SuspendedWaiter {
-        Thread thread;
-        int lockMode;
-        int lockCount;
+        final Thread thread;
+        final LockMode lockMode;
+        final int lockCount;
 
-        public SuspendedWaiter(Thread thread, int lockMode, int lockCount) {
+        public SuspendedWaiter(final Thread thread, final LockMode lockMode, final int lockCount) {
             this.thread = thread;
             this.lockMode = lockMode;
             this.lockCount = lockCount;
@@ -66,50 +66,55 @@ public class ReentrantReadWriteLock implements Lock {
 
     private final static Logger LOG = LogManager.getLogger(ReentrantReadWriteLock.class);
 
-    protected Object id_ = null;
-	protected Thread owner_ = null;
-    protected Stack<SuspendedWaiter> suspendedThreads = new Stack<SuspendedWaiter>();
+    private final Object id_;
+	private Thread owner_ = null;
+    private final Stack<SuspendedWaiter> suspendedThreads = new Stack<>();
 
-    protected int holds_ = 0;
-    public int mode_ = Lock.NO_LOCK;
-    private Stack<Integer> modeStack = new Stack<Integer>();
+    private int holds_ = 0;
+    private LockMode mode_ = LockMode.NO_LOCK;
+    private Stack<LockMode> modeStack = new Stack<>();
     private int writeLocks = 0;
     private boolean DEBUG = false;
     private Stack<StackTraceElement[]> seStack;
     private LockListener listener = null;
 
-    public ReentrantReadWriteLock(Object id) {
-        id_ = id;
-        if (DEBUG)
-            {seStack = new Stack<StackTraceElement[]>();}
+    public ReentrantReadWriteLock(final Object id) {
+        this.id_ = id;
+        if (DEBUG) {
+            seStack = new Stack<>();
+        }
     }
 
+    @Override
     public String getId() {
         return id_.toString();
     }
 
-    /* @deprecated Use other method
-      * @see org.exist.storage.lock.Lock#acquire()
-      */
+    @Override
     public boolean acquire() throws LockException {
-        return acquire(Lock.READ_LOCK);
+        return acquire(LockMode.READ_LOCK);
     }
 
-    public boolean acquire(int mode) throws LockException {
-        if (mode == Lock.NO_LOCK) {
+    @Override
+    public boolean acquire(final LockMode mode) throws LockException {
+        if (mode == LockMode.NO_LOCK) {
             LOG.warn("acquired with no lock !");
             return true;
         }
-        if (Thread.interrupted())
-            {throw new LockException();}
-        Thread caller = Thread.currentThread();
+
+        if (Thread.interrupted()) {
+            throw new LockException();
+        }
+
+        final Thread caller = Thread.currentThread();
         synchronized (this) {
             WaitingThread waitingOnResource;
             if (caller == owner_) {
                 ++holds_;
-                modeStack.push(Integer.valueOf(mode));
-                if (mode == Lock.WRITE_LOCK)
-                    {writeLocks++;}
+                modeStack.push(mode);
+                if (mode == LockMode.WRITE_LOCK) {
+                    writeLocks++;
+                }
                 if (DEBUG) {
                     final Throwable t = new Throwable();
                     seStack.push(t.getStackTrace());
@@ -119,9 +124,10 @@ public class ReentrantReadWriteLock implements Lock {
             } else if (owner_ == null) {
                 owner_ = caller;
                 holds_ = 1;
-                modeStack.push(Integer.valueOf(mode));
-                if (mode== Lock.WRITE_LOCK)
-                    {writeLocks++;}
+                modeStack.push(mode);
+                if (mode== LockMode.WRITE_LOCK) {
+                    writeLocks++;
+                }
                 if (DEBUG) {
                     final Throwable t = new Throwable();
                     seStack.push(t.getStackTrace());
@@ -135,9 +141,10 @@ public class ReentrantReadWriteLock implements Lock {
                 suspendedThreads.push(suspended);
                 owner_ = caller;
                 holds_ = 1;
-                modeStack.push(Integer.valueOf(mode));
-                if (mode== Lock.WRITE_LOCK)
-                    {writeLocks++;}
+                modeStack.push(mode);
+                if (mode== LockMode.WRITE_LOCK) {
+                    writeLocks++;
+                }
                 mode_ = mode;
                 listener = waitingOnResource;
                 return true;
@@ -152,18 +159,20 @@ public class ReentrantReadWriteLock implements Lock {
                             suspendedThreads.push(suspended);
                             owner_ = caller;
                             holds_ = 1;
-                            modeStack.push(Integer.valueOf(mode));
-                            if (mode== Lock.WRITE_LOCK)
-                                {writeLocks++;}
+                            modeStack.push(mode);
+                            if (mode== LockMode.WRITE_LOCK) {
+                                writeLocks++;
+                            }
                             mode_ = mode;
                             listener = waitingOnResource;
                             DeadlockDetection.clearCollectionWaiter(owner_);
                             return true;
                         } else if (caller == owner_) {
                             ++holds_;
-                            modeStack.push(Integer.valueOf(mode));
-                            if (mode == Lock.WRITE_LOCK)
-                                {writeLocks++;}
+                            modeStack.push(mode);
+                            if (mode == LockMode.WRITE_LOCK) {
+                                writeLocks++;
+                            }
                             if (DEBUG) {
                                 final Throwable t = new Throwable();
                                 seStack.push(t.getStackTrace());
@@ -174,9 +183,10 @@ public class ReentrantReadWriteLock implements Lock {
                         } else if (owner_ == null) {
                             owner_ = caller;
                             holds_ = 1;
-                            modeStack.push(Integer.valueOf(mode));
-                            if (mode == Lock.WRITE_LOCK)
-                                {writeLocks++;}
+                            modeStack.push(mode);
+                            if (mode == LockMode.WRITE_LOCK) {
+                                writeLocks++;
+                            }
                             if (DEBUG) {
                                 final Throwable t = new Throwable();
                                 seStack.push(t.getStackTrace());
@@ -194,18 +204,21 @@ public class ReentrantReadWriteLock implements Lock {
         }
     }
 
+    @Override
     public synchronized void wakeUp() {
         notify();
     }
 
-    public boolean attempt(int mode) {
-        Thread caller = Thread.currentThread();
+    @Override
+    public boolean attempt(final LockMode mode) {
+        final Thread caller = Thread.currentThread();
         synchronized (this) {
             if (caller == owner_) {
                 ++holds_;
-                modeStack.push(Integer.valueOf(mode));
-                if (mode == Lock.WRITE_LOCK)
-                    {writeLocks++;}
+                modeStack.push(mode);
+                if (mode == LockMode.WRITE_LOCK) {
+                    writeLocks++;
+                }
                 if (DEBUG) {
                     final Throwable t = new Throwable();
                     seStack.push(t.getStackTrace());
@@ -215,9 +228,10 @@ public class ReentrantReadWriteLock implements Lock {
             } else if (owner_ == null) {
                 owner_ = caller;
                 holds_ = 1;
-                modeStack.push(Integer.valueOf(mode));
-                if (mode == Lock.WRITE_LOCK)
-                    {writeLocks++;}
+                modeStack.push(mode);
+                if (mode == LockMode.WRITE_LOCK) {
+                    writeLocks++;
+                }
                 if (DEBUG) {
                     final Throwable t = new Throwable();
                     seStack.push(t.getStackTrace());
@@ -230,23 +244,24 @@ public class ReentrantReadWriteLock implements Lock {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.util.Lock#isLockedForWrite()
-     */
+    @Override
     public synchronized boolean isLockedForWrite() {
         return writeLocks > 0;
     }
 
-    public boolean isLockedForRead(Thread owner) {
+    @Override
+    public boolean isLockedForRead(final Thread owner) {
         // always returns false for this lock
         return false;
     }
 
+    @Override
     public synchronized boolean hasLock() {
         return holds_ > 0;
     }
 
-    public boolean hasLock(Thread owner) {
+    @Override
+    public boolean hasLock(final Thread owner) {
         return this.owner_ == owner;
     }
 
@@ -254,10 +269,8 @@ public class ReentrantReadWriteLock implements Lock {
         return this.owner_;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.util.Lock#release(int)
-     */
-    public synchronized void release(int mode) {
+    @Override
+    public synchronized void release(final LockMode mode) {
         if (Thread.currentThread() != owner_) {
             
             if(LOG.isDebugEnabled()){
@@ -277,14 +290,14 @@ public class ReentrantReadWriteLock implements Lock {
             }
             return;
         }
-        Integer top = modeStack.pop();
-        mode_ = top.intValue();
+        LockMode top = modeStack.pop();
+        mode_ = top;
         top = null; 	
         if (mode_ != mode) {
             LOG.warn("Released lock of different type. Expected " + mode_ +
                 " got " + mode, new Throwable());
         }      	
-        if (mode_ == Lock.WRITE_LOCK) {
+        if (mode_ == LockMode.WRITE_LOCK) {
             writeLocks--;
         }
         if (DEBUG) {
@@ -298,7 +311,7 @@ public class ReentrantReadWriteLock implements Lock {
                 holds_ = suspended.lockCount;
             } else {
                 owner_ = null;
-                mode_ = Lock.NO_LOCK;
+                mode_ = LockMode.NO_LOCK;
                 notify();
             }
         }
@@ -308,7 +321,8 @@ public class ReentrantReadWriteLock implements Lock {
         }
     }
 
-    public void release(int mode, int count) {
+    @Override
+    public void release(final LockMode mode, final int count) {
         throw new UnsupportedOperationException(getClass().getName() +
                 " does not support releasing multiple locks");
     }
@@ -319,19 +333,21 @@ public class ReentrantReadWriteLock implements Lock {
      * Returns zero if current thread does not hold lock.
      **/
     public synchronized long holds() {
-        if (Thread.currentThread() != owner_)
-            {return 0;}
+        if (Thread.currentThread() != owner_) {
+            return 0;
+        }
         return holds_;
     }
 
+    @Override
     public synchronized LockInfo getLockInfo() {
-        final String lockType = mode_ == Lock.WRITE_LOCK ? LockInfo.WRITE_LOCK : LockInfo.READ_LOCK;
+        final String lockType = mode_ == LockMode.WRITE_LOCK ? LockInfo.WRITE_LOCK : LockInfo.READ_LOCK;
         return new LockInfo(LockInfo.COLLECTION_LOCK, lockType, getId(), 
             new String[] { (owner_==null)?"":owner_.getName() });
     }
 
     @Override
-    public void debug(PrintStream out) {
+    public void debug(final PrintStream out) {
         getLockInfo().debug(out);
     }
 }

--- a/src/org/exist/storage/structural/NativeStructuralIndex.java
+++ b/src/org/exist/storage/structural/NativeStructuralIndex.java
@@ -35,6 +35,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.btree.DBException;
 import org.exist.storage.index.BTreeStore;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
@@ -89,7 +90,7 @@ public class NativeStructuralIndex extends AbstractIndex implements RawBackupSup
             {return;}
         final Lock lock = btree.getLock();
         try {
-            lock.acquire(Lock.WRITE_LOCK);
+            lock.acquire(LockMode.WRITE_LOCK);
             btree.flush();
         } catch (final LockException e) {
             LOG.warn("Failed to acquire lock for '" + FileUtils.fileName(btree.getFile()) + "'", e);
@@ -98,7 +99,7 @@ public class NativeStructuralIndex extends AbstractIndex implements RawBackupSup
             LOG.error(e.getMessage(), e);
             //TODO : throw an exception ? -pb
         } finally {
-            lock.release(Lock.WRITE_LOCK);
+            lock.release(LockMode.WRITE_LOCK);
         }
     }
 

--- a/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
+++ b/src/org/exist/storage/structural/NativeStructuralIndexWorker.java
@@ -19,6 +19,8 @@
  */
 package org.exist.storage.structural;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.dom.TypedQNameComparator;
 import org.exist.dom.persistent.AttrImpl;
 import org.exist.dom.persistent.NodeProxy;
@@ -60,6 +62,8 @@ import org.exist.security.PermissionDeniedException;
  * long pointing to the storage address of the actual node in dom.dbx.
  */
 public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex {
+
+    private final static Logger LOG = LogManager.getLogger(NativeStructuralIndexWorker.class);
 
     private NativeStructuralIndex index;
     private ReindexMode mode = ReindexMode.STORE;
@@ -582,9 +586,13 @@ public class NativeStructuralIndexWorker implements IndexWorker, StructuralIndex
 
     @Override
     public void removeCollection(Collection collection, DBBroker broker, boolean reindex) throws PermissionDeniedException {
-        for (final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
-            final DocumentImpl doc = i.next();
-            removeDocument(doc);
+        try {
+            for (final Iterator<DocumentImpl> i = collection.iterator(broker); i.hasNext(); ) {
+                final DocumentImpl doc = i.next();
+                removeDocument(doc);
+            }
+        } catch(final LockException e) {
+            LOG.error(e);
         }
     }
 

--- a/src/org/exist/storage/txn/Txn.java
+++ b/src/org/exist/storage/txn/Txn.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.exist.Transaction;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.LockException;
 
 /**
@@ -60,11 +61,11 @@ public class Txn implements Transaction {
         return id;
     }
     
-    public void registerLock(final Lock lock, final int lockMode) {
+    public void registerLock(final Lock lock, final LockMode lockMode) {
         locksHeld.add(new LockInfo(lock, lockMode));
     }
     
-    public void acquireLock(final Lock lock, final int lockMode) throws LockException {
+    public void acquireLock(final Lock lock, final LockMode lockMode) throws LockException {
         lock.acquire(lockMode);
         locksHeld.add(new LockInfo(lock, lockMode));
     }
@@ -97,9 +98,9 @@ public class Txn implements Transaction {
 
     private static class LockInfo {
         final Lock lock;
-        final int lockMode;
+        final LockMode lockMode;
         
-        public LockInfo(final Lock lock, final int lockMode) {
+        public LockInfo(final Lock lock, final LockMode lockMode) {
             this.lock = lock;
             this.lockMode = lockMode;
         }

--- a/src/org/exist/util/io/Resource.java
+++ b/src/org/exist/util/io/Resource.java
@@ -469,7 +469,7 @@ public class Resource extends File {
 //	        info.getDocument().getMetadata().setMimeType(mimeType.getName());
 
             is = new FileInputSource(file);
-            collection.store(txn, broker, info, is, false);
+            collection.store(txn, broker, info, is);
 
             tm.commit(txn);
 
@@ -510,7 +510,7 @@ public class Resource extends File {
                 info.getDocument().getMetadata().setMimeType(mimeType.getName());
 
                 is = new FileInputSource(file);
-                destination.store(txn, broker, info, is, false);
+                destination.store(txn, broker, info, is);
 
                 source.removeBinaryResource(txn, broker, doc);
             }
@@ -547,7 +547,7 @@ public class Resource extends File {
                     final Date created = new Date(meta.getCreated());
                     final Date lastModified = new Date(meta.getLastModified());
 
-                    BinaryDocument binary = destination.validateBinaryResource(txn, broker, newName, is, mimeType.getName(), -1, created, lastModified);
+                    BinaryDocument binary = destination.validateBinaryResource(txn, broker, newName);
 
                     binary = destination.addBinaryResource(txn, broker, binary, is, mimeType.getName(), -1, created, lastModified);
 
@@ -679,7 +679,7 @@ public class Resource extends File {
                     final IndexInfo info = collection.validateXMLResource(transaction, broker, fileName, str);
                     info.getDocument().getMetadata().setMimeType(mimeType.getName());
                     info.getDocument().getPermissions().setMode(DEFAULT_RESOURCE_PERM);
-                    collection.store(transaction, broker, info, str, false);
+                    collection.store(transaction, broker, info, str);
 
                 } else {
                     // store as binary resource

--- a/src/org/exist/util/io/Resource.java
+++ b/src/org/exist/util/io/Resource.java
@@ -52,7 +52,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
@@ -309,7 +309,7 @@ public class Resource extends File {
         XmldbURI newName;
 
         try (final DBBroker broker = db.getBroker()) {
-            source = broker.openCollection(uri.removeLastSegment(), Lock.WRITE_LOCK);
+            source = broker.openCollection(uri.removeLastSegment(), LockMode.WRITE_LOCK);
             if (source == null) {
                 return false;
             }
@@ -317,7 +317,7 @@ public class Resource extends File {
             if (doc == null) {
                 return false;
             }
-            destination = broker.openCollection(destinationPath.removeLastSegment(), Lock.WRITE_LOCK);
+            destination = broker.openCollection(destinationPath.removeLastSegment(), LockMode.WRITE_LOCK);
             if (destination == null) {
                 return false;
             }
@@ -335,10 +335,10 @@ public class Resource extends File {
             return false;
         } finally {
             if (source != null) {
-                source.release(Lock.WRITE_LOCK);
+                source.release(LockMode.WRITE_LOCK);
             }
             if (destination != null) {
-                destination.release(Lock.WRITE_LOCK);
+                destination.release(LockMode.WRITE_LOCK);
             }
         }
     }
@@ -363,7 +363,7 @@ public class Resource extends File {
             XmldbURI newName;
 
             try {
-                source = broker.openCollection(uri.removeLastSegment(), Lock.WRITE_LOCK);
+                source = broker.openCollection(uri.removeLastSegment(), LockMode.WRITE_LOCK);
                 if (source == null) {
                     return false;
                 }
@@ -371,7 +371,7 @@ public class Resource extends File {
                 if (doc == null) {
                     return false;
                 }
-                destination = broker.openCollection(destinationPath.removeLastSegment(), Lock.WRITE_LOCK);
+                destination = broker.openCollection(destinationPath.removeLastSegment(), LockMode.WRITE_LOCK);
                 if (destination == null) {
                     return false;
                 }
@@ -396,10 +396,10 @@ public class Resource extends File {
                 return false;
             } finally {
                 if (source != null) {
-                    source.release(Lock.WRITE_LOCK);
+                    source.release(LockMode.WRITE_LOCK);
                 }
                 if (destination != null) {
-                    destination.release(Lock.WRITE_LOCK);
+                    destination.release(LockMode.WRITE_LOCK);
                 }
             }
         } catch (final EXistException e) {
@@ -579,12 +579,12 @@ public class Resource extends File {
 
         try (final DBBroker broker = db.getBroker()) {
 
-            collection = broker.openCollection(uri.removeLastSegment(), Lock.NO_LOCK);
+            collection = broker.openCollection(uri.removeLastSegment(), LockMode.NO_LOCK);
             if (collection == null) {
                 return false;
             }
             // keep the write lock in the transaction
-            //transaction.registerLock(collection.getLock(), Lock.WRITE_LOCK);
+            //transaction.registerLock(collection.getLock(), LockMode.WRITE_LOCK);
 
             final DocumentImpl doc = collection.getDocument(broker, uri.lastSegment());
             if (doc == null) {
@@ -639,11 +639,11 @@ public class Resource extends File {
             final XmldbURI fileName = uri.lastSegment();
 
 //			try {
-//				resource = broker.getXMLResource(uri, Lock.READ_LOCK);
+//				resource = broker.getXMLResource(uri, LockMode.READ_LOCK);
 //			} catch (final PermissionDeniedException e1) {
 //			} finally {
 //				if (resource != null) {
-//					resource.getUpdateLock().release(Lock.READ_LOCK);
+//					resource.getUpdateLock().release(LockMode.READ_LOCK);
 //					collection = resource.getCollection();
 //					initialized = true;
 //					
@@ -652,11 +652,11 @@ public class Resource extends File {
 //			}
 //			
             try {
-                resource = broker.getResource(uri, Lock.READ_LOCK);
+                resource = broker.getResource(uri, LockMode.READ_LOCK);
             } catch (final PermissionDeniedException e1) {
             } finally {
                 if (resource != null) {
-                    resource.getUpdateLock().release(Lock.READ_LOCK);
+                    resource.getUpdateLock().release(LockMode.READ_LOCK);
                     collection = resource.getCollection();
                     initialized = true;
 
@@ -697,7 +697,7 @@ public class Resource extends File {
                 throw new IOException(e);
             } finally {
                 if (resource != null) {
-                    resource.getUpdateLock().release(Lock.READ_LOCK);
+                    resource.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
 
@@ -730,7 +730,7 @@ public class Resource extends File {
                     //resource
                 } else {
                     try {
-                        resource = broker.getXMLResource(uri, Lock.READ_LOCK);
+                        resource = broker.getXMLResource(uri, LockMode.READ_LOCK);
                         if (resource == null) {
                             //may be, it's collection ... checking ...
                             collection = broker.getCollection(uri);
@@ -742,7 +742,7 @@ public class Resource extends File {
                         }
                     } finally {
                         if (resource != null) {
-                            resource.getUpdateLock().release(Lock.READ_LOCK);
+                            resource.getUpdateLock().release(LockMode.READ_LOCK);
                         }
                     }
                 }
@@ -910,7 +910,7 @@ public class Resource extends File {
         try {
             final BrokerPool db = BrokerPool.getInstance();
             try (final DBBroker broker = db.getBroker()) {
-                collection.getLock().acquire(Lock.READ_LOCK);
+                collection.getLock().acquire(LockMode.READ_LOCK);
 
                 final File[] children = new File[collection.getChildCollectionCount(broker) +
                         collection.getDocumentCount(broker)];
@@ -948,7 +948,7 @@ public class Resource extends File {
                 return null;
 
             } finally {
-                collection.release(Lock.READ_LOCK);
+                collection.release(LockMode.READ_LOCK);
             }
 
         } catch (final Exception e) {
@@ -1197,7 +1197,7 @@ public class Resource extends File {
 
                     //resource
                 } else {
-                    resource = broker.getXMLResource(uri, Lock.READ_LOCK);
+                    resource = broker.getXMLResource(uri, LockMode.READ_LOCK);
                     if (resource == null) {
                         //may be, it's collection ... checking ...
                         collection = broker.getCollection(uri);
@@ -1228,7 +1228,7 @@ public class Resource extends File {
                 throw new IOException(e);
             } finally {
                 if (resource != null) {
-                    resource.getUpdateLock().release(Lock.READ_LOCK);
+                    resource.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
         } catch (final EXistException e) {

--- a/src/org/exist/util/io/Resource.java
+++ b/src/org/exist/util/io/Resource.java
@@ -652,11 +652,10 @@ public class Resource extends File {
 //			}
 //			
             try {
-                resource = broker.getResource(uri, LockMode.READ_LOCK);
+                resource = broker.getResource(uri, Permission.READ);
             } catch (final PermissionDeniedException e1) {
             } finally {
                 if (resource != null) {
-                    resource.getUpdateLock().release(LockMode.READ_LOCK);
                     collection = resource.getCollection();
                     initialized = true;
 

--- a/src/org/exist/xmldb/AbstractEXistResource.java
+++ b/src/org/exist/xmldb/AbstractEXistResource.java
@@ -24,7 +24,7 @@ import org.exist.security.Permission;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import com.evolvedbinary.j8fu.function.FunctionE;
 import org.exist.xmldb.function.LocalXmldbDocumentFunction;
@@ -134,7 +134,7 @@ public abstract class AbstractEXistResource extends AbstractLocal implements EXi
      * @return A function to receive a read-only operation to perform against the resource
      */
     public <R> FunctionE<LocalXmldbDocumentFunction<R>, R, XMLDBException> read(final DBBroker broker, final Txn transaction) throws XMLDBException {
-        return with(Lock.READ_LOCK, broker, transaction);
+        return with(LockMode.READ_LOCK, broker, transaction);
     }
 
     /**
@@ -157,7 +157,7 @@ public abstract class AbstractEXistResource extends AbstractLocal implements EXi
      * @return A function to receive an operation to perform against the resource
      */
     public <R> FunctionE<LocalXmldbDocumentFunction<R>, R, XMLDBException> modify(final DBBroker broker, final Txn transaction) throws XMLDBException {
-        return writeOp -> this.<R>with(Lock.WRITE_LOCK, broker, transaction).apply((document, broker1, transaction1) -> {
+        return writeOp -> this.<R>with(LockMode.WRITE_LOCK, broker, transaction).apply((document, broker1, transaction1) -> {
             final R result = writeOp.apply(document, broker1, transaction1);
             broker.storeXMLResource(transaction1, document);
             return result;
@@ -172,7 +172,7 @@ public abstract class AbstractEXistResource extends AbstractLocal implements EXi
      * @param transaction The transaction to use for the operation
      * @return A function to receive an operation to perform on the locked database resource
      */
-    private <R> FunctionE<LocalXmldbDocumentFunction<R>, R, XMLDBException> with(final int lockMode, final DBBroker broker, final Txn transaction) throws XMLDBException {
+    private <R> FunctionE<LocalXmldbDocumentFunction<R>, R, XMLDBException> with(final LockMode lockMode, final DBBroker broker, final Txn transaction) throws XMLDBException {
         return documentOp ->
                 collection.<R>with(lockMode, broker, transaction).apply((collection, broker1, transaction1) -> {
                     DocumentImpl doc = null;

--- a/src/org/exist/xmldb/AbstractLocal.java
+++ b/src/org/exist/xmldb/AbstractLocal.java
@@ -24,7 +24,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import com.evolvedbinary.j8fu.function.FunctionE;
 import org.exist.xmldb.function.LocalXmldbCollectionFunction;
@@ -90,7 +90,7 @@ public abstract class AbstractLocal {
      * @return A function to receive a read-only operation to perform against the collection
      */
     protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> read(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws XMLDBException {
-        return this.<R>with(Lock.READ_LOCK, broker, transaction, collectionUri);
+        return this.<R>with(LockMode.READ_LOCK, broker, transaction, collectionUri);
     }
 
     /**
@@ -105,7 +105,7 @@ public abstract class AbstractLocal {
      * @throws XMLDBException if the collection could not be read
      */
     protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> read(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri, final int errorCode) throws XMLDBException {
-        return this.<R>with(Lock.READ_LOCK, broker, transaction, collectionUri, errorCode);
+        return this.<R>with(LockMode.READ_LOCK, broker, transaction, collectionUri, errorCode);
     }
 
     /**
@@ -127,7 +127,7 @@ public abstract class AbstractLocal {
      * @return A function to receive a read/write operation to perform against the collection
      */
     protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> modify(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws XMLDBException {
-        return this.<R>with(Lock.WRITE_LOCK, broker, transaction, collectionUri);
+        return this.<R>with(LockMode.WRITE_LOCK, broker, transaction, collectionUri);
     }
 
     /**
@@ -143,7 +143,7 @@ public abstract class AbstractLocal {
      * if the collection does not exist, or {@link ErrorCodes#PERMISSION_DENIED} if the caller does not have
      * permission to open the collection.
      */
-    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> with(final int lockMode, final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws XMLDBException {
+    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> with(final LockMode lockMode, final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws XMLDBException {
         return with(lockMode, broker, transaction, collectionUri, ErrorCodes.INVALID_COLLECTION);
     }
 
@@ -160,7 +160,7 @@ public abstract class AbstractLocal {
      * the collection. The error code of the XMLDBException will be either taken from the `errorCode` param
      * or set to {@link ErrorCodes#PERMISSION_DENIED}
      */
-    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> with(final int lockMode, final DBBroker broker, final Txn transaction, final XmldbURI collectionUri, final int errorCode) throws XMLDBException {
+    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> with(final LockMode lockMode, final DBBroker broker, final Txn transaction, final XmldbURI collectionUri, final int errorCode) throws XMLDBException {
         return collectionOp -> {
             org.exist.collections.Collection coll = null;
             try {

--- a/src/org/exist/xmldb/LocalCollection.java
+++ b/src/org/exist/xmldb/LocalCollection.java
@@ -172,7 +172,7 @@ public class LocalCollection extends AbstractLocal implements CollectionImpl {
                     ok = false;
                 }
 
-                if (collection.hasSubcollection(broker, id)) {
+                if (collection.hasChildCollection(broker, id)) {
                     ok = false;
                 }
 
@@ -579,11 +579,11 @@ public class LocalCollection extends AbstractLocal implements CollectionImpl {
                 }
 
                 if (uri != null || res.inputSource != null) {
-                    collection.store(transaction, broker, info, (uri != null) ? new InputSource(uri) : res.inputSource, false);
+                    collection.store(transaction, broker, info, (uri != null) ? new InputSource(uri) : res.inputSource);
                 } else if (res.root != null) {
-                    collection.store(transaction, broker, info, res.root, false);
+                    collection.store(transaction, broker, info, res.root);
                 } else {
-                    collection.store(transaction, broker, info, res.content, false);
+                    collection.store(transaction, broker, info, res.content);
                 }
 
                 return null;

--- a/src/org/exist/xmldb/LocalCollection.java
+++ b/src/org/exist/xmldb/LocalCollection.java
@@ -35,6 +35,7 @@ import org.exist.security.Permission;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.Txn;
@@ -568,7 +569,7 @@ public class LocalCollection extends AbstractLocal implements CollectionImpl {
                 } else {
                     info = collection.validateXMLResource(transaction, broker, resURI, res.content);
                 }
-                //Notice : the document should now have a Lock.WRITE_LOCK update lock
+                //Notice : the document should now have a LockMode.WRITE_LOCK update lock
                 //TODO : check that no exception occurs in order to allow it to be released
                 info.getDocument().getMetadata().setMimeType(res.getMimeType());
                 if (res.datecreated != null) {
@@ -753,7 +754,7 @@ public class LocalCollection extends AbstractLocal implements CollectionImpl {
      * @param transaction The transaction to use for the operation
      * @return A function to receive an operation to perform on the locked database collection
      */
-    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> with(final int lockMode, final DBBroker broker, final Txn transaction) throws XMLDBException {
+    protected <R> FunctionE<LocalXmldbCollectionFunction<R>, R, XMLDBException> with(final LockMode lockMode, final DBBroker broker, final Txn transaction) throws XMLDBException {
         return op -> this.<R>with(lockMode, broker, transaction, path).apply((collection, broker1, transaction1) -> {
             collection.setReader(userReader);
             return op.apply(collection, broker1, transaction1);

--- a/src/org/exist/xmldb/LocalIndexQueryService.java
+++ b/src/org/exist/xmldb/LocalIndexQueryService.java
@@ -21,17 +21,13 @@ package org.exist.xmldb;
 
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.sync.Sync;
 import org.exist.util.Occurrences;
-import org.exist.xquery.XQuery;
-import org.exist.xquery.value.Sequence;
 import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.XMLDBException;
 
@@ -87,13 +83,13 @@ public class LocalIndexQueryService extends AbstractLocalService implements Inde
         withDb((broker, transaction) -> {
             DocumentImpl doc = null;
             try {
-                doc = broker.getXMLResource(collectionPath.append(docName), Lock.READ_LOCK);
+                doc = broker.getXMLResource(collectionPath.append(docName), LockMode.READ_LOCK);
                 broker.reindexXMLResource(transaction, doc, DBBroker.IndexMode.STORE);
                 broker.sync(Sync.MAJOR);
                 return null;
             } finally {
                 if(doc != null) {
-                    doc.getUpdateLock().release(Lock.READ_LOCK);
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
         });

--- a/src/org/exist/xmldb/LocalUserManagementService.java
+++ b/src/org/exist/xmldb/LocalUserManagementService.java
@@ -320,7 +320,7 @@ public class LocalUserManagementService extends AbstractLocalService implements 
     @Override
     public Permission getSubCollectionPermissions(final Collection parent, final String name) throws XMLDBException {
         if(parent instanceof LocalCollection) {
-            return this.<Permission>read(((LocalCollection) parent).getPathURI()).apply((collection, broker, transaction) -> collection.getSubCollectionEntry(broker, name).getPermissions());
+            return this.<Permission>read(((LocalCollection) parent).getPathURI()).apply((collection, broker, transaction) -> collection.getChildCollectionEntry(broker, name).getPermissions());
         } else {
             return null;
         }
@@ -338,7 +338,7 @@ public class LocalUserManagementService extends AbstractLocalService implements 
     @Override
     public Date getSubCollectionCreationTime(final Collection parent, final String name) throws XMLDBException {
         if(parent instanceof LocalCollection) {
-            return this.<Date>read(((LocalCollection) parent).getPathURI()).apply((collection, broker, transaction) -> new Date(collection.getSubCollectionEntry(broker, name).getCreated()));
+            return this.<Date>read(((LocalCollection) parent).getPathURI()).apply((collection, broker, transaction) -> new Date(collection.getChildCollectionEntry(broker, name).getCreated()));
         } else {
             return null;
         }

--- a/src/org/exist/xmldb/LocalXPathQueryService.java
+++ b/src/org/exist/xmldb/LocalXPathQueryService.java
@@ -31,7 +31,7 @@ import org.exist.source.Source;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.XQueryPool;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.LockedDocumentMap;
 import org.exist.storage.txn.Txn;
 import org.exist.util.LockException;
@@ -368,7 +368,7 @@ public class LocalXPathQueryService extends AbstractLocalService implements XPat
                     final org.exist.collections.Collection coll = reservedBroker.getCollection(collection.getPathURI());
                     lockedDocuments = new LockedDocumentMap();
                     docs = new DefaultDocumentSet();
-                    coll.allDocs(reservedBroker, docs, true, lockedDocuments, Lock.WRITE_LOCK);
+                    coll.allDocs(reservedBroker, docs, true, lockedDocuments, LockMode.WRITE_LOCK);
                 } catch (final LockException e) {
                     LOG.debug("Deadlock detected. Starting over again. Docs: " + docs.getDocumentCount() + "; locked: " +
                             lockedDocuments.size());

--- a/src/org/exist/xmlrpc/RpcConnection.java
+++ b/src/org/exist/xmlrpc/RpcConnection.java
@@ -221,7 +221,7 @@ public class RpcConnection implements RpcAPI {
                     ok = false;
                 }
 
-                if (collection.hasSubcollection(broker, id)) {
+                if (collection.hasChildCollection(broker, id)) {
                     ok = false;
                 }
 
@@ -943,7 +943,7 @@ public class RpcConnection implements RpcAPI {
                     ok = false;
                 }
 
-                if (collection.hasSubcollection(broker, id)) {
+                if (collection.hasChildCollection(broker, id)) {
                     ok = false;
                 }
 
@@ -1015,7 +1015,7 @@ public class RpcConnection implements RpcAPI {
     public Map<String, Object> getSubCollectionPermissions(final String parentPath, final String name) throws EXistException, PermissionDeniedException, URISyntaxException {
 
         final XmldbURI uri = XmldbURI.xmldbUriFor(parentPath);
-        final Permission perm = this.<Permission>readCollection(uri).apply((collection, broker, transaction) -> collection.getSubCollectionEntry(broker, name).getPermissions());
+        final Permission perm = this.<Permission>readCollection(uri).apply((collection, broker, transaction) -> collection.getChildCollectionEntry(broker, name).getPermissions());
 
         final Map<String, Object> result = new HashMap<>();
         result.put("owner", perm.getOwner().getName());
@@ -1047,7 +1047,7 @@ public class RpcConnection implements RpcAPI {
     @Override
     public long getSubCollectionCreationTime(final String parentPath, final String name) throws EXistException, PermissionDeniedException, URISyntaxException {
         final XmldbURI uri = XmldbURI.xmldbUriFor(parentPath);
-        return this.<Long>readCollection(uri).apply((collection, broker, transaction) -> collection.getSubCollectionEntry(broker, name).getCreated());
+        return this.<Long>readCollection(uri).apply((collection, broker, transaction) -> collection.getChildCollectionEntry(broker, name).getCreated());
     }
 
     private List<ACEAider> getACEs(final Permission perm) {
@@ -1313,7 +1313,7 @@ public class RpcConnection implements RpcAPI {
                     info.getDocument().getMetadata().setLastModified(modified.getTime());
                 }
 
-                collection.store(transaction, broker, info, source, false);
+                collection.store(transaction, broker, info, source);
 
                 LOG.debug("parsing " + docUri + " took " + (System.currentTimeMillis() - startTime) + "ms.");
                 return true;
@@ -1433,7 +1433,7 @@ public class RpcConnection implements RpcAPI {
                     if (modified != null) {
                         info.getDocument().getMetadata().setLastModified(modified.getTime());
                     }
-                    collection.store(transaction, broker, info, source, false);
+                    collection.store(transaction, broker, info, source);
                 } else {
                     try (final InputStream is = source.getByteStream()) {
                         final DocumentImpl doc = collection.addBinaryResource(transaction, broker, docUri.lastSegment(), is, mime.getName(), source.getByteStreamLength());

--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -79,6 +79,7 @@ import org.exist.stax.ExtendedXMLStreamReader;
 import org.exist.storage.DBBroker;
 import org.exist.storage.UpdateListener;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.LockedDocumentMap;
 import org.exist.util.Collations;
 import org.exist.util.Configuration;
@@ -1168,7 +1169,7 @@ public class XQueryContext implements BinaryValueManager, Context
                     if( collection != null ) {
                         collection.allDocs( getBroker(), ndocs, true);
                     } else {
-                        doc = getBroker().getXMLResource( staticDocumentPaths[i], Lock.READ_LOCK );
+                        doc = getBroker().getXMLResource( staticDocumentPaths[i], LockMode.READ_LOCK );
 
                         if( doc != null ) {
 
@@ -1177,7 +1178,7 @@ public class XQueryContext implements BinaryValueManager, Context
                                 
                             	ndocs.add( doc );
                             }
-                            doc.getUpdateLock().release( Lock.READ_LOCK );
+                            doc.getUpdateLock().release( LockMode.READ_LOCK );
                         }
                     }
                 }
@@ -2718,7 +2719,7 @@ public class XQueryContext implements BinaryValueManager, Context
                             DocumentImpl sourceDoc = null;
 
                             try {
-                                sourceDoc = getBroker().getXMLResource( locationUri.toCollectionPathURI(), Lock.READ_LOCK );
+                                sourceDoc = getBroker().getXMLResource( locationUri.toCollectionPathURI(), LockMode.READ_LOCK );
 
                                 if(sourceDoc == null) {
                                     throw moduleLoadException("Module location hint URI '" + location + "' does not refer to anything.", location);
@@ -2737,7 +2738,7 @@ public class XQueryContext implements BinaryValueManager, Context
                                 throw moduleLoadException("Permission denied to read module source from location hint URI '" + location + ".", location, e);
                             } finally {
                                 if(sourceDoc != null) {
-                                    sourceDoc.getUpdateLock().release(Lock.READ_LOCK);
+                                    sourceDoc.getUpdateLock().release(LockMode.READ_LOCK);
                                 }
                             }
                         } catch(final URISyntaxException e) {

--- a/src/org/exist/xquery/functions/fn/ExtCollection.java
+++ b/src/org/exist/xquery/functions/fn/ExtCollection.java
@@ -38,6 +38,7 @@ import org.exist.numbering.NodeId;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.UpdateListener;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.Cardinality;
@@ -166,7 +167,7 @@ public class ExtCollection extends Function {
             boolean lockAcquired = false;
             try {
                 if (!context.inProtectedMode() && !dlock.hasLock()) {
-                    dlock.acquire(Lock.READ_LOCK);
+                    dlock.acquire(LockMode.READ_LOCK);
                     lockAcquired = true;
                 }
                 result.add(new NodeProxy(doc)); // , -1, Node.DOCUMENT_NODE));
@@ -174,7 +175,7 @@ public class ExtCollection extends Function {
                 throw new XPathException(e.getMessage());
             } finally {
                 if (lockAcquired)
-                    {dlock.release(Lock.READ_LOCK);}
+                    {dlock.release(LockMode.READ_LOCK);}
             }
         }
         registerUpdateListener();

--- a/src/org/exist/xquery/functions/transform/Transform.java
+++ b/src/org/exist/xquery/functions/transform/Transform.java
@@ -61,7 +61,7 @@ import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.numbering.NodeId;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.serializers.XIncludeFilter;
 import org.exist.storage.serializers.EXistOutputKeys;
@@ -551,7 +551,7 @@ public class Transform extends BasicFunction {
                 final String docPath = uri.substring(XmldbURI.EMBEDDED_SERVER_URI_PREFIX.length());
                 DocumentImpl doc = null;
                 try {
-                    doc = context.getBroker().getXMLResource(XmldbURI.create(docPath), Lock.READ_LOCK);
+                    doc = context.getBroker().getXMLResource(XmldbURI.create(docPath), LockMode.READ_LOCK);
                     if (!caching || (doc != null && (templates == null || doc.getMetadata().getLastModified() > lastModified))) {
                         templates = getSource(doc);
                     }
@@ -560,7 +560,7 @@ public class Transform extends BasicFunction {
                     throw new XPathException(Transform.this, "Permission denied to read stylesheet: " + uri);
                 } finally {
                     if (doc != null) {
-                        doc.getUpdateLock().release(Lock.READ_LOCK);
+                        doc.getUpdateLock().release(LockMode.READ_LOCK);
                     }
                 }
             } else {

--- a/src/org/exist/xquery/functions/util/BinaryDoc.java
+++ b/src/org/exist/xquery/functions/util/BinaryDoc.java
@@ -31,7 +31,7 @@ import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -96,7 +96,7 @@ public class BinaryDoc extends BasicFunction {
         final String path = args[0].getStringValue();
         DocumentImpl doc = null;
         try {
-            doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), Lock.READ_LOCK);
+            doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), LockMode.READ_LOCK);
             if(doc == null)
             {
                 return defaultReturn;
@@ -135,7 +135,7 @@ public class BinaryDoc extends BasicFunction {
             throw new XPathException(this, path + ": I/O error while reading resource",e);
         } finally {
             if (doc != null)
-                {doc.getUpdateLock().release(Lock.READ_LOCK);}
+                {doc.getUpdateLock().release(LockMode.READ_LOCK);}
         }
     }
 }

--- a/src/org/exist/xquery/functions/util/DocumentNameOrId.java
+++ b/src/org/exist/xquery/functions/util/DocumentNameOrId.java
@@ -34,7 +34,7 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
@@ -127,11 +127,11 @@ public class DocumentNameOrId extends BasicFunction {
                 if (node.getImplementationType() == NodeValue.PERSISTENT_NODE) {
                     final NodeProxy proxy = (NodeProxy) node;
                     doc = proxy.getOwnerDocument();
-                    doc.getUpdateLock().acquire(Lock.READ_LOCK);
+                    doc.getUpdateLock().acquire(LockMode.READ_LOCK);
                 }
             } else if(Type.subTypeOf(args[0].getItemType(), Type.STRING)) {
                 final String path = args[0].getStringValue();
-                doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), Lock.READ_LOCK);
+                doc = context.getBroker().getXMLResource(XmldbURI.xmldbUriFor(path), LockMode.READ_LOCK);
             }
 
             final QName fnName = getSignature().getName();
@@ -183,7 +183,7 @@ public class DocumentNameOrId extends BasicFunction {
             throw new XPathException(this, args[0].getStringValue() + ": permission denied to read resource");
         } finally {
             if(doc != null) { 
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
         

--- a/src/org/exist/xquery/functions/util/Eval.java
+++ b/src/org/exist/xquery/functions/util/Eval.java
@@ -59,7 +59,7 @@ import org.exist.source.StringSource;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.XQueryPool;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -490,7 +490,7 @@ public class Eval extends BasicFunction {
 
                 DocumentImpl sourceDoc = null;
                 try {
-                    sourceDoc = context.getBroker().getXMLResource(locationUri.toCollectionPathURI(), Lock.READ_LOCK);
+                    sourceDoc = context.getBroker().getXMLResource(locationUri.toCollectionPathURI(), LockMode.READ_LOCK);
                     if (sourceDoc == null)
                         {throw new XPathException(this, "source for module " + location + " not found in database");}
                     if (sourceDoc.getResourceType() != DocumentImpl.BINARY_FILE ||
@@ -502,7 +502,7 @@ public class Eval extends BasicFunction {
                     throw new XPathException(this, "permission denied to read module source from " + location);
                 } finally {
                     if(sourceDoc != null)
-                        {sourceDoc.getUpdateLock().release(Lock.READ_LOCK);}
+                        {sourceDoc.getUpdateLock().release(LockMode.READ_LOCK);}
                 }
             } catch(final URISyntaxException e) {
                 throw new XPathException(this, e);

--- a/src/org/exist/xquery/functions/xmldb/XMLDBGetMimeType.java
+++ b/src/org/exist/xquery/functions/xmldb/XMLDBGetMimeType.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.QName;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
@@ -85,7 +85,7 @@ public class XMLDBGetMimeType extends BasicFunction {
 				// relative collection Path: add the current base URI
 				pathUri = context.getBaseURI().toXmldbURI().resolveCollectionPath(pathUri);
 				// try to open the document and acquire a lock
-				doc = (DocumentImpl)context.getBroker().getXMLResource(pathUri, Lock.READ_LOCK);
+				doc = (DocumentImpl)context.getBroker().getXMLResource(pathUri, LockMode.READ_LOCK);
 				if(doc != null) {
 					return new StringValue(((DocumentImpl)doc).getMetadata().getMimeType());
 				}
@@ -95,7 +95,7 @@ public class XMLDBGetMimeType extends BasicFunction {
 			} finally {
 				//release all locks
 				if(doc != null) {
-                    doc.getUpdateLock().release(Lock.READ_LOCK);
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
                 }
 			}
 		}

--- a/src/org/exist/xquery/functions/xmldb/XMLDBSetMimeType.java
+++ b/src/org/exist/xquery/functions/xmldb/XMLDBSetMimeType.java
@@ -29,8 +29,7 @@ import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
-import org.exist.storage.txn.TransactionManager;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
@@ -138,7 +137,7 @@ public class XMLDBSetMimeType extends BasicFunction {
             pathUri = context.getBaseURI().toXmldbURI().resolveCollectionPath(pathUri);
 
             // try to open the document and acquire a lock
-            doc = (DocumentImpl) broker.getXMLResource(pathUri, Lock.WRITE_LOCK);
+            doc = (DocumentImpl) broker.getXMLResource(pathUri, LockMode.WRITE_LOCK);
             if (doc == null) {
                 // no document selected, abort
                 txn.abort();
@@ -161,7 +160,7 @@ public class XMLDBSetMimeType extends BasicFunction {
         } finally {
             //release all locks
             if (doc != null) {
-                doc.getUpdateLock().release(Lock.WRITE_LOCK);
+                doc.getUpdateLock().release(LockMode.WRITE_LOCK);
             }
         }
 
@@ -186,7 +185,7 @@ public class XMLDBSetMimeType extends BasicFunction {
 
         try {
             // try to open the document and acquire a lock
-            doc = (DocumentImpl) context.getBroker().getXMLResource(pathUri, Lock.READ_LOCK);
+            doc = (DocumentImpl) context.getBroker().getXMLResource(pathUri, LockMode.READ_LOCK);
             if (doc == null) {
                 throw new XPathException("Resource '" + pathUri + "' does not exist.");
             } else {
@@ -200,7 +199,7 @@ public class XMLDBSetMimeType extends BasicFunction {
         } finally {
 
             if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
 

--- a/src/org/exist/xquery/update/Modification.java
+++ b/src/org/exist/xquery/update/Modification.java
@@ -40,6 +40,7 @@ import org.exist.dom.persistent.NodeHandle;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.Txn;
 import org.exist.util.LockException;
@@ -268,10 +269,10 @@ public abstract class Modification extends AbstractExpression
                 if(next.getMetadata().getSplitCount() > splitCount) {
                     Lock lock = next.getUpdateLock();
                     try {
-                        lock.acquire(Lock.WRITE_LOCK);
+                        lock.acquire(LockMode.WRITE_LOCK);
                         broker.defragXMLResource(transaction, next);
                     } finally {
-                        lock.release(Lock.WRITE_LOCK);
+                        lock.release(LockMode.WRITE_LOCK);
                     }}
                 broker.checkXMLResourceConsistency(next);
             }

--- a/src/org/exist/xquery/util/DocUtils.java
+++ b/src/org/exist/xquery/util/DocUtils.java
@@ -36,7 +36,7 @@ import org.exist.dom.memtree.SAXAdapter;
 import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
@@ -142,7 +142,7 @@ public class DocUtils {
 
 			// check if the loaded documents should remain locked
 			boolean lockOnLoad = context.lockDocumentsOnLoad();
-            final int lockType = lockOnLoad ? Lock.WRITE_LOCK : Lock.READ_LOCK;
+            final LockMode lockType = lockOnLoad ? LockMode.WRITE_LOCK : LockMode.READ_LOCK;
 			DocumentImpl doc = null;
 			try
 			{

--- a/test/src/org/exist/IndexerTest.java
+++ b/test/src/org/exist/IndexerTest.java
@@ -172,7 +172,7 @@ public class IndexerTest {
             Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
             IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, xml);
             //TODO : unlock the collection here ?
-            collection.store(txn, broker, info, xml, false);
+            collection.store(txn, broker, info, xml);
             @SuppressWarnings("unused")
 		org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
             broker.flush();

--- a/test/src/org/exist/IndexerTest2.java
+++ b/test/src/org/exist/IndexerTest2.java
@@ -134,7 +134,7 @@ public class IndexerTest2 {
             Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
             IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI2, XML);
             //TODO : unlock the collection here ?
-            collection.store(txn, broker, info, XML, false);
+            collection.store(txn, broker, info, XML);
             @SuppressWarnings("unused")
             org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
             broker.flush();

--- a/test/src/org/exist/IndexerTest3.java
+++ b/test/src/org/exist/IndexerTest3.java
@@ -339,7 +339,7 @@ public class IndexerTest3 {
             Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
             IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, xml);
             //TODO : unlock the collection here ?
-            collection.store(txn, broker, info, xml, false);
+            collection.store(txn, broker, info, xml);
             @SuppressWarnings("unused")
 		org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
             broker.flush();

--- a/test/src/org/exist/backup/SystemExportFiltersTest.java
+++ b/test/src/org/exist/backup/SystemExportFiltersTest.java
@@ -197,7 +197,7 @@ public class SystemExportFiltersTest {
         IndexInfo info = col.validateXMLResource(txn, broker, name, data);
         assertNotNull(info);
 
-        col.store(txn, broker, info, data, false);
+        col.store(txn, broker, info, data);
 
         return info.getDocument();
     }

--- a/test/src/org/exist/backup/SystemExportImportTest.java
+++ b/test/src/org/exist/backup/SystemExportImportTest.java
@@ -189,15 +189,15 @@ public class SystemExportImportTest {
 
             IndexInfo info = test.validateXMLResource(transaction, broker, doc01uri.lastSegment(), XML1);
             assertNotNull(info);
-            test.store(transaction, broker, info, XML1, false);
+            test.store(transaction, broker, info, XML1);
 
             info = test.validateXMLResource(transaction, broker, doc02uri.lastSegment(), XML2);
             assertNotNull(info);
-            test.store(transaction, broker, info, XML2, false);
+            test.store(transaction, broker, info, XML2);
 
             info = test.validateXMLResource(transaction, broker, doc03uri.lastSegment(), XML3);
             assertNotNull(info);
-            test.store(transaction, broker, info, XML3, false);
+            test.store(transaction, broker, info, XML3);
 
             test.addBinaryResource(transaction, broker, doc11uri.lastSegment(), BINARY.getBytes(), null);
 

--- a/test/src/org/exist/collections/CollectionRemovalTest.java
+++ b/test/src/org/exist/collections/CollectionRemovalTest.java
@@ -29,7 +29,7 @@ import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -123,12 +123,12 @@ public class CollectionRemovalTest {
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate(user, password)));
             final Txn transaction = transact.beginTransaction()) {
 
-            test = broker.openCollection(uri, Lock.WRITE_LOCK);
+            test = broker.openCollection(uri, LockMode.WRITE_LOCK);
             broker.removeCollection(transaction, test);
             transact.commit(transaction);
 		} finally {
             if (test != null) {
-                test.release(Lock.WRITE_LOCK);
+                test.release(LockMode.WRITE_LOCK);
             }
 		}
     }
@@ -137,7 +137,7 @@ public class CollectionRemovalTest {
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             Collection test = null;
             try {
-                test = broker.openCollection(uri, Lock.WRITE_LOCK);
+                test = broker.openCollection(uri, LockMode.WRITE_LOCK);
                 assertNotNull(test);
 
                 DocumentImpl doc = test.getDocument(broker, XmldbURI.createInternal("document.xml"));
@@ -148,7 +148,7 @@ public class CollectionRemovalTest {
                 String xml = serializer.serialize(doc);
             } finally {
                 if (test != null) {
-                    test.release(Lock.WRITE_LOCK);
+                    test.release(LockMode.WRITE_LOCK);
                 }
             }
         }

--- a/test/src/org/exist/collections/CollectionRemovalTest.java
+++ b/test/src/org/exist/collections/CollectionRemovalTest.java
@@ -201,7 +201,7 @@ public class CollectionRemovalTest {
 			IndexInfo info = test.validateXMLResource(transaction, broker,
 					XmldbURI.create("document.xml"), DATA);
 			assertNotNull(info);
-			test.store(transaction, broker, info, DATA, false);
+			test.store(transaction, broker, info, DATA);
 
             Collection childCol1 = broker.getOrCreateCollection(transaction,
                     TestConstants.TEST_COLLECTION_URI2.append("test4"));
@@ -214,7 +214,7 @@ public class CollectionRemovalTest {
             info = childCol1.validateXMLResource(transaction, broker,
 					XmldbURI.create("document.xml"), DATA);
 			assertNotNull(info);
-			childCol1.store(transaction, broker, info, DATA, false);
+			childCol1.store(transaction, broker, info, DATA);
 
             Collection childCol = broker.getOrCreateCollection(transaction,
                     TestConstants.TEST_COLLECTION_URI3);
@@ -227,7 +227,7 @@ public class CollectionRemovalTest {
             info = childCol.validateXMLResource(transaction, broker,
 					XmldbURI.create("document.xml"), DATA);
 			assertNotNull(info);
-			childCol.store(transaction, broker, info, DATA, false);
+			childCol.store(transaction, broker, info, DATA);
 
             transact.commit(transaction);
 		}

--- a/test/src/org/exist/collections/triggers/TestTrigger.java
+++ b/test/src/org/exist/collections/triggers/TestTrigger.java
@@ -63,7 +63,7 @@ public class TestTrigger extends SAXTrigger implements DocumentTrigger {
                 parent.setTriggersEnabled(false);
                 IndexInfo info = parent.validateXMLResource(transaction, broker, docPath, TEMPLATE);
                 //TODO : unlock the collection here ?
-                parent.store(transaction, broker, info, TEMPLATE, false);
+                parent.store(transaction, broker, info, TEMPLATE);
                 this.doc = info.getDocument();
             }
             transactMgr.commit(transaction);

--- a/test/src/org/exist/config/TwoDatabasesTest.java
+++ b/test/src/org/exist/config/TwoDatabasesTest.java
@@ -39,7 +39,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.security.Subject;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import org.exist.util.Configuration;
 import org.exist.util.LockException;
@@ -105,7 +105,7 @@ public class TwoDatabasesTest {
                 assertTrue(top1 != null);
             } finally {
                 if (top1 != null) {
-                    top1.getLock().release(Lock.READ_LOCK);
+                    top1.getLock().release(LockMode.READ_LOCK);
                 }
             }
         }
@@ -121,7 +121,7 @@ public class TwoDatabasesTest {
                 assertTrue(top2 != null);
             } finally {
                 if(top2 != null) {
-                    top2.getLock().release(Lock.READ_LOCK);
+                    top2.getLock().release(LockMode.READ_LOCK);
                 }
             }
         }
@@ -148,7 +148,7 @@ public class TwoDatabasesTest {
                 pool1.getTransactionManager().commit(transaction1);
             } finally {
                 if(top1 != null) {
-                    top1.release(Lock.READ_LOCK);
+                    top1.release(LockMode.READ_LOCK);
                 }
             }
         }
@@ -161,7 +161,7 @@ public class TwoDatabasesTest {
                 pool2.getTransactionManager().commit(transaction2);
             } finally {
                 if(top2 != null) {
-                    top2.release(Lock.READ_LOCK);
+                    top2.release(LockMode.READ_LOCK);
                 }
             }
         }
@@ -194,9 +194,9 @@ public class TwoDatabasesTest {
             MutableDocumentSet docs = new DefaultDocumentSet();
             top.getDocuments(broker, docs);
             XmldbURI[] uris = docs.getNames();
-            //binDoc = (BinaryDocument)broker.getXMLResource(XmldbURI.create("xmldb:exist:///bin"),Lock.READ_LOCK);
+            //binDoc = (BinaryDocument)broker.getXMLResource(XmldbURI.create("xmldb:exist:///bin"),LockMode.READ_LOCK);
             binDoc = (BinaryDocument) top.getDocument(broker, XmldbURI.create("xmldb:exist:///bin"));
-            top.release(Lock.READ_LOCK);
+            top.release(LockMode.READ_LOCK);
             assertTrue(binDoc != null);
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             broker.readBinaryResource(binDoc, os);
@@ -204,7 +204,7 @@ public class TwoDatabasesTest {
             return comp.equals(bin + suffix);
         } finally {
             if (binDoc != null) {
-                binDoc.getUpdateLock().release(Lock.READ_LOCK);
+                binDoc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
     }

--- a/test/src/org/exist/config/TwoDatabasesTest.java
+++ b/test/src/org/exist/config/TwoDatabasesTest.java
@@ -167,7 +167,7 @@ public class TwoDatabasesTest {
         }
     }
 
-    private void get() throws EXistException, IOException, PermissionDeniedException {
+    private void get() throws EXistException, IOException, PermissionDeniedException, LockException {
         try (final DBBroker broker1 = pool1.get(Optional.of(user1))) {
             assertTrue(getBin(broker1, "1"));
         }
@@ -186,7 +186,7 @@ public class TwoDatabasesTest {
         return top;
     }
 
-    private boolean getBin(final DBBroker broker, final String suffix) throws PermissionDeniedException, IOException {
+    private boolean getBin(final DBBroker broker, final String suffix) throws PermissionDeniedException, IOException, LockException {
         BinaryDocument binDoc = null;
         try {
             Collection top = broker.getCollection(XmldbURI.create("xmldb:exist:///"));

--- a/test/src/org/exist/dom/memtree/DOMIndexerTest.java
+++ b/test/src/org/exist/dom/memtree/DOMIndexerTest.java
@@ -104,7 +104,7 @@ public class DOMIndexerTest {
             Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
             IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, XML);
             //TODO : unlock the collection here ?
-            collection.store(txn, broker, info, XML, false);
+            collection.store(txn, broker, info, XML);
             @SuppressWarnings("unused")
             org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
             broker.flush();

--- a/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
+++ b/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
@@ -450,11 +450,11 @@ public class BasicNodeSetTest {
             // store some documents.
             for(final Path f : FileUtils.list(dir, XMLFilenameFilter.asPredicate())) {
                 final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
-                root.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                root.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
             }
 
             IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("nested.xml"), NESTED_XML);
-            root.store(transaction, broker, info, NESTED_XML, false);
+            root.store(transaction, broker, info, NESTED_XML);
             transact.commit(transaction);
             
             

--- a/test/src/org/exist/dom/persistent/DocTypeTest.java
+++ b/test/src/org/exist/dom/persistent/DocTypeTest.java
@@ -16,7 +16,7 @@ import org.exist.collections.IndexInfo;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
@@ -85,7 +85,7 @@ public class DocTypeTest {
                 transact.commit(transaction);
             }
 
-			doc = broker.getXMLResource(root.getURI().append(XmldbURI.create("test2.xml")),Lock.READ_LOCK);
+			doc = broker.getXMLResource(root.getURI().append(XmldbURI.create("test2.xml")),LockMode.READ_LOCK);
 
 			final DocumentType docType = doc.getDoctype();
 			assertNotNull(docType);
@@ -102,7 +102,7 @@ public class DocTypeTest {
 
 		} finally {
 		    if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
 		}
 	}
@@ -112,7 +112,7 @@ public class DocTypeTest {
 		DocumentImpl doc = null;
 		try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
-            doc = broker.getXMLResource(root.getURI().append(XmldbURI.create("test.xml")), Lock.READ_LOCK);
+            doc = broker.getXMLResource(root.getURI().append(XmldbURI.create("test.xml")), LockMode.READ_LOCK);
 
             DocumentType docType = doc.getDoctype();
 
@@ -131,7 +131,7 @@ public class DocTypeTest {
 
         } finally {
 		    if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
 		}
 	}

--- a/test/src/org/exist/dom/persistent/DocTypeTest.java
+++ b/test/src/org/exist/dom/persistent/DocTypeTest.java
@@ -80,7 +80,7 @@ public class DocTypeTest {
                 final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test2.xml"), is);
 
                 assertNotNull(info);
-                root.store(transaction, broker, info, is, false);
+                root.store(transaction, broker, info, is);
 
                 transact.commit(transaction);
             }
@@ -152,7 +152,7 @@ public class DocTypeTest {
             IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), XML);
             //TODO : unlock the collection here ?
             assertNotNull(info);
-            root.store(transaction, broker, info, XML, false);
+            root.store(transaction, broker, info, XML);
             
             transact.commit(transaction);
         }

--- a/test/src/org/exist/dom/persistent/NodeTest.java
+++ b/test/src/org/exist/dom/persistent/NodeTest.java
@@ -7,7 +7,7 @@ import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.util.Configuration;
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import org.exist.Indexer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -56,7 +55,7 @@ public class NodeTest {
     public void document() throws EXistException, LockException, PermissionDeniedException {
         DocumentImpl doc = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),Lock.READ_LOCK);
+            doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),LockMode.READ_LOCK);
             NodeList children = doc.getChildNodes();
             for (int i = 0; i < children.getLength(); i++) {
                 IStoredNode node = (IStoredNode<?>) children.item(i);
@@ -65,7 +64,7 @@ public class NodeTest {
             }
         } finally {
             if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
     }
@@ -74,7 +73,7 @@ public class NodeTest {
 	public void childAxis() throws EXistException, LockException, PermissionDeniedException {
 		DocumentImpl doc = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),Lock.READ_LOCK);
+            doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),LockMode.READ_LOCK);
             Element rootNode = doc.getDocumentElement();
             
             //Testing getChildNodes()
@@ -106,7 +105,7 @@ public class NodeTest {
         	assertEquals(parent.getNodeName(), "test");
         } finally {
         	if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
 	}
@@ -116,7 +115,7 @@ public class NodeTest {
         DocumentImpl doc = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             
-            doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),Lock.READ_LOCK);
+            doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),LockMode.READ_LOCK);
             Element rootNode = doc.getDocumentElement();
             Element child = (Element) rootNode.getFirstChild();
             assertNotNull(child);
@@ -142,7 +141,7 @@ public class NodeTest {
             assertEquals(count, 4);
         } finally {
             if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
     }
@@ -151,7 +150,7 @@ public class NodeTest {
 	public void attributeAxis() throws EXistException, LockException, PermissionDeniedException {
 		DocumentImpl doc = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),Lock.READ_LOCK);
+            doc = root.getDocumentWithLock(broker, XmldbURI.create("test.xml"),LockMode.READ_LOCK);
             Element rootNode = doc.getDocumentElement();
             Element first = (Element) rootNode.getFirstChild();
             assertEquals(first.getNodeName(), "a");
@@ -188,7 +187,7 @@ public class NodeTest {
             assertEquals(attr.getNamespaceURI(), "http://foo.org");
             assertEquals(attr.getValue(), "m");
         } finally {
-        	if (doc != null) doc.getUpdateLock().release(Lock.READ_LOCK);
+        	if (doc != null) doc.getUpdateLock().release(LockMode.READ_LOCK);
         }
 	}
 
@@ -212,7 +211,7 @@ public class NodeTest {
             rootNode.accept(visitor);
         } finally {
             if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
         }
     }

--- a/test/src/org/exist/dom/persistent/NodeTest.java
+++ b/test/src/org/exist/dom/persistent/NodeTest.java
@@ -232,7 +232,7 @@ public class NodeTest {
             IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), XML);
             //TODO : unlock the collection here ?
             assertNotNull(info);
-            root.store(transaction, broker, info, XML, false);
+            root.store(transaction, broker, info, XML);
             
             transact.commit(transaction);
         }

--- a/test/src/org/exist/numbering/DLNStorageTest.java
+++ b/test/src/org/exist/numbering/DLNStorageTest.java
@@ -115,7 +115,7 @@ public class DLNStorageTest {
             //TODO : unlock the collection here ?
             assertNotNull(info);
 
-            test.store(transaction, broker, info, TEST_XML, false);
+            test.store(transaction, broker, info, TEST_XML);
 
             transact.commit(transaction);
         }

--- a/test/src/org/exist/storage/AbstractUpdateTest.java
+++ b/test/src/org/exist/storage/AbstractUpdateTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractUpdateTest {
 	        
 	        info = test.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), TEST_XML);
 	        //TODO : unlock the collection here ?
-	        test.store(transaction, broker, info, TEST_XML, false);
+	        test.store(transaction, broker, info, TEST_XML);
 	
 	        transact.commit(transaction);	
 	    }

--- a/test/src/org/exist/storage/AbstractUpdateTest.java
+++ b/test/src/org/exist/storage/AbstractUpdateTest.java
@@ -26,7 +26,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -67,12 +67,12 @@ public abstract class AbstractUpdateTest {
 
             DocumentImpl doc = null;
             try {
-                doc = broker.getXMLResource(TEST_COLLECTION_URI.append("test2/test.xml"), Lock.READ_LOCK);
+                doc = broker.getXMLResource(TEST_COLLECTION_URI.append("test2/test.xml"), LockMode.READ_LOCK);
                 assertNotNull("Document '" + TEST_COLLECTION_URI.append("test2/test.xml") + "' should not be null", doc);
                 final String data = serializer.serialize(doc);
             } finally {
                 if(doc != null) {
-                    doc.getUpdateLock().release(Lock.READ_LOCK);
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
             

--- a/test/src/org/exist/storage/CollectionTest.java
+++ b/test/src/org/exist/storage/CollectionTest.java
@@ -38,6 +38,7 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.util.Configuration;
 import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.Test;
@@ -63,7 +64,7 @@ public class CollectionTest {
         "</test>";
 
     @Test
-    public void storeRead() throws EXistException, IOException, PermissionDeniedException, BTreeException, DatabaseConfigurationException, TriggerException  {
+    public void storeRead() throws EXistException, IOException, PermissionDeniedException, BTreeException, DatabaseConfigurationException, TriggerException, LockException {
         store();
         BrokerPool.stopAll(false);
         read();
@@ -87,7 +88,7 @@ public class CollectionTest {
         }
     }
     
-    public void read() throws EXistException, IOException, PermissionDeniedException, BTreeException, DatabaseConfigurationException {
+    public void read() throws EXistException, IOException, PermissionDeniedException, BTreeException, DatabaseConfigurationException, LockException {
         BrokerPool.FORCE_CORRUPTION = false;
         BrokerPool pool = startDB();
 

--- a/test/src/org/exist/storage/ConcurrentStoreTest.java
+++ b/test/src/org/exist/storage/ConcurrentStoreTest.java
@@ -36,10 +36,7 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
-import org.exist.util.FileUtils;
-import org.exist.util.XMLFilenameFilter;
+import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.Test;
@@ -79,7 +76,7 @@ public class ConcurrentStoreTest {
     }
 
     @Test
-    public void read() throws EXistException, PermissionDeniedException, DatabaseConfigurationException {
+    public void read() throws EXistException, PermissionDeniedException, DatabaseConfigurationException, LockException {
         BrokerPool.FORCE_CORRUPTION = false;
         pool = startDB();
 
@@ -137,7 +134,7 @@ public class ConcurrentStoreTest {
                 for (final Path f : files) {
                     try {
                         info = test.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
-                        test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                        test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
                     } catch (SAXException e) {
                         System.err.println("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
                     }
@@ -173,7 +170,7 @@ public class ConcurrentStoreTest {
                 Path f = dir.resolve("hamlet.xml");
                 try {
                     IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), new InputSource(f.toUri().toASCIIString()));
-                    test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                    test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
                 } catch (SAXException e) {
                     System.err.println("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
                 }

--- a/test/src/org/exist/storage/CopyCollectionTest.java
+++ b/test/src/org/exist/storage/CopyCollectionTest.java
@@ -116,7 +116,7 @@ public class CopyCollectionTest {
             final Path f = getSampleData();
             final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"),
                     new InputSource(f.toUri().toASCIIString()));
-            test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+            test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
             
             final Collection dest = broker.getOrCreateCollection(transaction, XmldbURI.ROOT_COLLECTION_URI.append("destination"));
             broker.saveCollection(transaction, dest);
@@ -171,7 +171,7 @@ public class CopyCollectionTest {
                 final Path f = getSampleData();
 
                 IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), new InputSource(f.toUri().toASCIIString()));
-                test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
 
                 transact.commit(transaction);
             }

--- a/test/src/org/exist/storage/CopyCollectionTest.java
+++ b/test/src/org/exist/storage/CopyCollectionTest.java
@@ -31,7 +31,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -138,12 +138,12 @@ public class CopyCollectionTest {
             
             DocumentImpl doc = null;
             try {
-                doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("destination/test3/test.xml"), Lock.READ_LOCK);
+                doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("destination/test3/test.xml"), LockMode.READ_LOCK);
                 assertNotNull("Document should not be null", doc);
                 final String data = serializer.serialize(doc);
             } finally {
                 if(doc != null) {
-                    doc.getUpdateLock().release(Lock.READ_LOCK);
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
         }
@@ -196,7 +196,7 @@ public class CopyCollectionTest {
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
             final Serializer serializer = broker.getSerializer();
             serializer.reset();
-            final DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("destination/test3/test.xml"), Lock.READ_LOCK);
+            final DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("destination/test3/test.xml"), LockMode.READ_LOCK);
             assertNotNull("Document should be null", doc);
         }
     }

--- a/test/src/org/exist/storage/CopyResourceTest.java
+++ b/test/src/org/exist/storage/CopyResourceTest.java
@@ -31,7 +31,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -129,13 +129,13 @@ public class CopyResourceTest {
 
 			DocumentImpl doc = null;
 			try {
-				doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test").append(testCollectionName).append("new_test.xml"), Lock.READ_LOCK);
+				doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test").append(testCollectionName).append("new_test.xml"), LockMode.READ_LOCK);
 				assertNotNull("Document should not be null", doc);
 				final String data = serializer.serialize(doc);
 				assertNotNull(data);
 			} finally {
 				if(doc != null) {
-					doc.getUpdateLock().release(Lock.READ_LOCK);
+					doc.getUpdateLock().release(LockMode.READ_LOCK);
 				}
 			}
 		}
@@ -200,17 +200,17 @@ public class CopyResourceTest {
 
 			DocumentImpl doc = null;
 			try {
-				doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test").append(testCollectionName).append(subCollection).append("test2.xml"), Lock.READ_LOCK);
+				doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test").append(testCollectionName).append(subCollection).append("test2.xml"), LockMode.READ_LOCK);
 				assertNotNull("Document should not be null", doc);
 				final String data = serializer.serialize(doc);
 				assertNotNull(data);
 			} finally {
 				if(doc != null) {
-					doc.getUpdateLock().release(Lock.READ_LOCK);
+					doc.getUpdateLock().release(LockMode.READ_LOCK);
 				}
 			}
 
-			doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test").append(testCollectionName).append("new_test2.xml"), Lock.READ_LOCK);
+			doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test").append(testCollectionName).append("new_test2.xml"), LockMode.READ_LOCK);
 			assertNull("Document should not exist", doc);
 		}
 	}

--- a/test/src/org/exist/storage/CopyResourceTest.java
+++ b/test/src/org/exist/storage/CopyResourceTest.java
@@ -103,7 +103,7 @@ public class CopyResourceTest {
                 assertNotNull(f);
                 info = subTestCollection.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), new InputSource(f.toUri().toASCIIString()));
                 assertNotNull(info);
-                subTestCollection.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                subTestCollection.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
 
                 transact.commit(transaction);
             }
@@ -174,7 +174,7 @@ public class CopyResourceTest {
                 assertNotNull(f);
                 info = subTestCollection.validateXMLResource(transaction, broker, XmldbURI.create("test2.xml"), new InputSource(f.toUri().toASCIIString()));
                 assertNotNull(info);
-                subTestCollection.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                subTestCollection.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
 
                 transact.commit(transaction);
             }

--- a/test/src/org/exist/storage/DirtyShutdownTest.java
+++ b/test/src/org/exist/storage/DirtyShutdownTest.java
@@ -67,7 +67,7 @@ public class DirtyShutdownTest {
                     IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"),
                             new InputSource(f.toUri().toASCIIString()));
                     assertNotNull(info);
-                    root.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                    root.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
 
                     transact.commit(transaction);
                 }
@@ -90,7 +90,7 @@ public class DirtyShutdownTest {
                 IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"),
                         new InputSource(f.toUri().toASCIIString()));
                 assertNotNull(info);
-                root.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                root.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
 
                 transact.commit(transaction);
             }

--- a/test/src/org/exist/storage/LargeValuesTest.java
+++ b/test/src/org/exist/storage/LargeValuesTest.java
@@ -7,7 +7,7 @@ import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -19,7 +19,6 @@ import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.TestUtils;
 
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -110,7 +109,7 @@ public class LargeValuesTest {
         BrokerPool.FORCE_CORRUPTION = false;
 
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
-            final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.READ_LOCK);
+            final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.READ_LOCK);
             assertNotNull(root);
 
             final DocumentImpl doc = root.getDocument(broker, XmldbURI.create("test.xml"));
@@ -144,7 +143,7 @@ public class LargeValuesTest {
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
 
-            final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.READ_LOCK);
+            final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.READ_LOCK);
             assertNotNull(root);
             broker.removeCollection(transaction, root);
 

--- a/test/src/org/exist/storage/LargeValuesTest.java
+++ b/test/src/org/exist/storage/LargeValuesTest.java
@@ -90,7 +90,7 @@ public class LargeValuesTest {
                 final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"),
                         new InputSource(file.toUri().toASCIIString()));
                 assertNotNull(info);
-                root.store(transaction, broker, info, new InputSource(file.toUri().toASCIIString()), false);
+                root.store(transaction, broker, info, new InputSource(file.toUri().toASCIIString()));
                 broker.saveCollection(transaction, root);
 
                 transact.commit(transaction);

--- a/test/src/org/exist/storage/MoveCollectionTest.java
+++ b/test/src/org/exist/storage/MoveCollectionTest.java
@@ -104,7 +104,7 @@ public class MoveCollectionTest {
             assertNotNull(f);
             IndexInfo info = test.validateXMLResource(transaction, broker, TestConstants.TEST_XML_URI, new InputSource(f.toUri().toASCIIString()));
             assertNotNull(info);
-            test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+            test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
             
             Collection dest = broker.getOrCreateCollection(transaction, TestConstants.DESTINATION_COLLECTION_URI);
             assertNotNull(dest);
@@ -159,7 +159,7 @@ public class MoveCollectionTest {
                 assertNotNull(f);
                 IndexInfo info = test2.validateXMLResource(transaction, broker, TestConstants.TEST_XML_URI, new InputSource(f.toUri().toASCIIString()));
                 assertNotNull(info);
-                test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
 
                 transact.commit(transaction);
             }

--- a/test/src/org/exist/storage/MoveCollectionTest.java
+++ b/test/src/org/exist/storage/MoveCollectionTest.java
@@ -31,7 +31,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -124,11 +124,11 @@ public class MoveCollectionTest {
             Serializer serializer = broker.getSerializer();
             serializer.reset();
             
-            DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("/destination1/test3/test.xml"), Lock.READ_LOCK);
+            DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("/destination1/test3/test.xml"), LockMode.READ_LOCK);
             assertNotNull("Document should not be null", doc);
             String data = serializer.serialize(doc);
             assertNotNull(data);
-            doc.getUpdateLock().release(Lock.READ_LOCK);
+            doc.getUpdateLock().release(LockMode.READ_LOCK);
         }
     }
 
@@ -185,7 +185,7 @@ public class MoveCollectionTest {
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             Serializer serializer = broker.getSerializer();
             serializer.reset();            
-            DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("destination2/test3/test.xml"), Lock.READ_LOCK);
+            DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("destination2/test3/test.xml"), LockMode.READ_LOCK);
             assertNull("Document should be null", doc);
         }
     }

--- a/test/src/org/exist/storage/MoveOverwriteCollectionTest.java
+++ b/test/src/org/exist/storage/MoveOverwriteCollectionTest.java
@@ -130,7 +130,7 @@ public class MoveOverwriteCollectionTest {
 
     private void store(Txn txn, DBBroker broker, Collection col, XmldbURI name, String data) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
         IndexInfo info = col.validateXMLResource(txn, broker, name, data);
-        col.store(txn, broker, info, data, false);
+        col.store(txn, broker, info, data);
     }
 
     private void move(final DBBroker broker) throws Exception {

--- a/test/src/org/exist/storage/MoveOverwriteResourceTest.java
+++ b/test/src/org/exist/storage/MoveOverwriteResourceTest.java
@@ -126,7 +126,7 @@ public class MoveOverwriteResourceTest {
 
     private void store(Txn txn, DBBroker broker, Collection col, XmldbURI name, String data) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
         IndexInfo info = col.validateXMLResource(txn, broker, name, data);
-        col.store(txn, broker, info, data, false);
+        col.store(txn, broker, info, data);
     }
 
     private void move(final DBBroker broker) throws Exception {

--- a/test/src/org/exist/storage/MoveResourceTest.java
+++ b/test/src/org/exist/storage/MoveResourceTest.java
@@ -32,7 +32,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -106,18 +106,18 @@ public class MoveResourceTest {
             final Serializer serializer = broker.getSerializer();
             serializer.reset();
 
-            final DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test/new_test.xml"), Lock.READ_LOCK);
+            final DocumentImpl doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test/new_test.xml"), LockMode.READ_LOCK);
             assertNotNull("Document should not be null", doc);
             final String data = serializer.serialize(doc);
             assertNotNull(data);
-            doc.getUpdateLock().release(Lock.READ_LOCK);
+            doc.getUpdateLock().release(LockMode.READ_LOCK);
 
             final TransactionManager transact = pool.getTransactionManager();
             try(final Txn transaction = transact.beginTransaction()) {
 
-                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
+                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
                 assertNotNull(root);
-                transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
+                transaction.registerLock(root.getLock(), LockMode.WRITE_LOCK);
                 broker.removeCollection(transaction, root);
 
                 transact.commit(transaction);
@@ -183,19 +183,19 @@ public class MoveResourceTest {
             final Serializer serializer = broker.getSerializer();
             serializer.reset();
 
-            final DocumentImpl doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append("new_test2.xml"), Lock.READ_LOCK);
+            final DocumentImpl doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append("new_test2.xml"), LockMode.READ_LOCK);
             assertNotNull("Document should not be null", doc);
             final String data = serializer.serialize(doc);
             assertNotNull(data);
 
-            doc.getUpdateLock().release(Lock.READ_LOCK);
+            doc.getUpdateLock().release(LockMode.READ_LOCK);
 
             final TransactionManager transact = pool.getTransactionManager();
             try(final Txn transaction = transact.beginTransaction()) {
 
-                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
+                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
                 assertNotNull(root);
-                transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
+                transaction.registerLock(root.getLock(), LockMode.WRITE_LOCK);
                 broker.removeCollection(transaction, root);
 
                 transact.commit(transaction);

--- a/test/src/org/exist/storage/MoveResourceTest.java
+++ b/test/src/org/exist/storage/MoveResourceTest.java
@@ -86,7 +86,7 @@ public class MoveResourceTest {
 
             final IndexInfo info = test2.validateXMLResource(transaction, broker, TestConstants.TEST_XML_URI, new InputSource(f.toUri().toASCIIString()));
             assertNotNull(info);
-            test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+            test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
 
             final DocumentImpl doc = test2.getDocument(broker, TestConstants.TEST_XML_URI);
             assertNotNull(doc);
@@ -153,7 +153,7 @@ public class MoveResourceTest {
                 final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create("new_test2.xml"),
                         new InputSource(f.toUri().toASCIIString()));
                 test2.store(transaction, broker, info, new InputSource(f.toUri()
-                        .toASCIIString()), false);
+                        .toASCIIString()));
 
                 transact.commit(transaction);
             }

--- a/test/src/org/exist/storage/RangeIndexUpdateTest.java
+++ b/test/src/org/exist/storage/RangeIndexUpdateTest.java
@@ -195,13 +195,13 @@ public class RangeIndexUpdateTest {
 
             IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_string.xml"), XML);
             assertNotNull(info);
-            root.store(transaction, broker, info, XML, false);
+            root.store(transaction, broker, info, XML);
 
             docs.add(info.getDocument());
 
             info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_string2.xml"), XML2);
             assertNotNull(info);
-            root.store(transaction, broker, info, XML2, false);
+            root.store(transaction, broker, info, XML2);
 
             docs.add(info.getDocument());
 

--- a/test/src/org/exist/storage/RecoverBinaryTest.java
+++ b/test/src/org/exist/storage/RecoverBinaryTest.java
@@ -34,7 +34,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
@@ -102,7 +102,7 @@ public class RecoverBinaryTest {
         BrokerPool.FORCE_CORRUPTION = false;
 
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
-            final BinaryDocument binDoc = (BinaryDocument) broker.getXMLResource(TestConstants.TEST_COLLECTION_URI.append(TestConstants.TEST_BINARY_URI), Lock.READ_LOCK);
+            final BinaryDocument binDoc = (BinaryDocument) broker.getXMLResource(TestConstants.TEST_COLLECTION_URI.append(TestConstants.TEST_BINARY_URI), LockMode.READ_LOCK);
             assertNotNull("Binary document is null", binDoc);
 
             try(final InputStream is = broker.getBinaryResource(binDoc)) {

--- a/test/src/org/exist/storage/RecoverBinaryTest2.java
+++ b/test/src/org/exist/storage/RecoverBinaryTest2.java
@@ -105,7 +105,7 @@ public class RecoverBinaryTest2 {
     }
 
     //@Test
-    public void read2() throws EXistException, DatabaseConfigurationException, PermissionDeniedException, IOException, TriggerException {
+    public void read2() throws EXistException, DatabaseConfigurationException, PermissionDeniedException, IOException, TriggerException, LockException {
 
         BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();

--- a/test/src/org/exist/storage/RecoveryTest.java
+++ b/test/src/org/exist/storage/RecoveryTest.java
@@ -38,7 +38,7 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.btree.BTreeException;
 import org.exist.storage.dom.DOMFile;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -184,32 +184,32 @@ public class RecoveryTest {
             
             DocumentImpl doc = null;
             try {
-                doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test/test2/hamlet.xml"), Lock.READ_LOCK);
+                doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test/test2/hamlet.xml"), LockMode.READ_LOCK);
                 assertNotNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/hamlet.xml' should not be null", doc);
                 final String data = serializer.serialize(doc);
                 assertNotNull(data);
             } finally {
                 if(doc != null) {
-                    doc.getUpdateLock().release(Lock.READ_LOCK);
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
                     doc = null;
                 }
             }
 
             try {
-                doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test/test2/test_string.xml"), Lock.READ_LOCK);
+                doc = broker.getXMLResource(XmldbURI.ROOT_COLLECTION_URI.append("test/test2/test_string.xml"), LockMode.READ_LOCK);
                 assertNotNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/test_string.xml' should not be null", doc);
                 final String data = serializer.serialize(doc);
                 assertNotNull(data);
             } finally {
                 if(doc != null) {
-                    doc.getUpdateLock().release(Lock.READ_LOCK);
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
             
             final List<Path> files = FileUtils.list(dir);
             assertNotNull(files);
             
-            doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(FileUtils.fileName(files.get(files.size() - 1))), Lock.READ_LOCK);
+            doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(FileUtils.fileName(files.get(files.size() - 1))), LockMode.READ_LOCK);
             assertNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/'" + FileUtils.fileName(files.get(files.size() - 1)) + " should not exist anymore", doc);
             
             final XQuery xquery = pool.getXQueryService();
@@ -221,7 +221,7 @@ public class RecoveryTest {
                 final String value = serializer.serialize((NodeValue) next);
             }
             
-            final BinaryDocument binDoc = (BinaryDocument) broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(TestConstants.TEST_BINARY_URI), Lock.READ_LOCK);
+            final BinaryDocument binDoc = (BinaryDocument) broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(TestConstants.TEST_BINARY_URI), LockMode.READ_LOCK);
             assertNotNull("Binary document is null", binDoc);
             try(final InputStream is = broker.getBinaryResource(binDoc)) {
                 final byte[] bdata = new byte[(int) broker.getBinaryResourceSize(binDoc)];
@@ -239,9 +239,9 @@ public class RecoveryTest {
             final TransactionManager transact = pool.getTransactionManager();
             try(final Txn transaction = transact.beginTransaction()) {
 
-                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
+                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
                 assertNotNull(root);
-                transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
+                transaction.registerLock(root.getLock(), LockMode.WRITE_LOCK);
                 broker.removeCollection(transaction, root);
 
                 transact.commit(transaction);

--- a/test/src/org/exist/storage/RecoveryTest.java
+++ b/test/src/org/exist/storage/RecoveryTest.java
@@ -125,7 +125,7 @@ public class RecoveryTest {
                     try {
                         final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
                         assertNotNull(info);
-                        test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                        test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
                     } catch (SAXException e) {
 //                	    TODO : why pass invalid couments ?
                         System.err.println("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
@@ -137,7 +137,7 @@ public class RecoveryTest {
                     try {
                         final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
                         assertNotNull(info);
-                        test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                        test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
                     } catch (SAXException e) {
 //                	    TODO : why pass invalid documents ?
                         System.err.println("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
@@ -148,7 +148,7 @@ public class RecoveryTest {
                 assertNotNull(info);
                 //TODO : unlock the collection here ?
 
-                test2.store(transaction, broker, info, TEST_XML, false);
+                test2.store(transaction, broker, info, TEST_XML);
                 // remove last document
                 test2.removeXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(files.get(files.size() - 1))));
 

--- a/test/src/org/exist/storage/RecoveryTest2.java
+++ b/test/src/org/exist/storage/RecoveryTest2.java
@@ -100,7 +100,7 @@ public class RecoveryTest2 {
             for (final Path f : docs) {
                 final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
                 assertNotNull(info);
-                test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
             }
 
             transact.commit(transaction);

--- a/test/src/org/exist/storage/RecoveryTest2.java
+++ b/test/src/org/exist/storage/RecoveryTest2.java
@@ -36,7 +36,7 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.btree.BTreeException;
 import org.exist.storage.dom.DOMFile;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -117,11 +117,11 @@ public class RecoveryTest2 {
             Serializer serializer = broker.getSerializer();
             serializer.reset();
             
-            DocumentImpl doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append("terms-eng.xml"), Lock.READ_LOCK);
+            DocumentImpl doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append("terms-eng.xml"), LockMode.READ_LOCK);
             assertNotNull("Document should not be null", doc);
             String data = serializer.serialize(doc);
             assertNotNull(data);
-            doc.getUpdateLock().release(Lock.READ_LOCK);
+            doc.getUpdateLock().release(LockMode.READ_LOCK);
         }
     }
     

--- a/test/src/org/exist/storage/RecoveryTest3.java
+++ b/test/src/org/exist/storage/RecoveryTest3.java
@@ -93,7 +93,7 @@ public class RecoveryTest3 {
                 try {
                     final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
                     assertNotNull(info);
-                    test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                    test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
                 } catch (final SAXException e) {
                     //TODO : why store invalid documents ?
                     System.err.println("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
@@ -144,7 +144,7 @@ public class RecoveryTest3 {
                     try {
                         final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
                         assertNotNull(info);
-                        test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                        test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
                     } catch (SAXException e) {
                         System.err.println("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
                     }

--- a/test/src/org/exist/storage/RecoveryTest3.java
+++ b/test/src/org/exist/storage/RecoveryTest3.java
@@ -32,7 +32,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
@@ -118,9 +118,9 @@ public class RecoveryTest3 {
 
             try (final Txn transaction = transact.beginTransaction()) {
 
-                root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
+                root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
                 assertNotNull(root);
-                transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
+                transaction.registerLock(root.getLock(), LockMode.WRITE_LOCK);
                 broker.removeCollection(transaction, root);
 
                 transact.commit(transaction);

--- a/test/src/org/exist/storage/ReindexTest.java
+++ b/test/src/org/exist/storage/ReindexTest.java
@@ -4,7 +4,7 @@ import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
@@ -107,9 +107,9 @@ public class ReindexTest {
 
             BrokerPool.FORCE_CORRUPTION = true;
 
-            Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.WRITE_LOCK);
+            Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
             assertNotNull(root);
-            transaction.registerLock(root.getLock(), Lock.WRITE_LOCK);
+            transaction.registerLock(root.getLock(), LockMode.WRITE_LOCK);
             broker.removeCollection(transaction, root);
             pool.getJournalManager().get().flush(true, false);
             transact.commit(transaction);
@@ -126,7 +126,7 @@ public class ReindexTest {
         BrokerPool.FORCE_CORRUPTION = false;
         final BrokerPool pool = startDB();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.READ_LOCK);
+            Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.READ_LOCK);
             assertNull("Removed collection does still exist", root);
         }
     }

--- a/test/src/org/exist/storage/ReindexTest.java
+++ b/test/src/org/exist/storage/ReindexTest.java
@@ -75,7 +75,7 @@ public class ReindexTest {
                         try {
                             final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
                             assertNotNull(info);
-                            root.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                            root.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
                         } catch (SAXException e) {
                             System.err.println("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
                         }

--- a/test/src/org/exist/storage/RemoveCollectionTest.java
+++ b/test/src/org/exist/storage/RemoveCollectionTest.java
@@ -154,7 +154,7 @@ public class RemoveCollectionTest {
                     assertNotNull(is);
                     final IndexInfo info = test.validateXMLResource(transaction, broker, doc.getURI(), is);
                     assertNotNull(info);
-                    test.store(transaction, broker, info, is, false);
+                    test.store(transaction, broker, info, is);
                 }
                 generator.releaseAll();
                 transact.commit(transaction);
@@ -180,7 +180,7 @@ public class RemoveCollectionTest {
             assertNotNull(is);
             final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create("hamlet.xml"), is);
             assertNotNull(info);
-            test.store(transaction, broker, info, is, false);
+            test.store(transaction, broker, info, is);
             transact.commit(transaction);
         }
 
@@ -192,7 +192,7 @@ public class RemoveCollectionTest {
                 assertNotNull(is);
                 final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create(file.getFileName().toString()), is);
                 assertNotNull(info);
-                test.store(transaction, broker, info, is, false);
+                test.store(transaction, broker, info, is);
             }
             generator.releaseAll();
             transact.commit(transaction);

--- a/test/src/org/exist/storage/RemoveCollectionTest.java
+++ b/test/src/org/exist/storage/RemoveCollectionTest.java
@@ -29,7 +29,7 @@ import org.exist.collections.IndexInfo;
 import org.exist.collections.CollectionConfigurationManager;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
@@ -208,12 +208,12 @@ public class RemoveCollectionTest {
         DocumentImpl doc = null;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
             if (checkResource) {
-                doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI.append("hamlet.xml"), Lock.READ_LOCK);
+                doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI.append("hamlet.xml"), LockMode.READ_LOCK);
                 assertNull("Resource should have been removed", doc);
             }
 	    } finally {
             if (doc != null) {
-                doc.getUpdateLock().release(Lock.READ_LOCK);
+                doc.getUpdateLock().release(LockMode.READ_LOCK);
             }
             stopDB();
         }

--- a/test/src/org/exist/storage/RemoveRootCollectionTest.java
+++ b/test/src/org/exist/storage/RemoveRootCollectionTest.java
@@ -72,7 +72,7 @@ public class RemoveRootCollectionTest {
             assertNotNull(is);
             final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("hamlet.xml"), is);
             assertNotNull(info);
-            root.store(transaction, broker, info, is, false);
+            root.store(transaction, broker, info, is);
             transact.commit(transaction);
         }
 	}

--- a/test/src/org/exist/storage/RemoveTest.java
+++ b/test/src/org/exist/storage/RemoveTest.java
@@ -27,7 +27,7 @@ import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -97,12 +97,12 @@ public class RemoveTest extends AbstractUpdateTest {
             
             DocumentImpl doc = null;
             try {
-                doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(TestConstants.TEST_XML_URI), Lock.READ_LOCK);
+                doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(TestConstants.TEST_XML_URI), LockMode.READ_LOCK);
                 assertNotNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/test.xml' should not be null", doc);
                 final String data = serializer.serialize(doc);
             } finally {
                 if(doc != null) {
-                    doc.getUpdateLock().release(Lock.READ_LOCK);
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
             

--- a/test/src/org/exist/storage/ResourceTest.java
+++ b/test/src/org/exist/storage/ResourceTest.java
@@ -31,7 +31,7 @@ import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.TestConstants;
@@ -112,7 +112,7 @@ public class ResourceTest {
             
             BinaryDocument binDoc = null;
             try {
-                binDoc = (BinaryDocument) broker.getXMLResource(docPath, Lock.READ_LOCK);
+                binDoc = (BinaryDocument) broker.getXMLResource(docPath, LockMode.READ_LOCK);
 
                 // if document is not present, null is returned
                 if(binDoc == null) {
@@ -125,7 +125,7 @@ public class ResourceTest {
                 }
             } finally {
                 if(binDoc != null) {
-                    binDoc.getUpdateLock().release(Lock.READ_LOCK);
+                    binDoc.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
             
@@ -161,7 +161,7 @@ public class ResourceTest {
             
             BinaryDocument binDoc = null;
             try {
-                binDoc = (BinaryDocument) broker.getXMLResource(docPath, Lock.READ_LOCK);
+                binDoc = (BinaryDocument) broker.getXMLResource(docPath, LockMode.READ_LOCK);
 
                 // if document is not present, null is returned
                 if(binDoc == null) {
@@ -174,7 +174,7 @@ public class ResourceTest {
                 }
             } finally {
                 if(binDoc != null) {
-                    binDoc.getUpdateLock().release(Lock.READ_LOCK);
+                    binDoc.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
             

--- a/test/src/org/exist/storage/ShutdownTest.java
+++ b/test/src/org/exist/storage/ShutdownTest.java
@@ -78,7 +78,7 @@ public class ShutdownTest {
                     try {
                         final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
                         assertNotNull(info);
-                        test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()), false);
+                        test.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
                     } catch (SAXException e) {
                         System.err.println("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
                     }

--- a/test/src/org/exist/storage/UpdateRecoverTest.java
+++ b/test/src/org/exist/storage/UpdateRecoverTest.java
@@ -28,7 +28,7 @@ import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
@@ -285,13 +285,13 @@ public class UpdateRecoverTest {
 
             DocumentImpl doc = null;
             try {
-                doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(TestConstants.TEST_XML_URI), Lock.READ_LOCK);
+                doc = broker.getXMLResource(TestConstants.TEST_COLLECTION_URI2.append(TestConstants.TEST_XML_URI), LockMode.READ_LOCK);
                 assertNotNull("Document '" + XmldbURI.ROOT_COLLECTION + "/test/test2/test.xml' should not be null", doc);
                 final String data = serializer.serialize(doc);
                 assertNotNull(data);
             } finally {
                 if(doc != null) {
-                    doc.getUpdateLock().release(Lock.READ_LOCK);
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
                 }
             }
         }

--- a/test/src/org/exist/storage/UpdateRecoverTest.java
+++ b/test/src/org/exist/storage/UpdateRecoverTest.java
@@ -111,7 +111,7 @@ public class UpdateRecoverTest {
                 assertNotNull(info);
                 //TODO : unlock the collection here ?
 
-                test2.store(transaction, broker, info, TEST_XML, false);
+                test2.store(transaction, broker, info, TEST_XML);
 
                 transact.commit(transaction);
             }

--- a/test/src/org/exist/storage/lock/DeadlockTest.java
+++ b/test/src/org/exist/storage/lock/DeadlockTest.java
@@ -171,7 +171,7 @@ public class DeadlockTest {
 			IndexInfo info = test.validateXMLResource(transaction, broker,
 					XmldbURI.create("hamlet.xml"), is);
 			assertNotNull(info);
-			test.store(transaction, broker, info, is, false);
+			test.store(transaction, broker, info, is);
 			transact.commit(transaction);
 
 			// initialize XML:DB driver
@@ -279,7 +279,7 @@ public class DeadlockTest {
                                     broker, XmldbURI.create("test" + fileCount
                                             + ".xml"), is);
                             assertNotNull(info);
-                            coll.store(transaction, broker, info, is, false);
+                            coll.store(transaction, broker, info, is);
                             transact.commit(transaction);
                         }
                     }

--- a/test/src/org/exist/storage/lock/GetXMLResourceNoLockTest.java
+++ b/test/src/org/exist/storage/lock/GetXMLResourceNoLockTest.java
@@ -16,6 +16,7 @@ import org.exist.collections.Collection;
 import org.exist.start.Main;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.junit.Test;
@@ -44,12 +45,12 @@ public class GetXMLResourceNoLockTest {
         final BrokerPool pool = BrokerPool.getInstance();
 
 		try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-			Collection testCollection = broker.openCollection(TestConstants.TEST_COLLECTION_URI, Lock.READ_LOCK);
+			Collection testCollection = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.READ_LOCK);
 			try {
 
 				XmldbURI docPath = TestConstants.TEST_COLLECTION_URI.append(DOCUMENT_NAME_URI);
 				
-				BinaryDocument binDoc = (BinaryDocument) broker.getXMLResource(docPath, Lock.NO_LOCK);
+				BinaryDocument binDoc = (BinaryDocument) broker.getXMLResource(docPath, LockMode.NO_LOCK);
 				
 				// if document is not present, null is returned
 				if(binDoc == null)
@@ -60,7 +61,7 @@ public class GetXMLResourceNoLockTest {
 				
 			} finally {
 	    		if(testCollection != null) {
-					testCollection.getLock().release(Lock.READ_LOCK);
+					testCollection.getLock().release(LockMode.READ_LOCK);
 				}
 			}
 			

--- a/test/src/org/exist/validation/ValidationFunctions_DTD_Test.java
+++ b/test/src/org/exist/validation/ValidationFunctions_DTD_Test.java
@@ -263,7 +263,7 @@ public class ValidationFunctions_DTD_Test {
     private static void storeDocument(DBBroker broker, Txn txn, org.exist.collections.Collection collection, String name, String data) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
         XmldbURI docUri  = XmldbURI.create(name);
         IndexInfo info = collection.validateXMLResource(txn, broker, docUri, data);
-        collection.store(txn, broker, info, data, false);
+        collection.store(txn, broker, info, data);
     }
 
     private static void storeTextDocument(DBBroker broker, Txn txn, org.exist.collections.Collection collection, String name, String data) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {

--- a/test/src/org/exist/xqj/MarshallerTest.java
+++ b/test/src/org/exist/xqj/MarshallerTest.java
@@ -153,7 +153,7 @@ public class MarshallerTest {
             broker.saveCollection(transaction, root);
 
             final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), TEST_DOC);
-            root.store(transaction, broker, info, TEST_DOC, false);
+            root.store(transaction, broker, info, TEST_DOC);
 
             transact.commit(transaction);
         } catch (Exception e) {

--- a/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -107,7 +107,7 @@ public class ConstructedNodesRecoveryTest {
             //store test document
             IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(documentName), testDocument);
             assertNotNull(info);
-            root.store(transaction, broker, info, new InputSource(new StringReader(testDocument)), false);
+            root.store(transaction, broker, info, new InputSource(new StringReader(testDocument)));
 
             //commit the transaction
             transact.commit(transaction);

--- a/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/test/src/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -9,7 +9,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.source.StringSource;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.lock.Lock;
+import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionException;
 import org.exist.storage.txn.TransactionManager;
@@ -138,7 +138,7 @@ public class ConstructedNodesRecoveryTest {
             broker.saveCollection(transaction, root);
 
             //get the test document
-            DocumentImpl doc = root.getDocumentWithLock(broker, XmldbURI.create(documentName), Lock.READ_LOCK);
+            DocumentImpl doc = root.getDocumentWithLock(broker, XmldbURI.create(documentName), LockMode.READ_LOCK);
 
             Serializer serializer = broker.getSerializer();
             serializer.reset();

--- a/test/src/org/exist/xquery/LexerTest.java
+++ b/test/src/org/exist/xquery/LexerTest.java
@@ -75,7 +75,7 @@ public class LexerTest {
 	
 	            IndexInfo info = collection.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), xml);
 	            //TODO : unlock the collection here ?
-	            collection.store(transaction, broker, info, xml, false);
+	            collection.store(transaction, broker, info, xml);
 	            transact.commit(transaction);
 			}
 

--- a/test/src/org/exist/xquery/XQueryUpdateTest.java
+++ b/test/src/org/exist/xquery/XQueryUpdateTest.java
@@ -456,7 +456,7 @@ public class XQueryUpdateTest {
 
             IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(docName), data);
             //TODO : unlock the collection here ?
-            root.store(transaction, broker, info, data, false);
+            root.store(transaction, broker, info, data);
 
             mgr.commit(transaction);
         }

--- a/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
+++ b/test/src/org/exist/xquery/xqts/QT3TS_To_junit.java
@@ -185,7 +185,7 @@ public class QT3TS_To_junit {
 
         if (mime != null && mime.isXMLType()) {
             final IndexInfo info = col.validateXMLResource(txn, broker, XmldbURI.create(fileName), new FileInputSource(file));
-            col.store(txn, broker, info, new FileInputSource(file), false);
+            col.store(txn, broker, info, new FileInputSource(file));
         } else {
             try(final InputStream is = Files.newInputStream(file)) {
                 col.addBinaryResource(txn, broker,

--- a/test/src/org/exist/xquery/xqts/XQTS_To_junit.java
+++ b/test/src/org/exist/xquery/xqts/XQTS_To_junit.java
@@ -171,7 +171,7 @@ public class XQTS_To_junit {
                         new FileInputSource(file)
                     );
                 //info.getDocument().getMetadata().setMimeType();
-                col.store(txn, broker, info, new FileInputSource(file), false);
+                col.store(txn, broker, info, new FileInputSource(file));
             } else {
                 try(final InputStream is = Files.newInputStream(file)) {
                     col.addBinaryResource(txn, broker,


### PR DESCRIPTION
This PR extracts an interface for Collection and adds all the missing javadoc for its public methods.

It also changes the Locking Mode to be an enumeration from an int, which revealed at least one bug from a mistaken use of the wrong int in `org.exist.util.io.Resource`.

This is laying the ground work for some serious improvements to the Collection Cache and its synchronization with Collections, which will follow in a separate PR shortly.