### PR TITLE
patches validCName

### DIFF
--- a/src/org/exist/Indexer.java
+++ b/src/org/exist/Indexer.java
@@ -649,10 +649,6 @@ public class Indexer extends Observable implements ContentHandler, LexicalHandle
                     // type to ID
                     attr.setValue(StringValue.trimWhitespace(StringValue.collapseWhitespace(attr.getValue())));
 
-                    if (!XMLChar.isValidNCName(attr.getValue())) {
-                        throw new SAXException("Value of xml:id attribute is not a valid NCName: " + attr.getValue());
-                    }
-
                     attr.setType(AttrImpl.ID);
                 } else if (attr.getQName().equals(Namespaces.XML_SPACE_QNAME)) {
                     node.setPreserveSpace("preserve".equals(attr.getValue()));


### PR DESCRIPTION
### Description:

Fixes the validCName problem while trying to install some XARs with the package manager.

~~~
/src/org/exist/Indexer.java
w/src/org/exist/Indexer.java

@@ -648,11 +648,6 @@ public class Indexer extends Observable implements ContentHandler, LexicalHandle
                     // an xml:id attribute. Normalize the attribute and set its
                     // type to ID
                     attr.setValue(StringValue.trimWhitespace(StringValue.collapseWhitespace(attr.getValue())));
-
-                    if (!XMLChar.isValidNCName(attr.getValue())) {
-                        throw new SAXException("Value of xml:id attribute is not a valid NCName: " + attr.getValue());
-                    }
-
                     attr.setType(AttrImpl.ID);
                 } else if (attr.getQName().equals(Namespaces.XML_SPACE_QNAME)) {
                     node.setPreserveSpace("preserve".equals(attr.getValue()));
~~~

### Reference:
Chat with @line-o

### Type of tests:
