### PR TITLE
[refactor] Moving lock ownership is dangerous

### DIFF
--- a/src/org/exist/storage/txn/Txn.java
+++ b/src/org/exist/storage/txn/Txn.java
@@ -60,11 +60,16 @@ public class Txn implements Transaction {
     public long getId() {
         return id;
     }
-    
+
+    /**
+     * @deprecated Moving a Lock to a Txn is error prone and should not be done
+     *   instead use {@link #acquireLock(Lock, LockMode)} to take a second lock
+     */
+    @Deprecated
     public void registerLock(final Lock lock, final LockMode lockMode) {
         locksHeld.add(new LockInfo(lock, lockMode));
     }
-    
+
     public void acquireLock(final Lock lock, final LockMode lockMode) throws LockException {
         lock.acquire(lockMode);
         locksHeld.add(new LockInfo(lock, lockMode));

--- a/src/org/exist/xmlrpc/RpcConnection.java
+++ b/src/org/exist/xmlrpc/RpcConnection.java
@@ -1486,8 +1486,8 @@ public class RpcConnection implements RpcAPI {
     private boolean storeBinary(final byte[] data, final XmldbURI docUri, final String mimeType,
                                 final int overwrite, final Date created, final Date modified) throws EXistException, PermissionDeniedException {
         return this.<Boolean>writeCollection(docUri.removeLastSegment()).apply((collection, broker, transaction) -> {
-            // keep the write lock in the transaction
-            transaction.registerLock(collection.getLock(), LockMode.WRITE_LOCK);
+            // keep a write lock in the transaction
+            transaction.acquireLock(collection.getLock(), LockMode.WRITE_LOCK);
             if (overwrite == 0) {
                 final DocumentImpl old = collection.getDocument(broker, docUri.lastSegment());
                 if (old != null) {
@@ -1880,8 +1880,8 @@ public class RpcConnection implements RpcAPI {
 
     private boolean remove(final XmldbURI docUri) throws EXistException, PermissionDeniedException {
         return this.<Boolean>writeCollection(docUri.removeLastSegment()).apply((collection, broker, transaction) -> {
-            // keep the write lock in the transaction
-            transaction.registerLock(collection.getLock(), LockMode.WRITE_LOCK);
+            // keep a write lock in the transaction
+            transaction.acquireLock(collection.getLock(), LockMode.WRITE_LOCK);
 
             final DocumentImpl doc = collection.getDocument(broker, docUri.lastSegment());
             if (doc == null) {
@@ -1905,8 +1905,8 @@ public class RpcConnection implements RpcAPI {
     private boolean removeCollection(final XmldbURI collURI) throws EXistException, PermissionDeniedException {
         try {
             return this.<Boolean>writeCollection(collURI).apply((collection, broker, transaction) -> {
-                // keep the write lock in the transaction
-                transaction.registerLock(collection.getLock(), LockMode.WRITE_LOCK);
+                // keep a write lock in the transaction
+                transaction.acquireLock(collection.getLock(), LockMode.WRITE_LOCK);
                 if(LOG.isDebugEnabled()) {
                     LOG.debug("removing collection " + collURI);
                 }

--- a/test/src/org/exist/storage/MoveResourceTest.java
+++ b/test/src/org/exist/storage/MoveResourceTest.java
@@ -142,11 +142,17 @@ public class MoveResourceTest {
             final TransactionManager transact = pool.getTransactionManager();
             try(final Txn transaction = transact.beginTransaction()) {
 
-                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
-                assertNotNull(root);
-                transaction.registerLock(root.getLock(), LockMode.WRITE_LOCK);
-                broker.removeCollection(transaction, root);
-
+                Collection root = null;
+                try {
+                    root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
+                    assertNotNull(root);
+                    transaction.acquireLock(root.getLock(), LockMode.WRITE_LOCK);
+                    broker.removeCollection(transaction, root);
+                } finally {
+                    if(root != null) {
+                        root.release(LockMode.WRITE_LOCK);
+                    }
+                }
                 transact.commit(transaction);
             }
         }
@@ -203,10 +209,17 @@ public class MoveResourceTest {
             final TransactionManager transact = pool.getTransactionManager();
             try(final Txn transaction = transact.beginTransaction()) {
 
-                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
-                assertNotNull(root);
-                transaction.registerLock(root.getLock(), LockMode.WRITE_LOCK);
-                broker.removeCollection(transaction, root);
+                Collection root = null;
+                try {
+                    root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
+                    assertNotNull(root);
+                    transaction.acquireLock(root.getLock(), LockMode.WRITE_LOCK);
+                    broker.removeCollection(transaction, root);
+                } finally {
+                    if(root != null) {
+                        root.release(LockMode.WRITE_LOCK);
+                    }
+                }
 
                 transact.commit(transaction);
             }

--- a/test/src/org/exist/storage/RecoveryTest.java
+++ b/test/src/org/exist/storage/RecoveryTest.java
@@ -232,11 +232,17 @@ public class RecoveryTest {
             
             final TransactionManager transact = pool.getTransactionManager();
             try(final Txn transaction = transact.beginTransaction()) {
-
-                final Collection root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
-                assertNotNull(root);
-                transaction.registerLock(root.getLock(), LockMode.WRITE_LOCK);
-                broker.removeCollection(transaction, root);
+                Collection root = null;
+                try {
+                    root = broker.openCollection(TestConstants.TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
+                    assertNotNull(root);
+                    transaction.acquireLock(root.getLock(), LockMode.WRITE_LOCK);
+                    broker.removeCollection(transaction, root);
+                } finally {
+                    if(root != null) {
+                        root.release(LockMode.WRITE_LOCK);
+                    }
+                }
 
                 transact.commit(transaction);
             }


### PR DESCRIPTION
This simple change greatly simplifies lock release code when locks need to be associated with the transaction lifecycle.

Previously moving lock ownership to a transaction was error prone and likely to lead to complex and possibly incorrect release semantics. This small refactoring opens the door to using ARM (Automatic Resource Management) for lock leases.