### PR TITLE
Some more F+O 3.1 functions

### DIFF
--- a/src/org/exist/xquery/BasicFunction.java
+++ b/src/org/exist/xquery/BasicFunction.java
@@ -29,62 +29,66 @@ import org.exist.xquery.util.ExpressionDumper;
 /**
  * Abstract base class for simple functions. Subclasses should overwrite
  * method {@link #eval(Sequence[], Sequence)}.
- * 
+ *
  * @author Wolfgang Meier (wolfgang@exist-db.org)
  */
 public abstract class BasicFunction extends Function {
 
-	public BasicFunction(XQueryContext context, FunctionSignature signature) {
-		super(context, signature);
-	}
+    public BasicFunction(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.Expression#eval(org.exist.xquery.value.Sequence, org.exist.xquery.value.Item)
-	 */
-	public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+    @Override
+    public Sequence eval(Sequence contextSequence, final Item contextItem) throws XPathException {
         if (context.getProfiler().isEnabled()) {
-            context.getProfiler().start(this);       
+            context.getProfiler().start(this);
             context.getProfiler().message(this, Profiler.DEPENDENCIES, "DEPENDENCIES", Dependency.getDependenciesName(this.getDependencies()));
-            if (contextSequence != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT SEQUENCE", contextSequence);}
-            if (contextItem != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT ITEM", contextItem.toSequence());}
+            if (contextSequence != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT SEQUENCE", contextSequence);
+            }
+            if (contextItem != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT ITEM", contextItem.toSequence());
+            }
         }
-        
-		if (contextItem != null)
-			{contextSequence = contextItem.toSequence();}
-        
-		final int argCount = getArgumentCount();
-		final Sequence[] args = new Sequence[argCount];
-		for (int i = 0; i < argCount; i++) {
+
+        if (contextItem != null) {
+            contextSequence = contextItem.toSequence();
+        }
+
+        final int argCount = getArgumentCount();
+        final Sequence[] args = new Sequence[argCount];
+        for (int i = 0; i < argCount; i++) {
             try {
                 args[i] = getArgument(i).eval(contextSequence, contextItem);
             } catch (final XPathException e) {
-				if(e.getErrorCode() == null || e.getErrorCode() == ErrorCodes.ERROR) {
-					e.prependMessage(
-							ErrorCodes.XPTY0004,
-							"checking function parameter " + (i + 1) + " in call " + ExpressionDumper.dump(this) + ": ");
-				}
+                if (e.getErrorCode() == null || e.getErrorCode() == ErrorCodes.ERROR) {
+                    e.prependMessage(
+                            ErrorCodes.XPTY0004,
+                            "checking function parameter " + (i + 1) + " in call " + ExpressionDumper.dump(this) + ": ");
+                }
 
                 throw e;
             }
         }
-		       
-        final Sequence result = eval(args, contextSequence);
-        
-        if (context.getProfiler().isEnabled())           
-            {context.getProfiler().end(this, "", result);}   
-     
-        return result;        
-	}
 
-	/**
-	 * Process the function. All arguments are passed in the array args. The number of
-	 * arguments, their type and cardinality have already been checked to match 
-	 * the function signature.
-	 * 
-	 * @param args
-	 * @param contextSequence
-	 */
-	public abstract Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException;
+        final Sequence result = eval(args, contextSequence);
+
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", result);
+        }
+
+        return result;
+    }
+
+    /**
+     * Process the function. All arguments are passed in the array args. The number of
+     * arguments, their type and cardinality have already been checked to match
+     * the function signature.
+     *
+     * @param args The arguments given to the function
+     * @param contextSequence The context sequence for the function or null
+     *
+     * @return The result of the XPath function
+     */
+    public abstract Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException;
 }

--- a/src/org/exist/xquery/functions/fn/FnHasChildren.java
+++ b/src/org/exist/xquery/functions/fn/FnHasChildren.java
@@ -1,0 +1,96 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2016 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xquery.functions.fn;
+
+import org.exist.dom.QName;
+import org.exist.dom.persistent.NodeProxy;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+import org.w3c.dom.Node;
+
+public class FnHasChildren extends Function {
+
+    private final static QName QN_HAS_CHILDREN = new QName("has-children", Function.BUILTIN_FUNCTION_NS);
+
+    public final static FunctionSignature FNS_HAS_CHILDREN_0 = new FunctionSignature(
+            QN_HAS_CHILDREN,
+            "Returns true if the context item has one or more child nodes",
+            FunctionSignature.NO_ARGS,
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if the context item has one of more child nodes, false otherwise")
+    );
+
+    public final static FunctionSignature FNS_HAS_CHILDREN_1 = new FunctionSignature(
+            QN_HAS_CHILDREN,
+            "Returns true if the supplied node has one or more child nodes",
+            new SequenceType[] {
+                    new FunctionParameterSequenceType("node", Type.NODE, Cardinality.ZERO_OR_ONE, "The node to test")
+            },
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if $node has one of more child nodes, false otherwise")
+    );
+
+    public FnHasChildren(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(Sequence contextSequence, final Item contextItem) throws XPathException {
+        final NodeValue node;
+
+        if(getArgumentCount() == 0) {
+            // default to the context item
+
+            if(contextItem == null) {
+                throw new XPathException(this, ErrorCodes.XPDY0002, "Context item is absent");
+            }
+
+            contextSequence = contextItem.toSequence();
+
+            if(contextSequence.isEmpty()) {
+                return BooleanValue.FALSE;
+            }
+
+            final Item item = contextSequence.itemAt(0);
+            if(!Type.subTypeOf(item.getType(), Type.NODE)) {
+                throw new XPathException(this, ErrorCodes.XPTY0004, "Context item is not a node()");
+            }
+
+            node = (NodeValue)item;
+
+        } else {
+            final Sequence arg0 = getArgument(0).eval(contextSequence, contextItem);
+            if(getArgumentCount() == 1 && arg0.isEmpty()) {
+                return BooleanValue.FALSE;
+            } else {
+                node = (NodeValue)arg0.itemAt(0);
+            }
+        }
+
+        final Node w3cNode;
+        if(node instanceof NodeProxy) {
+            w3cNode = node.getNode();
+        } else if(node instanceof org.exist.dom.memtree.NodeImpl) {
+            w3cNode = ((org.exist.dom.memtree.NodeImpl)node);
+        } else {
+            throw new XPathException(this, ErrorCodes.XPTY0004, "Context item is not a node()");
+        }
+
+        return BooleanValue.valueOf(w3cNode.hasChildNodes());
+    }
+}

--- a/src/org/exist/xquery/functions/fn/FnInnerMost.java
+++ b/src/org/exist/xquery/functions/fn/FnInnerMost.java
@@ -1,0 +1,88 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2016 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.xquery.functions.fn;
+
+import org.exist.dom.QName;
+import org.exist.numbering.NodeId;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+public class FnInnerMost extends BasicFunction {
+
+    public final static FunctionSignature FNS_INNERMOST = new FunctionSignature(
+            new QName("innermost", Function.BUILTIN_FUNCTION_NS),
+            "Returns every node within the input sequence that is not an ancestor of another member of the input sequence; the nodes are returned in document order with duplicates eliminated.",
+            new SequenceType[] {
+                    new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ZERO_OR_MORE, "The nodes to test")
+            },
+            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE, "The nodes that are not an ancestor of another node in the input sequence")
+    );
+
+    public FnInnerMost(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final Sequence nodes = args[0];
+        if(nodes.isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        } else if(nodes.hasOne()) {
+            return nodes;
+        } else {
+            final Sequence results = new ValueSequence();
+
+            final List<NodeId> nodeIds = getNodeIds(nodes);
+            final Set<NodeId> found = new HashSet<>();
+
+            final SequenceIterator it = nodes.iterate();
+            while(it.hasNext()) {
+                final Item item = it.nextItem();
+                final NodeValue node = ((NodeValue)item);
+                final NodeId currentNodeId = node.getNodeId();
+
+                if(!found.contains(currentNodeId) &&
+                        nodeIds.parallelStream().noneMatch(nodeId -> nodeId.isDescendantOf(currentNodeId))) {
+                    results.add(node);
+                    found.add(currentNodeId);
+                }
+            }
+
+            return results;
+        }
+    }
+
+    private List<NodeId> getNodeIds(final Sequence nodes) throws XPathException {
+        final List<NodeId> nodeIds = new ArrayList<>();
+        final SequenceIterator it = nodes.iterate();
+        while(it.hasNext()) {
+            final Item item = it.nextItem();
+            final NodeValue node = ((NodeValue)item);
+            nodeIds.add(node.getNodeId());
+        }
+        return nodeIds;
+    }
+}

--- a/src/org/exist/xquery/functions/fn/FnModule.java
+++ b/src/org/exist/xquery/functions/fn/FnModule.java
@@ -164,6 +164,7 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(FunNumber.signatures[0], FunNumber.class),
         new FunctionDef(FunNumber.signatures[1], FunNumber.class),
         new FunctionDef(FunOneOrMore.signature, FunOneOrMore.class),
+        new FunctionDef(FnOuterMost.FNS_OUTERMOST, FnOuterMost.class),
         new FunctionDef(FunPosition.signature, FunPosition.class),
         new FunctionDef(FunQName.signature, FunQName.class),
         new FunctionDef(FunRemove.signature, FunRemove.class),

--- a/src/org/exist/xquery/functions/fn/FnModule.java
+++ b/src/org/exist/xquery/functions/fn/FnModule.java
@@ -131,6 +131,7 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(FunImplicitTimezone.signature, FunImplicitTimezone.class),
         new FunctionDef(FunIndexOf.fnIndexOf[0], FunIndexOf.class),
         new FunctionDef(FunIndexOf.fnIndexOf[1], FunIndexOf.class),
+        new FunctionDef(FnInnerMost.FNS_INNERMOST, FnInnerMost.class),
         new FunctionDef(FunIRIToURI.signature, FunIRIToURI.class),
         new FunctionDef(FunInScopePrefixes.signature, FunInScopePrefixes.class),
         new FunctionDef(FunInsertBefore.signature, FunInsertBefore.class),

--- a/src/org/exist/xquery/functions/fn/FnModule.java
+++ b/src/org/exist/xquery/functions/fn/FnModule.java
@@ -122,6 +122,8 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(FunAdjustTimezone.fnAdjustTimeToTimezone[1], FunAdjustTimezone.class),
         new FunctionDef(FunAdjustTimezone.fnAdjustDateTimeToTimezone[0], FunAdjustTimezone.class),
         new FunctionDef(FunAdjustTimezone.fnAdjustDateTimeToTimezone[1], FunAdjustTimezone.class),
+        new FunctionDef(FnHasChildren.FNS_HAS_CHILDREN_0, FnHasChildren.class),
+        new FunctionDef(FnHasChildren.FNS_HAS_CHILDREN_1, FnHasChildren.class),
         new FunctionDef(FunId.signature[0], FunId.class),
         new FunctionDef(FunId.signature[1], FunId.class),
         new FunctionDef(FunIdRef.signature[0], FunIdRef.class),

--- a/src/org/exist/xquery/functions/fn/FnOuterMost.java
+++ b/src/org/exist/xquery/functions/fn/FnOuterMost.java
@@ -1,0 +1,88 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001- 2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.fn;
+
+import org.exist.dom.QName;
+import org.exist.numbering.NodeId;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+public class FnOuterMost extends BasicFunction {
+
+    public final static FunctionSignature FNS_OUTERMOST = new FunctionSignature(
+            new QName("outermost", Function.BUILTIN_FUNCTION_NS),
+            "Returns every node within the input sequence that has no ancestor that is itself a member of the input sequence; the nodes are returned in document order with duplicates eliminated.",
+            new SequenceType[] {
+                    new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ZERO_OR_MORE, "The nodes to test")
+            },
+            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE, "The nodes that have no ancestor which is itself in the input sequence")
+    );
+
+    public FnOuterMost(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final Sequence nodes = args[0];
+        if(nodes.isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        } else if(nodes.hasOne()) {
+            return nodes;
+        } else {
+            final Sequence results = new ValueSequence();
+
+            final List<NodeId> nodeIds = getNodeIds(nodes);
+            final Set<NodeId> found = new HashSet<>();
+
+            final SequenceIterator it = nodes.iterate();
+            while(it.hasNext()) {
+                final Item item = it.nextItem();
+                final NodeValue node = ((NodeValue)item);
+                final NodeId currentNodeId = node.getNodeId();
+
+                if(!found.contains(currentNodeId) &&
+                        nodeIds.parallelStream().noneMatch(nodeId -> currentNodeId.isDescendantOf(nodeId))) {
+                    results.add(node);
+                    found.add(currentNodeId);
+                }
+            }
+
+            return results;
+        }
+    }
+
+    private List<NodeId> getNodeIds(final Sequence nodes) throws XPathException {
+        final List<NodeId> nodeIds = new ArrayList<>();
+        final SequenceIterator it = nodes.iterate();
+        while(it.hasNext()) {
+            final Item item = it.nextItem();
+            final NodeValue node = ((NodeValue)item);
+            nodeIds.add(node.getNodeId());
+        }
+        return nodeIds;
+    }
+}

