### PR TITLE
[bugfix] Range index query optimizer fix

### DIFF
--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeQueryRewriter.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeQueryRewriter.java
@@ -41,6 +41,12 @@ public class RangeQueryRewriter extends QueryRewriter {
 
     @Override
     public Pragma rewriteLocationStep(LocationStep locationStep) throws XPathException {
+        int axis = locationStep.getAxis();
+        if (!(axis == Constants.CHILD_AXIS || axis == Constants.DESCENDANT_AXIS ||
+                axis == Constants.DESCENDANT_SELF_AXIS || axis == Constants.ATTRIBUTE_AXIS ||
+                axis == Constants.DESCENDANT_ATTRIBUTE_AXIS || axis == Constants.SELF_AXIS)) {
+            return null;
+        }
         if (locationStep.hasPredicates()) {
             Expression parentExpr = locationStep.getParentExpression();
             if ((parentExpr instanceof RewritableExpression)) {
@@ -69,7 +75,6 @@ public class RangeQueryRewriter extends QueryRewriter {
                     }
 
                     // check if inner steps are on an axis we can optimize
-                    final int axis;
                     if (innerExpr instanceof InternalFunctionCall) {
                         InternalFunctionCall fcall = (InternalFunctionCall) innerExpr;
                         axis = ((Optimizable) fcall.getFunction()).getOptimizeAxis();

--- a/extensions/indexes/range/test/src/xquery/optimizer.xql
+++ b/extensions/indexes/range/test/src/xquery/optimizer.xql
@@ -536,7 +536,7 @@ declare
     %test:args("main", "official", "Dorfprozelten")
     %test:assertEquals("Dorfprozelten")
 function ot:equality-field-nested($type as xs:string, $subtype as xs:string, $name as xs:string) {
-    //tei:placeName[@type = $type][@subtype = $subtype][. = $name]/text()
+    collection($ot:COLLECTION)//tei:placeName[@type = $type][@subtype = $subtype][. = $name]/text()
 };
 
 declare
@@ -544,7 +544,45 @@ declare
     %test:args("main", "official", "Hofthiergarten")
     %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2]")
 function ot:optimize-field-self($type as xs:string, $subtype as xs:string, $name as xs:string) {
-    //tei:placeName[@type = $type][@subtype = $subtype][. = $name]/text()
+    collection($ot:COLLECTION)//tei:placeName[@type = $type][@subtype = $subtype][. = $name]/text()
+};
+
+declare 
+    %test:assertEquals("Rudi Rüssel")
+function ot:parent-attr-equals() {
+    collection($ot:COLLECTION)//name[parent::address/@id = "rüssel"]/text()
+};
+
+declare 
+    %test:stats
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 0]")
+function ot:optimize-parent-attr-equals() {
+    collection($ot:COLLECTION)//name[parent::address/@id = "rüssel"]/text()
+};
+
+declare 
+    %test:assertEquals("Rudi Rüssel")
+function ot:parent-nested-attr-equals() {
+    collection($ot:COLLECTION)//name[parent::address[@id = "rüssel"]]/text()
+};
+
+declare 
+    %test:stats
+    %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 0]")
+function ot:optimize-parent-nested-attr-equals() {
+    collection($ot:COLLECTION)//name[parent::address[@id = "rüssel"]]/text()
+};
+
+declare 
+    %test:assertEquals("Rudi Rüssel")
+function ot:self-parent-attr-equals() {
+    collection($ot:COLLECTION)//name[./parent::address/@id = "rüssel"]/text()
+};
+
+declare 
+    %test:assertEquals("Rudi Rüssel")
+function ot:self-parent-nested-attr-equals() {
+    collection($ot:COLLECTION)//name[./parent::address[@id = "rüssel"]]/text()
 };
 
 (: Filters :)


### PR DESCRIPTION
Fix query optimizer to not rewrite query using new range index if context step is on a reverse axis. Results will be wrong. Closes #1238.

Add test cases.