### PR TITLE
include required jars for contentextraction module in WAR build

### DIFF
--- a/build/scripts/dist.xml
+++ b/build/scripts/dist.xml
@@ -127,6 +127,11 @@
               <include name="*.jar"/>
             </lib>
 
+            <!-- Include content extraction jars -->
+            <lib dir="extensions/contentextraction/lib">
+              <include name="*.jar"/>
+            </lib>
+
             <!-- Add configuration files to WEB-INF -->
             <webinf dir=".">
                 <include name="client.properties"/>


### PR DESCRIPTION
This should fix https://github.com/eXist-db/exist/issues/1215