### PR TITLE
[fix?] Lucene index – make query-field only depend on the context sequence

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/QueryField.java
@@ -89,6 +89,8 @@ public class QueryField extends Query implements Optimizable {
     /* (non-Javadoc)
     * @see org.exist.xquery.PathExpr#analyze(org.exist.xquery.Expression)
     */
+
+    @Override
     public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
         super.analyze(new AnalyzeContextInfo(contextInfo));
 
@@ -174,6 +176,7 @@ public class QueryField extends Query implements Optimizable {
         return result;
     }
 
+    @Override
     public int getDependencies() {
         return Dependency.CONTEXT_SET;
     }

--- a/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/org/exist/xquery/modules/lucene/QueryField.java
@@ -90,6 +90,9 @@ public class QueryField extends Query implements Optimizable {
     * @see org.exist.xquery.PathExpr#analyze(org.exist.xquery.Expression)
     */
     public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+        super.analyze(new AnalyzeContextInfo(contextInfo));
+
+        this.contextId = contextInfo.getContextId();
     }
 
     public boolean canOptimize(Sequence contextSequence) {
@@ -166,9 +169,13 @@ public class QueryField extends Query implements Optimizable {
         		context.getProfiler().traceIndexUsage( context, "lucene", this, PerformanceStats.BASIC_INDEX, System.currentTimeMillis() - start );
         	}
         } else {
-            result = preselectResult;
+            result = preselectResult.selectAncestorDescendant(contextSequence.toNodeSet(), NodeSet.DESCENDANT, true, getContextId(), true);;
         }
         return result;
+    }
+
+    public int getDependencies() {
+        return Dependency.CONTEXT_SET;
     }
 
     @Override

--- a/extensions/indexes/lucene/test/src/xquery/lucene/query-field.xql
+++ b/extensions/indexes/lucene/test/src/xquery/lucene/query-field.xql
@@ -1,0 +1,58 @@
+xquery version "3.0";
+
+module namespace qf="http://exist-db.org/xquery/lucene/test/query-field";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $qf:XCONF1 :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene diacritics="no">
+                <text field="testField" qname="test"/>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $qf:testCol := xmldb:create-collection("/db", "queryfieldtest");
+declare variable $qf:confCol := xmldb:create-collection("/db/system/config/db", "queryfieldtest");
+
+declare
+%test:setUp
+function qf:setup() {
+
+    (
+        xmldb:store($qf:confCol, "collection.xconf", $qf:XCONF1),
+        xmldb:store($qf:testCol, "test1.xml",
+                <test>
+                    <p>Rüsselsheim</p>
+                    <p>Russelsheim</p>
+                    <p>Māori</p>
+                    <p>Maori</p>
+                </test>
+        ),
+        xmldb:store($qf:testCol, "test2.xml",
+                <test>
+                    <p>Rüsselsheim</p>
+                    <p>Russelsheim</p>
+                    <p>Māori</p>
+                    <p>Maori</p>
+                </test>
+        )
+    )
+};
+
+declare
+%test:tearDown
+function qf:tearDown() {
+    xmldb:remove($qf:testCol),
+    xmldb:remove($qf:confCol)
+};
+
+
+(: assert that ft:query-field is only called once for the context sequence, not for each item :)
+declare
+%test:stats
+%test:assertXPath("$result/stats:index[@type eq 'lucene' and @calls eq '1']")
+function qf:query-field-context() {
+    count(collection($qf:testCol)/*[ft:query-field("testField", "Rüsselsheim", <options/>)])
+};

--- a/extensions/indexes/lucene/test/src/xquery/lucene/suite-query-field.xql
+++ b/extensions/indexes/lucene/test/src/xquery/lucene/suite-query-field.xql
@@ -1,0 +1,8 @@
+xquery version "3.0";
+
+import module namespace test="http://exist-db.org/xquery/xqsuite"
+at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+import module namespace qf="http://exist-db.org/xquery/lucene/test/query-field" at "query-field.xql";
+
+test:suite(util:list-functions(xs:anyURI("http://exist-db.org/xquery/lucene/test/query-field")))


### PR DESCRIPTION
I've noticed that ft:query-field is not evaluated only once for the context sequence, but once for each item in the context sequence. For example, given an index named "testField" on the qname `test` with a collection with test1.xml and test2.xml both containing the following data:
 
```xml
<test>
  <p>Rüsselsheim</p>
  <p>Russelsheim</p>
  <p>Māori</p>
  <p>Maori</p>
</test>
````

the query `/test[ft:query-field("testField", "Rüsselsheim", <options/>)]` will execute ft:query-field two times instead of only once. While this still leads to the correct results, the performance is not as good as it could be for larger context sequences. I've included an xquery test demonstrating this.

This code fixes the issue by making the function only depend on the context sequence. Please be aware that I don't think that I have completely understood the dependency stuff yet, but I am pretty certain that query-field will only ever depend on the context sequence, never on the context item. If this assumption is correct, the changes should be safe to merge. At least all lucene index tests still pass (at least those that are passing on the current develop – there are some failing xquery tests in there, maybe someone should have a look at those, too..).
 


