### PR TITLE
[feature] conditional range index configs based on an attribute value

### DIFF
--- a/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
@@ -36,13 +36,26 @@ import java.util.*;
 
 public class ComplexRangeIndexConfigElement extends RangeIndexConfigElement {
 
+    public static final Comparator<ComplexRangeIndexConfigElement> NUM_CONDITIONS_COMPARATOR =
+            Comparator.comparingInt(ComplexRangeIndexConfigElement::getNumberOfConditions).reversed();
+
+
     public final static String FIELD_ELEMENT = "field";
+    public final static String CONDITION_ELEMENT = "condition";
 
     private static final Logger LOG = LogManager.getLogger(ComplexRangeIndexConfigElement.class);
 
     private Map<String, RangeIndexConfigField> fields = new HashMap<String, RangeIndexConfigField>();
 
-    public ComplexRangeIndexConfigElement(Element node, NodeList children, Map<String, String> namespaces)
+
+    protected ArrayList<RangeIndexConfigCondition> conditions = new ArrayList<RangeIndexConfigCondition>();
+    public ArrayList<RangeIndexConfigCondition> getConditions() {
+        return conditions;
+    }
+    public int getNumberOfConditions() { return conditions.size(); }
+
+
+    public ComplexRangeIndexConfigElement(final Element node, final NodeList children, final Map<String, String> namespaces)
             throws DatabaseConfigurationException {
         super(node, namespaces);
 
@@ -52,6 +65,8 @@ public class ComplexRangeIndexConfigElement extends RangeIndexConfigElement {
                 if (FIELD_ELEMENT.equals(child.getLocalName())) {
                     RangeIndexConfigField field = new RangeIndexConfigField(path, (Element) child, namespaces);
                     fields.put(field.getName(), field);
+                } else if (CONDITION_ELEMENT.equals(child.getLocalName())){
+                    conditions.add(new RangeIndexConfigCondition((Element) child, path));
                 } else if (FILTER_ELEMENT.equals(child.getLocalName())) {
                     analyzer.addFilter((Element) child);
                 } else {
@@ -137,4 +152,23 @@ public class ComplexRangeIndexConfigElement extends RangeIndexConfigElement {
         }
         return null;
     }
+
+    public boolean matchConditions(Node node) {
+        for (RangeIndexConfigCondition condition : conditions) {
+            if (!condition.matches(node))
+                return false;
+        }
+
+        return true;
+    }
+
+    public boolean findCondition(QName lhe, String rhe, RangeIndex.Operator operator) {
+        for (RangeIndexConfigCondition condition : conditions) {
+            if (condition.find(lhe, rhe, operator))
+                return true;
+        }
+
+        return false;
+    }
+
 }

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigCondition.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigCondition.java
@@ -1,0 +1,99 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2013 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *  $Id$
+ */
+package org.exist.indexing.range;
+
+import org.exist.dom.QName;
+import org.exist.storage.ElementValue;
+import org.exist.storage.NodePath;
+import org.exist.util.DatabaseConfigurationException;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import javax.xml.XMLConstants;
+
+/**
+ *
+ * A condition that can be defined for complex range config elements.
+ * As of now, limited to attribute equality.
+ *
+ * @author Marcel Schaeben
+ */
+public class RangeIndexConfigCondition {
+
+    public String getValue() {
+        return value;
+    }
+    public QName getAttribute() {
+        return attribute;
+    }
+    public RangeIndex.Operator getOperator() { return operator; }
+
+    private final String attributeString;
+    private final QName attribute;
+    private final String value;
+    private final RangeIndex.Operator operator;
+
+    public RangeIndexConfigCondition(Element elem, NodePath parentPath) throws DatabaseConfigurationException {
+
+        this.operator = RangeIndex.Operator.EQ;
+
+        this.attributeString = elem.getAttribute("attribute");
+        if (parentPath.getLastComponent().getNameType() == ElementValue.ATTRIBUTE) {
+            throw new DatabaseConfigurationException("Range index module: Attribute condition cannot be defined for an attribute:" + parentPath.toString());
+        }
+        if (this.attributeString == null || this.attributeString.length() == 0) {
+            throw new DatabaseConfigurationException("Range index module: Empty or no attribute qname in condition");
+        } else {
+            this.attribute = new QName(QName.extractLocalName(this.attributeString), XMLConstants.NULL_NS_URI, QName.extractPrefix(this.attributeString), ElementValue.ATTRIBUTE);
+            this.value = elem.getAttribute("value");
+        }
+
+    }
+
+    /**
+     * Test if a node matches this condition. Used by the indexer.
+     * @param node The node to test.
+     * @return true if the node is an element node and an attribute matches this condition.
+     */
+    public boolean matches(Node node) {
+        if (node.getNodeType() == Node.ELEMENT_NODE && ((Element)node).getAttribute(attributeString).equals(value)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Test if an expression defined by the arguments matches this condition. Used by the query rewriter.
+     * @param lhe The QName of the attribute to test
+     * @param rhe The expected value of the attribute
+     * @param operator The operator of the comparison expression (defaults to equals for now)
+     * @return
+     */
+    public boolean find(QName lhe, String rhe, RangeIndex.Operator operator) {
+        if (operator.equals(this.operator) && lhe.equals(this.attribute) && rhe.equals(value)) {
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexWorker.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexWorker.java
@@ -874,9 +874,13 @@ public class RangeIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                     } else {
                         while (configIter.hasNext()) {
                             RangeIndexConfigElement configuration = configIter.next();
-                            if (configuration.match(path)) {
+                            boolean match = configuration.match(path);
+                            if (match) {
                                 TextCollector collector = contentStack.pop();
-                                indexText(element, element.getQName(), path, configuration, collector);
+                                match = collector instanceof ComplexTextCollector
+                                        ? match && ((ComplexTextCollector)collector).getConfig().matchConditions(element)
+                                        : match;
+                                if (match) indexText(element, element.getQName(), path, configuration, collector);
                             }
                         }
                     }

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/OptimizeFieldPragma.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/OptimizeFieldPragma.java
@@ -23,19 +23,15 @@ package org.exist.xquery.modules.range;
 
 import org.exist.Namespaces;
 import org.exist.collections.Collection;
-import org.exist.dom.persistent.NodeSet;
 import org.exist.dom.QName;
 import org.exist.indexing.range.*;
 import org.exist.storage.IndexSpec;
 import org.exist.storage.NodePath;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
-import org.exist.xquery.pragmas.*;
 import org.exist.xquery.value.*;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * A pragma which checks if an XPath expression could be replaced with a range field lookup.
@@ -97,15 +93,18 @@ public class OptimizeFieldPragma extends Pragma {
     private Expression tryRewriteToFields(LocationStep locationStep, List<Predicate> preds, NodePath contextPath, Sequence contextSequence) throws XPathException {
         // without context path, we cannot rewrite the entire query
         if (contextPath != null) {
-            List<Expression> args = null;
-            SequenceConstructor arg0 = null;
-            SequenceConstructor arg1 = null;
-
             List<Predicate> notOptimizable = new ArrayList<Predicate>(preds.size());
             List<RangeIndexConfig> configs = getConfigurations(contextSequence);
             // walk through the predicates attached to the current location step
             // check if expression can be optimized
+
+            final Map<Predicate, List<Expression>> predicateArgs = new IdentityHashMap<Predicate, List<Expression>>(preds.size());
+
             for (final Predicate pred : preds) {
+                List<Expression> args = null;
+                SequenceConstructor arg0 = null;
+                SequenceConstructor arg1 = null;
+
                 if (pred.getLength() != 1) {
                     // can only optimize predicates with one expression
                     notOptimizable.add(pred);
@@ -127,12 +126,78 @@ public class OptimizeFieldPragma extends Pragma {
                 path.append(innerPath);
 
                 if (path.length() > 0) {
-                    // find a range index configuration matching the full path to the predicate expression
-                    RangeIndexConfigElement rice = findConfiguration(path, true, configs);
+                    // find all complex range index configurations matching the full path to the predicate expression
+                    final List<ComplexRangeIndexConfigElement> rices = findConfigurations(path, configs);
+
+                    // config with most conditions for path comes first
+                    rices.sort(ComplexRangeIndexConfigElement.NUM_CONDITIONS_COMPARATOR);
+
+                    if (rices.isEmpty()) {
+                        notOptimizable.add(pred);
+                        continue;
+                    }
+
                     // found index configuration with sub-fields
-                    if (rice != null && rice.isComplex() && rice.getNodePath().match(contextPath) && findConfiguration(path, false, configs) == null) {
+
+                    ComplexRangeIndexConfigElement rice = null;
+                    final List<Predicate> precedingPreds = preds.subList(0, preds.indexOf(pred));
+                    final ArrayList<Predicate> matchedPreds = new ArrayList<Predicate>();
+
+                    for (ComplexRangeIndexConfigElement testRice : rices) {
+
+                        if (testRice.getNumberOfConditions() > 0) {
+                            // find a config element where the conditions match preceding predicates
+
+                            matchedPreds.clear();
+
+                            for (Predicate precedingPred : precedingPreds ) {
+                                Expression inner = precedingPred.getExpression(0);
+                                if (inner instanceof InternalFunctionCall) {
+                                    Function function = ((InternalFunctionCall)inner).getFunction();
+                                    if (function instanceof Lookup) {
+                                        inner = ((Lookup)function).getFallback();
+                                    }
+                                }
+
+                                if (inner instanceof GeneralComparison) {
+                                    final GeneralComparison comparison = (GeneralComparison) inner;
+
+                                    final Expression lhe = comparison.getLeft();
+                                    final Expression rhe = comparison.getRight();
+                                    if (lhe instanceof LocationStep && rhe instanceof LiteralValue) {
+                                        final QName lh = ((LocationStep)lhe).getTest().getName();
+                                        final String rh = ((LiteralValue) rhe).getValue().toString();
+                                        final RangeIndex.Operator operator = RangeQueryRewriter.getOperator(inner);
+
+                                        if (lh != null && testRice.findCondition(lh, rh, operator)) {
+                                            matchedPreds.add(precedingPred);
+                                        }
+                                    }
+                                }
+
+                            }
+
+                            if (matchedPreds.size() == testRice.getNumberOfConditions()) {
+                                // all conditions matched
+                                rice = testRice;
+                                // if any preceding predicates found to be part of a condition for this config
+                                // had been matched to another config before, remove them as is is the correct match
+                                predicateArgs.keySet().removeAll(matchedPreds);
+                                // also do not re-add them after optimizing
+                                notOptimizable.removeAll(matchedPreds);
+
+                                break;
+                            }
+
+                        } else {
+                            // no conditional configs for this node path, take the first one found if any
+                            rice = testRice;
+                        }
+                    }
+
+                    if (rice != null && rice.getNodePath().match(contextPath)) {
                         // check for a matching sub-path and retrieve field information
-                        RangeIndexConfigField field = ((ComplexRangeIndexConfigElement) rice).getField(path);
+                        RangeIndexConfigField field = rice.getField(path);
                         if (field != null) {
                             if (args == null) {
                                 // initialize args
@@ -148,6 +213,11 @@ public class OptimizeFieldPragma extends Pragma {
                             arg1.add(new LiteralValue(context, new StringValue(RangeQueryRewriter.getOperator(innerExpr).toString())));
                             // append right hand expression as additional parameter
                             args.add(getKeyArg(innerExpr));
+
+                            // store the collected arguments with a reference to the predicate
+                            // so they can be removed if a better match is found (if the predicate happens to be
+                            // one of the conditions for the following predicate
+                            predicateArgs.put(pred, args);
                         } else {
                             notOptimizable.add(pred);
                             continue;
@@ -156,18 +226,37 @@ public class OptimizeFieldPragma extends Pragma {
                         notOptimizable.add(pred);
                         continue;
                     }
+
                 } else {
                     notOptimizable.add(pred);
                     continue;
                 }
             }
-            if (args != null) {
+
+            if (!predicateArgs.isEmpty()) {
+
                 // the entire filter expression can be replaced
                 // create range:field-equals function
                 FieldLookup func = new FieldLookup(context, FieldLookup.signatures[0]);
                 func.setFallback(locationStep);
                 func.setLocation(locationStep.getLine(), locationStep.getColumn());
-                func.setArguments(args);
+
+                if (predicateArgs.size() == 1) {
+                    func.setArguments(predicateArgs.entrySet().iterator().next().getValue());
+                } else {
+                    final List<Expression> mergedArgs = new ArrayList<Expression>(predicateArgs.size() * 4);
+                    final SequenceConstructor arg0 = new SequenceConstructor(context);
+                    mergedArgs.add(arg0);
+                    final SequenceConstructor arg1 = new SequenceConstructor(context);
+                    mergedArgs.add(arg1);
+                    for (final List<Expression> args : predicateArgs.values()) {
+                        arg0.add(args.get(0));
+                        arg1.add(args.get(1));
+                        mergedArgs.addAll(args.subList(2, args.size()));
+                    }
+
+                    func.setArguments(mergedArgs);
+                }
 
                 Expression optimizedExpr = new InternalFunctionCall(func);
                 if (notOptimizable.size() > 0) {
@@ -197,18 +286,21 @@ public class OptimizeFieldPragma extends Pragma {
         return null;
     }
 
+
     /**
-     * Scan all index configurations to find one matching path.
+     * Find all complex configurations matching the path
      */
-    private RangeIndexConfigElement findConfiguration(NodePath path, boolean complex, List<RangeIndexConfig> configs) {
+    private List<ComplexRangeIndexConfigElement> findConfigurations(NodePath path, List<RangeIndexConfig> configs) {
+        ArrayList<ComplexRangeIndexConfigElement> rices = new ArrayList<ComplexRangeIndexConfigElement>();
+
         for (RangeIndexConfig config : configs) {
-            final RangeIndexConfigElement rice = config.find(path);
-            if (rice != null && ((complex && rice.isComplex()) ||
-                    (!complex && !rice.isComplex()))) {
-                return rice;
+            List<ComplexRangeIndexConfigElement> foundRices = config.findAll(path);
+            if (rices.addAll(foundRices)) {
+                break;
             }
         }
-        return null;
+
+        return rices;
     }
 
     private List<RangeIndexConfig> getConfigurations(Sequence contextSequence) {

--- a/extensions/indexes/range/test/src/xquery/conditions.xql
+++ b/extensions/indexes/range/test/src/xquery/conditions.xql
@@ -1,0 +1,168 @@
+xquery version "3.1";
+
+(:~
+ : Test conditions for complex range configuration elements.
+ :
+ :)
+module namespace ct="http://exist-db.org/xquery/range/conditions/test";
+
+import module namespace range="http://exist-db.org/xquery/range" at "java:org.exist.xquery.modules.range.RangeIndexModule";
+import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+declare namespace tei="http://www.tei-c.org/ns/1.0";
+declare namespace stats="http://exist-db.org/xquery/profiling";
+
+declare variable $ct:COLLECTION_CONFIG :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:tei="http://www.tei-c.org/ns/1.0">
+            <range>
+                <create qname="tei:note">
+                    <condition attribute="type" value="availability" />
+                    <field name="availability" type="xs:string" case="no"></field>
+                </create>
+                <create qname="tei:note">
+                    <condition attribute="type" value="text_type" />
+                    <field name="text_type" type="xs:string" case="no"></field>
+                </create>
+                <create match="//tei:note">
+                    <condition attribute="type" value="orig_place" />
+                    <field name="orig_place" match="tei:place/tei:placeName" type="xs:string" case="no"></field>
+                </create>
+                <create qname="tei:note" type="xs:string" case="no" />
+                <create qname="tei:placeName">
+                    <condition attribute="type" value="someType" />
+                    <condition attribute="cert" value="high" />
+                    <field name="certainPlaceOfSomeType" type="xs:string" />
+                </create>
+                <create qname="tei:placeName">
+                    <field name="allTypesOfPlaces" match="@type" type="xs:string" />
+                </create>
+                <create qname="tei:placeName">
+                    <condition attribute="cert" value="low" />
+                    <field name="typesOfUncertainPlaces" match="@type" type="xs:string" />
+                </create>
+            </range>
+        </index>
+    </collection>;
+
+
+declare variable $ct:DATA :=
+    <TEI xmlns="http://www.tei-c.org/ns/1.0">
+        <teiHeader>
+            <fileDesc>
+                <titleStmt><title>conditional fields!</title></titleStmt>
+            </fileDesc>
+            <sourceDesc>
+                <msDesc>
+                    <msContents>
+                        <msItemStruct>
+                            <note type="availability">publiziert</note>
+                            <note type="text_type">literarisch</note>
+                            <note type="orig_place">
+                                <place>
+                                    <placeName cert="low" type="thirdType">Oxyrhynchos</placeName>
+                                </place>
+                            </note>
+                            <note>
+                                <place>
+                                    <placeName cert="high" type="someType" n="1">Achmim</placeName>
+                                </place>
+                                <place>
+                                    <placeName cert="low" type="someType">Bubastos</placeName>
+                                </place>
+                                <place>
+                                    <placeName cert="high" type="someOtherType">Alexandria</placeName>
+                                </place>
+                            </note>
+                            <note>foo</note>
+                            <note type="bar">foo</note>
+                            <note type="something">literarisch</note>
+                        </msItemStruct>
+                    </msContents>
+                </msDesc>
+            </sourceDesc>
+        </teiHeader>
+    </TEI>;
+
+declare variable $ct:COLLECTION_NAME := "optimizertest";
+declare variable $ct:COLLECTION := "/db/" || $ct:COLLECTION_NAME;
+
+declare
+%test:setUp
+function ct:setup() {
+    xmldb:create-collection("/db/system/config/db", $ct:COLLECTION_NAME),
+    xmldb:store("/db/system/config/db/" || $ct:COLLECTION_NAME, "collection.xconf", $ct:COLLECTION_CONFIG),
+    xmldb:create-collection("/db", $ct:COLLECTION_NAME),
+    xmldb:store($ct:COLLECTION, "data2.xml", $ct:DATA)
+
+};
+
+declare
+%test:tearDown
+function ct:cleanup() {
+    xmldb:remove($ct:COLLECTION),
+    xmldb:remove("/db/system/config/db/" || $ct:COLLECTION_NAME)
+};
+
+(: rewrite expression with predicate that matches a condition to a field  :)
+(: the standard range lookup should not be used for the @type predicate :)
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-with-condition() {
+    collection($ct:COLLECTION)//tei:note[@type="availability"][.="publiziert"]
+};
+
+(: rewrite expression with predicate that matches a condition to a field  :)
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-with-condition2() {
+    collection($ct:COLLECTION)//tei:note[@type="orig_place"][tei:place/tei:placeName eq "Oxyrhynchos"]
+};
+
+(: do not use a conditional field for optimizing if condition does not match :)
+declare
+%test:stats
+%test:assertXPath("not($result//stats:index[@type = 'new-range'][@optimization = 2])")
+function ct:no-optimize-condition2() {
+    collection($ct:COLLECTION)//tei:note[@type="something"][. = "literarisch"]
+};
+
+(: only the elements matching the condition should have been indexed :)
+declare
+%test:assertEquals(1)
+function ct:conditional-config-restricts-results() {
+count(collection($ct:COLLECTION)//range:field-eq("text_type", "literarisch"))
+};
+
+(: if there are multiple config elements for a qname and some have a condition and :)
+(: some have not, pick the one without condition if no condition matches :)
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2]")
+function ct:use-config-without-condition-optimize() {
+collection($ct:COLLECTION)//tei:note[.="foo"]
+};
+
+declare
+%test:assertEquals(2)
+function ct:use-config-without-condition-result() {
+count(collection($ct:COLLECTION)//tei:note[.="foo"])
+};
+
+(: rewrite expression with multiple conditions to the correct field :)
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2][@calls = 1] and not($result//stats:index[@type='range'])")
+function ct:multiple-conditions() {
+collection($ct:COLLECTION)//tei:placeName[@cert="high"][@type="someType"][.="Achmim"]
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2][@calls = 1] and $result//stats:index[@type='range'][@calls=1]")
+function ct:multiple-conditions-inbetween() {
+collection($ct:COLLECTION)//tei:placeName[@cert="high"][not(.="")][@type="someType"][.="Achmim"]
+};

--- a/extensions/indexes/range/test/src/xquery/suite-conditions.xql
+++ b/extensions/indexes/range/test/src/xquery/suite-conditions.xql
@@ -1,0 +1,8 @@
+xquery version "3.0";
+
+import module namespace test="http://exist-db.org/xquery/xqsuite"
+at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+import module namespace ct="http://exist-db.org/xquery/range/conditions/test" at "conditions.xql";
+
+test:suite(util:list-functions(xs:anyURI("http://exist-db.org/xquery/range/conditions/test")))


### PR DESCRIPTION
This adds the possibility to add an attribute condition on complex range index config elements:

```xml
<create qname="tei:note">
  <condition attribute="type" value="text_type" />
  <field name="text_type" type="xs:string" case="no"></field>
</create>
```

Will only store the text of the `tei:note` element in the `text_type`field if it has an attribute named "type" with the value "text_type". 
 
Queries like
```xq
tei:note[@type="text_type"][.="some text type"] 
```
will be rewritten to 
```xq
tei:note[range:field("text_type", "eq", "some text type")] 
```

I tried to add as little complexity as possible to keep the performance impact at a minimum, especially if there are no conditions defined. If anyone has any suggestions for some benchmarks  I could do let me know...


_Background_: In a project I have to deal with data like
```xml
<note type="language">
    <term type="language">nicht ermittelt</term>
</note>
<note type="script">
    <term type="script"/>
    <note type="writing_direction">nicht ermittelt</note>
    <note type="ink"/>
    <note type="hand_desc">
        <p/>
    </note>
    <note type="structural_markers">
        <p/>
    </note>
</note>
```

And I want to build a faceted search feature with the contents of the note element as keys. Using conditional range index fields based on the note's type and retrieving them with range:index-keys-for-field gives better performance compared to defining separate index fields on the type and the text values  and then using distinct-values() on them...