### PR TITLE
disable seqential token re-creation by default

### DIFF
--- a/extensions/modules/src/org/exist/xquery/modules/persistentlogin/PersistentLogin.java
+++ b/extensions/modules/src/org/exist/xquery/modules/persistentlogin/PersistentLogin.java
@@ -91,12 +91,18 @@ public class PersistentLogin {
             seriesMap.remove(tokens[0]);
             return null;
         }
+
+    // sequential token checking is disabled by default
+    if (data.seqBehavior) {
+        LOG.debug("Using sequential tokens");
         if (!data.checkAndUpdateToken(tokens[1])) {
             LOG.debug("Out-of-sequence request or cookie theft attack. Deleting session.");
             seriesMap.remove(tokens[0]);
             throw new XPathException("Token mismatch. This may indicate an out-of-sequence request (likely) or a cookie theft attack.  " +
                     "Session is deleted for security reasons.");
         }
+    }
+
         return data;
     }
 
@@ -137,6 +143,9 @@ public class PersistentLogin {
         private String series;
         private long expires;
         private DurationValue timeToLive;
+
+        // disable sequential token checking by default
+        private boolean seqBehavior = false;
 
         private Map<String, Long> invalidatedTokens = new HashMap<>();
 


### PR DESCRIPTION
### Description:

Quick fix to disable sequential token re-creation in PersistentLogin, which was creating problems with AJAX. I left the token re-creation code, not sure if this should be made configurable.

### Reference:

https://trello.com/c/p8CLLdNs/46-review-persistent-login-module-and-create-best-practice-recommendation-to-use-in-our-apps

### Type of tests:

Compiled and manually verified. Also ran "./build.sh test"