--- a/test/src/xquery/xquery3/fn.xql
+++ b/test/src/xquery/xquery3/fn.xql
@@ -69,3 +69,30 @@ declare
 function fnt:has-children-empty() {
     has-children(())
 };
+
+
+declare
+    %test:assertEquals("b,e,h")
+function fnt:innermost() {
+    let $doc := document {
+        <a>
+            <b/>
+            <c>
+                <d/>
+                <e/>
+            </c>
+            <f>
+                <g>
+                    <h/>
+                </g>
+            </f>
+        </a>
+    } return
+        string-join(
+            for $inner in fn:innermost($doc/a/b, $doc/a/c, $doc/a/c/e, $doc/a/f, $doc/a/f/g/h, $doc/a/b)
+            return
+                local-name($inner)
+            ,
+            ","
+        )
+};

--- a/test/src/xquery/xquery3/fn.xql
+++ b/test/src/xquery/xquery3/fn.xql
@@ -1,13 +1,13 @@
 xquery version "3.0";
 
-module namespace fn="http://exist-db.org/xquery/test/fnfunctions";
+module namespace fnt="http://exist-db.org/xquery/test/fnfunctions";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 declare namespace xpf = "http://www.w3.org/2005/xpath-functions";
 
 declare
     %test:assertEquals(0, 4, 3, 2, 1)
