### PR TITLE
[feature] Config parameter to hide error messages from the XQueryServlet response

### DIFF
--- a/webapp/WEB-INF/web.xml.tmpl
+++ b/webapp/WEB-INF/web.xml.tmpl
@@ -174,6 +174,12 @@
             <param-name>encoding</param-name>
             <param-value>UTF-8</param-value>
         </init-param>
+
+        <init-param>
+            <param-name>hide-error-messages</param-name>
+            <param-value>false</param-value>
+        </init-param>
+
     </servlet>
 
     <!--


### PR DESCRIPTION
Detailed error messages from the XQueryServlet can be disabled by setting a parameter in `web.xml`:

```xml
    <init-param>
        <param-name>hide-error-messages</param-name>
        <param-value>false</param-value>
    </init-param>
```

This should be set in production to avoid an exploitable XSS vulnerability.