### PR TITLE
Slow memory leak

### DIFF
--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -3643,6 +3643,8 @@ public class XQueryContext implements BinaryValueManager, Context
                 LOG.error("Cleaning up XQueryContext: Ignoring: " + t.getMessage(), t);
             }
         }
+        // now it is safe to clear the cleanup tasks list as we know they have run
+        // do not move this anywhere else
         cleanupTasks.clear();
     }
 }

--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -1418,8 +1418,6 @@ public class XQueryContext implements BinaryValueManager, Context
 
         clearUpdateListeners();
 
-        cleanupTasks.clear();
-
         profiler.reset();
         
         analyzed = false;
@@ -3645,5 +3643,6 @@ public class XQueryContext implements BinaryValueManager, Context
                 LOG.error("Cleaning up XQueryContext: Ignoring: " + t.getMessage(), t);
             }
         }
+        cleanupTasks.clear();
     }
 }


### PR DESCRIPTION
On several servers I saw memory consumption increasing slowly over time. Stress testing revealed instances of BinaryValueFromInputStream staying in memory and building up over weeks until eXist would eventually crash.

Debugging showed the registered XQueryContext.BinaryValueCleanupTask is never executed because cleanupTasks list is cleared too early (in XQueryContext.reset). Thus when XQueryContext.runCleanupTasks is called, the list of tasks is already empty.

The fix is simple: clear cleanupTasks after tasks have been executed, not before.