### PR TITLE
do not hide IOException at webdav createCollection

### DIFF
--- a/extensions/webdav/src/org/exist/webdav/ExistCollection.java
+++ b/extensions/webdav/src/org/exist/webdav/ExistCollection.java
@@ -285,9 +285,6 @@ public class ExistCollection extends ExistResource {
             LOG.error(e);
             throw e;
 
-        } catch (IOException e) {
-            LOG.error(e);
-
         } catch (Throwable e) {
             LOG.error(e);
             throw new EXistException(e);


### PR DESCRIPTION
`IOException` hidden and `ConflictException` is not raise on `IOException`