### PR TITLE
Java Client cannot be started via Java Webstart: NPE and missing JAR

### DIFF
--- a/src/org/exist/client/InteractiveClient.java
+++ b/src/org/exist/client/InteractiveClient.java
@@ -1833,7 +1833,7 @@ public class InteractiveClient {
                     properties.load(pin);
                 }
             }
-        } catch (final IOException e) {
+        } catch (final NullPointerException | IOException e) {
             System.err.println("WARN - Unable to load properties from: " + propFile.toAbsolutePath().toString());
         }
         return properties;

--- a/src/org/exist/webstart/JnlpJarFiles.java
+++ b/src/org/exist/webstart/JnlpJarFiles.java
@@ -68,7 +68,7 @@ public class JnlpJarFiles {
             "log4j-core-%latest%",
             "log4j-jul-%latest%",
             "log4j-slf4j-impl-%latest%",
-            "pkg-repo",
+            "pkg-java-fork",
             "quartz-%latest%",
             "rsyntaxtextarea-%latest%",
             "slf4j-api-%latest%",


### PR DESCRIPTION
### Description:

A null pointer exception appears when starting the Java client via webstart. The stack trace:

```
java.lang.NullPointerException
	at java.util.Properties$LineReader.readLine(Properties.java:434)
	at java.util.Properties.load0(Properties.java:353)
	at java.util.Properties.load(Properties.java:341)
 	at org.exist.client.InteractiveClient.loadClientProperties(InteractiveClient.java:1833)
 	at org.exist.client.InteractiveClient.run(InteractiveClient.java:2116)
 	at org.exist.client.InteractiveClient.main(InteractiveClient.java:237)
```

The code does not handle null-values for the stream. As a result the application crashes.

### Impact

*no one* can start the client right now via webstart, so I'd label it as rather significant

### Reference:

- http://markmail.org/message/zofbibpuko5aqh4u 

### Type of tests:

- start exist-db
- browse to portal.
- click on java client icon
- check (macOS): `Library/Application Support/Oracle/Java/Deployment/log/*`

note: `client.properties` is never on the class path ?


------

second: a test showed that a JAR file could not be loaded: (running from .dmg)

```
2017-03-11 16:05:04,482 [qtp237741661-52] INFO  (TemporaryFileManager.java [<init>]:81) - Temporary folder is: /var/folders/XXXXXX 
2017-03-11 16:05:42,827 [qtp237741661-56] INFO  (JnlpServlet.java [init]:53) - Initializing JNLP servlet 
2017-03-11 16:05:42,828 [qtp237741661-56] INFO  (JnlpJarFiles.java [<init>]:126) - Initializing jar files Webstart 
2017-03-11 16:05:42,838 [qtp237741661-56] ERROR (JnlpJarFiles.java [getJarFromLocation]:101) - Could not resolve file pattern: /XXXX/eXist-db.app/Contents/Resources/eXist-db/lib/core/pkg-repo.jar 
```