### PR TITLE
always call `preEval` for all `FLWORClause` except `WhereClause`

### DIFF
--- a/src/org/exist/xquery/ForExpr.java
+++ b/src/org/exist/xquery/ForExpr.java
@@ -152,8 +152,14 @@ public class ForExpr extends BindingExpression {
             // calling the where expression for each item in the input sequence)
             // This is possible if the input sequence is a node set and has no
             // dependencies on the current context item.
-            if (at == null && returnExpr instanceof FLWORClause && isOuterFor) {
-                in = ((FLWORClause)returnExpr).preEval(in);
+            if (isOuterFor) {
+                if (returnExpr instanceof WhereClause) {
+                    if (at == null) {
+                        in = ((WhereClause) returnExpr).preEval(in);
+                    }
+                } else if (returnExpr instanceof FLWORClause) {
+                    in = ((FLWORClause) returnExpr).preEval(in);
+                }
             }
 
             final IntegerValue atVal = new IntegerValue(1);

--- a/test/src/xquery/xquery3/groupby.xql
+++ b/test/src/xquery/xquery3/groupby.xql
@@ -599,3 +599,12 @@ declare
 function groupby:recursive-groupby() {
     groupby:recursive-groupby($groupby:values-recursive/v)
 };
+
+declare
+%test:assertEquals(1, 2)
+function groupby:issue-967() {
+    for $nr at $pos in (1,2)
+    group by $pos
+    return
+    $nr
+};


### PR DESCRIPTION
close #967 