### PR TITLE
[bugfix] Memory leak: map constructor

### DIFF
--- a/src/org/exist/xquery/functions/map/MapExpr.java
+++ b/src/org/exist/xquery/functions/map/MapExpr.java
@@ -76,13 +76,24 @@ public class MapExpr extends AbstractExpression {
         dumper.display("}");
     }
 
+    @Override
+    public void resetState(boolean postOptimization) {
+        super.resetState(postOptimization);
+        mappings.forEach(m -> m.resetState(postOptimization));
+    }
+
     private static class Mapping {
-        Expression key;
-        Expression value;
+        final Expression key;
+        final Expression value;
 
         public Mapping(Expression key, Expression value) {
             this.key = key;
             this.value = value;
+        }
+
+        private void resetState(boolean postOptimization) {
+            key.resetState(postOptimization);
+            value.resetState(postOptimization);
         }
     }
 }


### PR DESCRIPTION
Analyzing a heap dump from one of @joewiz servers, I found another memory leak: the literal constructor for maps does not implement resetState for its subexpressions, so any data held in those expressions is not cleared.

Fix is quite simple: overwrite resetState and pass it on to all subexpressions.