### PR TITLE
Increase max memory default and cache size, small fixes

### DIFF
--- a/bin/client.bat
+++ b/bin/client.bat
@@ -47,7 +47,7 @@ echo home directory of eXist.
 goto :eof
 
 :gotExistHome
-set MX=1024
+set MX=2048
 rem @WINDOWS_INSTALLER_3@
 
 set JAVA_ENDORSED_DIRS="%EXIST_HOME%\lib\endorsed"

--- a/bin/functions.d/eXist-settings.sh
+++ b/bin/functions.d/eXist-settings.sh
@@ -76,7 +76,7 @@ restore_library_path() {
 
 set_client_java_options() {
     if [ -z "${CLIENT_JAVA_OPTIONS}" ]; then
-	CLIENT_JAVA_OPTIONS="-Xms128m -Xmx1024m -Dfile.encoding=UTF-8";
+	CLIENT_JAVA_OPTIONS="-Xms128m -Xmx2048m -Dfile.encoding=UTF-8";
     fi
 
     OS=`uname`
@@ -90,7 +90,7 @@ set_client_java_options() {
 
 set_java_options() {
     if [ -z "${JAVA_OPTIONS}" ]; then
-	JAVA_OPTIONS="-Xms128m -Xmx1024m -Dfile.encoding=UTF-8";
+	JAVA_OPTIONS="-Xms128m -Xmx2048m -Dfile.encoding=UTF-8";
     fi
     JAVA_OPTIONS="${JAVA_OPTIONS} -Djava.endorsed.dirs=${JAVA_ENDORSED_DIRS}";
 }

--- a/bin/run.bat
+++ b/bin/run.bat
@@ -50,7 +50,7 @@ echo home directory of eXist.
 goto :eof
 
 :gotExistHome
-set MX=768
+set MX=2048
 rem @WINDOWS_INSTALLER_3@
 
 set JAVA_ENDORSED_DIRS="%EXIST_HOME%\lib\endorsed"

--- a/bin/server.bat
+++ b/bin/server.bat
@@ -48,7 +48,7 @@ echo home directory of eXist.
 goto :eof
 
 :gotExistHome
-set MX=1024
+set MX=2048
 rem @WINDOWS_INSTALLER_3@
 
 set JAVA_ENDORSED_DIRS="%EXIST_HOME%\lib\endorsed"

--- a/bin/startup.bat
+++ b/bin/startup.bat
@@ -49,7 +49,7 @@ goto :eof
 
 :gotExistHome
 
-set MX=1024
+set MX=2048
 rem @WINDOWS_INSTALLER_3@
 
 set JAVA_ENDORSED_DIRS="%EXIST_HOME%\lib\endorsed"

--- a/build/scripts/build-impl.xml
+++ b/build/scripts/build-impl.xml
@@ -139,7 +139,7 @@
         <copy file="${basedir}/conf.xml.tmpl" tofile="${basedir}/conf.xml" filtering="true">
 			<filterset>
 				<filter token="dataDir" value="webapp/WEB-INF/data"/>
-                <filter token="cacheSize" value="128"/>
+                <filter token="cacheSize" value="256"/>
 			</filterset>
 		</copy>
         <copy file="${basedir}/conf.xml.tmpl" tofile="${basedir}/installer/conf.xml" filtering="true">

--- a/build/scripts/macosx.xml
+++ b/build/scripts/macosx.xml
@@ -176,7 +176,7 @@
         <copy file="${basedir}/conf.xml.tmpl" tofile="${app.exist}/conf.xml" filtering="true">
             <filterset>
                 <filter token="dataDir" value="webapp/WEB-INF/data"/>
-                <filter token="cacheSize" value="128"/>
+                <filter token="cacheSize" value="256"/>
             </filterset>
         </copy>
         <chmod perm="+x">

--- a/installer/UnixShortcutSpec.xml
+++ b/installer/UnixShortcutSpec.xml
@@ -3,7 +3,7 @@
 	<programGroup defaultName="eXist-db XML Database" location="applications"/>
 	
 	<shortcut 
-		name="org-exist-start-Main"
+		name="eXist-db Database"
 		genericName="eXist-db"
 		type="Application"
 		encoding="UTF-8"

--- a/installer/userInput.xml
+++ b/installer/userInput.xml
@@ -28,11 +28,11 @@
         <field type="space"/>
         <field type="text" variable="MAX_MEMORY">
           <description align="left" txt="Configure the maximum amount of memory to be used by eXist-db. The recommended minimum memory setting is 1024m. If your machine has enough memory, using 2048m should be sufficient for most data sets. Note: 1200m is usually the limit on 32-bit systems."/>
-          <spec txt="Maximum memory in mb:" size="5" set="2048"/>
+          <spec txt="Maximum memory in MB:" size="5" set="2048"/>
         </field>
         <field type="text" variable="cacheSize">
             <description align="left" txt="Configure the amount of memory to be reserved for internal caches. If the maximum memory is set above to 1024m, 128m is a good value; for 2048m, use 256m; for 512m, not more than 64mb. Too small settings may lead to bad upload/indexing performance."/>
-          <spec txt="Cache memory in mb:" size="5" set="256"/>
+          <spec txt="Cache memory in MB:" size="5" set="256"/>
         </field>
     </panel>
 </userInput>

--- a/installer/userInput.xml
+++ b/installer/userInput.xml
@@ -28,11 +28,11 @@
         <field type="space"/>
         <field type="text" variable="MAX_MEMORY">
           <description align="left" txt="Configure the maximum amount of memory to be used by eXist-db. The recommended minimum memory setting is 1024m. If your machine has enough memory, using 2048m should be sufficient for most data sets. Note: 1200m is usually the limit on 32-bit systems."/>
-          <spec txt="Maximum memory in mb:" size="5" set="1024"/>
+          <spec txt="Maximum memory in mb:" size="5" set="2048"/>
         </field>
         <field type="text" variable="cacheSize">
             <description align="left" txt="Configure the amount of memory to be reserved for internal caches. If the maximum memory is set above to 1024m, 128m is a good value; for 2048m, use 256m; for 512m, not more than 64mb. Too small settings may lead to bad upload/indexing performance."/>
-          <spec txt="Cache memory in mb:" size="5" set="128"/>
+          <spec txt="Cache memory in mb:" size="5" set="256"/>
         </field>
     </panel>
 </userInput>

--- a/src/org/exist/launcher/vm.properties
+++ b/src/org/exist/launcher/vm.properties
@@ -4,7 +4,7 @@
 
 # Minimum and maximum memory
 memory.min=256
-memory.max=1024
+memory.max=2048
 
 vmoptions=-Dfile.encoding=UTF-8
 

--- a/tools/yajsw/src/org/exist/yajsw/Main.java
+++ b/tools/yajsw/src/org/exist/yajsw/Main.java
@@ -11,7 +11,7 @@ import java.util.Observer;
 /**
  *
  */
-public class Main implements Observer {
+public class Main implements Observer, Comparable {
 
     public static final int WAIT_HINT_UPDATE = 10000;
 
@@ -63,5 +63,10 @@ public class Main implements Observer {
     public static void main(String[] args) {
         final Main main = new Main();
         main.start(args);
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        return o == this ? 0 : -1;
     }
 }

--- a/vm.properties
+++ b/vm.properties
@@ -3,7 +3,7 @@
 # "java -jar start.jar" without parameters on the shell).
 
 # Minimum and maximum memory
-memory.max=1024
+memory.max=2048
 memory.min=64
 
 # General vm options


### PR DESCRIPTION
Increase the default used by the installer for Java max memory from 1024m to 2048m. Most computers today should have >4gb main memory. Giving just 1gb to eXist easily results in out of memory issues and crashes.

Also fix a ClassCastException popping up during startup/shutdown.