### PR TITLE
Adds --forking and --pidfile options to server.sh

### DIFF
--- a/bin/server.sh
+++ b/bin/server.sh
@@ -5,11 +5,11 @@
 # $Id$
 # -----------------------------------------------------------------------------
 
-## @UNIX_INSTALLER_1@ 
+## @UNIX_INSTALLER_1@
 
 #
-# In addition to the other parameter options for the standalone server 
-# pass -j or --jmx to enable JMX agent.  The port for it can be specified 
+# In addition to the other parameter options for the standalone server
+# pass -j or --jmx to enable JMX agent.  The port for it can be specified
 # with optional port number e.g. -j1099 or --jmx=1099.
 #
 
@@ -44,6 +44,14 @@ check_jmx_status;
 # save LANG
 set_locale_lang;
 
-"${JAVA_RUN}" $JAVA_OPTIONS $OPTIONS -jar "$EXIST_HOME/start.jar" standalone "${JAVA_OPTS[@]}"
+if [ $FORKING == "1" ]; then
+    JAVA_RUN="exec ${JAVA_RUN}"
+fi
+
+if [ $PIDFILE ]; then
+    echo $$ > $PIDFILE
+fi
+
+${JAVA_RUN} $JAVA_OPTIONS $OPTIONS -jar "$EXIST_HOME/start.jar" standalone "${JAVA_OPTS[@]}"
 
 restore_locale_lang;

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -5,11 +5,11 @@
 # $Id$
 # -----------------------------------------------------------------------------
 
-## @UNIX_INSTALLER_1@ 
+## @UNIX_INSTALLER_1@
 
 #
-# In addition to the other parameter options for the jetty container 
-# pass -j or --jmx to enable JMX agent. The port for it can be specified 
+# In addition to the other parameter options for the jetty container
+# pass -j or --jmx to enable JMX agent. The port for it can be specified
 # with optional port number e.g. -j1099 or --jmx=1099.
 #
 usage="startup.sh [-j[jmx-port]|--jmx[=jmx-port]]\n"
@@ -51,7 +51,15 @@ set_locale_lang;
 # enable the JMX agent? If so, concat to $JAVA_OPTIONS:
 check_jmx_status;
 
-"${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} \
+if [ $FORKING == "1" ]; then
+    JAVA_RUN="exec ${JAVA_RUN}"
+fi
+
+if [ $PIDFILE ]; then
+    echo $$ > $PIDFILE
+fi
+
+${JAVA_RUN} ${JAVA_OPTIONS} ${OPTIONS} \
 	${DEBUG_OPTS} -jar "$EXIST_HOME/start.jar" \
 	jetty ${JAVA_OPTS[@]}
 


### PR DESCRIPTION
This is supposed for standalone deployments to be controlled by systemd and alike services.

in order to let systemd supervise and control the process it needs to be aware of its pid which is not the case when the `server.sh` script launches Java as a subprocess.

in parts i also changed the indentation to be more comprehendable.
