### PR TITLE
Resolving XQuery modules or loading documents from disk fails

### DIFF
--- a/src/org/exist/source/SourceFactory.java
+++ b/src/org/exist/source/SourceFactory.java
@@ -2,21 +2,21 @@
  *  eXist Open Source Native XML Database
  *  Copyright (C) 2001-04 The eXist Project
  *  http://exist-db.org
- *  
+ *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
  *  as published by the Free Software Foundation; either version 2
  *  of the License, or (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU Lesser General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
+ *
  *  $Id$
  */
 package org.exist.source;
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -80,76 +81,105 @@ public class SourceFactory {
         else if (location.startsWith("file:") || !location.contains(":")) {
             location = location.replaceAll("^(file:)?/*(.*)$", "$2");
 
-            final Path p = Paths.get(contextPath, location);
-            if (Files.isReadable(p)) {
-                location = p.toUri().toASCIIString();
-                source = new FileSource(p, checkXQEncoding);
-            }
-
-            final Path p2 = Paths.get(location);
-            if (Files.isReadable(p2)) {
-                location = p2.toUri().toASCIIString();
-                source = new FileSource(p2, checkXQEncoding);
-            }
-
-            final Path p3 = Paths.get(contextPath).toAbsolutePath().resolve(location);
-            if (Files.isReadable(p3)) {
-                location = p3.toUri().toASCIIString();
-                source = new FileSource(p3, checkXQEncoding);
-            }
-
-            /*
-             * Try to load as an absolute path
-             */
-            final Path p4 = Paths.get("/" + location);
-            if (Files.isReadable(p4)) {
-                location = p4.toUri().toASCIIString();
-                source = new FileSource(p4, checkXQEncoding);
-            }
-
-            /*
-             * Try to load from the folder of the contextPath
-             */
-
-            final Path p5 = Paths.get(contextPath).resolveSibling(location);
-            if (Files.isReadable(p5)) {
-                location = p5.toUri().toASCIIString();
-                source = new FileSource(p5, checkXQEncoding);
-            }
-
-            /*
-             * Try to load from the folder of the contextPath URL
-             */
-            final Path p6 = Paths.get(contextPath.replaceFirst("^file:/*(/.*)$", "$1")).resolveSibling(location);
-            if (Files.isReadable(p6)) {
-                location = p6.toUri().toASCIIString();
-                source = new FileSource(p6, checkXQEncoding);
-            }
-
-            /*
-             * Lastly we try to load it using EXIST_HOME as the reference point
-             */
-            Path p7 = null;
             try {
-                p7 = FileUtils.resolve(BrokerPool.getInstance().getConfiguration().getExistHome(), location);
-                if (Files.isReadable(p7)) {
-                    location = p7.toUri().toASCIIString();
-                    source = new FileSource(p7, checkXQEncoding);
+                final Path p = Paths.get(contextPath, location);
+                if (Files.isReadable(p)) {
+                    location = p.toUri().toASCIIString();
+                    source = new FileSource(p, checkXQEncoding);
                 }
-            } catch (final EXistException e) {
-                LOG.warn(e);
+            } catch (InvalidPathException e) {
+                // continue trying
             }
 
             if (source == null) {
-                throw new FileNotFoundException(
-                        "cannot read module source from file at " + location
-                                + ". \nTried " + p.toAbsolutePath() + "\n"
-                                + " and " + p2.toAbsolutePath() + "\n"
-                                + " and " + p3.toAbsolutePath() + "\n"
-                                + " and " + p4.toAbsolutePath() + "\n"
-                                + " and " + p5.toAbsolutePath() + "\n"
-                                + " and " + p6.toAbsolutePath() + "\n"
-                                + " and " + p7.toAbsolutePath());
+                try {
+                    final Path p2 = Paths.get(location);
+                    if (Files.isReadable(p2)) {
+                        location = p2.toUri().toASCIIString();
+                        source = new FileSource(p2, checkXQEncoding);
+                    }
+                } catch (InvalidPathException e) {
+                    // continue trying
+                }
+            }
+
+            if (source == null) {
+                try {
+                    final Path p3 = Paths.get(contextPath).toAbsolutePath().resolve(location);
+                    if (Files.isReadable(p3)) {
+                        location = p3.toUri().toASCIIString();
+                        source = new FileSource(p3, checkXQEncoding);
+                    }
+                } catch (InvalidPathException e) {
+                    // continue trying
+                }
+            }
+
+            if (source == null) {
+                /*
+                 * Try to load as an absolute path
+                 */
+                try {
+                    final Path p4 = Paths.get("/" + location);
+                    if (Files.isReadable(p4)) {
+                        location = p4.toUri().toASCIIString();
+                        source = new FileSource(p4, checkXQEncoding);
+                    }
+                } catch (InvalidPathException e) {
+                    // continue trying
+                }
+            }
+
+            if (source == null) {
+                /*
+                 * Try to load from the folder of the contextPath
+                 */
+                try {
+                    final Path p5 = Paths.get(contextPath).resolveSibling(location);
+                    if (Files.isReadable(p5)) {
+                        location = p5.toUri().toASCIIString();
+                        source = new FileSource(p5, checkXQEncoding);
+                    }
+                } catch (InvalidPathException e) {
+                    // continue trying
+                }
+            }
+
+            if (source == null) {
+                /*
+                 * Try to load from the folder of the contextPath URL
+                 */
+                try {
+                    final Path p6 = Paths.get(contextPath.replaceFirst("^file:/*(/.*)$", "$1")).resolveSibling(location);
+                    if (Files.isReadable(p6)) {
+                        location = p6.toUri().toASCIIString();
+                        source = new FileSource(p6, checkXQEncoding);
+                    }
+                } catch (InvalidPathException e) {
+                    // continue trying
+                }
+            }
+
+            if (source == null) {
+                /*
+                 * Lastly we try to load it using EXIST_HOME as the reference point
+                 */
+                Path p7 = null;
+                try {
+                    p7 = FileUtils.resolve(BrokerPool.getInstance().getConfiguration().getExistHome(), location);
+                    if (Files.isReadable(p7)) {
+                        location = p7.toUri().toASCIIString();
+                        source = new FileSource(p7, checkXQEncoding);
+                    }
+                } catch (final EXistException e) {
+                    LOG.warn(e);
+                } catch (InvalidPathException e) {
+                    // continue and abort below
+                }
+            }
+
+            if (source == null) {
+                throw new FileNotFoundException("cannot read module source from file at " + location + ". \n");
             }
         }
         


### PR DESCRIPTION
InvalidPathException is thrown while probing locations in SourceFactory. Issue only pops up when running tests on windows.

Closes #1217 and #1041