-function fn:fold-right() {
+function fnt:fold-right() {
 let $seq := (1,2,3,4)
 return
     fold-right ($seq, (0) , function($item as xs:integer, $accu as xs:integer*) {
@@ -18,6 +18,54 @@ return
 declare
     %test:args('test', 't e s t', '') %test:assertFalse
     %test:args('test', 't e s t', 'x') %test:assertTrue
-function fn:analyze-matches($str, $pat, $flags) {
+function fnt:analyze-matches($str, $pat, $flags) {
 	exists(analyze-string($str, $pat, $flags)/xpf:match)
+};
+
+declare
+    %test:assertTrue
+function fnt:has-children-contextItem() {
+    <a><b/></a>/has-children()
+};
+
+declare
+    %test:assertFalse
+function fnt:has-children-contextItem-noChildren() {
+    <a/>/has-children()
+};
+
+declare
+    %test:assertFalse
+function fnt:has-children-contextItem-empty() {
+    ()/has-children()
+};
+
+declare
+    %test:assertError("XPDY0002")
+function fnt:has-children-contextItem-absent() {
+    has-children()
+};
+
+declare
+    %test:assertError("XPTY0004")
+function fnt:has-children-contextItem-notNode() {
+    "str1"/has-children()
+};
+
+declare
+    %test:assertTrue
+function fnt:has-children() {
+    has-children(<a><b/></a>)
+};
+
+declare
+    %test:assertFalse
+function fnt:has-children-noChildren() {
+   has-children(<a/>)
+};
+
+declare
+    %test:assertFalse
+function fnt:has-children-empty() {
+    has-children(())
 };

--- a/test/src/xquery/xquery3/fn.xql
+++ b/test/src/xquery/xquery3/fn.xql
@@ -96,3 +96,29 @@ function fnt:innermost() {
             ","
         )
 };
+
+declare
+    %test:assertEquals("b,c,f")
+function fnt:outermost() {
+    let $doc := document {
+        <a>
+            <b/>
+            <c>
+                <d/>
+                <e/>
+            </c>
+            <f>
+                <g>
+                    <h/>
+                </g>
+            </f>
+        </a>
+    } return
+        string-join(
+            for $inner in fn:outermost($doc/a/b, $doc/a/c, $doc/a/c/e, $doc/a/f, $doc/a/f/g/h, $doc/a/b)
+            return
+                local-name($inner)
+            ,
+            ","
+        )
+};


### PR DESCRIPTION
Implements from XPath Functions and Operators 3.0:

```xquery
fn:has-children() as xs:boolean
fn:has-children($node as node()?) as xs:boolean
fn:innermost($nodes as node()*) as node()*
fn:outermost($nodes as node()*) as node()*
```