### PR TITLE
[bugfix] Lucene occasionally throws exception upon unclosed token stream

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/PlainTextHighlighter.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/PlainTextHighlighter.java
@@ -103,25 +103,24 @@ public class PlainTextHighlighter {
                                 }
                             }
                             if (stateList.size() == terms.length) {
-                            	if (offsets == null)
-                            		offsets = new ArrayList<>();
-                            	
-                                
-                                
+                                if (offsets == null)
+                                    offsets = new ArrayList<>();
+
+
                                 stream.restoreState(stateList.get(0));
                                 int start = stream.getAttribute(OffsetAttribute.class).startOffset();
                                 stream.restoreState(stateList.get(terms.length - 1));
-                            	int end = stream.getAttribute(OffsetAttribute.class).endOffset();
-                            	offsets.add(new Offset(start, end));
-                                
+                                int end = stream.getAttribute(OffsetAttribute.class).endOffset();
+                                offsets.add(new Offset(start, end));
+
                                 //restore state as before
-                                stream.restoreState(stateList.get(stateList.size() -1));
+                                stream.restoreState(stateList.get(stateList.size() - 1));
                             }
                         }
                     } else {
-                    	if (offsets == null)
-                    		offsets = new ArrayList<>();
-                        
+                        if (offsets == null)
+                            offsets = new ArrayList<>();
+
                         OffsetAttribute offsetAttr = stream.getAttribute(OffsetAttribute.class);
                         offsets.add(new Offset(offsetAttr.startOffset(), offsetAttr.endOffset()));
                     }
@@ -129,6 +128,8 @@ public class PlainTextHighlighter {
             }
         } catch (IOException e) {
         	e.printStackTrace();
+        } finally {
+            stream.close();
         }
         return offsets;
 	}


### PR DESCRIPTION
Just close it in finally and all is good. Exception:

```
Caused by: java.lang.IllegalStateException: TokenStream contract violation: close() call missing
	at org.apache.lucene.analysis.Tokenizer.setReader(Tokenizer.java:90)
	at org.apache.lucene.analysis.Analyzer$TokenStreamComponents.setReader(Analyzer.java:323)
	at org.apache.lucene.analysis.standard.StandardAnalyzer$1.setReader(StandardAnalyzer.java:133)
	at org.apache.lucene.analysis.Analyzer.tokenStream(Analyzer.java:147)
	at org.exist.indexing.lucene.PlainTextHighlighter.getOffsets(PlainTextHighlighter.java:68)
	at org.exist.indexing.lucene.LuceneIndexWorker$1.collect(LuceneIndexWorker.java:741)
```