### PR TITLE
Write operations without lock and possible NPE fix

### DIFF
--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -1530,12 +1530,12 @@ public class NativeBroker extends DBBroker {
                     // remove from parent collection
                     //TODO : resolve URIs ! (uri.resolve(".."))
                     final Collection parentCollection = openCollection(collection.getParentURI(), LockMode.WRITE_LOCK);
-                    // keep the lock for the transaction
-                    if(transaction != null) {
-                        transaction.registerLock(parentCollection.getLock(), LockMode.WRITE_LOCK);
-                    }
-
                     if(parentCollection != null) {
+                        // keep the lock for the transaction
+                        if(transaction != null) {
+                            transaction.registerLock(parentCollection.getLock(), LockMode.WRITE_LOCK);
+                        }
+
                         try {
                             LOG.debug("Removing collection '" + collName + "' from its parent...");
                             //TODO : resolve from collection's base URI

--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -626,10 +626,12 @@ public class NativeBroker extends DBBroker {
         throws LockException, PermissionDeniedException, IOException, TriggerException {
         try {
             pushSubject(pool.getSecurityManager().getSystemSubject());
-            final Collection temp = getOrCreateCollection(transaction, XmldbURI.TEMP_COLLECTION_URI);
-            temp.setPermissions(0771);
-            saveCollection(transaction, temp);
-            return temp;
+            final Tuple2<Boolean, Collection> temp = getOrCreateCollectionExplicit(transaction, XmldbURI.TEMP_COLLECTION_URI);
+            if (temp._1) {
+                temp._2.setPermissions(0771);
+                saveCollection(transaction, temp._2);
+            }
+            return temp._2;
         } finally {
             popSubject();
         }

--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -1938,6 +1938,9 @@ public class NativeBroker extends DBBroker {
                 temp.addDocument(transaction, this, targetDoc);
 
                 storeXMLResource(transaction, targetDoc);
+
+                saveCollection(transaction, temp);
+
                 flush();
                 closeDocument();
                 //commit the transaction


### PR DESCRIPTION
### Description:
Address 2 bugs:
 - storeTempResource must hold write lock on collection
 - avoid NPE removeCollection (possible only when storage corrupted)

### Reference:
address bugfixes of #1296