### PR TITLE
Use XQuery version compatible with features tested

### DIFF
--- a/test/src/xquery/maps/maps.xql
+++ b/test/src/xquery/maps/maps.xql
@@ -1,4 +1,4 @@
-xquery version "1.0";
+xquery version "3.1";
 
 module namespace mt="http://exist-db.org/xquery/test/maps";
 


### PR DESCRIPTION
### Description:

This file includes tests for maps, a feature incompatible with the version number 1.0. Also, it uses function annotations. Bumping the version declaration to 3.1 resolves this. 

I'm unsure why the 1.0 version works at all - it seems eXist is not checking version declarations at all? I could swear I've gotten warnings before when using 3.1 features in 3.0 queries, etc.

### Reference:

https://github.com/eXist-db/exist/pull/1283/files#diff-a526c6c09af806c26cd8be952d1ba5bb

### Type of tests:

n/a