### PR TITLE
Fix variable declaration

### DIFF
--- a/src/org/exist/storage/ProcessMonitor.java
+++ b/src/org/exist/storage/ProcessMonitor.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.http.servlets.RequestWrapper;
 import org.exist.http.urlrewrite.XQueryURLRewrite;
+import org.exist.source.Source;
 import org.exist.util.Configuration;
 import org.exist.xquery.Variable;
 import org.exist.xquery.XPathException;
@@ -162,7 +163,8 @@ public class ProcessMonitor implements BrokerPoolService {
         final long elapsed = System.currentTimeMillis() - watchdog.getStartTime();
         if (found && elapsed > minTime) {
             synchronized (history) {
-                final String sourceKey = watchdog.getContext().getSource().path();
+                final Source source = watchdog.getContext().getSource();
+                final String sourceKey = source == null ? "unknown" : source.path();
                 QueryHistory qh = new QueryHistory(sourceKey, historyTimespan);
                 qh.setMostRecentExecutionTime(watchdog.getStartTime());
                 qh.setMostRecentExecutionDuration(elapsed);

--- a/src/org/exist/xquery/PathExpr.java
+++ b/src/org/exist/xquery/PathExpr.java
@@ -277,16 +277,18 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                 }
                 //TOUNDERSTAND : why did I have to write this test :-) ? -pb
                 //it looks like an empty sequence could be considered as a sub-type of Type.NODE
-                //well, no so stupid I think...    
-                if (steps.size() > 1 && !(result instanceof VirtualNodeSet) &&
-                        !(expr instanceof EnclosedExpr) && !result.isEmpty() &&
-                        !Type.subTypeOf(result.getItemType(), Type.NODE)) {
-                    gotAtomicResult = true;
-                }
-                if (steps.size() > 1 && getLastExpression() instanceof Step) {
-                    // remove duplicate nodes if this is a path
-                    // expression with more than one step
-                    result.removeDuplicates();
+                //well, no so stupid I think...
+                if (result != null) {
+                    if (steps.size() > 1 && !(result instanceof VirtualNodeSet) &&
+                            !(expr instanceof EnclosedExpr) && !result.isEmpty() &&
+                            !Type.subTypeOf(result.getItemType(), Type.NODE)) {
+                        gotAtomicResult = true;
+                    }
+                    if (steps.size() > 1 && getLastExpression() instanceof Step) {
+                        // remove duplicate nodes if this is a path
+                        // expression with more than one step
+                        result.removeDuplicates();
+                    }
                 }
                 if (!staticContext) {
                     currentContext = result;
@@ -300,7 +302,7 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                 allowMixedNodesInReturn = expr.allowMixedNodesInReturn();
             }
 
-            if (gotAtomicResult && !allowMixedNodesInReturn &&
+            if (gotAtomicResult && result != null && !allowMixedNodesInReturn &&
                     !Type.subTypeOf(result.getItemType(), Type.ATOMIC)) {
                 throw new XPathException(this, ErrorCodes.XPTY0018,
                         "Cannot mix nodes and atomic values in the result of a path expression.");

--- a/src/org/exist/xquery/VariableDeclaration.java
+++ b/src/org/exist/xquery/VariableDeclaration.java
@@ -141,7 +141,7 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
             context.popInScopeNamespaces();
         }
 
-        return Sequence.EMPTY_SEQUENCE;
+        return null;
 	}
 	
 	/* (non-Javadoc)

--- a/test/src/xquery/axes.xql
+++ b/test/src/xquery/axes.xql
@@ -72,3 +72,26 @@ function axes:descendant-axis-except-nested2() {
     return
         ($node//div except $node//div//div)/head
 };
+
+declare
+%test:assertError("err:XPDY0002")
+%test:name("expect error because variable declaration should not change context sequence")
+function axes:context-self() {
+util:eval("
+        declare variable $foo := 123;
+
+        .
+    ")
+};
+
+declare
+%test:assertError("err:XPDY0002")
+%test:name("expect error because preceding let should not change context sequence")
+function axes:context-let-self() {
+util:eval("
+        let $a := 123
+        let $b := .
+        return
+            $b
+    ")
+};


### PR DESCRIPTION
A variable declaration should not return a context sequence, not even an empty one or followup expressions may start from a wrong context.

Closes #1114.