### PR TITLE
Fix creation of the systemd unit configuration file.

### DIFF
--- a/tools/yajsw/bin/installDaemon.sh
+++ b/tools/yajsw/bin/installDaemon.sh
@@ -79,7 +79,7 @@ function install_systemd_config {
     fi
     systemd_service="${systemd_sys_dir}/eXist-db.service"
     echo "Installing template ${wrapper_home}/templates/systemd.vm as non-privileged service ${systemd_service}";
-    sudo echo -e "$(eval "echo -e \"`<${wrapper_home}/templates/systemd.vm`\"")" > "${systemd_service}";
+    eval "echo -e \"`<${wrapper_home}/templates/systemd.vm`\"" | sudo tee "${systemd_service}" > /dev/null
     sudo chmod 664 "${systemd_service}"
     echo -e "\nEnabling the service...\n";
     sudo systemctl daemon-reload


### PR DESCRIPTION
When executed by a regular user, the installation of the systemd unit configuration file fails trying to write to a protected space (`/etc/systemd/system`). This patch ensures that the file is created as the superuser.