### PR TITLE
Further junit rules

### DIFF
--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -19,6 +19,7 @@
  */
 package org.exist.indexing.lucene;
 
+import static org.exist.util.PropertiesBuilder.propertiesBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -50,6 +51,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.ElementValue;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
@@ -61,11 +63,7 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xupdate.Modification;
 import org.exist.xupdate.XUpdateProcessor;
 
-import org.junit.AfterClass;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -252,14 +250,13 @@ public class LuceneIndexTest {
             "   </index>" +
             "</collection>";
 
-
-    private static BrokerPool pool;
     private static Collection root;
     private Boolean savedConfig;
 
     @Test
     public void simpleQueries() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG1, XML1, "test.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             checkIndex(docs, broker, new QName[] { new QName("head") }, "title", 1);
@@ -300,6 +297,7 @@ public class LuceneIndexTest {
     @Test
     public void configuration() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG4, XML4, "test.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             checkIndex(docs, broker, new QName[] { new QName("a") }, "x", 1);
@@ -324,6 +322,7 @@ public class LuceneIndexTest {
     @Test
     public void inlineAndIgnore() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG5, XML5, "test.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             checkIndex(docs, broker, new QName[] { new QName("head") }, "title", 1);
@@ -401,6 +400,7 @@ public class LuceneIndexTest {
     @Test
     public void attributeMatch() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException, ParserConfigurationException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG7, XML8, "test.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
@@ -471,6 +471,7 @@ public class LuceneIndexTest {
     @Test
     public void boosts() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         configureAndStore(COLLECTION_CONFIG6, XML6, "test.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             final XQuery xquery = pool.getXQueryService();
@@ -486,6 +487,7 @@ public class LuceneIndexTest {
     @Test
     public void queryTranslation() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         configureAndStore(COLLECTION_CONFIG1, XML7, "test.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             final XQuery xquery = pool.getXQueryService();
@@ -615,6 +617,7 @@ public class LuceneIndexTest {
     @Test
     public void analyzers() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG3, XML3, "test.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             checkIndex(docs, broker, new QName[] { new QName("head") }, "TITLE", 1);
@@ -636,9 +639,10 @@ public class LuceneIndexTest {
         }
     }
 
-        @Test
+    @Test
     public void MultiTermQueryRewriteMethod() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         configureAndStore(COLLECTION_CONFIG8, XML9, "test.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
@@ -666,6 +670,7 @@ public class LuceneIndexTest {
     @Test
     public void dropSingleDoc() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG1, XML1, "dropDocument.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
@@ -680,6 +685,7 @@ public class LuceneIndexTest {
     @Test
     public void dropDocuments() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         configureAndStore(COLLECTION_CONFIG1, "samples/shakespeare");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             final XQuery xquery = pool.getXQueryService();
@@ -712,6 +718,7 @@ public class LuceneIndexTest {
     @Test
     public void removeCollection() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG1, "samples/shakespeare");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -739,6 +746,7 @@ public class LuceneIndexTest {
     @Test
     public void reindex() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG1, XML1, "dropDocument.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             broker.reindexCollection(TestConstants.TEST_COLLECTION_URI);
@@ -762,6 +770,7 @@ public class LuceneIndexTest {
     @Test
     public void xupdateRemove() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException, ParserConfigurationException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG2, XML2, "xupdate.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -840,6 +849,7 @@ public class LuceneIndexTest {
     @Test
     public void xupdateInsert() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException, ParserConfigurationException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG2, XML2, "xupdate.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -1004,6 +1014,7 @@ public class LuceneIndexTest {
     @Test
     public void xupdateUpdate() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException, ParserConfigurationException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG2, XML2, "xupdate.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -1081,6 +1092,7 @@ public class LuceneIndexTest {
     @Test
     public void xupdateReplace() throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException, XPathException, ParserConfigurationException {
         final DocumentSet docs = configureAndStore(COLLECTION_CONFIG2, XML2, "xupdate.xml");
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -1152,6 +1164,7 @@ public class LuceneIndexTest {
 
     private DocumentSet configureAndStore(final String configuration, final String data, final String docName) throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException {
         final MutableDocumentSet docs = new DefaultDocumentSet();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -1176,6 +1189,7 @@ public class LuceneIndexTest {
 
         final MutableDocumentSet docs = new DefaultDocumentSet();
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
@@ -1224,6 +1238,7 @@ public class LuceneIndexTest {
 
     @Before
     public void setup() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -1242,6 +1257,7 @@ public class LuceneIndexTest {
 
     @After
     public void cleanup() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
@@ -1262,23 +1278,15 @@ public class LuceneIndexTest {
         }
     }
 
-    @BeforeClass
-    public static void startDB() throws DatabaseConfigurationException, EXistException {
-        final Path confFile = ConfigurationHelper.lookup("conf.xml");
-        final Configuration config = new Configuration(confFile.toAbsolutePath().toString());
-        config.setProperty(Indexer.PROPERTY_SUPPRESS_WHITESPACE, "none");
-        config.setProperty(Indexer.PRESERVE_WS_MIXED_CONTENT_ATTRIBUTE, Boolean.TRUE);
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-        assertNotNull(pool);
-    }
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(propertiesBuilder()
+            .set(Indexer.PROPERTY_SUPPRESS_WHITESPACE, "none")
+            .put(Indexer.PRESERVE_WS_MIXED_CONTENT_ATTRIBUTE, Boolean.TRUE)
+            .build());
 
     @AfterClass
-    public static void stopDB() {
+    public static void cleanupDb() {
         TestUtils.cleanupDB();
-        BrokerPool.stopAll(false);
-        pool = null;
-        root = null;
     }
 }
 

--- a/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/SerializeAttrMatchesTest.java
+++ b/extensions/indexes/lucene/test/src/org/exist/indexing/lucene/SerializeAttrMatchesTest.java
@@ -35,10 +35,8 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
-import org.exist.util.ConfigurationHelper;
-import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
@@ -49,7 +47,6 @@ import org.junit.*;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -75,7 +72,6 @@ public class SerializeAttrMatchesTest {
             "<w xml:id=\"VSK.P13.t1.p3.w239\" lemma=\"књига\">књигом</w>\n" +
             "<w xml:id=\"VSK.P13.t1.p3.w241\">пешкешите</w>. –</s></p>";
 
-    private static BrokerPool pool = null;
     private Collection test = null;
 
     @Test
@@ -86,6 +82,7 @@ public class SerializeAttrMatchesTest {
         final String query = "for $hit in collection(\"" + TestConstants.TEST_COLLECTION_URI.toString() + "\")//w[ft:query(@lemma, <query><regex>књиг.*</regex></query>)]\n" +
         "return util:expand($hit, \"highlight-matches=both\")";
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             final XQuery xquery = pool.getXQueryService();
             final Sequence seq = xquery.execute(broker, query, null);
@@ -100,6 +97,7 @@ public class SerializeAttrMatchesTest {
 
     private DocumentSet configureAndStore(final String configuration, final String data, final String docName) throws EXistException, CollectionConfigurationException, PermissionDeniedException, SAXException, TriggerException, LockException, IOException {
         final MutableDocumentSet docs = new DefaultDocumentSet();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -120,8 +118,12 @@ public class SerializeAttrMatchesTest {
         return docs;
     }
 
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
     @Before
     public void setup() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -135,6 +137,7 @@ public class SerializeAttrMatchesTest {
 
     @After
     public void cleanup() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -150,18 +153,8 @@ public class SerializeAttrMatchesTest {
         }
     }
 
-    @BeforeClass
-    public static void startDB() throws DatabaseConfigurationException, EXistException {
-        final Path confFile = ConfigurationHelper.lookup("conf.xml");
-        final Configuration config = new Configuration(confFile.toAbsolutePath().toString());
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-    }
-
     @AfterClass
-    public static void stopDB() {
+    public static void cleanupDb() {
         TestUtils.cleanupDB();
-        BrokerPool.stopAll(false);
-        pool = null;
     }
 }

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/CustomIndexTest.java
@@ -34,6 +34,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.*;
 import org.exist.util.serializer.SAXSerializer;
@@ -46,9 +47,7 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
 import org.exist.xupdate.Modification;
 import org.exist.xupdate.XUpdateProcessor;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -58,7 +57,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -98,7 +96,6 @@ public class CustomIndexTest {
     private static String XUPDATE_END =
         "</xu:modifications>";
 
-    private BrokerPool pool;
     private MutableDocumentSet docs;
 
     /**
@@ -107,6 +104,7 @@ public class CustomIndexTest {
      */
     @Test
     public void xupdateRemove() throws EXistException, PermissionDeniedException, XPathException, ParserConfigurationException, IOException, SAXException, LockException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             	final Txn transaction = transact.beginTransaction()) {
@@ -187,6 +185,7 @@ public class CustomIndexTest {
 
     @Test
     public void xupdateInsert() throws EXistException, LockException, XPathException, PermissionDeniedException, SAXException, IOException, ParserConfigurationException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             	final Txn transaction = transact.beginTransaction()) {
@@ -303,6 +302,7 @@ public class CustomIndexTest {
 
     @Test
     public void xupdateUpdate() throws EXistException, LockException, XPathException, PermissionDeniedException, SAXException, IOException, ParserConfigurationException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             	final Txn transaction = transact.beginTransaction()) {
@@ -363,6 +363,7 @@ public class CustomIndexTest {
 
     @Test
     public void xupdateReplace() throws LockException, XPathException, PermissionDeniedException, SAXException, EXistException, IOException, ParserConfigurationException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             	final Txn transaction = transact.beginTransaction()) {
@@ -415,6 +416,7 @@ public class CustomIndexTest {
 
     @Test
     public void xupdateRename() throws EXistException, LockException, XPathException, PermissionDeniedException, SAXException, IOException, ParserConfigurationException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             	final Txn transaction = transact.beginTransaction()) {
@@ -449,6 +451,7 @@ public class CustomIndexTest {
  
     @Test
     public void reindex() throws PermissionDeniedException, XPathException, URISyntaxException, EXistException, IOException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             	final Txn transaction = transact.beginTransaction()) {
@@ -479,6 +482,7 @@ public class CustomIndexTest {
 
     @Test
     public void dropIndex() throws EXistException, PermissionDeniedException, XPathException, LockException, TriggerException, IOException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -509,6 +513,7 @@ public class CustomIndexTest {
 
     @Test
     public void query() throws PermissionDeniedException, XPathException, EXistException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
@@ -533,6 +538,7 @@ public class CustomIndexTest {
 
     @Test
     public void indexKeys() throws SAXException, PermissionDeniedException, XPathException, EXistException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
@@ -602,13 +608,12 @@ public class CustomIndexTest {
         assertEquals(count, found);        
     }
 
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
     @Before
     public void setUp() throws DatabaseConfigurationException, EXistException, PermissionDeniedException, IOException, SAXException, CollectionConfigurationException, LockException {
-        final Path confFile = ConfigurationHelper.lookup("conf.xml");
-        final Configuration config = new Configuration(confFile.toAbsolutePath().toString());
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
@@ -657,7 +662,5 @@ public class CustomIndexTest {
             
             transact.commit(transaction);
         }
-
-        BrokerPool.stopAll(false);
     }
 }

--- a/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
+++ b/extensions/indexes/ngram/test/src/org/exist/indexing/ngram/MatchListenerTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.Properties;
@@ -50,9 +49,8 @@ import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
-import org.exist.util.ConfigurationHelper;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
@@ -62,6 +60,7 @@ import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -113,12 +112,12 @@ public class MatchListenerTest {
     private static String MATCH_START = "<exist:match xmlns:exist=\"http://exist.sourceforge.net/NS/exist\">";
     private static String MATCH_END = "</exist:match>";
 
-    private static BrokerPool pool;
 
     @Test
     public void nestedContent() throws PermissionDeniedException, IOException, LockException, CollectionConfigurationException, SAXException, EXistException, XPathException {
         configureAndStore(CONF1, XML);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
             final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
@@ -156,6 +155,7 @@ public class MatchListenerTest {
     public void matchInParent() throws PermissionDeniedException, IOException, LockException, CollectionConfigurationException, SAXException, EXistException, XPathException {
         configureAndStore(CONF1, XML);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
 
             final XQuery xquery = pool.getXQueryService();
@@ -172,6 +172,7 @@ public class MatchListenerTest {
     public void matchInAncestor() throws PermissionDeniedException, IOException, LockException, CollectionConfigurationException, SAXException, EXistException, XPathException {
         configureAndStore(CONF1, XML);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
 
             final XQuery xquery = pool.getXQueryService();
@@ -194,6 +195,7 @@ public class MatchListenerTest {
     public void nestedIndex() throws PermissionDeniedException, IOException, LockException, CollectionConfigurationException, SAXException, EXistException, XPathException {
         configureAndStore(CONF1, XML);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
 
             final XQuery xquery = pool.getXQueryService();
@@ -222,6 +224,7 @@ public class MatchListenerTest {
     public void mixedContentQueries() throws PermissionDeniedException, XPathException, SAXException, EXistException, CollectionConfigurationException, LockException, IOException {
         configureAndStore(CONF1, XML);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
 
             final XQuery xquery = pool.getXQueryService();
@@ -262,6 +265,7 @@ public class MatchListenerTest {
     public void indexOnInnerElement() throws PermissionDeniedException, IOException, LockException, CollectionConfigurationException, SAXException, EXistException, XPathException {
         configureAndStore(CONF2, XML);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
             final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
@@ -285,6 +289,7 @@ public class MatchListenerTest {
     public void doubleMatch() throws PermissionDeniedException, XPathException, SAXException, EXistException, CollectionConfigurationException, LockException, IOException {
         configureAndStore(CONF1, XML);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
             final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
@@ -315,6 +320,7 @@ public class MatchListenerTest {
     public void wildcardMatch() throws PermissionDeniedException, IOException, LockException, CollectionConfigurationException, SAXException, EXistException, XPathException, XpathException {
         configureAndStore(CONF1, XML);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
             final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
@@ -453,6 +459,7 @@ public class MatchListenerTest {
     public void smallStrings() throws PermissionDeniedException, IOException, LockException, CollectionConfigurationException, SAXException, EXistException, XPathException, XpathException {
         configureAndStore(CONF3, XML2);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
             final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
@@ -477,6 +484,7 @@ public class MatchListenerTest {
     public void constructedNodes() throws PermissionDeniedException, XPathException, SAXException, IOException, XpathException, CollectionConfigurationException, LockException, EXistException {
         configureAndStore(CONF3, XML2);
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
             final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
@@ -499,13 +507,12 @@ public class MatchListenerTest {
         }
     }
 
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
     @BeforeClass
     public static void startDB() throws EXistException, DatabaseConfigurationException, PermissionDeniedException, IOException, TriggerException {
-        final Path confFile = ConfigurationHelper.lookup("conf.xml");
-        final Configuration config = new Configuration(confFile.toAbsolutePath().toString());
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
@@ -526,7 +533,7 @@ public class MatchListenerTest {
 
     @AfterClass
     public static void closeDB() throws EXistException, PermissionDeniedException, IOException, TriggerException {
-        final BrokerPool pool = BrokerPool.getInstance();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
 
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
@@ -543,10 +550,10 @@ public class MatchListenerTest {
 
             transact.commit(transaction);
         }
-        BrokerPool.stopAll(false);
     }
 
     private void configureAndStore(String config, String xml) throws PermissionDeniedException, IOException, SAXException, EXistException, LockException, CollectionConfigurationException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {

--- a/src/org/exist/util/FileUtils.java
+++ b/src/org/exist/util/FileUtils.java
@@ -224,6 +224,31 @@ public class FileUtils {
     }
 
     /**
+     * Makes directories on the filesystem the filesystem
+     *
+     * This method will never throw an IOException, it
+     * instead returns `false` if an error occurs
+     * whilst creating a file or directory
+     *
+     * Note that creation of a directory is not an atomic-operation
+     * and so if an error occurs during creation, some of the directories
+     * descendants may have already been created
+     *
+     * @return false if an error occurred, true otherwise
+     */
+    public static boolean mkdirsQuietly(final Path dir) {
+        try {
+            if (!Files.exists(dir)) {
+                Files.createDirectories(dir);
+            }
+            return true;
+        } catch (final IOException ioe) {
+            LOG.error("Unable to mkdirs: " + dir.toAbsolutePath().toString(), ioe);
+            return false;
+        }
+    }
+
+    /**
      * Attempts to resolve the child
      * against the parent.
      *

--- a/src/org/exist/util/PropertiesBuilder.java
+++ b/src/org/exist/util/PropertiesBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2016 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.util;
+
+import java.util.Properties;
+
+/**
+ * Simple fluent builder pattern for {@link Properties}
+ */
+public class PropertiesBuilder {
+
+    private final Properties properties;
+
+    private PropertiesBuilder(final Properties properties) {
+        this.properties = properties;
+    }
+
+    public static PropertiesBuilder propertiesBuilder() {
+        return new PropertiesBuilder(new Properties());
+    }
+
+    public PropertiesBuilder set(final String key, final String value) {
+        properties.setProperty(key, value);
+        return this;
+    }
+
+    public PropertiesBuilder put(final String key, final Object value) {
+        properties.put(key, value);
+        return this;
+    }
+
+    public Properties build() {
+        return properties;
+    }
+}

--- a/test/src/org/exist/IndexerTest.java
+++ b/test/src/org/exist/IndexerTest.java
@@ -26,8 +26,6 @@ import java.util.Optional;
 import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
-import org.exist.EXistException;
-import org.exist.Indexer;
 import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.security.AuthenticationException;
@@ -36,22 +34,20 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
 import org.exist.util.serializer.SAXSerializer;
-import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
-import org.junit.AfterClass;
+import org.junit.*;
+
+import static org.exist.util.PropertiesBuilder.propertiesBuilder;
 import static org.junit.Assert.assertEquals;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+
 import org.xml.sax.SAXException;
 
 /**
@@ -60,6 +56,11 @@ import org.xml.sax.SAXException;
  * @author ljo
  */
 public class IndexerTest {
+
+	@ClassRule
+	public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(propertiesBuilder()
+            .set(Indexer.PROPERTY_SUPPRESS_WHITESPACE, "none")
+            .build());
 
     private final static String XML =
         "<?xml version=\"1.0\"?>\n" +
@@ -161,20 +162,20 @@ public class IndexerTest {
 	"    <result>{$test}</result>";
 
     private void store_preserve_ws_mixed_content_value(final boolean propValue, final String xml) throws PermissionDeniedException, IOException, EXistException, SAXException, LockException, AuthenticationException {
-    	final BrokerPool pool = BrokerPool.getInstance();
-	pool.getConfiguration().setProperty(Indexer.PROPERTY_PRESERVE_WS_MIXED_CONTENT, propValue);
+    	final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+		pool.getConfiguration().setProperty(Indexer.PROPERTY_PRESERVE_WS_MIXED_CONTENT, propValue);
 
         final TransactionManager txnMgr = pool.getTransactionManager();
 
     	try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate("admin", "")));
-	    final Txn txn = txnMgr.beginTransaction()) {
+	    		final Txn txn = txnMgr.beginTransaction()) {
 
-            Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
-            IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, xml);
+            final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
+            final IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, xml);
             //TODO : unlock the collection here ?
             collection.store(txn, broker, info, xml);
             @SuppressWarnings("unused")
-		org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
+			final org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
             broker.flush();
             broker.saveCollection(txn, collection);
             txnMgr.commit(txn);
@@ -183,29 +184,30 @@ public class IndexerTest {
     }
     
     private String store_and_retrieve_ws_mixed_content_value(final boolean preserve, final String typeXml, final String typeXquery) throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-	store_preserve_ws_mixed_content_value(preserve, typeXml);
-        final BrokerPool pool = BrokerPool.getInstance();
+		store_preserve_ws_mixed_content_value(preserve, typeXml);
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            XQuery xquery = broker.getBrokerPool().getXQueryService();
-            Sequence result = xquery.execute(broker, typeXquery, null);
-            StringWriter out = new StringWriter();
-            Properties props = new Properties();
-            props.setProperty(OutputKeys.INDENT, "yes");
-            SAXSerializer serializer = new SAXSerializer(out, props);
-            serializer.startDocument();
-            for (SequenceIterator i = result.iterate(); i.hasNext(); ) {
-                Item next = i.nextItem();
-                next.toSAX(broker, serializer, props);
-            }
-            serializer.endDocument();
-            return out.toString();
+            final XQuery xquery = pool.getXQueryService();
+            final Sequence result = xquery.execute(broker, typeXquery, null);
+            try(final StringWriter out = new StringWriter()) {
+				final Properties props = new Properties();
+				props.setProperty(OutputKeys.INDENT, "yes");
+				final SAXSerializer serializer = new SAXSerializer(out, props);
+				serializer.startDocument();
+				for (final SequenceIterator i = result.iterate(); i.hasNext(); ) {
+					final Item next = i.nextItem();
+					next.toSAX(broker, serializer, props);
+				}
+				serializer.endDocument();
+				return out.toString();
+			}
         }
     }
 
     @Ignore
     @Test
     public void retrieve_preserve_mixed_ws() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-	//Nodes 1, 7 and 13 are not in mixed-contents and should not be preserved. They are the spaces between elements x and y, y and z, and z and x.
+		//Nodes 1, 7 and 13 are not in mixed-contents and should not be preserved. They are the spaces between elements x and y, y and z, and z and x.
         assertEquals(RESULT_PRESERVE_MIXED_WS_XML, store_and_retrieve_ws_mixed_content_value(true, XML, XQUERY));
     }
 
@@ -218,19 +220,5 @@ public class IndexerTest {
     @Test
     public void retrieve_xslt_preserve_mixed_ws() throws EXistException, PermissionDeniedException, IOException, LockException, AuthenticationException, SAXException, XPathException {
         assertEquals(RESULT_XML_XSLT, store_and_retrieve_ws_mixed_content_value(true, XML_XSLT, XQUERY_XSLT));
-    }
-
-    @BeforeClass
-    public static void setUp() throws DatabaseConfigurationException, EXistException {
-        Configuration config = new Configuration();
-	// fixme! default is both, which should be tested too.
-	config.setProperty(Indexer.PROPERTY_SUPPRESS_WHITESPACE, "none");
-        BrokerPool.configure(1, 5, config);
-
-    }  
-
-    @AfterClass
-    public static void tearDown() {
-        BrokerPool.stopAll(false);
     }
 }

--- a/test/src/org/exist/IndexerTest2.java
+++ b/test/src/org/exist/IndexerTest2.java
@@ -26,8 +26,6 @@ import java.util.Optional;
 import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
-import org.exist.EXistException;
-import org.exist.Indexer;
 import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.security.AuthenticationException;
@@ -36,125 +34,123 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
 import org.exist.util.serializer.SAXSerializer;
-import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
-import org.junit.AfterClass;
+
+import static org.exist.util.PropertiesBuilder.propertiesBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
 /**
  * Tests the indexer.
- * 
+ *
  * @author ljo
  */
 public class IndexerTest2 {
 
     private final static String XML =
-        "<?xml version=\"1.0\"?>\n" +
-	"<TEI xmlns=\"http://www.tei-c.org/ns/1.0\">\n" +
-	"<p>Government of new Territory of Nevada—Governor <name>Nye</name> <lb/>and the practical jokers—<name>Mr. Clemens</name> begins journalistic life <lb/>on <name>Virginia City</name> <name>Enterprise</name>.</p>\n" +
-	"</TEI>\n";
+            "<?xml version=\"1.0\"?>\n" +
+            "<TEI xmlns=\"http://www.tei-c.org/ns/1.0\">\n" +
+            "<p>Government of new Territory of Nevada—Governor <name>Nye</name> <lb/>and the practical jokers—<name>Mr. Clemens</name> begins journalistic life <lb/>on <name>Virginia City</name> <name>Enterprise</name>.</p>\n" +
+            "</TEI>\n";
 
     private final static String XQUERY =
-	"declare namespace tei=\"http://www.tei-c.org/ns/1.0\"; " +
-	"declare boundary-space preserve; " +
-	"declare function local:get-text($input as node()*) as item()* {" +
-	"   for $node in $input/node() " +
-	"       return " +
-	"           typeswitch($node)" +
-	"               case text() return $node " +
-	"               default return local:get-text($node) " +
-	"}; " +
-	"let $in-memory := " +
-	"<TEI xmlns=\"http://www.tei-c.org/ns/1.0\">\n" +
-	"<p>Government of new Territory of Nevada—Governor <name>Nye</name> <lb/>and the practical jokers—<name>Mr. Clemens</name> begins journalistic life <lb/>on <name>Virginia City</name> <name>Enterprise</name>.</p>\n" +
-	"</TEI>" +
-"let $stored := doc('" + TestConstants.TEST_COLLECTION_URI.toString() + "/"+ TestConstants.TEST_XML_URI2.toString() + "') " +
-"return " +
-"<result name=\"" + TestConstants.TEST_COLLECTION_URI.toString() + "/"+ TestConstants.TEST_XML_URI2.toString() + "\">\n" +
-"    <inline>{string-join(local:get-text($in-memory))}</inline>\n" +
-"    <stored>{string-join(local:get-text($stored))}</stored>\n" +
-"</result>";
+            "declare namespace tei=\"http://www.tei-c.org/ns/1.0\"; " +
+            "declare boundary-space preserve; " +
+            "declare function local:get-text($input as node()*) as item()* {" +
+            "   for $node in $input/node() " +
+            "       return " +
+            "           typeswitch($node)" +
+            "               case text() return $node " +
+            "               default return local:get-text($node) " +
+            "}; " +
+            "let $in-memory := " +
+            "<TEI xmlns=\"http://www.tei-c.org/ns/1.0\">\n" +
+            "<p>Government of new Territory of Nevada—Governor <name>Nye</name> <lb/>and the practical jokers—<name>Mr. Clemens</name> begins journalistic life <lb/>on <name>Virginia City</name> <name>Enterprise</name>.</p>\n" +
+            "</TEI>" +
+            "let $stored := doc('" + TestConstants.TEST_COLLECTION_URI.toString() + "/"+ TestConstants.TEST_XML_URI2.toString() + "') " +
+            "return " +
+            "<result name=\"" + TestConstants.TEST_COLLECTION_URI.toString() + "/"+ TestConstants.TEST_XML_URI2.toString() + "\">\n" +
+            "    <inline>{string-join(local:get-text($in-memory))}</inline>\n" +
+            "    <stored>{string-join(local:get-text($stored))}</stored>\n" +
+            "</result>";
 
     @Test
     public void store_preserve_mixed_ws() throws PermissionDeniedException, IOException, EXistException, SAXException, LockException, XPathException, AuthenticationException {
-        final BrokerPool pool = BrokerPool.getInstance();
-	assertTrue(((Boolean) pool.getConfiguration().getProperty(Indexer.PROPERTY_PRESERVE_WS_MIXED_CONTENT)).booleanValue());
-	assertEquals("none", pool.getConfiguration().getProperty(Indexer.PROPERTY_SUPPRESS_WHITESPACE));
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        assertTrue(((Boolean) pool.getConfiguration().getProperty(Indexer.PROPERTY_PRESERVE_WS_MIXED_CONTENT)).booleanValue());
+        assertEquals("none", pool.getConfiguration().getProperty(Indexer.PROPERTY_SUPPRESS_WHITESPACE));
     }
 
     @Test
-    public void retrieve_boundary_space_preserve_with_preserve_mixed_ws() throws EXistException, PermissionDeniedException, SAXException, XPathException {
+    public void retrieve_boundary_space_preserve_with_preserve_mixed_ws() throws EXistException, PermissionDeniedException, SAXException, XPathException, IOException {
         assertEquals("<result name=\"" + TestConstants.TEST_COLLECTION_URI.toString() + "/"+ TestConstants.TEST_XML_URI2.toString() + "\">\n" +
-"    <inline>\n" +
-"Government of new Territory of Nevada—Governor Nye and the practical jokers—Mr. Clemens begins journalistic life on Virginia City Enterprise.\n" + "</inline>\n" +
-"    <stored>\n" +
-"Government of new Territory of Nevada—Governor Nye and the practical jokers—Mr. Clemens begins journalistic life on Virginia City Enterprise.\n" + "</stored>\n" +
-"</result>", executeQuery());
+                "    <inline>\n" +
+                "Government of new Territory of Nevada—Governor Nye and the practical jokers—Mr. Clemens begins journalistic life on Virginia City Enterprise.\n" + "</inline>\n" +
+                "    <stored>\n" +
+                "Government of new Territory of Nevada—Governor Nye and the practical jokers—Mr. Clemens begins journalistic life on Virginia City Enterprise.\n" + "</stored>\n" +
+                "</result>", executeQuery());
     }
 
-    private String executeQuery() throws EXistException, PermissionDeniedException, SAXException, XPathException {
-        final BrokerPool pool = BrokerPool.getInstance();
-        StringWriter out = out = new StringWriter();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            XQuery xquery = broker.getBrokerPool().getXQueryService();
-            Sequence result = xquery.execute(broker, XQUERY, null);
-            Properties props = new Properties();
+    private String executeQuery() throws EXistException, PermissionDeniedException, SAXException, XPathException, IOException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                final StringWriter out = new StringWriter()) {
+            final XQuery xquery = broker.getBrokerPool().getXQueryService();
+            final Sequence result = xquery.execute(broker, XQUERY, null);
+            final Properties props = new Properties();
             props.setProperty(OutputKeys.INDENT, "yes");
-            SAXSerializer serializer = new SAXSerializer(out, props);
+            final SAXSerializer serializer = new SAXSerializer(out, props);
             serializer.startDocument();
-            for (SequenceIterator i = result.iterate(); i.hasNext(); ) {
-                Item next = i.nextItem();
+            for (final SequenceIterator i = result.iterate(); i.hasNext(); ) {
+                final Item next = i.nextItem();
                 next.toSAX(broker, serializer, props);
             }
             serializer.endDocument();
+
+            return out.toString();
         }
-        return out.toString();
     }
 
-      private static void storeDoc() throws PermissionDeniedException, IOException, EXistException, SAXException, LockException, AuthenticationException {
-        final BrokerPool pool = BrokerPool.getInstance();
+    private static void storeDoc() throws PermissionDeniedException, IOException, EXistException, SAXException, LockException, AuthenticationException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager txnMgr = pool.getTransactionManager();
 
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate("admin", "")));
-	    final Txn txn = txnMgr.beginTransaction()) {
+                final Txn txn = txnMgr.beginTransaction()) {
 
-            Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
-            IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI2, XML);
+            final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
+            final IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI2, XML);
             //TODO : unlock the collection here ?
             collection.store(txn, broker, info, XML);
             @SuppressWarnings("unused")
-            org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
+            final org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
             broker.flush();
             broker.saveCollection(txn, collection);
             txnMgr.commit(txn);
         }
     }
 
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(propertiesBuilder()
+            .put(Indexer.PROPERTY_PRESERVE_WS_MIXED_CONTENT, true)
+            .set(Indexer.PROPERTY_SUPPRESS_WHITESPACE, "none")
+            .build());
+
     @BeforeClass
     public static void setUp() throws DatabaseConfigurationException, EXistException, PermissionDeniedException, IOException, SAXException, LockException, AuthenticationException {
-        Configuration config = new Configuration();
-	config.setProperty(Indexer.PROPERTY_PRESERVE_WS_MIXED_CONTENT, true);
-	// fixme! - Test all four: both, leading, trailing, none
-	config.setProperty(Indexer.PROPERTY_SUPPRESS_WHITESPACE, "none");
-        BrokerPool.configure(1, 5, config);
         storeDoc();
-    }  
-
-    @AfterClass
-    public static void tearDown() {
-        BrokerPool.stopAll(false);
     }
 }

--- a/test/src/org/exist/IndexerTest3.java
+++ b/test/src/org/exist/IndexerTest3.java
@@ -36,6 +36,7 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.Configuration;
 import org.exist.util.DatabaseConfigurationException;
@@ -47,301 +48,303 @@ import org.exist.xquery.XQuery;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
-import org.junit.AfterClass;
+import org.junit.*;
+
 import static org.junit.Assert.assertEquals;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+
 import org.xml.sax.SAXException;
 
 /**
  * Tests the indexer.
- * 
+ *
  * @author ljo
  */
 public class IndexerTest3 {
 
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
     private final static String XML1 =
-        "<?xml version=\"1.0\"?>\n" +
-	"<k>\n" + 
-	"<l>a <b>b</b> c <d> d </d>  <e>  </e> f</l>\n" +
-	"<m> a <b>b</b> c <d> d </d>  <e>  </e> f </m>\n" +
-	"<n> a<b>b</b> c <d> d </d>  <e>  </e>f </n>\n" +
-	"<o>  <b>b</b> c <d> d </d>  <e>  </e>  </o>\n" +
-	"</k>\n";
+            "<?xml version=\"1.0\"?>\n" +
+                    "<k>\n" +
+                    "<l>a <b>b</b> c <d> d </d>  <e>  </e> f</l>\n" +
+                    "<m> a <b>b</b> c <d> d </d>  <e>  </e> f </m>\n" +
+                    "<n> a<b>b</b> c <d> d </d>  <e>  </e>f </n>\n" +
+                    "<o>  <b>b</b> c <d> d </d>  <e>  </e>  </o>\n" +
+                    "</k>\n";
 
     private final static String XML2 =
-        "<?xml version=\"1.0\"?>\n" +
-	"<k>\n" + 
-	"<l>a <b>b</b> c <d> d </d>  <e>  </e> f</l>\n" +
-	"</k>\n";
+            "<?xml version=\"1.0\"?>\n" +
+                    "<k>\n" +
+                    "<l>a <b>b</b> c <d> d </d>  <e>  </e> f</l>\n" +
+                    "</k>\n";
 
     private final static String XML3 =
-        "<?xml version=\"1.0\"?>\n" +
-	"<k>\n" + 
-	"<m> a <b>b</b> c <d> d </d>  <e>  </e> f </m>\n" +
-	"</k>\n";
+            "<?xml version=\"1.0\"?>\n" +
+                    "<k>\n" +
+                    "<m> a <b>b</b> c <d> d </d>  <e>  </e> f </m>\n" +
+                    "</k>\n";
 
     private final static String XML4 =
-        "<?xml version=\"1.0\"?>\n" +
-	"<k>\n" + 
-	"<n> a<b>b</b> c <d> d </d>  <e>  </e>f </n>\n" +
-	"</k>\n";
+            "<?xml version=\"1.0\"?>\n" +
+                    "<k>\n" +
+                    "<n> a<b>b</b> c <d> d </d>  <e>  </e>f </n>\n" +
+                    "</k>\n";
 
     private final static String XML5 =
-        "<?xml version=\"1.0\"?>\n" +
-	"<k>\n" + 
-	"<o>  <b>b</b> c <d> d </d>  <e>  </e>  </o>\n" +
-	"</k>\n";
+            "<?xml version=\"1.0\"?>\n" +
+                    "<k>\n" +
+                    "<o>  <b>b</b> c <d> d </d>  <e>  </e>  </o>\n" +
+                    "</k>\n";
 
     private final static String XML6 =
-        "<?xml version=\"1.0\"?>\n" +
-	"<k>\n" + 
-	"<!--    a comment with whitespace    leading, intermediate\n" +
-        " and trailing   -->\n" +
-	"</k>\n";
-    
+            "<?xml version=\"1.0\"?>\n" +
+                    "<k>\n" +
+                    "<!--    a comment with whitespace    leading, intermediate\n" +
+                    " and trailing   -->\n" +
+                    "</k>\n";
+
     private final static String XML7 =
-        "<?xml version=\"1.0\"?>\n" +
-        "<k>\n" +
-        "    <o>    leading and trailing    </o>\n" +
-        "</k>\n";
-    
+            "<?xml version=\"1.0\"?>\n" +
+                    "<k>\n" +
+                    "    <o>    leading and trailing    </o>\n" +
+                    "</k>\n";
+
     private final static String RESULT_SUPPRESS_WS_NONE_XML1 =
-	"<result>" +
-	"<k>\n" + 
-	"<l>a <b>b</b> c <d> d </d>  <e>  </e> f</l>\n" +
-	"<m> a <b>b</b> c <d> d </d>  <e>  </e> f </m>\n" +
-	"<n> a<b>b</b> c <d> d </d>  <e>  </e>f </n>\n" +
-	"<o>  <b>b</b> c <d> d </d>  <e>  </e>  </o>\n" +
-        "</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "<l>a <b>b</b> c <d> d </d>  <e>  </e> f</l>\n" +
+                    "<m> a <b>b</b> c <d> d </d>  <e>  </e> f </m>\n" +
+                    "<n> a<b>b</b> c <d> d </d>  <e>  </e>f </n>\n" +
+                    "<o>  <b>b</b> c <d> d </d>  <e>  </e>  </o>\n" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_NONE_XML2 =
-	"<result>" +
-	"<k>\n" + 
-	"<l>a <b>b</b> c <d> d </d>  <e>  </e> f</l>\n" +
-        "</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "<l>a <b>b</b> c <d> d </d>  <e>  </e> f</l>\n" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_NONE_XML3 =
-	"<result>" +
-	"<k>\n" + 
-	"<m> a <b>b</b> c <d> d </d>  <e>  </e> f </m>\n" +
-        "</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "<m> a <b>b</b> c <d> d </d>  <e>  </e> f </m>\n" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_NONE_XML4 =
-	"<result>" +
-	"<k>\n" + 
-	"<n> a<b>b</b> c <d> d </d>  <e>  </e>f </n>\n" +
-        "</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "<n> a<b>b</b> c <d> d </d>  <e>  </e>f </n>\n" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_NONE_XML5 =
-	"<result>" +
-	"<k>\n" +
-	"<o>  <b>b</b> c <d> d </d>  <e>  </e>  </o>\n" +
-        "</k>" +
-	"</result>";
-    
+            "<result>" +
+                    "<k>\n" +
+                    "<o>  <b>b</b> c <d> d </d>  <e>  </e>  </o>\n" +
+                    "</k>" +
+                    "</result>";
+
     private final static String RESULT_SUPPRESS_WS_NONE_XML6 =
-	"<result>" +
-	"<k>\n" +
-        "<!--    a comment with whitespace    leading, intermediate\n" +
-        " and trailing   -->\n" +
-        "</k>" +
-	"</result>";
-    
+            "<result>" +
+                    "<k>\n" +
+                    "<!--    a comment with whitespace    leading, intermediate\n" +
+                    " and trailing   -->\n" +
+                    "</k>" +
+                    "</result>";
+
     private final static String RESULT_SUPPRESS_WS_NONE_XML7 =
-	"<result>" +
-	"<k>\n" +
-        "    <o>    leading and trailing    </o>\n" +
-        "</k>" +
-	"</result>";
-    
+            "<result>" +
+                    "<k>\n" +
+                    "    <o>    leading and trailing    </o>\n" +
+                    "</k>" +
+                    "</result>";
+
     private final static String RESULT_SUPPRESS_WS_LEADING_XML1 =
-	"<result>" +
-	"<k>" + 
-	"<l>a <b>b</b> c <d>d </d> <e>  </e> f</l>" +
-	"<m>a <b>b</b> c <d>d </d> <e>  </e> f </m>" +
-	"<n>a<b>b</b> c <d>d </d>  <e>  </e>f </n>" +
-	"<o> <b>b</b> c <d>d </d> <e>  </e>  </o>" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>" +
+                    "<l>a <b>b</b> c <d>d </d> <e>  </e> f</l>" +
+                    "<m>a <b>b</b> c <d>d </d> <e>  </e> f </m>" +
+                    "<n>a<b>b</b> c <d>d </d>  <e>  </e>f </n>" +
+                    "<o> <b>b</b> c <d>d </d> <e>  </e>  </o>" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_LEADING_XML2 =
-	"<result>" +
-	"<k>" + 
-	"<l>a <b>b</b> c <d>d </d> <e>  </e> f</l>" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>" +
+                    "<l>a <b>b</b> c <d>d </d> <e>  </e> f</l>" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_LEADING_XML3 =
-	"<result>" +
-	"<k>" + 
-	"<m>a <b>b</b> c <d>d </d> <e>  </e> f </m>" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>" +
+                    "<m>a <b>b</b> c <d>d </d> <e>  </e> f </m>" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_LEADING_XML4 =
-	"<result>" +
-	"<k>" + 
-	"<n>a<b>b</b> c <d>d </d>  <e>  </e>f </n>" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>" +
+                    "<n>a<b>b</b> c <d>d </d>  <e>  </e>f </n>" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_LEADING_XML5 =
-	"<result>" +
-	"<k>" + 
-	"<o> <b>b</b> c <d>d </d> <e>  </e>  </o>" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>" +
+                    "<o> <b>b</b> c <d>d </d> <e>  </e>  </o>" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_LEADING_XML6 =
-	"<result>" +
-	"<k>\n" +
-        "<!--    a comment with whitespace    leading, intermediate\n" +
-        " and trailing   -->\n" +
-        "</k>" +
-	"</result>";
-    
+            "<result>" +
+                    "<k>\n" +
+                    "<!--    a comment with whitespace    leading, intermediate\n" +
+                    " and trailing   -->\n" +
+                    "</k>" +
+                    "</result>";
+
     private final static String RESULT_SUPPRESS_WS_LEADING_XML7 =
-	"<result>" +
-	"<k>\n" +
-        "    <o>leading and trailing    </o>\n" +
-        "</k>" +
-	"</result>";
-    
+            "<result>" +
+                    "<k>\n" +
+                    "    <o>leading and trailing    </o>\n" +
+                    "</k>" +
+                    "</result>";
+
     private final static String RESULT_SUPPRESS_WS_TRAILING_XML1 =
-	"<result>" +
-	"<k>" +
- 	"<l>a <b>b</b> c <d> d</d>  <e>  </e> f</l>" +
-	"<m> a <b>b</b> c <d> d</d>  <e>  </e> f</m>" +
-	"<n> a<b>b</b> c <d> d</d>  <e>  </e>f</n>" + // kolla " a" och "f "
-	"<o>  <b>b</b> c <d> d</d>  <e>  </e> </o>" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>" +
+                    "<l>a <b>b</b> c <d> d</d>  <e>  </e> f</l>" +
+                    "<m> a <b>b</b> c <d> d</d>  <e>  </e> f</m>" +
+                    "<n> a<b>b</b> c <d> d</d>  <e>  </e>f</n>" + // kolla " a" och "f "
+                    "<o>  <b>b</b> c <d> d</d>  <e>  </e> </o>" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_TRAILING_XML2 =
-	"<result>" +
-	"<k>" +
- 	"<l>a <b>b</b> c <d> d</d>  <e>  </e> f</l>" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>" +
+                    "<l>a <b>b</b> c <d> d</d>  <e>  </e> f</l>" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_TRAILING_XML3 =
-	"<result>" +
-	"<k>" +
-	"<m> a <b>b</b> c <d> d</d>  <e>  </e> f</m>" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>" +
+                    "<m> a <b>b</b> c <d> d</d>  <e>  </e> f</m>" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_TRAILING_XML4 =
-	"<result>" +
-	"<k>" +
-	"<n> a<b>b</b> c <d> d</d>  <e>  </e>f</n>" + // kolla " a" och "f "
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>" +
+                    "<n> a<b>b</b> c <d> d</d>  <e>  </e>f</n>" + // kolla " a" och "f "
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_TRAILING_XML5 =
-	"<result>" +
-	"<k>" +
-	"<o>  <b>b</b> c <d> d</d>  <e>  </e> </o>" +
-	"</k>" +
-	"</result>";
-    
+            "<result>" +
+                    "<k>" +
+                    "<o>  <b>b</b> c <d> d</d>  <e>  </e> </o>" +
+                    "</k>" +
+                    "</result>";
+
     private final static String RESULT_SUPPRESS_WS_TRAILING_XML6 =
-	"<result>" +
-	"<k>\n" +
-        "<!--    a comment with whitespace    leading, intermediate\n" +
-        " and trailing   -->\n" +
-        "</k>" +
-	"</result>";
-    
+            "<result>" +
+                    "<k>\n" +
+                    "<!--    a comment with whitespace    leading, intermediate\n" +
+                    " and trailing   -->\n" +
+                    "</k>" +
+                    "</result>";
+
     private final static String RESULT_SUPPRESS_WS_TRAILING_XML7 =
-	"<result>" +
-	"<k>\n" +
-        "    <o>    leading and trailing</o>\n" +
-        "</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "    <o>    leading and trailing</o>\n" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_BOTH_XML1 =
-	"<result>" +
-	"<k>\n" + 
-	"<l>a <b>b</b> c <d>d</d>  <e>  </e> f</l>\n" +  // kolla "a"
-	"<m>a <b>b</b> c <d>d</d>  <e>  </e> f</m>\n" +  // kolla "f "
-	"<n>a<b>b</b> c <d>d</d>  <e>  </e>f</n>\n" +
-	"<o> <b>b</b> c <d>d</d>  <e>  </e> </o>\n" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "<l>a <b>b</b> c <d>d</d>  <e>  </e> f</l>\n" +  // kolla "a"
+                    "<m>a <b>b</b> c <d>d</d>  <e>  </e> f</m>\n" +  // kolla "f "
+                    "<n>a<b>b</b> c <d>d</d>  <e>  </e>f</n>\n" +
+                    "<o> <b>b</b> c <d>d</d>  <e>  </e> </o>\n" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_BOTH_XML2 =
-	"<result>" +
-	"<k>\n" + 
-	"<l>a <b>b</b> c <d>d</d>  <e>  </e> f</l>\n" +  // kolla "a"
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "<l>a <b>b</b> c <d>d</d>  <e>  </e> f</l>\n" +  // kolla "a"
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_BOTH_XML3 =
-	"<result>" +
-	"<k>\n" + 
-	"<m>a <b>b</b> c <d>d</d>  <e>  </e> f</m>\n" +  // kolla "f "
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "<m>a <b>b</b> c <d>d</d>  <e>  </e> f</m>\n" +  // kolla "f "
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_BOTH_XML4 =
-	"<result>" +
-	"<k>\n" + 
-	"<n>a<b>b</b> c <d>d</d>  <e> </e>f</n>\n" +
-	"</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "<n>a<b>b</b> c <d>d</d>  <e> </e>f</n>\n" +
+                    "</k>" +
+                    "</result>";
 
     private final static String RESULT_SUPPRESS_WS_BOTH_XML5 =
-	"<result>" +
-	"<k>\n" + 
-	"<o>  <b>b</b>c <d>d</d> <e> </e> </o>\n" +
-	"</k>" +
-	"</result>";
-    
-     private final static String RESULT_SUPPRESS_WS_BOTH_XML6 =
-	"<result>" +
-	"<k>\n" +
-        "<!--    a comment with whitespace    leading, intermediate\n" +
-        " and trailing   -->\n" +
-        "</k>" +
-	"</result>";
-     
-     private final static String RESULT_SUPPRESS_WS_BOTH_XML7 =
-	"<result>" +
-	"<k>\n" +
-        "    <o>leading and trailing</o>\n" +
-        "</k>" +
-	"</result>";
+            "<result>" +
+                    "<k>\n" +
+                    "<o>  <b>b</b>c <d>d</d> <e> </e> </o>\n" +
+                    "</k>" +
+                    "</result>";
+
+    private final static String RESULT_SUPPRESS_WS_BOTH_XML6 =
+            "<result>" +
+                    "<k>\n" +
+                    "<!--    a comment with whitespace    leading, intermediate\n" +
+                    " and trailing   -->\n" +
+                    "</k>" +
+                    "</result>";
+
+    private final static String RESULT_SUPPRESS_WS_BOTH_XML7 =
+            "<result>" +
+                    "<k>\n" +
+                    "    <o>leading and trailing</o>\n" +
+                    "</k>" +
+                    "</result>";
 
     private final static String XQUERY =
-	"let $test := doc('" + TestConstants.TEST_COLLECTION_URI.toString() + "/"+ TestConstants.TEST_XML_URI.toString() + "') " +
-	"return " +
-	"    <result>{$test/k}</result>";
+            "let $test := doc('" + TestConstants.TEST_COLLECTION_URI.toString() + "/" + TestConstants.TEST_XML_URI.toString() + "') " +
+                    "return " +
+                    "    <result>{$test/k}</result>";
 
     private void store_suppress_type(final String propValue, final String xml) throws PermissionDeniedException, IOException, EXistException, SAXException, LockException, AuthenticationException {
-    	final BrokerPool pool = BrokerPool.getInstance();
-	pool.getConfiguration().setProperty(Indexer.PROPERTY_SUPPRESS_WHITESPACE, propValue);
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        pool.getConfiguration().setProperty(Indexer.PROPERTY_SUPPRESS_WHITESPACE, propValue);
         // Make sure to keep preserve whitespace mixed content stable even if default changes. fixme! - should test both. /ljo
         boolean propWSMValue = false;
         pool.getConfiguration().setProperty(Indexer.PROPERTY_PRESERVE_WS_MIXED_CONTENT, propWSMValue);
 
         final TransactionManager txnMgr = pool.getTransactionManager();
 
-    	try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate("admin", "")));
-	    final Txn txn = txnMgr.beginTransaction()) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate("admin", "")));
+                final Txn txn = txnMgr.beginTransaction()) {
 
-            Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
-            IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, xml);
+            final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
+            final IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, xml);
             //TODO : unlock the collection here ?
             collection.store(txn, broker, info, xml);
             @SuppressWarnings("unused")
-		org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
+            final org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
             broker.flush();
             broker.saveCollection(txn, collection);
             txnMgr.commit(txn);
@@ -349,18 +352,18 @@ public class IndexerTest3 {
     }
 
     private String store_and_retrieve_suppress_type(final String type, final String typeXml, final String typeXquery) throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-	store_suppress_type(type, typeXml);
-        final BrokerPool pool = BrokerPool.getInstance();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            XQuery xquery = broker.getBrokerPool().getXQueryService();
-            Sequence result = xquery.execute(broker, typeXquery, null);
-            StringWriter out = new StringWriter();
-            Properties props = new Properties();
+        store_suppress_type(type, typeXml);
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                final StringWriter out = new StringWriter()) {
+            final XQuery xquery = pool.getXQueryService();
+            final Sequence result = xquery.execute(broker, typeXquery, null);
+            final Properties props = new Properties();
             props.setProperty(OutputKeys.INDENT, "no");
-            SAXSerializer serializer = new SAXSerializer(out, props);
+            final SAXSerializer serializer = new SAXSerializer(out, props);
             serializer.startDocument();
-            for (SequenceIterator i = result.iterate(); i.hasNext(); ) {
-                Item next = i.nextItem();
+            for (final SequenceIterator i = result.iterate(); i.hasNext(); ) {
+                final Item next = i.nextItem();
                 next.toSAX(broker, serializer, props);
             }
             serializer.endDocument();
@@ -370,167 +373,156 @@ public class IndexerTest3 {
 
     @Test
     public void retrieve_suppress_ws_none1() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_NONE_XML1, store_and_retrieve_suppress_type("none", XML1, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_NONE_XML1, store_and_retrieve_suppress_type("none", XML1, XQUERY));
     }
 
     @Test
     public void retrieve_suppress_ws_none2() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_NONE_XML2, store_and_retrieve_suppress_type("none", XML2, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_NONE_XML2, store_and_retrieve_suppress_type("none", XML2, XQUERY));
     }
 
     @Test
     public void retrieve_suppress_ws_none3() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_NONE_XML3, store_and_retrieve_suppress_type("none", XML3, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_NONE_XML3, store_and_retrieve_suppress_type("none", XML3, XQUERY));
     }
 
     @Test
     public void retrieve_suppress_ws_none4() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_NONE_XML4, store_and_retrieve_suppress_type("none", XML4, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_NONE_XML4, store_and_retrieve_suppress_type("none", XML4, XQUERY));
     }
 
     @Test
     public void retrieve_suppress_ws_none5() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_NONE_XML5, store_and_retrieve_suppress_type("none", XML5, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_NONE_XML5, store_and_retrieve_suppress_type("none", XML5, XQUERY));
     }
-    
+
     @Test
     public void retrieve_suppress_ws_none6() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_NONE_XML6, store_and_retrieve_suppress_type("none", XML6, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_NONE_XML6, store_and_retrieve_suppress_type("none", XML6, XQUERY));
     }
 
     @Test
     public void retrieve_suppress_ws_none7() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_NONE_XML7, store_and_retrieve_suppress_type("none", XML7, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_NONE_XML7, store_and_retrieve_suppress_type("none", XML7, XQUERY));
     }
-    
+
     @Ignore
     @Test
     public void retrieve_suppress_ws_leading1() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_LEADING_XML1, store_and_retrieve_suppress_type("leading", XML1, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_LEADING_XML1, store_and_retrieve_suppress_type("leading", XML1, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_leading2() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_LEADING_XML2, store_and_retrieve_suppress_type("leading", XML2, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_LEADING_XML2, store_and_retrieve_suppress_type("leading", XML2, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_leading3() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_LEADING_XML3, store_and_retrieve_suppress_type("leading", XML3, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_LEADING_XML3, store_and_retrieve_suppress_type("leading", XML3, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_leading4() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_LEADING_XML4, store_and_retrieve_suppress_type("leading", XML4, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_LEADING_XML4, store_and_retrieve_suppress_type("leading", XML4, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_leading5() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_LEADING_XML5, store_and_retrieve_suppress_type("leading", XML5, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_LEADING_XML5, store_and_retrieve_suppress_type("leading", XML5, XQUERY));
     }
 
     @Test
     public void retrieve_suppress_ws_leading6() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_LEADING_XML6, store_and_retrieve_suppress_type("leading", XML6, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_LEADING_XML6, store_and_retrieve_suppress_type("leading", XML6, XQUERY));
     }
-    
+
     @Test
     public void retrieve_suppress_ws_leading7() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_LEADING_XML7, store_and_retrieve_suppress_type("leading", XML7, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_LEADING_XML7, store_and_retrieve_suppress_type("leading", XML7, XQUERY));
     }
-    
+
     @Ignore
     @Test
     public void retrieve_suppress_ws_trailing1() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML1, store_and_retrieve_suppress_type("trailing", XML1, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML1, store_and_retrieve_suppress_type("trailing", XML1, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_trailing2() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML2, store_and_retrieve_suppress_type("trailing", XML2, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML2, store_and_retrieve_suppress_type("trailing", XML2, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_trailing3() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML3, store_and_retrieve_suppress_type("trailing", XML3, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML3, store_and_retrieve_suppress_type("trailing", XML3, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_trailing4() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML4, store_and_retrieve_suppress_type("trailing", XML4, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML4, store_and_retrieve_suppress_type("trailing", XML4, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_trailing5() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML5, store_and_retrieve_suppress_type("trailing", XML5, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML5, store_and_retrieve_suppress_type("trailing", XML5, XQUERY));
     }
 
     @Test
     public void retrieve_suppress_ws_trailing6() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML6, store_and_retrieve_suppress_type("trailing", XML6, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML6, store_and_retrieve_suppress_type("trailing", XML6, XQUERY));
     }
-    
+
     @Test
     public void retrieve_suppress_ws_trailing7() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML7, store_and_retrieve_suppress_type("trailing", XML7, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_TRAILING_XML7, store_and_retrieve_suppress_type("trailing", XML7, XQUERY));
     }
-    
+
     @Ignore
     @Test
     public void retrieve_suppress_ws_both1() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_BOTH_XML1, store_and_retrieve_suppress_type("both", XML1, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_BOTH_XML1, store_and_retrieve_suppress_type("both", XML1, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_both2() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_BOTH_XML2, store_and_retrieve_suppress_type("both", XML2, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_BOTH_XML2, store_and_retrieve_suppress_type("both", XML2, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_both3() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_BOTH_XML3, store_and_retrieve_suppress_type("both", XML3, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_BOTH_XML3, store_and_retrieve_suppress_type("both", XML3, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_both4() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_BOTH_XML4, store_and_retrieve_suppress_type("both", XML4, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_BOTH_XML4, store_and_retrieve_suppress_type("both", XML4, XQUERY));
     }
 
     @Ignore
     @Test
     public void retrieve_suppress_ws_both5() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_BOTH_XML5, store_and_retrieve_suppress_type("both", XML5, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_BOTH_XML5, store_and_retrieve_suppress_type("both", XML5, XQUERY));
     }
 
     @Test
     public void retrieve_suppress_ws_both6() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_BOTH_XML6, store_and_retrieve_suppress_type("both", XML6, XQUERY));
+        assertEquals(RESULT_SUPPRESS_WS_BOTH_XML6, store_and_retrieve_suppress_type("both", XML6, XQUERY));
     }
-    
+
     @Test
     public void retrieve_suppress_ws_both7() throws EXistException, IOException, LockException, AuthenticationException, PermissionDeniedException, SAXException, XPathException {
-            assertEquals(RESULT_SUPPRESS_WS_BOTH_XML7, store_and_retrieve_suppress_type("both", XML7, XQUERY));
-    }
-    
-    @BeforeClass
-    public static void setUp() throws DatabaseConfigurationException, EXistException {
-        Configuration config = new Configuration();
-        BrokerPool.configure(1, 5, config);
-    }  
-
-    @AfterClass
-    public static void tearDown() {
-        BrokerPool.stopAll(false);
+        assertEquals(RESULT_SUPPRESS_WS_BOTH_XML7, store_and_retrieve_suppress_type("both", XML7, XQUERY));
     }
 }

--- a/test/src/org/exist/backup/SystemExportFiltersTest.java
+++ b/test/src/org/exist/backup/SystemExportFiltersTest.java
@@ -35,13 +35,13 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
-import org.exist.util.ConfigurationHelper;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 import org.xmldb.api.DatabaseManager;
@@ -93,12 +93,50 @@ public class SystemExportFiltersTest {
 
     private static String BINARY = "test";
 
-    private static BrokerPool pool;
+    @Rule
+    public final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
+    @Before
+    public void startDB() throws DatabaseConfigurationException, EXistException, PermissionDeniedException, IOException, SAXException, CollectionConfigurationException, LockException, ClassNotFoundException, InstantiationException, XMLDBException, IllegalAccessException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        pool.getPluginsManager().addPlugin("org.exist.storage.md.Plugin");
+
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+            final Txn txn = pool.getTransactionManager().beginTransaction()) {
+
+            final Collection test = createCollection(txn, broker, TEST_COLLECTION_URI);
+
+            final CollectionConfigurationManager mgr = pool.getConfigurationManager();
+            mgr.addConfiguration(txn, broker, test, COLLECTION_CONFIG);
+
+            storeXMLDocument(txn, broker, test, doc01uri.lastSegment(), XML1);
+            storeXMLDocument(txn, broker, test, doc02uri.lastSegment(), XML2);
+            storeXMLDocument(txn, broker, test, doc03uri.lastSegment(), XML3);
+
+            test.addBinaryResource(txn, broker, doc11uri.lastSegment(), BINARY.getBytes(), null);
+
+            txn.commit();
+        }
+
+        rundb();
+    }
+
+    private void rundb() throws ClassNotFoundException, XMLDBException, IllegalAccessException, InstantiationException {
+        final Class cl = Class.forName("org.exist.xmldb.DatabaseImpl");
+        final Database database = (Database) cl.newInstance();
+        database.setProperty("create-database", "true");
+        DatabaseManager.registerDatabase(database);
+    }
+
+    @After
+    public void cleanup() throws PermissionDeniedException, IOException, TriggerException, EXistException {
+        TestUtils.cleanupDB();
+    }
 
     @Test
     public void exportImport() throws Exception {
         Path file;
-
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             List<String> filters = new ArrayList<>();
@@ -155,36 +193,6 @@ public class SystemExportFiltersTest {
         return serializer.serialize(document);
     }
 
-    @Before
-    public void startDB() throws DatabaseConfigurationException, EXistException, PermissionDeniedException, IOException, SAXException, CollectionConfigurationException, LockException, ClassNotFoundException, InstantiationException, XMLDBException, IllegalAccessException {
-
-        final Path confFile = ConfigurationHelper.lookup("conf.xml");
-        final Configuration config = new Configuration(confFile.toAbsolutePath().toString());
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-        assertNotNull(pool);
-        pool.getPluginsManager().addPlugin("org.exist.storage.md.Plugin");
-
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
-                final Txn txn = pool.getTransactionManager().beginTransaction()) {
-
-            final Collection test = createCollection(txn, broker, TEST_COLLECTION_URI);
-
-            final CollectionConfigurationManager mgr = pool.getConfigurationManager();
-            mgr.addConfiguration(txn, broker, test, COLLECTION_CONFIG);
-
-            storeXMLDocument(txn, broker, test, doc01uri.lastSegment(), XML1);
-            storeXMLDocument(txn, broker, test, doc02uri.lastSegment(), XML2);
-            storeXMLDocument(txn, broker, test, doc03uri.lastSegment(), XML3);
-
-            test.addBinaryResource(txn, broker, doc11uri.lastSegment(), BINARY.getBytes(), null);
-
-            txn.commit();
-        }
-
-        rundb();
-    }
-
     private Collection createCollection(Txn txn, DBBroker broker, XmldbURI uri) throws PermissionDeniedException, IOException, TriggerException {
         final Collection col = broker.getOrCreateCollection(txn, uri);
         assertNotNull(col);
@@ -200,20 +208,5 @@ public class SystemExportFiltersTest {
         col.store(txn, broker, info, data);
 
         return info.getDocument();
-    }
-
-
-    private void rundb() throws ClassNotFoundException, XMLDBException, IllegalAccessException, InstantiationException {
-        final Class cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        final Database database = (Database) cl.newInstance();
-        database.setProperty("create-database", "true");
-        DatabaseManager.registerDatabase(database);
-    }
-    
-    @After
-    public void cleanup() throws PermissionDeniedException, IOException, TriggerException, EXistException {
-        TestUtils.cleanupDB();
-        BrokerPool.stopAll(false);
-        pool = null;
     }
 }

--- a/test/src/org/exist/collections/CollectionRemovalTest.java
+++ b/test/src/org/exist/collections/CollectionRemovalTest.java
@@ -33,19 +33,16 @@ import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
-import org.exist.xmldb.DatabaseInstanceManager;
 import org.exist.xmldb.XPathQueryServiceImpl;
 import org.exist.xmldb.XmldbURI;
-import org.junit.After;
-import org.junit.AfterClass;
+import org.junit.*;
+
 import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
 import org.xml.sax.SAXException;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Database;
@@ -75,7 +72,8 @@ public class CollectionRemovalTest {
     private final static String QUERY1 = "/document/chapter";
     private final static String QUERY2 = "//chapter[title = 'Chapter 1']";
 
-    private static BrokerPool pool;
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
     @Test
     public void failingRemoveCollection()
@@ -119,6 +117,7 @@ public class CollectionRemovalTest {
     private void removeCollection(final String user, final String password, final XmldbURI uri)
             throws AuthenticationException, EXistException, PermissionDeniedException, IOException, TriggerException {
         Collection test = null;
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate(user, password)));
             final Txn transaction = transact.beginTransaction()) {
@@ -134,6 +133,7 @@ public class CollectionRemovalTest {
     }
 
     private void retrieveDoc(final XmldbURI uri) throws EXistException, PermissionDeniedException, SAXException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             Collection test = null;
             try {
@@ -169,16 +169,17 @@ public class CollectionRemovalTest {
         assertEquals(expected, result.getSize());
     }
 
-    @After
-    public void clearDB() throws XMLDBException {
-        final org.xmldb.api.base.Collection root =
-                DatabaseManager.getCollection("xmldb:exist://" + TestConstants.TEST_COLLECTION_URI.toString(), "admin", "");
-        final CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
-        service.removeCollection(".");
+    @BeforeClass
+    public static void startDB() throws DatabaseConfigurationException, EXistException, ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
+        // initialize XML:DB driver
+        final Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
+        final Database database = (Database) cl.newInstance();
+        DatabaseManager.registerDatabase(database);
     }
 
     @Before
 	public void initDB() throws EXistException, DatabaseConfigurationException, PermissionDeniedException, IOException, SAXException, LockException, ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -233,23 +234,11 @@ public class CollectionRemovalTest {
 		}
 	}
 
-    @BeforeClass
-    public static void startDB() throws DatabaseConfigurationException, EXistException, ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException {
-        final Configuration config = new Configuration();
-        BrokerPool.configure(1, 40, config, Optional.empty());
-        pool = BrokerPool.getInstance();
-
-        // initialize XML:DB driver
-        final Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-        final Database database = (Database) cl.newInstance();
-        DatabaseManager.registerDatabase(database);
+    @After
+    public void clearDB() throws XMLDBException {
+        final org.xmldb.api.base.Collection root =
+                DatabaseManager.getCollection("xmldb:exist://" + TestConstants.TEST_COLLECTION_URI.toString(), "admin", "");
+        final CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        service.removeCollection(".");
     }
-    @AfterClass
-	public static void stopDB() throws XMLDBException {
-        org.xmldb.api.base.Collection root = DatabaseManager.getCollection(
-                "xmldb:exist:///db", "admin", "");
-        final DatabaseInstanceManager dim = (DatabaseInstanceManager) root.getService("DatabaseInstanceManager", "1.0");
-        dim.shutdown();
-		pool = null;
-	}
 }

--- a/test/src/org/exist/dom/memtree/DOMIndexerTest.java
+++ b/test/src/org/exist/dom/memtree/DOMIndexerTest.java
@@ -37,9 +37,8 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.xmldb.XmldbURI;
@@ -48,8 +47,7 @@ import org.exist.xquery.XQuery;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
@@ -59,6 +57,9 @@ import org.xml.sax.SAXException;
  * @author wolf
  */
 public class DOMIndexerTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
     private final static String XML =
         "<?xml version=\"1.0\"?>" +
@@ -95,18 +96,18 @@ public class DOMIndexerTest {
 
     @Test
     public void store() throws PermissionDeniedException, IOException, EXistException, SAXException, LockException, AuthenticationException {
-    	final BrokerPool pool = BrokerPool.getInstance();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager txnMgr = pool.getTransactionManager();
 
     	try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate("admin", "")));
                 final Txn txn = txnMgr.beginTransaction()) {
 
-            Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
-            IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, XML);
+            final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
+            final IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, XML);
             //TODO : unlock the collection here ?
             collection.store(txn, broker, info, XML);
             @SuppressWarnings("unused")
-            org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
+            final org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
             broker.flush();
             broker.saveCollection(txn, collection);
             txnMgr.commit(txn);
@@ -114,34 +115,23 @@ public class DOMIndexerTest {
     }
 
     @Test
-    public void xQuery() throws EXistException, PermissionDeniedException, SAXException, XPathException {
-        final BrokerPool pool = BrokerPool.getInstance();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-            XQuery xquery = broker.getBrokerPool().getXQueryService();
-            Sequence result = xquery.execute(broker, XQUERY, null);
-            int count = result.getItemCount();
-            StringWriter out = new StringWriter();
-            Properties props = new Properties();
+    public void xQuery() throws EXistException, PermissionDeniedException, SAXException, XPathException, IOException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                final StringWriter out = new StringWriter()) {
+            final XQuery xquery = pool.getXQueryService();
+            final Sequence result = xquery.execute(broker, XQUERY, null);
+            final int count = result.getItemCount();
+            final Properties props = new Properties();
             props.setProperty(OutputKeys.INDENT, "yes");
-            SAXSerializer serializer = new SAXSerializer(out, props);
+            final SAXSerializer serializer = new SAXSerializer(out, props);
             serializer.startDocument();
-            for (SequenceIterator i = result.iterate(); i.hasNext(); ) {
-                Item next = i.nextItem();
+            for (final SequenceIterator i = result.iterate(); i.hasNext(); ) {
+                final Item next = i.nextItem();
                 next.toSAX(broker, serializer, props);
             }
             serializer.endDocument();
             out.toString();
         }
-    }
-
-    @Before
-    public void setUp() throws DatabaseConfigurationException, EXistException {
-        Configuration config = new Configuration();
-        BrokerPool.configure(1, 5, config);
-    }  
-
-    @After
-    public void tearDown() {
-        BrokerPool.stopAll(false);
     }
 }

--- a/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
+++ b/test/src/org/exist/dom/persistent/BasicNodeSetTest.java
@@ -24,10 +24,10 @@ import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.txn.TransactionException;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.FileUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
 import org.exist.storage.BrokerPool;
@@ -36,8 +36,6 @@ import org.exist.storage.ElementValue;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.XMLFilenameFilter;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.AncestorSelector;
@@ -53,6 +51,7 @@ import org.exist.xquery.value.Item;
 import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.Type;
+import org.junit.ClassRule;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -89,9 +88,7 @@ public class BasicNodeSetTest {
                 "<para n='1.2.1'/>" +
             "</section>" +
         "</section>";
-    
 
-    private static BrokerPool pool = null;
     private static Collection root = null;
     private static DBBroker broker = null;
     private static Sequence seqSpeech = null;
@@ -404,24 +401,23 @@ public class BasicNodeSetTest {
         executeQuery(broker, "//SPEECH[fn:contains(LINE, 'perturbed spirit')]/following-sibling::*", 1, null);
     }
     
-    private static Sequence executeQuery(DBBroker broker, String query, int expected, String expectedResult) throws XPathException, SAXException, PermissionDeniedException {
-        XQuery xquery = broker.getBrokerPool().getXQueryService();
-        Sequence seq = xquery.execute(broker, query, null);
+    private static Sequence executeQuery(final DBBroker broker, final String query, final int expected, final String expectedResult) throws XPathException, SAXException, PermissionDeniedException {
+        final XQuery xquery = broker.getBrokerPool().getXQueryService();
+        final Sequence seq = xquery.execute(broker, query, null);
         assertEquals(expected, seq.getItemCount());
         
         if (expectedResult != null) {
-            Item item = seq.itemAt(0);
-            String value = serialize(broker, item);
+            final Item item = seq.itemAt(0);
+            final String value = serialize(broker, item);
             assertEquals(expectedResult, value);
         }
         return seq;
     }
 
-    private static String serialize(DBBroker broker, Item item) throws SAXException, XPathException {
-        Serializer serializer = broker.getSerializer();
-	
+    private static String serialize(final DBBroker broker, final Item item) throws SAXException, XPathException {
+        final Serializer serializer = broker.getSerializer();
         serializer.reset();
-        String value;
+        final String value;
         if(Type.subTypeOf(item.getType(), Type.NODE)) {
             value = serializer.serialize((NodeValue) item);
         } else {	
@@ -429,11 +425,13 @@ public class BasicNodeSetTest {
         }
         return value;
     }
-	
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
     @BeforeClass
     public static void setUp() throws Exception {
-        pool = startDB();
-
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final Txn transaction = transact.beginTransaction()) {
 
@@ -441,11 +439,11 @@ public class BasicNodeSetTest {
             root = broker.getOrCreateCollection(transaction, XmldbURI.create(XmldbURI.ROOT_COLLECTION + "/test"));
             broker.saveCollection(transaction, root);
 
-            String existHome = System.getProperty("exist.home");
-            Path existDir = existHome==null ? Paths.get(".") : Paths.get(existHome);
+            final String existHome = System.getProperty("exist.home");
+            Path existDir = existHome == null ? Paths.get(".") : Paths.get(existHome);
             existDir = existDir.normalize();
-            String directory = "samples/shakespeare";
-            Path dir = existDir.resolve(directory);
+            final String directory = "samples/shakespeare";
+            final Path dir = existDir.resolve(directory);
 
             // store some documents.
             for(final Path f : FileUtils.list(dir, XMLFilenameFilter.asPredicate())) {
@@ -453,10 +451,9 @@ public class BasicNodeSetTest {
                 root.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
             }
 
-            IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("nested.xml"), NESTED_XML);
+            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("nested.xml"), NESTED_XML);
             root.store(transaction, broker, info, NESTED_XML);
             transact.commit(transaction);
-            
             
             //for the tests
             docs = root.allDocs(broker, new DefaultDocumentSet(), true);
@@ -473,30 +470,20 @@ public class BasicNodeSetTest {
             throw e;
         }
     }
-	
-    private static BrokerPool startDB() throws DatabaseConfigurationException, EXistException {
-        final String file = "conf.xml";
-        final Optional<Path> home = Optional.ofNullable(System.getProperty("exist.home", System.getProperty("user.dir"))).map(Paths::get);
-        
-        final Configuration config = new Configuration(file, home);
-        BrokerPool.configure(1, 5, config);
-        return BrokerPool.getInstance();
-    }
 
     @AfterClass
     public static void tearDown() throws PermissionDeniedException, IOException, TriggerException, TransactionException {
-        
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final Txn transaction = transact.beginTransaction()) {
             root = broker.getOrCreateCollection(transaction, XmldbURI.create(XmldbURI.ROOT_COLLECTION + "/test"));
-//          broker.removeCollection(transaction, root);
+            broker.removeCollection(transaction, root);
 
             transact.commit(transaction);
         } finally {
             if(broker != null) {
                 broker.close();
             }
-            BrokerPool.stopAll(false);
         }
     }
 }

--- a/test/src/org/exist/numbering/DLNStorageTest.java
+++ b/test/src/org/exist/numbering/DLNStorageTest.java
@@ -1,26 +1,26 @@
 package org.exist.numbering;
 
+import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
+import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.NodeHandle;
 import org.exist.dom.persistent.NodeProxy;
+import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.StorageAddress;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.value.Sequence;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Text;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.IOException;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -76,7 +76,7 @@ public class DLNStorageTest {
             assertEquals(attr.getNodeName(), "href");
             assertEquals(attr.getName(), "href");
             assertEquals(attr.getValue(), "#");
-             // test DOMFile.getNodeValue()
+            // test DOMFile.getNodeValue()
             assertEquals(href.getStringValue(), "#");
 
             // test text node
@@ -94,15 +94,12 @@ public class DLNStorageTest {
         }
     }
 
-    @Before
-    public void setUp() throws Exception {
-        final String file = "conf.xml";
-        final Optional<Path> home = Optional.ofNullable(System.getProperty("exist.home", System.getProperty("user.dir"))).map(Paths::get);
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
-        final Configuration config = new Configuration(file, home);
-        BrokerPool.configure(1, 5, config);
-
-        BrokerPool pool = BrokerPool.getInstance();
+    @BeforeClass
+    public static void setUp() throws Exception {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
             final Txn transaction = transact.beginTransaction()) {
@@ -121,8 +118,18 @@ public class DLNStorageTest {
         }
     }
 
-    @After
-    protected void tearDown() {
-        BrokerPool.stopAll(false);
+    @AfterClass
+    public static void tearDown() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+            final Txn transaction = transact.beginTransaction()) {
+
+            final Collection root = broker.getOrCreateCollection(transaction, XmldbURI.create(XmldbURI.ROOT_COLLECTION + TEST_COLLECTION));
+            assertNotNull(root);
+            broker.removeCollection(transaction, root);
+
+            transact.commit(transaction);
+        }
     }
 }

--- a/test/src/org/exist/storage/BFileOverflowTest.java
+++ b/test/src/org/exist/storage/BFileOverflowTest.java
@@ -27,11 +27,9 @@ import org.exist.storage.index.BFile;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.FixedByteArray;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -45,11 +43,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class BFileOverflowTest {
 
-    private BrokerPool pool;
+    @Rule
+    public final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
     @Test
     public void add() throws EXistException, IOException {
-        TransactionManager mgr = pool.getTransactionManager();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager mgr = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             broker.flush();
@@ -93,6 +93,7 @@ public class BFileOverflowTest {
     @Test
     public void read() throws EXistException {
         BrokerPool.FORCE_CORRUPTION = false;
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             BFile collectionsDb = (BFile)((NativeBroker)broker).getStorage(NativeBroker.COLLECTIONS_DBX_ID);
             
@@ -100,17 +101,4 @@ public class BFileOverflowTest {
             Value val = collectionsDb.get(key);
         }
     }
-
-    @Before
-    public void setUp() throws DatabaseConfigurationException, EXistException {
-        Configuration config = new Configuration();
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-    }
-
-    @After
-    public void tearDown() {
-        BrokerPool.stopAll(false);
-    }
-
 }

--- a/test/src/org/exist/storage/BFileRecoverTest.java
+++ b/test/src/org/exist/storage/BFileRecoverTest.java
@@ -33,11 +33,9 @@ import org.exist.storage.index.BFile;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.FixedByteArray;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -48,11 +46,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class BFileRecoverTest {
 
-    private BrokerPool pool;
+    @Rule
+    public final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
     @Test
     public void add() throws EXistException, IOException, BTreeException {
-        TransactionManager mgr = pool.getTransactionManager();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager mgr = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             broker.flush();
             broker.sync(Sync.MAJOR);
@@ -84,6 +84,7 @@ public class BFileRecoverTest {
 
     @Test
     public void read() throws EXistException, IOException, BTreeException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         BrokerPool.FORCE_CORRUPTION = false;
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             BFile collectionsDb = (BFile)((NativeBroker)broker).getStorage(NativeBroker.COLLECTIONS_DBX_ID);
@@ -97,17 +98,4 @@ public class BFileRecoverTest {
             }
         }
     }
-
-    @Before
-    public void setUp() throws DatabaseConfigurationException, EXistException {
-        Configuration config = new Configuration();
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-    }
-
-    @After
-    public void tearDown() {
-        BrokerPool.stopAll(false);
-    }
-
 }

--- a/test/src/org/exist/storage/DOMFileRecoverTest.java
+++ b/test/src/org/exist/storage/DOMFileRecoverTest.java
@@ -38,12 +38,10 @@ import org.exist.storage.btree.Value;
 import org.exist.storage.dom.DOMFile;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.ReadOnlyException;
 import org.exist.xquery.TerminatedException;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
@@ -55,13 +53,15 @@ import static org.junit.Assert.assertNotNull;
  *
  */
 public class DOMFileRecoverTest {
-	
-	private BrokerPool pool;
+
+    @Rule
+    public final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
     @Test
 	public void add() throws EXistException, ReadOnlyException, TerminatedException, IOException, BTreeException {
 		BrokerPool.FORCE_CORRUPTION = false;
 
+		final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final NodeIdFactory idFact = pool.getNodeFactory();
 
 		try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
@@ -147,6 +147,7 @@ public class DOMFileRecoverTest {
 
     @Test
     public void get() throws EXistException, IOException, BTreeException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
         	//Recover and read the data
 
@@ -174,16 +175,4 @@ public class DOMFileRecoverTest {
             domDb.dump(writer);
 	    }
     }
-
-    @Before
-	public void setUp() throws DatabaseConfigurationException, EXistException {
-        Configuration config = new Configuration();
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-	}
-
-    @After
-	protected void tearDown() {
-		BrokerPool.stopAll(false);
-	}
 }

--- a/test/src/org/exist/storage/LargeValuesTest.java
+++ b/test/src/org/exist/storage/LargeValuesTest.java
@@ -11,17 +11,15 @@ import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.TestUtils;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -51,7 +49,8 @@ public class LargeValuesTest {
 
     private static final int KEY_LENGTH = 5000;
 
-    private static BrokerPool pool = null;
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
     @Test
     public void storeAndRecover() throws PermissionDeniedException, DatabaseConfigurationException, IOException, LockException, CollectionConfigurationException, SAXException, EXistException {
@@ -64,6 +63,7 @@ public class LargeValuesTest {
      * Store some documents, reindex the collection and crash without commit.
      */
     private void storeDocuments() throws EXistException, DatabaseConfigurationException, PermissionDeniedException, IOException, SAXException, CollectionConfigurationException, LockException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
@@ -108,6 +108,7 @@ public class LargeValuesTest {
 
         BrokerPool.FORCE_CORRUPTION = false;
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));) {
             final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.READ_LOCK);
             assertNotNull(root);
@@ -139,6 +140,7 @@ public class LargeValuesTest {
     }
 
     private void remove() throws EXistException, PermissionDeniedException, DatabaseConfigurationException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
@@ -177,17 +179,8 @@ public class LargeValuesTest {
         return file;
     }
 
-
-    @BeforeClass
-    public static void startDB() throws DatabaseConfigurationException, EXistException {
-        final Configuration config = new Configuration();
-        BrokerPool.configure(1, 5, config, Optional.empty());
-        pool = BrokerPool.getInstance();
-    }
-
     @AfterClass
-    public static void closeDB() {
+    public static void cleanupDb() {
         TestUtils.cleanupDB();
-        pool.shutdown();
     }
 }

--- a/test/src/org/exist/storage/LowLevelText.java
+++ b/test/src/org/exist/storage/LowLevelText.java
@@ -3,7 +3,7 @@ package org.exist.storage;
 import org.exist.EXistException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.source.StringSource;
-import org.exist.util.Configuration;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XPathException;
@@ -11,6 +11,7 @@ import org.exist.xquery.XQuery;
 import org.exist.xquery.XQueryContext;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -27,12 +28,12 @@ public class LowLevelText {
 
 	private static final String TEST_XQUERY_SOURCE = "/test";
 
-	private static final String MY_TEST_INSTANCE = "exist";
+	@ClassRule
+	public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
-    private BrokerPool brokerPool;
 	private DBBroker broker;
 
-	private XQueryPool pool;
+	private XQueryPool xqueryPool;
 
 	private StringSource stringSource;
 
@@ -40,19 +41,13 @@ public class LowLevelText {
 
 	@Before
 	public void setUp() throws DatabaseConfigurationException, EXistException, XPathException, PermissionDeniedException, IOException {
-
-		Configuration configuration = new Configuration();
-		BrokerPool.configure(MY_TEST_INSTANCE, 1, 1, configuration);
-		brokerPool = BrokerPool.getInstance(MY_TEST_INSTANCE);
-
-		//BUG: need to be released!
-		broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
-		pool = new XQueryPool();
-		pool.configure(configuration);
+		final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+		broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+		xqueryPool = pool.getXQueryPool();
 		stringSource = new StringSource(TEST_XQUERY_SOURCE);
 
-		XQuery xquery = brokerPool.getXQueryService();
-		XQueryContext context = new XQueryContext(broker.getBrokerPool());
+		final XQuery xquery = pool.getXQueryService();
+		final XQueryContext context = new XQueryContext(broker.getBrokerPool());
 		preCompiledXQuery = xquery.compile(broker, context, stringSource);
 	}
 
@@ -61,19 +56,18 @@ public class LowLevelText {
 		if(broker != null) {
 			broker.close();
 		}
-		BrokerPool.stopAll(false);
 	}
 
 	@Test
 	public void borrowCompiledXQuery1() throws PermissionDeniedException {
 		// put the preCompiledXQuery in cache - NOTE: returnCompiledXQuery() is not a good name
-		pool.returnCompiledXQuery(stringSource, preCompiledXQuery);
+		xqueryPool.returnCompiledXQuery(stringSource, preCompiledXQuery);
 		callAndTestBorrowCompiledXQuery(stringSource);
 	}
 
 	@Test
 	public void borrowCompiledXQuery2() throws PermissionDeniedException {
-		pool.returnCompiledXQuery(stringSource, preCompiledXQuery);
+		xqueryPool.returnCompiledXQuery(stringSource, preCompiledXQuery);
 
 		callAndTestBorrowCompiledXQuery(stringSource);
 		callAndTestBorrowCompiledXQuery(stringSource);
@@ -81,7 +75,7 @@ public class LowLevelText {
 
 	@Test
 	public void borrowCompiledXQuery3() throws PermissionDeniedException {
-		pool.returnCompiledXQuery(stringSource, preCompiledXQuery);
+		xqueryPool.returnCompiledXQuery(stringSource, preCompiledXQuery);
 
 		callAndTestBorrowCompiledXQuery(stringSource);
 		callAndTestBorrowCompiledXQuery(stringSource);
@@ -93,7 +87,7 @@ public class LowLevelText {
 	 */
 	@Test
 	public void borrowCompiledXQueryNewStringSource() throws PermissionDeniedException {
-		pool.returnCompiledXQuery(stringSource, preCompiledXQuery);
+		xqueryPool.returnCompiledXQuery(stringSource, preCompiledXQuery);
 		StringSource localStringSource = new StringSource(TEST_XQUERY_SOURCE);
 
 		callAndTestBorrowCompiledXQuery(localStringSource);
@@ -104,7 +98,7 @@ public class LowLevelText {
 	 */
 	@Test
 	public void borrowCompiledXQueryNewStringSource2() throws PermissionDeniedException {
-		pool.returnCompiledXQuery(stringSource, preCompiledXQuery);
+		xqueryPool.returnCompiledXQuery(stringSource, preCompiledXQuery);
 		StringSource localStringSource = new StringSource(TEST_XQUERY_SOURCE);
 
 		callAndTestBorrowCompiledXQuery(localStringSource);
@@ -112,13 +106,13 @@ public class LowLevelText {
 	}
 
 	private void callAndTestBorrowCompiledXQuery(StringSource stringSourceArg) throws PermissionDeniedException {
-		final CompiledXQuery compiledXQuery = pool.borrowCompiledXQuery(broker, stringSourceArg);
+		final CompiledXQuery compiledXQuery = xqueryPool.borrowCompiledXQuery(broker, stringSourceArg);
 		assertNotNull(
 				"borrowCompiledXQuery should retrieve something for this stringSource",
 				compiledXQuery);
 		assertEquals(
 				"borrowCompiledXQuery should retrieve the preCompiled XQuery for this stringSource",
 				compiledXQuery, preCompiledXQuery);
-        pool.returnCompiledXQuery(stringSourceArg, compiledXQuery);
+		xqueryPool.returnCompiledXQuery(stringSourceArg, compiledXQuery);
 	}
 }

--- a/test/src/org/exist/storage/RangeIndexUpdateTest.java
+++ b/test/src/org/exist/storage/RangeIndexUpdateTest.java
@@ -34,6 +34,7 @@ import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
@@ -43,17 +44,16 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.StringValue;
 import org.exist.xupdate.Modification;
 import org.exist.xupdate.XUpdateProcessor;
-import org.junit.AfterClass;
+import org.junit.*;
+
 import static org.junit.Assert.*;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.file.Path;
 import java.util.Optional;
 
 public class RangeIndexUpdateTest {
@@ -88,11 +88,11 @@ public class RangeIndexUpdateTest {
 
     private final static QName ITEM_QNAME = new QName("item", "", "");
 
-    private static BrokerPool pool;
     private static MutableDocumentSet docs;
 
     @Test
     public void updates() throws EXistException, PermissionDeniedException, XPathException, ParserConfigurationException, IOException, SAXException, LockException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction();) {
@@ -171,16 +171,13 @@ public class RangeIndexUpdateTest {
         assertEquals(count, found);
     }
 
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
     @BeforeClass
     public static void startDB() throws DatabaseConfigurationException, EXistException, PermissionDeniedException, IOException, SAXException, CollectionConfigurationException, LockException {
-        final Path confFile = ConfigurationHelper.lookup("conf.xml");
-        final Configuration config = new Configuration(confFile.toAbsolutePath().toString());
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-
-
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
-
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
 	            final Txn transaction = transact.beginTransaction()) {
 
@@ -211,6 +208,7 @@ public class RangeIndexUpdateTest {
 
     @AfterClass
     public static void cleanup() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
@@ -226,8 +224,6 @@ public class RangeIndexUpdateTest {
 
             transact.commit(transaction);
         } finally {
-            BrokerPool.stopAll(false);
-            pool = null;
             docs = null;
         }
     }

--- a/test/src/org/exist/storage/RemoveRootCollectionTest.java
+++ b/test/src/org/exist/storage/RemoveRootCollectionTest.java
@@ -7,67 +7,77 @@ import java.util.Optional;
 
 import org.exist.collections.*;
 import org.exist.storage.txn.*;
-import org.exist.util.Configuration;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
 import org.xml.sax.InputSource;
 
 
 public class RemoveRootCollectionTest {
-	
-	private BrokerPool pool;
-	private DBBroker broker;
-	private TransactionManager transact;
-	Collection root;
-	
-	@Test public void removeEmptyRootCollection() throws Exception {
-		try(final Txn transaction = transact.beginTransaction()) {
+
+    private DBBroker broker;
+    Collection root;
+
+    @Test
+    public void removeEmptyRootCollection() throws Exception {
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final Txn transaction = transact.beginTransaction()) {
             broker.removeCollection(transaction, root);
             transact.commit(transaction);
         }
-		assertEquals(0, root.getChildCollectionCount(broker));
-		assertEquals(0, root.getDocumentCount(broker));
-	}
+        assertEquals(0, root.getChildCollectionCount(broker));
+        assertEquals(0, root.getDocumentCount(broker));
+    }
 
-	@Test public void removeRootCollectionWithChildCollection() throws Exception {
-		addChildToRoot();
-		try(final Txn transaction = transact.beginTransaction()) {
+    @Test
+    public void removeRootCollectionWithChildCollection() throws Exception {
+        addChildToRoot();
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final Txn transaction = transact.beginTransaction()) {
             broker.removeCollection(transaction, root);
             transact.commit(transaction);
         }
-		assertEquals(0, root.getChildCollectionCount(broker));
-		assertEquals(0, root.getDocumentCount(broker));
-	}
+        assertEquals(0, root.getChildCollectionCount(broker));
+        assertEquals(0, root.getDocumentCount(broker));
+    }
 
-	@Ignore @Test public void removeRootCollectionWithDocument() throws Exception {
-		addDocumentToRoot();
-		try(final Txn transaction = transact.beginTransaction()) {
+    @Ignore
+    @Test
+    public void removeRootCollectionWithDocument() throws Exception {
+        addDocumentToRoot();
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final Txn transaction = transact.beginTransaction()) {
             broker.removeCollection(transaction, root);
             transact.commit(transaction);
         }
-		assertEquals(0, root.getChildCollectionCount(broker));
-		assertEquals(0, root.getDocumentCount(broker));
-	}
+        assertEquals(0, root.getChildCollectionCount(broker));
+        assertEquals(0, root.getDocumentCount(broker));
+    }
 
+    @Rule
+    public final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
-	@Before public void startDB() throws Exception {
-		Configuration config = new Configuration();
-		BrokerPool.configure(1, 1, config);
-		pool = BrokerPool.getInstance();  assertNotNull(pool);
-		broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));  assertNotNull(broker);
-		transact = pool.getTransactionManager();  assertNotNull(transact);
-		root = broker.getCollection(XmldbURI.ROOT_COLLECTION_URI);  assertNotNull(root);
-	}
+    @Before
+    public void startDB() throws Exception {
+        final BrokerPool pool = BrokerPool.getInstance();
+        broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+        root = broker.getCollection(XmldbURI.ROOT_COLLECTION_URI);
+    }
 
-	@After public void stopDB() {
-		if(broker != null) {
-			broker.close();
-		}
-		BrokerPool.stopAll(false);
-	}
-	
-	private void addDocumentToRoot() throws Exception {
-		try(final Txn transaction = transact.beginTransaction()) {
+    @After
+    public void stopDB() {
+        if (broker != null) {
+            broker.close();
+        }
+    }
+
+    private void addDocumentToRoot() throws Exception {
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final Txn transaction = transact.beginTransaction()) {
             final InputSource is = new InputSource(Paths.get("samples/shakespeare/hamlet.xml").toUri().toASCIIString());
             assertNotNull(is);
             final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("hamlet.xml"), is);
@@ -75,13 +85,15 @@ public class RemoveRootCollectionTest {
             root.store(transaction, broker, info, is);
             transact.commit(transaction);
         }
-	}
-	
-	private void addChildToRoot() throws Exception {
-		try(final Txn transaction = transact.beginTransaction()) {
+    }
+
+    private void addChildToRoot() throws Exception {
+        final BrokerPool pool = BrokerPool.getInstance();
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final Txn transaction = transact.beginTransaction()) {
             final Collection child = broker.getOrCreateCollection(transaction, XmldbURI.ROOT_COLLECTION_URI.append("child"));
             broker.saveCollection(transaction, child);
             transact.commit(transaction);
         }
-	}
+    }
 }

--- a/test/src/org/exist/storage/StartupTriggerTest.java
+++ b/test/src/org/exist/storage/StartupTriggerTest.java
@@ -8,7 +8,6 @@ import org.exist.security.internal.aider.UserAider;
 import org.exist.util.Configuration;
 import org.exist.util.DatabaseConfigurationException;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/test/src/org/exist/storage/btree/BTreeTest.java
+++ b/test/src/org/exist/storage/btree/BTreeTest.java
@@ -1,17 +1,18 @@
 package org.exist.storage.btree;
 
+import org.easymock.EasyMock;
 import org.exist.EXistException;
 import org.exist.storage.BrokerPool;
+import org.exist.storage.DefaultCacheManager;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.*;
 import org.exist.xquery.TerminatedException;
 import org.exist.xquery.value.AtomicValue;
 import org.exist.xquery.value.DoubleValue;
-import org.junit.After;
+import org.junit.*;
+
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
-
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -27,17 +28,15 @@ import java.util.TreeMap;
  */
 public class BTreeTest {
 
-    private BrokerPool pool;
     private Path file = null;
 
     private int count = 0;
     private static final int COUNT = 5000;
 
     @Test
-    public void simpleUpdates() {
-        BTree btree = null;
-        try {
-            btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file);
+    public void simpleUpdates() throws DBException, IOException, TerminatedException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file)) {
             btree.create((short) -1);
 
             String prefixStr = "K";
@@ -67,29 +66,13 @@ public class BTreeTest {
             btree.query(query, new StringIndexCallback());
             assertEquals(COUNT, count);
             btree.flush();
-        } catch (DBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } finally {
-            if (btree != null)
-                try {
-                    btree.close();
-                } catch (DBException e) {
-                }
         }
     }
 
     @Test
-    public void strings() {
-        BTree btree = null;
-        try {
-            btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file);
+    public void strings() throws DBException, IOException, TerminatedException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file)) {
             btree.create((short) -1);
 
             String prefixStr = "C";
@@ -138,32 +121,16 @@ public class BTreeTest {
             query = new IndexQuery(IndexQuery.LT, new Value(prefixStr));
             btree.query(query, new StringIndexCallback());
             assertEquals(count, 0);
-        } catch (DBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (TerminatedException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } finally {
-            if (btree != null)
-                try {
-                    btree.close();
-                } catch (DBException e) {
-                }
         }
     }
 
     @Test
-    public void longStrings() {
+    public void longStrings() throws DBException, IOException {
         // Test storage of long keys up to half of the page size (4k)
-        Random rand = new Random(System.currentTimeMillis());
+        final Random rand = new Random(System.currentTimeMillis());
 
-        BTree btree = null;
-        try {
-            btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file);
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file)) {
             btree.setSplitFactor(0.7);
             btree.create((short) -1);
 
@@ -192,26 +159,13 @@ public class BTreeTest {
                 long p = btree.findValue(new Value(entry.getKey().toString()));
                 assertEquals(p, entry.getValue().intValue());
             }
-        } catch (DBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } finally {
-            if (btree != null)
-                try {
-                    btree.close();
-                } catch (DBException e) {
-                }
         }
     }
 
     @Test
-    public void stringsTruncated() {
-        BTree btree = null;
-        try {
-            btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file);
+    public void stringsTruncated() throws DBException, IOException, TerminatedException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file)) {
             btree.create((short) -1);
 
             char prefix = 'A';
@@ -233,29 +187,13 @@ public class BTreeTest {
                 assertEquals(COUNT, count);
                 prefix++;
             }
-        } catch (DBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (TerminatedException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } finally {
-            if (btree != null)
-                try {
-                    btree.close();
-                } catch (DBException e) {
-                }
         }
     }
 
     @Test
-    public void removeStrings() {
-        BTree btree = null;
-        try {
-            btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file);
+    public void removeStrings() throws DBException, IOException, TerminatedException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file)) {
             btree.create((short) -1);
 
             char prefix = 'A';
@@ -286,28 +224,13 @@ public class BTreeTest {
             IndexQuery query = new IndexQuery(IndexQuery.TRUNC_RIGHT, new Value(Character.toString('D')));
             btree.query(query, new StringIndexCallback());
             assertEquals(0, count);
-        } catch (DBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (TerminatedException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } finally {
-            if (btree != null)
-                try {
-                    btree.close();
-                } catch (DBException e) {
-                }
         }
     }
 
     @Test
-    public void numbers() throws TerminatedException {
-        try {
-            BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file);
+    public void numbers() throws TerminatedException, DBException, EXistException, IOException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file)) {
             btree.create((short) -1);
 
             for (int i = 1; i <= COUNT; i++) {
@@ -340,24 +263,13 @@ public class BTreeTest {
                 btree.query(query, new SimpleCallback());
                 assertEquals(COUNT - 1, count);
             }
-
-            btree.close();
-        } catch (DBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (EXistException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
         }
     }
 
     @Test
-    public void numbersWithPrefix() {
-        try {
-            BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file);
+    public void numbersWithPrefix() throws DBException, EXistException, IOException, TerminatedException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final BTree btree = new BTree(pool, (byte) 0, false, pool.getCacheManager(), file)) {
             btree.create((short) -1);
 
             for (int i = 1; i <= COUNT; i++) {
@@ -412,49 +324,21 @@ public class BTreeTest {
                 btree.query(query, prefix, new PrefixIndexCallback());
                 assertEquals(COUNT - 1, count);
             }
-
-            btree.close();
-        } catch (DBException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (TerminatedException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        } catch (EXistException e) {
-            e.printStackTrace();
-            fail(e.getMessage());
         }
     }
 
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
     @Before
     public void initialize() {
-        try {
-            Configuration config = new Configuration();
-            BrokerPool.configure(1, 5, config);
-            pool = BrokerPool.getInstance();
-
-            file = Paths.get(System.getProperty("exist.home", ".")).resolve("test/junit/test.dbx");
-            assertFalse(Files.exists(file));
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        file = Paths.get(System.getProperty("exist.home", ".")).resolve("test/junit/test.dbx");
+        assertFalse(Files.exists(file));
     }
 
     @After
     public void cleanUp() {
-    	try {
-	        BrokerPool.stopAll(false);
-
-            FileUtils.deleteQuietly(file);
-        } catch (Exception e) {
-	        fail(e.getMessage());
-	    }
-        pool = null;
-        file = null;
+        FileUtils.deleteQuietly(file);
     }
 
     private final class SimpleCallback implements BTreeCallback {
@@ -462,7 +346,8 @@ public class BTreeTest {
         public SimpleCallback() {
             count = 0;
         }
-        
+
+        @Override
         public boolean indexInfo(Value value, long pointer) throws TerminatedException {
             count++;
             return false;
@@ -474,7 +359,8 @@ public class BTreeTest {
         public PrefixIndexCallback() {
             count = 0;
         }
-        
+
+        @Override
         public boolean indexInfo(Value value, long pointer) throws TerminatedException {
             int prefix = ByteConversion.byteToInt(value.data(), value.start());
             assertEquals(99, prefix);
@@ -489,7 +375,8 @@ public class BTreeTest {
         public StringIndexCallback() {
             count = 0;
         }
-        
+
+        @Override
         public boolean indexInfo(Value value, long pointer) throws TerminatedException {
             @SuppressWarnings("unused")
 			XMLString key = UTF8.decode(value.data(), value.start(), value.getLength());

--- a/test/src/org/exist/test/ExistEmbeddedServer.java
+++ b/test/src/org/exist/test/ExistEmbeddedServer.java
@@ -1,0 +1,112 @@
+package org.exist.test;
+
+import org.exist.EXistException;
+import org.exist.storage.BrokerPool;
+import org.exist.util.Configuration;
+import org.exist.util.ConfigurationHelper;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.FileUtils;
+import org.junit.rules.ExternalResource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Exist embedded Server Rule for JUnit
+ */
+public class ExistEmbeddedServer extends ExternalResource {
+
+    private final Optional<String> instanceName;
+    private final Optional<Path> configFile;
+    private final Optional<Properties> configProperties;
+
+    private BrokerPool pool = null;
+
+    public ExistEmbeddedServer() {
+        this(null, null, null);
+    }
+
+    public ExistEmbeddedServer(final Properties configProperties) {
+        this(null, null, configProperties);
+    }
+
+    public ExistEmbeddedServer(final String instanceName, final Path configFile) {
+        this(instanceName, configFile, null);
+    }
+
+    public ExistEmbeddedServer(final String instanceName, final Path configFile, final Properties configProperties) {
+        this.instanceName = Optional.ofNullable(instanceName);
+        this.configFile = Optional.ofNullable(configFile);
+        this.configProperties = Optional.ofNullable(configProperties);
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        startDb();
+        super.before();
+    }
+
+    private void startDb() throws DatabaseConfigurationException, EXistException {
+        if(pool == null) {
+
+            final String name = instanceName.orElse(BrokerPool.DEFAULT_INSTANCE_NAME);
+
+            final Optional<Path> home = Optional.ofNullable(System.getProperty("exist.home", System.getProperty("user.dir"))).map(Paths::get);
+            final Path confFile = configFile.orElseGet(() -> ConfigurationHelper.lookup("conf.xml", home));
+
+            final Configuration config;
+            if(confFile.isAbsolute() && Files.exists(confFile)) {
+                //TODO(AR) is this correct?
+                config = new Configuration(confFile.toAbsolutePath().toString());
+            } else {
+                config = new Configuration(FileUtils.fileName(confFile), home);
+            }
+
+            // override any specified config properties
+            if(configProperties.isPresent()) {
+                for(final Map.Entry<Object, Object> configProperty : configProperties.get().entrySet()) {
+                    config.setProperty(configProperty.getKey().toString(), configProperty.getValue());
+                }
+            }
+
+            BrokerPool.configure(name,1, 5, config, Optional.empty());
+            this.pool = BrokerPool.getInstance(name);
+        } else {
+            throw new IllegalStateException("ExistEmbeddedServer already running");
+        }
+    }
+
+    public BrokerPool getBrokerPool() {
+        return pool;
+    }
+
+    public void restart() throws EXistException, DatabaseConfigurationException {
+        if(pool != null) {
+            stopDb();
+            startDb();
+        } else {
+            throw new IllegalStateException("ExistEmbeddedServer already stopped");
+        }
+    }
+
+    @Override
+    protected void after() {
+        stopDb();
+        super.after();
+    }
+
+    private void stopDb() {
+        if(pool != null) {
+            pool.shutdown();
+
+            // clear instance variables
+            pool = null;
+        } else {
+            throw new IllegalStateException("ExistEmbeddedServer already stopped");
+        }
+    }
+}

--- a/test/src/org/exist/test/ExistWebServer.java
+++ b/test/src/org/exist/test/ExistWebServer.java
@@ -9,7 +9,7 @@ import java.net.ServerSocket;
 import java.util.Random;
 
 /**
- * Exist Jetty Web Server Rule to JUnit
+ * Exist Jetty Web Server Rule for JUnit
  */
 public class ExistWebServer extends ExternalResource {
     private final static int MIN_RANDOM_PORT = 49152;

--- a/test/src/org/exist/test/ExistXmldbEmbeddedServer.java
+++ b/test/src/org/exist/test/ExistXmldbEmbeddedServer.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
- * Exist embedded XML:DB Server Rule to JUnit
+ * Exist embedded XML:DB Server Rule for JUnit
  */
 public class ExistXmldbEmbeddedServer extends ExternalResource {
 

--- a/test/src/org/exist/validation/ValidationFunctions_DTD_Test.java
+++ b/test/src/org/exist/validation/ValidationFunctions_DTD_Test.java
@@ -27,10 +27,13 @@ import java.util.Optional;
 import org.exist.EXistException;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.Configuration;
 import org.exist.util.LockException;
 
 import org.junit.*;
 
+import static org.exist.util.PropertiesBuilder.propertiesBuilder;
 import static org.junit.Assert.*;
 
 import org.exist.collections.IndexInfo;
@@ -39,7 +42,6 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
 import org.exist.util.XMLReaderObjectFactory;
 import org.exist.xmldb.XmldbURI;
 import org.xml.sax.SAXException;
@@ -52,14 +54,12 @@ import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.XPathQueryService;
 
 /**
- *  Set of Tests for validation:validate($a) and validation:validate($a, $b)
- * regaring validatin using DTD's.
+ * Set of Tests for validation:validate($a) and validation:validate($a, $b)
+ * regarding validating using DTD's.
  *
  * @author Dannes Wessels (dizzzz@exist-db.org)
  */
 public class ValidationFunctions_DTD_Test {
-    
-    private static Configuration config = null;
     
     private final static String TEST_COLLECTION = "testValidationFunctionsDTD";
 
@@ -155,19 +155,12 @@ public class ValidationFunctions_DTD_Test {
         assertEquals( "invalid document", "false", r );
     }
 
-    @Before
-    public void clearGrammarCache() throws XMLDBException {
-        service.query("validation:clear-grammar-cache()");
-    }
-    
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(propertiesBuilder()
+            .set(XMLReaderObjectFactory.PROPERTY_VALIDATION_MODE, "auto").build());
 
     @BeforeClass
     public static void startup() throws Exception {
-        config = new Configuration();
-        config.setProperty(XMLReaderObjectFactory.PROPERTY_VALIDATION_MODE, "auto");
-
-        BrokerPool.configure(1, 5, config);
-
         //create the collections we need for these tests
         createTestCollections();
 
@@ -178,11 +171,14 @@ public class ValidationFunctions_DTD_Test {
         service = getXPathService();
     }
 
+    @Before
+    public void clearGrammarCache() throws XMLDBException {
+        service.query("validation:clear-grammar-cache()");
+    }
 
     @AfterClass
     public static void shutdown() throws Exception {
         removeTestCollections();
-        BrokerPool.stopAll(true);
     }
 
     private static XPathQueryService getXPathService() throws Exception {
@@ -196,7 +192,7 @@ public class ValidationFunctions_DTD_Test {
 
     private static void createTestCollections() throws Exception {
 
-        final BrokerPool pool = BrokerPool.getInstance();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
 
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD)));
@@ -225,7 +221,8 @@ public class ValidationFunctions_DTD_Test {
 
     private static void createTestDocuments() throws Exception {
 
-        final BrokerPool pool = BrokerPool.getInstance();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final Configuration config = pool.getConfiguration();
         final TransactionManager transact = pool.getTransactionManager();
 
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getGuestSubject()));
@@ -273,7 +270,7 @@ public class ValidationFunctions_DTD_Test {
 
     private static void removeTestCollections() throws Exception {
 
-        final BrokerPool pool = BrokerPool.getInstance();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
 
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate(ADMIN_UID, ADMIN_PWD)));

--- a/test/src/org/exist/xqj/MarshallerTest.java
+++ b/test/src/org/exist/xqj/MarshallerTest.java
@@ -22,13 +22,16 @@
 package org.exist.xqj;
 
 import org.exist.EXistException;
+import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.LockException;
+import org.exist.util.XMLReaderObjectFactory;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.value.*;
@@ -39,14 +42,17 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+
+import static org.exist.util.PropertiesBuilder.propertiesBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
 import javax.xml.stream.XMLStreamException;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.io.StringReader;
 import java.util.Optional;
@@ -65,8 +71,6 @@ import java.util.Properties;
  */
 public class MarshallerTest {
 
-    private static BrokerPool pool;
-
     private static XmldbURI TEST_COLLECTION_URI = XmldbURI.ROOT_COLLECTION_URI.append("xqjmarhallertest");
 
     private static String TEST_DOC =
@@ -81,6 +85,7 @@ public class MarshallerTest {
     
     @Test
     public void atomicValues() throws EXistException, XPathException, SAXException, XMLStreamException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             ValueSequence values = new ValueSequence(3);
             values.add(new StringValue("foo"));
@@ -107,6 +112,7 @@ public class MarshallerTest {
 
     @Test
     public void nodes() throws EXistException, PermissionDeniedException, SAXException, XPathException, XMLStreamException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             DocumentImpl doc = (DocumentImpl) broker.getXMLResource(TEST_COLLECTION_URI.append("test.xml"));
             NodeProxy p = new NodeProxy(doc, pool.getNodeFactory().createFromString("1.1"));
@@ -138,14 +144,13 @@ public class MarshallerTest {
         assertEquals("test",n.getLocalName());
     }
 
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
     @BeforeClass
-    public static void startDB() throws EXistException, DatabaseConfigurationException {
-        final Configuration config = new Configuration();
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-
+    public static void startDB() throws EXistException, DatabaseConfigurationException, PermissionDeniedException, IOException, SAXException, LockException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
-
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
 
@@ -156,24 +161,18 @@ public class MarshallerTest {
             root.store(transaction, broker, info, TEST_DOC);
 
             transact.commit(transaction);
-        } catch (Exception e) {
-            fail(e.getMessage());
         }
     }
 
     @AfterClass
-    public static void shutdown() {
+    public static void shutdown() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = transact.beginTransaction()) {
             Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
             broker.removeCollection(transaction, root);
             transact.commit(transaction);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
         }
-        BrokerPool.stopAll(false);
-        pool = null;
     }
 }

--- a/test/src/org/exist/xquery/LexerTest.java
+++ b/test/src/org/exist/xquery/LexerTest.java
@@ -19,9 +19,8 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.parser.XQueryLexer;
@@ -30,8 +29,7 @@ import org.exist.xquery.parser.XQueryTreeParser;
 import org.exist.xquery.value.Sequence;
 
 import antlr.collections.AST;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
@@ -45,13 +43,8 @@ public class LexerTest {
 			+ "\u5165\u4E86\u5341\u4E09\u5E74\u65F6\u95F4\u3002</p>"
 			+ "</body></text>";
 
-	/**
-	 * Start a local database instance.
-	 */
-	private void configure() throws DatabaseConfigurationException, EXistException {
-		Configuration config = new Configuration();
-		BrokerPool.configure(1, 5, config);
-	}
+	@ClassRule
+	public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
 	@Test
 	public void query() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException, RecognitionException, XPathException, TokenStreamException {
@@ -107,16 +100,4 @@ public class LexerTest {
             int count = result.getItemCount();
 		}
 	}
-
-    @Before
-	public void setUp() throws EXistException, DatabaseConfigurationException {
-		if (!BrokerPool.isConfigured(BrokerPool.DEFAULT_INSTANCE_NAME)) {
-            configure();
-        }
-	}
-
-    @After
-    public void tearDown() throws Exception {
-        BrokerPool.stopAll(false);
-    }
 }

--- a/test/src/org/exist/xquery/OpNumericTest.java
+++ b/test/src/org/exist/xquery/OpNumericTest.java
@@ -2,7 +2,7 @@ package org.exist.xquery;
 
 import org.exist.EXistException;
 import org.exist.storage.*;
-import org.exist.util.Configuration;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.xquery.Constants.ArithmeticOperator;
 import org.exist.xquery.value.*;
@@ -24,15 +24,15 @@ public class OpNumericTest {
 	private static IntegerValue integer;
 	private static DecimalValue decimal;
 
+	@ClassRule
+	public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
 	@BeforeClass
 	public static void setUp() throws DatabaseConfigurationException, EXistException, XPathException {
-		Configuration config = new Configuration();
-		BrokerPool.configure(1, 5, config);
-
-		BrokerPool pool = BrokerPool.getInstance();
+		final BrokerPool pool = existEmbeddedServer.getBrokerPool();
 
 		broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
-		context = new XQueryContext(broker.getBrokerPool());
+		context = new XQueryContext(pool);
 
 		dtDuration = new DayTimeDurationValue("P1D");
 		ymDuration = new YearMonthDurationValue("P1Y");
@@ -48,7 +48,6 @@ public class OpNumericTest {
         if(broker != null) {
 			broker.close();
 		}
-        BrokerPool.stopAll(false);
         broker = null;
         context = null;
     }

--- a/test/src/org/exist/xquery/OptimizerTest.java
+++ b/test/src/org/exist/xquery/OptimizerTest.java
@@ -22,18 +22,12 @@
 package org.exist.xquery;
 
 import org.exist.TestUtils;
-import org.exist.storage.BrokerPool;
-import org.exist.util.Configuration;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.FileUtils;
 import org.exist.util.XMLFilenameFilter;
-import org.exist.xmldb.DatabaseInstanceManager;
 import org.exist.xmldb.IndexQueryService;
 import org.exist.xmldb.XmldbURI;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Database;
@@ -48,6 +42,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+
+import static org.exist.util.PropertiesBuilder.propertiesBuilder;
+import static org.junit.Assert.assertEquals;
 
 /**
  * 
@@ -82,15 +79,15 @@ public class OptimizerTest {
     private static Collection testCollection;
 
     @Test
-    public void nestedQuery() {
+    public void nestedQuery() throws XMLDBException {
         execute("/root/a[descendant::b = 'one']", true, "Inner b node should be returned.", 2);
         execute("/root/a[b = 'one']", true, "Inner b node should not be returned.", 1);
         execute("/root/a[b = 'one']", false, "Inner b node should not be returned.", 1);
     }
 
     @Test
-    public void simplePredicates() {
-        int r = execute("//SPEECH[ft:query(LINE, 'king')]", false);
+    public void simplePredicates() throws XMLDBException {
+        long r = execute("//SPEECH[ft:query(LINE, 'king')]", false);
         execute("//SPEECH[ft:query(LINE, 'king')]", true, MSG_OPT_ERROR, r);
 
         r = execute("//SPEECH[SPEAKER = 'HAMLET']", false);
@@ -125,8 +122,8 @@ public class OptimizerTest {
     }
 
     @Test
-    public void simplePredicatesRegex() {
-        int r = execute("//SPEECH[matches(SPEAKER, '^HAM.*')]", false);
+    public void simplePredicatesRegex() throws XMLDBException {
+        long r = execute("//SPEECH[matches(SPEAKER, '^HAM.*')]", false);
         execute("//SPEECH[matches(SPEAKER, '^HAM.*')]", true, MSG_OPT_ERROR, r);
         r = execute("//SPEECH[starts-with(SPEAKER, 'HAML')]", false);
         execute("//SPEECH[starts-with(SPEAKER, 'HAML')]", true, MSG_OPT_ERROR, r);
@@ -137,62 +134,61 @@ public class OptimizerTest {
     }
 
     @Test
-    public void twoPredicates() {
-        int r = execute("//SPEECH[ft:query(LINE, 'king')][SPEAKER='HAMLET']", false);
+    public void twoPredicates() throws XMLDBException {
+        long r = execute("//SPEECH[ft:query(LINE, 'king')][SPEAKER='HAMLET']", false);
         execute("//SPEECH[ft:query(LINE, 'king')][SPEAKER='HAMLET']", true, MSG_OPT_ERROR, r);
         r = execute("//SPEECH[SPEAKER='HAMLET'][ft:query(LINE, 'king')]", false);
         execute("//SPEECH[SPEAKER='HAMLET'][ft:query(LINE, 'king')]", true, MSG_OPT_ERROR, r);
     }
 
     @Test
-    public void twoPredicatesNPEBug808() {
+    public void twoPredicatesNPEBug808() throws XMLDBException {
         // Bug #808 NPE $docs[ngram:contains(first, "luke")][ngram:contains(last, "sky")]
-        int r = execute("let $sps := collection('/db/test')//SPEECH return $sps[ngram:contains(SPEAKER, 'HAMLET')][ngram:contains(LINE, 'king')]", false);
+        long r = execute("let $sps := collection('/db/test')//SPEECH return $sps[ngram:contains(SPEAKER, 'HAMLET')][ngram:contains(LINE, 'king')]", false);
         execute("let $sps := collection('/db/test')//SPEECH return $sps[ngram:contains(SPEAKER, 'HAMLET')][ngram:contains(LINE, 'king')]", true, MSG_OPT_ERROR, r);
     }
 
     @Test
-    public void noOptimization() {
-        int r = execute("/root//b[parent::c/b = 'two']", false);
-        Assert.assertEquals(1, r);
+    public void noOptimization() throws XMLDBException {
+        long r = execute("/root//b[parent::c/b = 'two']", false);
+        assertEquals(1, r);
         execute("/root//b[parent::c/b = 'two']", true, "Parent axis should not be optimized.", r);
         
         r = execute("/root//b[ancestor::a/c/b = 'two']", false);
-        Assert.assertEquals(1, r);
+        assertEquals(1, r);
         execute("/root//b[ancestor::a/c/b = 'two']", true, "Ancestor axis should not be optimized.", r);
 
         r = execute("/root//b[ancestor::a/b = 'two']", false);
-        Assert.assertEquals(0, r);
+        assertEquals(0, r);
         execute("/root//b[ancestor::a/b = 'two']", true, "Ancestor axis should not be optimized.", r);
 
         r = execute("/root//b[text()/parent::b = 'two']", false);
-        Assert.assertEquals(1, r);
+        assertEquals(1, r);
         execute("/root//b[text()/parent::b = 'two']", true, "Parent axis should not be optimized.", r);
 
         r = execute("/root//b[matches(text()/parent::b, 'two')]", false);
-        Assert.assertEquals(1, r);
+        assertEquals(1, r);
         execute("/root//b[matches(text()/parent::b, 'two')]", true, "Parent axis should not be optimized.", r);
     }
 
     @Test
-    public void reversePaths() {
-
-        int r = execute("/root//b/parent::c[b = 'two']", false);
-        Assert.assertEquals(1, r);
+    public void reversePaths() throws XMLDBException {
+        long r = execute("/root//b/parent::c[b = 'two']", false);
+        assertEquals(1, r);
         execute("/root//b/parent::c[b = 'two']", true, MSG_OPT_ERROR, r);
     }
 
     @Test @Ignore
-    public void reversePathsWithWildcard() {
+    public void reversePathsWithWildcard() throws XMLDBException {
         //parent with wildcard
-        int r = execute("/root//b/parent::*[b = 'two']", false);
-        Assert.assertEquals(1, r);
+        long r = execute("/root//b/parent::*[b = 'two']", false);
+        assertEquals(1, r);
         execute("/root//b/parent::*[b = 'two']", true, MSG_OPT_ERROR, r);
     }
 
     @Test
-    public void booleanOperator() {
-        int r = execute("//SPEECH[ft:query(LINE, 'king')][SPEAKER='HAMLET']", false);
+    public void booleanOperator() throws XMLDBException {
+        long r = execute("//SPEECH[ft:query(LINE, 'king')][SPEAKER='HAMLET']", false);
         execute("//SPEECH[ft:query(LINE, 'king') and SPEAKER='HAMLET']", false, MSG_OPT_ERROR, r);
         execute("//SPEECH[ft:query(LINE, 'king') and SPEAKER='HAMLET']", true, MSG_OPT_ERROR, r);
         r = execute("//SPEECH[ft:query(LINE, 'king') or SPEAKER='HAMLET']", false);
@@ -205,7 +201,7 @@ public class OptimizerTest {
         execute("//SPEECH[(ft:query(LINE, 'king') or ft:query(LINE, 'love')) and SPEAKER='HAMLET']", true, MSG_OPT_ERROR, r);
 
         r = execute("//SPEECH[(ft:query(LINE, 'juliet') and ft:query(LINE, 'romeo')) or SPEAKER='HAMLET']", false);
-        Assert.assertEquals(368, r);
+        assertEquals(368, r);
         execute("//SPEECH[(ft:query(LINE, 'juliet') and ft:query(LINE, 'romeo')) or SPEAKER='HAMLET']", true, MSG_OPT_ERROR, r);
 
 
@@ -213,96 +209,71 @@ public class OptimizerTest {
         execute("//SPEECH[true() and true()]", true, MSG_OPT_ERROR, 2628);
     }
 
-    private int execute(String query, boolean optimize) {
-        try {
-            XQueryService service = (XQueryService) testCollection.getService("XQueryService", "1.0");
-            if (optimize)
-                query = OPTIMIZE + query;
-            else
-                query = NO_OPTIMIZE + query;
-            query = NAMESPACES + query;
-            ResourceSet result = service.query(query);
-            return (int) result.getSize();
-        } catch (XMLDBException e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
+    private long execute(String query, boolean optimize) throws XMLDBException {
+        XQueryService service = (XQueryService) testCollection.getService("XQueryService", "1.0");
+        if (optimize) {
+            query = OPTIMIZE + query;
+        } else {
+            query = NO_OPTIMIZE + query;
         }
-        return 0;
+        query = NAMESPACES + query;
+        ResourceSet result = service.query(query);
+        return result.getSize();
     }
 
-    private void execute(String query, boolean optimize, String message, int expected) {
-        try {
-            XQueryService service = (XQueryService) testCollection.getService("XQueryService", "1.0");
-            if (optimize)
-                query = NAMESPACES + OPTIMIZE + query;
-            else
-                query = NAMESPACES + NO_OPTIMIZE + query;
-            ResourceSet result = service.query(query);
-            Assert.assertEquals(message, expected, result.getSize());
-        } catch (XMLDBException e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
+    private void execute(String query, boolean optimize, String message, long expected) throws XMLDBException {
+        XQueryService service = (XQueryService) testCollection.getService("XQueryService", "1.0");
+        if (optimize) {
+            query = NAMESPACES + OPTIMIZE + query;
+        } else {
+            query = NAMESPACES + NO_OPTIMIZE + query;
         }
+        ResourceSet result = service.query(query);
+        assertEquals(message, expected, result.getSize());
     }
-    
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(propertiesBuilder()
+            .put(FunctionFactory.PROPERTY_DISABLE_DEPRECATED_FUNCTIONS, Boolean.FALSE).build());    //Since we use the deprecated text:match-all() function, we have to be sure is is enabled
+
     @BeforeClass
-    public static void initDatabase() {
-		try {
-			//Since we use the deprecated text:match-all() function, we have to be sure is is enabled
-            Configuration config = new Configuration();
-            config.setProperty(FunctionFactory.PROPERTY_DISABLE_DEPRECATED_FUNCTIONS, new Boolean(false));
-            BrokerPool.configure(1, 5, config); 
-            
-			// initialize driver
-			Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
-			Database database = (Database) cl.newInstance();
-			database.setProperty("create-database", "true");
-			DatabaseManager.registerDatabase(database);
+    public static void initDatabase() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException, IOException {
+        // initialize driver
+        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
+        Database database = (Database) cl.newInstance();
+        database.setProperty("create-database", "true");
+        DatabaseManager.registerDatabase(database);
 
-			Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
-			CollectionManagementService service =
-				(CollectionManagementService) root.getService("CollectionManagementService", "1.0");
-			testCollection = service.createCollection("test");
-			Assert.assertNotNull(testCollection);
+        Collection root = DatabaseManager.getCollection(XmldbURI.LOCAL_DB, "admin", "");
+        CollectionManagementService service =
+                (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        testCollection = service.createCollection("test");
+        Assert.assertNotNull(testCollection);
 
-            IndexQueryService idxConf = (IndexQueryService) testCollection.getService("IndexQueryService", "1.0");
-            idxConf.configureCollection(COLLECTION_CONFIG);
-            
-            XMLResource resource = (XMLResource) testCollection.createResource("test.xml", "XMLResource");
-            resource.setContent(XML);
-            testCollection.storeResource(resource);
+        IndexQueryService idxConf = (IndexQueryService) testCollection.getService("IndexQueryService", "1.0");
+        idxConf.configureCollection(COLLECTION_CONFIG);
 
-            String existHome = System.getProperty("exist.home");
-            Path existDir = existHome == null ? Paths.get(".") : Paths.get(existHome);
-            existDir = existDir.normalize();
-            Path dir = existDir.resolve("samples/shakespeare");
-            if (!Files.isReadable(dir)) {
-                throw new IOException("Unable to read samples directory");
-            }
-            final List<Path> files = FileUtils.list(dir, XMLFilenameFilter.asPredicate());
-            for (Path file : files) {
-                resource = (XMLResource) testCollection.createResource(FileUtils.fileName(file), XMLResource.RESOURCE_TYPE);
-                resource.setContent(file);
-                testCollection.storeResource(resource);
-            }
-        } catch (Exception e) {
-			e.printStackTrace();
-            Assert.fail(e.getMessage());
+        XMLResource resource = (XMLResource) testCollection.createResource("test.xml", "XMLResource");
+        resource.setContent(XML);
+        testCollection.storeResource(resource);
+
+        String existHome = System.getProperty("exist.home");
+        Path existDir = existHome == null ? Paths.get(".") : Paths.get(existHome);
+        existDir = existDir.normalize();
+        Path dir = existDir.resolve("samples/shakespeare");
+        if (!Files.isReadable(dir)) {
+            throw new IOException("Unable to read samples directory");
         }
-	}
+        final List<Path> files = FileUtils.list(dir, XMLFilenameFilter.asPredicate());
+        for (Path file : files) {
+            resource = (XMLResource) testCollection.createResource(FileUtils.fileName(file), XMLResource.RESOURCE_TYPE);
+            resource.setContent(file);
+            testCollection.storeResource(resource);
+        }
+    }
 
     @AfterClass
-    public static void shutdownDB() {
-        try {
-            TestUtils.cleanupDB();
-            DatabaseInstanceManager dim =
-                (DatabaseInstanceManager) testCollection.getService(
-                    "DatabaseInstanceManager", "1.0");
-            dim.shutdown();
-        } catch (XMLDBException e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-        }
-        testCollection = null;
+    public static void cleanupDb() {
+        TestUtils.cleanupDB();
 	}
 }

--- a/test/src/org/exist/xquery/XQueryUpdateTest.java
+++ b/test/src/org/exist/xquery/XQueryUpdateTest.java
@@ -1,13 +1,12 @@
 package org.exist.xquery;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.IndexInfo;
+import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -15,19 +14,17 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
-import org.exist.util.Configuration;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 import org.xml.sax.SAXException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class XQueryUpdateTest {
 
@@ -42,10 +39,9 @@ public class XQueryUpdateTest {
 
     protected final static int ITEMS_TO_APPEND = 1000;
 
-    private BrokerPool pool;
-
     @Test
     public void append() throws EXistException, PermissionDeniedException, XPathException, SAXException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             XQuery xquery = pool.getXQueryService();
@@ -84,6 +80,7 @@ public class XQueryUpdateTest {
 
         append();
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             XQuery xquery = pool.getXQueryService();
@@ -125,6 +122,7 @@ public class XQueryUpdateTest {
 
     @Test
     public void insertBefore() throws EXistException, PermissionDeniedException, XPathException, SAXException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             String query =
@@ -171,6 +169,7 @@ public class XQueryUpdateTest {
 
     @Test
     public void insertAfter() throws EXistException, PermissionDeniedException, XPathException, SAXException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             String query =
@@ -220,6 +219,7 @@ public class XQueryUpdateTest {
 
         append();
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             XQuery xquery = pool.getXQueryService();
@@ -296,6 +296,7 @@ public class XQueryUpdateTest {
 
         append();
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             XQuery xquery = pool.getXQueryService();
 
@@ -315,6 +316,7 @@ public class XQueryUpdateTest {
 
         append();
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             XQuery xquery = pool.getXQueryService();
@@ -343,6 +345,7 @@ public class XQueryUpdateTest {
 
         append();
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             XQuery xquery = pool.getXQueryService();
@@ -375,6 +378,7 @@ public class XQueryUpdateTest {
 
     @Test
     public void attrUpdate() throws EXistException, LockException, SAXException, PermissionDeniedException, IOException, XPathException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             store(broker, "test.xml", UPDATE_XML);
 
@@ -394,6 +398,7 @@ public class XQueryUpdateTest {
 
     @Test
     public void appendCDATA() throws EXistException, PermissionDeniedException, XPathException, SAXException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             XQuery xquery = pool.getXQueryService();
@@ -424,6 +429,7 @@ public class XQueryUpdateTest {
     @Ignore
     @Test
     public void insertAttribDoc_1730726() throws EXistException, PermissionDeniedException, XPathException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             String query =
                 "declare namespace xmldb = \"http://exist-db.org/xquery/xmldb\"; "+
@@ -438,16 +444,36 @@ public class XQueryUpdateTest {
         }
     }
 
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
     @Before
-    public void setUp() throws EXistException, DatabaseConfigurationException, LockException, SAXException, PermissionDeniedException, IOException {
-        this.pool = startDB();
+    public void loadTestData() throws EXistException, DatabaseConfigurationException, LockException, SAXException, PermissionDeniedException, IOException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             store(broker, "test.xml", TEST_XML);
         }
     }
 
+    @After
+    public void removeTestData() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager transact = pool.getTransactionManager();
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+                final Txn transaction = transact.beginTransaction()) {
+
+            final Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
+            assertNotNull(root);
+            broker.removeCollection(transaction, root);
+
+            transact.commit(transaction);
+        }
+    }
+
+
     private void store(DBBroker broker, String docName, String data) throws PermissionDeniedException, EXistException, SAXException, LockException, IOException {
         Collection root;
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager mgr = pool.getTransactionManager();
         try (final Txn transaction = mgr.beginTransaction()) {
 
@@ -462,20 +488,5 @@ public class XQueryUpdateTest {
         }
         DocumentImpl doc = root.getDocument(broker, XmldbURI.create(docName));
         broker.getSerializer().serialize(doc);
-    }
-
-    protected BrokerPool startDB() throws DatabaseConfigurationException, EXistException {
-        final String file = "conf.xml";
-        final Optional<Path> home = Optional.ofNullable(System.getProperty("exist.home", System.getProperty("user.dir"))).map(Paths::get);
-
-        final Configuration config = new Configuration(file, home);
-        BrokerPool.configure(1, 5, config);
-        return BrokerPool.getInstance();
-    }
-
-    @After
-    public void tearDown() {
-        pool = null;
-        BrokerPool.stopAll(false);
     }
 }

--- a/test/src/org/exist/xquery/value/ValueSequenceTest.java
+++ b/test/src/org/exist/xquery/value/ValueSequenceTest.java
@@ -11,15 +11,10 @@ import org.exist.security.*;
 import org.exist.security.SecurityManager;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
+import org.exist.test.ExistEmbeddedServer;
 import org.exist.xmldb.XmldbURI;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 
 /**
@@ -28,7 +23,8 @@ import java.util.Optional;
  */
 public class ValueSequenceTest {
 
-    private static BrokerPool pool;
+    @ClassRule
+    public final static ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
 
     @Test
     public void sortInDocumentOrder() throws EXistException, PermissionDeniedException, AuthenticationException {
@@ -45,6 +41,7 @@ public class ValueSequenceTest {
             memtree.endElement();
         memtree.endDocument();
 
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final Subject admin = pool.getSecurityManager().authenticate("admin", "");
         try(final DBBroker broker = pool.get(Optional.of(admin))) {
 
@@ -63,20 +60,5 @@ public class ValueSequenceTest {
             //call sort
             seq.sortInDocumentOrder();
         }
-    }
-
-    @BeforeClass
-    public static void startDb() throws EXistException, DatabaseConfigurationException {
-        final String conf = "conf.xml";
-        final Optional<Path> home = Optional.ofNullable(System.getProperty("exist.home", System.getProperty("user.dir"))).map(Paths::get);
-        final Configuration config = new Configuration(conf, home);
-        BrokerPool.configure(1, 5, config);
-        pool = BrokerPool.getInstance();
-    }
-
-    @AfterClass
-    public static void stopDb() {
-        pool = null;
-        BrokerPool.stopAll(false);
     }
 }

--- a/test/src/org/exist/xquery/xqts/QT3TS_case.java
+++ b/test/src/org/exist/xquery/xqts/QT3TS_case.java
@@ -31,6 +31,7 @@ import java.util.*;
 import junit.framework.Assert;
 
 import org.custommonkey.xmlunit.Diff;
+import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.w3c.tests.TestCase;
@@ -75,7 +76,8 @@ public class QT3TS_case extends TestCase {
     }
 
     private Sequence enviroment(String file) throws Exception {
-        try(final DBBroker broker = db.get(Optional.of(db.getSecurityManager().getSystemSubject()))) {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             final XQuery xquery = broker.getBrokerPool().getXQueryService();
 
             broker.getConfiguration().setProperty(XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, true);
@@ -87,10 +89,10 @@ public class QT3TS_case extends TestCase {
         }
     }
 
-    private HashMap<String, Sequence> enviroments(String file) {
-        HashMap<String, Sequence> enviroments = new HashMap<String, Sequence>();
-
-        try(final DBBroker broker = db.get(Optional.of(db.getSecurityManager().getSystemSubject()))) {
+    private Map<String, Sequence> enviroments(String file) {
+        final Map<String, Sequence> enviroments = new HashMap<>();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             XQuery xquery = broker.getBrokerPool().getXQueryService();
 
             broker.getConfiguration().setProperty(XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, true);
@@ -135,7 +137,8 @@ public class QT3TS_case extends TestCase {
     private String getEnviroment(String file, String name) {
         String enviroment = null;
 
-        try(final DBBroker broker = db.get(Optional.of(db.getSecurityManager().getSystemSubject()))) {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             XQuery xquery = broker.getBrokerPool().getXQueryService();
 
             broker.getConfiguration().setProperty(XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, true);
@@ -186,11 +189,12 @@ public class QT3TS_case extends TestCase {
         XQuery xquery = null;
 
         // try {
-        Set<String> extectedError = new HashSet<String>();
-        try(final DBBroker broker = db.get(Optional.of(db.getSecurityManager().getSystemSubject()))) {
+        Set<String> extectedError = new HashSet<>();
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
             xquery = broker.getBrokerPool().getXQueryService();
 
-            final XQueryContext context = new XQueryContext(db);
+            final XQueryContext context = new XQueryContext(pool);
 
             broker.getConfiguration().setProperty(XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, true);
 

--- a/test/src/org/exist/xquery/xqts/XQTS_case.java
+++ b/test/src/org/exist/xquery/xqts/XQTS_case.java
@@ -36,6 +36,7 @@ import org.exist.dom.persistent.ElementImpl;
 import org.exist.dom.NodeListImpl;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.source.FileSource;
+import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.util.FileUtils;
 import org.exist.w3c.tests.TestCase;
@@ -137,11 +138,12 @@ public class XQTS_case extends TestCase {
 
         XQuery xquery = null;
 
-        try(final DBBroker broker = db.get(Optional.of(db.getSecurityManager().getSystemSubject()))) {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
             broker.getConfiguration().setProperty( XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, true);
 
-            xquery = db.getXQueryService();
+            xquery = pool.getXQueryService();
 
             prepare(broker, xquery);
 


### PR DESCRIPTION
Further cleanup of the JUnit tests which directly use the Internal API of eXist. Should result in less code and some tests now only start the database once rather than multiple times which should speed up the test suite.