### PR TITLE
[bugfix] Correct the args definitions for shutdown command line tools

### DIFF
--- a/src/org/exist/jetty/ServerShutdown.java
+++ b/src/org/exist/jetty/ServerShutdown.java
@@ -44,15 +44,13 @@ public class ServerShutdown {
     /* database connection arguments */
     private static final Argument<String> userArg = stringArgument("-u", "--user")
             .description("specify username (has to be a member of group dba).")
-            .required()
             .defaultValue("admin")
             .build();
     private static final Argument<String> passwordArg = stringArgument("-p", "--password")
             .description("specify password for the user.")
-            .required()
             .defaultValue("")
             .build();
-    private static final Argument<String> uriArg = stringArgument("-u", "--uri")
+    private static final Argument<String> uriArg = stringArgument("-l", "--uri")
             .description("the XML:DB URI of the database instance to be shut down.")
             .build();
 


### PR DESCRIPTION
There was a small mistake in the arguments definitions for the shutdown command line tools. This corrects that.
