### PR TITLE
XSL stylesheet caching and compiling bugfixes

### DIFF
--- a/extensions/modules/src/org/exist/xquery/modules/xslfo/ApacheFopProcessorAdapter.java
+++ b/extensions/modules/src/org/exist/xquery/modules/xslfo/ApacheFopProcessorAdapter.java
@@ -14,7 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.xmlgraphics.io.ResourceResolver;
 import org.apache.xmlgraphics.io.URIResolverAdapter;
 import org.exist.storage.DBBroker;
-import org.exist.xquery.functions.transform.EXistURIResolver;
+import org.exist.xslt.EXistURIResolver;
 import org.exist.xquery.value.NodeValue;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -126,7 +126,9 @@ public class ApacheFopProcessorAdapter implements ProcessorAdapter {
      */
     private ResourceResolver getResourceResolver(final DBBroker broker, final String baseUri) {
         final ResourceResolverFactory.SchemeAwareResourceResolverBuilder builder = ResourceResolverFactory.createSchemeAwareResourceResolverBuilder(ResourceResolverFactory.createDefaultResourceResolver());
-        final URIResolverAdapter uriResolver = new URIResolverAdapter(new ExistSchemeRewriter(new EXistURIResolver(broker, baseUri)));
+        final URIResolverAdapter uriResolver = new URIResolverAdapter(
+            new ExistSchemeRewriter(new EXistURIResolver(broker.getBrokerPool(), baseUri))
+        );
         builder.registerResourceResolverForScheme("exist", uriResolver);
         builder.registerResourceResolverForScheme("http", uriResolver);
         builder.registerResourceResolverForScheme("https", uriResolver);

--- a/src/org/exist/xquery/functions/transform/EXistURIResolver.java
+++ b/src/org/exist/xquery/functions/transform/EXistURIResolver.java
@@ -43,6 +43,8 @@ import java.nio.file.Path;
 /**
  * Implementation of URIResolver which
  * will resolve paths from the eXist database
+ *
+ * @Deprecated use org.exist.xslt.EXistURIResolver
  */
 public class EXistURIResolver implements URIResolver {
     private static final Logger LOG = LogManager.getLogger(EXistURIResolver.class);

--- a/src/org/exist/xquery/functions/transform/EXistURIResolver.java
+++ b/src/org/exist/xquery/functions/transform/EXistURIResolver.java
@@ -44,7 +44,7 @@ import java.nio.file.Path;
  * Implementation of URIResolver which
  * will resolve paths from the eXist database
  *
- * @Deprecated use org.exist.xslt.EXistURIResolver
+ * @Deprecated use {@link org.exist.xslt.EXistURIResolver}
  */
 public class EXistURIResolver implements URIResolver {
     private static final Logger LOG = LogManager.getLogger(EXistURIResolver.class);

--- a/src/org/exist/xquery/functions/transform/Transform.java
+++ b/src/org/exist/xquery/functions/transform/Transform.java
@@ -1,23 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2011 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.xquery.functions.transform;
 
@@ -26,12 +24,9 @@ import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.MemTreeBuilder;
-import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.http.servlets.ResponseWrapper;
 import org.exist.numbering.NodeId;
-import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.storage.serializers.XIncludeFilter;
@@ -41,28 +36,22 @@ import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.response.ResponseModule;
 import org.exist.xquery.value.*;
+import org.exist.xslt.StylesheetUri;
+import org.exist.xslt.Stylesheet;
+import org.exist.xslt.TemplatesFactory;
 import org.exist.xslt.TransformerFactoryAllocator;
+import org.exist.xslt.XSLTErrorsListener;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-import org.xml.sax.SAXException;
 
 import javax.xml.transform.*;
 import javax.xml.transform.sax.SAXResult;
-import javax.xml.transform.sax.SAXTransformerFactory;
-import javax.xml.transform.sax.TemplatesHandler;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -150,8 +139,6 @@ public class Transform extends BasicFunction {
     };
 
     private static final Logger logger = LogManager.getLogger(Transform.class);
-    private final Map<String, CachedStylesheet> cache = new HashMap<>();
-    private boolean caching = true;
 
     private boolean stopOnError = true;
     private boolean stopOnWarn = false;
@@ -162,11 +149,6 @@ public class Transform extends BasicFunction {
      */
     public Transform(XQueryContext context, FunctionSignature signature) {
         super(context, signature);
-
-        final Object property = context.getBroker().getConfiguration().getProperty(TransformerFactoryAllocator.PROPERTY_CACHING_ATTRIBUTE);
-        if (property != null) {
-            caching = (Boolean) property;
-        }
     }
 
     /* (non-Javadoc)
@@ -208,10 +190,16 @@ public class Transform extends BasicFunction {
                 "yes".equals(serializationProps.getProperty(EXistOutputKeys.EXPAND_XINCLUDES, "yes"));
 
 
+        final XSLTErrorsListener<XPathException> errorListener =
+            new XSLTErrorsListener<XPathException>(stopOnError, stopOnWarn) {
+                @Override
+                protected void raiseError(String error, Exception ex) throws XPathException {
+                    throw new XPathException(Transform.this, error, ex);
+                }
+            };
+
         // Setup handler and error listener
-        final TransformerHandler handler = createHandler(stylesheetItem, stylesheetParams, attributes);
-        final TransformErrorListener errorListener = new TransformErrorListener();
-        handler.getTransformer().setErrorListener(errorListener);
+        final TransformerHandler handler = createHandler(stylesheetItem, stylesheetParams, attributes, errorListener);
 
 
         if (isCalledAs("transform")) {
@@ -360,17 +348,24 @@ public class Transform extends BasicFunction {
      * @throws TransformerFactoryConfigurationError
      * @throws XPathException
      */
-    private TransformerHandler createHandler(Item stylesheetItem, Properties options, Properties attributes) throws TransformerFactoryConfigurationError, XPathException {
-        final SAXTransformerFactory factory = TransformerFactoryAllocator.getTransformerFactory(context.getBroker().getBrokerPool());
+    private TransformerHandler createHandler(
+        Item stylesheetItem,
+        Properties options,
+        Properties attributes,
+        XSLTErrorsListener<XPathException> errorListener
+    )
+        throws TransformerFactoryConfigurationError, XPathException
+    {
 
-        //set any attributes
-        for (final Map.Entry<Object, Object> attribute : attributes.entrySet()) {
-            factory.setAttribute((String) attribute.getKey(), attribute.getValue());
+        boolean useCache = true;
+        final Object property = context.getBroker().getConfiguration().getProperty(TransformerFactoryAllocator.PROPERTY_CACHING_ATTRIBUTE);
+        if (property != null) {
+            useCache = (Boolean) property;
         }
 
         TransformerHandler handler;
         try {
-            Templates templates = null;
+            Stylesheet stylesheet = null;
             if (Type.subTypeOf(stylesheetItem.getType(), Type.NODE)) {
                 final NodeValue stylesheetNode = (NodeValue) stylesheetItem;
                 // if the passed node is a document node or document root element,
@@ -378,53 +373,50 @@ public class Transform extends BasicFunction {
                 if (stylesheetNode.getImplementationType() == NodeValue.PERSISTENT_NODE) {
                     final NodeProxy root = (NodeProxy) stylesheetNode;
                     if (root.getNodeId() == NodeId.DOCUMENT_NODE || root.getNodeId().getTreeLevel() == 1) {
-                        //as this is a persistent node (e.g. a stylesheet stored in the db)
-                        //set the URI Resolver as a DatabaseResolver
-                        factory.setURIResolver(new EXistURIResolver(context.getBroker(), root.getOwnerDocument().getCollection().getURI().toString()));
 
                         final String uri = XmldbURI.XMLDB_URI_PREFIX + context.getBroker().getBrokerPool().getId() + "://" + root.getOwnerDocument().getURI();
-                        templates = getSource(factory, uri);
+
+                        stylesheet = TemplatesFactory.stylesheet(uri, context.getModuleLoadPath(), attributes, useCache);
                     }
                 }
-                if (templates == null) {
-                    if (stylesheetItem instanceof Document) {
-                        String uri = ((Document) stylesheetItem).getDocumentURI();
-
-						/*
-                         * This must be checked because in the event the stylesheet is
-						 * an in-memory document, it will cause an NPE
-						 */
-                        if (uri != null) {
-                            uri = uri.substring(0, uri.lastIndexOf('/'));
-                            factory.setURIResolver(new EXistURIResolver(context.getBroker(), uri));
-                        }
-                    }
-                    templates = getSource(factory, stylesheetNode);
+                if (stylesheet == null) {
+                    stylesheet = TemplatesFactory.stylesheet(
+                        getContext().getBroker(),
+                        stylesheetNode,
+                        context.getModuleLoadPath()
+                    );
                 }
             } else {
+                String baseUri = context.getModuleLoadPath();
                 if (stylesheetItem instanceof Document) {
-                    String uri = ((Document) stylesheetItem).getDocumentURI();
+                    baseUri = ((Document) stylesheetItem).getDocumentURI();
 
-					/*
-					 * This must be checked because in the event the stylesheet is 
-					 * an in-memory document, it will cause an NPE
-					 */
-                    if (uri != null) {
-                        uri = uri.substring(0, uri.lastIndexOf('/'));
-                        factory.setURIResolver(new EXistURIResolver(context.getBroker(), uri));
+                    /*
+                     * This must be checked because in the event the stylesheet is
+                     * an in-memory document, it will cause an NPE
+                     */
+                    if (baseUri == null) {
+                        baseUri = context.getModuleLoadPath();
+                    } else {
+                        baseUri = baseUri.substring(0, baseUri.lastIndexOf('/'));
                     }
                 }
 
-                final String stylesheet = stylesheetItem.getStringValue();
-                templates = getSource(factory, stylesheet);
+                final String uri = stylesheetItem.getStringValue();
+
+                stylesheet = TemplatesFactory.stylesheet(uri, baseUri, attributes, useCache);
             }
-            handler = factory.newTransformerHandler(templates);
+
+            handler = stylesheet.newTransformerHandler(getContext().getBroker(), errorListener);
 
             if (options != null) {
                 setParameters(options, handler.getTransformer());
             }
 
-        } catch (final TransformerConfigurationException e) {
+        } catch (final Exception e) {
+            if (e instanceof XPathException) {
+                throw (XPathException) e;
+            }
             throw new XPathException(this, "Unable to set up transformer: " + e.getMessage(), e);
         }
         return handler;
@@ -489,216 +481,6 @@ public class Transform extends BasicFunction {
         for (Object o : parameters.keySet()) {
             final String key = (String) o;
             handler.setParameter(key, parameters.getProperty(key));
-        }
-    }
-
-    private Templates getSource(SAXTransformerFactory factory, String stylesheet)
-            throws XPathException, TransformerConfigurationException {
-        String base;
-        if (stylesheet.indexOf(':') == Constants.STRING_NOT_FOUND) {
-            Path f = Paths.get(stylesheet).normalize();
-            if (Files.isReadable(f)) {
-                stylesheet = f.toUri().toASCIIString();
-            } else {
-                stylesheet = context.getModuleLoadPath() + File.separatorChar + stylesheet;
-                f = Paths.get(stylesheet).normalize();
-                if (Files.isReadable(f)) {
-                    stylesheet = f.toUri().toASCIIString();
-                }
-            }
-        }
-
-        //TODO : use dedicated function in XmldbURI
-        final int p = stylesheet.lastIndexOf("/");
-        if (p != Constants.STRING_NOT_FOUND) {
-            base = stylesheet.substring(0, p);
-        } else {
-            base = stylesheet;
-        }
-
-        CachedStylesheet cached = cache.get(stylesheet);
-        try {
-            if (cached == null) {
-                cached = new CachedStylesheet(factory, stylesheet, base);
-                cache.put(stylesheet, cached);
-            }
-            return cached.getTemplates();
-
-        } catch (final MalformedURLException e) {
-            LOG.debug(e.getMessage(), e);
-            throw new XPathException(this, "Malformed URL for stylesheet: " + stylesheet, e);
-
-        } catch (final IOException e) {
-            throw new XPathException(this, "IO error while loading stylesheet: " + stylesheet, e);
-        }
-    }
-
-    private Templates getSource(SAXTransformerFactory factory, NodeValue stylesheetRoot) throws XPathException, TransformerConfigurationException {
-        final TemplatesHandler handler = factory.newTemplatesHandler();
-        try {
-            handler.startDocument();
-            stylesheetRoot.toSAX(context.getBroker(), handler, null);
-            handler.endDocument();
-            return handler.getTemplates();
-
-        } catch (final SAXException e) {
-            throw new XPathException(this,
-                    "A SAX exception occurred while compiling the stylesheet: " + e.getMessage(), e);
-        }
-    }
-
-    public static class ExternalResolver implements URIResolver {
-        private final String baseURI;
-
-        public ExternalResolver(final String base) {
-            this.baseURI = base;
-        }
-
-        @Override
-        public Source resolve(final String href, final String base) throws TransformerException {
-            try {
-                //TODO : use dedicated function in XmldbURI
-                final URL url = new URL(baseURI + "/" + href);
-                final URLConnection connection = url.openConnection();
-                return new StreamSource(connection.getInputStream());
-            } catch (final IOException e) {
-                LOG.warn(e);
-                return null;
-            }
-        }
-    }
-
-    //TODO: revisit this class with XmldbURI in mind
-    private class CachedStylesheet {
-
-        SAXTransformerFactory factory;
-        long lastModified = -1;
-        Templates templates = null;
-        String uri;
-
-        public CachedStylesheet(SAXTransformerFactory factory, String uri, String baseURI)
-                throws TransformerConfigurationException, IOException, XPathException {
-            this.factory = factory;
-            this.uri = uri;
-            if (!baseURI.startsWith(XmldbURI.EMBEDDED_SERVER_URI_PREFIX)) {
-                factory.setURIResolver(new ExternalResolver(baseURI));
-            }
-            getTemplates();
-        }
-
-        public Templates getTemplates() throws TransformerConfigurationException, IOException, XPathException {
-            if (uri.startsWith(XmldbURI.EMBEDDED_SERVER_URI_PREFIX)) {
-                final String docPath = uri.substring(XmldbURI.EMBEDDED_SERVER_URI_PREFIX.length());
-                DocumentImpl doc = null;
-                try {
-                    doc = context.getBroker().getXMLResource(XmldbURI.create(docPath), LockMode.READ_LOCK);
-                    if (!caching || (doc != null && (templates == null || doc.getMetadata().getLastModified() > lastModified))) {
-                        templates = getSource(doc);
-                    }
-                    lastModified = doc.getMetadata().getLastModified();
-                } catch (final PermissionDeniedException e) {
-                    throw new XPathException(Transform.this, "Permission denied to read stylesheet: " + uri);
-                } finally {
-                    if (doc != null) {
-                        doc.getUpdateLock().release(LockMode.READ_LOCK);
-                    }
-                }
-
-            } else {
-                final URL url = new URL(uri);
-                final URLConnection connection = url.openConnection();
-                long modified = connection.getLastModified();
-                if (!caching || (templates == null || modified > lastModified || modified == 0)) {
-                    LOG.debug("compiling stylesheet " + url);
-                    try (final InputStream is = connection.getInputStream()) {
-                        templates = factory.newTemplates(new StreamSource(is));
-                    }
-                }
-                lastModified = modified;
-            }
-            return templates;
-        }
-
-        private Templates getSource(DocumentImpl stylesheet)
-                throws XPathException, TransformerConfigurationException {
-            factory.setURIResolver(new EXistURIResolver(context.getBroker(), stylesheet.getCollection().getURI().toString()));
-            final TransformErrorListener errorListener = new TransformErrorListener();
-            factory.setErrorListener(errorListener);
-            final TemplatesHandler handler = factory.newTemplatesHandler();
-
-            try {
-                handler.startDocument();
-                final Serializer serializer = context.getBroker().getSerializer();
-                serializer.reset();
-                serializer.setSAXHandlers(handler, null);
-                serializer.toSAX(stylesheet);
-                handler.endDocument();
-                final Templates t = handler.getTemplates();
-                errorListener.checkForErrors();
-                return t;
-
-            } catch (final Exception e) {
-                if (e instanceof XPathException) {
-                    throw (XPathException) e;
-                }
-                throw new XPathException(Transform.this,
-                        "An exception occurred while compiling the stylesheet: " + stylesheet.getURI() +
-                                ": " + e.getMessage(), e);
-            }
-        }
-    }
-
-    private class TransformErrorListener implements ErrorListener {
-
-        private final static int NO_ERROR = 0;
-        private final static int WARNING = 1;
-        private final static int ERROR = 2;
-        private final static int FATAL = 3;
-
-        private int errorCode = NO_ERROR;
-        private Exception exception;
-
-        protected void checkForErrors() throws XPathException {
-            switch (errorCode) {
-                case WARNING:
-                    if (stopOnWarn) {
-                        throw new XPathException("XSL transform reported warning: " + exception.getMessage(),
-                                exception);
-                    }
-                    break;
-                case ERROR:
-                    if (stopOnError) {
-                        throw new XPathException("XSL transform reported error: " + exception.getMessage(), exception);
-                    }
-                    break;
-                case FATAL:
-                    throw new XPathException("XSL transform reported error: " + exception.getMessage(), exception);
-            }
-        }
-
-        public void warning(TransformerException except) throws TransformerException {
-            LOG.warn("XSL transform reports warning: " + except.getMessage(), except);
-            errorCode = WARNING;
-            exception = except;
-            if (stopOnWarn) {
-                throw except;
-            }
-        }
-
-        public void error(TransformerException except) throws TransformerException {
-            LOG.warn("XSL transform reports recoverable error: " + except.getMessage(), except);
-            errorCode = ERROR;
-            exception = except;
-            if (stopOnError) {
-                throw except;
-            }
-        }
-
-        public void fatalError(TransformerException except) throws TransformerException {
-            LOG.warn("XSL transform reports fatal error: " + except.getMessage(), except);
-            errorCode = FATAL;
-            exception = except;
-            throw except;
         }
     }
 }

--- a/src/org/exist/xquery/functions/transform/Transform.java
+++ b/src/org/exist/xquery/functions/transform/Transform.java
@@ -36,7 +36,6 @@ import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.response.ResponseModule;
 import org.exist.xquery.value.*;
-import org.exist.xslt.StylesheetUri;
 import org.exist.xslt.Stylesheet;
 import org.exist.xslt.TemplatesFactory;
 import org.exist.xslt.TransformerFactoryAllocator;
@@ -54,8 +53,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 
 /**

--- a/src/org/exist/xquery/functions/transform/TransformModule.java
+++ b/src/org/exist/xquery/functions/transform/TransformModule.java
@@ -1,23 +1,21 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2001-09 The eXist Project
+ * Copyright (C) 2001-2017 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *  
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
- *  $Id$
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.xquery.functions.transform;
 

--- a/src/org/exist/xslt/EXistURIResolver.java
+++ b/src/org/exist/xslt/EXistURIResolver.java
@@ -1,0 +1,201 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xslt;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.dom.persistent.BinaryDocument;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.security.Permission;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.xmldb.XmldbURI;
+
+/**
+ * Implementation of URIResolver which
+ * will resolve paths from the eXist database
+ */
+public class EXistURIResolver implements URIResolver {
+
+  private static final Logger LOG = LogManager.getLogger(EXistURIResolver.class);
+
+  final BrokerPool db;
+  final String basePath;
+
+  public EXistURIResolver(final BrokerPool db, final String docPath) {
+    this.db = db;
+    this.basePath = normalize(docPath);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("EXistURIResolver base path set to " + basePath);
+    }
+  }
+
+  private String normalize(String uri) {
+    if (uri.startsWith(XmldbURI.EMBEDDED_SERVER_URI_PREFIX)) {
+      return uri.substring(XmldbURI.EMBEDDED_SERVER_URI_PREFIX.length());
+    }
+
+    return uri;
+  }
+
+  /**
+   * Simplify a path removing any "." and ".." path elements.
+   * Assumes an absolute path is given.
+   */
+  private String normalizePath(final String path) {
+    if (!path.startsWith("/")) {
+      throw new IllegalArgumentException("normalizePath may only be applied to an absolute path; " +
+          "argument was: " + path + "; base: " + basePath);
+    }
+
+    final String[] pathComponents = path.substring(1).split("/");
+
+    final int numPathComponents = Array.getLength(pathComponents);
+    final String[] simplifiedComponents = new String[numPathComponents];
+    int numSimplifiedComponents = 0;
+
+    for (final String s : pathComponents) {
+      // Remove empty elements ("/")
+      if (s.isEmpty()) {
+        continue;
+      }
+      // Remove identity elements (".")
+      if (".".equals(s)) {
+        continue;
+      }
+      // Remove parent elements ("..") unless at the root
+      if ("..".equals(s)) {
+        if (numSimplifiedComponents > 0) {
+          numSimplifiedComponents--;
+        }
+        continue;
+      }
+      simplifiedComponents[numSimplifiedComponents++] = s;
+    }
+
+    if (numSimplifiedComponents == 0) {
+      return "/";
+    }
+
+    final StringBuilder sb = new StringBuilder(path.length());
+    for (int x = 0; x < numSimplifiedComponents; x++) {
+      sb.append("/").append(simplifiedComponents[x]);
+    }
+
+    if (path.endsWith("/")) {
+      sb.append("/");
+    }
+
+    return sb.toString();
+  }
+
+  @Override
+  public Source resolve(final String href, String base) throws TransformerException {
+    String path;
+
+    if (href.isEmpty()) {
+      path = base;
+    } else {
+      URI hrefURI = null;
+      try {
+        hrefURI = new URI(href);
+      } catch (final URISyntaxException e) {
+      }
+      if (hrefURI != null && hrefURI.isAbsolute()) {
+        path = href;
+      } else {
+        if (href.startsWith("/")) {
+          path = href;
+        } else if (href.startsWith(XmldbURI.EMBEDDED_SERVER_URI_PREFIX)) {
+          path = href.substring(XmldbURI.EMBEDDED_SERVER_URI_PREFIX.length());
+        } else if (base == null || base.length() == 0) {
+          path = basePath + "/" + href;
+        } else {
+          // Maybe base never contains this prefix?  Check to be sure.
+          if (base.startsWith(XmldbURI.EMBEDDED_SERVER_URI_PREFIX)) {
+            base = base.substring(XmldbURI.EMBEDDED_SERVER_URI_PREFIX.length());
+          }
+          path = base.substring(0, base.lastIndexOf("/") + 1) + href;
+        }
+      }
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Resolving path " + href + " with base " + base + " to " + path);
+      // + " (URI = " + uri.toASCIIString() + ")");
+    }
+
+    if (path.startsWith("/")) {
+      path = normalizePath(path);
+      return databaseSource(path);
+    } else {
+      return urlSource(path);
+    }
+  }
+
+  private Source urlSource(final String path) throws TransformerException {
+    try {
+      final URL url = new URL(path);
+      return new StreamSource(url.openStream());
+    } catch (final IOException e) {
+      throw new TransformerException(e.getMessage(), e);
+    }
+  }
+
+  private Source databaseSource(final String path) throws TransformerException {
+    final XmldbURI uri = XmldbURI.create(path);
+
+    final DBBroker broker = db.getActiveBroker();
+
+    final DocumentImpl doc;
+    try {
+      doc = broker.getResource(uri, Permission.READ);
+      if (doc == null) {
+        LOG.error("Document " + path + " not found");
+        throw new TransformerException("Resource " + path + " not found in database.");
+      }
+
+      final Source source;
+      if (doc instanceof BinaryDocument) {
+        final Path p = broker.getBinaryFile((BinaryDocument) doc);
+        source = new StreamSource(p.toFile());
+        source.setSystemId(p.toUri().toString());
+        return source;
+      } else {
+        source = new DOMSource(doc);
+        source.setSystemId(uri.toASCIIString());
+        return source;
+      }
+    } catch (final PermissionDeniedException | IOException e) {
+      throw new TransformerException(e.getMessage(), e);
+    }
+  }
+}

--- a/src/org/exist/xslt/Stylesheet.java
+++ b/src/org/exist/xslt/Stylesheet.java
@@ -19,14 +19,22 @@
  */
 package org.exist.xslt;
 
-import org.exist.xquery.XPathException;
-import org.exist.xquery.value.Sequence;
+import java.io.IOException;
+import javax.xml.transform.Templates;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.sax.TransformerHandler;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.xml.sax.SAXException;
 
 /**
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
- *
  */
-public abstract class Transformer extends javax.xml.transform.Transformer {
+public interface Stylesheet {
 
-	public abstract Sequence transform(Sequence xmlSource) throws XPathException;
+  <E extends Exception> Templates templates(DBBroker broker, XSLTErrorsListener<E> errorListener)
+      throws E, PermissionDeniedException, SAXException, TransformerConfigurationException, IOException;
+
+  <E extends Exception> TransformerHandler newTransformerHandler(DBBroker broker, XSLTErrorsListener<E> errorListener)
+      throws E, PermissionDeniedException, SAXException, TransformerConfigurationException, IOException;
 }

--- a/src/org/exist/xslt/Stylesheet.java
+++ b/src/org/exist/xslt/Stylesheet.java
@@ -28,6 +28,8 @@ import org.exist.storage.DBBroker;
 import org.xml.sax.SAXException;
 
 /**
+ * {@link javax.xml.transform.Templates} resolver and compiler interface.
+ *
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
  */
 public interface Stylesheet {

--- a/src/org/exist/xslt/StylesheetResolverAndCompiler.java
+++ b/src/org/exist/xslt/StylesheetResolverAndCompiler.java
@@ -31,6 +31,7 @@ import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TemplatesHandler;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamSource;
+import net.jcip.annotations.ThreadSafe;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.persistent.DocumentImpl;
@@ -48,6 +49,7 @@ import org.xml.sax.SAXException;
  *
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
  */
+@ThreadSafe
 public class StylesheetResolverAndCompiler implements Stylesheet {
 
   protected final static Logger LOG = LogManager.getLogger(StylesheetResolverAndCompiler.class);

--- a/src/org/exist/xslt/StylesheetResolverAndCompiler.java
+++ b/src/org/exist/xslt/StylesheetResolverAndCompiler.java
@@ -44,11 +44,13 @@ import org.exist.xquery.Constants;
 import org.xml.sax.SAXException;
 
 /**
+ * {@link javax.xml.transform.Templates} resolver and compiler.
+ *
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
  */
-public class StylesheetUri implements Stylesheet {
+public class StylesheetResolverAndCompiler implements Stylesheet {
 
-  protected final static Logger LOG = LogManager.getLogger(StylesheetUri.class);
+  protected final static Logger LOG = LogManager.getLogger(StylesheetResolverAndCompiler.class);
 
   SAXTransformerFactory factory;
 
@@ -60,7 +62,7 @@ public class StylesheetUri implements Stylesheet {
 
   Properties properties;
 
-  public StylesheetUri(String uri) {
+  public StylesheetResolverAndCompiler(String uri) {
     this.uri = uri;
 
     final int p = uri.lastIndexOf("/");
@@ -71,7 +73,7 @@ public class StylesheetUri implements Stylesheet {
     }
   }
 
-  public StylesheetUri(String uri, Properties properties) {
+  public StylesheetResolverAndCompiler(String uri, Properties properties) {
     this(uri);
 
     this.properties = properties;

--- a/src/org/exist/xslt/StylesheetUri.java
+++ b/src/org/exist/xslt/StylesheetUri.java
@@ -1,0 +1,189 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xslt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Map;
+import java.util.Properties;
+import javax.xml.transform.Templates;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TemplatesHandler;
+import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock.LockMode;
+import org.exist.storage.serializers.Serializer;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.Constants;
+import org.xml.sax.SAXException;
+
+/**
+ * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
+ */
+public class StylesheetUri implements Stylesheet {
+
+  protected final static Logger LOG = LogManager.getLogger(StylesheetUri.class);
+
+  SAXTransformerFactory factory;
+
+  long lastModified = -1;
+  Templates templates = null;
+
+  String uri;
+  String base;
+
+  Properties properties;
+
+  public StylesheetUri(String uri) {
+    this.uri = uri;
+
+    final int p = uri.lastIndexOf("/");
+    if (p != Constants.STRING_NOT_FOUND) {
+      base = uri.substring(0, p);
+    } else {
+      base = uri;
+    }
+  }
+
+  public StylesheetUri(String uri, Properties properties) {
+    this(uri);
+
+    this.properties = properties;
+  }
+
+  public <E extends Exception> Templates templates(DBBroker broker, XSLTErrorsListener<E> errorListener)
+      throws E, TransformerConfigurationException, IOException, PermissionDeniedException, SAXException {
+
+    if (uri.startsWith(XmldbURI.EMBEDDED_SERVER_URI_PREFIX)) {
+      final String docPath = uri.substring(XmldbURI.EMBEDDED_SERVER_URI_PREFIX.length());
+      DocumentImpl doc = null;
+      try {
+        doc = broker.getXMLResource(XmldbURI.create(docPath), LockMode.READ_LOCK);
+        if (doc == null) {
+          throw new IOException("XSL stylesheet not found: "+docPath);
+        }
+        if (templates == null || doc.getMetadata().getLastModified() > lastModified) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("compiling stylesheet " + doc.getURI());
+          }
+          templates = compileTemplates(broker, doc, errorListener);
+          lastModified = doc.getMetadata().getLastModified();
+        }
+      } finally {
+        if (doc != null) {
+          doc.getUpdateLock().release(LockMode.READ_LOCK);
+        }
+      }
+
+    } else {
+      final URL url = new URL(uri);
+      final URLConnection connection = url.openConnection();
+      long modified = connection.getLastModified();
+      if (templates == null || modified > lastModified || modified == 0) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("compiling stylesheet " + url);
+        }
+        try (final InputStream is = connection.getInputStream()) {
+          templates = factory(broker.getBrokerPool(), errorListener).newTemplates(new StreamSource(is));
+        }
+      }
+      lastModified = modified;
+    }
+
+    return templates;
+  }
+
+  @Override
+  public <E extends Exception> TransformerHandler newTransformerHandler(DBBroker broker, XSLTErrorsListener<E> errorListener)
+      throws E, PermissionDeniedException, SAXException, TransformerConfigurationException, IOException {
+
+    TransformerHandler handler = cachedFactory(broker.getBrokerPool())
+        .newTransformerHandler(templates(broker, errorListener));
+
+    handler.getTransformer().setErrorListener(errorListener);
+
+    return handler;
+  }
+
+  private <E extends Exception> Templates compileTemplates(
+      DBBroker broker,
+      DocumentImpl stylesheet,
+      XSLTErrorsListener<E> errorListener)
+      throws E, TransformerConfigurationException, SAXException
+  {
+    //factory.setURIResolver(new EXistURIResolver(broker, stylesheet.getCollection().getURI().toString()));
+
+    final TemplatesHandler handler = factory(broker.getBrokerPool(), errorListener).newTemplatesHandler();
+
+    handler.startDocument();
+
+    final Serializer serializer = broker.newSerializer();
+    serializer.reset();
+    serializer.setSAXHandlers(handler, null);
+    serializer.toSAX(stylesheet);
+
+    handler.endDocument();
+
+    final Templates t = handler.getTemplates();
+
+    //check for errors
+    errorListener.checkForErrors();
+
+    return t;
+  }
+
+  private SAXTransformerFactory cachedFactory(BrokerPool db) {
+    if (factory == null) {
+      factory = TransformerFactoryAllocator.getTransformerFactory(db);
+
+      if (properties != null) {
+        //set any attributes
+        for (final Map.Entry<Object, Object> attribute : properties.entrySet()) {
+          factory.setAttribute((String) attribute.getKey(), attribute.getValue());
+        }
+      }
+      factory.setURIResolver(new EXistURIResolver(db, base));
+    }
+    return factory;
+  }
+
+  private <E extends Exception> SAXTransformerFactory factory(BrokerPool db, XSLTErrorsListener<E> errorListener) {
+    SAXTransformerFactory newFactory = TransformerFactoryAllocator.getTransformerFactory(db);
+
+    if (properties != null) {
+      //set any attributes
+      for (final Map.Entry<Object, Object> attribute : properties.entrySet()) {
+        newFactory.setAttribute((String) attribute.getKey(), attribute.getValue());
+      }
+    }
+    newFactory.setURIResolver(new EXistURIResolver(db, base));
+    newFactory.setErrorListener(errorListener);
+    return newFactory;
+  }
+}

--- a/src/org/exist/xslt/TemplatesFactory.java
+++ b/src/org/exist/xslt/TemplatesFactory.java
@@ -66,8 +66,7 @@ public class TemplatesFactory {
 
     String uri = uri(stylesheet, baseUri);
 
-    cache.computeIfAbsent(uri, StylesheetResolverAndCompiler::new);
-    return cache.get(uri);
+    return cache.computeIfAbsent(uri, StylesheetResolverAndCompiler::new);
   }
 
   public static Stylesheet stylesheet(String stylesheet, String baseUri, boolean useCache) {

--- a/src/org/exist/xslt/TemplatesFactory.java
+++ b/src/org/exist/xslt/TemplatesFactory.java
@@ -1,0 +1,151 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xslt;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import javax.xml.transform.Templates;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TemplatesHandler;
+import javax.xml.transform.sax.TransformerHandler;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.xquery.Constants;
+import org.exist.xquery.value.NodeValue;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+/**
+ * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
+ */
+public class TemplatesFactory {
+
+  private final static ConcurrentMap<String, StylesheetUri> cache = new ConcurrentHashMap<>();
+
+  public static Stylesheet stylesheet(String stylesheet, String baseUri, Properties properties, boolean useCache) {
+
+    if (useCache && properties == null) {
+      return stylesheet(stylesheet, baseUri);
+    }
+
+    String uri = uri(stylesheet, baseUri);
+
+    return new StylesheetUri(uri, properties);
+  }
+
+  private static Stylesheet stylesheet(String stylesheet, String baseUri) {
+
+    String uri = uri(stylesheet, baseUri);
+
+    cache.computeIfAbsent(uri, StylesheetUri::new);
+    return cache.get(uri);
+  }
+
+  public static Stylesheet stylesheet(String stylesheet, String baseUri, boolean useCache) {
+    if (useCache) {
+      return stylesheet(stylesheet, baseUri);
+    } else {
+      return new StylesheetUri(uri(stylesheet, baseUri));
+    }
+  }
+
+  private static String uri(String stylesheet, String baseUri) {
+    String uri = stylesheet;
+    if (stylesheet.indexOf(':') == Constants.STRING_NOT_FOUND) {
+      Path f = Paths.get(stylesheet).normalize();
+      if (Files.isReadable(f)) {
+        uri = f.toUri().toASCIIString();
+      } else {
+        stylesheet = baseUri + File.separatorChar + stylesheet;
+        f = Paths.get(stylesheet).normalize();
+        if (Files.isReadable(f)) {
+          uri = f.toUri().toASCIIString();
+        }
+      }
+    }
+    return uri;
+  }
+
+  public static <E extends Exception> Stylesheet stylesheet(DBBroker broker, NodeValue node, String baseUri)
+      throws E, TransformerConfigurationException
+  {
+    SAXTransformerFactory factory = TransformerFactoryAllocator
+        .getTransformerFactory(broker.getBrokerPool());
+
+    String base = baseUri;
+    Document doc = node.getOwnerDocument();
+    if (doc != null) {
+      String uri = doc.getDocumentURI();
+
+      /*
+       * This must be checked because in the event the stylesheet is
+       * an in-memory document, it will cause an NPE
+       */
+      if (uri != null) {
+        base = uri.substring(0, uri.lastIndexOf('/'));
+      }
+    }
+
+    if (base != null) {
+      factory.setURIResolver(new EXistURIResolver(broker.getBrokerPool(), base));
+    }
+
+    return new Stylesheet() {
+      @Override
+      public <E extends Exception> Templates templates(DBBroker broker, XSLTErrorsListener<E> errorListener)
+          throws E, TransformerConfigurationException, IOException, PermissionDeniedException, SAXException {
+
+        final TemplatesHandler handler = factory.newTemplatesHandler();
+
+        handler.startDocument();
+
+        node.toSAX(broker, handler, null);
+
+        handler.endDocument();
+
+        final Templates t = handler.getTemplates();
+
+        //check for errors
+        errorListener.checkForErrors();
+
+        return t;
+      }
+
+      @Override
+      public <E extends Exception> TransformerHandler newTransformerHandler(DBBroker broker,
+          XSLTErrorsListener<E> errorListener)
+          throws E, PermissionDeniedException, SAXException, TransformerConfigurationException, IOException {
+        TransformerHandler handler = factory
+            .newTransformerHandler(templates(broker, errorListener));
+
+        handler.getTransformer().setErrorListener(errorListener);
+
+        return handler;
+      }
+    };
+  }
+}

--- a/src/org/exist/xslt/TemplatesFactory.java
+++ b/src/org/exist/xslt/TemplatesFactory.java
@@ -32,6 +32,7 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TemplatesHandler;
 import javax.xml.transform.sax.TransformerHandler;
+import net.jcip.annotations.ThreadSafe;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
 import org.exist.xquery.Constants;
@@ -40,8 +41,12 @@ import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 /**
+ * Factory for stylesheet resolver and compiler instances
+ * and if instance is safe for reuse then it cached.
+ *
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
  */
+@ThreadSafe
 public class TemplatesFactory {
 
   private final static ConcurrentMap<String, StylesheetResolverAndCompiler> cache = new ConcurrentHashMap<>();

--- a/src/org/exist/xslt/TemplatesFactory.java
+++ b/src/org/exist/xslt/TemplatesFactory.java
@@ -44,7 +44,7 @@ import org.xml.sax.SAXException;
  */
 public class TemplatesFactory {
 
-  private final static ConcurrentMap<String, StylesheetUri> cache = new ConcurrentHashMap<>();
+  private final static ConcurrentMap<String, StylesheetResolverAndCompiler> cache = new ConcurrentHashMap<>();
 
   public static Stylesheet stylesheet(String stylesheet, String baseUri, Properties properties, boolean useCache) {
 
@@ -54,14 +54,14 @@ public class TemplatesFactory {
 
     String uri = uri(stylesheet, baseUri);
 
-    return new StylesheetUri(uri, properties);
+    return new StylesheetResolverAndCompiler(uri, properties);
   }
 
   private static Stylesheet stylesheet(String stylesheet, String baseUri) {
 
     String uri = uri(stylesheet, baseUri);
 
-    cache.computeIfAbsent(uri, StylesheetUri::new);
+    cache.computeIfAbsent(uri, StylesheetResolverAndCompiler::new);
     return cache.get(uri);
   }
 
@@ -69,7 +69,7 @@ public class TemplatesFactory {
     if (useCache) {
       return stylesheet(stylesheet, baseUri);
     } else {
-      return new StylesheetUri(uri(stylesheet, baseUri));
+      return new StylesheetResolverAndCompiler(uri(stylesheet, baseUri));
     }
   }
 

--- a/src/org/exist/xslt/TemplatesFactory.java
+++ b/src/org/exist/xslt/TemplatesFactory.java
@@ -85,8 +85,7 @@ public class TemplatesFactory {
       if (Files.isReadable(f)) {
         uri = f.toUri().toASCIIString();
       } else {
-        stylesheet = baseUri + File.separatorChar + stylesheet;
-        f = Paths.get(stylesheet).normalize();
+        f = Paths.get(baseUri, stylesheet).normalize();
         if (Files.isReadable(f)) {
           uri = f.toUri().toASCIIString();
         }

--- a/src/org/exist/xslt/TransformerFactoryAllocator.java
+++ b/src/org/exist/xslt/TransformerFactoryAllocator.java
@@ -1,21 +1,21 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2015 The eXist Project
- *  http://exist-db.org
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.xslt;
 
@@ -55,8 +55,6 @@ public class TransformerFactoryAllocator {
 
     public final static String PROPERTY_BROKER_POOL = "transformer.brokerPool";
 
-    private static volatile SAXTransformerFactory saxTransformerFactory = null;
-
     //private constructor
     private TransformerFactoryAllocator() {
     }
@@ -75,21 +73,6 @@ public class TransformerFactoryAllocator {
      * TransformerFactoryAllocator.getTransformerFactory(broker).newInstance()
      */
     public static SAXTransformerFactory getTransformerFactory(final BrokerPool pool) {
-        if(saxTransformerFactory == null) {
-            synchronized (TransformerFactoryAllocator.class) {
-                // Check again, after having acquired the lock to make sure
-                // the instance was not created meanwhile by another thread
-                if (saxTransformerFactory == null) {
-                    // Lazy initialisation
-                    saxTransformerFactory = initTransformerFactory(pool);
-                }
-            }
-        }
-
-        return saxTransformerFactory;
-    }
-
-    private static SAXTransformerFactory initTransformerFactory(final BrokerPool pool) {
         //Get the transformer class name from conf.xml
         final String transformerFactoryClassName = (String) pool.getConfiguration().getProperty(PROPERTY_TRANSFORMER_CLASS);
 

--- a/src/org/exist/xslt/XSLTErrorsListener.java
+++ b/src/org/exist/xslt/XSLTErrorsListener.java
@@ -1,0 +1,93 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xslt;
+
+import javax.xml.transform.ErrorListener;
+import javax.xml.transform.TransformerException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
+ */
+public abstract class XSLTErrorsListener<E extends Exception> implements ErrorListener {
+
+  private final static Logger LOG = LogManager.getLogger(XSLTErrorsListener.class);
+
+  private final static int NO_ERROR = 0;
+  private final static int WARNING = 1;
+  private final static int ERROR = 2;
+  private final static int FATAL = 3;
+
+  boolean stopOnError;
+  boolean stopOnWarn;
+
+  private int errorCode = NO_ERROR;
+  private Exception exception;
+
+  public XSLTErrorsListener(boolean stopOnError, boolean stopOnWarn) {
+    this.stopOnError = stopOnError;
+    this.stopOnWarn = stopOnWarn;
+  }
+
+  protected abstract void raiseError(String error, Exception ex) throws E;
+
+  public void checkForErrors() throws E {
+    switch (errorCode) {
+      case WARNING:
+        if (stopOnWarn) {
+          raiseError("XSL transform reported warning: " + exception.getMessage(), exception);
+        }
+        break;
+      case ERROR:
+        if (stopOnError) {
+          raiseError("XSL transform reported error: " + exception.getMessage(), exception);
+        }
+        break;
+      case FATAL:
+        raiseError("XSL transform reported error: " + exception.getMessage(), exception);
+    }
+  }
+
+  public void warning(TransformerException except) throws TransformerException {
+    LOG.warn("XSL transform reports warning: " + except.getMessage(), except);
+    errorCode = WARNING;
+    exception = except;
+    if (stopOnWarn) {
+      throw except;
+    }
+  }
+
+  public void error(TransformerException except) throws TransformerException {
+    LOG.warn("XSL transform reports recoverable error: " + except.getMessage(), except);
+    errorCode = ERROR;
+    exception = except;
+    if (stopOnError) {
+      throw except;
+    }
+  }
+
+  public void fatalError(TransformerException except) throws TransformerException {
+    LOG.warn("XSL transform reports fatal error: " + except.getMessage(), except);
+    errorCode = FATAL;
+    exception = except;
+    throw except;
+  }
+}

--- a/test/src/org/exist/xquery/TransformTest.java
+++ b/test/src/org/exist/xquery/TransformTest.java
@@ -24,7 +24,7 @@ public class TransformTest {
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer();
 
-	private static final String TEST_COLLECTION_NAME = "transform-test";
+    private static final String TEST_COLLECTION_NAME = "transform-test";
 
     private Collection testCollection;
     
@@ -34,14 +34,10 @@ public class TransformTest {
      */
     @Test
     public void transform() throws XMLDBException {
-    	@SuppressWarnings("unused")
-		String imports = 
-    		"import module namespace transform='http://exist-db.org/xquery/transform';\n";
-
         String query =
             "import module namespace transform='http://exist-db.org/xquery/transform';\n" +
-            "let $xml := <empty />,\n" +
-            "	$xsl := 'xmldb:exist:///db/"+TEST_COLLECTION_NAME+"/xsl1/1.xsl'\n" +
+            "let $xml := <empty/>\n" +
+            "let $xsl := 'xmldb:exist:///db/"+TEST_COLLECTION_NAME+"/xsl1/1.xsl'\n" +
             "return transform:transform($xml, $xsl, ())";
         String result = execQuery(query);
         assertEquals(result, "<doc>" +

--- a/test/src/org/exist/xslt/TransformerFactoryAllocatorTest.java
+++ b/test/src/org/exist/xslt/TransformerFactoryAllocatorTest.java
@@ -1,6 +1,5 @@
 package org.exist.xslt;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.runners.Parameterized.Parameters;
@@ -16,7 +15,6 @@ import org.junit.Test;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.verify;
 import static org.easymock.EasyMock.replay;
-import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import org.junit.runners.Parameterized.Parameter;
 
@@ -24,7 +22,7 @@ import org.junit.runners.Parameterized.Parameter;
  * @author Adam Retter <adam@exist-db.org>
  */
 @RunWith(value = Parameterized.class)
-public class TransfomerFactoryAllocatorTest {
+public class TransformerFactoryAllocatorTest {
 
     @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
@@ -56,12 +54,5 @@ public class TransfomerFactoryAllocatorTest {
         assertEquals(transformerFactoryClass, transformerFactory.getClass().getName());
 
         verify(mockBrokerPool, mockConfiguration);
-    }
-
-    @After
-    public void resetTransformerFactoryAllocatorSingleton() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
-        Field field = TransformerFactoryAllocator.class.getDeclaredField("saxTransformerFactory");
-        field.setAccessible(true);
-        field.set(null, null);
     }
 }


### PR DESCRIPTION
### Description:
inline xsl stylesheets caching and compiling between XSLTServlet and xquery `transform` function;
[bugfix] avoid concurrent use of different variables: DBBroker, ErrorListener, SAXTransformerFactory (and it attributes).

### Reference:
close #1312 
