### PR TITLE
Fixes a StringIndexOutOfBoundsException in XQDocParser. 

### DIFF
--- a/src/org/exist/xquery/xqdoc/parser/XQDocParser.g
+++ b/src/org/exist/xquery/xqdoc/parser/XQDocParser.g
@@ -44,7 +44,7 @@ contents returns [String content]
 		TRIM { buf.append('\n'); }
 		|
 		SIMPLE_COLON { 
-			if (buf.charAt(buf.length() - 1) != '\n')
+			if (buf.length()>0 && buf.charAt(buf.length() - 1) != '\n')
 				buf.append(':');
 		}
 		|

--- a/src/org/exist/xquery/xqdoc/parser/XQDocParser.java
+++ b/src/org/exist/xquery/xqdoc/parser/XQDocParser.java
@@ -145,7 +145,7 @@ public XQDocParser(ParserSharedInputState state) {
 					match(SIMPLE_COLON);
 					if ( inputState.guessing==0 ) {
 						
-									if (buf.charAt(buf.length() - 1) != '\n')
+									if (buf.length()>0 && buf.charAt(buf.length() - 1) != '\n')
 										buf.append(':');
 								
 					}


### PR DESCRIPTION
Fixes a StringIndexOutOfBoundsException in XQDocParser. fixes https://github.com/eXist-db/exist/issues/1220

I am not sure if other files need to be checked in too? ./build.sh generates a few more files…. not yet in the archive.