### PR TITLE
[testsuite] range index tests: tear down was commented out

### DIFF
--- a/extensions/indexes/range/test/src/xquery/optimizer.xql
+++ b/extensions/indexes/range/test/src/xquery/optimizer.xql
@@ -149,12 +149,12 @@ function ot:setup() {
     xmldb:store($ot:COLLECTION, "diacritics.xml", $ot:DATA_SR_WITH_DIACRITICS)
 };
 
-(: declare
+declare
     %test:tearDown
 function ot:cleanup() {
     xmldb:remove($ot:COLLECTION),
     xmldb:remove("/db/system/config/db/" || $ot:COLLECTION_NAME)
-}; :)
+};
 
 declare
     %test:stats


### PR DESCRIPTION
 leading to followup errors in other tests. Closes #1201