### PR TITLE
[feature] extend range index conditions

### DIFF
--- a/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/ComplexRangeIndexConfigElement.java
@@ -27,6 +27,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.exist.dom.QName;
 import org.exist.storage.NodePath;
 import org.exist.util.DatabaseConfigurationException;
+import org.exist.xquery.Predicate;
 import org.exist.xquery.value.Type;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -66,7 +67,7 @@ public class ComplexRangeIndexConfigElement extends RangeIndexConfigElement {
                     RangeIndexConfigField field = new RangeIndexConfigField(path, (Element) child, namespaces);
                     fields.put(field.getName(), field);
                 } else if (CONDITION_ELEMENT.equals(child.getLocalName())){
-                    conditions.add(new RangeIndexConfigCondition((Element) child, path));
+                    conditions.add(new RangeIndexConfigAttributeCondition((Element) child, path));
                 } else if (FILTER_ELEMENT.equals(child.getLocalName())) {
                     analyzer.addFilter((Element) child);
                 } else {
@@ -162,9 +163,9 @@ public class ComplexRangeIndexConfigElement extends RangeIndexConfigElement {
         return true;
     }
 
-    public boolean findCondition(QName lhe, String rhe, RangeIndex.Operator operator) {
+    public boolean findCondition(Predicate predicate) {
         for (RangeIndexConfigCondition condition : conditions) {
-            if (condition.find(lhe, rhe, operator))
+            if (condition.find(predicate))
                 return true;
         }
 

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndex.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndex.java
@@ -29,6 +29,9 @@ import org.exist.indexing.IndexWorker;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.storage.DBBroker;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Main implementation class for the new range index. This extends the existing LuceneIndex.
  *
@@ -58,6 +61,15 @@ public class RangeIndex extends LuceneIndex {
         private final String name;
         private final boolean supportsCollation;
 
+        private static final Map<String, Operator> LOOKUP_MAP;
+
+        static {
+            LOOKUP_MAP = new HashMap<String, Operator>();
+            for (Operator operator : Operator.values()) {
+                LOOKUP_MAP.put(operator.name, operator);
+            }
+        }
+
         Operator(String name, boolean supportsCollation) {
             this.name = name;
             this.supportsCollation = supportsCollation;
@@ -71,6 +83,8 @@ public class RangeIndex extends LuceneIndex {
         public boolean supportsCollation() {
             return supportsCollation;
         }
+
+        public static Operator getByName(String name) { return LOOKUP_MAP.get(name); }
     }
 
     private static final String DIR_NAME = "range";

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
@@ -26,76 +26,380 @@ import org.exist.storage.ElementValue;
 import org.exist.storage.NodePath;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.xquery.*;
-import org.exist.xquery.modules.range.Lookup;
 import org.exist.xquery.modules.range.RangeQueryRewriter;
+import org.exist.indexing.range.RangeIndex.Operator;
+import org.exist.xquery.value.AtomicValue;
+import org.exist.xquery.value.NumericValue;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.StringValue;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import javax.xml.XMLConstants;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 /**
  *
- * A condition that can be defined for complex range config elements.
- * As of now, limited to attribute equality.
+ * A condition that can be defined for complex range config elements
+ * that compares an attribute.
  *
  * @author Marcel Schaeben
  */
-public class RangeIndexConfigAttributeCondition extends RangeIndexConfigCondition {
+public class RangeIndexConfigAttributeCondition extends RangeIndexConfigCondition{
 
-    private final String attributeString;
+    private final String attributeName;
     private final QName attribute;
     private final String value;
-    private final RangeIndex.Operator operator;
+    private final Operator operator;
+    private boolean caseSensitive = true;
+    private boolean numericComparison = false;
+    private Double numericValue = null;
+    private String lowercaseValue = null;
+    private Pattern pattern = null;
 
     public RangeIndexConfigAttributeCondition(Element elem, NodePath parentPath) throws DatabaseConfigurationException {
 
-        this.operator = RangeIndex.Operator.EQ;
-
-        this.attributeString = elem.getAttribute("attribute");
         if (parentPath.getLastComponent().getNameType() == ElementValue.ATTRIBUTE) {
             throw new DatabaseConfigurationException("Range index module: Attribute condition cannot be defined for an attribute:" + parentPath.toString());
         }
-        if (this.attributeString == null || this.attributeString.length() == 0) {
+
+        this.attributeName = elem.getAttribute("attribute");
+        if (this.attributeName == null || this.attributeName.length() == 0) {
             throw new DatabaseConfigurationException("Range index module: Empty or no attribute qname in condition");
+        }
+
+        this.attribute = new QName(QName.extractLocalName(this.attributeName), XMLConstants.NULL_NS_URI, QName.extractPrefix(this.attributeName), ElementValue.ATTRIBUTE);
+        this.value = elem.getAttribute("value");
+
+
+        // parse operator (default to 'eq' if missing)
+        if (elem.hasAttribute("operator")) {
+            final String operatorName = elem.getAttribute("operator");
+            this.operator = Operator.getByName(operatorName.toLowerCase());
+            if (this.operator == null) {
+                throw new DatabaseConfigurationException("Range index module: Invalid operator specified in range index condition: " + operatorName + ".");
+            }
         } else {
-            this.attribute = new QName(QName.extractLocalName(this.attributeString), XMLConstants.NULL_NS_URI, QName.extractPrefix(this.attributeString), ElementValue.ATTRIBUTE);
-            this.value = elem.getAttribute("value");
+            this.operator = Operator.EQ;
+        }
+
+
+        final String caseString = elem.getAttribute("case");
+        final String numericString = elem.getAttribute("numeric");
+
+        this.caseSensitive = (caseString != null && !caseString.equalsIgnoreCase("no"));
+        this.numericComparison = (numericString != null && numericString.equalsIgnoreCase("yes"));
+
+        // try to create a pattern matcher for a 'matches' condition
+        if (this.operator == Operator.MATCH) {
+            final int flags = this.caseSensitive ? 0 : CASE_INSENSITIVE;
+            try {
+                this.pattern = Pattern.compile(this.value, flags);
+            } catch (PatternSyntaxException e) {
+                RangeIndex.LOG.error(e);
+                throw new DatabaseConfigurationException("Range index module: Invalid regular expression in condition: " + this.value);
+            }
+        }
+
+        // try to parse the number value if numeric comparison is specified
+        // store a reference to numeric value to avoid having to parse each time
+        if (this.numericComparison) {
+
+            switch(this.operator) {
+                case MATCH:
+                case STARTS_WITH:
+                case ENDS_WITH:
+                case CONTAINS:
+                    throw new DatabaseConfigurationException("Range index module: Numeric comparison not applicable for operator: " + this.operator.name());
+            }
+
+            try {
+                this.numericValue = Double.parseDouble(this.value);
+            } catch (NumberFormatException e)  {
+                throw new DatabaseConfigurationException("Range index module: Numeric attribute condition specified, but required value cannot be parsed as number: " + this.value);
+            }
         }
 
     }
 
+    // lazily evaluate lowercase value to convert once when needed
+    private String getLowercaseValue() {
+        if (this.lowercaseValue == null) {
+            if (this.value != null) {
+                this.lowercaseValue = this.value.toLowerCase();
+            }
+        }
+
+        return this.lowercaseValue;
+    }
+
+
     @Override
     public boolean matches(Node node) {
-        if (node.getNodeType() == Node.ELEMENT_NODE && ((Element)node).getAttribute(attributeString).equals(value)) {
+
+        if (node.getNodeType() == Node.ELEMENT_NODE && matchValue(((Element)node).getAttribute(attributeName))) {
             return true;
         }
 
         return false;
     }
 
+    private boolean matchValue(String testValue) {
+
+        switch (operator) {
+            case EQ:
+            case NE:
+                boolean matches;
+                if (this.numericComparison) {
+                    double testDouble = toDouble(testValue);
+                    matches = this.numericValue.equals(testDouble);
+                } else if (!this.caseSensitive) {
+                    matches = this.value.equalsIgnoreCase(testValue);
+                } else {
+                    matches = this.value.equals(testValue);
+                }
+                return this.operator == Operator.EQ ? matches : !matches;
+
+            case GT:
+            case LT:
+            case GE:
+            case LE:
+                int result;
+                if (this.numericComparison) {
+                    final double testDouble = toDouble(testValue);
+                    result = Double.compare(testDouble, this.numericValue);
+                } else if (!this.caseSensitive) {
+                    result = testValue.toLowerCase().compareTo(this.getLowercaseValue());
+                } else {
+                    result = testValue.compareTo(this.value);
+                }
+
+                return matchOrdinal(this.operator, result);
+
+            case ENDS_WITH:
+                return this.caseSensitive ? testValue.endsWith(this.value) : testValue.toLowerCase().endsWith(this.getLowercaseValue());
+            case STARTS_WITH:
+                return this.caseSensitive ? testValue.startsWith(this.value) : testValue.toLowerCase().startsWith(this.getLowercaseValue());
+            case CONTAINS:
+                return this.caseSensitive ? testValue.contains(this.value) : testValue.toLowerCase().contains(this.getLowercaseValue());
+
+            case MATCH:
+                final Matcher matcher = this.pattern.matcher(testValue);
+                return matcher.matches();
+        }
+
+        return false;
+
+    }
+
+    private boolean matchOrdinal(Operator operator, int result) {
+
+        switch(operator) {
+            case GT:
+                return result > 0;
+            case LT:
+                return result < 0;
+            case GE:
+                return result >= 0;
+            case LE:
+                return result <= 0;
+        }
+
+        return false;
+    }
+
+    private Double toDouble(String value) {
+
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e)  {
+            RangeIndex.LOG.debug("Non-numeric value encountered for numeric condition on @'" + this.attributeName + "': " + value);
+            return new Double(0);
+        }
+    }
+
+
     @Override
     public boolean find(Predicate predicate) {
 
-        Expression inner = this.getInnerExpression(predicate);
+        final Expression inner = this.getInnerExpression(predicate);
+        Operator operator;
+        Expression lhe;
+        Expression rhe ;
 
+        // get the type of the expression inside the predicate and determine right and left hand arguments
         if (inner instanceof GeneralComparison) {
+
             final GeneralComparison comparison = (GeneralComparison) inner;
 
-            final Expression lhe = comparison.getLeft();
-            final Expression rhe = comparison.getRight();
-            if (lhe instanceof LocationStep && rhe instanceof LiteralValue) {
-                final QName attribute = ((LocationStep)lhe).getTest().getName();
-                final String value = ((LiteralValue) rhe).getValue().toString();
-                final RangeIndex.Operator operator = RangeQueryRewriter.getOperator(inner);
+            operator = RangeQueryRewriter.getOperator(inner);
+            lhe = comparison.getLeft();
+            rhe = comparison.getRight();
 
-                if (operator.equals(this.operator) && attribute.equals(this.attribute) && value.equals(value)) {
-                    return true;
-                }
+        } else if (inner instanceof InternalFunctionCall) {
+            // calls to matches() will not have been rewritten to a comparison, so check for function call
+
+            final Function func = ((InternalFunctionCall) inner).getFunction();
+            if (func.isCalledAs("matches")) {
+                operator = Operator.MATCH;
+                lhe = func.getArgument(0);
+                rhe = func.getArgument(1);
+
+                lhe = unwrapSubExpression(lhe);
+                rhe = unwrapSubExpression(rhe);
+            } else {
+
+                // predicate expression cannot be parsed as condition
+                return false;
             }
+        } else {
+
+            // predicate expression cannot be parsed as condition
+            return false;
         }
 
 
 
+        // find the attribute name and value pair from the predicate to check against
+
+        // first assume attribute is on the left and value is on the right
+        LocationStep testStep = findLocationStep(lhe);
+        AtomicValue testValue = findAtomicValue(rhe);
+
+
+        switch (this.operator) {
+            case EQ:
+            case NE:
+
+                // the equality operators are commutative so if attribute/value pair has not been found,
+                // check the other way around
+                if (testStep == null && testValue == null) {
+                    testStep = findLocationStep(rhe);
+                    testValue = findAtomicValue(lhe);
+                }
+
+            case GT:
+            case LT:
+            case GE:
+            case LE:
+
+                // for ordinal comparisons, attribute and value can also be the other way around in the predicate
+                // but the operator has to be inverted
+                if (testStep == null && testValue == null) {
+                    testStep = findLocationStep(rhe);
+                    testValue = findAtomicValue(lhe);
+                    operator = invertOrdinalOperator(operator);
+                }
+
+        }
+
+        if (testStep != null && testValue != null) {
+            final QName qname = testStep.getTest().getName();
+            Comparable foundValue;
+            Comparable requiredValue;
+            boolean valueTypeMatches;
+
+            try {
+                if (this.numericComparison) {
+                    valueTypeMatches = testValue instanceof NumericValue;
+                    requiredValue = this.numericValue;
+                    foundValue = testValue.toJavaObject(Double.class);
+                }  else {
+                    valueTypeMatches = testValue instanceof StringValue;
+
+                    if (this.caseSensitive) {
+                        requiredValue = this.getLowercaseValue();
+                        foundValue = testValue.getStringValue().toLowerCase();
+                    } else {
+                        requiredValue = this.value;
+                        foundValue = testValue.getStringValue();
+                    }
+                }
+
+                if (qname.getNameType() == ElementValue.ATTRIBUTE
+                        && operator.equals(this.operator)
+                        && qname.equals(this.attribute)
+                        && valueTypeMatches
+                        && foundValue.equals(requiredValue)) {
+
+                    return true;
+                }
+
+
+            } catch (XPathException e) {
+                RangeIndex.LOG.error("Value conversion error when testing predicate for condition, value: " + testValue.toString());
+                RangeIndex.LOG.error(e);
+            }
+
+        }
+
         return false;
+    }
+
+    private Expression unwrapSubExpression(Expression expr) {
+
+        if (expr instanceof Atomize) {
+            expr = ((Atomize) expr).getExpression();
+        }
+
+        if (expr instanceof DynamicCardinalityCheck) {
+            if (expr.getSubExpressionCount() == 1) {
+                expr = expr.getSubExpression(0);
+            }
+        }
+
+        if (expr instanceof PathExpr) {
+            if (expr.getSubExpressionCount() == 1) {
+                expr = expr.getSubExpression(0);
+            }
+        }
+
+        return expr;
+    }
+
+    private LocationStep findLocationStep(Expression expr) {
+
+        if (expr instanceof LocationStep) {
+            return (LocationStep) expr;
+        }
+
+        return null;
+    }
+
+    private AtomicValue findAtomicValue(Expression expr) {
+
+        if (expr instanceof AtomicValue) {
+            return (AtomicValue) expr;
+        }
+        else if (expr instanceof LiteralValue) {
+            return ((LiteralValue) expr).getValue();
+
+        } else if (expr instanceof VariableReference || expr instanceof Function) {
+            try {
+                final Sequence result = expr.eval(null);
+                if (result instanceof AtomicValue) {
+                    return (AtomicValue) result;
+                }
+            } catch (XPathException e) {
+                RangeIndex.LOG.error(e);
+            }
+        }
+
+        return null;
+    }
+
+    private Operator invertOrdinalOperator(Operator operator) {
+        switch(operator) {
+            case LE: return Operator.GE;
+            case GE: return Operator.LE;
+            case LT: return Operator.GT;
+            case GT: return Operator.LT;
+        }
+
+        return null;
     }
 }

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigAttributeCondition.java
@@ -1,0 +1,101 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2013 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *  $Id$
+ */
+package org.exist.indexing.range;
+
+import org.exist.dom.QName;
+import org.exist.storage.ElementValue;
+import org.exist.storage.NodePath;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.xquery.*;
+import org.exist.xquery.modules.range.Lookup;
+import org.exist.xquery.modules.range.RangeQueryRewriter;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import javax.xml.XMLConstants;
+
+/**
+ *
+ * A condition that can be defined for complex range config elements.
+ * As of now, limited to attribute equality.
+ *
+ * @author Marcel Schaeben
+ */
+public class RangeIndexConfigAttributeCondition extends RangeIndexConfigCondition {
+
+    private final String attributeString;
+    private final QName attribute;
+    private final String value;
+    private final RangeIndex.Operator operator;
+
+    public RangeIndexConfigAttributeCondition(Element elem, NodePath parentPath) throws DatabaseConfigurationException {
+
+        this.operator = RangeIndex.Operator.EQ;
+
+        this.attributeString = elem.getAttribute("attribute");
+        if (parentPath.getLastComponent().getNameType() == ElementValue.ATTRIBUTE) {
+            throw new DatabaseConfigurationException("Range index module: Attribute condition cannot be defined for an attribute:" + parentPath.toString());
+        }
+        if (this.attributeString == null || this.attributeString.length() == 0) {
+            throw new DatabaseConfigurationException("Range index module: Empty or no attribute qname in condition");
+        } else {
+            this.attribute = new QName(QName.extractLocalName(this.attributeString), XMLConstants.NULL_NS_URI, QName.extractPrefix(this.attributeString), ElementValue.ATTRIBUTE);
+            this.value = elem.getAttribute("value");
+        }
+
+    }
+
+    @Override
+    public boolean matches(Node node) {
+        if (node.getNodeType() == Node.ELEMENT_NODE && ((Element)node).getAttribute(attributeString).equals(value)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean find(Predicate predicate) {
+
+        Expression inner = this.getInnerExpression(predicate);
+
+        if (inner instanceof GeneralComparison) {
+            final GeneralComparison comparison = (GeneralComparison) inner;
+
+            final Expression lhe = comparison.getLeft();
+            final Expression rhe = comparison.getRight();
+            if (lhe instanceof LocationStep && rhe instanceof LiteralValue) {
+                final QName attribute = ((LocationStep)lhe).getTest().getName();
+                final String value = ((LiteralValue) rhe).getValue().toString();
+                final RangeIndex.Operator operator = RangeQueryRewriter.getOperator(inner);
+
+                if (operator.equals(this.operator) && attribute.equals(this.attribute) && value.equals(value)) {
+                    return true;
+                }
+            }
+        }
+
+
+
+        return false;
+    }
+}

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigCondition.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigCondition.java
@@ -1,99 +1,52 @@
-/*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2013 The eXist Project
- *  http://exist-db.org
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
- */
 package org.exist.indexing.range;
 
-import org.exist.dom.QName;
-import org.exist.storage.ElementValue;
-import org.exist.storage.NodePath;
-import org.exist.util.DatabaseConfigurationException;
-import org.w3c.dom.Element;
+import org.exist.xquery.*;
+import org.exist.xquery.modules.range.Lookup;
 import org.w3c.dom.Node;
 
-import javax.xml.XMLConstants;
 
 /**
  *
- * A condition that can be defined for complex range config elements.
- * As of now, limited to attribute equality.
+ * Base class for conditions that can be defined for complex range config elements.
  *
  * @author Marcel Schaeben
  */
-public class RangeIndexConfigCondition {
+public abstract class RangeIndexConfigCondition {
 
-    public String getValue() {
-        return value;
-    }
-    public QName getAttribute() {
-        return attribute;
-    }
-    public RangeIndex.Operator getOperator() { return operator; }
-
-    private final String attributeString;
-    private final QName attribute;
-    private final String value;
-    private final RangeIndex.Operator operator;
-
-    public RangeIndexConfigCondition(Element elem, NodePath parentPath) throws DatabaseConfigurationException {
-
-        this.operator = RangeIndex.Operator.EQ;
-
-        this.attributeString = elem.getAttribute("attribute");
-        if (parentPath.getLastComponent().getNameType() == ElementValue.ATTRIBUTE) {
-            throw new DatabaseConfigurationException("Range index module: Attribute condition cannot be defined for an attribute:" + parentPath.toString());
-        }
-        if (this.attributeString == null || this.attributeString.length() == 0) {
-            throw new DatabaseConfigurationException("Range index module: Empty or no attribute qname in condition");
-        } else {
-            this.attribute = new QName(QName.extractLocalName(this.attributeString), XMLConstants.NULL_NS_URI, QName.extractPrefix(this.attributeString), ElementValue.ATTRIBUTE);
-            this.value = elem.getAttribute("value");
-        }
-
-    }
 
     /**
      * Test if a node matches this condition. Used by the indexer.
      * @param node The node to test.
      * @return true if the node is an element node and an attribute matches this condition.
      */
-    public boolean matches(Node node) {
-        if (node.getNodeType() == Node.ELEMENT_NODE && ((Element)node).getAttribute(attributeString).equals(value)) {
-            return true;
-        }
+    public abstract boolean matches(Node node);
+
+    /**
+     * Test if an expression defined by the arguments matches this condition. Used by the query rewriter.
+     * @param predicate The predicate to test.
+     * @return true if the predicate matches this condition.
+     */
+    public boolean find(Predicate predicate) {
 
         return false;
     }
 
     /**
-     * Test if an expression defined by the arguments matches this condition. Used by the query rewriter.
-     * @param lhe The QName of the attribute to test
-     * @param rhe The expected value of the attribute
-     * @param operator The operator of the comparison expression (defaults to equals for now)
-     * @return
+     * Get the inner expression of a predicate. Will unwrap the original expression if it has previously
+     * been rewritten into an index function call.
+     * @param predicate The predicate to test.
+     * @return The fallback expression from a rewritten function call or the original inner expression.
      */
-    public boolean find(QName lhe, String rhe, RangeIndex.Operator operator) {
-        if (operator.equals(this.operator) && lhe.equals(this.attribute) && rhe.equals(value)) {
-                return true;
+    protected Expression getInnerExpression(Predicate predicate) {
+        Expression inner = predicate.getExpression(0);
+        if (inner instanceof InternalFunctionCall) {
+            Function function = ((InternalFunctionCall)inner).getFunction();
+            if (function instanceof Lookup) {
+                return ((Lookup)function).getFallback();
+            }
         }
 
-        return false;
+        return inner;
     }
+
 }

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/OptimizeFieldPragma.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/OptimizeFieldPragma.java
@@ -151,28 +151,9 @@ public class OptimizeFieldPragma extends Pragma {
                             matchedPreds.clear();
 
                             for (Predicate precedingPred : precedingPreds ) {
-                                Expression inner = precedingPred.getExpression(0);
-                                if (inner instanceof InternalFunctionCall) {
-                                    Function function = ((InternalFunctionCall)inner).getFunction();
-                                    if (function instanceof Lookup) {
-                                        inner = ((Lookup)function).getFallback();
-                                    }
-                                }
 
-                                if (inner instanceof GeneralComparison) {
-                                    final GeneralComparison comparison = (GeneralComparison) inner;
-
-                                    final Expression lhe = comparison.getLeft();
-                                    final Expression rhe = comparison.getRight();
-                                    if (lhe instanceof LocationStep && rhe instanceof LiteralValue) {
-                                        final QName lh = ((LocationStep)lhe).getTest().getName();
-                                        final String rh = ((LiteralValue) rhe).getValue().toString();
-                                        final RangeIndex.Operator operator = RangeQueryRewriter.getOperator(inner);
-
-                                        if (lh != null && testRice.findCondition(lh, rh, operator)) {
-                                            matchedPreds.add(precedingPred);
-                                        }
-                                    }
+                                if (testRice.findCondition(precedingPred)) {
+                                    matchedPreds.add(precedingPred);
                                 }
 
                             }

--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeQueryRewriter.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/RangeQueryRewriter.java
@@ -169,7 +169,7 @@ public class RangeQueryRewriter extends QueryRewriter {
         return null;
     }
 
-    protected static RangeIndex.Operator getOperator(Expression expr) {
+    public static RangeIndex.Operator getOperator(Expression expr) {
         if (expr instanceof InternalFunctionCall) {
             InternalFunctionCall fcall = (InternalFunctionCall) expr;
             Function function = fcall.getFunction();

--- a/extensions/indexes/range/test/src/xquery/conditions.xql
+++ b/extensions/indexes/range/test/src/xquery/conditions.xql
@@ -25,6 +25,14 @@ declare variable $ct:COLLECTION_CONFIG :=
                     <condition attribute="type" value="text_type" />
                     <field name="text_type" type="xs:string" case="no"></field>
                 </create>
+                <create qname="tei:note">
+                    <condition attribute="type" operator="starts-with" value="start" />
+                    <field name="text_type_start" type="xs:string" case="no"></field>
+                </create>
+                <create qname="tei:note">
+                    <condition attribute="type" operator="ends-with" value="end" />
+                    <field name="text_type_end" type="xs:string" case="no"></field>
+                </create>
                 <create match="//tei:note">
                     <condition attribute="type" value="orig_place" />
                     <field name="orig_place" match="tei:place/tei:placeName" type="xs:string" case="no"></field>
@@ -41,6 +49,63 @@ declare variable $ct:COLLECTION_CONFIG :=
                 <create qname="tei:placeName">
                     <condition attribute="cert" value="low" />
                     <field name="typesOfUncertainPlaces" match="@type" type="xs:string" />
+                </create>
+
+                <create qname="tei:term">
+                    <condition attribute="n" operator="lt" value="b" />
+                    <field name="termsBeforeB" type="xs:string" />
+                </create>
+                <create qname="tei:term">
+                    <condition attribute="n" operator="gt" value="b" />
+                    <field name="termsAfterB" type="xs:string" />
+                </create>
+                <create qname="tei:term">
+                    <condition attribute="n" operator="le" value="b" />
+                    <field name="termsBeforeOrEqualB" type="xs:string" />
+                </create>
+                <create qname="tei:term">
+                    <condition attribute="n" operator="ge" value="b" />
+                    <field name="termsAfterOrEqualB" type="xs:string" />
+                </create>
+                <create qname="tei:term">
+                    <condition attribute="n" operator="ne" value="b" />
+                    <field name="termsNotB" type="xs:string" />
+                </create>
+
+                <create qname="tei:entry">
+                    <condition attribute="n" operator="contains" value="1234" />
+                    <field name="entryNContains1234" type="xs:string" />
+                </create>
+                <create qname="tei:entry">
+                    <condition attribute="n" operator="matches" value="some_\d+_thing" />
+                    <field name="entryNMatches" type="xs:string" />
+                </create>
+
+                <create qname="tei:num">
+                    <condition attribute="value" operator="lt" value="2" />
+                    <field name="lessThanTwoString" type="xs:string" />
+                </create>
+                <create qname="tei:num">
+                    <condition attribute="value" operator="lt" value="2" numeric="yes"/>
+                    <field name="lessThanTwoNumeric" type="xs:string" />
+                </create>
+                <create qname="tei:num">
+                    <condition attribute="value" operator="eq" value="1" numeric="yes"/>
+                    <field name="exactlyOne" type="xs:string" />
+                </create>
+
+                <create qname="tei:figure">
+                    <condition attribute="n" operator="lt" value="2" numeric="yes"/>
+                    <field name="figNLT2" type="xs:string" />
+                </create>
+
+                <create qname="tei:p">
+                    <condition attribute="type" value="aabbcc" case="no" />
+                    <field name="pCase" type="xs:string" />
+                </create>
+                <create qname="tei:p">
+                    <condition attribute="type" operator="matches" value="bb" case="no" />
+                    <field name="pMatchCase" type="xs:string" />
                 </create>
             </range>
         </index>
@@ -75,6 +140,7 @@ declare variable $ct:DATA :=
                                     <placeName cert="high" type="someOtherType">Alexandria</placeName>
                                 </place>
                             </note>
+                            <note type="start_end">startswithendswith</note>
                             <note>foo</note>
                             <note type="bar">foo</note>
                             <note type="something">literarisch</note>
@@ -83,6 +149,28 @@ declare variable $ct:DATA :=
                 </msDesc>
             </sourceDesc>
         </teiHeader>
+        <text>
+            <body>
+                <p>
+                    <term n="a">eins</term>
+                    <term n="b">zwei</term>
+                    <term n="c">drei</term>
+
+                    <entry n="some_1234_thing">something</entry>
+
+                    <num value="1">one</num>
+                    <num value="110">onehundredandten</num>
+                    <num value="2">two</num>
+                    <num value="001.0">zerozeroonepointzero</num>
+
+                    <figure n="1">one</figure>
+                    <figure n="110">onehundredandten</figure>
+                    <figure n="2">two</figure>
+                </p>
+
+                <p type="aaBBcc">CaseSensitivity</p>
+            </body>
+        </text>
     </TEI>;
 
 declare variable $ct:COLLECTION_NAME := "optimizertest";
@@ -110,16 +198,95 @@ function ct:cleanup() {
 declare
 %test:stats
 %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
-function ct:optimize-with-condition() {
+function ct:optimize-eq() {
     collection($ct:COLLECTION)//tei:note[@type="availability"][.="publiziert"]
 };
+
+(: rewrite expression with predicate that matches a condition to a field  :)
+(: the standard range lookup should not be used for the @type predicate :)
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-eq-numeric() {
+    collection($ct:COLLECTION)//tei:num[@value = 1][.="publiziert"]
+};
+
+(: rewrite expression with predicate that matches a condition to a field  :)
+(: the standard range lookup should not be used for the @type predicate :)
+declare
+%test:stats
+%test:assertXPath("not($result//stats:index[@type = 'new-range'][@optimization = 2])")
+function ct:no-optimize-eq-numeric() {
+    collection($ct:COLLECTION)//tei:num[@value = "1"][.="publiziert"]
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-eq-var() {
+    let $var := "availability"
+    return collection($ct:COLLECTION)//tei:note[@type=$var][.="publiziert"]
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-eq-func() {
+    collection($ct:COLLECTION)//tei:note[@type=lower-case("AVAILABILITY")][.="publiziert"]
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-eq-reverse-var-nested() {
+    let $var := "availability"
+    let $var2 := $var
+    return collection($ct:COLLECTION)//tei:note[$var2=@type][.="publiziert"]
+};
+
+declare variable $ct:var := "availability";
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-eq-static-var() {
+    collection($ct:COLLECTION)//tei:note[@type=$ct:var][.="publiziert"]
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-eq-reverse() {
+    collection($ct:COLLECTION)//tei:note["availability" = @type][.="publiziert"]
+};
+
 
 (: rewrite expression with predicate that matches a condition to a field  :)
 declare
 %test:stats
 %test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
-function ct:optimize-with-condition2() {
+function ct:optimize-eq2() {
     collection($ct:COLLECTION)//tei:note[@type="orig_place"][tei:place/tei:placeName eq "Oxyrhynchos"]
+};
+
+
+
+declare
+%test:assertEquals(1)
+function ct:index-eq-no-case() {
+count(range:index-keys-for-field("pCase", function($k, $n) { $k }, 10))
+};
+
+declare
+%test:stats
+%test:assertXPath("not($result//stats:index[@type = 'new-range'][@optimization = 2])")
+function ct:optimize-case() {
+collection($ct:COLLECTION)//tei:note[@type="Availablity"][.="publiziert"]
+};
+
+declare
+%test:assertXPath("count($result) eq 2 and contains($result, 'one') and contains($result, 'zerozeroonepointzero')")
+function ct:index-eq-numeric() {
+range:index-keys-for-field("exactlyOne", function($k, $n) { $k }, 10)
 };
 
 (: do not use a conditional field for optimizing if condition does not match :)
@@ -127,13 +294,13 @@ declare
 %test:stats
 %test:assertXPath("not($result//stats:index[@type = 'new-range'][@optimization = 2])")
 function ct:no-optimize-condition2() {
-    collection($ct:COLLECTION)//tei:note[@type="something"][. = "literarisch"]
+collection($ct:COLLECTION)//tei:note[@type="something"][. = "literarisch"]
 };
 
 (: only the elements matching the condition should have been indexed :)
 declare
 %test:assertEquals(1)
-function ct:conditional-config-restricts-results() {
+function ct:conditional-config-results-eq() {
 count(collection($ct:COLLECTION)//range:field-eq("text_type", "literarisch"))
 };
 
@@ -166,3 +333,196 @@ declare
 function ct:multiple-conditions-inbetween() {
 collection($ct:COLLECTION)//tei:placeName[@cert="high"][not(.="")][@type="someType"][.="Achmim"]
 };
+
+
+declare
+%test:assertEquals("startswithendswith")
+function ct:index-ends-with() {
+range:index-keys-for-field("text_type_end", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-ends-with() {
+collection($ct:COLLECTION)//tei:note[ends-with(@type, "end")][. = "startswithendswith"]
+};
+
+declare
+%test:assertEquals("startswithendswith")
+function ct:index-starts-with() {
+range:index-keys-for-field("text_type_start", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-starts-with() {
+collection($ct:COLLECTION)//tei:note[starts-with(@type, "start")][. = "startswithendswith"]
+};
+
+declare
+%test:assertEquals("eins")
+function ct:index-lt() {
+range:index-keys-for-field("termsBeforeB", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-lt() {
+collection($ct:COLLECTION)//tei:term[@n < "b"][. = "eins"]
+};
+
+
+declare
+%test:assertEquals("eins")
+function ct:index-lt() {
+range:index-keys-for-field("termsBeforeB", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-lt() {
+collection($ct:COLLECTION)//tei:term[@n < "b"][. = "eins"]
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-lt-numeric() {
+collection($ct:COLLECTION)//tei:figure[@n < 2][. = "one"]
+};
+
+declare
+%test:stats
+%test:assertXPath("not($result//stats:index[@type = 'new-range'][@optimization = 2])")
+function ct:no-optimize-lt-numeric() {
+collection($ct:COLLECTION)//tei:figure[@n < "2"][. = "one"]
+};
+
+
+declare
+%test:assertXPath("count($result) eq 3 and contains($result, 'one') and contains($result, 'onehundredandten') and contains($result, 'zerozeroonepointzero')")
+function ct:index-lt-non-numeric() {
+range:index-keys-for-field("lessThanTwoString", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:assertXPath("count($result) eq 2 and contains($result, 'one') and contains($result, 'zerozeroonepointzero')")
+function ct:index-lt-numeric() {
+range:index-keys-for-field("lessThanTwoNumeric", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:assertEquals("drei")
+function ct:index-gt() {
+range:index-keys-for-field("termsAfterB", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-gt() {
+collection($ct:COLLECTION)//tei:term[@n > "b"][. = "drei"]
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-gt-inverse() {
+collection($ct:COLLECTION)//tei:term["b" < @n][. = "eins"]
+};
+
+declare
+%test:assertEquals("drei")
+function ct:result-gt() {
+collection($ct:COLLECTION)//tei:term[@n > "b"][. = "drei"]/text()
+};
+
+declare
+%test:assertEquals("eins")
+function ct:result-gt-inverse() {
+collection($ct:COLLECTION)//tei:term["b" > @n][. = "eins"]/text()
+};
+
+declare
+%test:assertXPath("count($result) eq 2 and contains($result, 'eins') and contains($result, 'zwei')")
+function ct:index-le() {
+range:index-keys-for-field("termsBeforeOrEqualB", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-le() {
+collection($ct:COLLECTION)//tei:term[@n le "b"][. = "eins"]
+};
+
+declare
+%test:assertXPath("count($result) eq 2 and contains($result, 'zwei') and contains($result, 'drei')")
+function ct:result-le-inverse() {
+collection($ct:COLLECTION)//tei:term["b" le @n][true()]
+};
+
+declare
+%test:assertXPath("count($result) eq 2 and contains($result, 'zwei') and contains($result, 'drei')")
+function ct:index-ge() {
+range:index-keys-for-field("termsAfterOrEqualB", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-ge() {
+collection($ct:COLLECTION)//tei:term[@n ge "b"][. = "drei"]
+};
+
+
+declare
+%test:assertXPath("count($result) eq 2 and contains($result, 'eins') and contains($result, 'drei')")
+function ct:index-ne() {
+range:index-keys-for-field("termsNotB", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-ne() {
+collection($ct:COLLECTION)//tei:term[@n ne "b"][. = "drei"]
+};
+
+declare
+%test:assertEquals("something")
+function ct:index-contains() {
+range:index-keys-for-field("entryNContains1234", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-contains() {
+collection($ct:COLLECTION)//tei:entry[contains(@n, "1234")][. = "something"]
+};
+
+declare
+%test:assertEquals("something")
+function ct:index-matches() {
+range:index-keys-for-field("entryNMatches", function($k, $n) { $k }, 10)
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-matches() {
+collection($ct:COLLECTION)//tei:entry[matches(@n, "some_\d+_thing")][. = "something"]
+};
+
+declare
+%test:stats
+%test:assertXPath("$result//stats:index[@type = 'new-range'][@optimization = 2] and not($result//stats:index[@type='range'])")
+function ct:optimize-matches-no-case() {
+collection($ct:COLLECTION)//tei:p[matches(@type, "bb")][. = "something"]
+};
+


### PR DESCRIPTION
This adds a few extensions to the attribute range index condition introduced in #1233:

- ability to specify an operator for the condition, implemented operators are`eq, ne, lt, gt, le, ge, starts-with, ends-with, contains, matches`. Can be specified using an `operator` attribute on the `condition` element. If the attribute is missing, `eq` is assumed as default.

- case insensitive comparison by specifing `case="no"` on the `condition` element

- numeric comparison by specifing `numeric="yes"`. When enabled, `01.0` will equal `1` and `2` will be less than `110`, for example. By default, string matching is assumed. The rewriter will respect the type of the value (string, numeric) when matching a condition to a predicate.

- rewriting improvements:
    - the order of attribute name and value can be reversed in the predicate, respecting semantics of the operator (`[@a = "x"]` and `["x" = @a]` will both match a condition on `a`, for example)
  - variables and function calls in predicates will be resolved to a value

- some refactoring:
  - `RangeIndexConfigCondition` is now an abstract base class with `RangeIndexConfigAttributeCondition` being a subclass. This should make it easier to implement other types of conditions in the future
  - moved most of the rewriting code from `OptimizeFieldPragma` to the condition itself as it will differ for different kinds of conditions

I'll be happy to add some documentation on this to the "New Range Index" page later on...
