### PR TITLE
Use full project.name for shared-resources app

### DIFF
--- a/installer/apps.properties
+++ b/installer/apps.properties
@@ -1,2 +1,2 @@
 apps.repo=http://demo.exist-db.org/exist/apps/public-repo
-apps=shared,dashboard,eXide,monex,doc,fundocs,markdown
+apps=shared-resources,dashboard,eXide,monex,doc,fundocs,markdown


### PR DESCRIPTION
### Description:

Once https://github.com/eXist-db/shared-resources/pull/20 is merged and shared-resources-0.4.1.xar is deployed to the public repo, the shared-resources app will no longer use a hard-coded value for the expath-pkg.xml file's `package/@abbrev` value, but instead will inherit the `project.name` property. This PR allows the installer to retrieve the app by its updated package/@abbrev. Nowhere else is this app or package referred to by the name `shared`; elsewhere it is always `shared-resources`. 

**Note:** Please do not merge this PR until https://github.com/eXist-db/shared-resources/pull/20 is merged and https://github.com/eXist-db/shared-resources/issues/19 confirms that the new version of shared-resources has been released to the public repo.

### Reference:

https://github.com/eXist-db/shared-resources/pull/20

### Type of tests:

None