### PR TITLE
Do not interpret quotes as string literals inside string constructor

### DIFF
--- a/src/org/exist/xquery/parser/XQuery.g
+++ b/src/org/exist/xquery/parser/XQuery.g
@@ -2484,10 +2484,10 @@ options {
 	APOS_ATTRIBUTE_CONTENT
 	{ $setType(APOS_ATTRIBUTE_CONTENT); }
 	|
-	{ !(parseStringLiterals || inElementContent) }?
+	{ !(parseStringLiterals || inElementContent || inStringConstructor) }?
 	QUOT { $setType(QUOT); }
 	|
-	{ !(parseStringLiterals || inElementContent) }?
+	{ !(parseStringLiterals || inElementContent || inStringConstructor) }?
 	APOS { $setType(APOS); }
 	|
 	{ inElementContent }?
@@ -2514,7 +2514,7 @@ options {
 		$setType(Token.SKIP);
 	}
 	|
-	{ !(inAttributeContent || inElementContent) }?
+	{ !(inAttributeContent || inElementContent || inStringConstructor) }?
 	EXPR_COMMENT
 	{
 		String comment = $getText;
@@ -2532,7 +2532,7 @@ options {
 	|
 	ncname:NCNAME { $setType(ncname.getType()); }
 	|
-	{ parseStringLiterals && !inElementContent }?
+	{ parseStringLiterals && !inElementContent && !inStringConstructor }?
 	STRING_LITERAL { $setType(STRING_LITERAL); }
 	|
 	BRACED_URI_LITERAL { $setType(BRACED_URI_LITERAL); }

--- a/src/org/exist/xquery/parser/XQueryLexer.java
+++ b/src/org/exist/xquery/parser/XQueryLexer.java
@@ -4469,7 +4469,7 @@ inputState.guessing--;
 						
 				}
 			}
-			else if (((LA(1)=='(') && (LA(2)==':') && ((LA(3) >= '\u0003' && LA(3) <= '\ufffe')) && ((LA(4) >= '\u0003' && LA(4) <= '\ufffe')))&&( !(inAttributeContent || inElementContent) )) {
+			else if (((LA(1)=='(') && (LA(2)==':') && ((LA(3) >= '\u0003' && LA(3) <= '\ufffe')) && ((LA(4) >= '\u0003' && LA(4) <= '\ufffe')))&&( !(inAttributeContent || inElementContent || inStringConstructor) )) {
 				mEXPR_COMMENT(false);
 				if ( inputState.guessing==0 ) {
 					
@@ -4700,7 +4700,7 @@ inputState.guessing--;
 								_ttype = ESCAPE_QUOT;
 							}
 						}
-						else if (((LA(1)=='"'||LA(1)=='\'') && ((LA(2) >= '\u0003' && LA(2) <= '\ufffe')) && (true) && (true))&&( parseStringLiterals && !inElementContent )) {
+						else if (((LA(1)=='"'||LA(1)=='\'') && ((LA(2) >= '\u0003' && LA(2) <= '\ufffe')) && (true) && (true))&&( parseStringLiterals && !inElementContent && !inStringConstructor )) {
 							mSTRING_LITERAL(false);
 							if ( inputState.guessing==0 ) {
 								_ttype = STRING_LITERAL;
@@ -4839,13 +4839,13 @@ inputState.guessing--;
 										_ttype = APOS_ATTRIBUTE_CONTENT;
 									}
 								}
-								else if (((LA(1)=='"') && (true) && (true) && (true))&&( !(parseStringLiterals || inElementContent) )) {
+								else if (((LA(1)=='"') && (true) && (true) && (true))&&( !(parseStringLiterals || inElementContent || inStringConstructor) )) {
 									mQUOT(false);
 									if ( inputState.guessing==0 ) {
 										_ttype = QUOT;
 									}
 								}
-								else if (((LA(1)=='\'') && (true) && (true) && (true))&&( !(parseStringLiterals || inElementContent) )) {
+								else if (((LA(1)=='\'') && (true) && (true) && (true))&&( !(parseStringLiterals || inElementContent || inStringConstructor) )) {
 									mAPOS(false);
 									if ( inputState.guessing==0 ) {
 										_ttype = APOS;

--- a/test/src/xquery/xquery3/strconstr.xql
+++ b/test/src/xquery/xquery3/strconstr.xql
@@ -17,12 +17,29 @@ function sc:simple() {
     ``[Hello world!]``
 };
 
+(:
+ : Character entities are not expanded, chars like <> are allowed.
+ :)
+declare
+    %test:assertEquals("Hello &amp;<world>{!}(:no comment:)")
+function sc:special-chars() {
+    ``[Hello &<world>{!}(:no comment:)]``
+};
+
 declare
     %test:assertEquals("Hello my world!")
 function sc:simple-interpolation() {
     let $a := "my"
     return
         ``[Hello `{$a}` world!]``
+};
+
+declare
+    %test:assertEquals('Hello "my" ''my'' world!')
+function sc:simple-interpolation-quoted() {
+    let $a := "my"
+    return
+        ``[Hello "`{$a}`" '`{$a}`' world!]``
 };
 
 declare


### PR DESCRIPTION
Make sure special chars do not need to be escaped and character entities are not expanded.

Closes #1317 