### PR TITLE
Capitalize "dashboard" in menu bar entry

### DIFF
--- a/src/org/exist/launcher/Launcher.java
+++ b/src/org/exist/launcher/Launcher.java
@@ -338,7 +338,7 @@ public class Launcher extends Observable implements Observer {
             popup.addSeparator();
             final Desktop desktop = Desktop.getDesktop();
             if (desktop.isSupported(Desktop.Action.BROWSE)) {
-                dashboardItem = new MenuItem("Open dashboard");
+                dashboardItem = new MenuItem("Open Dashboard");
                 popup.add(dashboardItem);
                 dashboardItem.addActionListener(actionEvent -> dashboard(desktop));
                 eXideItem = new MenuItem("Open eXide");


### PR DESCRIPTION
### Description:

Capitalize "dashboard" in menu bar entry, "Open dashboard".

The name of the app is capitalized, "Dashboard": https://github.com/eXist-db/dashboard/blob/master/repo.xml#L3

It is also capitalized in the tool window: https://github.com/eXist-db/exist/blob/develop/src/org/exist/launcher/UtilityPanel.java#L75.

The capitalized version will look better alongside the other non-lower-case app resources in the eXist menu bar: eXide, Java Admin Client, and Monitoring and Profiling.
