### PR TITLE
Code cleanup org.exist.xquery.value.*

### DIFF
--- a/src/org/exist/xquery/value/AbstractDateTimeValue.java
+++ b/src/org/exist/xquery/value/AbstractDateTimeValue.java
@@ -50,346 +50,417 @@ import java.util.regex.Pattern;
  */
 public abstract class AbstractDateTimeValue extends ComputableValue {
 
-    private final static Logger LOG = LogManager.getLogger(AbstractDateTimeValue.class);
-
-	//Provisionally public
-	public final XMLGregorianCalendar calendar;
-	private XMLGregorianCalendar implicitCalendar, canonicalCalendar, trimmedCalendar;
-	
-	protected static final Pattern negativeDateStart = Pattern.compile("^\\d\\d?-(\\d+)-(.*)");
-
-	public final static int YEAR = 0;
-	public final static int MONTH = 1;
-	public final static int DAY = 2;
-	public final static int HOUR = 3;
-	public final static int MINUTE = 4;
-	public final static int SECOND = 5;
-	public final static int MILLISECOND = 6;
-
-    protected static byte[] daysPerMonth = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    public final static int YEAR = 0;
+    public final static int MONTH = 1;
+    public final static int DAY = 2;
+    public final static int HOUR = 3;
+    public final static int MINUTE = 4;
+    public final static int SECOND = 5;
+    public final static int MILLISECOND = 6;
+    protected static final Pattern negativeDateStart = Pattern.compile("^\\d\\d?-(\\d+)-(.*)");
     protected static final short[] monthData = {306, 337, 0, 31, 61, 92, 122, 153, 184, 214, 245, 275};
+    private final static Logger LOG = LogManager.getLogger(AbstractDateTimeValue.class);
+    private static final Duration tzLowerBound = TimeUtils.getInstance().newDurationDayTime("-PT14H");
+    private static final Duration tzUpperBound = tzLowerBound.negate();
+    protected static byte[] daysPerMonth = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    //Provisionally public
+    public final XMLGregorianCalendar calendar;
+    private XMLGregorianCalendar implicitCalendar, canonicalCalendar, trimmedCalendar;
 
     /**
-	 * Create a new date time value based on the given calendar.  The calendar is
-	 * <em>not</em> cloned, so it is the subclass's responsibility to make sure there are
-	 * no external references to it that would allow for mutation.
-	 *
-	 * @param calendar the calendar to wrap into an XPath value
-	 */
-	protected AbstractDateTimeValue(XMLGregorianCalendar calendar) {
-		this.calendar = calendar;
-	}
-	
-	protected AbstractDateTimeValue(String lexicalValue) throws XPathException {
+     * Create a new date time value based on the given calendar.  The calendar is
+     * <em>not</em> cloned, so it is the subclass's responsibility to make sure there are
+     * no external references to it that would allow for mutation.
+     *
+     * @param calendar the calendar to wrap into an XPath value
+     */
+    protected AbstractDateTimeValue(XMLGregorianCalendar calendar) {
+        this.calendar = calendar;
+    }
+
+    protected AbstractDateTimeValue(String lexicalValue) throws XPathException {
         lexicalValue = StringValue.trimWhitespace(lexicalValue);
 
         //lexicalValue = normalizeDate(lexicalValue);
         //lexicalValue = normalizeTime(getType(), lexicalValue);
-		try {
-			calendar = parse(lexicalValue);
-		} catch (final IllegalArgumentException e) {
-			throw new XPathException(ErrorCodes.FORG0001, "illegal lexical form for date-time-like value '" + lexicalValue + "' " + e.getMessage(), e);
-		}
-	}
-	
-	/**
-	 * Return a calendar with the timezone field set, to be used for order comparison.
-	 * If the original calendar did not specify a timezone, set the local timezone (unadjusted
-	 * for daylight savings).  The returned calendars will be totally ordered between themselves.
-	 * We also set any missing fields to ensure that normalization doesn't discard important data!
-	 * (This is probably a bug in the JAXP implementation, but the workaround doesn't hurt us,
-	 * so it's faster to just fix it here.)
-	 *
-	 * @return the calendar represented by this object, with the timezone field filled in with an implicit value if necessary
-	 */
-	protected XMLGregorianCalendar getImplicitCalendar() {
-		if (implicitCalendar == null) {
-			implicitCalendar = (XMLGregorianCalendar) calendar.clone();
-			if (calendar.getTimezone() == DatatypeConstants.FIELD_UNDEFINED) {
-				implicitCalendar.setTimezone(TimeUtils.getInstance().getLocalTimezoneOffsetMinutes());
-			}
-			// fill in fields from default reference; don't have to worry about weird combinations of fields being set, since we control that on creation
-			switch(getType()) {
-				case Type.DATE: implicitCalendar.setTime(0,0,0); break;
-				case Type.TIME: implicitCalendar.setYear(1972); implicitCalendar.setMonth(12); implicitCalendar.setDay(31); break;
-				default:
-			}
-			implicitCalendar = implicitCalendar.normalize();	// the comparison routines will normalize it anyway, just do it once here
-		}
-		return implicitCalendar;
-	}
-	
-	// TODO: method not currently used, apparently the XPath spec never needs to canonicalize
-	// date/times after all (see section 17.1.2 on casting)
-	protected XMLGregorianCalendar getCanonicalCalendar() {
-		if (canonicalCalendar == null) {
-			canonicalCalendar = getTrimmedCalendar().normalize();
-		}
-		return canonicalCalendar;
-	}
-	
-	public XMLGregorianCalendar getTrimmedCalendar() {
-		if (trimmedCalendar == null) {
-			trimmedCalendar = cloneXMLGregorianCalendar(calendar);
-			final BigDecimal fract = trimmedCalendar.getFractionalSecond();
-			if (fract != null) {
-				// TODO: replace following algorithm in JDK 1.5 with fract.stripTrailingZeros();
-				final String s = fract.toString();
-				int i = s.length();
-				while (i > 0 && s.charAt(i-1) == '0') i--;
-				if (i == 0) {trimmedCalendar.setFractionalSecond(null);}
-				else if (i != s.length()) {trimmedCalendar.setFractionalSecond(new BigDecimal(s.substring(0, i)));}
-			}
-		}
-		return trimmedCalendar;
-	}
-	
-	protected XMLGregorianCalendar getCanonicalOrTrimmedCalendar() {
-		try {
-			return getCanonicalCalendar();
-		} catch (final Exception e) {
-			return getTrimmedCalendar();
-		}
-		
-	}
-
-	protected abstract AbstractDateTimeValue createSameKind(XMLGregorianCalendar cal) throws XPathException;
-	
-	public long getTimeInMillis() {
-		// use getImplicitCalendar() rather than relying on toGregorianCalendar timezone defaulting
-		// to maintain consistency
-		return getImplicitCalendar().toGregorianCalendar().getTimeInMillis();
-	}
-	
-	protected abstract QName getXMLSchemaType();
-	
-	public String getStringValue() throws XPathException {
-		String r = getTrimmedCalendar().toXMLFormat();
-		// hacked to match the format mandated in XPath 2 17.1.2, which is different from the XML Schema canonical format
-		//if (r.charAt(r.length()-1) == 'Z') r = r.substring(0, r.length()-1) + "+00:00";
-		
-		//Let's try these lexical transformations...		
-		final boolean startsWithDashDash = r.startsWith("--");
-		r = r.replaceAll("--", "");
-		if (startsWithDashDash)
-			{r = "--" + r;}
-		
-		final Matcher m = negativeDateStart.matcher(r);
-		if (m.matches()) {
-			final int year = Integer.parseInt(m.group(1));
-			final DecimalFormat df = new DecimalFormat("0000");
-			r = "-" + df.format(year) + "-" + m.group(2);
-		}
-		
-		return r;
-	}
-
-	public boolean effectiveBooleanValue() throws XPathException {
-		throw new XPathException(ErrorCodes.FORG0006, "effective boolean value invalid operand type: " + Type.getTypeName(getType()));
-	}
-	
-	public abstract AtomicValue convertTo(int requiredType) throws XPathException;
-
-	public int getPart(int part) {
-		switch (part) {
-			case YEAR: return calendar.getYear(); 
-			case MONTH: return calendar.getMonth();
-			case DAY: return calendar.getDay();
-			case HOUR: return calendar.getHour();
-			case MINUTE: return calendar.getMinute();
-			case SECOND: return calendar.getSecond();
-			case MILLISECOND: final int mSec=calendar.getMillisecond();
-                                          if(mSec == DatatypeConstants.FIELD_UNDEFINED)
-                                              {return 0;}
-                                          else
-                                              {return calendar.getMillisecond();}
-			default: throw new IllegalArgumentException("Invalid argument to method getPart");
-		}
-	}
-	
-	private static final Duration tzLowerBound = TimeUtils.getInstance().newDurationDayTime("-PT14H");
-	private static final Duration tzUpperBound = tzLowerBound.negate();
-	protected void validateTimezone(DayTimeDurationValue offset) throws XPathException {
-		final Duration tz = offset.duration;
-		final Number secs = tz.getField(DatatypeConstants.SECONDS);
-		if (secs != null && ((BigDecimal) secs).compareTo(BigDecimal.valueOf(0)) != 0)
-			{throw new XPathException(ErrorCodes.FODT0003, "duration " + offset + " has fractional minutes so cannot be used as a timezone offset");}
-		if (! (
-				tz.equals(tzLowerBound) ||
-				tz.equals(tzUpperBound) ||
-				(tz.isLongerThan(tzLowerBound) && tz.isShorterThan(tzUpperBound))
-			))
-			{throw new XPathException(ErrorCodes.FODT0003, "duration " + offset + " outside valid timezone offset range");}
-	}
-
-	public AbstractDateTimeValue adjustedToTimezone(DayTimeDurationValue offset) throws XPathException {
-		if (offset == null) {offset = new DayTimeDurationValue(TimeUtils.getInstance().getLocalTimezoneOffsetMillis());}
-		validateTimezone(offset);
-		XMLGregorianCalendar xgc = (XMLGregorianCalendar) calendar.clone();
-		if (xgc.getTimezone() != DatatypeConstants.FIELD_UNDEFINED) {
-			if (getType() == Type.DATE) {xgc.setTime(0,0,0);}	// set the fields so we don't lose precision when shifting timezones
-			xgc = xgc.normalize();
-			xgc.add(offset.duration);
-		}
-		try {
-			xgc.setTimezone((int) (offset.getValue()/60));
-		} catch (final IllegalArgumentException e) {
-			throw new XPathException(ErrorCodes.FORG0001, "illegal timezone offset " + offset, e);
-		}
-		return createSameKind(xgc);
-	}
-	
-	public AbstractDateTimeValue withoutTimezone() throws XPathException {
-		final XMLGregorianCalendar xgc = (XMLGregorianCalendar) calendar.clone();
-		xgc.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
-		return createSameKind(xgc);
-	}
-	
-	public Sequence getTimezone() throws XPathException {
-		final int tz = calendar.getTimezone();
-		if (tz == DatatypeConstants.FIELD_UNDEFINED) {return Sequence.EMPTY_SEQUENCE;}
-		return new DayTimeDurationValue(tz * 60000L);
-	}
-
-	@Override
-	public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
-		final int cmp = compareTo(collator, other);
-		switch (operator) {
-			case EQ: return cmp == 0;
-			case NEQ: return cmp != 0;
-			case LT: return cmp < 0;
-			case LTEQ: return cmp <= 0;
-			case GT: return cmp > 0;
-			case GTEQ: return cmp >= 0;
-			default :
-				throw new XPathException("Unknown operator type in comparison");
-		}
-	}
-
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == getType()) {
-			// filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
-			final int r =  getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
-			if (r == DatatypeConstants.INDETERMINATE) {throw new RuntimeException("indeterminate order between " + this + " and " + other);}
-			return r;
-		}
-		throw new XPathException(
-			"Type error: cannot compare " + Type.getTypeName(getType()) + " to "
-				+ Type.getTypeName(other.getType()));
-	}
-
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		final AbstractDateTimeValue otherDate = other.getType() == getType() ? (AbstractDateTimeValue) other : (AbstractDateTimeValue) other.convertTo(getType());
-		return getImplicitCalendar().compare(otherDate.getImplicitCalendar()) > 0 ? this : other;
-	}
-
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		final AbstractDateTimeValue otherDate = other.getType() == getType() ? (AbstractDateTimeValue) other : (AbstractDateTimeValue) other.convertTo(getType());
-		return getImplicitCalendar().compare(otherDate.getImplicitCalendar()) < 0 ? this : other;
-	}
-
-	// override for xs:time
-	public ComputableValue plus(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-			case Type.YEAR_MONTH_DURATION:
-			case Type.DAY_TIME_DURATION:
-				return other.plus(this);
-			default:
-				throw new XPathException(
-						"Operand to plus should be of type xdt:dayTimeDuration or xdt:yearMonthDuration; got: "
-							+ Type.getTypeName(other.getType()));
-		}
-	}
-
-	public ComputableValue mult(ComputableValue other) throws XPathException {
-		throw new XPathException("multiplication is not supported for type " + Type.getTypeName(getType()));
-	}
-
-	public ComputableValue div(ComputableValue other) throws XPathException {
-		throw new XPathException("division is not supported for type " + Type.getTypeName(getType()));
-	}
-
-	public int conversionPreference(Class<?> javaClass) {
-		if (javaClass.isAssignableFrom(DateValue.class)) {return 0;}
-		if (javaClass.isAssignableFrom(XMLGregorianCalendar.class)) {return 1;}
-		if (javaClass.isAssignableFrom(GregorianCalendar.class)) {return 2;}
-		if (javaClass == Date.class) {return 3;}
-		return Integer.MAX_VALUE;
-	}
-
-        @Override
-	public <T> T toJavaObject(Class<T> target) throws XPathException {
-            if (target == Object.class || target.isAssignableFrom(DateValue.class)) {
-                return (T)this;
-            } else if (target.isAssignableFrom(XMLGregorianCalendar.class)) {
-                return (T)calendar.clone();
-            } else if (target.isAssignableFrom(GregorianCalendar.class)) {
-                return (T)calendar.toGregorianCalendar();
-            } else if (target == Date.class) {
-                return (T)calendar.toGregorianCalendar().getTime();
-            }
-
-            throw new XPathException("cannot convert value of type " + Type.getTypeName(getType()) + " to Java object of type " + target.getName());
-	}
-    
-    /* (non-Javadoc)
-     * @see java.lang.Comparable#compareTo(java.lang.Object)
-     */
-    public int compareTo(Object o)
-    {
-        if (o instanceof AbstractDateTimeValue) {
-			final AbstractDateTimeValue dt = (AbstractDateTimeValue) o;
-    		return calendar.compare(dt.calendar);
-		}
-
-        final AtomicValue other = (AtomicValue)o;
-        if(Type.subTypeOf(other.getType(), Type.DATE_TIME))
-        	try {
-        		//TODO : find something that will consume less resources
-        		return calendar.compare(TimeUtils.getInstance().newXMLGregorianCalendar(other.getStringValue()));
-            } catch (final XPathException e) {
-				LOG.error("Failed to get string value of '{}'", other, e);
-        		//Why not ?
-        		return Constants.SUPERIOR;
-        	}
-        else
-            {return getType() > other.getType() ? Constants.SUPERIOR : Constants.INFERIOR;}
-    }	
+        try {
+            calendar = parse(lexicalValue);
+        } catch (final IllegalArgumentException e) {
+            throw new XPathException(ErrorCodes.FORG0001, "illegal lexical form for date-time-like value '" + lexicalValue + "' " + e.getMessage(), e);
+        }
+    }
 
     /**
      * Utility method that is able to clone a calendar whose year is 0
-     * (whatever a year 0 means). 
+     * (whatever a year 0 means).
      * It looks like the JDK is unable to do that.
+     *
      * @param calendar The Calendar to clone
      * @return the cloned Calendar
      */
     public static XMLGregorianCalendar cloneXMLGregorianCalendar(XMLGregorianCalendar calendar) {
-    	boolean hacked = false;
-		if (calendar.getYear() == 0) {
-			calendar.setYear(1);
-			hacked = true;
-		}
-		final XMLGregorianCalendar result = (XMLGregorianCalendar)calendar.clone();
-		if (hacked) {
-			//reset everything
-			calendar.setYear(0);
-			//-1 could also be considered
-			result.setYear(0);
-		}
-		return result;
+        boolean hacked = false;
+        if (calendar.getYear() == 0) {
+            calendar.setYear(1);
+            hacked = true;
+        }
+        final XMLGregorianCalendar result = (XMLGregorianCalendar) calendar.clone();
+        if (hacked) {
+            //reset everything
+            calendar.setYear(0);
+            //-1 could also be considered
+            result.setYear(0);
+        }
+        return result;
+    }
+
+    private static boolean isDigit(char ch) {
+        return '0' <= ch && ch <= '9';
+    }
+
+    /**
+     * Calculate the Julian day number at 00:00 on a given date. Code taken from saxon
+     * {@link <a href="http://saxon.sourceforge.net">http://saxon.sourceforge.net</a>}. Original algorithm is taken from
+     * http://vsg.cape.com/~pbaum/date/jdalg.htm and
+     * http://vsg.cape.com/~pbaum/date/jdalg2.htm
+     * (adjusted to handle BC dates correctly)
+     * <p/>
+     * <p>Note that this assumes dates in the proleptic Gregorian calendar</p>
+     *
+     * @param year  the year
+     * @param month the month (1-12)
+     * @param day   the day (1-31)
+     * @return the Julian day number
+     */
+    public static int getJulianDayNumber(int year, int month, int day) {
+        int z = year - (month < 3 ? 1 : 0);
+        final short f = monthData[month - 1];
+        if (z >= 0) {
+            return day + f + 365 * z + z / 4 - z / 100 + z / 400 + 1721118;
+        } else {
+            // for negative years, add 12000 years and then subtract the days!
+            z += 12000;
+            final int j = day + f + 365 * z + z / 4 - z / 100 + z / 400 + 1721118;
+            return j - (365 * 12000 + 12000 / 4 - 12000 / 100 + 12000 / 400);  // number of leap years in 12000 years
+        }
+    }
+
+    /**
+     * Return a calendar with the timezone field set, to be used for order comparison.
+     * If the original calendar did not specify a timezone, set the local timezone (unadjusted
+     * for daylight savings).  The returned calendars will be totally ordered between themselves.
+     * We also set any missing fields to ensure that normalization doesn't discard important data!
+     * (This is probably a bug in the JAXP implementation, but the workaround doesn't hurt us,
+     * so it's faster to just fix it here.)
+     *
+     * @return the calendar represented by this object, with the timezone field filled in with an implicit value if necessary
+     */
+    protected XMLGregorianCalendar getImplicitCalendar() {
+        if (implicitCalendar == null) {
+            implicitCalendar = (XMLGregorianCalendar) calendar.clone();
+            if (calendar.getTimezone() == DatatypeConstants.FIELD_UNDEFINED) {
+                implicitCalendar.setTimezone(TimeUtils.getInstance().getLocalTimezoneOffsetMinutes());
+            }
+            // fill in fields from default reference; don't have to worry about weird combinations of fields being set, since we control that on creation
+            switch (getType()) {
+                case Type.DATE:
+                    implicitCalendar.setTime(0, 0, 0);
+                    break;
+                case Type.TIME:
+                    implicitCalendar.setYear(1972);
+                    implicitCalendar.setMonth(12);
+                    implicitCalendar.setDay(31);
+                    break;
+                default:
+            }
+            implicitCalendar = implicitCalendar.normalize();    // the comparison routines will normalize it anyway, just do it once here
+        }
+        return implicitCalendar;
+    }
+
+    // TODO: method not currently used, apparently the XPath spec never needs to canonicalize
+    // date/times after all (see section 17.1.2 on casting)
+    protected XMLGregorianCalendar getCanonicalCalendar() {
+        if (canonicalCalendar == null) {
+            canonicalCalendar = getTrimmedCalendar().normalize();
+        }
+        return canonicalCalendar;
+    }
+
+    public XMLGregorianCalendar getTrimmedCalendar() {
+        if (trimmedCalendar == null) {
+            trimmedCalendar = cloneXMLGregorianCalendar(calendar);
+            final BigDecimal fract = trimmedCalendar.getFractionalSecond();
+            if (fract != null) {
+                // TODO: replace following algorithm in JDK 1.5 with fract.stripTrailingZeros();
+                final String s = fract.toString();
+                int i = s.length();
+                while (i > 0 && s.charAt(i - 1) == '0') i--;
+                if (i == 0) {
+                    trimmedCalendar.setFractionalSecond(null);
+                } else if (i != s.length()) {
+                    trimmedCalendar.setFractionalSecond(new BigDecimal(s.substring(0, i)));
+                }
+            }
+        }
+        return trimmedCalendar;
+    }
+
+    protected XMLGregorianCalendar getCanonicalOrTrimmedCalendar() {
+        try {
+            return getCanonicalCalendar();
+        } catch (final Exception e) {
+            return getTrimmedCalendar();
+        }
+
+    }
+
+    protected abstract AbstractDateTimeValue createSameKind(XMLGregorianCalendar cal) throws XPathException;
+
+    public long getTimeInMillis() {
+        // use getImplicitCalendar() rather than relying on toGregorianCalendar timezone defaulting
+        // to maintain consistency
+        return getImplicitCalendar().toGregorianCalendar().getTimeInMillis();
+    }
+
+    protected abstract QName getXMLSchemaType();
+
+    public String getStringValue() throws XPathException {
+        String r = getTrimmedCalendar().toXMLFormat();
+        // hacked to match the format mandated in XPath 2 17.1.2, which is different from the XML Schema canonical format
+        //if (r.charAt(r.length()-1) == 'Z') r = r.substring(0, r.length()-1) + "+00:00";
+
+        //Let's try these lexical transformations...
+        final boolean startsWithDashDash = r.startsWith("--");
+        r = r.replaceAll("--", "");
+        if (startsWithDashDash) {
+            r = "--" + r;
+        }
+
+        final Matcher m = negativeDateStart.matcher(r);
+        if (m.matches()) {
+            final int year = Integer.parseInt(m.group(1));
+            final DecimalFormat df = new DecimalFormat("0000");
+            r = "-" + df.format(year) + "-" + m.group(2);
+        }
+
+        return r;
+    }
+
+    public boolean effectiveBooleanValue() throws XPathException {
+        throw new XPathException(ErrorCodes.FORG0006, "effective boolean value invalid operand type: " + Type.getTypeName(getType()));
+    }
+
+    public abstract AtomicValue convertTo(int requiredType) throws XPathException;
+
+    public int getPart(int part) {
+        switch (part) {
+            case YEAR:
+                return calendar.getYear();
+            case MONTH:
+                return calendar.getMonth();
+            case DAY:
+                return calendar.getDay();
+            case HOUR:
+                return calendar.getHour();
+            case MINUTE:
+                return calendar.getMinute();
+            case SECOND:
+                return calendar.getSecond();
+            case MILLISECOND:
+                final int mSec = calendar.getMillisecond();
+                if (mSec == DatatypeConstants.FIELD_UNDEFINED) {
+                    return 0;
+                } else {
+                    return calendar.getMillisecond();
+                }
+            default:
+                throw new IllegalArgumentException("Invalid argument to method getPart");
+        }
+    }
+
+    protected void validateTimezone(DayTimeDurationValue offset) throws XPathException {
+        final Duration tz = offset.duration;
+        final Number secs = tz.getField(DatatypeConstants.SECONDS);
+        if (secs != null && ((BigDecimal) secs).compareTo(BigDecimal.valueOf(0)) != 0) {
+            throw new XPathException(ErrorCodes.FODT0003, "duration " + offset + " has fractional minutes so cannot be used as a timezone offset");
+        }
+        if (!(
+                tz.equals(tzLowerBound) ||
+                        tz.equals(tzUpperBound) ||
+                        (tz.isLongerThan(tzLowerBound) && tz.isShorterThan(tzUpperBound))
+        )) {
+            throw new XPathException(ErrorCodes.FODT0003, "duration " + offset + " outside valid timezone offset range");
+        }
+    }
+
+    public AbstractDateTimeValue adjustedToTimezone(DayTimeDurationValue offset) throws XPathException {
+        if (offset == null) {
+            offset = new DayTimeDurationValue(TimeUtils.getInstance().getLocalTimezoneOffsetMillis());
+        }
+        validateTimezone(offset);
+        XMLGregorianCalendar xgc = (XMLGregorianCalendar) calendar.clone();
+        if (xgc.getTimezone() != DatatypeConstants.FIELD_UNDEFINED) {
+            if (getType() == Type.DATE) {
+                xgc.setTime(0, 0, 0);
+            }    // set the fields so we don't lose precision when shifting timezones
+            xgc = xgc.normalize();
+            xgc.add(offset.duration);
+        }
+        try {
+            xgc.setTimezone((int) (offset.getValue() / 60));
+        } catch (final IllegalArgumentException e) {
+            throw new XPathException(ErrorCodes.FORG0001, "illegal timezone offset " + offset, e);
+        }
+        return createSameKind(xgc);
+    }
+
+    public AbstractDateTimeValue withoutTimezone() throws XPathException {
+        final XMLGregorianCalendar xgc = (XMLGregorianCalendar) calendar.clone();
+        xgc.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
+        return createSameKind(xgc);
+    }
+
+    public Sequence getTimezone() throws XPathException {
+        final int tz = calendar.getTimezone();
+        if (tz == DatatypeConstants.FIELD_UNDEFINED) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+        return new DayTimeDurationValue(tz * 60000L);
+    }
+
+    @Override
+    public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
+        final int cmp = compareTo(collator, other);
+        switch (operator) {
+            case EQ:
+                return cmp == 0;
+            case NEQ:
+                return cmp != 0;
+            case LT:
+                return cmp < 0;
+            case LTEQ:
+                return cmp <= 0;
+            case GT:
+                return cmp > 0;
+            case GTEQ:
+                return cmp >= 0;
+            default:
+                throw new XPathException("Unknown operator type in comparison");
+        }
+    }
+
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == getType()) {
+            // filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
+            final int r = getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
+            if (r == DatatypeConstants.INDETERMINATE) {
+                throw new RuntimeException("indeterminate order between " + this + " and " + other);
+            }
+            return r;
+        }
+        throw new XPathException(
+                "Type error: cannot compare " + Type.getTypeName(getType()) + " to "
+                        + Type.getTypeName(other.getType()));
+    }
+
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        final AbstractDateTimeValue otherDate = other.getType() == getType() ? (AbstractDateTimeValue) other : (AbstractDateTimeValue) other.convertTo(getType());
+        return getImplicitCalendar().compare(otherDate.getImplicitCalendar()) > 0 ? this : other;
+    }
+
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        final AbstractDateTimeValue otherDate = other.getType() == getType() ? (AbstractDateTimeValue) other : (AbstractDateTimeValue) other.convertTo(getType());
+        return getImplicitCalendar().compare(otherDate.getImplicitCalendar()) < 0 ? this : other;
+    }
+
+    // override for xs:time
+    public ComputableValue plus(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.YEAR_MONTH_DURATION:
+            case Type.DAY_TIME_DURATION:
+                return other.plus(this);
+            default:
+                throw new XPathException(
+                        "Operand to plus should be of type xdt:dayTimeDuration or xdt:yearMonthDuration; got: "
+                                + Type.getTypeName(other.getType()));
+        }
+    }
+
+    public ComputableValue mult(ComputableValue other) throws XPathException {
+        throw new XPathException("multiplication is not supported for type " + Type.getTypeName(getType()));
+    }
+
+    public ComputableValue div(ComputableValue other) throws XPathException {
+        throw new XPathException("division is not supported for type " + Type.getTypeName(getType()));
+    }
+
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(DateValue.class)) {
+            return 0;
+        }
+        if (javaClass.isAssignableFrom(XMLGregorianCalendar.class)) {
+            return 1;
+        }
+        if (javaClass.isAssignableFrom(GregorianCalendar.class)) {
+            return 2;
+        }
+        if (javaClass == Date.class) {
+            return 3;
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public <T> T toJavaObject(Class<T> target) throws XPathException {
+        if (target == Object.class || target.isAssignableFrom(DateValue.class)) {
+            return (T) this;
+        } else if (target.isAssignableFrom(XMLGregorianCalendar.class)) {
+            return (T) calendar.clone();
+        } else if (target.isAssignableFrom(GregorianCalendar.class)) {
+            return (T) calendar.toGregorianCalendar();
+        } else if (target == Date.class) {
+            return (T) calendar.toGregorianCalendar().getTime();
+        }
+
+        throw new XPathException("cannot convert value of type " + Type.getTypeName(getType()) + " to Java object of type " + target.getName());
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Comparable#compareTo(java.lang.Object)
+     */
+    public int compareTo(Object o) {
+        if (o instanceof AbstractDateTimeValue) {
+            final AbstractDateTimeValue dt = (AbstractDateTimeValue) o;
+            return calendar.compare(dt.calendar);
+        }
+
+        final AtomicValue other = (AtomicValue) o;
+        if (Type.subTypeOf(other.getType(), Type.DATE_TIME))
+            try {
+                //TODO : find something that will consume less resources
+                return calendar.compare(TimeUtils.getInstance().newXMLGregorianCalendar(other.getStringValue()));
+            } catch (final XPathException e) {
+                LOG.error("Failed to get string value of '{}'", other, e);
+                //Why not ?
+                return Constants.SUPERIOR;
+            }
+        else {
+            return getType() > other.getType() ? Constants.SUPERIOR : Constants.INFERIOR;
+        }
     }
 
     public boolean equals(Object obj) {
-    	if (obj instanceof AbstractDateTimeValue) {
-    		final AbstractDateTimeValue dt = (AbstractDateTimeValue) obj;
-			return calendar.equals(dt.calendar);
-		}
-    	
-    	return false;
-	}
-    
+        if (obj instanceof AbstractDateTimeValue) {
+            final AbstractDateTimeValue dt = (AbstractDateTimeValue) obj;
+            return calendar.equals(dt.calendar);
+        }
+
+        return false;
+    }
+
     public int hashCode() {
-    	return calendar.hashCode();
+        return calendar.hashCode();
     }
 
     public int getDayOfWeek() {
@@ -424,44 +495,38 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
         if (lexRep.indexOf('T') != NOT_FOUND) {
             // found Date Time separater, must be xsd:DateTime
             format = "%Y-%M-%DT%h:%m:%s" + "%z";
-        } 
-        else if (lexRepLength >= 3 && lexRep.charAt(2) == ':') {
+        } else if (lexRepLength >= 3 && lexRep.charAt(2) == ':') {
             // found ":", must be xsd:Time
-            format = "%h:%m:%s" +"%z";
-        } 
-        else if (lexRep.startsWith("--")) {
+            format = "%h:%m:%s" + "%z";
+        } else if (lexRep.startsWith("--")) {
             // check for GDay || GMonth || GMonthDay
             if (lexRepLength >= 3 && lexRep.charAt(2) == '-') {
                 // GDAY
                 // Fix 4971612: invalid SCCS macro substitution in data string
                 format = "---%D" + "%z";
-            } 
-            else if (lexRepLength == 4 || (lexRepLength >= 6 && (lexRep.charAt(4) == '+' || (lexRep.charAt(4) == '-' && (lexRep.charAt(5) == '-' || lexRepLength == 10))))) {
+            } else if (lexRepLength == 4 || (lexRepLength >= 6 && (lexRep.charAt(4) == '+' || (lexRep.charAt(4) == '-' && (lexRep.charAt(5) == '-' || lexRepLength == 10))))) {
                 // GMonth
                 // Fix 4971612: invalid SCCS macro substitution in data string
                 format = "--%M--%Z";
                 final Parser p = new Parser(format, lexRep);
                 try {
-                	final XMLGregorianCalendar c = p.parse();
+                    final XMLGregorianCalendar c = p.parse();
                     // check for validity
                     if (!c.isValid()) {
                         throw new IllegalArgumentException(
-                                DatatypeMessageFormatter.formatMessage(null,"InvalidXGCRepresentation", new Object[]{lexicalRepresentation})
+                                DatatypeMessageFormatter.formatMessage(null, "InvalidXGCRepresentation", new Object[]{lexicalRepresentation})
                                 //"\"" + lexicalRepresentation + "\" is not a valid representation of an XML Gregorian Calendar value."
                         );
                     }
                     return c;
-                }
-                catch(final IllegalArgumentException e) {
+                } catch (final IllegalArgumentException e) {
                     format = "--%M%z";
                 }
-            } 
-            else {
+            } else {
                 // GMonthDay or invalid lexicalRepresentation
                 format = "--%M-%D" + "%z";
             }
-        } 
-        else {
+        } else {
             // check for Date || GYear | GYearMonth
             int countSeparator = 0;
 
@@ -478,7 +543,7 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
                 lexRepLength -= 6;
             }
 
-            for (int i=1; i < lexRepLength; i++) {
+            for (int i = 1; i < lexRepLength; i++) {
                 if (lexRep.charAt(i) == '-') {
                     countSeparator++;
                 }
@@ -486,12 +551,10 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
             if (countSeparator == 0) {
                 // GYear
                 format = "%Y" + "%z";
-            } 
-            else if (countSeparator == 1) {
+            } else if (countSeparator == 1) {
                 // GYearMonth
                 format = "%Y-%M" + "%z";
-            } 
-            else {
+            } else {
                 // Date or invalid lexicalRepresentation
                 // Fix 4971612: invalid SCCS macro substitution in data string
                 format = "%Y-%M-%D" + "%z";
@@ -503,13 +566,13 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
         // check for validity
         if (!c.isValid()) {
             throw new IllegalArgumentException(
-                    DatatypeMessageFormatter.formatMessage(null,"InvalidXGCRepresentation", new Object[]{lexicalRepresentation})
+                    DatatypeMessageFormatter.formatMessage(null, "InvalidXGCRepresentation", new Object[]{lexicalRepresentation})
                     //"\"" + lexicalRepresentation + "\" is not a valid representation of an XML Gregorian Calendar value."
             );
         }
         return c;
     }
-    
+
     private final class Parser {
         private final String format;
         private final String value;
@@ -519,7 +582,7 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
 
         private int fidx;
         private int vidx;
-        
+
         private BigInteger year = null;
         private int month = DatatypeConstants.FIELD_UNDEFINED;
         private int day = DatatypeConstants.FIELD_UNDEFINED;
@@ -528,8 +591,8 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
 
         private int hour = DatatypeConstants.FIELD_UNDEFINED;
         private int minute = DatatypeConstants.FIELD_UNDEFINED;
-        private int second = DatatypeConstants.FIELD_UNDEFINED ;
-        
+        private int second = DatatypeConstants.FIELD_UNDEFINED;
+
         private BigDecimal fractionalSecond = null;
 
         private Parser(String format, String value) {
@@ -538,18 +601,18 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
             this.flen = format.length();
             this.vlen = value.length();
         }
-        
+
         /**
          * <p>Parse a formated <code>String</code> into an <code>XMLGregorianCalendar</code>.</p>
-         * 
+         * <p>
          * <p>If <code>String</code> is not formated as a legal <code>XMLGregorianCalendar</code> value,
          * an <code>IllegalArgumentException</code> is thrown.</p>
-         * 
+         *
          * @throws IllegalArgumentException If <code>String</code> is not formated as a legal <code>XMLGregorianCalendar</code> value.
          */
         public XMLGregorianCalendar parse() throws IllegalArgumentException {
-        	char vch;
-        	while (fidx < flen) {
+            char vch;
+            while (fidx < flen) {
                 final char fch = format.charAt(fidx++);
 
                 if (fch != '%') { // not a meta character
@@ -559,41 +622,40 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
 
                 // seen meta character. we don't do error check against the format
                 switch (format.charAt(fidx++)) {
-                    case 'Y' : // year
+                    case 'Y': // year
                         parseYear();
                         break;
 
-                    case 'M' : // month
-                    	month = parseInt(2, 2);
+                    case 'M': // month
+                        month = parseInt(2, 2);
                         break;
 
-                    case 'D' : // days
-                    	day = parseInt(2, 2);
+                    case 'D': // days
+                        day = parseInt(2, 2);
                         break;
 
-                    case 'h' : // hours
-                    	hour = parseInt(2, 2);
+                    case 'h': // hours
+                        hour = parseInt(2, 2);
                         break;
 
-                    case 'm' : // minutes
-                    	minute = parseInt(2, 2);
+                    case 'm': // minutes
+                        minute = parseInt(2, 2);
                         break;
 
-                    case 's' : // parse seconds.
-                    	second = parseInt(2, 2);
+                    case 's': // parse seconds.
+                        second = parseInt(2, 2);
 
                         if (peek() == '.') {
-                        	fractionalSecond = parseBigDecimal();
+                            fractionalSecond = parseBigDecimal();
                         }
                         break;
 
-                    case 'z' : // time zone. missing, 'Z', or [+-]nn:nn
+                    case 'z': // time zone. missing, 'Z', or [+-]nn:nn
                         vch = peek();
                         if (vch == 'Z') {
                             vidx++;
                             timezone = 0;
-                        } 
-                        else if (vch == '+' || vch == '-') {
+                        } else if (vch == '+' || vch == '-') {
                             vidx++;
                             final int h = parseInt(2, 2);
                             skip(':');
@@ -603,18 +665,17 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
                                 throw new IllegalArgumentException(
                                         DatatypeMessageFormatter.formatMessage(null, "InvalidFieldValue", new Object[]{m, "timezone minutes"})
                                 );
-                            
+
                             timezone = (h * 60 + m) * (vch == '+' ? 1 : -1);
                         }
                         break;
 
-                    case 'Z' : // time zone. 'Z', or [+-]nn:nn
+                    case 'Z': // time zone. 'Z', or [+-]nn:nn
                         vch = peek();
                         if (vch == 'Z') {
                             vidx++;
                             timezone = 0;
-                        } 
-                        else if (vch == '+' || vch == '-') {
+                        } else if (vch == '+' || vch == '-') {
                             vidx++;
                             final int h = parseInt(2, 2);
                             skip(':');
@@ -624,16 +685,16 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
                                 throw new IllegalArgumentException(
                                         DatatypeMessageFormatter.formatMessage(null, "InvalidFieldValue", new Object[]{m, "timezone minutes"})
                                 );
-                            
+
                             timezone = (h * 60 + m) * (vch == '+' ? 1 : -1);
                         } else {
                             throw new IllegalArgumentException(
-                                    DatatypeMessageFormatter.formatMessage(null, "InvalidFieldValue", new Object[]{ "do not defined", "timezone"})
+                                    DatatypeMessageFormatter.formatMessage(null, "InvalidFieldValue", new Object[]{"do not defined", "timezone"})
                             );
                         }
                         break;
 
-                    default :
+                    default:
                         // illegal meta character. impossible.
                         throw new InternalError();
                 }
@@ -643,41 +704,42 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
                 // some tokens are left in the input
                 throw new IllegalArgumentException(value); //,vidx);
             }
-            
-           	if (hour == 24 && minute == 0 && second == 0) {
-                if (getType() == Type.TIME)
-                	{hour = 0;}
-           	}
-            
+
+            if (hour == 24 && minute == 0 && second == 0) {
+                if (getType() == Type.TIME) {
+                    hour = 0;
+                }
+            }
+
             return TimeUtils.getInstance().getFactory()
-        		.newXMLGregorianCalendar(year, month, day, hour, minute, second, fractionalSecond, timezone);
+                    .newXMLGregorianCalendar(year, month, day, hour, minute, second, fractionalSecond, timezone);
         }
-        
+
         private char peek() throws IllegalArgumentException {
             if (vidx == vlen) {
                 return (char) -1;
             }
             return value.charAt(vidx);
         }
-        
+
         private char read() throws IllegalArgumentException {
             if (vidx == vlen) {
                 throw new IllegalArgumentException(value); //,vidx);
             }
             return value.charAt(vidx++);
         }
-        
+
         private void skip(char ch) throws IllegalArgumentException {
             if (read() != ch) {
                 throw new IllegalArgumentException(value); //,vidx-1);
             }
         }
-        
+
         private void parseYear()
-            throws IllegalArgumentException {
+                throws IllegalArgumentException {
             final int vstart = vidx;
             int sign = 0;
-            
+
             // skip leading negative, if it exists
             if (peek() == '-') {
                 vidx++;
@@ -696,12 +758,12 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
 //            	year = Integer.parseInt(yearString);
 //            }
 //            else {
-            	year = new BigInteger(yearString);
+            year = new BigInteger(yearString);
 //            }
         }
-        
+
         private int parseInt(int minDigits, int maxDigits)
-            throws IllegalArgumentException {
+                throws IllegalArgumentException {
             final int vstart = vidx;
             while (isDigit(peek()) && (vidx - vstart) < maxDigits) {
                 vidx++;
@@ -711,7 +773,7 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
                 throw new IllegalArgumentException(value); //,vidx);
             }
 
-            // NumberFormatException is IllegalArgumentException            
+            // NumberFormatException is IllegalArgumentException
             //           try {
             return Integer.parseInt(value.substring(vstart, vidx));
             //            } catch( NumberFormatException e ) {
@@ -721,7 +783,7 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
         }
 
         private BigDecimal parseBigDecimal()
-            throws IllegalArgumentException {
+                throws IllegalArgumentException {
             final int vstart = vidx;
 
             if (peek() == '.') {
@@ -733,37 +795,6 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
                 vidx++;
             }
             return new BigDecimal(value.substring(vstart, vidx));
-        }
-    }
-
-    private static boolean isDigit(char ch) {
-        return '0' <= ch && ch <= '9';
-    }
-
-    /**
-     * Calculate the Julian day number at 00:00 on a given date. Code taken from saxon
-     * {@link <a href="http://saxon.sourceforge.net">http://saxon.sourceforge.net</a>}. Original algorithm is taken from
-     * http://vsg.cape.com/~pbaum/date/jdalg.htm and
-     * http://vsg.cape.com/~pbaum/date/jdalg2.htm
-     * (adjusted to handle BC dates correctly)
-     * <p/>
-     * <p>Note that this assumes dates in the proleptic Gregorian calendar</p>
-     *
-     * @param year  the year
-     * @param month the month (1-12)
-     * @param day   the day (1-31)
-     * @return the Julian day number
-     */
-    public static int getJulianDayNumber(int year, int month, int day) {
-        int z = year - (month < 3 ? 1 : 0);
-        final short f = monthData[month - 1];
-        if (z >= 0) {
-            return day + f + 365 * z + z / 4 - z / 100 + z / 400 + 1721118;
-        } else {
-            // for negative years, add 12000 years and then subtract the days!
-            z += 12000;
-            final int j = day + f + 365 * z + z / 4 - z / 100 + z / 400 + 1721118;
-            return j - (365 * 12000 + 12000 / 4 - 12000 / 100 + 12000 / 400);  // number of leap years in 12000 years
         }
     }
 

--- a/src/org/exist/xquery/value/AbstractDateTimeValue.java
+++ b/src/org/exist/xquery/value/AbstractDateTimeValue.java
@@ -21,6 +21,18 @@
  */
 package org.exist.xquery.value;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.xerces.util.DatatypeMessageFormatter;
+import org.exist.xquery.Constants;
+import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.XPathException;
+
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.Duration;
+import javax.xml.datatype.XMLGregorianCalendar;
+import javax.xml.namespace.QName;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.Collator;
@@ -30,19 +42,6 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.Duration;
-import javax.xml.datatype.XMLGregorianCalendar;
-import javax.xml.namespace.QName;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-import org.apache.xerces.util.DatatypeMessageFormatter;
-import org.exist.xquery.Constants;
-import org.exist.xquery.Constants.Comparison;
-import org.exist.xquery.ErrorCodes;
-import org.exist.xquery.XPathException;
 
 /**
  * @author wolf

--- a/src/org/exist/xquery/value/AbstractDateTimeValue.java
+++ b/src/org/exist/xquery/value/AbstractDateTimeValue.java
@@ -348,7 +348,7 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
         		//TODO : find something that will consume less resources
         		return calendar.compare(TimeUtils.getInstance().newXMLGregorianCalendar(other.getStringValue()));
             } catch (final XPathException e) {
-        		LOG.error("Failed to get string value of '" + other + "'", e);
+				LOG.error("Failed to get string value of '{}'", other, e);
         		//Why not ?
         		return Constants.SUPERIOR;
         	}

--- a/src/org/exist/xquery/value/AbstractDateTimeValue.java
+++ b/src/org/exist/xquery/value/AbstractDateTimeValue.java
@@ -602,7 +602,7 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
 
                             if (m >= 60 || m < 0)
                                 throw new IllegalArgumentException(
-                                        DatatypeMessageFormatter.formatMessage(null, "InvalidFieldValue", new Object[]{ Integer.valueOf(m), "timezone minutes"})
+                                        DatatypeMessageFormatter.formatMessage(null, "InvalidFieldValue", new Object[]{m, "timezone minutes"})
                                 );
                             
                             timezone = (h * 60 + m) * (vch == '+' ? 1 : -1);
@@ -623,7 +623,7 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
 
                             if (m >= 60 || m < 0)
                                 throw new IllegalArgumentException(
-                                        DatatypeMessageFormatter.formatMessage(null, "InvalidFieldValue", new Object[]{ Integer.valueOf(m), "timezone minutes"})
+                                        DatatypeMessageFormatter.formatMessage(null, "InvalidFieldValue", new Object[]{m, "timezone minutes"})
                                 );
                             
                             timezone = (h * 60 + m) * (vch == '+' ? 1 : -1);

--- a/src/org/exist/xquery/value/AbstractSequence.java
+++ b/src/org/exist/xquery/value/AbstractSequence.java
@@ -59,7 +59,7 @@ public abstract class AbstractSequence implements Sequence {
     public AtomicValue convertTo(int requiredType) throws XPathException {
         final Item first = itemAt(0);
         if(Type.subTypeOf(first.getType(), Type.ATOMIC))
-            {return ((AtomicValue)first).convertTo(requiredType);}
+            {return first.convertTo(requiredType);}
         else
             //TODO : clean atomization
             {return new StringValue(first.getStringValue()).convertTo(requiredType);}
@@ -200,7 +200,7 @@ public abstract class AbstractSequence implements Sequence {
             return (T)l;
         }
         if(!isEmpty()) {
-            return (T)itemAt(0).toJavaObject(target);
+            return itemAt(0).toJavaObject(target);
         }
         return null;
     }

--- a/src/org/exist/xquery/value/AbstractSequence.java
+++ b/src/org/exist/xquery/value/AbstractSequence.java
@@ -21,7 +21,10 @@
 package org.exist.xquery.value;
 
 import org.exist.collections.Collection;
-import org.exist.dom.persistent.*;
+import org.exist.dom.persistent.DocumentSet;
+import org.exist.dom.persistent.EmptyNodeSet;
+import org.exist.dom.persistent.NodeHandle;
+import org.exist.dom.persistent.NodeProxy;
 import org.exist.numbering.NodeId;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.XPathException;

--- a/src/org/exist/xquery/value/AbstractSequence.java
+++ b/src/org/exist/xquery/value/AbstractSequence.java
@@ -41,31 +41,39 @@ import java.util.List;
  */
 public abstract class AbstractSequence implements Sequence {
 
-    /** To retain compatibility with eXist versions before september 20th 2005 ,
+    /**
+     * To retain compatibility with eXist versions before september 20th 2005 ,
      * for conversion to boolean;
-     * @see http://cvs.sourceforge.net/viewcvs.py/exist/eXist-1.0/src/org/exist/xquery/value/AbstractSequence.java?r1=1.11&r2=1.12 */
+     *
+     * @see http://cvs.sourceforge.net/viewcvs.py/exist/eXist-1.0/src/org/exist/xquery/value/AbstractSequence.java?r1=1.11&r2=1.12
+     */
     private static final boolean OLD_EXIST_VERSION_COMPATIBILITY = false;
 
     protected boolean isEmpty = true;
     protected boolean hasOne = false;
 
     public int getCardinality() {
-        if (isEmpty())
-            {return Cardinality.EMPTY;}
-        if (hasOne())
-            {return Cardinality.EXACTLY_ONE;}
-        if (hasMany())
-            {return Cardinality.ONE_OR_MORE;}
+        if (isEmpty()) {
+            return Cardinality.EMPTY;
+        }
+        if (hasOne()) {
+            return Cardinality.EXACTLY_ONE;
+        }
+        if (hasMany()) {
+            return Cardinality.ONE_OR_MORE;
+        }
         throw new IllegalArgumentException("Illegal argument");
     }
 
     public AtomicValue convertTo(int requiredType) throws XPathException {
         final Item first = itemAt(0);
-        if(Type.subTypeOf(first.getType(), Type.ATOMIC))
-            {return first.convertTo(requiredType);}
-        else
-            //TODO : clean atomization
-            {return new StringValue(first.getStringValue()).convertTo(requiredType);}
+        if (Type.subTypeOf(first.getType(), Type.ATOMIC)) {
+            return first.convertTo(requiredType);
+        } else
+        //TODO : clean atomization
+        {
+            return new StringValue(first.getStringValue()).convertTo(requiredType);
+        }
     }
 
     public boolean hasMany() {
@@ -74,8 +82,8 @@ public abstract class AbstractSequence implements Sequence {
 
     @Override
     public Sequence tail() throws XPathException {
-    	final ValueSequence tmp = new ValueSequence(getItemCount() - 1);
-    	Item item;
+        final ValueSequence tmp = new ValueSequence(getItemCount() - 1);
+        Item item;
         final SequenceIterator iterator = iterate();
         iterator.nextItem();
         while (iterator.hasNext()) {
@@ -84,10 +92,11 @@ public abstract class AbstractSequence implements Sequence {
         }
         return tmp;
     }
-    
+
     public String getStringValue() throws XPathException {
-        if(isEmpty())
-            {return "";}
+        if (isEmpty()) {
+            return "";
+        }
         final Item first = iterate().nextItem();
         return first.getStringValue();
     }
@@ -98,8 +107,9 @@ public abstract class AbstractSequence implements Sequence {
             buf.append("(");
             boolean gotOne = false;
             for (final SequenceIterator i = iterate(); i.hasNext(); ) {
-                if (gotOne)
-                    {buf.append(", ");}
+                if (gotOne) {
+                    buf.append(", ");
+                }
                 buf.append(i.nextItem());
                 gotOne = true;
             }
@@ -131,46 +141,54 @@ public abstract class AbstractSequence implements Sequence {
         //Nothing to do
     }
 
-    /** See
+    /**
+     * See
      * <a <href="http://www.w3.org/TR/xquery/#id-ebv">2.4.3 Effective Boolean Value</a>
+     *
      * @see org.exist.xquery.value.Sequence#effectiveBooleanValue()
      */
-    public boolean effectiveBooleanValue() throws XPathException {		
-        if (isEmpty())
-            {return false;}
+    public boolean effectiveBooleanValue() throws XPathException {
+        if (isEmpty()) {
+            return false;
+        }
         final Item first = itemAt(0);
         //If its operand is a sequence whose first item is a node, fn:boolean returns true.		
-        if (Type.subTypeOf(first.getType(), Type.NODE))
-            {return true;}
+        if (Type.subTypeOf(first.getType(), Type.NODE)) {
+            return true;
+        }
         if (hasMany()) {
-            if (OLD_EXIST_VERSION_COMPATIBILITY)		
-                {return true;}
-            else
-                {throw new XPathException(
-                    "err:FORG0006: effectiveBooleanValue: first item of '" + 
-                    (toString().length() < 20 ? toString() : toString().substring(0, 20)+ "...") + 
-                    "' is not a node, and sequence length > 1");}
+            if (OLD_EXIST_VERSION_COMPATIBILITY) {
+                return true;
+            } else {
+                throw new XPathException(
+                        "err:FORG0006: effectiveBooleanValue: first item of '" +
+                                (toString().length() < 20 ? toString() : toString().substring(0, 20) + "...") +
+                                "' is not a node, and sequence length > 1");
+            }
         }
         //From now, we'll work with singletons...
         //Not sure about this one : does it mean than any singleton, including false() and 0 will return true ?
-        if (OLD_EXIST_VERSION_COMPATIBILITY)
-            {return true;}
-        else
-            {return ((AtomicValue)first).effectiveBooleanValue();}
+        if (OLD_EXIST_VERSION_COMPATIBILITY) {
+            return true;
+        } else {
+            return ((AtomicValue) first).effectiveBooleanValue();
+        }
     }
 
     /* (non-Javadoc)
      * @see org.exist.xquery.value.Sequence#conversionPreference(java.lang.Class)
      */
     public int conversionPreference(Class<?> javaClass) {
-        if (javaClass.isAssignableFrom(Sequence.class))
-            {return 0;}
-        else if (javaClass.isAssignableFrom(List.class) || javaClass.isArray())
-            {return 1;}
-        else if (javaClass == Object.class)
-            {return 20;}
-        if(!isEmpty())
-            {return itemAt(0).conversionPreference(javaClass);}
+        if (javaClass.isAssignableFrom(Sequence.class)) {
+            return 0;
+        } else if (javaClass.isAssignableFrom(List.class) || javaClass.isArray()) {
+            return 1;
+        } else if (javaClass == Object.class) {
+            return 20;
+        }
+        if (!isEmpty()) {
+            return itemAt(0).conversionPreference(javaClass);
+        }
         return Integer.MAX_VALUE;
     }
 
@@ -179,48 +197,49 @@ public abstract class AbstractSequence implements Sequence {
      */
     @Override
     public <T> T toJavaObject(final Class<T> target) throws XPathException {
-        if(Sequence.class.isAssignableFrom(target)) {
-            return (T)this;
-        } else if(target.isArray()) {
+        if (Sequence.class.isAssignableFrom(target)) {
+            return (T) this;
+        } else if (target.isArray()) {
             final Class<?> componentType = target.getComponentType();
             // assume single-dimensional, then double-check that instance really matches desired type
             final Object array = Array.newInstance(componentType, getItemCount());
-            if(!target.isInstance(array)) {
+            if (!target.isInstance(array)) {
                 return null;
             }
             int index = 0;
-            for(final SequenceIterator i = iterate(); i.hasNext(); index++) {
+            for (final SequenceIterator i = iterate(); i.hasNext(); index++) {
                 final Item item = i.nextItem();
                 final Object obj = item.toJavaObject(componentType);
                 Array.set(array, index, obj);
             }
-            return (T)array;
-        } else if(target.isAssignableFrom(List.class)) {
+            return (T) array;
+        } else if (target.isAssignableFrom(List.class)) {
             final List<Item> l = new ArrayList<>(getItemCount());
-            for(final SequenceIterator i = iterate(); i.hasNext(); ) {
+            for (final SequenceIterator i = iterate(); i.hasNext(); ) {
                 l.add(i.nextItem());
             }
-            return (T)l;
+            return (T) l;
         }
-        if(!isEmpty()) {
+        if (!isEmpty()) {
             return itemAt(0).toJavaObject(target);
         }
         return null;
     }
 
-    public void clearContext(int contextId)  throws XPathException {
+    public void clearContext(int contextId) throws XPathException {
         Item next;
         for (final SequenceIterator i = unorderedIterator(); i.hasNext(); ) {
             next = i.nextItem();
-            if (next instanceof NodeProxy)
-                {((NodeProxy)next).clearContext(contextId);}
+            if (next instanceof NodeProxy) {
+                ((NodeProxy) next).clearContext(contextId);
+            }
         }
     }
 
     public void setSelfAsContext(int contextId) throws XPathException {
         Item next;
         NodeValue node;
-        for (final SequenceIterator i = unorderedIterator(); i.hasNext();) {
+        for (final SequenceIterator i = unorderedIterator(); i.hasNext(); ) {
             next = i.nextItem();
             if (Type.subTypeOf(next.getType(), Type.NODE)) {
                 node = (NodeValue) next;

--- a/src/org/exist/xquery/value/AbstractSequence.java
+++ b/src/org/exist/xquery/value/AbstractSequence.java
@@ -193,7 +193,7 @@ public abstract class AbstractSequence implements Sequence {
             }
             return (T)array;
         } else if(target.isAssignableFrom(List.class)) {
-            final List<Item> l = new ArrayList<Item>(getItemCount());
+            final List<Item> l = new ArrayList<>(getItemCount());
             for(final SequenceIterator i = iterate(); i.hasNext(); ) {
                 l.add(i.nextItem());
             }

--- a/src/org/exist/xquery/value/AnyURIValue.java
+++ b/src/org/exist/xquery/value/AnyURIValue.java
@@ -243,7 +243,7 @@ public class AnyURIValue extends AtomicValue {
 	public boolean effectiveBooleanValue() throws XPathException {
 		// If its operand is a singleton value of type xs:string, xs:anyURI, xs:untypedAtomic, 
 		//or a type derived from one of these, fn:boolean returns false if the operand value has zero length; otherwise it returns true.
-		return uri.length() > 0;
+		return !uri.isEmpty();
 	}	
 
 	/* (non-Javadoc)

--- a/src/org/exist/xquery/value/AnyURIValue.java
+++ b/src/org/exist/xquery/value/AnyURIValue.java
@@ -89,7 +89,7 @@ public class AnyURIValue extends AtomicValue {
 	 * See Section 5.4 of XML Linking:
 	 * http://www.w3.org/TR/2000/PR-xlink-20001220/#link-locators
 	 */
-	private String uri;
+	private final String uri;
 	//TODO: save escaped(URI) version?
 	
 	AnyURIValue() {

--- a/src/org/exist/xquery/value/AnyURIValue.java
+++ b/src/org/exist/xquery/value/AnyURIValue.java
@@ -39,81 +39,84 @@ import java.util.BitSet;
  */
 public class AnyURIValue extends AtomicValue {
 
-	static BitSet needEncoding;
-    static final int caseDiff = ('a' - 'A'); 
+    public static final AnyURIValue EMPTY_URI = new AnyURIValue();
+    static final int caseDiff = ('a' - 'A');
+    static BitSet needEncoding;
+
     static {
 
-    needEncoding = new BitSet(128);
-	int i;
-	for (i = 0x00; i <= 0x1F; i++) {
-		needEncoding.set(i);
-	}
-	needEncoding.set(0x7F);
-	needEncoding.set(0x20);
-	needEncoding.set('<');
-	needEncoding.set('>');
-	needEncoding.set('"');
-	needEncoding.set('{');
-	needEncoding.set('}');
-	needEncoding.set('|');
-	needEncoding.set('\\');
-	needEncoding.set('^');
-	needEncoding.set('`');
+        needEncoding = new BitSet(128);
+        int i;
+        for (i = 0x00; i <= 0x1F; i++) {
+            needEncoding.set(i);
+        }
+        needEncoding.set(0x7F);
+        needEncoding.set(0x20);
+        needEncoding.set('<');
+        needEncoding.set('>');
+        needEncoding.set('"');
+        needEncoding.set('{');
+        needEncoding.set('}');
+        needEncoding.set('|');
+        needEncoding.set('\\');
+        needEncoding.set('^');
+        needEncoding.set('`');
     }
-    
-	public static final AnyURIValue EMPTY_URI = new AnyURIValue();
-	
-	/* Very important - this string does not need to be a valid uri.
-	 * 
-	 * From XML Linking (see below for link), with some wording changes:
-	 * The value of the [anyURI] must be a URI reference as defined in
-	 * [IETF RFC 2396], or must result in a URI reference after the escaping
-	 * procedure described below is applied. The procedure is applied when
-	 * passing the URI reference to a URI resolver.
-	 * 
-	 * Some characters are disallowed in URI references, even if they are
-	 * allowed in XML; the disallowed characters include all non-ASCII
-	 * characters, plus the excluded characters listed in Section 2.4 of
-	 * [IETF RFC 2396], except for the number sign (#) and percent sign (%)
-	 * and the square bracket characters re-allowed in [IETF RFC 2732].
-	 * Disallowed characters must be escaped as follows:
-	 * 1. Each disallowed character is converted to UTF-8 [IETF RFC 2279]
-	 *    as one or more bytes.
-	 * 2. Any bytes corresponding to a disallowed character are escaped
-	 *    with the URI escaping mechanism (that is, converted to %HH,
-	 *    where HH is the hexadecimal notation of the byte value).
-	 * 3. The original character is replaced by the resulting character
-	 *    sequence.
-	 * 
-	 * See Section 5.4 of XML Linking:
-	 * http://www.w3.org/TR/2000/PR-xlink-20001220/#link-locators
-	 */
-	private final String uri;
-	//TODO: save escaped(URI) version?
-	
-	AnyURIValue() {
-		this.uri = "";
-	}
-	public AnyURIValue(URI uri) {
-		this.uri = uri.toString();
-	}
-	public AnyURIValue(XmldbURI uri) {
-		this.uri = uri.toString();
-	}
-	public AnyURIValue(String s) throws XPathException {
-		final String wsTrimString = normalizeEscaped(StringValue.trimWhitespace(s));
-		final String escapedString = escape(wsTrimString);
+
+    /* Very important - this string does not need to be a valid uri.
+     *
+     * From XML Linking (see below for link), with some wording changes:
+     * The value of the [anyURI] must be a URI reference as defined in
+     * [IETF RFC 2396], or must result in a URI reference after the escaping
+     * procedure described below is applied. The procedure is applied when
+     * passing the URI reference to a URI resolver.
+     *
+     * Some characters are disallowed in URI references, even if they are
+     * allowed in XML; the disallowed characters include all non-ASCII
+     * characters, plus the excluded characters listed in Section 2.4 of
+     * [IETF RFC 2396], except for the number sign (#) and percent sign (%)
+     * and the square bracket characters re-allowed in [IETF RFC 2732].
+     * Disallowed characters must be escaped as follows:
+     * 1. Each disallowed character is converted to UTF-8 [IETF RFC 2279]
+     *    as one or more bytes.
+     * 2. Any bytes corresponding to a disallowed character are escaped
+     *    with the URI escaping mechanism (that is, converted to %HH,
+     *    where HH is the hexadecimal notation of the byte value).
+     * 3. The original character is replaced by the resulting character
+     *    sequence.
+     *
+     * See Section 5.4 of XML Linking:
+     * http://www.w3.org/TR/2000/PR-xlink-20001220/#link-locators
+     */
+    private final String uri;
+    //TODO: save escaped(URI) version?
+
+    AnyURIValue() {
+        this.uri = "";
+    }
+
+    public AnyURIValue(URI uri) {
+        this.uri = uri.toString();
+    }
+
+    public AnyURIValue(XmldbURI uri) {
+        this.uri = uri.toString();
+    }
+
+    public AnyURIValue(String s) throws XPathException {
+        final String wsTrimString = normalizeEscaped(StringValue.trimWhitespace(s));
+        final String escapedString = escape(wsTrimString);
         try {
-			new URI(escapedString);
-		} catch (final URISyntaxException e) {
-			try {
-				XmldbURI.xmldbUriFor(escapedString);
-			} catch (final URISyntaxException ex) {
-				throw new XPathException(
-					"Type error: the given string '" + s + "' cannot be cast to " + Type.getTypeName(getType()));
-			}
-		}
-		/*
+            new URI(escapedString);
+        } catch (final URISyntaxException e) {
+            try {
+                XmldbURI.xmldbUriFor(escapedString);
+            } catch (final URISyntaxException ex) {
+                throw new XPathException(
+                        "Type error: the given string '" + s + "' cannot be cast to " + Type.getTypeName(getType()));
+            }
+        }
+        /*
 		The URI value is whitespace normalized according to the rules for the xs:anyURI type in [XML Schema]. 
 		<xs:simpleType name="anyURI" id="anyURI">
 			...
@@ -122,22 +125,22 @@ public class AnyURIValue extends AtomicValue {
 			</xs:restriction>
 		</xs:simpleType>
 		*/
-		//TODO : find a way to perform the 3 operations at the same time
-		//s = StringValue.expand(s); //Should we have character entities
-		s = StringValue.normalizeWhitespace(wsTrimString); //Should we have TABs, new lines...
-		this.uri = StringValue.collapseWhitespace(s);
-	}
+        //TODO : find a way to perform the 3 operations at the same time
+        //s = StringValue.expand(s); //Should we have character entities
+        s = StringValue.normalizeWhitespace(wsTrimString); //Should we have TABs, new lines...
+        this.uri = StringValue.collapseWhitespace(s);
+    }
 
-	/**
-	 * This function accepts a String representation of an xs:anyURI and applies
-	 * the escaping method described in Section 5.4 of XML Linking (http://www.w3.org/TR/2000/PR-xlink-20001220/#link-locators)
-	 * to turn it into a valid URI
-	 * 
-         * @see <a href="http://www.w3.org/TR/2000/PR-xlink-20001220/#link-locators">http://www.w3.org/TR/2000/PR-xlink-20001220/#link-locators</A>
-	 * @param uri The xs:anyURI to escape into a valid URI
-	 * @return An escaped string representation of the provided xs:anyURI
-	 */
-	 public static String escape(String uri) {
+    /**
+     * This function accepts a String representation of an xs:anyURI and applies
+     * the escaping method described in Section 5.4 of XML Linking (http://www.w3.org/TR/2000/PR-xlink-20001220/#link-locators)
+     * to turn it into a valid URI
+     *
+     * @param uri The xs:anyURI to escape into a valid URI
+     * @return An escaped string representation of the provided xs:anyURI
+     * @see <a href="http://www.w3.org/TR/2000/PR-xlink-20001220/#link-locators">http://www.w3.org/TR/2000/PR-xlink-20001220/#link-locators</A>
+     */
+    public static String escape(String uri) {
 
         return FunEscapeURI.escape(uri, false);
 
@@ -224,171 +227,179 @@ public class AnyURIValue extends AtomicValue {
 //		} catch(UnsupportedEncodingException e) {
 //			throw new RuntimeException(e);
 //		}
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#getType()
-	 */
-	public int getType() {
-		return Type.ANY_URI;
-	}
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getStringValue()
-	 */
-	public String getStringValue() throws XPathException {
-		return uri;
-	}
-	
-	public boolean effectiveBooleanValue() throws XPathException {
-		// If its operand is a singleton value of type xs:string, xs:anyURI, xs:untypedAtomic, 
-		//or a type derived from one of these, fn:boolean returns false if the operand value has zero length; otherwise it returns true.
-		return !uri.isEmpty();
-	}	
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#convertTo(int)
-	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.ITEM :
-			case Type.ATOMIC :
-			case Type.ANY_URI :
-				return this;
-			case Type.STRING :
-				return new StringValue(uri);
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());
-			default :
-				throw new XPathException(
-					"Type error: cannot cast xs:anyURI to "
-						+ Type.getTypeName(requiredType));
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#getType()
+     */
+    public int getType() {
+        return Type.ANY_URI;
+    }
 
-	@Override
-	public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
-		if (other.getType() == Type.ANY_URI) {
-			final String otherURI = other.getStringValue();
-			final int cmp = uri.compareTo(otherURI);
-			switch (operator) {
-				case EQ:
-					return cmp == 0;
-				case NEQ:
-					return cmp != 0;
-				case GT :
-					return cmp > 0;
-				case GTEQ :
-					return cmp >= 0;
-				case LT :
-					return cmp < 0;
-				case LTEQ :
-					return cmp <= 0;					
-				default :
-					throw new XPathException(
-						"XPTY0004: cannot apply operator "
-							+ operator.generalComparisonSymbol
-							+ " to xs:anyURI");
-			}
-		} else
-			{return compareTo(collator, operator, other.convertTo(Type.ANY_URI));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getStringValue()
+     */
+    public String getStringValue() throws XPathException {
+        return uri;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#compareTo(org.exist.xquery.value.AtomicValue)
-	 */
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == Type.ANY_URI) {
-			final String otherURI = other.getStringValue();
-			return uri.compareTo(otherURI);
-		} else {
-			return compareTo(collator, other.convertTo(Type.ANY_URI));
-		}
-	}
+    public boolean effectiveBooleanValue() throws XPathException {
+        // If its operand is a singleton value of type xs:string, xs:anyURI, xs:untypedAtomic,
+        //or a type derived from one of these, fn:boolean returns false if the operand value has zero length; otherwise it returns true.
+        return !uri.isEmpty();
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
-	 */
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException("max is not supported for values of type xs:anyURI");
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#convertTo(int)
+     */
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.ITEM:
+            case Type.ATOMIC:
+            case Type.ANY_URI:
+                return this;
+            case Type.STRING:
+                return new StringValue(uri);
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            default:
+                throw new XPathException(
+                        "Type error: cannot cast xs:anyURI to "
+                                + Type.getTypeName(requiredType));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#min(org.exist.xquery.value.AtomicValue)
-	 */
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException("min is not supported for values of type xs:anyURI");
-	}
+    @Override
+    public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
+        if (other.getType() == Type.ANY_URI) {
+            final String otherURI = other.getStringValue();
+            final int cmp = uri.compareTo(otherURI);
+            switch (operator) {
+                case EQ:
+                    return cmp == 0;
+                case NEQ:
+                    return cmp != 0;
+                case GT:
+                    return cmp > 0;
+                case GTEQ:
+                    return cmp >= 0;
+                case LT:
+                    return cmp < 0;
+                case LTEQ:
+                    return cmp <= 0;
+                default:
+                    throw new XPathException(
+                            "XPTY0004: cannot apply operator "
+                                    + operator.generalComparisonSymbol
+                                    + " to xs:anyURI");
+            }
+        } else {
+            return compareTo(collator, operator, other.convertTo(Type.ANY_URI));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
-	 */
-	public int conversionPreference(Class<?> javaClass) {
-		if (javaClass.isAssignableFrom(AnyURIValue.class))
-			{return 0;}
-		if (javaClass == XmldbURI.class)
-			{return 1;}
-		if (javaClass == URI.class)
-			{return 2;}
-		if (javaClass == URL.class)
-			{return 3;}
-		if (javaClass == String.class || javaClass == CharSequence.class)
-			{return 4;}
-		if (javaClass == Object.class)
-			{return 20;}
-		return Integer.MAX_VALUE;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#compareTo(org.exist.xquery.value.AtomicValue)
+     */
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == Type.ANY_URI) {
+            final String otherURI = other.getStringValue();
+            return uri.compareTo(otherURI);
+        } else {
+            return compareTo(collator, other.convertTo(Type.ANY_URI));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
-	 */
-	@Override
-        public <T> T toJavaObject(final Class<T> target) throws XPathException {
-		if (target.isAssignableFrom(AnyURIValue.class)) {
-			return (T)this;
-		} else if (target == XmldbURI.class) {
-			return (T)toXmldbURI();
-		} else if (target == URI.class) {
-			return (T)toURI();
-		} else if (target == URL.class) {
-			try {
-				return (T)new URL(uri);
-			} catch (final MalformedURLException e) {
-				throw new XPathException(ErrorCodes.FORG0001,
-					"failed to convert " + uri + " into a Java URL: " + e.getMessage(),
-					e);
-			}
-		} else if (target == String.class || target == CharSequence.class)
-			{return (T)uri;}
-		else if (target == Object.class) {
-			return (T)uri;
-                }
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
+     */
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException("max is not supported for values of type xs:anyURI");
+    }
 
-		throw new XPathException(
-			"cannot convert value of type "
-				+ Type.getTypeName(getType())
-				+ " to Java object of type "
-				+ target.getName());
-	}
-	
-	public XmldbURI toXmldbURI() throws XPathException {
-		try {
-			return XmldbURI.xmldbUriFor(uri, false);
-		} catch (final URISyntaxException e) {
-			throw new XPathException(ErrorCodes.FORG0001,
-				"failed to convert " + uri + " into an XmldbURI: " + e.getMessage(),
-				e);
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#min(org.exist.xquery.value.AtomicValue)
+     */
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException("min is not supported for values of type xs:anyURI");
+    }
 
-	public URI toURI() throws XPathException {
-		try {
-			return new URI(escape(uri));
-		} catch (final URISyntaxException e) {
-			throw new XPathException(ErrorCodes.FORG0001,
-				"failed to convert " + uri + " into an URI: " + e.getMessage(),
-				e);
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
+     */
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(AnyURIValue.class)) {
+            return 0;
+        }
+        if (javaClass == XmldbURI.class) {
+            return 1;
+        }
+        if (javaClass == URI.class) {
+            return 2;
+        }
+        if (javaClass == URL.class) {
+            return 3;
+        }
+        if (javaClass == String.class || javaClass == CharSequence.class) {
+            return 4;
+        }
+        if (javaClass == Object.class) {
+            return 20;
+        }
+        return Integer.MAX_VALUE;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
+     */
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target.isAssignableFrom(AnyURIValue.class)) {
+            return (T) this;
+        } else if (target == XmldbURI.class) {
+            return (T) toXmldbURI();
+        } else if (target == URI.class) {
+            return (T) toURI();
+        } else if (target == URL.class) {
+            try {
+                return (T) new URL(uri);
+            } catch (final MalformedURLException e) {
+                throw new XPathException(ErrorCodes.FORG0001,
+                        "failed to convert " + uri + " into a Java URL: " + e.getMessage(),
+                        e);
+            }
+        } else if (target == String.class || target == CharSequence.class) {
+            return (T) uri;
+        } else if (target == Object.class) {
+            return (T) uri;
+        }
+
+        throw new XPathException(
+                "cannot convert value of type "
+                        + Type.getTypeName(getType())
+                        + " to Java object of type "
+                        + target.getName());
+    }
+
+    public XmldbURI toXmldbURI() throws XPathException {
+        try {
+            return XmldbURI.xmldbUriFor(uri, false);
+        } catch (final URISyntaxException e) {
+            throw new XPathException(ErrorCodes.FORG0001,
+                    "failed to convert " + uri + " into an XmldbURI: " + e.getMessage(),
+                    e);
+        }
+    }
+
+    public URI toURI() throws XPathException {
+        try {
+            return new URI(escape(uri));
+        } catch (final URISyntaxException e) {
+            throw new XPathException(ErrorCodes.FORG0001,
+                    "failed to convert " + uri + " into an URI: " + e.getMessage(),
+                    e);
+        }
+    }
 
     @Override
     public int hashCode() {
@@ -397,10 +408,12 @@ public class AnyURIValue extends AtomicValue {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
-            {return true;}
-        if (obj instanceof AnyURIValue)
-            {return ((AnyURIValue)obj).uri.equals(uri);}
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof AnyURIValue) {
+            return ((AnyURIValue) obj).uri.equals(uri);
+        }
         return false;
     }
 

--- a/src/org/exist/xquery/value/AnyURIValue.java
+++ b/src/org/exist/xquery/value/AnyURIValue.java
@@ -21,19 +21,18 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.functions.fn.FunEscapeURI;
+
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.Collator;
 import java.util.BitSet;
-
-import org.exist.xmldb.XmldbURI;
-import org.exist.xquery.Constants;
-import org.exist.xquery.Constants.Comparison;
-import org.exist.xquery.ErrorCodes;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.functions.fn.FunEscapeURI;
 
 /**
  * @author Wolfgang Meier (wolfgang@exist-db.org)

--- a/src/org/exist/xquery/value/AtomicValue.java
+++ b/src/org/exist/xquery/value/AtomicValue.java
@@ -22,11 +22,11 @@ package org.exist.xquery.value;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
+import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.EmptyNodeSet;
 import org.exist.dom.persistent.NodeHandle;
 import org.exist.dom.persistent.NodeSet;
-import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.numbering.NodeId;
 import org.exist.storage.DBBroker;
 import org.exist.storage.Indexable;

--- a/src/org/exist/xquery/value/AtomicValue.java
+++ b/src/org/exist/xquery/value/AtomicValue.java
@@ -47,206 +47,208 @@ import java.util.Properties;
 /**
  * Represents an atomic value. All simple values that are not nodes extend AtomicValue.
  * As every single item is also a sequence, this class implements both: Item and Sequence.
- * 
+ *
  * @author wolf
  */
 public abstract class AtomicValue implements Item, Sequence, Indexable {
 
-    /** An empty atomic value */
-	public final static AtomicValue EMPTY_VALUE = new EmptyValue();
+    /**
+     * An empty atomic value
+     */
+    public final static AtomicValue EMPTY_VALUE = new EmptyValue();
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#getType()
-	 */
-	public int getType() {
-		return Type.ATOMIC;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#getType()
+     */
+    public int getType() {
+        return Type.ATOMIC;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#getStringValue()
-	 */
-	public abstract String getStringValue() throws XPathException;
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#getStringValue()
+     */
+    public abstract String getStringValue() throws XPathException;
 
-	@Override
-	public Sequence tail() throws XPathException {
-		return Sequence.EMPTY_SEQUENCE;
-	}
-	
-	public abstract AtomicValue convertTo(int requiredType) throws XPathException;
+    @Override
+    public Sequence tail() throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
 
-	public abstract boolean compareTo(Collator collator, Comparison operator, AtomicValue other)
-		throws XPathException;
+    public abstract AtomicValue convertTo(int requiredType) throws XPathException;
 
-	public abstract int compareTo(Collator collator, AtomicValue other) throws XPathException;
+    public abstract boolean compareTo(Collator collator, Comparison operator, AtomicValue other)
+            throws XPathException;
 
-	public abstract AtomicValue max(Collator collator, AtomicValue other) throws XPathException;
+    public abstract int compareTo(Collator collator, AtomicValue other) throws XPathException;
 
-	public abstract AtomicValue min(Collator collator, AtomicValue other) throws XPathException;
+    public abstract AtomicValue max(Collator collator, AtomicValue other) throws XPathException;
+
+    public abstract AtomicValue min(Collator collator, AtomicValue other) throws XPathException;
 
     /**
      * Compares this atomic value to another. Returns true if the current value is of type string
      * and its value starts with the string value of the other value.
-     * 
+     *
      * @param collator Collator used for string comparison.
      * @param other
      * @throws XPathException if this is not a string.
      */
-	public boolean startsWith(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException("Cannot call starts-with on value of type " + 
-				Type.getTypeName(getType()));
-	}
-	
-	/**
+    public boolean startsWith(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException("Cannot call starts-with on value of type " +
+                Type.getTypeName(getType()));
+    }
+
+    /**
      * Compares this atomic value to another. Returns true if the current value is of type string
      * and its value ends with the string value of the other value.
-     * 
+     *
      * @param collator Collator used for string comparison.
      * @param other
      * @throws XPathException if this is not a string.
      */
-	public boolean endsWith(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException("Cannot call ends-with on value of type " + 
-				Type.getTypeName(getType()));
-	}
-	
-	/**
+    public boolean endsWith(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException("Cannot call ends-with on value of type " +
+                Type.getTypeName(getType()));
+    }
+
+    /**
      * Compares this atomic value to another. Returns true if the current value is of type string
      * and its value contains the string value of the other value.
-     * 
+     *
      * @param collator Collator used for string comparison.
      * @param other
      * @throws XPathException if this is not a string.
      */
-	public boolean contains(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException("Cannot call contains on value of type " + 
-				Type.getTypeName(getType()));
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getLength()
-	 */
-	public int getItemCount() {
-		return 1;
-	}
+    public boolean contains(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException("Cannot call contains on value of type " +
+                Type.getTypeName(getType()));
+    }
 
-	public int getCardinality() {
-		return Cardinality.EXACTLY_ONE;
-	}
-	
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getLength()
+     */
+    public int getItemCount() {
+        return 1;
+    }
+
+    public int getCardinality() {
+        return Cardinality.EXACTLY_ONE;
+    }
+
     public void removeDuplicates() {
         // this is a single value, so there are no duplicates to remove
     }
-    
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#iterate()
-	 */
-	public SequenceIterator iterate() throws XPathException {
-		return new SingleItemIterator(this);
-	}
 
-	public SequenceIterator unorderedIterator() throws XPathException {
-		return new SingleItemIterator(this);
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getItemType()
-	 */
-	public int getItemType() {
-		return getType();
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#iterate()
+     */
+    public SequenceIterator iterate() throws XPathException {
+        return new SingleItemIterator(this);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#itemAt(int)
-	 */
-	public Item itemAt(int pos) {
-		return pos > 0 ? null : this;
-	}
+    public SequenceIterator unorderedIterator() throws XPathException {
+        return new SingleItemIterator(this);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toSequence()
-	 */
-	public Sequence toSequence() {
-		return this;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getItemType()
+     */
+    public int getItemType() {
+        return getType();
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toSAX(org.exist.storage.DBBroker, org.xml.sax.ContentHandler)
-	 */
-	public void toSAX(DBBroker broker, ContentHandler handler, Properties properties) throws SAXException {
-		try {
-			final String s = getStringValue();
-			handler.characters(s.toCharArray(), 0, s.length());
-		} catch (final XPathException e) {
-			throw new SAXException(e);
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#itemAt(int)
+     */
+    public Item itemAt(int pos) {
+        return pos > 0 ? null : this;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#copyTo(org.exist.storage.DBBroker, org.exist.dom.memtree.DocumentBuilderReceiver)
-	 */
-	public void copyTo(DBBroker broker, DocumentBuilderReceiver receiver) throws SAXException {
-		try {
-			final String s = getStringValue();
-			receiver.characters(s);
-		} catch (final XPathException e) {
-			throw new SAXException(e);
-		}
-	}
-	
-	public boolean isEmpty() {
-		return false;
-	}
-	
-	public boolean hasOne() {
-		return true;
-	}
-	
-	public boolean hasMany() {
-		return false;
-	}	
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toSequence()
+     */
+    public Sequence toSequence() {
+        return this;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#add(org.exist.xquery.value.Item)
-	 */
-	public void add(Item item) throws XPathException {
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toSAX(org.exist.storage.DBBroker, org.xml.sax.ContentHandler)
+     */
+    public void toSAX(DBBroker broker, ContentHandler handler, Properties properties) throws SAXException {
+        try {
+            final String s = getStringValue();
+            handler.characters(s.toCharArray(), 0, s.length());
+        } catch (final XPathException e) {
+            throw new SAXException(e);
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#addAll(org.exist.xquery.value.Sequence)
-	 */
-	public void addAll(Sequence other) throws XPathException {
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#copyTo(org.exist.storage.DBBroker, org.exist.dom.memtree.DocumentBuilderReceiver)
+     */
+    public void copyTo(DBBroker broker, DocumentBuilderReceiver receiver) throws SAXException {
+        try {
+            final String s = getStringValue();
+            receiver.characters(s);
+        } catch (final XPathException e) {
+            throw new SAXException(e);
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#atomize()
-	 */
-	public AtomicValue atomize() throws XPathException {
-		return this;
-	}
+    public boolean isEmpty() {
+        return false;
+    }
 
-	/* (non-Javadoc)
+    public boolean hasOne() {
+        return true;
+    }
+
+    public boolean hasMany() {
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#add(org.exist.xquery.value.Item)
+     */
+    public void add(Item item) throws XPathException {
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#addAll(org.exist.xquery.value.Sequence)
+     */
+    public void addAll(Sequence other) throws XPathException {
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#atomize()
+     */
+    public AtomicValue atomize() throws XPathException {
+        return this;
+    }
+
+    /* (non-Javadoc)
          * @see org.exist.xquery.value.Item#effectiveBooleanValue()
          */
-	public abstract boolean effectiveBooleanValue() throws XPathException;
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#toNodeSet()
-	 */
-	public NodeSet toNodeSet() throws XPathException {
-		//TODO : solution that may be worth to investigate
-		/*
+    public abstract boolean effectiveBooleanValue() throws XPathException;
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#toNodeSet()
+     */
+    public NodeSet toNodeSet() throws XPathException {
+        //TODO : solution that may be worth to investigate
+        /*
 		if (!effectiveBooleanValue())
 			return NodeSet.EMPTY_SET;
 		*/
-		throw new XPathException(
-				"cannot convert " + Type.getTypeName(getType()) + "('" + getStringValue() + "')"
-					+ " to a node set");
-	}
+        throw new XPathException(
+                "cannot convert " + Type.getTypeName(getType()) + "('" + getStringValue() + "')"
+                        + " to a node set");
+    }
 
     public MemoryNodeSet toMemNodeSet() throws XPathException {
-		throw new XPathException(
-				"cannot convert " + Type.getTypeName(getType()) + "('" + getStringValue() + "')"
-					+ " to a node set");
+        throw new XPathException(
+                "cannot convert " + Type.getTypeName(getType()) + "('" + getStringValue() + "')"
+                        + " to a node set");
     }
 
     /* (non-Javadoc)
@@ -259,100 +261,103 @@ public abstract class AtomicValue implements Item, Sequence, Indexable {
     public Iterator<Collection> getCollectionIterator() {
         return EmptyNodeSet.EMPTY_COLLECTION_ITERATOR;
     }
-    
+
     public AtomicValue promote(AtomicValue otherValue) throws XPathException {
         if (getType() != otherValue.getType()) {
-            if (Type.subTypeOf(getType(), Type.DECIMAL) && 
-                    (Type.subTypeOf(otherValue.getType(), Type.DOUBLE) 
-                        || Type.subTypeOf(otherValue.getType(), Type.FLOAT)))
-                    {return convertTo(otherValue.getType());}
-    
+            if (Type.subTypeOf(getType(), Type.DECIMAL) &&
+                    (Type.subTypeOf(otherValue.getType(), Type.DOUBLE)
+                            || Type.subTypeOf(otherValue.getType(), Type.FLOAT))) {
+                return convertTo(otherValue.getType());
+            }
+
             if (Type.subTypeOf(getType(), Type.FLOAT) &&
-                    Type.subTypeOf(otherValue.getType(), Type.DOUBLE))
-                {return convertTo(Type.DOUBLE);}
-    
+                    Type.subTypeOf(otherValue.getType(), Type.DOUBLE)) {
+                return convertTo(Type.DOUBLE);
+            }
+
             if (Type.subTypeOf(getType(), Type.ANY_URI) &&
-                    Type.subTypeOf(otherValue.getType(), Type.STRING))
-                {return convertTo(Type.STRING);}
+                    Type.subTypeOf(otherValue.getType(), Type.STRING)) {
+                return convertTo(Type.STRING);
+            }
         }
         return this;
     }
-    
-	/**
-     * Dump a string representation of this value to the given 
+
+    /**
+     * Dump a string representation of this value to the given
      * ExpressionDumper.
-     * 
-	 * @param dumper
-	 */
-	public void dump(ExpressionDumper dumper) {
-	    try {
+     *
+     * @param dumper
+     */
+    public void dump(ExpressionDumper dumper) {
+        try {
             dumper.display(getStringValue());
         } catch (final XPathException e) {
         }
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
-	 */
-	public int conversionPreference(Class<?> javaClass) {
-		return Integer.MAX_VALUE;
-	}
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
-	 */
-        @Override
-	public <T> T toJavaObject(final Class<T> target) throws XPathException {
-		throw new XPathException(
-			"cannot convert value of type "
-				+ Type.getTypeName(getType())
-				+ " to Java object of type "
-				+ target.getName());
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
+     */
+    public int conversionPreference(Class<?> javaClass) {
+        return Integer.MAX_VALUE;
+    }
 
-	public String toString() {
-		try {
-			return getStringValue();
-		} catch (final XPathException e) {
-			return super.toString();
-		}
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#isCached()
-	 */
-	public boolean isCached() {
-		// always returns false by default
-		return false;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#setIsCached(boolean)
-	 */
-	public void setIsCached(boolean cached) {
-		// ignore
-	}
-	
-	public void clearContext(int contextId) throws XPathException {
-		// ignore
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#setSelfAsContext()
-	 */
-	public void setSelfAsContext(int contextId) throws XPathException {
-	}
-	
-        /* (non-Javadoc)
-         * @see org.exist.xquery.value.Sequence#isPersistentSet()
-         */
-        public boolean isPersistentSet() {
-            return false;
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
+     */
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        throw new XPathException(
+                "cannot convert value of type "
+                        + Type.getTypeName(getType())
+                        + " to Java object of type "
+                        + target.getName());
+    }
+
+    public String toString() {
+        try {
+            return getStringValue();
+        } catch (final XPathException e) {
+            return super.toString();
         }
+    }
 
-        @Override
-        public void nodeMoved(NodeId oldNodeId, NodeHandle newNode) {
-        }
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#isCached()
+     */
+    public boolean isCached() {
+        // always returns false by default
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#setIsCached(boolean)
+     */
+    public void setIsCached(boolean cached) {
+        // ignore
+    }
+
+    public void clearContext(int contextId) throws XPathException {
+        // ignore
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#setSelfAsContext()
+     */
+    public void setSelfAsContext(int contextId) throws XPathException {
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#isPersistentSet()
+     */
+    public boolean isPersistentSet() {
+        return false;
+    }
+
+    @Override
+    public void nodeMoved(NodeId oldNodeId, NodeHandle newNode) {
+    }
 	
         /*
 	public byte[] serialize(short collectionId)	throws EXistException {	
@@ -372,11 +377,11 @@ public abstract class AtomicValue implements Item, Sequence, Indexable {
 		return ValueIndexFactory.serialize(this, collectionId, caseSensitive);
 	}	
 	*/
-	
-	public byte[] serializeValue(int offset) throws EXistException {		
-		//TODO : pass the factory as an argument
-		return ValueIndexFactory.serialize(this, offset);
-	}
+
+    public byte[] serializeValue(int offset) throws EXistException {
+        //TODO : pass the factory as an argument
+        return ValueIndexFactory.serialize(this, offset);
+    }
 	
 	/* (non-Javadoc)
 	 * @deprecated
@@ -388,10 +393,10 @@ public abstract class AtomicValue implements Item, Sequence, Indexable {
 		return ValueIndexFactory.serialize(this, offset, caseSensitive);
 	}
 	*/
-	
-	public int compareTo(Object other) {		
-		throw new IllegalArgumentException("Invalid call to compareTo by " + Type.getTypeName(this.getItemType()));
-	}
+
+    public int compareTo(Object other) {
+        throw new IllegalArgumentException("Invalid call to compareTo by " + Type.getTypeName(this.getItemType()));
+    }
 
     public int getState() {
         return 0;
@@ -412,150 +417,151 @@ public abstract class AtomicValue implements Item, Sequence, Indexable {
 
     private final static class EmptyValue extends AtomicValue {
 
-		@Override
-    	public boolean hasOne() {
-    		return false;
-    	}
+        @Override
+        public boolean hasOne() {
+            return false;
+        }
 
-		@Override
-    	public boolean isEmpty() {
-			return true;
-		}
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
 
-		@Override
-		public String getStringValue() {
-			return "";
-		}
+        @Override
+        public String getStringValue() {
+            return "";
+        }
 
-		@Override
-		public AtomicValue convertTo(int requiredType) throws XPathException {
-			switch (requiredType) {
-				case Type.ATOMIC :
-				case Type.ITEM :
-				case Type.STRING :
-					return StringValue.EMPTY_STRING;
-				case Type.NORMALIZED_STRING:
-				case Type.TOKEN:
-				case Type.LANGUAGE:
-				case Type.NMTOKEN:
-				case Type.NAME:
-				case Type.NCNAME:
-				case Type.ID:
-				case Type.IDREF:
-				case Type.ENTITY:
-					return new StringValue("", requiredType);
-				case Type.ANY_URI :
-					return AnyURIValue.EMPTY_URI;
-				case Type.BOOLEAN :
-					return BooleanValue.FALSE;
-				//case Type.FLOAT :
-					//return new FloatValue(value); 
-				//case Type.DOUBLE :
-				//case Type.NUMBER :
-					//return new DoubleValue(this);
-				//case Type.DECIMAL :
-					//return new DecimalValue(value);
-				//case Type.INTEGER :
-				//case Type.NON_POSITIVE_INTEGER :
-				//case Type.NEGATIVE_INTEGER :
-				//case Type.POSITIVE_INTEGER :
-				//case Type.LONG :
-				//case Type.INT :
-				//case Type.SHORT :
-				//case Type.BYTE :
-				//case Type.NON_NEGATIVE_INTEGER :
-				//case Type.UNSIGNED_LONG :
-				//case Type.UNSIGNED_INT :
-				//case Type.UNSIGNED_SHORT :
-				//case Type.UNSIGNED_BYTE :
-					//return new IntegerValue(value, requiredType);
-				//case Type.BASE64_BINARY :
-					//return new Base64Binary(value);
-	            //case Type.HEX_BINARY :
-	                //return new HexBinary(value);
-				//case Type.DATE_TIME :
-					//return new DateTimeValue(value);
-				//case Type.TIME :
-					//return new TimeValue(value);
-				//case Type.DATE :
-					//return new DateValue(value);
-				//case Type.DURATION :
-					//return new DurationValue(value);
-				//case Type.YEAR_MONTH_DURATION : 
-					//return new YearMonthDurationValue(value);
-				//case Type.DAY_TIME_DURATION :	
-					//return new DayTimeDurationValue(value);
-	            //case Type.GYEAR :
-	                //return new GYearValue(value);
-	            //case Type.GMONTH :
-	                //return new GMonthValue(value);
-	            //case Type.GDAY :
-	                //return new GDayValue(value);
-	            //case Type.GYEARMONTH :
-	                //return new GYearMonthValue(value);
-	            //case Type.GMONTHDAY :
-	                //return new GMonthDayValue(value);
-				//case Type.UNTYPED_ATOMIC :
-					//return new UntypedAtomicValue(getStringValue());
-				default :
-					throw new XPathException("cannot convert empty value to " + requiredType);
-			}
-		}
+        @Override
+        public AtomicValue convertTo(int requiredType) throws XPathException {
+            switch (requiredType) {
+                case Type.ATOMIC:
+                case Type.ITEM:
+                case Type.STRING:
+                    return StringValue.EMPTY_STRING;
+                case Type.NORMALIZED_STRING:
+                case Type.TOKEN:
+                case Type.LANGUAGE:
+                case Type.NMTOKEN:
+                case Type.NAME:
+                case Type.NCNAME:
+                case Type.ID:
+                case Type.IDREF:
+                case Type.ENTITY:
+                    return new StringValue("", requiredType);
+                case Type.ANY_URI:
+                    return AnyURIValue.EMPTY_URI;
+                case Type.BOOLEAN:
+                    return BooleanValue.FALSE;
+                //case Type.FLOAT :
+                //return new FloatValue(value);
+                //case Type.DOUBLE :
+                //case Type.NUMBER :
+                //return new DoubleValue(this);
+                //case Type.DECIMAL :
+                //return new DecimalValue(value);
+                //case Type.INTEGER :
+                //case Type.NON_POSITIVE_INTEGER :
+                //case Type.NEGATIVE_INTEGER :
+                //case Type.POSITIVE_INTEGER :
+                //case Type.LONG :
+                //case Type.INT :
+                //case Type.SHORT :
+                //case Type.BYTE :
+                //case Type.NON_NEGATIVE_INTEGER :
+                //case Type.UNSIGNED_LONG :
+                //case Type.UNSIGNED_INT :
+                //case Type.UNSIGNED_SHORT :
+                //case Type.UNSIGNED_BYTE :
+                //return new IntegerValue(value, requiredType);
+                //case Type.BASE64_BINARY :
+                //return new Base64Binary(value);
+                //case Type.HEX_BINARY :
+                //return new HexBinary(value);
+                //case Type.DATE_TIME :
+                //return new DateTimeValue(value);
+                //case Type.TIME :
+                //return new TimeValue(value);
+                //case Type.DATE :
+                //return new DateValue(value);
+                //case Type.DURATION :
+                //return new DurationValue(value);
+                //case Type.YEAR_MONTH_DURATION :
+                //return new YearMonthDurationValue(value);
+                //case Type.DAY_TIME_DURATION :
+                //return new DayTimeDurationValue(value);
+                //case Type.GYEAR :
+                //return new GYearValue(value);
+                //case Type.GMONTH :
+                //return new GMonthValue(value);
+                //case Type.GDAY :
+                //return new GDayValue(value);
+                //case Type.GYEARMONTH :
+                //return new GYearMonthValue(value);
+                //case Type.GMONTHDAY :
+                //return new GMonthDayValue(value);
+                //case Type.UNTYPED_ATOMIC :
+                //return new UntypedAtomicValue(getStringValue());
+                default:
+                    throw new XPathException("cannot convert empty value to " + requiredType);
+            }
+        }
 
-		@Override
-		public boolean effectiveBooleanValue() throws XPathException {
-			return false;
-		}
+        @Override
+        public boolean effectiveBooleanValue() throws XPathException {
+            return false;
+        }
 
-		@Override
-		public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-			if (other instanceof EmptyValue)
-				{return Constants.EQUAL;}
-			else
-				{return Constants.INFERIOR;}
-		}
+        @Override
+        public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+            if (other instanceof EmptyValue) {
+                return Constants.EQUAL;
+            } else {
+                return Constants.INFERIOR;
+            }
+        }
 
-		@Override
-		public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
-			return false;
-		}
+        @Override
+        public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
+            return false;
+        }
 
-		@Override
-		public Item itemAt(int pos) {
-			return null;
-		}
+        @Override
+        public Item itemAt(int pos) {
+            return null;
+        }
 
-		@Override
-		public Sequence toSequence() {
-			return this;
-		}
+        @Override
+        public Sequence toSequence() {
+            return this;
+        }
 
-		@Override
-		public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-			return this;
-		}
+        @Override
+        public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+            return this;
+        }
 
-		@Override
-		public void add(Item item) throws XPathException {
-		}
+        @Override
+        public void add(Item item) throws XPathException {
+        }
 
-		@Override
-		public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-			return this;
-		}
+        @Override
+        public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+            return this;
+        }
 
-		@Override
-		public int conversionPreference(Class<?> javaClass) {
-			return Integer.MAX_VALUE;
-		}
+        @Override
+        public int conversionPreference(Class<?> javaClass) {
+            return Integer.MAX_VALUE;
+        }
 
-		@Override
-                public <T> T toJavaObject(final Class<T> target) throws XPathException {
-			throw new XPathException(
-				"cannot convert value of type "
-					+ Type.getTypeName(getType())
-					+ " to Java object of type "
-					+ target.getName());
-		}
-	}
+        @Override
+        public <T> T toJavaObject(final Class<T> target) throws XPathException {
+            throw new XPathException(
+                    "cannot convert value of type "
+                            + Type.getTypeName(getType())
+                            + " to Java object of type "
+                            + target.getName());
+        }
+    }
 }

--- a/src/org/exist/xquery/value/Base64BinaryDocument.java
+++ b/src/org/exist/xquery/value/Base64BinaryDocument.java
@@ -21,8 +21,9 @@
  */
 package org.exist.xquery.value;
 
-import java.io.InputStream;
 import org.exist.xquery.XPathException;
+
+import java.io.InputStream;
 
 /**
  * Wrapper around Base64Binary.

--- a/src/org/exist/xquery/value/Base64BinaryDocument.java
+++ b/src/org/exist/xquery/value/Base64BinaryDocument.java
@@ -27,19 +27,12 @@ import java.io.InputStream;
 
 /**
  * Wrapper around Base64Binary.
+ *
  * @author dizzzzz
  */
 public class Base64BinaryDocument extends BinaryValueFromInputStream {
 
     private String url = null;
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
 
     private Base64BinaryDocument(BinaryValueManager manager, InputStream is) throws XPathException {
         super(manager, new Base64BinaryValueType(), is);
@@ -49,5 +42,13 @@ public class Base64BinaryDocument extends BinaryValueFromInputStream {
         final Base64BinaryDocument b64BinaryDocument = new Base64BinaryDocument(manager, is);
         manager.registerBinaryValueInstance(b64BinaryDocument);
         return b64BinaryDocument;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
     }
 }

--- a/src/org/exist/xquery/value/Base64BinaryValueType.java
+++ b/src/org/exist/xquery/value/Base64BinaryValueType.java
@@ -1,9 +1,10 @@
 package org.exist.xquery.value;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.exist.util.io.Base64OutputStream;
 import org.exist.xquery.XPathException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  *

--- a/src/org/exist/xquery/value/Base64BinaryValueType.java
+++ b/src/org/exist/xquery/value/Base64BinaryValueType.java
@@ -7,7 +7,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- *
  * @author Adam Retter <adam@existsolutions.com>
  */
 public class Base64BinaryValueType extends BinaryValueType<Base64OutputStream> {
@@ -28,7 +27,7 @@ public class Base64BinaryValueType extends BinaryValueType<Base64OutputStream> {
 
     @Override
     public void verifyString(String str) throws XPathException {
-        if(!getMatcher(str).matches()) {
+        if (!getMatcher(str).matches()) {
             throw new XPathException("FORG0001: Invalid base64 data");
         }
     }

--- a/src/org/exist/xquery/value/BinaryValue.java
+++ b/src/org/exist/xquery/value/BinaryValue.java
@@ -142,7 +142,7 @@ public abstract class BinaryValue extends AtomicValue {
                 streamBinaryTo(baos);
                 return (T)baos.toByteArray();
             } catch(final IOException ioe) {
-                LOG.error("Unable to Stream BinaryValue to byte[]: " + ioe.getMessage(), ioe);
+                LOG.error("Unable to Stream BinaryValue to byte[]: {}", ioe.getMessage(), ioe);
             }
 
         }
@@ -227,7 +227,7 @@ public abstract class BinaryValue extends AtomicValue {
             try {
                 baos.close();   //close the stream to ensure all data is flushed
             } catch(final IOException ioe) {
-                LOG.error("Unable to close stream: " + ioe.getMessage(), ioe);
+                LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
             }
         }
 
@@ -259,7 +259,7 @@ public abstract class BinaryValue extends AtomicValue {
         try {
             fos.close();
         } catch(final IOException ioe) {
-            LOG.error("Unable to close stream: " + ioe.getMessage(), ioe);
+            LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
         }
     }
 

--- a/src/org/exist/xquery/value/BinaryValue.java
+++ b/src/org/exist/xquery/value/BinaryValue.java
@@ -21,18 +21,18 @@
  */
 package org.exist.xquery.value;
 
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.XPathException;
+
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.Collator;
-import org.apache.commons.io.output.CloseShieldOutputStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.commons.io.output.ByteArrayOutputStream;
-
-import org.exist.xquery.Constants.Comparison;
-import org.exist.xquery.XPathException;
 
 /**
  * @author Adam Retter <adam@existsolutions.com>

--- a/src/org/exist/xquery/value/BinaryValue.java
+++ b/src/org/exist/xquery/value/BinaryValue.java
@@ -63,12 +63,12 @@ public abstract class BinaryValue extends AtomicValue {
     public int getType() {
         return getBinaryValueType().getXQueryType();
     }
-    
+
     @Override
     public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
         if (other.getType() == Type.HEX_BINARY || other.getType() == Type.BASE64_BINARY) {
-            final int value = compareTo((BinaryValue)other);
-            switch(operator) {
+            final int value = compareTo((BinaryValue) other);
+            switch (operator) {
                 case EQ:
                     return value == 0;
                 case NEQ:
@@ -92,7 +92,7 @@ public abstract class BinaryValue extends AtomicValue {
     @Override
     public int compareTo(Collator collator, AtomicValue other) throws XPathException {
         if (other.getType() == Type.HEX_BINARY || other.getType() == Type.BASE64_BINARY) {
-            return compareTo((BinaryValue)other);
+            return compareTo((BinaryValue) other);
         } else {
             throw new XPathException("Cannot compare value of type xs:hexBinary with " + Type.getTypeName(other.getType()));
         }
@@ -103,25 +103,25 @@ public abstract class BinaryValue extends AtomicValue {
         final InputStream is = getInputStream();
         final InputStream otherIs = otherValue.getInputStream();
 
-        if(is == null && otherIs == null) {
+        if (is == null && otherIs == null) {
             return 0;
-        } else if(is == null) {
+        } else if (is == null) {
             return -1;
-        } else if(otherIs == null) {
+        } else if (otherIs == null) {
             return 1;
         } else {
             int read = -1;
             int otherRead = -1;
-            while(true) {
+            while (true) {
                 try {
                     read = is.read();
-                } catch(final IOException ioe) {
+                } catch (final IOException ioe) {
                     return -1;
                 }
 
                 try {
                     otherRead = otherIs.read();
-                } catch(final IOException ioe) {
+                } catch (final IOException ioe) {
                     return 1;
                 }
 
@@ -132,16 +132,16 @@ public abstract class BinaryValue extends AtomicValue {
 
     @Override
     public <T> T toJavaObject(Class<T> target) throws XPathException {
-        if(target.isAssignableFrom(getClass())) {
-            return (T)this;
+        if (target.isAssignableFrom(getClass())) {
+            return (T) this;
         }
 
-        if(target == byte[].class) {
+        if (target == byte[].class) {
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             try {
                 streamBinaryTo(baos);
-                return (T)baos.toByteArray();
-            } catch(final IOException ioe) {
+                return (T) baos.toByteArray();
+            } catch (final IOException ioe) {
                 LOG.error("Unable to Stream BinaryValue to byte[]: {}", ioe.getMessage(), ioe);
             }
 
@@ -149,12 +149,12 @@ public abstract class BinaryValue extends AtomicValue {
 
         throw new XPathException("Cannot convert value of type " + Type.getTypeName(getType()) + " to Java object of type " + target.getName());
     }
-    
+
     /**
      * Return the underlying Java object for this binary value. Might be a File or byte[].
      */
     public <T> T toJavaObject() throws XPathException {
-    	return (T)toJavaObject(byte[].class);
+        return (T) toJavaObject(byte[].class);
     }
 
     @Override
@@ -172,10 +172,10 @@ public abstract class BinaryValue extends AtomicValue {
 
         final AtomicValue result;
 
-        if(requiredType == getType() || requiredType == Type.ITEM || requiredType == Type.ATOMIC) {
+        if (requiredType == getType() || requiredType == Type.ITEM || requiredType == Type.ATOMIC) {
             result = this;
         } else {
-            switch(requiredType) {
+            switch (requiredType) {
                 case Type.BASE64_BINARY:
                     result = convertTo(new Base64BinaryValueType());
                     break;
@@ -212,7 +212,7 @@ public abstract class BinaryValue extends AtomicValue {
     public boolean effectiveBooleanValue() throws XPathException {
         throw new XPathException("FORG0006: value of type " + Type.getTypeName(getType()) + " has no boolean value.");
     }
-    
+
     //TODO ideally this should be moved out into serialization where we can stream the output from the buf/channel by calling streamTo()
     @Override
     public String getStringValue() throws XPathException {
@@ -221,12 +221,12 @@ public abstract class BinaryValue extends AtomicValue {
 
         try {
             streamTo(baos);
-        } catch(final IOException ex) {
+        } catch (final IOException ex) {
             throw new XPathException("Unable to encode string value: " + ex.getMessage(), ex);
         } finally {
             try {
                 baos.close();   //close the stream to ensure all data is flushed
-            } catch(final IOException ioe) {
+            } catch (final IOException ioe) {
                 LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
             }
         }
@@ -243,7 +243,7 @@ public abstract class BinaryValue extends AtomicValue {
      * Streams the encoded binary data
      */
     public void streamTo(OutputStream os) throws IOException {
-        
+
         //we need to create a safe output stream that cannot be closed
         final OutputStream safeOutputStream = new CloseShieldOutputStream(os);
 
@@ -258,7 +258,7 @@ public abstract class BinaryValue extends AtomicValue {
         //particularly nessecary for Apache Commons Codec stream encoders
         try {
             fos.close();
-        } catch(final IOException ioe) {
+        } catch (final IOException ioe) {
             LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
         }
     }

--- a/src/org/exist/xquery/value/BinaryValueFromBinaryString.java
+++ b/src/org/exist/xquery/value/BinaryValueFromBinaryString.java
@@ -11,16 +11,16 @@ import java.io.*;
 /**
  * Representation of an XSD binary value e.g. (xs:base64Binary or xs:hexBinary)
  * whose source is backed by a pre-encoded String.
- *
+ * <p>
  * Note - BinaryValueFromBinaryString is a special case of BinaryValue
  * where the value is already encoded.
- * 
+ *
  * @author Adam Retter <adam@existsolutions.com>
  */
 public class BinaryValueFromBinaryString extends BinaryValue {
 
     private final static Logger LOG = LogManager.getLogger(BinaryValueFromBinaryString.class);
-    
+
     private final String value;
 
     public BinaryValueFromBinaryString(BinaryValueType binaryValueType, String value) throws XPathException {
@@ -41,20 +41,20 @@ public class BinaryValueFromBinaryString extends BinaryValue {
             fos = binaryValueType.getEncoder(baos);
             streamBinaryTo(fos);
 
-        } catch(final IOException ioe) {
+        } catch (final IOException ioe) {
             throw new XPathException(ioe);
         } finally {
-            if(fos != null) {
+            if (fos != null) {
                 try {
                     fos.close();
-                } catch(final IOException ioe) {
+                } catch (final IOException ioe) {
                     LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
                 }
             }
 
             try {
                 baos.close();
-            } catch(final IOException ioe) {
+            } catch (final IOException ioe) {
                 LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
             }
         }
@@ -64,23 +64,23 @@ public class BinaryValueFromBinaryString extends BinaryValue {
 
     @Override
     public void streamBinaryTo(OutputStream os) throws IOException {
-        
+
         //we need to create a safe output stream that cannot be closed
         final OutputStream safeOutputStream = new CloseShieldOutputStream(os);
-        
+
         //get the decoder
         final FilterOutputStream fos = getBinaryValueType().getDecoder(safeOutputStream);
-        
+
         //write with the decoder
         final byte data[] = value.getBytes();
         fos.write(data);
-        
+
         //we do have to close the decoders output stream though
         //to ensure that all bytes have been written, this is
         //particularly nessecary for Apache Commons Codec stream encoders
         try {
             fos.close();
-        } catch(final IOException ioe) {
+        } catch (final IOException ioe) {
             LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
         }
     }
@@ -100,7 +100,7 @@ public class BinaryValueFromBinaryString extends BinaryValue {
 
         try {
             streamBinaryTo(baos);
-        } catch(final IOException ioe) {
+        } catch (final IOException ioe) {
             LOG.error("Unable to get read only buffer: {}", ioe.getMessage(), ioe);
         }
 

--- a/src/org/exist/xquery/value/BinaryValueFromBinaryString.java
+++ b/src/org/exist/xquery/value/BinaryValueFromBinaryString.java
@@ -48,14 +48,14 @@ public class BinaryValueFromBinaryString extends BinaryValue {
                 try {
                     fos.close();
                 } catch(final IOException ioe) {
-                    LOG.error("Unable to close stream: " + ioe.getMessage(), ioe);
+                    LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
                 }
             }
 
             try {
                 baos.close();
             } catch(final IOException ioe) {
-                LOG.error("Unable to close stream: " + ioe.getMessage(), ioe);
+                LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
             }
         }
 
@@ -81,7 +81,7 @@ public class BinaryValueFromBinaryString extends BinaryValue {
         try {
             fos.close();
         } catch(final IOException ioe) {
-            LOG.error("Unable to close stream: " + ioe.getMessage(), ioe);
+            LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
         }
     }
 
@@ -101,7 +101,7 @@ public class BinaryValueFromBinaryString extends BinaryValue {
         try {
             streamBinaryTo(baos);
         } catch(final IOException ioe) {
-            LOG.error("Unable to get read only buffer: " + ioe.getMessage(), ioe);
+            LOG.error("Unable to get read only buffer: {}", ioe.getMessage(), ioe);
         }
 
         return new ByteArrayInputStream(baos.toByteArray());

--- a/src/org/exist/xquery/value/BinaryValueFromFile.java
+++ b/src/org/exist/xquery/value/BinaryValueFromFile.java
@@ -1,18 +1,15 @@
 package org.exist.xquery.value;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileChannel.MapMode;
 import org.exist.util.io.ByteBufferAccessor;
 import org.exist.util.io.ByteBufferInputStream;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
 
 /**
  * Representation of an XSD binary value e.g. (xs:base64Binary or xs:hexBinary)

--- a/src/org/exist/xquery/value/BinaryValueFromFile.java
+++ b/src/org/exist/xquery/value/BinaryValueFromFile.java
@@ -29,7 +29,7 @@ public class BinaryValueFromFile extends BinaryValue {
             this.file = file;
             this.channel = new RandomAccessFile(file, "r").getChannel();
             this.buf = channel.map(MapMode.READ_ONLY, 0, channel.size());
-        } catch(final IOException ioe) {
+        } catch (final IOException ioe) {
             throw new XPathException(ioe);
         }
     }
@@ -49,15 +49,15 @@ public class BinaryValueFromFile extends BinaryValue {
 
     @Override
     public void streamBinaryTo(OutputStream os) throws IOException {
-        if(!channel.isOpen()) {
+        if (!channel.isOpen()) {
             throw new IOException("Underlying channel has been closed");
         }
 
         try {
             byte data[] = new byte[READ_BUFFER_SIZE];
-            while(buf.hasRemaining()) {
+            while (buf.hasRemaining()) {
                 final int remaining = buf.remaining();
-                if(remaining < READ_BUFFER_SIZE) {
+                if (remaining < READ_BUFFER_SIZE) {
                     data = new byte[remaining];
                 }
 
@@ -85,25 +85,26 @@ public class BinaryValueFromFile extends BinaryValue {
 
             @Override
             public ByteBuffer getBuffer() {
-                if(roBuf == null) {
+                if (roBuf == null) {
                     roBuf = buf.asReadOnlyBuffer();
                 }
                 return roBuf;
             }
         });
     }
-    
+
     @Override
     public Object toJavaObject() throws XPathException {
-    	return file;
+        return file;
     }
 
     @Override
     public void destroy(XQueryContext context, Sequence contextSequence) {
         // do not close if this object is part of the contextSequence
         if (contextSequence == this ||
-                (contextSequence instanceof ValueSequence && ((ValueSequence)contextSequence).containsValue(this)))
-            {return;}
+                (contextSequence instanceof ValueSequence && ((ValueSequence) contextSequence).containsValue(this))) {
+            return;
+        }
         try {
             this.close();
         } catch (final IOException e) {

--- a/src/org/exist/xquery/value/BinaryValueFromInputStream.java
+++ b/src/org/exist/xquery/value/BinaryValueFromInputStream.java
@@ -30,7 +30,7 @@ public class BinaryValueFromInputStream extends BinaryValue {
 
         try {
 
-            this.cache = FilterInputStreamCacheFactory.getCacheInstance(() -> manager.getCacheClass(), is);
+            this.cache = FilterInputStreamCacheFactory.getCacheInstance(manager::getCacheClass, is);
             this.is = new CachingFilterInputStream(cache);
 
         } catch (final IOException ioe) {

--- a/src/org/exist/xquery/value/BinaryValueFromInputStream.java
+++ b/src/org/exist/xquery/value/BinaryValueFromInputStream.java
@@ -1,16 +1,16 @@
 package org.exist.xquery.value;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.util.io.CachingFilterInputStream;
 import org.exist.util.io.FilterInputStreamCache;
 import org.exist.util.io.FilterInputStreamCacheFactory;
-import org.exist.util.io.FilterInputStreamCacheFactory.FilterInputStreamCacheConfiguration;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Representation of an XSD binary value e.g. (xs:base64Binary or xs:hexBinary)

--- a/src/org/exist/xquery/value/BinaryValueFromInputStream.java
+++ b/src/org/exist/xquery/value/BinaryValueFromInputStream.java
@@ -23,7 +23,7 @@ public class BinaryValueFromInputStream extends BinaryValue {
     private final static Logger LOG = LogManager.getLogger(BinaryValueFromInputStream.class);
 
     private final CachingFilterInputStream is;
-    private FilterInputStreamCache cache;
+    private final FilterInputStreamCache cache;
 
     protected BinaryValueFromInputStream(final BinaryValueManager manager, final BinaryValueType binaryValueType, final InputStream is) throws XPathException {
         super(manager, binaryValueType);

--- a/src/org/exist/xquery/value/BinaryValueFromInputStream.java
+++ b/src/org/exist/xquery/value/BinaryValueFromInputStream.java
@@ -72,7 +72,7 @@ public class BinaryValueFromInputStream extends BinaryValue {
             try {
                 is.reset();
             } catch (final IOException ioe) {
-                LOG.error("Unable to reset stream: " + ioe.getMessage(), ioe);
+                LOG.error("Unable to reset stream: {}", ioe.getMessage(), ioe);
             }
         }
     }
@@ -103,7 +103,7 @@ public class BinaryValueFromInputStream extends BinaryValue {
         try {
             this.close();
         } catch (final IOException e) {
-            LOG.warn("Error during cleanup of binary value: " + e.getMessage(), e);
+            LOG.warn("Error during cleanup of binary value: {}", e.getMessage(), e);
         }
         context.destroyBinaryValue(this);
     }

--- a/src/org/exist/xquery/value/BinaryValueManager.java
+++ b/src/org/exist/xquery/value/BinaryValueManager.java
@@ -6,9 +6,9 @@ package org.exist.xquery.value;
  */
 public interface BinaryValueManager {
 
-    public void registerBinaryValueInstance(BinaryValue binaryValue);
+    void registerBinaryValueInstance(BinaryValue binaryValue);
 
-    public void runCleanupTasks();
+    void runCleanupTasks();
 
-    public String getCacheClass();
+    String getCacheClass();
 }

--- a/src/org/exist/xquery/value/BinaryValueManager.java
+++ b/src/org/exist/xquery/value/BinaryValueManager.java
@@ -1,7 +1,6 @@
 package org.exist.xquery.value;
 
 /**
- *
  * @author Adam Retter <adam@existsolutions.com>
  */
 public interface BinaryValueManager {

--- a/src/org/exist/xquery/value/BinaryValueType.java
+++ b/src/org/exist/xquery/value/BinaryValueType.java
@@ -9,7 +9,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 /**
- *
  * @author Adam Retter <adam@existsolutions.com>
  */
 public abstract class BinaryValueType<T extends FilterOutputStream> {
@@ -29,18 +28,18 @@ public abstract class BinaryValueType<T extends FilterOutputStream> {
     public T getEncoder(OutputStream os) throws IOException {
         return instantiateCoder(os, true);
     }
-    
+
     public T getDecoder(OutputStream os) throws IOException {
         return instantiateCoder(os, false);
     }
-    
+
     private T instantiateCoder(OutputStream stream, boolean encoder) throws IOException {
         try {
             final Constructor<T> c = coder.getConstructor(OutputStream.class, boolean.class);
             final T f = c.newInstance(stream, encoder);
             return f;
-        } catch(final NoSuchMethodException | InvocationTargetException | IllegalAccessException | IllegalArgumentException | InstantiationException nsme) {
-            throw new IOException("Unable to get binary coder '" + coder.getName() +  "': " + nsme.getMessage(), nsme);
+        } catch (final NoSuchMethodException | InvocationTargetException | IllegalAccessException | IllegalArgumentException | InstantiationException nsme) {
+            throw new IOException("Unable to get binary coder '" + coder.getName() + "': " + nsme.getMessage(), nsme);
         }
     }
 

--- a/src/org/exist/xquery/value/BinaryValueType.java
+++ b/src/org/exist/xquery/value/BinaryValueType.java
@@ -1,11 +1,12 @@
 package org.exist.xquery.value;
 
+import org.exist.xquery.XPathException;
+
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import org.exist.xquery.XPathException;
 
 /**
  *

--- a/src/org/exist/xquery/value/BooleanValue.java
+++ b/src/org/exist/xquery/value/BooleanValue.java
@@ -29,186 +29,200 @@ import java.text.Collator;
 
 public class BooleanValue extends AtomicValue {
 
-	public final static BooleanValue TRUE = new BooleanValue(true);
-	public final static BooleanValue FALSE = new BooleanValue(false);
+    public final static BooleanValue TRUE = new BooleanValue(true);
+    public final static BooleanValue FALSE = new BooleanValue(false);
 
-	private final boolean value;
+    private final boolean value;
 
-	/**
-	 * Returns one of the static fields TRUE or FALSE depending on
-	 * the value of the parameter.
-	 * 
-	 * @param bool
-	 */
-	public final static BooleanValue valueOf(boolean bool) {
-		return bool ? TRUE : FALSE;
-	}
-	
-	public BooleanValue(boolean bool) {
-		value = bool;
+    public BooleanValue(boolean bool) {
+        value = bool;
     }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#getType()
-	 */
-	public int getType() {
-		return Type.BOOLEAN;
-	}
+    /**
+     * Returns one of the static fields TRUE or FALSE depending on
+     * the value of the parameter.
+     *
+     * @param bool
+     */
+    public final static BooleanValue valueOf(boolean bool) {
+        return bool ? TRUE : FALSE;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#getStringValue()
-	 */
-	public String getStringValue() throws XPathException {
-		return value ? "true" : "false";
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#getType()
+     */
+    public int getType() {
+        return Type.BOOLEAN;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#convertTo(int)
-	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.BOOLEAN :
-			case Type.ATOMIC :
-			case Type.ITEM :
-				return this;
-			case Type.NUMBER :
-			case Type.INTEGER :				
-				return new IntegerValue(value ? 1 : 0);
-			case Type.DECIMAL :
-				return new DecimalValue(value ? 1 : 0);
-			case Type.FLOAT :
-				return new FloatValue(value ? 1 : 0);
-			case Type.DOUBLE :
-				return new DoubleValue(value ? 1 : 0);
-			case Type.STRING :
-				return new StringValue(getStringValue());
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());				
-			default :
-				throw new XPathException(ErrorCodes.XPTY0004, 
-					"cannot convert 'xs:boolean(" + value + ")' to " + Type.getTypeName(requiredType));
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#getStringValue()
+     */
+    public String getStringValue() throws XPathException {
+        return value ? "true" : "false";
+    }
 
-	@Override
-	public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.BOOLEAN)) {
-			boolean otherVal = ((BooleanValue) other).getValue();
-			switch (operator) {
-				case EQ:
-					return value == otherVal;
-				case NEQ:
-					return value != otherVal;
-				case LT:
-					return (!value) && otherVal;
-				case LTEQ:
-					return value == otherVal || (!value) && otherVal;
-				case GT:
-					return value && (!otherVal);
-				case GTEQ:
-					return value == otherVal || value && (!otherVal);
-				default :
-					throw new XPathException("Type error: cannot apply this operator to a boolean value");
-			}
-		}
-		throw new XPathException(ErrorCodes.XPTY0004, 
-			"cannot convert 'xs:boolean(" + value + ")' to " + Type.getTypeName(other.getType()));
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#convertTo(int)
+     */
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.BOOLEAN:
+            case Type.ATOMIC:
+            case Type.ITEM:
+                return this;
+            case Type.NUMBER:
+            case Type.INTEGER:
+                return new IntegerValue(value ? 1 : 0);
+            case Type.DECIMAL:
+                return new DecimalValue(value ? 1 : 0);
+            case Type.FLOAT:
+                return new FloatValue(value ? 1 : 0);
+            case Type.DOUBLE:
+                return new DoubleValue(value ? 1 : 0);
+            case Type.STRING:
+                return new StringValue(getStringValue());
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            default:
+                throw new XPathException(ErrorCodes.XPTY0004,
+                        "cannot convert 'xs:boolean(" + value + ")' to " + Type.getTypeName(requiredType));
+        }
+    }
 
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		final boolean otherVal = other.effectiveBooleanValue();
-		if (otherVal == value)
-			{return Constants.EQUAL;}
-		else if (value)
-			{return Constants.SUPERIOR;}
-		else
-			{return Constants.INFERIOR;}
-	}
+    @Override
+    public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.BOOLEAN)) {
+            boolean otherVal = ((BooleanValue) other).getValue();
+            switch (operator) {
+                case EQ:
+                    return value == otherVal;
+                case NEQ:
+                    return value != otherVal;
+                case LT:
+                    return (!value) && otherVal;
+                case LTEQ:
+                    return value == otherVal || (!value) && otherVal;
+                case GT:
+                    return value && (!otherVal);
+                case GTEQ:
+                    return value == otherVal || value && (!otherVal);
+                default:
+                    throw new XPathException("Type error: cannot apply this operator to a boolean value");
+            }
+        }
+        throw new XPathException(ErrorCodes.XPTY0004,
+                "cannot convert 'xs:boolean(" + value + ")' to " + Type.getTypeName(other.getType()));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#effectiveBooleanValue()
-	 */
-	public boolean effectiveBooleanValue() throws XPathException {
-		return value;
-	}
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        final boolean otherVal = other.effectiveBooleanValue();
+        if (otherVal == value) {
+            return Constants.EQUAL;
+        } else if (value) {
+            return Constants.SUPERIOR;
+        } else {
+            return Constants.INFERIOR;
+        }
+    }
 
-	public boolean getValue() {
-		return value;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#effectiveBooleanValue()
+     */
+    public boolean effectiveBooleanValue() throws XPathException {
+        return value;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
-	 */
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == Type.BOOLEAN) {
-			boolean otherValue = ((BooleanValue) other).value;
-			return value && (!otherValue) ? this : other;
-		} else
-			{throw new XPathException(
-				"Invalid argument to aggregate function: expected boolean, got: "
-					+ Type.getTypeName(other.getType()));}
-	}
+    public boolean getValue() {
+        return value;
+    }
 
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == Type.BOOLEAN) {
-			final boolean otherValue = ((BooleanValue) other).value;
-			return (!value) && otherValue ? this : other;
-		} else
-			{throw new XPathException(
-				"Invalid argument to aggregate function: expected boolean, got: "
-					+ Type.getTypeName(other.getType()));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
+     */
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == Type.BOOLEAN) {
+            boolean otherValue = ((BooleanValue) other).value;
+            return value && (!otherValue) ? this : other;
+        } else {
+            throw new XPathException(
+                    "Invalid argument to aggregate function: expected boolean, got: "
+                            + Type.getTypeName(other.getType()));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
-	 */
-	public int conversionPreference(Class<?> javaClass) {
-		if(javaClass.isAssignableFrom(BooleanValue.class)) {return 0;}
-		if(javaClass == Boolean.class || javaClass == boolean.class) {return 1;}
-		if(javaClass == Object.class) {return 20;}
-		if(javaClass == String.class || javaClass == CharSequence.class) {return 2;}
-		
-		return Integer.MAX_VALUE;
-	}
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == Type.BOOLEAN) {
+            final boolean otherValue = ((BooleanValue) other).value;
+            return (!value) && otherValue ? this : other;
+        } else {
+            throw new XPathException(
+                    "Invalid argument to aggregate function: expected boolean, got: "
+                            + Type.getTypeName(other.getType()));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
-	 */
-        @Override
-	public <T> T toJavaObject(final Class<T> target) throws XPathException {
-		if(target.isAssignableFrom(BooleanValue.class)) {
-			return (T)this;
-                } else if(target == Boolean.class || target == boolean.class || target == Object.class) {
-			return (T)Boolean.valueOf(value);
-                } else if(target == String.class || target == CharSequence.class) {
-			final StringValue v = (StringValue)convertTo(Type.STRING);
-			return (T)v.value;
-		}
-		
-		throw new XPathException("cannot convert value of type " + Type.getTypeName(getType()) +
-			" to Java object of type " + target.getName());
-	}
-    
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
+     */
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(BooleanValue.class)) {
+            return 0;
+        }
+        if (javaClass == Boolean.class || javaClass == boolean.class) {
+            return 1;
+        }
+        if (javaClass == Object.class) {
+            return 20;
+        }
+        if (javaClass == String.class || javaClass == CharSequence.class) {
+            return 2;
+        }
+
+        return Integer.MAX_VALUE;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
+     */
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target.isAssignableFrom(BooleanValue.class)) {
+            return (T) this;
+        } else if (target == Boolean.class || target == boolean.class || target == Object.class) {
+            return (T) Boolean.valueOf(value);
+        } else if (target == String.class || target == CharSequence.class) {
+            final StringValue v = (StringValue) convertTo(Type.STRING);
+            return (T) v.value;
+        }
+
+        throw new XPathException("cannot convert value of type " + Type.getTypeName(getType()) +
+                " to Java object of type " + target.getName());
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     public int compareTo(Object o) {
-        final AtomicValue other = (AtomicValue)o;
-        if(Type.subTypeOf(other.getType(), Type.BOOLEAN)) {
-            if(value == ((BooleanValue)other).value)
-                {return Constants.EQUAL;}
-            else if(value)
-                {return Constants.SUPERIOR;}
-            else
-                {return Constants.INFERIOR;}
-        } else
-            {return getType() < other.getType() ? Constants.INFERIOR : Constants.SUPERIOR;}
+        final AtomicValue other = (AtomicValue) o;
+        if (Type.subTypeOf(other.getType(), Type.BOOLEAN)) {
+            if (value == ((BooleanValue) other).value) {
+                return Constants.EQUAL;
+            } else if (value) {
+                return Constants.SUPERIOR;
+            } else {
+                return Constants.INFERIOR;
+            }
+        } else {
+            return getType() < other.getType() ? Constants.INFERIOR : Constants.SUPERIOR;
+        }
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof BooleanValue)
-            {return value == ((BooleanValue)obj).value;}
+        if (obj instanceof BooleanValue) {
+            return value == ((BooleanValue) obj).value;
+        }
         return false;
     }
 }

--- a/src/org/exist/xquery/value/BooleanValue.java
+++ b/src/org/exist/xquery/value/BooleanValue.java
@@ -32,7 +32,7 @@ public class BooleanValue extends AtomicValue {
 	public final static BooleanValue TRUE = new BooleanValue(true);
 	public final static BooleanValue FALSE = new BooleanValue(false);
 
-	private boolean value;
+	private final boolean value;
 
 	/**
 	 * Returns one of the static fields TRUE or FALSE depending on

--- a/src/org/exist/xquery/value/BooleanValue.java
+++ b/src/org/exist/xquery/value/BooleanValue.java
@@ -20,12 +20,12 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-
 import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import java.text.Collator;
 
 public class BooleanValue extends AtomicValue {
 

--- a/src/org/exist/xquery/value/ComputableValue.java
+++ b/src/org/exist/xquery/value/ComputableValue.java
@@ -22,9 +22,9 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-
 import org.exist.xquery.XPathException;
+
+import java.text.Collator;
 
 /**
  * @author Wolfgang Meier (wolfgang@exist-db.org)

--- a/src/org/exist/xquery/value/ComputableValue.java
+++ b/src/org/exist/xquery/value/ComputableValue.java
@@ -31,33 +31,36 @@ import java.text.Collator;
  */
 public abstract class ComputableValue extends AtomicValue {
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getStringValue()
-	 */
-	public abstract String getStringValue() throws XPathException;
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getStringValue()
+     */
+    public abstract String getStringValue() throws XPathException;
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#convertTo(int)
-	 */
-	public abstract AtomicValue convertTo(int requiredType) throws XPathException;
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#convertTo(int)
+     */
+    public abstract AtomicValue convertTo(int requiredType) throws XPathException;
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#compareTo(org.exist.xquery.value.AtomicValue)
-	 */
-	public abstract int compareTo(Collator collator, AtomicValue other) throws XPathException;
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#compareTo(org.exist.xquery.value.AtomicValue)
+     */
+    public abstract int compareTo(Collator collator, AtomicValue other) throws XPathException;
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
-	 */
-	public abstract AtomicValue max(Collator collator, AtomicValue other) throws XPathException;
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
+     */
+    public abstract AtomicValue max(Collator collator, AtomicValue other) throws XPathException;
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#min(org.exist.xquery.value.AtomicValue)
-	 */
-	public abstract AtomicValue min(Collator collator, AtomicValue other) throws XPathException;
-	
-	public abstract ComputableValue minus(ComputableValue other) throws XPathException;
-	public abstract ComputableValue plus(ComputableValue other) throws XPathException;
-	public abstract ComputableValue mult(ComputableValue other) throws XPathException;
-	public abstract ComputableValue div(ComputableValue other) throws XPathException;
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#min(org.exist.xquery.value.AtomicValue)
+     */
+    public abstract AtomicValue min(Collator collator, AtomicValue other) throws XPathException;
+
+    public abstract ComputableValue minus(ComputableValue other) throws XPathException;
+
+    public abstract ComputableValue plus(ComputableValue other) throws XPathException;
+
+    public abstract ComputableValue mult(ComputableValue other) throws XPathException;
+
+    public abstract ComputableValue div(ComputableValue other) throws XPathException;
 }

--- a/src/org/exist/xquery/value/DateTimeValue.java
+++ b/src/org/exist/xquery/value/DateTimeValue.java
@@ -22,14 +22,13 @@
  */
 package org.exist.xquery.value;
 
-import java.util.Date;
-import java.util.GregorianCalendar;
+import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-
-import org.exist.xquery.XPathException;
+import java.util.Date;
+import java.util.GregorianCalendar;
 
 /**
  * Represents a value of type xs:dateTime.

--- a/src/org/exist/xquery/value/DateTimeValue.java
+++ b/src/org/exist/xquery/value/DateTimeValue.java
@@ -32,119 +32,131 @@ import java.util.GregorianCalendar;
 
 /**
  * Represents a value of type xs:dateTime.
- * 
+ *
  * @author Wolfgang Meier (wolfgang@exist-db.org)
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>
  */
 public class DateTimeValue extends AbstractDateTimeValue {
 
-	public DateTimeValue() throws XPathException {
-		super(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar()));
-		normalize();
-	}
-	
-	public DateTimeValue(XMLGregorianCalendar calendar) {
-		super(fillCalendar(cloneXMLGregorianCalendar(calendar)));
-		normalize();
-	}
-	
-	public DateTimeValue(Date date) {
-		super(dateToXMLGregorianCalendar(date));
-		normalize();
-	}
-	
-	public DateTimeValue(String dateTime) throws XPathException {
-		super(dateTime);
-		try {
-			if (calendar.getXMLSchemaType() != DatatypeConstants.DATETIME) {throw new IllegalStateException();}
-		} catch (final IllegalStateException e) {
-			throw new XPathException("xs:dateTime instance must have all fields set");
-		}
-		normalize();
-	}
-	
-	protected void normalize() {
-		if (calendar.getHour() == 24 && calendar.getMinute() == 0 && calendar.getSecond() == 0) {
-			calendar.setHour(0);
-			calendar.add(TimeUtils.ONE_DAY);
-		}
-			
-	}
+    public DateTimeValue() throws XPathException {
+        super(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar()));
+        normalize();
+    }
 
-	private static XMLGregorianCalendar dateToXMLGregorianCalendar(Date date) {
-		final GregorianCalendar gc = new GregorianCalendar();
-		gc.setTime(date);
-		final XMLGregorianCalendar xgc = TimeUtils.getInstance().newXMLGregorianCalendar(gc);
-		xgc.normalize();
-		return xgc;
-	}
-	
-	private static XMLGregorianCalendar fillCalendar(XMLGregorianCalendar calendar) {
-		if (calendar.getHour() == DatatypeConstants.FIELD_UNDEFINED) {calendar.setHour(0);}
-		if (calendar.getMinute() == DatatypeConstants.FIELD_UNDEFINED) {calendar.setMinute(0);}
-		if (calendar.getSecond() == DatatypeConstants.FIELD_UNDEFINED) {calendar.setSecond(0);}
-		if (calendar.getMillisecond() == DatatypeConstants.FIELD_UNDEFINED) {calendar.setMillisecond(0);}
-		return calendar;
-	}
+    public DateTimeValue(XMLGregorianCalendar calendar) {
+        super(fillCalendar(cloneXMLGregorianCalendar(calendar)));
+        normalize();
+    }
 
-	protected AbstractDateTimeValue createSameKind(XMLGregorianCalendar cal) throws XPathException {
-		return new DateTimeValue(cal);
-	}
+    public DateTimeValue(Date date) {
+        super(dateToXMLGregorianCalendar(date));
+        normalize();
+    }
 
-	protected QName getXMLSchemaType() {
-		return DatatypeConstants.DATETIME;
-	}
-	
-	public int getType() {
-		return Type.DATE_TIME;
-	}
+    public DateTimeValue(String dateTime) throws XPathException {
+        super(dateTime);
+        try {
+            if (calendar.getXMLSchemaType() != DatatypeConstants.DATETIME) {
+                throw new IllegalStateException();
+            }
+        } catch (final IllegalStateException e) {
+            throw new XPathException("xs:dateTime instance must have all fields set");
+        }
+        normalize();
+    }
 
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.DATE_TIME :
-			case Type.ATOMIC :
-			case Type.ITEM :
-				return this;
-			case Type.DATE :
-				return new DateValue(calendar);
-			case Type.TIME :
-				return new TimeValue(calendar);
-            case Type.GYEAR :
+    private static XMLGregorianCalendar dateToXMLGregorianCalendar(Date date) {
+        final GregorianCalendar gc = new GregorianCalendar();
+        gc.setTime(date);
+        final XMLGregorianCalendar xgc = TimeUtils.getInstance().newXMLGregorianCalendar(gc);
+        xgc.normalize();
+        return xgc;
+    }
+
+    private static XMLGregorianCalendar fillCalendar(XMLGregorianCalendar calendar) {
+        if (calendar.getHour() == DatatypeConstants.FIELD_UNDEFINED) {
+            calendar.setHour(0);
+        }
+        if (calendar.getMinute() == DatatypeConstants.FIELD_UNDEFINED) {
+            calendar.setMinute(0);
+        }
+        if (calendar.getSecond() == DatatypeConstants.FIELD_UNDEFINED) {
+            calendar.setSecond(0);
+        }
+        if (calendar.getMillisecond() == DatatypeConstants.FIELD_UNDEFINED) {
+            calendar.setMillisecond(0);
+        }
+        return calendar;
+    }
+
+    protected void normalize() {
+        if (calendar.getHour() == 24 && calendar.getMinute() == 0 && calendar.getSecond() == 0) {
+            calendar.setHour(0);
+            calendar.add(TimeUtils.ONE_DAY);
+        }
+
+    }
+
+    protected AbstractDateTimeValue createSameKind(XMLGregorianCalendar cal) throws XPathException {
+        return new DateTimeValue(cal);
+    }
+
+    protected QName getXMLSchemaType() {
+        return DatatypeConstants.DATETIME;
+    }
+
+    public int getType() {
+        return Type.DATE_TIME;
+    }
+
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.DATE_TIME:
+            case Type.ATOMIC:
+            case Type.ITEM:
+                return this;
+            case Type.DATE:
+                return new DateValue(calendar);
+            case Type.TIME:
+                return new TimeValue(calendar);
+            case Type.GYEAR:
                 return new GYearValue(calendar);
-            case Type.GYEARMONTH :
+            case Type.GYEARMONTH:
                 return new GYearMonthValue(calendar);
-            case Type.GMONTHDAY :
+            case Type.GMONTHDAY:
                 return new GMonthDayValue(calendar);
-            case Type.GDAY :
+            case Type.GDAY:
                 return new GDayValue(calendar);
-            case Type.GMONTH :
+            case Type.GMONTH:
                 return new GMonthValue(calendar);
-			case Type.STRING :
-				return new StringValue(getStringValue());
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());				
-			default :
-				throw new XPathException(
-					"Type error: cannot cast xs:dateTime to "
-						+ Type.getTypeName(requiredType));
-		}
-	}
+            case Type.STRING:
+                return new StringValue(getStringValue());
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            default:
+                throw new XPathException(
+                        "Type error: cannot cast xs:dateTime to "
+                                + Type.getTypeName(requiredType));
+        }
+    }
 
-	public ComputableValue minus(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-			case Type.DATE_TIME:
-				return new DayTimeDurationValue(getTimeInMillis() - ((DateTimeValue) other).getTimeInMillis());
-			case Type.YEAR_MONTH_DURATION:
-				return ((YearMonthDurationValue) other).negate().plus(this);
-			case Type.DAY_TIME_DURATION:
-				return ((DayTimeDurationValue) other).negate().plus(this);
-			default:
-				throw new XPathException(
-						"Operand to minus should be of type xs:dateTime, xdt:dayTimeDuration or xdt:yearMonthDuration; got: "
-							+ Type.getTypeName(other.getType()));
-		}
-	}
+    public ComputableValue minus(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.DATE_TIME:
+                return new DayTimeDurationValue(getTimeInMillis() - ((DateTimeValue) other).getTimeInMillis());
+            case Type.YEAR_MONTH_DURATION:
+                return ((YearMonthDurationValue) other).negate().plus(this);
+            case Type.DAY_TIME_DURATION:
+                return ((DayTimeDurationValue) other).negate().plus(this);
+            default:
+                throw new XPathException(
+                        "Operand to minus should be of type xs:dateTime, xdt:dayTimeDuration or xdt:yearMonthDuration; got: "
+                                + Type.getTypeName(other.getType()));
+        }
+    }
 
-	public Date getDate() { return calendar.toGregorianCalendar().getTime(); }
+    public Date getDate() {
+        return calendar.toGregorianCalendar().getTime();
+    }
 
 }

--- a/src/org/exist/xquery/value/DateTimeValue.java
+++ b/src/org/exist/xquery/value/DateTimeValue.java
@@ -65,7 +65,7 @@ public class DateTimeValue extends AbstractDateTimeValue {
 	}
 	
 	protected void normalize() {
-		if (calendar.getHour() == 24 && calendar.getMinute() == 0 && calendar.getSecond() == 00) {
+		if (calendar.getHour() == 24 && calendar.getMinute() == 0 && calendar.getSecond() == 0) {
 			calendar.setHour(0);
 			calendar.add(TimeUtils.ONE_DAY);
 		}

--- a/src/org/exist/xquery/value/DateValue.java
+++ b/src/org/exist/xquery/value/DateValue.java
@@ -22,14 +22,13 @@
  */
 package org.exist.xquery.value;
 
-import java.util.GregorianCalendar;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-
-import org.exist.xquery.ErrorCodes;
-import org.exist.xquery.XPathException;
+import java.util.GregorianCalendar;
 
 /**
  * @author Wolfgang Meier (wolfgang@exist-db.org)

--- a/src/org/exist/xquery/value/DateValue.java
+++ b/src/org/exist/xquery/value/DateValue.java
@@ -36,88 +36,90 @@ import java.util.GregorianCalendar;
  */
 public class DateValue extends AbstractDateTimeValue {
 
-	public DateValue() throws XPathException {
-		super(stripCalendar(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar())));
-	}
+    public DateValue() throws XPathException {
+        super(stripCalendar(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar())));
+    }
 
-	public DateValue(String dateString) throws XPathException {
-		super(dateString);
-		try {
-			if (calendar.getXMLSchemaType() != DatatypeConstants.DATE) {throw new IllegalStateException();}
-		} catch (final IllegalStateException e) {
-			throw new XPathException("xs:date must not have hour, minute or second fields set");
-		}
-	}
-	
-	public DateValue(XMLGregorianCalendar calendar) throws XPathException {
-		super(stripCalendar(cloneXMLGregorianCalendar(calendar)));
-	}
-	
-	private static XMLGregorianCalendar stripCalendar(XMLGregorianCalendar calendar) {
-		calendar.setHour(DatatypeConstants.FIELD_UNDEFINED);
-		calendar.setMinute(DatatypeConstants.FIELD_UNDEFINED);
-		calendar.setSecond(DatatypeConstants.FIELD_UNDEFINED);
-		calendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
-		return calendar;
-	}
+    public DateValue(String dateString) throws XPathException {
+        super(dateString);
+        try {
+            if (calendar.getXMLSchemaType() != DatatypeConstants.DATE) {
+                throw new IllegalStateException();
+            }
+        } catch (final IllegalStateException e) {
+            throw new XPathException("xs:date must not have hour, minute or second fields set");
+        }
+    }
 
-	protected AbstractDateTimeValue createSameKind(XMLGregorianCalendar cal) throws XPathException {
-		return new DateValue(cal);
-	}
+    public DateValue(XMLGregorianCalendar calendar) throws XPathException {
+        super(stripCalendar(cloneXMLGregorianCalendar(calendar)));
+    }
 
-	protected QName getXMLSchemaType() {
-		return DatatypeConstants.DATE;
-	}
+    private static XMLGregorianCalendar stripCalendar(XMLGregorianCalendar calendar) {
+        calendar.setHour(DatatypeConstants.FIELD_UNDEFINED);
+        calendar.setMinute(DatatypeConstants.FIELD_UNDEFINED);
+        calendar.setSecond(DatatypeConstants.FIELD_UNDEFINED);
+        calendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
+        return calendar;
+    }
 
-	public int getType() {
-		return Type.DATE;
-	}
+    protected AbstractDateTimeValue createSameKind(XMLGregorianCalendar cal) throws XPathException {
+        return new DateValue(cal);
+    }
 
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.DATE :
-			case Type.ATOMIC :
-			case Type.ITEM :
+    protected QName getXMLSchemaType() {
+        return DatatypeConstants.DATE;
+    }
+
+    public int getType() {
+        return Type.DATE;
+    }
+
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.DATE:
+            case Type.ATOMIC:
+            case Type.ITEM:
                 return this;
-			case Type.DATE_TIME :
-				return new DateTimeValue(calendar);
-            case Type.GYEAR :
-            	return new GYearValue(this.calendar); 
-            case Type.GYEARMONTH :
+            case Type.DATE_TIME:
+                return new DateTimeValue(calendar);
+            case Type.GYEAR:
+                return new GYearValue(this.calendar);
+            case Type.GYEARMONTH:
                 return new GYearMonthValue(calendar);
-            case Type.GMONTHDAY :
+            case Type.GMONTHDAY:
                 return new GMonthDayValue(calendar);
-            case Type.GDAY :
+            case Type.GDAY:
                 return new GDayValue(calendar);
-            case Type.GMONTH :
+            case Type.GMONTH:
                 return new GMonthValue(calendar);
-			case Type.UNTYPED_ATOMIC: {			
-	            final DateValue dv = new DateValue(getStringValue()); 
-				return new UntypedAtomicValue(dv.getStringValue());		
-			}
-			case Type.STRING : {
-            	final DateValue dv = new DateValue(calendar); 
-				return new StringValue(dv.getStringValue());
-			}
-			default :
-				throw new XPathException(ErrorCodes.FORG0001, "can not convert " + 
-						Type.getTypeName(getType()) + "('" + getStringValue() + "') to " +
-						Type.getTypeName(requiredType));
-		}
-	}
+            case Type.UNTYPED_ATOMIC: {
+                final DateValue dv = new DateValue(getStringValue());
+                return new UntypedAtomicValue(dv.getStringValue());
+            }
+            case Type.STRING: {
+                final DateValue dv = new DateValue(calendar);
+                return new StringValue(dv.getStringValue());
+            }
+            default:
+                throw new XPathException(ErrorCodes.FORG0001, "can not convert " +
+                        Type.getTypeName(getType()) + "('" + getStringValue() + "') to " +
+                        Type.getTypeName(requiredType));
+        }
+    }
 
-	public ComputableValue minus(ComputableValue other) throws XPathException {
-		switch (other.getType()) {
-			case Type.DATE :
-				return new DayTimeDurationValue(getTimeInMillis() - ((DateValue) other).getTimeInMillis());
-			case Type.YEAR_MONTH_DURATION :
-				return ((YearMonthDurationValue) other).negate().plus(this);
-			case Type.DAY_TIME_DURATION :
-				return ((DayTimeDurationValue) other).negate().plus(this);
-			default :
-				throw new XPathException(
-					"Operand to minus should be of type xdt:yearMonthDuration or xdt:dayTimeDuration; got: "
-						+ Type.getTypeName(other.getType()));
-		}
-	}
+    public ComputableValue minus(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.DATE:
+                return new DayTimeDurationValue(getTimeInMillis() - ((DateValue) other).getTimeInMillis());
+            case Type.YEAR_MONTH_DURATION:
+                return ((YearMonthDurationValue) other).negate().plus(this);
+            case Type.DAY_TIME_DURATION:
+                return ((DayTimeDurationValue) other).negate().plus(this);
+            default:
+                throw new XPathException(
+                        "Operand to minus should be of type xdt:yearMonthDuration or xdt:dayTimeDuration; got: "
+                                + Type.getTypeName(other.getType()));
+        }
+    }
 }

--- a/src/org/exist/xquery/value/DayTimeDurationValue.java
+++ b/src/org/exist/xquery/value/DayTimeDurationValue.java
@@ -98,7 +98,7 @@ public class DayTimeDurationValue extends OrderedDurationValue {
 		final int m = canonicalDuration.getMinutes();
 		Number s = canonicalDuration.getField(DatatypeConstants.SECONDS);
         if (s == null)
-        	{s = Integer.valueOf(0);}
+        	{s = 0;}
 	
 		//Copied from Saxon 8.6.1		
         final FastStringBuffer sb = new FastStringBuffer(32);

--- a/src/org/exist/xquery/value/DayTimeDurationValue.java
+++ b/src/org/exist/xquery/value/DayTimeDurationValue.java
@@ -38,77 +38,79 @@ import java.math.BigInteger;
  */
 public class DayTimeDurationValue extends OrderedDurationValue {
 
-	public static final Duration CANONICAL_ZERO_DURATION =
-		TimeUtils.getInstance().newDuration(true, null, null, null, null, null, ZERO_DECIMAL);
-	
-	DayTimeDurationValue(Duration duration) throws XPathException {
-		super(duration);
-		if (duration.isSet(DatatypeConstants.YEARS) || duration.isSet(DatatypeConstants.MONTHS))
-			{throw new XPathException(ErrorCodes.XPTY0004, "the value '" + duration + "' is not an xdt:dayTimeDuration since it specifies year or month values");}
-	}
+    public static final Duration CANONICAL_ZERO_DURATION =
+            TimeUtils.getInstance().newDuration(true, null, null, null, null, null, ZERO_DECIMAL);
 
-	public DayTimeDurationValue(long millis) throws XPathException {
-		this(TimeUtils.getInstance().newDurationDayTime(millis));
-	}
-	
-	public DayTimeDurationValue(String str) throws XPathException {
-		this(createDurationDayTime(StringValue.trimWhitespace(str)));
-	}
+    DayTimeDurationValue(Duration duration) throws XPathException {
+        super(duration);
+        if (duration.isSet(DatatypeConstants.YEARS) || duration.isSet(DatatypeConstants.MONTHS)) {
+            throw new XPathException(ErrorCodes.XPTY0004, "the value '" + duration + "' is not an xdt:dayTimeDuration since it specifies year or month values");
+        }
+    }
 
-	private static Duration createDurationDayTime(String str) throws XPathException {
-		try {
-			return TimeUtils.getInstance().newDurationDayTime(str);
-		} catch (final IllegalArgumentException e) {
-			throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(Type.DAY_TIME_DURATION) +
-					" from \"" + str + "\"");            
-		}
-	}
-	
-	public DurationValue wrap() {
-		return this;
-	}
+    public DayTimeDurationValue(long millis) throws XPathException {
+        this(TimeUtils.getInstance().newDurationDayTime(millis));
+    }
 
-	public int getType() {
-		return Type.DAY_TIME_DURATION;
-	}
-	
-	public double getValue() {
-		double value = duration.getDays();
-		value = value * 24 + duration.getHours();
-		value = value * 60 + duration.getMinutes();
-		final Number n = duration.getField(DatatypeConstants.SECONDS);
-		value = value * 60 + (n == null ? 0 : n.doubleValue());
-		return value * duration.getSign();
-	}
-	
-	public long getValueInMilliseconds() {
-		return (long) (getValue() * 1000);
-	}
-	
-	protected Duration canonicalZeroDuration() {
-		return CANONICAL_ZERO_DURATION;
-	}
-	
-	public String getStringValue() {
-		final Duration canonicalDuration = getCanonicalDuration();
-		
-		final int d = canonicalDuration.getDays();
-		final int h = canonicalDuration.getHours();
-		final int m = canonicalDuration.getMinutes();
-		Number s = canonicalDuration.getField(DatatypeConstants.SECONDS);
-        if (s == null)
-        	{s = 0;}
-	
-		//Copied from Saxon 8.6.1		
+    public DayTimeDurationValue(String str) throws XPathException {
+        this(createDurationDayTime(StringValue.trimWhitespace(str)));
+    }
+
+    private static Duration createDurationDayTime(String str) throws XPathException {
+        try {
+            return TimeUtils.getInstance().newDurationDayTime(str);
+        } catch (final IllegalArgumentException e) {
+            throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(Type.DAY_TIME_DURATION) +
+                    " from \"" + str + "\"");
+        }
+    }
+
+    public DurationValue wrap() {
+        return this;
+    }
+
+    public int getType() {
+        return Type.DAY_TIME_DURATION;
+    }
+
+    public double getValue() {
+        double value = duration.getDays();
+        value = value * 24 + duration.getHours();
+        value = value * 60 + duration.getMinutes();
+        final Number n = duration.getField(DatatypeConstants.SECONDS);
+        value = value * 60 + (n == null ? 0 : n.doubleValue());
+        return value * duration.getSign();
+    }
+
+    public long getValueInMilliseconds() {
+        return (long) (getValue() * 1000);
+    }
+
+    protected Duration canonicalZeroDuration() {
+        return CANONICAL_ZERO_DURATION;
+    }
+
+    public String getStringValue() {
+        final Duration canonicalDuration = getCanonicalDuration();
+
+        final int d = canonicalDuration.getDays();
+        final int h = canonicalDuration.getHours();
+        final int m = canonicalDuration.getMinutes();
+        Number s = canonicalDuration.getField(DatatypeConstants.SECONDS);
+        if (s == null) {
+            s = 0;
+        }
+
+        //Copied from Saxon 8.6.1
         final FastStringBuffer sb = new FastStringBuffer(32);
         if (canonicalDuration.getSign() < 0) {
             sb.append('-');
         }
-        sb.append('P');        
+        sb.append('P');
         if (d != 0) {
             sb.append(d + "D");
         }
-        if ( d==0 || h!=0 || m!=0 || s.intValue() != 0) {
+        if (d == 0 || h != 0 || m != 0 || s.intValue() != 0) {
             sb.append('T');
         }
         if (h != 0) {
@@ -117,18 +119,18 @@ public class DayTimeDurationValue extends OrderedDurationValue {
         if (m != 0) {
             sb.append(m + "M");
         }
-        if ((s.intValue() != 0) || (d==0 && m==0 && h==0)) {
-        	//TODO : ugly -> factorize
-        	//sb.append(Integer.toString(s.intValue()));
-        	//double ms = s.doubleValue() - s.intValue();
-        	//if (ms != 0.0) {
-        	//	sb.append(".");
-        	//	sb.append(Double.toString(ms).substring(2));        		
-        	//}
-    		//0 is a dummy parameter
-    		FloatingPointConverter.appendFloat(sb, s.floatValue()).getNormalizedString(0);	
-        	sb.append("S");        			
-        	/*
+        if ((s.intValue() != 0) || (d == 0 && m == 0 && h == 0)) {
+            //TODO : ugly -> factorize
+            //sb.append(Integer.toString(s.intValue()));
+            //double ms = s.doubleValue() - s.intValue();
+            //if (ms != 0.0) {
+            //	sb.append(".");
+            //	sb.append(Double.toString(ms).substring(2));
+            //}
+            //0 is a dummy parameter
+            FloatingPointConverter.appendFloat(sb, s.floatValue()).getNormalizedString(0);
+            sb.append("S");
+            /*
             if (micros == 0) {
                 sb.append(s + "S");
             } else {
@@ -151,47 +153,47 @@ public class DayTimeDurationValue extends OrderedDurationValue {
         }
         //End of copy        
         return sb.toString();
-        
-	}
-	
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch(requiredType) {
-			case Type.ITEM:
-			case Type.ATOMIC:
-			case Type.DAY_TIME_DURATION:
-				return new DayTimeDurationValue(getCanonicalDuration());
-			case Type.STRING: {
-				final DayTimeDurationValue dtdv = new DayTimeDurationValue(getCanonicalDuration());
-				return new StringValue(dtdv.getStringValue());
-			}
-			case Type.DURATION:
-				return new DurationValue(TimeUtils.getInstance().newDuration(
-						duration.getSign() >= 0, null, null,
-						(BigInteger) duration.getField(DatatypeConstants.DAYS),
-						(BigInteger) duration.getField(DatatypeConstants.HOURS),
-						(BigInteger) duration.getField(DatatypeConstants.MINUTES),
-						(BigDecimal) duration.getField(DatatypeConstants.SECONDS)));
-			case Type.YEAR_MONTH_DURATION:
-				return new YearMonthDurationValue(YearMonthDurationValue.CANONICAL_ZERO_DURATION);				
-			//case Type.DOUBLE:
-				//return new DoubleValue(monthsValueSigned().doubleValue());
-				//return new DoubleValue(Double.NaN);
-			//case Type.DECIMAL:
-				//return new DecimalValue(monthsValueSigned().doubleValue());	
-			case Type.UNTYPED_ATOMIC : {
-				final DayTimeDurationValue dtdv = new DayTimeDurationValue(getCanonicalDuration());
-				return new UntypedAtomicValue(dtdv.getStringValue());
-			}
-			default:
-				throw new XPathException(ErrorCodes.XPTY0004, "cannot cast '" + 
-						Type.getTypeName(this.getItemType()) + "(\"" + getStringValue() + "\")' to " +
-						Type.getTypeName(requiredType));
-		}
-	}
-	
-	protected DurationValue createSameKind(Duration dur) throws XPathException {
-		return new DayTimeDurationValue(dur);
-	}
+
+    }
+
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.ITEM:
+            case Type.ATOMIC:
+            case Type.DAY_TIME_DURATION:
+                return new DayTimeDurationValue(getCanonicalDuration());
+            case Type.STRING: {
+                final DayTimeDurationValue dtdv = new DayTimeDurationValue(getCanonicalDuration());
+                return new StringValue(dtdv.getStringValue());
+            }
+            case Type.DURATION:
+                return new DurationValue(TimeUtils.getInstance().newDuration(
+                        duration.getSign() >= 0, null, null,
+                        (BigInteger) duration.getField(DatatypeConstants.DAYS),
+                        (BigInteger) duration.getField(DatatypeConstants.HOURS),
+                        (BigInteger) duration.getField(DatatypeConstants.MINUTES),
+                        (BigDecimal) duration.getField(DatatypeConstants.SECONDS)));
+            case Type.YEAR_MONTH_DURATION:
+                return new YearMonthDurationValue(YearMonthDurationValue.CANONICAL_ZERO_DURATION);
+            //case Type.DOUBLE:
+            //return new DoubleValue(monthsValueSigned().doubleValue());
+            //return new DoubleValue(Double.NaN);
+            //case Type.DECIMAL:
+            //return new DecimalValue(monthsValueSigned().doubleValue());
+            case Type.UNTYPED_ATOMIC: {
+                final DayTimeDurationValue dtdv = new DayTimeDurationValue(getCanonicalDuration());
+                return new UntypedAtomicValue(dtdv.getStringValue());
+            }
+            default:
+                throw new XPathException(ErrorCodes.XPTY0004, "cannot cast '" +
+                        Type.getTypeName(this.getItemType()) + "(\"" + getStringValue() + "\")' to " +
+                        Type.getTypeName(requiredType));
+        }
+    }
+
+    protected DurationValue createSameKind(Duration dur) throws XPathException {
+        return new DayTimeDurationValue(dur);
+    }
 	
 	/*
 	public ComputableValue plus(ComputableValue other) throws XPathException {
@@ -204,63 +206,65 @@ public class DayTimeDurationValue extends OrderedDurationValue {
 		}
 	}
 	*/
-	
-	public ComputableValue mult(ComputableValue other) throws XPathException {
-		if (other instanceof NumericValue) {
-			//If $arg2 is NaN an error is raised [err:FOCA0005]
-			if (((NumericValue)other).isNaN()) {
-				throw new XPathException(ErrorCodes.FOCA0005, "Operand is not a number");				
-			}		
-			//If $arg2 is positive or negative infinity, the result overflows
-			if (((NumericValue)other).isInfinite()) {
-				throw new XPathException(ErrorCodes.FODT0002, "Multiplication by infinity overflow");		
-			}		
-		}		
-		final BigDecimal factor = numberToBigDecimal(other, "Operand to mult should be of numeric type; got: ");
-		final boolean isFactorNegative = factor.signum() < 0;
-		final DayTimeDurationValue product = new DayTimeDurationValue(duration.multiply(factor.abs()));
-		if (isFactorNegative)
-			{return new DayTimeDurationValue(product.negate().getCanonicalDuration());}
-		return new DayTimeDurationValue(product.getCanonicalDuration());
-		
-	}
 
-	public ComputableValue div(ComputableValue other) throws XPathException {		
-		if (other.getType() == Type.DAY_TIME_DURATION) {		
-			final DecimalValue a = new DecimalValue(secondsValueSigned());
-			final DecimalValue b = new DecimalValue(((DayTimeDurationValue)other).secondsValueSigned());
-			return new DecimalValue(a.value.divide(b.value, 20, BigDecimal.ROUND_HALF_UP));
-		}		
-		if (other instanceof NumericValue) {
-			if (((NumericValue)other).isNaN()) {
-				throw new XPathException(ErrorCodes.FOCA0005, "Operand is not a number");				
-			}
-			//If $arg2 is positive or negative infinity, the result is a zero-length duration
-			if (((NumericValue)other).isInfinite()) {
-				return new DayTimeDurationValue("PT0S");
-			}
-			//If $arg2 is positive or negative zero, the result overflows and is handled as discussed in 10.1.1 Limits and Precision
-			if (((NumericValue)other).isZero()) { 
-				throw new XPathException(ErrorCodes.FODT0002, "Division by zero");
-			}
-		}
-		final BigDecimal divisor = numberToBigDecimal(other, "Operand to div should be of xdt:dayTimeDuration or numeric type; got: ");
-		final boolean isDivisorNegative = divisor.signum() < 0;
-		final BigDecimal secondsValueSigned = secondsValueSigned();
-		final DayTimeDurationValue quotient = fromDecimalSeconds(secondsValueSigned.divide(divisor.abs(), Math.max(Math.max(3, secondsValueSigned.scale()), divisor.scale()), BigDecimal.ROUND_HALF_UP));
-		if (isDivisorNegative)
-			{return new DayTimeDurationValue(quotient.negate().getCanonicalDuration());}
-		return new DayTimeDurationValue(quotient.getCanonicalDuration());		
-	}
+    public ComputableValue mult(ComputableValue other) throws XPathException {
+        if (other instanceof NumericValue) {
+            //If $arg2 is NaN an error is raised [err:FOCA0005]
+            if (((NumericValue) other).isNaN()) {
+                throw new XPathException(ErrorCodes.FOCA0005, "Operand is not a number");
+            }
+            //If $arg2 is positive or negative infinity, the result overflows
+            if (((NumericValue) other).isInfinite()) {
+                throw new XPathException(ErrorCodes.FODT0002, "Multiplication by infinity overflow");
+            }
+        }
+        final BigDecimal factor = numberToBigDecimal(other, "Operand to mult should be of numeric type; got: ");
+        final boolean isFactorNegative = factor.signum() < 0;
+        final DayTimeDurationValue product = new DayTimeDurationValue(duration.multiply(factor.abs()));
+        if (isFactorNegative) {
+            return new DayTimeDurationValue(product.negate().getCanonicalDuration());
+        }
+        return new DayTimeDurationValue(product.getCanonicalDuration());
 
-	private DayTimeDurationValue fromDecimalSeconds(BigDecimal x) throws XPathException {		
-		return new DayTimeDurationValue(TimeUtils.getInstance().newDuration(
-				x.signum() >= 0, null, null, null, null, null, x.abs()));
-	
-	}
+    }
+
+    public ComputableValue div(ComputableValue other) throws XPathException {
+        if (other.getType() == Type.DAY_TIME_DURATION) {
+            final DecimalValue a = new DecimalValue(secondsValueSigned());
+            final DecimalValue b = new DecimalValue(((DayTimeDurationValue) other).secondsValueSigned());
+            return new DecimalValue(a.value.divide(b.value, 20, BigDecimal.ROUND_HALF_UP));
+        }
+        if (other instanceof NumericValue) {
+            if (((NumericValue) other).isNaN()) {
+                throw new XPathException(ErrorCodes.FOCA0005, "Operand is not a number");
+            }
+            //If $arg2 is positive or negative infinity, the result is a zero-length duration
+            if (((NumericValue) other).isInfinite()) {
+                return new DayTimeDurationValue("PT0S");
+            }
+            //If $arg2 is positive or negative zero, the result overflows and is handled as discussed in 10.1.1 Limits and Precision
+            if (((NumericValue) other).isZero()) {
+                throw new XPathException(ErrorCodes.FODT0002, "Division by zero");
+            }
+        }
+        final BigDecimal divisor = numberToBigDecimal(other, "Operand to div should be of xdt:dayTimeDuration or numeric type; got: ");
+        final boolean isDivisorNegative = divisor.signum() < 0;
+        final BigDecimal secondsValueSigned = secondsValueSigned();
+        final DayTimeDurationValue quotient = fromDecimalSeconds(secondsValueSigned.divide(divisor.abs(), Math.max(Math.max(3, secondsValueSigned.scale()), divisor.scale()), BigDecimal.ROUND_HALF_UP));
+        if (isDivisorNegative) {
+            return new DayTimeDurationValue(quotient.negate().getCanonicalDuration());
+        }
+        return new DayTimeDurationValue(quotient.getCanonicalDuration());
+    }
+
+    private DayTimeDurationValue fromDecimalSeconds(BigDecimal x) throws XPathException {
+        return new DayTimeDurationValue(TimeUtils.getInstance().newDuration(
+                x.signum() >= 0, null, null, null, null, null, x.abs()));
+
+    }
 
     public boolean effectiveBooleanValue() throws XPathException {
         throw new XPathException(ErrorCodes.FORG0006, "value of type " + Type.getTypeName(getType()) +
-            " has no boolean value.");
+                " has no boolean value.");
     }
 }

--- a/src/org/exist/xquery/value/DayTimeDurationValue.java
+++ b/src/org/exist/xquery/value/DayTimeDurationValue.java
@@ -23,16 +23,15 @@
 
 package org.exist.xquery.value;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.Duration;
-
 import org.exist.util.FastStringBuffer;
 import org.exist.util.FloatingPointConverter;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.Duration;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 /**
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>

--- a/src/org/exist/xquery/value/DecimalValue.java
+++ b/src/org/exist/xquery/value/DecimalValue.java
@@ -545,18 +545,12 @@ public class DecimalValue extends NumericValue {
 	            }
 	            final Object result = stripTrailingZerosMethod.invoke(value, EMPTY_OBJECT_ARRAY);
 	            return (BigDecimal)result;
-	        } catch (final NoSuchMethodException e) {
-	            stripTrailingZerosMethodUnavailable = true;
-	            return stripTrailingZerosFallback(value);
-	        } catch (final IllegalAccessException e) {
-	            stripTrailingZerosMethodUnavailable = true;
-	            return stripTrailingZerosFallback(value);
-	        } catch (final InvocationTargetException e) {
+	        } catch (final NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
 	            stripTrailingZerosMethodUnavailable = true;
 	            return stripTrailingZerosFallback(value);
 	        }
 
-	    }
+        }
 	    
 	    private static BigDecimal stripTrailingZerosFallback(BigDecimal value) {
 

--- a/src/org/exist/xquery/value/DecimalValue.java
+++ b/src/org/exist/xquery/value/DecimalValue.java
@@ -337,7 +337,7 @@ public class DecimalValue extends NumericValue {
 			default: 
 				if (!(other instanceof DecimalValue)) {
 	            	final ComputableValue n = (ComputableValue)this.convertTo(other.getType());
-	            	return ((ComputableValue)n).div(other);
+	            	return n.div(other);
 				}
 				if (((DecimalValue)other).isZero())
 					{throw new XPathException(ErrorCodes.FOAR0001, "division by zero");}

--- a/src/org/exist/xquery/value/DecimalValue.java
+++ b/src/org/exist/xquery/value/DecimalValue.java
@@ -21,18 +21,18 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.util.FastStringBuffer;
+import org.exist.xquery.Constants;
+import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.XPathException;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.Collator;
 import java.util.regex.Pattern;
-
-import org.exist.util.FastStringBuffer;
-import org.exist.xquery.Constants;
-import org.exist.xquery.Constants.Comparison;
-import org.exist.xquery.ErrorCodes;
-import org.exist.xquery.XPathException;
 
 /**
  * @author wolf

--- a/src/org/exist/xquery/value/DecimalValue.java
+++ b/src/org/exist/xquery/value/DecimalValue.java
@@ -38,63 +38,114 @@ import java.util.regex.Pattern;
  * @author wolf
  */
 public class DecimalValue extends NumericValue {
+    public static final BigInteger BIG_INTEGER_TEN = BigInteger.valueOf(10);
     // i × 10^-n where i, n = integers  and n >= 0
-    // All ·minimally conforming· processors ·must· support decimal numbers 
-    // with a minimum of 18 decimal digits (i.e., with a ·totalDigits· of 18)	
-	@SuppressWarnings("unused")
-	private static final BigDecimal ZERO_BIGDECIMAL = new BigDecimal("0");
-	//Copied from Saxon 8.6.1    
-	private static final int DIVIDE_PRECISION = 18;
-	//Copied from Saxon 8.7
-	private static final Pattern decimalPattern = Pattern.compile("(\\-|\\+)?((\\.[0-9]+)|([0-9]+(\\.[0-9]*)?))");
-	//Copied from Saxon 8.8
+    // All ·minimally conforming· processors ·must· support decimal numbers
+    // with a minimum of 18 decimal digits (i.e., with a ·totalDigits· of 18)
+    @SuppressWarnings("unused")
+    private static final BigDecimal ZERO_BIGDECIMAL = new BigDecimal("0");
+    //Copied from Saxon 8.6.1
+    private static final int DIVIDE_PRECISION = 18;
+    //Copied from Saxon 8.7
+    private static final Pattern decimalPattern = Pattern.compile("(\\-|\\+)?((\\.[0-9]+)|([0-9]+(\\.[0-9]*)?))");
+    private static final Object[] EMPTY_OBJECT_ARRAY = {};
+    //Copied from Saxon 8.8
     private static boolean stripTrailingZerosMethodUnavailable = false;
     private static Method stripTrailingZerosMethod = null;
-    private static final Object[] EMPTY_OBJECT_ARRAY = {};
-    public static final BigInteger BIG_INTEGER_TEN = BigInteger.valueOf(10);
-	
-	BigDecimal value;
+    BigDecimal value;
 
-	public DecimalValue(BigDecimal decimal) {
-		this.value = stripTrailingZeros(decimal);		
-	}
+    public DecimalValue(BigDecimal decimal) {
+        this.value = stripTrailingZeros(decimal);
+    }
 
-	public DecimalValue(String str) throws XPathException {
+    public DecimalValue(String str) throws XPathException {
         str = StringValue.trimWhitespace(str);
-		try {
-			if (!decimalPattern.matcher(str).matches()) {
-				throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(this.getItemType()) +
-						" from \"" + str + "\"");            
-			}
-			value = stripTrailingZeros(new BigDecimal(str));
-		} catch (final NumberFormatException e) {
-			throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(this.getItemType()) +
-					" from \"" + getStringValue() + "\"");					
-		}
-	}
+        try {
+            if (!decimalPattern.matcher(str).matches()) {
+                throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(this.getItemType()) +
+                        " from \"" + str + "\"");
+            }
+            value = stripTrailingZeros(new BigDecimal(str));
+        } catch (final NumberFormatException e) {
+            throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(this.getItemType()) +
+                    " from \"" + getStringValue() + "\"");
+        }
+    }
 
-	public DecimalValue(double doubleValue) {
-		value = stripTrailingZeros(new BigDecimal(doubleValue));
-	}
+    public DecimalValue(double doubleValue) {
+        value = stripTrailingZeros(new BigDecimal(doubleValue));
+    }
+
+    /**
+     * Remove insignificant trailing zeros (the Java BigDecimal class retains trailing zeros,
+     * but the XPath 2.0 xs:decimal type does not). The BigDecimal#stripTrailingZeros() method
+     * was introduced in JDK 1.5: we use it if available, and simulate it if not.
+     */
+
+    private static BigDecimal stripTrailingZeros(BigDecimal value) {
+        if (stripTrailingZerosMethodUnavailable) {
+            return stripTrailingZerosFallback(value);
+        }
+
+        try {
+            if (stripTrailingZerosMethod == null) {
+                final Class<?>[] argTypes = {};
+                stripTrailingZerosMethod = BigDecimal.class.getMethod("stripTrailingZeros", argTypes);
+            }
+            final Object result = stripTrailingZerosMethod.invoke(value, EMPTY_OBJECT_ARRAY);
+            return (BigDecimal) result;
+        } catch (final NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            stripTrailingZerosMethodUnavailable = true;
+            return stripTrailingZerosFallback(value);
+        }
+
+    }
+
+    private static BigDecimal stripTrailingZerosFallback(BigDecimal value) {
+
+        // The code below differs from JDK 1.5 stripTrailingZeros in that it does not remove trailing zeros
+        // from integers, for example 1000 is not changed to 1E3.
+
+        int scale = value.scale();
+        if (scale > 0) {
+            BigInteger i = value.unscaledValue();
+            while (true) {
+                final BigInteger[] dr = i.divideAndRemainder(BIG_INTEGER_TEN);
+                if (dr[1].equals(BigInteger.ZERO)) {
+                    i = dr[0];
+                    scale--;
+                    if (scale == 0) {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+            if (scale != value.scale()) {
+                value = new BigDecimal(i, scale);
+            }
+        }
+        return value;
+    }
 
     public BigDecimal getValue() {
         return value;
     }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#getType()
-	 */
-	public int getType() {
-		return Type.DECIMAL;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#getType()
+     */
+    public int getType() {
+        return Type.DECIMAL;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getStringValue()
-	 */
-	public String getStringValue() throws XPathException {
-		/*
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getStringValue()
+     */
+    public String getStringValue() throws XPathException {
+        /*
 		String s = value.toString();
-		while (s.length() > 0  && s.indexOf('.') != Constants.STRING_NOT_FOUND && 
+		while (s.length() > 0  && s.indexOf('.') != Constants.STRING_NOT_FOUND &&
 				s.charAt(s.length() - 1) == '0') {
 			s = s.substring(0, s.length() - 1);
 		}
@@ -102,8 +153,8 @@ public class DecimalValue extends NumericValue {
 			s = s.substring(0, s.length() - 1);
 		return s;
 		*/
-		
-		//Copied from Saxon 8.8
+
+        //Copied from Saxon 8.8
         // Can't use the plain BigDecimal#toString() under JDK 1.5 because this produces values like "1E-5".
         // JDK 1.5 offers BigDecimal#toPlainString() which might do the job directly
         int scale = value.scale();
@@ -118,10 +169,10 @@ public class DecimalValue extends NumericValue {
             }
             sb.append(s);
             //Provisional hack : 10.0 mod 10.0 to trigger the bug
-            if (!"0".equals(s)){
-	            for (int i=0; i<(-scale); i++) {
-	                sb.append('0');
-	            }
+            if (!"0".equals(s)) {
+                for (int i = 0; i < (-scale); i++) {
+                    sb.append('0');
+                }
             }
             return sb.toString();
         } else {
@@ -130,329 +181,336 @@ public class DecimalValue extends NumericValue {
                 return s;
             }
             final int len = s.length();
-            final FastStringBuffer sb = new FastStringBuffer(len+1);
+            final FastStringBuffer sb = new FastStringBuffer(len + 1);
             if (value.signum() < 0) {
                 sb.append('-');
             }
             if (scale >= len) {
                 sb.append("0.");
-                for (int i=len; i<scale; i++) {
+                for (int i = len; i < scale; i++) {
                     sb.append('0');
                 }
                 sb.append(s);
             } else {
-                sb.append(s.substring(0, len-scale));
+                sb.append(s.substring(0, len - scale));
                 sb.append('.');
-                sb.append(s.substring(len-scale));
+                sb.append(s.substring(len - scale));
             }
             return sb.toString();
         }
         //End of copy
-	}
-	
-	public boolean hasFractionalPart() {
-		return (value.scale() > 0);
-	}
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#convertTo(int)
-	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.ATOMIC :
-			case Type.ITEM :
-			case Type.NUMBER :
-			case Type.DECIMAL :
-				return this;
-			case Type.DOUBLE :
-				return new DoubleValue(value.doubleValue());
-			case Type.FLOAT :
-				return new FloatValue(value.floatValue());
-			case Type.STRING :
-				return new StringValue(getStringValue());
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());
-			case Type.INTEGER :
-			case Type.NON_POSITIVE_INTEGER :
-			case Type.NEGATIVE_INTEGER :
-			case Type.LONG :
-			case Type.INT :
-			case Type.SHORT :
-			case Type.BYTE :
-			case Type.NON_NEGATIVE_INTEGER :
-			case Type.UNSIGNED_LONG :
-			case Type.UNSIGNED_INT :
-			case Type.UNSIGNED_SHORT :
-			case Type.UNSIGNED_BYTE :
-			case Type.POSITIVE_INTEGER :
-				return new IntegerValue(value.longValue(), requiredType);
-			case Type.BOOLEAN :
-				return value.signum() == 0 ? BooleanValue.FALSE : BooleanValue.TRUE;
-			default :
-				throw new XPathException(ErrorCodes.FORG0001,
-					"cannot convert  '" 
-                    +  Type.getTypeName(this.getType()) 
-                    + " ("
-                    + value
-                    + ")' into "
-                    + Type.getTypeName(requiredType));
-		}
-	}
-	
-	public boolean isNaN() {
-		return false;
-	}
+    public boolean hasFractionalPart() {
+        return (value.scale() > 0);
+    }
 
-	public boolean isInfinite() {
-		return false;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#convertTo(int)
+     */
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.ATOMIC:
+            case Type.ITEM:
+            case Type.NUMBER:
+            case Type.DECIMAL:
+                return this;
+            case Type.DOUBLE:
+                return new DoubleValue(value.doubleValue());
+            case Type.FLOAT:
+                return new FloatValue(value.floatValue());
+            case Type.STRING:
+                return new StringValue(getStringValue());
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            case Type.INTEGER:
+            case Type.NON_POSITIVE_INTEGER:
+            case Type.NEGATIVE_INTEGER:
+            case Type.LONG:
+            case Type.INT:
+            case Type.SHORT:
+            case Type.BYTE:
+            case Type.NON_NEGATIVE_INTEGER:
+            case Type.UNSIGNED_LONG:
+            case Type.UNSIGNED_INT:
+            case Type.UNSIGNED_SHORT:
+            case Type.UNSIGNED_BYTE:
+            case Type.POSITIVE_INTEGER:
+                return new IntegerValue(value.longValue(), requiredType);
+            case Type.BOOLEAN:
+                return value.signum() == 0 ? BooleanValue.FALSE : BooleanValue.TRUE;
+            default:
+                throw new XPathException(ErrorCodes.FORG0001,
+                        "cannot convert  '"
+                                + Type.getTypeName(this.getType())
+                                + " ("
+                                + value
+                                + ")' into "
+                                + Type.getTypeName(requiredType));
+        }
+    }
 
-	public boolean isZero() {
-		return value.signum() == 0;
-		//return value.compareTo(ZERO_BIGDECIMAL) == Constants.EQUAL;
-	}
-    
+    public boolean isNaN() {
+        return false;
+    }
+
+    public boolean isInfinite() {
+        return false;
+    }
+
+    public boolean isZero() {
+        return value.signum() == 0;
+        //return value.compareTo(ZERO_BIGDECIMAL) == Constants.EQUAL;
+    }
+
     public boolean isNegative() {
-        return value.signum()<0;
+        return value.signum() < 0;
     }
 
     public boolean isPositive() {
-        return value.signum()>0;
+        return value.signum() > 0;
     }
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#negate()
-	 */
-	public NumericValue negate() throws XPathException {
-		return new DecimalValue(value.negate());
-	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#ceiling()
-	 */
-	public NumericValue ceiling() throws XPathException {
-		return new DecimalValue(value.setScale(0, BigDecimal.ROUND_CEILING));
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#negate()
+     */
+    public NumericValue negate() throws XPathException {
+        return new DecimalValue(value.negate());
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#floor()
-	 */
-	public NumericValue floor() throws XPathException {
-		return new DecimalValue(value.setScale(0, BigDecimal.ROUND_FLOOR));
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#ceiling()
+     */
+    public NumericValue ceiling() throws XPathException {
+        return new DecimalValue(value.setScale(0, BigDecimal.ROUND_CEILING));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#round()
-	 */
-	public NumericValue round() throws XPathException {
-		switch (value.signum()) {
-			case -1 :
-				return new DecimalValue(value.setScale(0, BigDecimal.ROUND_HALF_DOWN));
-			case 0 :
-				return this;
-			case 1 :
-				return new DecimalValue(value.setScale(0, BigDecimal.ROUND_HALF_UP));
-			default :
-				return this;
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#floor()
+     */
+    public NumericValue floor() throws XPathException {
+        return new DecimalValue(value.setScale(0, BigDecimal.ROUND_FLOOR));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#round(org.exist.xquery.value.IntegerValue)
-	 */
-	public NumericValue round(IntegerValue precision) throws XPathException {
-		if (value.signum() == 0)
-			{return this;}
-		
-		int pre;
-		if (precision == null)
-			{pre = 0;}
-		else 
-			{pre = precision.getInt();}
-		
-		if ( pre >= 0 ) 
-			{return new DecimalValue(value.setScale(pre, BigDecimal.ROUND_HALF_EVEN));}
-		else 
-			{return new DecimalValue(
-						value.movePointRight(pre).
-						setScale(0, BigDecimal.ROUND_HALF_EVEN).
-						movePointLeft(pre));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#round()
+     */
+    public NumericValue round() throws XPathException {
+        switch (value.signum()) {
+            case -1:
+                return new DecimalValue(value.setScale(0, BigDecimal.ROUND_HALF_DOWN));
+            case 0:
+                return this;
+            case 1:
+                return new DecimalValue(value.setScale(0, BigDecimal.ROUND_HALF_UP));
+            default:
+                return this;
+        }
+    }
 
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#minus(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue minus(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-			case Type.DECIMAL:
-				return new DecimalValue(value.subtract(((DecimalValue) other).value));
-			case Type.INTEGER:
-				return minus((ComputableValue) other.convertTo(getType()));
-			default:
-				return ((ComputableValue) convertTo(other.getType())).minus(other);
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#round(org.exist.xquery.value.IntegerValue)
+     */
+    public NumericValue round(IntegerValue precision) throws XPathException {
+        if (value.signum() == 0) {
+            return this;
+        }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#plus(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue plus(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-		case Type.DECIMAL:
-			return new DecimalValue(value.add(((DecimalValue) other).value));
-		case Type.INTEGER:
-			return plus((ComputableValue) other.convertTo(getType()));
-		default:
-			return ((ComputableValue) convertTo(other.getType())).plus(other);
-		}
-	}
+        int pre;
+        if (precision == null) {
+            pre = 0;
+        } else {
+            pre = precision.getInt();
+        }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#mult(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue mult(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-			case Type.DECIMAL:
-				return new DecimalValue(value.multiply(((DecimalValue) other).value));
-			case Type.INTEGER:
-				return mult((ComputableValue) other.convertTo(getType()));
-			case Type.DAY_TIME_DURATION:
-			case Type.YEAR_MONTH_DURATION:
-				return other.mult(this);
-			default:
-				return ((ComputableValue) convertTo(other.getType())).mult(other);
-		}
-	}
+        if (pre >= 0) {
+            return new DecimalValue(value.setScale(pre, BigDecimal.ROUND_HALF_EVEN));
+        } else {
+            return new DecimalValue(
+                    value.movePointRight(pre).
+                            setScale(0, BigDecimal.ROUND_HALF_EVEN).
+                            movePointLeft(pre));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#div(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue div(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-			//case Type.DECIMAL:
-				//return new DecimalValue(value.divide(((DecimalValue) other).value, BigDecimal.ROUND_HALF_UP));
-			case Type.INTEGER:
-				return div((ComputableValue) other.convertTo(getType()));
-			default: 
-				if (!(other instanceof DecimalValue)) {
-	            	final ComputableValue n = (ComputableValue)this.convertTo(other.getType());
-	            	return n.div(other);
-				}
-				if (((DecimalValue)other).isZero())
-					{throw new XPathException(ErrorCodes.FOAR0001, "division by zero");}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#minus(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue minus(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.DECIMAL:
+                return new DecimalValue(value.subtract(((DecimalValue) other).value));
+            case Type.INTEGER:
+                return minus((ComputableValue) other.convertTo(getType()));
+            default:
+                return ((ComputableValue) convertTo(other.getType())).minus(other);
+        }
+    }
 
-				//Copied from Saxon 8.6.1	
-		        final int scale = Math.max(DIVIDE_PRECISION, Math.max(value.scale(), ((DecimalValue)other).value.scale()));
-				final BigDecimal result = value.divide(((DecimalValue)other).value, scale, BigDecimal.ROUND_HALF_DOWN);
-				return new DecimalValue(result);
-				//End of copy				
-		}		
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#plus(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue plus(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.DECIMAL:
+                return new DecimalValue(value.add(((DecimalValue) other).value));
+            case Type.INTEGER:
+                return plus((ComputableValue) other.convertTo(getType()));
+            default:
+                return ((ComputableValue) convertTo(other.getType())).plus(other);
+        }
+    }
 
-	public IntegerValue idiv(NumericValue other) throws XPathException {
-		if (other.isZero())
-			{throw new XPathException(ErrorCodes.FOAR0001, "division by zero");}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#mult(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue mult(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.DECIMAL:
+                return new DecimalValue(value.multiply(((DecimalValue) other).value));
+            case Type.INTEGER:
+                return mult((ComputableValue) other.convertTo(getType()));
+            case Type.DAY_TIME_DURATION:
+            case Type.YEAR_MONTH_DURATION:
+                return other.mult(this);
+            default:
+                return ((ComputableValue) convertTo(other.getType())).mult(other);
+        }
+    }
 
-		final DecimalValue dv = (DecimalValue)other.convertTo(Type.DECIMAL);
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#div(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue div(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            //case Type.DECIMAL:
+            //return new DecimalValue(value.divide(((DecimalValue) other).value, BigDecimal.ROUND_HALF_UP));
+            case Type.INTEGER:
+                return div((ComputableValue) other.convertTo(getType()));
+            default:
+                if (!(other instanceof DecimalValue)) {
+                    final ComputableValue n = (ComputableValue) this.convertTo(other.getType());
+                    return n.div(other);
+                }
+                if (((DecimalValue) other).isZero()) {
+                    throw new XPathException(ErrorCodes.FOAR0001, "division by zero");
+                }
+
+                //Copied from Saxon 8.6.1
+                final int scale = Math.max(DIVIDE_PRECISION, Math.max(value.scale(), ((DecimalValue) other).value.scale()));
+                final BigDecimal result = value.divide(((DecimalValue) other).value, scale, BigDecimal.ROUND_HALF_DOWN);
+                return new DecimalValue(result);
+            //End of copy
+        }
+    }
+
+    public IntegerValue idiv(NumericValue other) throws XPathException {
+        if (other.isZero()) {
+            throw new XPathException(ErrorCodes.FOAR0001, "division by zero");
+        }
+
+        final DecimalValue dv = (DecimalValue) other.convertTo(Type.DECIMAL);
         final BigInteger quot = value.divide(dv.value, 0, BigDecimal.ROUND_DOWN).toBigInteger();
         return new IntegerValue(quot);
-	}
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#mod(org.exist.xquery.value.NumericValue)
-	 */
-	public NumericValue mod(NumericValue other) throws XPathException {
-		if (other.getType() == Type.DECIMAL) {
-			if (other.isZero())
-				{throw new XPathException(ErrorCodes.FOAR0001, "division by zero");}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#mod(org.exist.xquery.value.NumericValue)
+     */
+    public NumericValue mod(NumericValue other) throws XPathException {
+        if (other.getType() == Type.DECIMAL) {
+            if (other.isZero()) {
+                throw new XPathException(ErrorCodes.FOAR0001, "division by zero");
+            }
 
-			final BigDecimal quotient = value.divide(((DecimalValue)other).value, 0, BigDecimal.ROUND_DOWN);
+            final BigDecimal quotient = value.divide(((DecimalValue) other).value, 0, BigDecimal.ROUND_DOWN);
             final BigDecimal remainder = value.subtract(quotient.setScale(0, BigDecimal.ROUND_DOWN).multiply(((DecimalValue) other).value));
             return new DecimalValue(remainder);
-		} else
-			{return ((NumericValue) convertTo(other.getType())).mod(other);}
-	}
+        } else {
+            return ((NumericValue) convertTo(other.getType())).mod(other);
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#abs(org.exist.xquery.value.NumericValue)
-	 */
-	public NumericValue abs() throws XPathException {
-		return new DecimalValue(value.abs());
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#abs(org.exist.xquery.value.NumericValue)
+     */
+    public NumericValue abs() throws XPathException {
+        return new DecimalValue(value.abs());
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#max(org.exist.xquery.value.AtomicValue)
-	 */
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == Type.DECIMAL) {
-			return new DecimalValue(value.max(((DecimalValue) other).value));
-		} else
-			{return new DecimalValue(
-				value.max(((DecimalValue) other.convertTo(Type.DECIMAL)).value));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#max(org.exist.xquery.value.AtomicValue)
+     */
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == Type.DECIMAL) {
+            return new DecimalValue(value.max(((DecimalValue) other).value));
+        } else {
+            return new DecimalValue(
+                    value.max(((DecimalValue) other.convertTo(Type.DECIMAL)).value));
+        }
+    }
 
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == Type.DECIMAL) {
-			return new DecimalValue(value.min(((DecimalValue) other).value));
-		} else {
-			return new DecimalValue(
-				value.min(((DecimalValue) other.convertTo(Type.DECIMAL)).value));
-		}
-	}
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == Type.DECIMAL) {
+            return new DecimalValue(value.min(((DecimalValue) other).value));
+        } else {
+            return new DecimalValue(
+                    value.min(((DecimalValue) other.convertTo(Type.DECIMAL)).value));
+        }
+    }
 
-	@Override
-	public boolean compareTo(Collator collator, Comparison operator, AtomicValue other)
-		throws XPathException {
-		if (other.isEmpty()) {
-			//Never equal, or inequal...
-			return false;
-		}		
-		if(Type.subTypeOf(other.getType(), Type.NUMBER)) {
-			if (isNaN()) {
-				//NaN does not equal itself.
-				if (((NumericValue)other).isNaN()) {
-					return operator == Comparison.NEQ;
-				}
-			}			
-			if(Type.subTypeOf(other.getType(), Type.DECIMAL)) {
-				final DecimalValue otherValue = (DecimalValue)other.convertTo(Type.DECIMAL);
-				switch(operator) {
-					case EQ:
-						return compareTo(otherValue) == Constants.EQUAL;
-					case NEQ:
-						return compareTo(otherValue) != Constants.EQUAL;
-					case GT:
-						return compareTo(otherValue) == Constants.SUPERIOR;
-					case GTEQ:
-						return compareTo(otherValue) != Constants.INFERIOR;
-					case LT:
-						return compareTo(otherValue) == Constants.INFERIOR;
-					case LTEQ:
-						return compareTo(otherValue) != Constants.SUPERIOR;
-					default:
-						throw new XPathException("Type error: cannot apply operator to numeric value");
-				}
-			}
-		}
-		//Default to the standard numeric comparison
-		return super.compareTo(collator, operator, other);
-	}
+    @Override
+    public boolean compareTo(Collator collator, Comparison operator, AtomicValue other)
+            throws XPathException {
+        if (other.isEmpty()) {
+            //Never equal, or inequal...
+            return false;
+        }
+        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+            if (isNaN()) {
+                //NaN does not equal itself.
+                if (((NumericValue) other).isNaN()) {
+                    return operator == Comparison.NEQ;
+                }
+            }
+            if (Type.subTypeOf(other.getType(), Type.DECIMAL)) {
+                final DecimalValue otherValue = (DecimalValue) other.convertTo(Type.DECIMAL);
+                switch (operator) {
+                    case EQ:
+                        return compareTo(otherValue) == Constants.EQUAL;
+                    case NEQ:
+                        return compareTo(otherValue) != Constants.EQUAL;
+                    case GT:
+                        return compareTo(otherValue) == Constants.SUPERIOR;
+                    case GTEQ:
+                        return compareTo(otherValue) != Constants.INFERIOR;
+                    case LT:
+                        return compareTo(otherValue) == Constants.INFERIOR;
+                    case LTEQ:
+                        return compareTo(otherValue) != Constants.SUPERIOR;
+                    default:
+                        throw new XPathException("Type error: cannot apply operator to numeric value");
+                }
+            }
+        }
+        //Default to the standard numeric comparison
+        return super.compareTo(collator, operator, other);
+    }
 
-	
     public int compareTo(Object o) {
-        final AtomicValue other = (AtomicValue)o;
-        if(Type.subTypeOf(other.getType(), Type.DECIMAL)) {
-        	DecimalValue otherAsDecimal = null;
-        	try {
-        		otherAsDecimal = (DecimalValue)other.convertTo(Type.DECIMAL);        		
-        	} catch (final XPathException e) {
-        		//TODO : is this relevant ?
-        		return Constants.INFERIOR;
-        	}
-        	return value.compareTo(otherAsDecimal.value);
-        } else
-            {return getType() < other.getType() ? Constants.INFERIOR : Constants.SUPERIOR;}
+        final AtomicValue other = (AtomicValue) o;
+        if (Type.subTypeOf(other.getType(), Type.DECIMAL)) {
+            DecimalValue otherAsDecimal = null;
+            try {
+                otherAsDecimal = (DecimalValue) other.convertTo(Type.DECIMAL);
+            } catch (final XPathException e) {
+                //TODO : is this relevant ?
+                return Constants.INFERIOR;
+            }
+            return value.compareTo(otherAsDecimal.value);
+        } else {
+            return getType() < other.getType() ? Constants.INFERIOR : Constants.SUPERIOR;
+        }
     }
 
     @Override
@@ -460,123 +518,84 @@ public class DecimalValue extends NumericValue {
         return value.hashCode();
     }
 
+    //Copied from Saxon 8.8
+
     /* (non-Javadoc)
     * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
     */
-	public int conversionPreference(Class<?> javaClass) {
-		if (javaClass.isAssignableFrom(DecimalValue.class))
-			{return 0;}
-		if (javaClass == BigDecimal.class)
-			{return 1;}
-		if (javaClass == Long.class || javaClass == long.class)
-			{return 4;}
-		if (javaClass == Integer.class || javaClass == int.class)
-			{return 5;}
-		if (javaClass == Short.class || javaClass == short.class)
-			{return 6;}
-		if (javaClass == Byte.class || javaClass == byte.class)
-			{return 7;}
-		if (javaClass == Double.class || javaClass == double.class)
-			{return 2;}
-		if (javaClass == Float.class || javaClass == float.class)
-			{return 3;}
-		if (javaClass == String.class)
-			{return 8;}
-		if (javaClass == Boolean.class || javaClass == boolean.class)
-			{return 9;}
-		if (javaClass == Object.class)
-			{return 20;}
-
-		return Integer.MAX_VALUE;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
-	 */
-        @Override
-	public <T> T toJavaObject(final Class<T> target) throws XPathException {
-		if(target.isAssignableFrom(DecimalValue.class)) {
-			return (T)this;
-                } else if(target == BigDecimal.class) {
-			return (T)value;
-                } else if(target == Double.class || target == double.class) {
-			return (T)Double.valueOf(value.doubleValue());
-                } else if(target == Float.class || target == float.class) {
-			return (T)Float.valueOf(value.floatValue());
-                } else if(target == Long.class || target == long.class) {
-			return (T)Long.valueOf( ((IntegerValue) convertTo(Type.LONG)).getValue() );
-		} else if(target == Integer.class || target == int.class) {
-			final IntegerValue v = (IntegerValue) convertTo(Type.INT);
-			return (T)Integer.valueOf((int) v.getValue());
-		} else if(target == Short.class || target == short.class) {
-			final IntegerValue v = (IntegerValue) convertTo(Type.SHORT);
-			return (T)Short.valueOf((short) v.getValue());
-		} else if(target == Byte.class || target == byte.class) {
-			final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
-			return (T)Byte.valueOf((byte) v.getValue());
-		} else if(target == String.class)
-			{return (T)getStringValue();}
-		else if(target == Boolean.class)
-			{return (T)Boolean.valueOf(effectiveBooleanValue());}
-
-		throw new XPathException(
-			"cannot convert value of type "
-				+ Type.getTypeName(getType())
-				+ " to Java object of type "
-				+ target.getName());
-	}
-	
-	//Copied from Saxon 8.8
-    /**
-	    * Remove insignificant trailing zeros (the Java BigDecimal class retains trailing zeros,
-	    * but the XPath 2.0 xs:decimal type does not). The BigDecimal#stripTrailingZeros() method
-	    * was introduced in JDK 1.5: we use it if available, and simulate it if not.
-	    */
-
-	    private static BigDecimal stripTrailingZeros(BigDecimal value) {
-	        if (stripTrailingZerosMethodUnavailable) {
-	            return stripTrailingZerosFallback(value);
-	        }
-
-	        try {
-	            if (stripTrailingZerosMethod == null) {
-	                final Class<?>[] argTypes = {};
-	                stripTrailingZerosMethod = BigDecimal.class.getMethod("stripTrailingZeros", argTypes);
-	            }
-	            final Object result = stripTrailingZerosMethod.invoke(value, EMPTY_OBJECT_ARRAY);
-	            return (BigDecimal)result;
-	        } catch (final NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-	            stripTrailingZerosMethodUnavailable = true;
-	            return stripTrailingZerosFallback(value);
-	        }
-
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(DecimalValue.class)) {
+            return 0;
         }
-	    
-	    private static BigDecimal stripTrailingZerosFallback(BigDecimal value) {
+        if (javaClass == BigDecimal.class) {
+            return 1;
+        }
+        if (javaClass == Long.class || javaClass == long.class) {
+            return 4;
+        }
+        if (javaClass == Integer.class || javaClass == int.class) {
+            return 5;
+        }
+        if (javaClass == Short.class || javaClass == short.class) {
+            return 6;
+        }
+        if (javaClass == Byte.class || javaClass == byte.class) {
+            return 7;
+        }
+        if (javaClass == Double.class || javaClass == double.class) {
+            return 2;
+        }
+        if (javaClass == Float.class || javaClass == float.class) {
+            return 3;
+        }
+        if (javaClass == String.class) {
+            return 8;
+        }
+        if (javaClass == Boolean.class || javaClass == boolean.class) {
+            return 9;
+        }
+        if (javaClass == Object.class) {
+            return 20;
+        }
 
-	        // The code below differs from JDK 1.5 stripTrailingZeros in that it does not remove trailing zeros
-	        // from integers, for example 1000 is not changed to 1E3.
+        return Integer.MAX_VALUE;
+    }
 
-	        int scale = value.scale();
-	        if (scale > 0) {
-	            BigInteger i = value.unscaledValue();
-	            while (true) {
-	                final BigInteger[] dr = i.divideAndRemainder(BIG_INTEGER_TEN);
-	                if (dr[1].equals(BigInteger.ZERO)) {
-	                    i = dr[0];
-	                    scale--;
-	                    if (scale==0) {
-	                        break;
-	                    }
-	                } else {
-	                    break;
-	                }
-	            }
-	            if (scale != value.scale()) {
-	                value = new BigDecimal(i, scale);
-	            }
-	        }
-	        return value;
-	    }
-	   //End of copy
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
+     */
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target.isAssignableFrom(DecimalValue.class)) {
+            return (T) this;
+        } else if (target == BigDecimal.class) {
+            return (T) value;
+        } else if (target == Double.class || target == double.class) {
+            return (T) Double.valueOf(value.doubleValue());
+        } else if (target == Float.class || target == float.class) {
+            return (T) Float.valueOf(value.floatValue());
+        } else if (target == Long.class || target == long.class) {
+            return (T) Long.valueOf(((IntegerValue) convertTo(Type.LONG)).getValue());
+        } else if (target == Integer.class || target == int.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.INT);
+            return (T) Integer.valueOf((int) v.getValue());
+        } else if (target == Short.class || target == short.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.SHORT);
+            return (T) Short.valueOf((short) v.getValue());
+        } else if (target == Byte.class || target == byte.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
+            return (T) Byte.valueOf((byte) v.getValue());
+        } else if (target == String.class) {
+            return (T) getStringValue();
+        } else if (target == Boolean.class) {
+            return (T) Boolean.valueOf(effectiveBooleanValue());
+        }
+
+        throw new XPathException(
+                "cannot convert value of type "
+                        + Type.getTypeName(getType())
+                        + " to Java object of type "
+                        + target.getName());
+    }
+    //End of copy
 }

--- a/src/org/exist/xquery/value/DoubleValue.java
+++ b/src/org/exist/xquery/value/DoubleValue.java
@@ -34,82 +34,89 @@ public class DoubleValue extends NumericValue {
     // m × 2^e, where m is an integer whose absolute value is less than 2^53,
     // and e is an integer between -1075 and 970, inclusive.
     // In addition also -INF, +INF and NaN.
-	public final static DoubleValue ZERO = new DoubleValue(0.0E0);
-	public final static DoubleValue POSITIVE_INFINITY = new DoubleValue(Double.POSITIVE_INFINITY);
-	public final static DoubleValue NEGATIVE_INFINITY = new DoubleValue(Double.NEGATIVE_INFINITY);
-	public final static DoubleValue NaN = new DoubleValue(Double.NaN);
+    public final static DoubleValue ZERO = new DoubleValue(0.0E0);
+    public final static DoubleValue POSITIVE_INFINITY = new DoubleValue(Double.POSITIVE_INFINITY);
+    public final static DoubleValue NEGATIVE_INFINITY = new DoubleValue(Double.NEGATIVE_INFINITY);
+    public final static DoubleValue NaN = new DoubleValue(Double.NaN);
 
-	private double value;
+    private double value;
 
-	public DoubleValue(double value) {
-		this.value = value;
-	}
+    public DoubleValue(double value) {
+        this.value = value;
+    }
 
-	public DoubleValue(AtomicValue otherValue) throws XPathException {
+    public DoubleValue(AtomicValue otherValue) throws XPathException {
         this(otherValue.getStringValue());
     }
 
     public DoubleValue(String stringValue) throws XPathException {
         try {
-			if ("INF".equals(stringValue))
-				{value = Double.POSITIVE_INFINITY;}
-			else if ("-INF".equals(stringValue))
-				{value = Double.NEGATIVE_INFINITY;}
-			else if ("NaN".equals(stringValue))
-				{value = Double.NaN;}
-			else
-				{value = Double.parseDouble(stringValue);}
-		} catch (final NumberFormatException e) {
-			throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(this.getItemType()) +
-					" from '" + stringValue + "'");
-		}
+            if ("INF".equals(stringValue)) {
+                value = Double.POSITIVE_INFINITY;
+            } else if ("-INF".equals(stringValue)) {
+                value = Double.NEGATIVE_INFINITY;
+            } else if ("NaN".equals(stringValue)) {
+                value = Double.NaN;
+            } else {
+                value = Double.parseDouble(stringValue);
+            }
+        } catch (final NumberFormatException e) {
+            throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(this.getItemType()) +
+                    " from '" + stringValue + "'");
+        }
     }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#getType()
-	 */
-	public int getType() {
-		return Type.DOUBLE;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#getType()
+     */
+    public int getType() {
+        return Type.DOUBLE;
+    }
 
-	public String getStringValue() {
-		final FastStringBuffer sb = new FastStringBuffer(20);
-		//0 is a dummy parameter
-		FloatingPointConverter.appendDouble(sb, value).getNormalizedString(0);	
-		return sb.toString();		
-	}
+    public String getStringValue() {
+        final FastStringBuffer sb = new FastStringBuffer(20);
+        //0 is a dummy parameter
+        FloatingPointConverter.appendDouble(sb, value).getNormalizedString(0);
+        return sb.toString();
+    }
 
-	public double getValue() {
-		return value;
-	}
-	
-	public boolean hasFractionalPart() {
-		if (isNaN())
-			{return false;}
-		if (isInfinite())
-			{return false;}
-		return new DecimalValue(new BigDecimal(value)).hasFractionalPart();
-	}
+    public double getValue() {
+        return value;
+    }
 
-	public Item itemAt(int pos) {
-		return pos == 0 ? this : null;
-	}
+    public void setValue(double val) {
+        value = val;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#isNaN()
-	 */
-	public boolean isNaN() {
-		return Double.isNaN(value);
-	}
+    public boolean hasFractionalPart() {
+        if (isNaN()) {
+            return false;
+        }
+        if (isInfinite()) {
+            return false;
+        }
+        return new DecimalValue(new BigDecimal(value)).hasFractionalPart();
+    }
 
-	public boolean isInfinite() {
-		return Double.isInfinite(value);
-	}
-	
-	public boolean isZero() {
-		return Double.compare(Math.abs(value), 0.0) == Constants.EQUAL;	
-	}
-    
+    public Item itemAt(int pos) {
+        return pos == 0 ? this : null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#isNaN()
+     */
+    public boolean isNaN() {
+        return Double.isNaN(value);
+    }
+
+    public boolean isInfinite() {
+        return Double.isInfinite(value);
+    }
+
+    public boolean isZero() {
+        return Double.compare(Math.abs(value), 0.0) == Constants.EQUAL;
+    }
+
     public boolean isNegative() {
         return (Double.compare(value, 0.0) < Constants.EQUAL);
     }
@@ -118,226 +125,245 @@ public class DoubleValue extends NumericValue {
         return (Double.compare(value, 0.0) > Constants.EQUAL);
     }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#convertTo(int)
-	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.ATOMIC :
-			case Type.ITEM :
-			case Type.NUMBER :
-			case Type.DOUBLE :
-				return this;
-			case Type.FLOAT :
-				//if (Float.compare(value, 0.0f) && (value < Float.MIN_VALUE || value > Float.MAX_VALUE)
-				//	throw new XPathException("Value is out of range for type xs:float");
-				//return new FloatValue((float) value);
-				return new FloatValue((float)value);
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());
-			case Type.STRING :
-				return new StringValue(getStringValue());
-			case Type.DECIMAL :
-				if (isNaN())
-					{throw new XPathException(ErrorCodes.FORG0001, "can not convert "
-                                             + Type.getTypeName(getType())
-                                             + "('"
-                                             + getStringValue()
-                                             + "') to "
-                                             + Type.getTypeName(requiredType));}
-				if (isInfinite())
-					{throw new XPathException(ErrorCodes.FORG0001, "can not convert "
-                                             + Type.getTypeName(getType()) 
-                                             + "('" + getStringValue() 
-                                             + "') to " 
-                                             + Type.getTypeName(requiredType));}
-				return new DecimalValue(new BigDecimal(value));
-			case Type.INTEGER :
-			case Type.NON_POSITIVE_INTEGER :
-			case Type.NEGATIVE_INTEGER :
-			case Type.LONG :
-			case Type.INT :
-			case Type.SHORT :
-			case Type.BYTE :
-			case Type.NON_NEGATIVE_INTEGER :
-			case Type.UNSIGNED_LONG :
-			case Type.UNSIGNED_INT :
-			case Type.UNSIGNED_SHORT :
-			case Type.UNSIGNED_BYTE :
-			case Type.POSITIVE_INTEGER :
-				if (isNaN())
-					{throw new XPathException(ErrorCodes.FORG0001, "can not convert "
-                                             + Type.getTypeName(getType())
-                                             + "('" + getStringValue()
-                                             + "') to "
-                                             + Type.getTypeName(requiredType));}
-				if (Double.isInfinite(value))
-					{throw new XPathException(ErrorCodes.FORG0001, "can not convert "
-                                             + Type.getTypeName(getType())
-                                             + "('"
-                                             + getStringValue()
-                                             + "') to "
-                                             + Type.getTypeName(requiredType));}
-				if (value > Integer.MAX_VALUE)
-					{throw new XPathException(ErrorCodes.FOCA0003, "Value is out of range for type xs:integer");}
-				return new IntegerValue((long) value, requiredType);
-			case Type.BOOLEAN :
-				return new BooleanValue(this.effectiveBooleanValue());				
-			default :
-				throw new XPathException(ErrorCodes.FORG0001, "cannot cast '"
-                                         + Type.getTypeName(this.getItemType())
-                                         + "(\""
-                                         + getStringValue()
-                                         + "\")' to "
-                                         + Type.getTypeName(requiredType));
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#convertTo(int)
+     */
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.ATOMIC:
+            case Type.ITEM:
+            case Type.NUMBER:
+            case Type.DOUBLE:
+                return this;
+            case Type.FLOAT:
+                //if (Float.compare(value, 0.0f) && (value < Float.MIN_VALUE || value > Float.MAX_VALUE)
+                //	throw new XPathException("Value is out of range for type xs:float");
+                //return new FloatValue((float) value);
+                return new FloatValue((float) value);
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            case Type.STRING:
+                return new StringValue(getStringValue());
+            case Type.DECIMAL:
+                if (isNaN()) {
+                    throw new XPathException(ErrorCodes.FORG0001, "can not convert "
+                            + Type.getTypeName(getType())
+                            + "('"
+                            + getStringValue()
+                            + "') to "
+                            + Type.getTypeName(requiredType));
+                }
+                if (isInfinite()) {
+                    throw new XPathException(ErrorCodes.FORG0001, "can not convert "
+                            + Type.getTypeName(getType())
+                            + "('" + getStringValue()
+                            + "') to "
+                            + Type.getTypeName(requiredType));
+                }
+                return new DecimalValue(new BigDecimal(value));
+            case Type.INTEGER:
+            case Type.NON_POSITIVE_INTEGER:
+            case Type.NEGATIVE_INTEGER:
+            case Type.LONG:
+            case Type.INT:
+            case Type.SHORT:
+            case Type.BYTE:
+            case Type.NON_NEGATIVE_INTEGER:
+            case Type.UNSIGNED_LONG:
+            case Type.UNSIGNED_INT:
+            case Type.UNSIGNED_SHORT:
+            case Type.UNSIGNED_BYTE:
+            case Type.POSITIVE_INTEGER:
+                if (isNaN()) {
+                    throw new XPathException(ErrorCodes.FORG0001, "can not convert "
+                            + Type.getTypeName(getType())
+                            + "('" + getStringValue()
+                            + "') to "
+                            + Type.getTypeName(requiredType));
+                }
+                if (Double.isInfinite(value)) {
+                    throw new XPathException(ErrorCodes.FORG0001, "can not convert "
+                            + Type.getTypeName(getType())
+                            + "('"
+                            + getStringValue()
+                            + "') to "
+                            + Type.getTypeName(requiredType));
+                }
+                if (value > Integer.MAX_VALUE) {
+                    throw new XPathException(ErrorCodes.FOCA0003, "Value is out of range for type xs:integer");
+                }
+                return new IntegerValue((long) value, requiredType);
+            case Type.BOOLEAN:
+                return new BooleanValue(this.effectiveBooleanValue());
+            default:
+                throw new XPathException(ErrorCodes.FORG0001, "cannot cast '"
+                        + Type.getTypeName(this.getItemType())
+                        + "(\""
+                        + getStringValue()
+                        + "\")' to "
+                        + Type.getTypeName(requiredType));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#getDouble()
-	 */
-	public double getDouble() throws XPathException {
-		return value;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#getDouble()
+     */
+    public double getDouble() throws XPathException {
+        return value;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#getInt()
-	 */
-	public int getInt() throws XPathException {
-		return (int) Math.round(value);
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#getInt()
+     */
+    public int getInt() throws XPathException {
+        return (int) Math.round(value);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#getLong()
-	 */
-	public long getLong() throws XPathException {
-		return Math.round(value);
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#getLong()
+     */
+    public long getLong() throws XPathException {
+        return Math.round(value);
+    }
 
-	public void setValue(double val) {
-		value = val;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#ceiling()
+     */
+    public NumericValue ceiling() throws XPathException {
+        return new DoubleValue(Math.ceil(value));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#ceiling()
-	 */
-	public NumericValue ceiling() throws XPathException {
-		return new DoubleValue(Math.ceil(value));
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#floor()
+     */
+    public NumericValue floor() throws XPathException {
+        return new DoubleValue(Math.floor(value));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#floor()
-	 */
-	public NumericValue floor() throws XPathException {
-		return new DoubleValue(Math.floor(value));
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#round()
+     */
+    public NumericValue round() throws XPathException {
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#round()
-	 */
-	public NumericValue round() throws XPathException {
+        if (Double.isNaN(value) || Double.isInfinite(value) || value == 0.0) {
+            return this;
+        }
 
-        if (Double.isNaN(value) || Double.isInfinite(value) || value == 0.0) {return this;}
+        if (value >= -0.5 && value < 0.0) {
+            return new DoubleValue(-0.0);
+        }
 
-        if (value >= -0.5 && value < 0.0) {return new DoubleValue(-0.0);}
-
-        if (value > Long.MIN_VALUE && value < Long.MAX_VALUE)
-            {return new DoubleValue(Math.round(value));}
+        if (value > Long.MIN_VALUE && value < Long.MAX_VALUE) {
+            return new DoubleValue(Math.round(value));
+        }
 
         //too big return original value unchanged
         return this;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#round(org.exist.xquery.value.IntegerValue)
-	 */
-	public NumericValue round(IntegerValue precision) throws XPathException {
-		if (precision == null) {return round();}
-		
-        if (Double.isNaN(value) || Double.isInfinite(value) || value == 0.0) {return this;}
-		
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#round(org.exist.xquery.value.IntegerValue)
+     */
+    public NumericValue round(IntegerValue precision) throws XPathException {
+        if (precision == null) {
+            return round();
+        }
+
+        if (Double.isNaN(value) || Double.isInfinite(value) || value == 0.0) {
+            return this;
+        }
+
 		/* use the decimal rounding method */
-		return (DoubleValue) ((DecimalValue) convertTo(Type.DECIMAL)).round(precision).convertTo(Type.DOUBLE);
-	}
-	
+        return (DoubleValue) ((DecimalValue) convertTo(Type.DECIMAL)).round(precision).convertTo(Type.DOUBLE);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#minus(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue minus(ComputableValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.DOUBLE))
-			{return new DoubleValue(value - ((DoubleValue) other).value);}
-		else
-			{return minus((ComputableValue) other.convertTo(getType()));}
-	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#plus(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue plus(ComputableValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.DOUBLE))
-			{return new DoubleValue(value + ((DoubleValue) other).value);}
-		else
-			{return plus((ComputableValue) other.convertTo(getType()));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#minus(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue minus(ComputableValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.DOUBLE)) {
+            return new DoubleValue(value - ((DoubleValue) other).value);
+        } else {
+            return minus((ComputableValue) other.convertTo(getType()));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#mult(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue mult(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-			case Type.DOUBLE:
-				return new DoubleValue(value * ((DoubleValue) other).value);
-			case Type.DAY_TIME_DURATION:
-			case Type.YEAR_MONTH_DURATION:
-				return other.mult(this);
-			default:
-				return mult((ComputableValue) other.convertTo(getType()));
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#plus(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue plus(ComputableValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.DOUBLE)) {
+            return new DoubleValue(value + ((DoubleValue) other).value);
+        } else {
+            return plus((ComputableValue) other.convertTo(getType()));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#div(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue div(ComputableValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
-			//Positive or negative zero divided by positive or negative zero returns NaN.
-			if (this.isZero() && ((NumericValue)other).isZero())
-				{return NaN;}
-            
-			//A negative number divided by positive zero returns -INF.
-			if (this.isNegative()  && 
-                    ((NumericValue)other).isZero() && ((NumericValue)other).isPositive())
-				{return NEGATIVE_INFINITY;}
-            
-			//A negative number divided by positive zero returns -INF.
-			if (this.isNegative()  && 
-                    ((NumericValue)other).isZero() && ((NumericValue)other).isNegative())
-				{return POSITIVE_INFINITY;}        
-            
-			//Division of Positive by negative zero returns -INF and INF, respectively. 
-			if (this.isPositive()  && 
-                    ((NumericValue)other).isZero() && ((NumericValue)other).isNegative())
-				{return NEGATIVE_INFINITY;}
-            
-			if (this.isPositive()  &&
-                    ((NumericValue)other).isZero() && ((NumericValue)other).isPositive())
-				{return POSITIVE_INFINITY;}
-            
-			//Also, INF or -INF divided by INF or -INF returns NaN.
-			if (this.isInfinite() && ((NumericValue)other).isInfinite())
-				{return NaN;}
-		}		
-        
-		if (Type.subTypeOf(other.getType(), Type.DOUBLE))
-			{return new DoubleValue(value / ((DoubleValue) other).value);}
-		else
-			{return div((ComputableValue) other.convertTo(getType()));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#mult(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue mult(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.DOUBLE:
+                return new DoubleValue(value * ((DoubleValue) other).value);
+            case Type.DAY_TIME_DURATION:
+            case Type.YEAR_MONTH_DURATION:
+                return other.mult(this);
+            default:
+                return mult((ComputableValue) other.convertTo(getType()));
+        }
+    }
 
-	public IntegerValue idiv(NumericValue other) throws XPathException {
-		final ComputableValue result = div(other);
-		return new IntegerValue(((IntegerValue)result.convertTo(Type.INTEGER)).getLong());		
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#div(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue div(ComputableValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+            //Positive or negative zero divided by positive or negative zero returns NaN.
+            if (this.isZero() && ((NumericValue) other).isZero()) {
+                return NaN;
+            }
+
+            //A negative number divided by positive zero returns -INF.
+            if (this.isNegative() &&
+                    ((NumericValue) other).isZero() && ((NumericValue) other).isPositive()) {
+                return NEGATIVE_INFINITY;
+            }
+
+            //A negative number divided by positive zero returns -INF.
+            if (this.isNegative() &&
+                    ((NumericValue) other).isZero() && ((NumericValue) other).isNegative()) {
+                return POSITIVE_INFINITY;
+            }
+
+            //Division of Positive by negative zero returns -INF and INF, respectively.
+            if (this.isPositive() &&
+                    ((NumericValue) other).isZero() && ((NumericValue) other).isNegative()) {
+                return NEGATIVE_INFINITY;
+            }
+
+            if (this.isPositive() &&
+                    ((NumericValue) other).isZero() && ((NumericValue) other).isPositive()) {
+                return POSITIVE_INFINITY;
+            }
+
+            //Also, INF or -INF divided by INF or -INF returns NaN.
+            if (this.isInfinite() && ((NumericValue) other).isInfinite()) {
+                return NaN;
+            }
+        }
+
+        if (Type.subTypeOf(other.getType(), Type.DOUBLE)) {
+            return new DoubleValue(value / ((DoubleValue) other).value);
+        } else {
+            return div((ComputableValue) other.convertTo(getType()));
+        }
+    }
+
+    public IntegerValue idiv(NumericValue other) throws XPathException {
+        final ComputableValue result = div(other);
+        return new IntegerValue(((IntegerValue) result.convertTo(Type.INTEGER)).getLong());
 		/*
 		if (Type.subTypeOf(other.getType(), Type.DOUBLE)) {
 			double result = value / ((DoubleValue) other).value;
@@ -347,127 +373,144 @@ public class DoubleValue extends NumericValue {
 		}
 		throw new XPathException("idiv called with incompatible argument type: " + getType() + " vs " + other.getType());
 		*/
-	}
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#mod(org.exist.xquery.value.NumericValue)
-	 */
-	public NumericValue mod(NumericValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.DOUBLE))
-			{return new DoubleValue(value % ((DoubleValue) other).value);}
-		else
-			{return mod((NumericValue) other.convertTo(getType()));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#mod(org.exist.xquery.value.NumericValue)
+     */
+    public NumericValue mod(NumericValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.DOUBLE)) {
+            return new DoubleValue(value % ((DoubleValue) other).value);
+        } else {
+            return mod((NumericValue) other.convertTo(getType()));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#negate()
-	 */
-	public NumericValue negate() throws XPathException {
-		return new DoubleValue(-value);
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#negate()
+     */
+    public NumericValue negate() throws XPathException {
+        return new DoubleValue(-value);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#abs()
-	 */
-	public NumericValue abs() throws XPathException {
-		return new DoubleValue(Math.abs(value));
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#abs()
+     */
+    public NumericValue abs() throws XPathException {
+        return new DoubleValue(Math.abs(value));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#max(org.exist.xquery.value.AtomicValue)
-	 */
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.DOUBLE))
-			{return new DoubleValue(Math.max(value, ((DoubleValue) other).value));}
-		else
-			{return new DoubleValue(
-				Math.max(value, ((DoubleValue) other.convertTo(Type.DOUBLE)).value));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#max(org.exist.xquery.value.AtomicValue)
+     */
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.DOUBLE)) {
+            return new DoubleValue(Math.max(value, ((DoubleValue) other).value));
+        } else {
+            return new DoubleValue(
+                    Math.max(value, ((DoubleValue) other.convertTo(Type.DOUBLE)).value));
+        }
+    }
 
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.DOUBLE))
-			{return new DoubleValue(Math.min(value, ((DoubleValue) other).value));}
-		else
-			{return new DoubleValue(
-				Math.min(value, ((DoubleValue) other.convertTo(Type.DOUBLE)).value));}
-	}
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.DOUBLE)) {
+            return new DoubleValue(Math.min(value, ((DoubleValue) other).value));
+        } else {
+            return new DoubleValue(
+                    Math.min(value, ((DoubleValue) other.convertTo(Type.DOUBLE)).value));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
-	 */
-	public int conversionPreference(Class<?> javaClass) {
-		if (javaClass.isAssignableFrom(DoubleValue.class))
-			{return 0;}
-		if (javaClass == Long.class || javaClass == long.class)
-			{return 3;}
-		if (javaClass == Integer.class || javaClass == int.class)
-			{return 4;}
-		if (javaClass == Short.class || javaClass == short.class)
-			{return 5;}
-		if (javaClass == Byte.class || javaClass == byte.class)
-			{return 6;}
-		if (javaClass == Double.class || javaClass == double.class)
-			{return 1;}
-		if (javaClass == Float.class || javaClass == float.class)
-			{return 2;}
-		if (javaClass == String.class)
-			{return 7;}
-		if (javaClass == Boolean.class || javaClass == boolean.class)
-			{return 8;}
-		if (javaClass == Object.class)
-			{return 20;}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
+     */
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(DoubleValue.class)) {
+            return 0;
+        }
+        if (javaClass == Long.class || javaClass == long.class) {
+            return 3;
+        }
+        if (javaClass == Integer.class || javaClass == int.class) {
+            return 4;
+        }
+        if (javaClass == Short.class || javaClass == short.class) {
+            return 5;
+        }
+        if (javaClass == Byte.class || javaClass == byte.class) {
+            return 6;
+        }
+        if (javaClass == Double.class || javaClass == double.class) {
+            return 1;
+        }
+        if (javaClass == Float.class || javaClass == float.class) {
+            return 2;
+        }
+        if (javaClass == String.class) {
+            return 7;
+        }
+        if (javaClass == Boolean.class || javaClass == boolean.class) {
+            return 8;
+        }
+        if (javaClass == Object.class) {
+            return 20;
+        }
 
-		return Integer.MAX_VALUE;
-	}
+        return Integer.MAX_VALUE;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
-	 */
-	@SuppressWarnings("unchecked")
-	public <T> T toJavaObject(final Class<T> target) throws XPathException {
-		if (target.isAssignableFrom(DoubleValue.class)) {
-			return (T)this;
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target.isAssignableFrom(DoubleValue.class)) {
+            return (T) this;
         } else if (target == Double.class || target == double.class) {
-        	return (T)Double.valueOf(value);
+            return (T) Double.valueOf(value);
         } else if (target == Float.class || target == float.class) {
-			return (T)new Float(value);
+            return (T) new Float(value);
         } else if (target == Long.class || target == long.class) {
-			return (T)Long.valueOf( ((IntegerValue) convertTo(Type.LONG)).getValue() );
-		} else if (target == Integer.class || target == int.class) {
-			final IntegerValue v = (IntegerValue) convertTo(Type.INT);
-			return (T)Integer.valueOf((int) v.getValue());
-		} else if (target == Short.class || target == short.class) {
-			final IntegerValue v = (IntegerValue) convertTo(Type.SHORT);
-			return (T)Short.valueOf((short) v.getValue());
-		} else if (target == Byte.class || target == byte.class) {
-			final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
-			return (T)Byte.valueOf((byte) v.getValue());
-		} else if (target == String.class)
-			{return (T)getStringValue();}
-		else if (target == Boolean.class)
-			{return (T)Boolean.valueOf(effectiveBooleanValue());}
+            return (T) Long.valueOf(((IntegerValue) convertTo(Type.LONG)).getValue());
+        } else if (target == Integer.class || target == int.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.INT);
+            return (T) Integer.valueOf((int) v.getValue());
+        } else if (target == Short.class || target == short.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.SHORT);
+            return (T) Short.valueOf((short) v.getValue());
+        } else if (target == Byte.class || target == byte.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
+            return (T) Byte.valueOf((byte) v.getValue());
+        } else if (target == String.class) {
+            return (T) getStringValue();
+        } else if (target == Boolean.class) {
+            return (T) Boolean.valueOf(effectiveBooleanValue());
+        }
 
-		throw new XPathException(
-			"cannot convert value of type "
-				+ Type.getTypeName(getType())
-				+ " to Java object of type "
-				+ target.getName());
-	}
+        throw new XPathException(
+                "cannot convert value of type "
+                        + Type.getTypeName(getType())
+                        + " to Java object of type "
+                        + target.getName());
+    }
 
-    /** size writen by {link #serialize(short, boolean)} */
-	public int getSerializedSize() {
-		return 1 + 8;
-	}
-	
+    /**
+     * size writen by {link #serialize(short, boolean)}
+     */
+    public int getSerializedSize() {
+        return 1 + 8;
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     public int compareTo(Object o) {
-        final AtomicValue other = (AtomicValue)o;
-        if(Type.subTypeOf(other.getType(), Type.DOUBLE))
-            {return Double.compare(value, ((DoubleValue)other).value);}
-        else
-            {return getType() < other.getType() ? Constants.INFERIOR : Constants.SUPERIOR;}
+        final AtomicValue other = (AtomicValue) o;
+        if (Type.subTypeOf(other.getType(), Type.DOUBLE)) {
+            return Double.compare(value, ((DoubleValue) other).value);
+        } else {
+            return getType() < other.getType() ? Constants.INFERIOR : Constants.SUPERIOR;
+        }
     }
 
     @Override

--- a/src/org/exist/xquery/value/DoubleValue.java
+++ b/src/org/exist/xquery/value/DoubleValue.java
@@ -21,14 +21,14 @@
  */
 package org.exist.xquery.value;
 
-import java.math.BigDecimal;
-import java.text.Collator;
-
 import org.exist.util.FastStringBuffer;
 import org.exist.util.FloatingPointConverter;
 import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import java.math.BigDecimal;
+import java.text.Collator;
 
 public class DoubleValue extends NumericValue {
     // m × 2^e, where m is an integer whose absolute value is less than 2^53,

--- a/src/org/exist/xquery/value/DoubleValue.java
+++ b/src/org/exist/xquery/value/DoubleValue.java
@@ -211,7 +211,7 @@ public class DoubleValue extends NumericValue {
 	 * @see org.exist.xquery.value.NumericValue#getLong()
 	 */
 	public long getLong() throws XPathException {
-		return (long) Math.round(value);
+		return Math.round(value);
 	}
 
 	public void setValue(double val) {

--- a/src/org/exist/xquery/value/DurationValue.java
+++ b/src/org/exist/xquery/value/DurationValue.java
@@ -332,7 +332,7 @@ public class DurationValue extends ComputableValue {
             case LTEQ:
             case GT:
             case GTEQ:
-                throw new XPathException(ErrorCodes.XPTY0004, "" + Type.getTypeName(other.getType()) + " type can not be ordered");
+                throw new XPathException(ErrorCodes.XPTY0004, Type.getTypeName(other.getType()) + " type can not be ordered");
             default:
                 throw new IllegalArgumentException("Unknown comparison operator");
         }

--- a/src/org/exist/xquery/value/DurationValue.java
+++ b/src/org/exist/xquery/value/DurationValue.java
@@ -23,17 +23,16 @@
 
 package org.exist.xquery.value;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.text.Collator;
-
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.Duration;
-
 import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.Duration;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.Collator;
 
 /**
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>

--- a/src/org/exist/xquery/value/EmptySequence.java
+++ b/src/org/exist/xquery/value/EmptySequence.java
@@ -25,67 +25,67 @@ import org.exist.xquery.XPathException;
 
 public class EmptySequence extends AbstractSequence {
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getItemType()
-	 */
-	public int getItemType() {
-		return Type.EMPTY;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getItemType()
+     */
+    public int getItemType() {
+        return Type.EMPTY;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#iterate()
-	 */
-	public SequenceIterator iterate() throws XPathException {
-		return EmptySequenceIterator.EMPTY_ITERATOR;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#unorderedIterator()
-	 */
-	public SequenceIterator unorderedIterator() throws XPathException {
-		return EmptySequenceIterator.EMPTY_ITERATOR;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getItemCount()
-	 */
-	public int getItemCount() {
-		return 0;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#iterate()
+     */
+    public SequenceIterator iterate() throws XPathException {
+        return EmptySequenceIterator.EMPTY_ITERATOR;
+    }
 
-	public Item itemAt(int pos) {
-		return null;
-	}
-	
-	public boolean isEmpty() {
-		return true;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#unorderedIterator()
+     */
+    public SequenceIterator unorderedIterator() throws XPathException {
+        return EmptySequenceIterator.EMPTY_ITERATOR;
+    }
 
-	public boolean hasOne() {
-		return false;
-	}
-	
-	public void add(Item item) throws XPathException {
-		throw new XPathException("cannot add an item to an empty sequence");
-	}
-	
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch(requiredType) {
-			case Type.BOOLEAN:
-				return new BooleanValue(false);
-			case Type.STRING:
-				return new StringValue("");
-			default:
-				throw new XPathException("cannot convert empty sequence to " + requiredType);
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getItemCount()
+     */
+    public int getItemCount() {
+        return 0;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#toNodeSet()
-	 */
-	public NodeSet toNodeSet() throws XPathException {
-		return NodeSet.EMPTY_SET;
-	}
+    public Item itemAt(int pos) {
+        return null;
+    }
+
+    public boolean isEmpty() {
+        return true;
+    }
+
+    public boolean hasOne() {
+        return false;
+    }
+
+    public void add(Item item) throws XPathException {
+        throw new XPathException("cannot add an item to an empty sequence");
+    }
+
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.BOOLEAN:
+                return new BooleanValue(false);
+            case Type.STRING:
+                return new StringValue("");
+            default:
+                throw new XPathException("cannot convert empty sequence to " + requiredType);
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#toNodeSet()
+     */
+    public NodeSet toNodeSet() throws XPathException {
+        return NodeSet.EMPTY_SET;
+    }
 
     public MemoryNodeSet toMemNodeSet() throws XPathException {
         return MemoryNodeSet.EMPTY;
@@ -97,8 +97,8 @@ public class EmptySequence extends AbstractSequence {
     public void removeDuplicates() {
         // nothing to do
     }
-    
+
     public String toString() {
-    	return "()";
+        return "()";
     }
 }

--- a/src/org/exist/xquery/value/EmptySequenceIterator.java
+++ b/src/org/exist/xquery/value/EmptySequenceIterator.java
@@ -22,18 +22,18 @@ package org.exist.xquery.value;
 
 public class EmptySequenceIterator implements SequenceIterator {
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.SequenceIterator#hasNext()
-	 */
-	public boolean hasNext() {
-		return false;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.SequenceIterator#hasNext()
+     */
+    public boolean hasNext() {
+        return false;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.SequenceIterator#nextItem()
-	 */
-	public Item nextItem() {
-		return null;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.SequenceIterator#nextItem()
+     */
+    public Item nextItem() {
+        return null;
+    }
 
 }

--- a/src/org/exist/xquery/value/FloatValue.java
+++ b/src/org/exist/xquery/value/FloatValue.java
@@ -21,14 +21,14 @@
  */
 package org.exist.xquery.value;
 
-import java.math.BigDecimal;
-import java.text.Collator;
-
 import org.exist.util.FastStringBuffer;
 import org.exist.util.FloatingPointConverter;
 import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import java.math.BigDecimal;
+import java.text.Collator;
 
 /**
  * @author wolf

--- a/src/org/exist/xquery/value/FloatValue.java
+++ b/src/org/exist/xquery/value/FloatValue.java
@@ -37,57 +37,58 @@ public class FloatValue extends NumericValue {
     // m × 2^e, where m is an integer whose absolute value is less than 2^24, 
     // and e is an integer between -149 and 104, inclusive.
     // In addition also -INF, +INF and NaN.
-	public final static FloatValue NaN = new FloatValue(Float.NaN);
-	public final static FloatValue POSITIVE_INFINITY = new FloatValue(Float.POSITIVE_INFINITY);
-	public final static FloatValue NEGATIVE_INFINITY = new FloatValue(Float.NEGATIVE_INFINITY);
-	public final static FloatValue ZERO = new FloatValue(0.0E0f);
+    public final static FloatValue NaN = new FloatValue(Float.NaN);
+    public final static FloatValue POSITIVE_INFINITY = new FloatValue(Float.POSITIVE_INFINITY);
+    public final static FloatValue NEGATIVE_INFINITY = new FloatValue(Float.NEGATIVE_INFINITY);
+    public final static FloatValue ZERO = new FloatValue(0.0E0f);
 
-	protected float value;
+    protected float value;
 
-	public FloatValue(float value) {
-		this.value = value;
-	}
-	
-	public FloatValue(String stringValue) throws XPathException {
-		try {
-			if ("INF".equals(stringValue))
-				{value = Float.POSITIVE_INFINITY;}
-			else if ("-INF".equals(stringValue))
-				{value = Float.NEGATIVE_INFINITY;}
-            else if ("NaN".equals(stringValue))
-                {value = Float.NaN;}
-			else
-				{value = Float.parseFloat(stringValue);}
-		} catch (final NumberFormatException e) {
-			throw new XPathException(ErrorCodes.FORG0001, "cannot construct " 
-                                     + Type.getTypeName(this.getItemType())
-                                     + " from \""
-                                     + getStringValue()
-                                     + "\"");					
-		}
-	}
-	
-	public float getValue() {
-		return value;
-	}	
-	
+    public FloatValue(float value) {
+        this.value = value;
+    }
+
+    public FloatValue(String stringValue) throws XPathException {
+        try {
+            if ("INF".equals(stringValue)) {
+                value = Float.POSITIVE_INFINITY;
+            } else if ("-INF".equals(stringValue)) {
+                value = Float.NEGATIVE_INFINITY;
+            } else if ("NaN".equals(stringValue)) {
+                value = Float.NaN;
+            } else {
+                value = Float.parseFloat(stringValue);
+            }
+        } catch (final NumberFormatException e) {
+            throw new XPathException(ErrorCodes.FORG0001, "cannot construct "
+                    + Type.getTypeName(this.getItemType())
+                    + " from \""
+                    + getStringValue()
+                    + "\"");
+        }
+    }
+
+    public float getValue() {
+        return value;
+    }
+
 	/*
 	public float getFloat() throws XPathException  {
 		return value;
 	}
 	*/
 
-	/* (non-Javadoc)
+    /* (non-Javadoc)
      * @see org.exist.xquery.value.AtomicValue#getType()
      */
     public int getType() {
         return Type.FLOAT;
     }
-    
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getStringValue()
-	 */
-	public String getStringValue() throws XPathException {
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getStringValue()
+     */
+    public String getStringValue() throws XPathException {
 		/*
 		if (value == Float.POSITIVE_INFINITY)
 			return "INF"; 
@@ -96,29 +97,29 @@ public class FloatValue extends NumericValue {
 		String s = String.valueOf(value);
 		s = s.replaceAll("\\.0+$", "");
 		return s;	
-		*/		
-		
-		final FastStringBuffer sb = new FastStringBuffer(20);
-		//0 is a dummy parameter
-		FloatingPointConverter.appendFloat(sb, value).getNormalizedString(0);	
-		return sb.toString();
-	}
+		*/
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#isNaN()
-	 */
-	public boolean isNaN() {
-		return Float.isNaN(value);
-	}
-	
-	public boolean isInfinite() {
-		return Float.isInfinite(value);
-	}
+        final FastStringBuffer sb = new FastStringBuffer(20);
+        //0 is a dummy parameter
+        FloatingPointConverter.appendFloat(sb, value).getNormalizedString(0);
+        return sb.toString();
+    }
 
-	public boolean isZero() {
-		return Float.compare(value, 0f) == Constants.EQUAL;	
-	}
-    
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#isNaN()
+     */
+    public boolean isNaN() {
+        return Float.isNaN(value);
+    }
+
+    public boolean isInfinite() {
+        return Float.isInfinite(value);
+    }
+
+    public boolean isZero() {
+        return Float.compare(value, 0f) == Constants.EQUAL;
+    }
+
     public boolean isNegative() {
         return (Float.compare(value, 0f) < Constants.EQUAL);
     }
@@ -127,191 +128,212 @@ public class FloatValue extends NumericValue {
         return (Float.compare(value, 0f) > Constants.EQUAL);
     }
 
-	public boolean hasFractionalPart() {
-		if (isNaN())
-			{return false;}
-		if (isInfinite())
-			{return false;}
-		return new DecimalValue(new BigDecimal(value)).hasFractionalPart();
-	}
+    public boolean hasFractionalPart() {
+        if (isNaN()) {
+            return false;
+        }
+        if (isInfinite()) {
+            return false;
+        }
+        return new DecimalValue(new BigDecimal(value)).hasFractionalPart();
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#convertTo(int)
-	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.ATOMIC :
-			case Type.ITEM :
-			case Type.NUMBER :
-			case Type.FLOAT :
-				return this;
-			case Type.DOUBLE :
-				return new DoubleValue(value);
-			case Type.STRING :
-				return new StringValue(getStringValue());
-			case Type.DECIMAL :
-				return new DecimalValue(value);
-			case Type.INTEGER :
-			case Type.NON_POSITIVE_INTEGER :
-			case Type.NEGATIVE_INTEGER :
-			case Type.LONG :
-			case Type.INT :
-			case Type.SHORT :
-			case Type.BYTE :
-			case Type.NON_NEGATIVE_INTEGER :
-			case Type.UNSIGNED_LONG :
-			case Type.UNSIGNED_INT :
-			case Type.UNSIGNED_SHORT :
-			case Type.UNSIGNED_BYTE :
-			case Type.POSITIVE_INTEGER :
-				if (!(Float.isInfinite(value) || Float.isNaN(value)))
-					{return new IntegerValue((long) value, requiredType);}
-				else
-					{throw new XPathException(ErrorCodes.FOCA0002, "cannot convert ' xs:float(\""
-                                             + getStringValue()
-                                             + "\")' to "
-                                             + Type.getTypeName(requiredType));}
-			case Type.BOOLEAN :
-				return (value == 0.0f || Float.isNaN(value))
-					? BooleanValue.FALSE
-					: BooleanValue.TRUE;
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());
-			default :
-				throw new XPathException(ErrorCodes.FORG0001, "cannot cast '"
-                                         + Type.getTypeName(this.getItemType())
-                                         + "(\""
-                                         + getStringValue()
-                                         + "\")' to "
-                                         + Type.getTypeName(requiredType));
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#convertTo(int)
+     */
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.ATOMIC:
+            case Type.ITEM:
+            case Type.NUMBER:
+            case Type.FLOAT:
+                return this;
+            case Type.DOUBLE:
+                return new DoubleValue(value);
+            case Type.STRING:
+                return new StringValue(getStringValue());
+            case Type.DECIMAL:
+                return new DecimalValue(value);
+            case Type.INTEGER:
+            case Type.NON_POSITIVE_INTEGER:
+            case Type.NEGATIVE_INTEGER:
+            case Type.LONG:
+            case Type.INT:
+            case Type.SHORT:
+            case Type.BYTE:
+            case Type.NON_NEGATIVE_INTEGER:
+            case Type.UNSIGNED_LONG:
+            case Type.UNSIGNED_INT:
+            case Type.UNSIGNED_SHORT:
+            case Type.UNSIGNED_BYTE:
+            case Type.POSITIVE_INTEGER:
+                if (!(Float.isInfinite(value) || Float.isNaN(value))) {
+                    return new IntegerValue((long) value, requiredType);
+                } else {
+                    throw new XPathException(ErrorCodes.FOCA0002, "cannot convert ' xs:float(\""
+                            + getStringValue()
+                            + "\")' to "
+                            + Type.getTypeName(requiredType));
+                }
+            case Type.BOOLEAN:
+                return (value == 0.0f || Float.isNaN(value))
+                        ? BooleanValue.FALSE
+                        : BooleanValue.TRUE;
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            default:
+                throw new XPathException(ErrorCodes.FORG0001, "cannot cast '"
+                        + Type.getTypeName(this.getItemType())
+                        + "(\""
+                        + getStringValue()
+                        + "\")' to "
+                        + Type.getTypeName(requiredType));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#negate()
-	 */
-	public NumericValue negate() throws XPathException {
-		return new FloatValue(-value);
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#negate()
+     */
+    public NumericValue negate() throws XPathException {
+        return new FloatValue(-value);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#ceiling()
-	 */
-	public NumericValue ceiling() throws XPathException {
-		return new FloatValue((float) Math.ceil(value));
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#ceiling()
+     */
+    public NumericValue ceiling() throws XPathException {
+        return new FloatValue((float) Math.ceil(value));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#floor()
-	 */
-	public NumericValue floor() throws XPathException {
-		return new FloatValue((float) Math.floor(value));
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#floor()
+     */
+    public NumericValue floor() throws XPathException {
+        return new FloatValue((float) Math.floor(value));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#round()
-	 */
-	public NumericValue round() throws XPathException {
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#round()
+     */
+    public NumericValue round() throws XPathException {
 
-		if (Float.isNaN(value) || Float.isInfinite(value) || value==0.0) {return this;}
+        if (Float.isNaN(value) || Float.isInfinite(value) || value == 0.0) {
+            return this;
+        }
 
-        if (value >= -0.5 && value < 0.0) {return new DoubleValue(-0.0);}
-        
-        if (value > Integer.MIN_VALUE && value < Integer.MAX_VALUE)
-            {return new FloatValue((float)Math.round(value));}
+        if (value >= -0.5 && value < 0.0) {
+            return new DoubleValue(-0.0);
+        }
+
+        if (value > Integer.MIN_VALUE && value < Integer.MAX_VALUE) {
+            return new FloatValue((float) Math.round(value));
+        }
 
         //too big return original value unchanged
         return this;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#round(org.exist.xquery.value.IntegerValue)
-	 */
-	public NumericValue round(IntegerValue precision) throws XPathException {
-		if (precision == null) {return round();}
+    }
 
-		if (Float.isNaN(value) || Float.isInfinite(value) || value==0.0) {return this;}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#round(org.exist.xquery.value.IntegerValue)
+     */
+    public NumericValue round(IntegerValue precision) throws XPathException {
+        if (precision == null) {
+            return round();
+        }
+
+        if (Float.isNaN(value) || Float.isInfinite(value) || value == 0.0) {
+            return this;
+        }
 		
 		/* use the decimal rounding method */
-		return (FloatValue) ((DecimalValue) convertTo(Type.DECIMAL)).round(precision).convertTo(Type.FLOAT);
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#minus(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue minus(ComputableValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.FLOAT))
-			{return new FloatValue(value - ((FloatValue) other).value);}
-		else
-			{return minus((ComputableValue) other.convertTo(getType()));}
-	}
+        return (FloatValue) ((DecimalValue) convertTo(Type.DECIMAL)).round(precision).convertTo(Type.FLOAT);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#plus(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue plus(ComputableValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.FLOAT))
-			{return new FloatValue(value + ((FloatValue) other).value);}
-		else
-			{return plus((ComputableValue) other.convertTo(getType()));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#minus(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue minus(ComputableValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.FLOAT)) {
+            return new FloatValue(value - ((FloatValue) other).value);
+        } else {
+            return minus((ComputableValue) other.convertTo(getType()));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#mult(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue mult(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-			case Type.FLOAT:
-				return new FloatValue(value * ((FloatValue) other).value);
-			case Type.DAY_TIME_DURATION:
-			case Type.YEAR_MONTH_DURATION:
-				return other.mult(this);
-			default:
-				return mult((ComputableValue) other.convertTo(getType()));
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#plus(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue plus(ComputableValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.FLOAT)) {
+            return new FloatValue(value + ((FloatValue) other).value);
+        } else {
+            return plus((ComputableValue) other.convertTo(getType()));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#div(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue div(ComputableValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
-			//Positive or negative zero divided by positive or negative zero returns NaN.
-			if (this.isZero() && ((NumericValue)other).isZero())
-				{return NaN;}
-            
-			//A negative number divided by positive zero returns -INF.
-			if (this.isNegative()  && 
-                    ((NumericValue)other).isZero() && ((NumericValue)other).isPositive())
-				{return NEGATIVE_INFINITY;}
-            
-			//A negative number divided by positive zero returns -INF.
-			if (this.isNegative()  && 
-                    ((NumericValue)other).isZero() && ((NumericValue)other).isNegative())
-				{return POSITIVE_INFINITY;}        
-            
-			//Division of Positive by negative zero returns -INF and INF, respectively. 
-			if (this.isPositive()  && 
-                    ((NumericValue)other).isZero() && ((NumericValue)other).isNegative())
-				{return NEGATIVE_INFINITY;}
-            
-			if (this.isPositive()  &&
-                    ((NumericValue)other).isZero() && ((NumericValue)other).isPositive())
-				{return POSITIVE_INFINITY;}
-            
-			//Also, INF or -INF divided by INF or -INF returns NaN.
-			if (this.isInfinite() && ((NumericValue)other).isInfinite())
-				{return NaN;}
-		}
-		if (Type.subTypeOf(other.getType(), Type.FLOAT))
-			{return new FloatValue(value / ((FloatValue) other).value);}
-		else
-			{return div((ComputableValue) other.convertTo(getType()));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#mult(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue mult(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.FLOAT:
+                return new FloatValue(value * ((FloatValue) other).value);
+            case Type.DAY_TIME_DURATION:
+            case Type.YEAR_MONTH_DURATION:
+                return other.mult(this);
+            default:
+                return mult((ComputableValue) other.convertTo(getType()));
+        }
+    }
 
-	public IntegerValue idiv(NumericValue other) throws XPathException {
-		final ComputableValue result = div(other);
-		return new IntegerValue(((IntegerValue)result.convertTo(Type.INTEGER)).getLong());		
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#div(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue div(ComputableValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+            //Positive or negative zero divided by positive or negative zero returns NaN.
+            if (this.isZero() && ((NumericValue) other).isZero()) {
+                return NaN;
+            }
+
+            //A negative number divided by positive zero returns -INF.
+            if (this.isNegative() &&
+                    ((NumericValue) other).isZero() && ((NumericValue) other).isPositive()) {
+                return NEGATIVE_INFINITY;
+            }
+
+            //A negative number divided by positive zero returns -INF.
+            if (this.isNegative() &&
+                    ((NumericValue) other).isZero() && ((NumericValue) other).isNegative()) {
+                return POSITIVE_INFINITY;
+            }
+
+            //Division of Positive by negative zero returns -INF and INF, respectively.
+            if (this.isPositive() &&
+                    ((NumericValue) other).isZero() && ((NumericValue) other).isNegative()) {
+                return NEGATIVE_INFINITY;
+            }
+
+            if (this.isPositive() &&
+                    ((NumericValue) other).isZero() && ((NumericValue) other).isPositive()) {
+                return POSITIVE_INFINITY;
+            }
+
+            //Also, INF or -INF divided by INF or -INF returns NaN.
+            if (this.isInfinite() && ((NumericValue) other).isInfinite()) {
+                return NaN;
+            }
+        }
+        if (Type.subTypeOf(other.getType(), Type.FLOAT)) {
+            return new FloatValue(value / ((FloatValue) other).value);
+        } else {
+            return div((ComputableValue) other.convertTo(getType()));
+        }
+    }
+
+    public IntegerValue idiv(NumericValue other) throws XPathException {
+        final ComputableValue result = div(other);
+        return new IntegerValue(((IntegerValue) result.convertTo(Type.INTEGER)).getLong());
 		/*
 		if (Type.subTypeOf(other.getType(), Type.FLOAT)) {
 			float result = value / ((FloatValue) other).value;
@@ -321,113 +343,128 @@ public class FloatValue extends NumericValue {
 		}
 		throw new XPathException("idiv called with incompatible argument type: " + getType() + " vs " + other.getType());
 		*/
-	}
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#mod(org.exist.xquery.value.NumericValue)
-	 */
-	public NumericValue mod(NumericValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.FLOAT))
-			{return new FloatValue(value % ((FloatValue) other).value);}
-		else
-			{return mod((NumericValue) other.convertTo(getType()));}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#mod(org.exist.xquery.value.NumericValue)
+     */
+    public NumericValue mod(NumericValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.FLOAT)) {
+            return new FloatValue(value % ((FloatValue) other).value);
+        } else {
+            return mod((NumericValue) other.convertTo(getType()));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#abs()
-	 */
-	public NumericValue abs() throws XPathException {
-		return new FloatValue(Math.abs(value));
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#abs()
+     */
+    public NumericValue abs() throws XPathException {
+        return new FloatValue(Math.abs(value));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#max(org.exist.xquery.value.AtomicValue)
-	 */
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.FLOAT))
-			{return new FloatValue(Math.max(value, ((FloatValue) other).value));}
-		else
-			{return convertTo(other.getType()).max(collator, other);}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#max(org.exist.xquery.value.AtomicValue)
+     */
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.FLOAT)) {
+            return new FloatValue(Math.max(value, ((FloatValue) other).value));
+        } else {
+            return convertTo(other.getType()).max(collator, other);
+        }
+    }
 
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.FLOAT))
-			{return new FloatValue(Math.min(value, ((FloatValue) other).value));}
-		else
-			{return convertTo(other.getType()).min(collator, other);}
-	}
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.FLOAT)) {
+            return new FloatValue(Math.min(value, ((FloatValue) other).value));
+        } else {
+            return convertTo(other.getType()).min(collator, other);
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
-	 */
-	public int conversionPreference(Class<?> javaClass) {
-		if (javaClass.isAssignableFrom(FloatValue.class))
-			{return 0;}
-		if (javaClass == Long.class || javaClass == long.class)
-			{return 3;}
-		if (javaClass == Integer.class || javaClass == int.class)
-			{return 4;}
-		if (javaClass == Short.class || javaClass == short.class)
-			{return 5;}
-		if (javaClass == Byte.class || javaClass == byte.class)
-			{return 6;}
-		if (javaClass == Double.class || javaClass == double.class)
-			{return 2;}
-		if (javaClass == Float.class || javaClass == float.class)
-			{return 1;}
-		if (javaClass == String.class)
-			{return 7;}
-		if (javaClass == Boolean.class || javaClass == boolean.class)
-			{return 8;}
-		if (javaClass == Object.class)
-			{return 20;}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
+     */
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(FloatValue.class)) {
+            return 0;
+        }
+        if (javaClass == Long.class || javaClass == long.class) {
+            return 3;
+        }
+        if (javaClass == Integer.class || javaClass == int.class) {
+            return 4;
+        }
+        if (javaClass == Short.class || javaClass == short.class) {
+            return 5;
+        }
+        if (javaClass == Byte.class || javaClass == byte.class) {
+            return 6;
+        }
+        if (javaClass == Double.class || javaClass == double.class) {
+            return 2;
+        }
+        if (javaClass == Float.class || javaClass == float.class) {
+            return 1;
+        }
+        if (javaClass == String.class) {
+            return 7;
+        }
+        if (javaClass == Boolean.class || javaClass == boolean.class) {
+            return 8;
+        }
+        if (javaClass == Object.class) {
+            return 20;
+        }
 
-		return Integer.MAX_VALUE;
-	}
+        return Integer.MAX_VALUE;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
-	 */
-        @Override
-	public <T> T toJavaObject(final Class<T> target) throws XPathException {
-		if (target.isAssignableFrom(FloatValue.class)) {
-			return (T)this;
-                } else if (target == Double.class || target == double.class) {
-			return (T)Double.valueOf(value);
-                } else if (target == Float.class || target == float.class) {
-			return (T)Float.valueOf(value);
-                } else if (target == Long.class || target == long.class) {
-			return (T)Long.valueOf( ((IntegerValue) convertTo(Type.LONG)).getValue() );
-		} else if (target == Integer.class || target == int.class) {
-			final IntegerValue v = (IntegerValue) convertTo(Type.INT);
-			return (T)Integer.valueOf((int) v.getValue());
-		} else if (target == Short.class || target == short.class) {
-			final IntegerValue v = (IntegerValue) convertTo(Type.SHORT);
-			return (T)Short.valueOf((short) v.getValue());
-		} else if (target == Byte.class || target == byte.class) {
-			final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
-			return (T)Byte.valueOf((byte) v.getValue());
-		} else if (target == String.class)
-			{return (T)getStringValue();}
-		else if (target == Boolean.class)
-			{return (T)Boolean.valueOf(effectiveBooleanValue());}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
+     */
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target.isAssignableFrom(FloatValue.class)) {
+            return (T) this;
+        } else if (target == Double.class || target == double.class) {
+            return (T) Double.valueOf(value);
+        } else if (target == Float.class || target == float.class) {
+            return (T) Float.valueOf(value);
+        } else if (target == Long.class || target == long.class) {
+            return (T) Long.valueOf(((IntegerValue) convertTo(Type.LONG)).getValue());
+        } else if (target == Integer.class || target == int.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.INT);
+            return (T) Integer.valueOf((int) v.getValue());
+        } else if (target == Short.class || target == short.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.SHORT);
+            return (T) Short.valueOf((short) v.getValue());
+        } else if (target == Byte.class || target == byte.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
+            return (T) Byte.valueOf((byte) v.getValue());
+        } else if (target == String.class) {
+            return (T) getStringValue();
+        } else if (target == Boolean.class) {
+            return (T) Boolean.valueOf(effectiveBooleanValue());
+        }
 
-		throw new XPathException(
-			"cannot convert value of type "
-				+ Type.getTypeName(getType())
-				+ " to Java object of type "
-				+ target.getName());
-	}
+        throw new XPathException(
+                "cannot convert value of type "
+                        + Type.getTypeName(getType())
+                        + " to Java object of type "
+                        + target.getName());
+    }
 
-	/* (non-Javadoc)
+    /* (non-Javadoc)
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     public int compareTo(Object o) {
-        final AtomicValue other = (AtomicValue)o;
-        if(Type.subTypeOf(other.getType(), Type.FLOAT))
-            {return Float.compare(value, ((FloatValue)other).value);}
-        else
-            {return getType() < other.getType() ? Constants.INFERIOR : Constants.SUPERIOR;}
+        final AtomicValue other = (AtomicValue) o;
+        if (Type.subTypeOf(other.getType(), Type.FLOAT)) {
+            return Float.compare(value, ((FloatValue) other).value);
+        } else {
+            return getType() < other.getType() ? Constants.INFERIOR : Constants.SUPERIOR;
+        }
     }
 
     @Override

--- a/src/org/exist/xquery/value/FunctionParameterSequenceType.java
+++ b/src/org/exist/xquery/value/FunctionParameterSequenceType.java
@@ -5,43 +5,43 @@ package org.exist.xquery.value;
 
 /**
  * This class is used to specify the name and description of an XQuery function parameter.
+ *
  * @author lcahlander
  * @version 1.3
- *
  */
 public class FunctionParameterSequenceType extends FunctionReturnSequenceType {
-	
-	private String attributeName = null;
 
-	/**
-	 * @param attributeName	The name of the parameter in the <strong>FunctionSignature</strong>.
-	 * @param primaryType	The <strong>Type</strong> of the parameter.
-	 * @param cardinality	The <strong>Cardinality</strong> of the parameter.
-	 * @param description	A description of the parameter in the <strong>FunctionSignature</strong>.
-	 * @see org.exist.xquery.FunctionSignature @see Type @see org.exist.xquery.Cardinality
-	 */
-	public FunctionParameterSequenceType(String attributeName, int primaryType, int cardinality, String description) {
-		super(primaryType, cardinality, description);
-		this.attributeName = attributeName;
-	}
+    private String attributeName = null;
 
-	public FunctionParameterSequenceType(String attributeName) {
-		super();
-		this.attributeName = attributeName;
-	}
-	
-	/**
-	 * @return the attributeName
-	 */
-	public String getAttributeName() {
-		return attributeName;
-	}
+    /**
+     * @param attributeName The name of the parameter in the <strong>FunctionSignature</strong>.
+     * @param primaryType   The <strong>Type</strong> of the parameter.
+     * @param cardinality   The <strong>Cardinality</strong> of the parameter.
+     * @param description   A description of the parameter in the <strong>FunctionSignature</strong>.
+     * @see org.exist.xquery.FunctionSignature @see Type @see org.exist.xquery.Cardinality
+     */
+    public FunctionParameterSequenceType(String attributeName, int primaryType, int cardinality, String description) {
+        super(primaryType, cardinality, description);
+        this.attributeName = attributeName;
+    }
 
-	/**
-	 * @param attributeName the attributeName to set
-	 */
-	public void setAttributeName(String attributeName) {
-		this.attributeName = attributeName;
-	}
-	
+    public FunctionParameterSequenceType(String attributeName) {
+        super();
+        this.attributeName = attributeName;
+    }
+
+    /**
+     * @return the attributeName
+     */
+    public String getAttributeName() {
+        return attributeName;
+    }
+
+    /**
+     * @param attributeName the attributeName to set
+     */
+    public void setAttributeName(String attributeName) {
+        this.attributeName = attributeName;
+    }
+
 }

--- a/src/org/exist/xquery/value/FunctionReference.java
+++ b/src/org/exist/xquery/value/FunctionReference.java
@@ -21,13 +21,13 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-import java.util.List;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.xquery.*;
 import org.exist.xquery.Constants.Comparison;
+
+import java.text.Collator;
+import java.util.List;
 
 /**
  * Represents a function item, i.e. a reference to a function that can be called dynamically.

--- a/src/org/exist/xquery/value/FunctionReference.java
+++ b/src/org/exist/xquery/value/FunctionReference.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 /**
  * Represents a function item, i.e. a reference to a function that can be called dynamically.
- * 
+ *
  * @author wolf
  */
 public class FunctionReference extends AtomicValue {
@@ -43,30 +43,30 @@ public class FunctionReference extends AtomicValue {
     public FunctionReference(FunctionCall fcall) {
         this.functionCall = fcall;
     }
-    
+
     public FunctionCall getCall() {
-    	return functionCall;
+        return functionCall;
     }
-    
+
     /**
      * Get the signature of the function.
-     * 
+     *
      * @return signature of this function
      */
     public FunctionSignature getSignature() {
         return functionCall.getSignature();
     }
-    
+
     /**
      * Calls {@link FunctionCall#analyze(AnalyzeContextInfo)}.
-     * 
+     *
      * @param contextInfo
      * @throws XPathException
      */
     public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
-    	functionCall.analyze(contextInfo);
+        functionCall.analyze(contextInfo);
         if (functionCall.getContext().optimizationsEnabled()) {
-            final Optimizer optimizer = new Optimizer( functionCall.getContext() );
+            final Optimizer optimizer = new Optimizer(functionCall.getContext());
             functionCall.accept(optimizer);
             if (optimizer.hasOptimized()) {
                 functionCall.resetState(true);
@@ -79,23 +79,22 @@ public class FunctionReference extends AtomicValue {
      * Calls {@link FunctionCall#eval(Sequence)}.
      */
     public Sequence eval(Sequence contextSequence) throws XPathException {
-    	return functionCall.eval(contextSequence);
+        return functionCall.eval(contextSequence);
     }
 
     /**
      * Calls {@link FunctionCall#evalFunction(Sequence, Item, Sequence[])}.
-     * 
      */
     public Sequence evalFunction(Sequence contextSequence, Item contextItem, Sequence[] seq) throws XPathException {
-    	return functionCall.evalFunction(contextSequence, contextItem, seq);
+        return functionCall.evalFunction(contextSequence, contextItem, seq);
     }
-    
+
     public void setArguments(List<Expression> arguments) throws XPathException {
-    	functionCall.setArguments(arguments);
+        functionCall.setArguments(arguments);
     }
-    
+
     public void setContext(XQueryContext context) {
-    	functionCall.setContext(context);
+        functionCall.setContext(context);
     }
 
     public void resetState(boolean postOptimization) {
@@ -109,7 +108,7 @@ public class FunctionReference extends AtomicValue {
     public int getType() {
         return Type.FUNCTION_REFERENCE;
     }
-    
+
     /* (non-Javadoc)
      * @see org.exist.xquery.value.Sequence#getStringValue()
      */
@@ -121,14 +120,15 @@ public class FunctionReference extends AtomicValue {
      * @see org.exist.xquery.value.Sequence#convertTo(int)
      */
     public AtomicValue convertTo(int requiredType) throws XPathException {
-        if (requiredType == Type.FUNCTION_REFERENCE)
-            {return this;}
+        if (requiredType == Type.FUNCTION_REFERENCE) {
+            return this;
+        }
         throw new XPathException("cannot convert function reference to " + Type.getTypeName(requiredType));
     }
-    
-	public boolean effectiveBooleanValue() throws XPathException {
-		throw new XPathException(ErrorCodes.FORG0006, "Effective boolean value is not defined for a FunctionReference");
-	}    
+
+    public boolean effectiveBooleanValue() throws XPathException {
+        throw new XPathException(ErrorCodes.FORG0006, "Effective boolean value is not defined for a FunctionReference");
+    }
 
     @Override
     public boolean compareTo(Collator collator, Comparison operator, AtomicValue other)

--- a/src/org/exist/xquery/value/FunctionReturnSequenceType.java
+++ b/src/org/exist/xquery/value/FunctionReturnSequenceType.java
@@ -5,42 +5,42 @@ package org.exist.xquery.value;
 
 /**
  * This class is used to specify the name and description of an XQuery function parameter.
+ *
  * @author lcahlander
  * @version 1.3
- *
  */
 public class FunctionReturnSequenceType extends SequenceType {
-	
-	private String description = null;
 
-	/**
-	 * @param primaryType	The <strong>Type</strong> of the parameter.
-	 * @param cardinality	The <strong>Cardinality</strong> of the parameter.
-	 * @param description	A description of the parameter in the <strong>FunctionSignature</strong>.
-	 * @see org.exist.xquery.FunctionSignature @see Type @see org.exist.xquery.Cardinality
-	 */
-	public FunctionReturnSequenceType(int primaryType, int cardinality, String description) {
-		super(primaryType, cardinality);
-		this.description = description;
-	}
+    private String description = null;
 
-	public FunctionReturnSequenceType() {
-		super();
-	}
-	
-	/**
-	 * @return the description
-	 */
-	public String getDescription() {
-		return description;
-	}
+    /**
+     * @param primaryType The <strong>Type</strong> of the parameter.
+     * @param cardinality The <strong>Cardinality</strong> of the parameter.
+     * @param description A description of the parameter in the <strong>FunctionSignature</strong>.
+     * @see org.exist.xquery.FunctionSignature @see Type @see org.exist.xquery.Cardinality
+     */
+    public FunctionReturnSequenceType(int primaryType, int cardinality, String description) {
+        super(primaryType, cardinality);
+        this.description = description;
+    }
 
-	/**
-	 * @param description the description to set
-	 */
-	public void setDescription(String description) {
-		this.description = description;
-	}
+    public FunctionReturnSequenceType() {
+        super();
+    }
 
-	
+    /**
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @param description the description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+
 }

--- a/src/org/exist/xquery/value/GDayValue.java
+++ b/src/org/exist/xquery/value/GDayValue.java
@@ -21,15 +21,14 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-import java.util.GregorianCalendar;
+import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-
-import org.exist.xquery.Constants.Comparison;
-import org.exist.xquery.XPathException;
+import java.text.Collator;
+import java.util.GregorianCalendar;
 
 public class GDayValue extends AbstractDateTimeValue {
 

--- a/src/org/exist/xquery/value/GDayValue.java
+++ b/src/org/exist/xquery/value/GDayValue.java
@@ -43,7 +43,9 @@ public class GDayValue extends AbstractDateTimeValue {
     public GDayValue(String timeValue) throws XPathException {
         super(timeValue);
         try {
-            if (calendar.getXMLSchemaType() != DatatypeConstants.GDAY) {throw new IllegalStateException();}
+            if (calendar.getXMLSchemaType() != DatatypeConstants.GDAY) {
+                throw new IllegalStateException();
+            }
         } catch (final IllegalStateException e) {
             throw new XPathException("xs:gDay instance must not have year, month or day fields set");
         }
@@ -59,21 +61,21 @@ public class GDayValue extends AbstractDateTimeValue {
         calendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
         return calendar;
     }
-    
+
     public AtomicValue convertTo(int requiredType) throws XPathException {
         switch (requiredType) {
-            case Type.GDAY :
-            case Type.ATOMIC :
-            case Type.ITEM :
+            case Type.GDAY:
+            case Type.ATOMIC:
+            case Type.ITEM:
                 return this;
-            case Type.STRING :
+            case Type.STRING:
                 return new StringValue(getStringValue());
-            case Type.UNTYPED_ATOMIC :
+            case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
-            default :
+            default:
                 throw new XPathException(
-                    "Type error: cannot cast xs:time to "
-                        + Type.getTypeName(requiredType));
+                        "Type error: cannot cast xs:time to "
+                                + Type.getTypeName(requiredType));
         }
     }
 
@@ -85,7 +87,7 @@ public class GDayValue extends AbstractDateTimeValue {
     public int getType() {
         return Type.GDAY;
     }
-    
+
     protected QName getXMLSchemaType() {
         return DatatypeConstants.GDAY;
     }
@@ -95,31 +97,36 @@ public class GDayValue extends AbstractDateTimeValue {
                 Type.getTypeName(getType()));
     }
 
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == getType()) {
-			if (!getTimezone().isEmpty()) {
-				if (!((AbstractDateTimeValue) other).getTimezone().isEmpty()) {
-					if (!((DayTimeDurationValue)getTimezone().itemAt(0)).compareTo(null, Comparison.EQ, (DayTimeDurationValue)((AbstractDateTimeValue)other).getTimezone().itemAt(0)))
-						{return DatatypeConstants.LESSER;}
-    			} else {
-    				if (!"PT0S".equals(((DayTimeDurationValue)getTimezone().itemAt(0)).getStringValue()))
-    					{return DatatypeConstants.LESSER;}
-    			}
-    		} else {
-    			if (!((AbstractDateTimeValue)other).getTimezone().isEmpty()) {
-    				if (!"PT0S".equals(((DayTimeDurationValue)((AbstractDateTimeValue)other).getTimezone().itemAt(0)).getStringValue()))
-    					{return DatatypeConstants.LESSER;}
-    			}
-			}
-			// filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
-			final int r =	this.getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
-				//getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
-			if (r == DatatypeConstants.INDETERMINATE) {throw new RuntimeException("indeterminate order between " + this + " and " + other);}
-			return r;
-		} 
-		throw new XPathException(
-			"Type error: cannot compare " + Type.getTypeName(getType()) + " to "
-				+ Type.getTypeName(other.getType()));
-	}
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == getType()) {
+            if (!getTimezone().isEmpty()) {
+                if (!((AbstractDateTimeValue) other).getTimezone().isEmpty()) {
+                    if (!((DayTimeDurationValue) getTimezone().itemAt(0)).compareTo(null, Comparison.EQ, (DayTimeDurationValue) ((AbstractDateTimeValue) other).getTimezone().itemAt(0))) {
+                        return DatatypeConstants.LESSER;
+                    }
+                } else {
+                    if (!"PT0S".equals(((DayTimeDurationValue) getTimezone().itemAt(0)).getStringValue())) {
+                        return DatatypeConstants.LESSER;
+                    }
+                }
+            } else {
+                if (!((AbstractDateTimeValue) other).getTimezone().isEmpty()) {
+                    if (!"PT0S".equals(((DayTimeDurationValue) ((AbstractDateTimeValue) other).getTimezone().itemAt(0)).getStringValue())) {
+                        return DatatypeConstants.LESSER;
+                    }
+                }
+            }
+            // filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
+            final int r = this.getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
+            //getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
+            if (r == DatatypeConstants.INDETERMINATE) {
+                throw new RuntimeException("indeterminate order between " + this + " and " + other);
+            }
+            return r;
+        }
+        throw new XPathException(
+                "Type error: cannot compare " + Type.getTypeName(getType()) + " to "
+                        + Type.getTypeName(other.getType()));
+    }
 
 }

--- a/src/org/exist/xquery/value/GMonthDayValue.java
+++ b/src/org/exist/xquery/value/GMonthDayValue.java
@@ -41,7 +41,9 @@ public class GMonthDayValue extends AbstractDateTimeValue {
     public GMonthDayValue(String timeValue) throws XPathException {
         super(timeValue);
         try {
-            if (calendar.getXMLSchemaType() != DatatypeConstants.GMONTHDAY) {throw new IllegalStateException();}
+            if (calendar.getXMLSchemaType() != DatatypeConstants.GMONTHDAY) {
+                throw new IllegalStateException();
+            }
         } catch (final IllegalStateException e) {
             throw new XPathException("xs:time instance must not have year, month or day fields set");
         }
@@ -56,21 +58,21 @@ public class GMonthDayValue extends AbstractDateTimeValue {
         calendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
         return calendar;
     }
-    
+
     public AtomicValue convertTo(int requiredType) throws XPathException {
         switch (requiredType) {
-            case Type.GMONTHDAY :
-            case Type.ATOMIC :
-            case Type.ITEM :
+            case Type.GMONTHDAY:
+            case Type.ATOMIC:
+            case Type.ITEM:
                 return this;
-            case Type.STRING :
+            case Type.STRING:
                 return new StringValue(getStringValue());
-            case Type.UNTYPED_ATOMIC :
+            case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
-            default :
+            default:
                 throw new XPathException(
-                    "Type error: cannot cast xs:time to "
-                        + Type.getTypeName(requiredType));
+                        "Type error: cannot cast xs:time to "
+                                + Type.getTypeName(requiredType));
         }
     }
 
@@ -82,7 +84,7 @@ public class GMonthDayValue extends AbstractDateTimeValue {
     public int getType() {
         return Type.GMONTHDAY;
     }
-    
+
     protected QName getXMLSchemaType() {
         return DatatypeConstants.GMONTHDAY;
     }

--- a/src/org/exist/xquery/value/GMonthDayValue.java
+++ b/src/org/exist/xquery/value/GMonthDayValue.java
@@ -21,13 +21,12 @@
  */
 package org.exist.xquery.value;
 
-import java.util.GregorianCalendar;
+import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-
-import org.exist.xquery.XPathException;
+import java.util.GregorianCalendar;
 
 public class GMonthDayValue extends AbstractDateTimeValue {
 

--- a/src/org/exist/xquery/value/GMonthValue.java
+++ b/src/org/exist/xquery/value/GMonthValue.java
@@ -32,8 +32,8 @@ import java.text.Collator;
 import java.util.GregorianCalendar;
 
 public class GMonthValue extends AbstractDateTimeValue {
-	
-	protected boolean addTrailingZ = false;
+
+    protected boolean addTrailingZ = false;
 
     public GMonthValue() throws XPathException {
         super(stripCalendar(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar())));
@@ -46,16 +46,22 @@ public class GMonthValue extends AbstractDateTimeValue {
     public GMonthValue(String timeValue) throws XPathException {
         super(fixTimezone(timeValue));
         timeValue = timeValue.trim();
-        if (timeValue.endsWith("Z"))
-        	{addTrailingZ = true;}
-        if (timeValue.endsWith("-00:00"))      
-        	{addTrailingZ = true;}
-        if (timeValue.endsWith("+00:00")) 
-        	{addTrailingZ = true;}            
-        if (addTrailingZ)
-        	{this.calendar.setTimezone(0);}
+        if (timeValue.endsWith("Z")) {
+            addTrailingZ = true;
+        }
+        if (timeValue.endsWith("-00:00")) {
+            addTrailingZ = true;
+        }
+        if (timeValue.endsWith("+00:00")) {
+            addTrailingZ = true;
+        }
+        if (addTrailingZ) {
+            this.calendar.setTimezone(0);
+        }
         try {
-            if (calendar.getXMLSchemaType() != DatatypeConstants.GMONTH) {throw new IllegalStateException();}
+            if (calendar.getXMLSchemaType() != DatatypeConstants.GMONTH) {
+                throw new IllegalStateException();
+            }
         } catch (final IllegalStateException e) {
             throw new XPathException("xs:gMonth instance must not have year, month or day fields set");
         }
@@ -71,21 +77,39 @@ public class GMonthValue extends AbstractDateTimeValue {
         calendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
         return calendar;
     }
-    
+
+    private static String fixTimezone(String value) {
+        //TODO : should we imply a default "Z" here ?
+        //TODO : should we raise an error on wrong TZ offsets (e.g. 60) ?
+        int p = value.indexOf('Z');
+        if (p != Constants.STRING_NOT_FOUND) {
+            return value.substring(0, p);
+        }
+        p = value.indexOf("-00:00");
+        if (p != Constants.STRING_NOT_FOUND) {
+            return value.substring(0, p);
+        }
+        p = value.indexOf("+00:00");
+        if (p != Constants.STRING_NOT_FOUND) {
+            return value.substring(0, p);
+        }
+        return value;
+    }
+
     public AtomicValue convertTo(int requiredType) throws XPathException {
         switch (requiredType) {
-            case Type.GMONTH :
-            case Type.ATOMIC :
-            case Type.ITEM :
+            case Type.GMONTH:
+            case Type.ATOMIC:
+            case Type.ITEM:
                 return this;
-            case Type.STRING :
+            case Type.STRING:
                 return new StringValue(getStringValue());
-            case Type.UNTYPED_ATOMIC :
+            case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
-            default :
+            default:
                 throw new XPathException(
-                    "Type error: cannot cast xs:gMonth to "
-                        + Type.getTypeName(requiredType));
+                        "Type error: cannot cast xs:gMonth to "
+                                + Type.getTypeName(requiredType));
         }
     }
 
@@ -98,18 +122,18 @@ public class GMonthValue extends AbstractDateTimeValue {
         return Type.GMONTH;
     }
     
-    protected QName getXMLSchemaType() {
-        return DatatypeConstants.GMONTH;
-    }
-    
     /*
-   	public String getStringValue() throws XPathException {
+       public String getStringValue() throws XPathException {
     	String r = super.getStringValue();
     	if (addTrailingZ) 
     		return r + "Z";
     	return r;
     }
-    */    
+    */
+
+    protected QName getXMLSchemaType() {
+        return DatatypeConstants.GMONTH;
+    }
 
     public ComputableValue minus(ComputableValue other) throws XPathException {
         throw new XPathException("Subtraction is not supported on values of type " +
@@ -117,45 +141,35 @@ public class GMonthValue extends AbstractDateTimeValue {
     }
 
     @Override
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == getType()) {
-			if (!getTimezone().isEmpty()) {
-				if (!((AbstractDateTimeValue) other).getTimezone().isEmpty()) {
-					if (!((DayTimeDurationValue)getTimezone().itemAt(0)).compareTo(null, Comparison.EQ, (DayTimeDurationValue)((AbstractDateTimeValue)other).getTimezone().itemAt(0)))
-						{return DatatypeConstants.LESSER;}
-    			} else {
-    				if (!"PT0S".equals(((DayTimeDurationValue)getTimezone().itemAt(0)).getStringValue()))
-    					{return DatatypeConstants.LESSER;}
-    			}
-    		} else {
-    			if (!((AbstractDateTimeValue)other).getTimezone().isEmpty()) {
-    				if (!"PT0S".equals(((DayTimeDurationValue)((AbstractDateTimeValue)other).getTimezone().itemAt(0)).getStringValue()))
-    					{return DatatypeConstants.LESSER;}
-    			}
-			}
-			// filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
-			final int r =	this.getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
-				//getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
-			if (r == DatatypeConstants.INDETERMINATE) {throw new RuntimeException("indeterminate order between " + this + " and " + other);}
-			return r;
-		} 
-		throw new XPathException(
-			"Type error: cannot compare " + Type.getTypeName(getType()) + " to "
-				+ Type.getTypeName(other.getType()));
-	}
-
-	private static String fixTimezone(String value) {    	
-    	//TODO : should we imply a default "Z" here ?
-    	//TODO : should we raise an error on wrong TZ offsets (e.g. 60) ?
-        int p = value.indexOf('Z');
-        if (p != Constants.STRING_NOT_FOUND)
-        	{return value.substring(0, p);}
-        p = value.indexOf("-00:00");    
-        if (p != Constants.STRING_NOT_FOUND)
-        	{return value.substring(0, p);}
-        p = value.indexOf("+00:00");    
-        if (p != Constants.STRING_NOT_FOUND)
-        	{return value.substring(0, p);}        
-        return value;
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == getType()) {
+            if (!getTimezone().isEmpty()) {
+                if (!((AbstractDateTimeValue) other).getTimezone().isEmpty()) {
+                    if (!((DayTimeDurationValue) getTimezone().itemAt(0)).compareTo(null, Comparison.EQ, (DayTimeDurationValue) ((AbstractDateTimeValue) other).getTimezone().itemAt(0))) {
+                        return DatatypeConstants.LESSER;
+                    }
+                } else {
+                    if (!"PT0S".equals(((DayTimeDurationValue) getTimezone().itemAt(0)).getStringValue())) {
+                        return DatatypeConstants.LESSER;
+                    }
+                }
+            } else {
+                if (!((AbstractDateTimeValue) other).getTimezone().isEmpty()) {
+                    if (!"PT0S".equals(((DayTimeDurationValue) ((AbstractDateTimeValue) other).getTimezone().itemAt(0)).getStringValue())) {
+                        return DatatypeConstants.LESSER;
+                    }
+                }
+            }
+            // filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
+            final int r = this.getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
+            //getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
+            if (r == DatatypeConstants.INDETERMINATE) {
+                throw new RuntimeException("indeterminate order between " + this + " and " + other);
+            }
+            return r;
+        }
+        throw new XPathException(
+                "Type error: cannot compare " + Type.getTypeName(getType()) + " to "
+                        + Type.getTypeName(other.getType()));
     }
 }

--- a/src/org/exist/xquery/value/GMonthValue.java
+++ b/src/org/exist/xquery/value/GMonthValue.java
@@ -21,16 +21,15 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-import java.util.GregorianCalendar;
+import org.exist.xquery.Constants;
+import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-
-import org.exist.xquery.Constants;
-import org.exist.xquery.Constants.Comparison;
-import org.exist.xquery.XPathException;
+import java.text.Collator;
+import java.util.GregorianCalendar;
 
 public class GMonthValue extends AbstractDateTimeValue {
 	

--- a/src/org/exist/xquery/value/GYearMonthValue.java
+++ b/src/org/exist/xquery/value/GYearMonthValue.java
@@ -43,7 +43,9 @@ public class GYearMonthValue extends AbstractDateTimeValue {
     public GYearMonthValue(String timeValue) throws XPathException {
         super(timeValue);
         try {
-            if (calendar.getXMLSchemaType() != DatatypeConstants.GYEARMONTH) {throw new IllegalStateException();}
+            if (calendar.getXMLSchemaType() != DatatypeConstants.GYEARMONTH) {
+                throw new IllegalStateException();
+            }
         } catch (final IllegalStateException e) {
             throw new XPathException("xs:gYearMonth instance must not have year, month or day fields set");
         }
@@ -58,21 +60,21 @@ public class GYearMonthValue extends AbstractDateTimeValue {
         calendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
         return calendar;
     }
-    
+
     public AtomicValue convertTo(int requiredType) throws XPathException {
         switch (requiredType) {
-            case Type.GYEARMONTH :
-            case Type.ATOMIC :
-            case Type.ITEM :
-            	return new GYearMonthValue(this.calendar); 
-            case Type.STRING :
+            case Type.GYEARMONTH:
+            case Type.ATOMIC:
+            case Type.ITEM:
+                return new GYearMonthValue(this.calendar);
+            case Type.STRING:
                 return new StringValue(getStringValue());
-            case Type.UNTYPED_ATOMIC :
+            case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
-            default :
+            default:
                 throw new XPathException(
-                    "Type error: cannot cast xs:time to "
-                        + Type.getTypeName(requiredType));
+                        "Type error: cannot cast xs:time to "
+                                + Type.getTypeName(requiredType));
         }
     }
 
@@ -84,42 +86,47 @@ public class GYearMonthValue extends AbstractDateTimeValue {
     public int getType() {
         return Type.GYEARMONTH;
     }
-    
+
     protected QName getXMLSchemaType() {
         return DatatypeConstants.GYEARMONTH;
     }
 
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == getType()) {
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == getType()) {
             if (!getTimezone().isEmpty()) {
-				if (!((AbstractDateTimeValue) other).getTimezone().isEmpty()) {
-					if (!((DayTimeDurationValue)getTimezone().itemAt(0)).compareTo(null, Comparison.EQ, (DayTimeDurationValue)((AbstractDateTimeValue)other).getTimezone().itemAt(0))) {
-						return DatatypeConstants.LESSER;
-	    			} else {
+                if (!((AbstractDateTimeValue) other).getTimezone().isEmpty()) {
+                    if (!((DayTimeDurationValue) getTimezone().itemAt(0)).compareTo(null, Comparison.EQ, (DayTimeDurationValue) ((AbstractDateTimeValue) other).getTimezone().itemAt(0))) {
+                        return DatatypeConstants.LESSER;
+                    } else {
                         // equal? Is this sufficient? /ljo
-                        if (this.getCanonicalOrTrimmedCalendar().compare(((AbstractDateTimeValue) other).getCanonicalOrTrimmedCalendar()) == 0)
-                            {return DatatypeConstants.EQUAL;}
-	    				if (!"PT0S".equals(((DayTimeDurationValue)getTimezone().itemAt(0)).getStringValue()))
-	    					{return DatatypeConstants.LESSER;}
-	    			}
-	    		} else {
-	    			if (!((AbstractDateTimeValue)other).getTimezone().isEmpty()) {
-	    				if (!"PT0S".equals(((DayTimeDurationValue)((AbstractDateTimeValue)other).getTimezone().itemAt(0)).getStringValue()))
-	    					{return DatatypeConstants.LESSER;}
-	    			}
-				}
-			}
-			// filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
-			final int r =	this.getCanonicalOrTrimmedCalendar().compare(((AbstractDateTimeValue) other).getCanonicalOrTrimmedCalendar());
+                        if (this.getCanonicalOrTrimmedCalendar().compare(((AbstractDateTimeValue) other).getCanonicalOrTrimmedCalendar()) == 0) {
+                            return DatatypeConstants.EQUAL;
+                        }
+                        if (!"PT0S".equals(((DayTimeDurationValue) getTimezone().itemAt(0)).getStringValue())) {
+                            return DatatypeConstants.LESSER;
+                        }
+                    }
+                } else {
+                    if (!((AbstractDateTimeValue) other).getTimezone().isEmpty()) {
+                        if (!"PT0S".equals(((DayTimeDurationValue) ((AbstractDateTimeValue) other).getTimezone().itemAt(0)).getStringValue())) {
+                            return DatatypeConstants.LESSER;
+                        }
+                    }
+                }
+            }
+            // filling in missing timezones with local timezone, should be total order as per XPath 2.0 10.4
+            final int r = this.getCanonicalOrTrimmedCalendar().compare(((AbstractDateTimeValue) other).getCanonicalOrTrimmedCalendar());
             //getImplicitCalendar().compare(((AbstractDateTimeValue) other).getImplicitCalendar());
-			if (r == DatatypeConstants.INDETERMINATE) {throw new RuntimeException("indeterminate order between " + this + " and " + other);}
-			return r;
-		}
-		throw new XPathException(
-			"Type error: cannot compare " + Type.getTypeName(getType()) + " to "
-				+ Type.getTypeName(other.getType()));
-	}
-    
+            if (r == DatatypeConstants.INDETERMINATE) {
+                throw new RuntimeException("indeterminate order between " + this + " and " + other);
+            }
+            return r;
+        }
+        throw new XPathException(
+                "Type error: cannot compare " + Type.getTypeName(getType()) + " to "
+                        + Type.getTypeName(other.getType()));
+    }
+
     public ComputableValue minus(ComputableValue other) throws XPathException {
         throw new XPathException("Subtraction is not supported on values of type " +
                 Type.getTypeName(getType()));

--- a/src/org/exist/xquery/value/GYearMonthValue.java
+++ b/src/org/exist/xquery/value/GYearMonthValue.java
@@ -21,15 +21,14 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-import java.util.GregorianCalendar;
+import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-
-import org.exist.xquery.Constants.Comparison;
-import org.exist.xquery.XPathException;
+import java.text.Collator;
+import java.util.GregorianCalendar;
 
 public class GYearMonthValue extends AbstractDateTimeValue {
 

--- a/src/org/exist/xquery/value/GYearValue.java
+++ b/src/org/exist/xquery/value/GYearValue.java
@@ -41,7 +41,9 @@ public class GYearValue extends AbstractDateTimeValue {
     public GYearValue(String timeValue) throws XPathException {
         super(timeValue);
         try {
-            if (calendar.getXMLSchemaType() != DatatypeConstants.GYEAR) {throw new IllegalStateException();}
+            if (calendar.getXMLSchemaType() != DatatypeConstants.GYEAR) {
+                throw new IllegalStateException();
+            }
         } catch (final IllegalStateException e) {
             throw new XPathException("xs:time instance must not have year, month or day fields set");
         }
@@ -57,21 +59,21 @@ public class GYearValue extends AbstractDateTimeValue {
         calendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
         return calendar;
     }
-    
+
     public AtomicValue convertTo(int requiredType) throws XPathException {
         switch (requiredType) {
-            case Type.GYEAR :
-            case Type.ATOMIC :
-            case Type.ITEM :
+            case Type.GYEAR:
+            case Type.ATOMIC:
+            case Type.ITEM:
                 return this;
-            case Type.STRING :
+            case Type.STRING:
                 return new StringValue(getStringValue());
-            case Type.UNTYPED_ATOMIC :
+            case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
-            default :
+            default:
                 throw new XPathException(
-                    "Type error: cannot cast xs:time to "
-                        + Type.getTypeName(requiredType));
+                        "Type error: cannot cast xs:time to "
+                                + Type.getTypeName(requiredType));
         }
     }
 
@@ -83,7 +85,7 @@ public class GYearValue extends AbstractDateTimeValue {
     public int getType() {
         return Type.GYEAR;
     }
-    
+
     protected QName getXMLSchemaType() {
         return DatatypeConstants.GYEAR;
     }

--- a/src/org/exist/xquery/value/GYearValue.java
+++ b/src/org/exist/xquery/value/GYearValue.java
@@ -21,13 +21,12 @@
  */
 package org.exist.xquery.value;
 
-import java.util.GregorianCalendar;
+import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-
-import org.exist.xquery.XPathException;
+import java.util.GregorianCalendar;
 
 public class GYearValue extends AbstractDateTimeValue {
 

--- a/src/org/exist/xquery/value/HexBinaryValueType.java
+++ b/src/org/exist/xquery/value/HexBinaryValueType.java
@@ -47,11 +47,11 @@ public class HexBinaryValueType extends BinaryValueType<HexOutputStream> {
     @Override
     protected void verifyString(String str) throws XPathException {
 
-        if((str.length() & 1) != 0) {
+        if ((str.length() & 1) != 0) {
             throw new XPathException(ErrorCodes.FORG0001, "A hexBinary value must contain an even number of characters");
         }
 
-        if(!getMatcher(str).matches()) {
+        if (!getMatcher(str).matches()) {
             throw new XPathException(ErrorCodes.FORG0001, "Invalid hexadecimal digit");
         }
     }

--- a/src/org/exist/xquery/value/HexBinaryValueType.java
+++ b/src/org/exist/xquery/value/HexBinaryValueType.java
@@ -21,12 +21,13 @@
  */
 package org.exist.xquery.value;
 
-import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.exist.util.io.HexOutputStream;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Adam Retter <adam@existsolutions.com>

--- a/src/org/exist/xquery/value/IntegerValue.java
+++ b/src/org/exist/xquery/value/IntegerValue.java
@@ -28,518 +28,562 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.Collator;
 
-/** [Definition:]   integer is <i>derived</i> from decimal by fixing the value of <i>fractionDigits<i> to be 0. 
- * This results in the standard mathematical concept of the integer numbers. 
- * The <i>value space</i> of integer is the infinite set {...,-2,-1,0,1,2,...}. 
+/**
+ * [Definition:]   integer is <i>derived</i> from decimal by fixing the value of <i>fractionDigits<i> to be 0.
+ * This results in the standard mathematical concept of the integer numbers.
+ * The <i>value space</i> of integer is the infinite set {...,-2,-1,0,1,2,...}.
  * The <i>base type</i> of integer is decimal.
- * cf http://www.w3.org/TR/xmlschema-2/#integer 
+ * cf http://www.w3.org/TR/xmlschema-2/#integer
  */
 public class IntegerValue extends NumericValue {
 
     //TODO this class should be split into numerous sub classes for each xs: type with proper
     //inheritance as defined by http://www.w3.org/TR/xmlschema-2/#built-in-datatypes
-    
-	public final static IntegerValue ZERO = new IntegerValue(0);
-        
-	private static final BigInteger ZERO_BIGINTEGER = new BigInteger("0");
-	private static final BigInteger ONE_BIGINTEGER = new BigInteger("1");
-	private static final BigInteger MINUS_ONE_BIGINTEGER = new BigInteger("-1");
-	
-    private static final BigInteger LARGEST_LONG  = new BigInteger("9223372036854775807");
-	private static final BigInteger SMALLEST_LONG  = new BigInteger("-9223372036854775808");
-	
+
+    public final static IntegerValue ZERO = new IntegerValue(0);
+
+    private static final BigInteger ZERO_BIGINTEGER = new BigInteger("0");
+    private static final BigInteger ONE_BIGINTEGER = new BigInteger("1");
+    private static final BigInteger MINUS_ONE_BIGINTEGER = new BigInteger("-1");
+
+    private static final BigInteger LARGEST_LONG = new BigInteger("9223372036854775807");
+    private static final BigInteger SMALLEST_LONG = new BigInteger("-9223372036854775808");
+
     private static final BigInteger LARGEST_UNSIGNED_LONG = new BigInteger("18446744073709551615");
-        
-    private static final BigInteger LARGEST_INT  = new BigInteger("2147483647");
-	private static final BigInteger SMALLEST_INT  = new BigInteger("-2147483648");
-        
+
+    private static final BigInteger LARGEST_INT = new BigInteger("2147483647");
+    private static final BigInteger SMALLEST_INT = new BigInteger("-2147483648");
+
     private static final BigInteger LARGEST_UNSIGNED_INT = new BigInteger("4294967295");
-	
+
     private static final BigInteger LARGEST_SHORT = new BigInteger("32767");
-	private static final BigInteger SMALLEST_SHORT = new BigInteger("-32768");
-	
+    private static final BigInteger SMALLEST_SHORT = new BigInteger("-32768");
+
     private static final BigInteger LARGEST_UNSIGNED_SHORT = new BigInteger("65535");
-        
+
     private static final BigInteger LARGEST_BYTE = new BigInteger("127");
-	private static final BigInteger SMALLEST_BYTE = new BigInteger("-128");
-        
+    private static final BigInteger SMALLEST_BYTE = new BigInteger("-128");
+
     private static final BigInteger LARGEST_UNSIGNED_BYTE = new BigInteger("255");
-	
-	private BigInteger value;
-	// 	private long value;
 
-	//should default type be NUMBER or LONG ? -shabanovd
-	private int type = Type.INTEGER;
+    private BigInteger value;
+    // 	private long value;
 
-	public IntegerValue(long value) {
-		this.value = BigInteger.valueOf(value); // new BigInteger(value);
-	}
+    //should default type be NUMBER or LONG ? -shabanovd
+    private int type = Type.INTEGER;
 
-	public IntegerValue(long value, int type) throws XPathException {
-		this(value);
-		this.type = type;
-		if (!checkType(value, type))
-			{throw new XPathException(
-				"Value is not a valid integer for type " + Type.getTypeName(type));}
-	}
+    public IntegerValue(long value) {
+        this.value = BigInteger.valueOf(value); // new BigInteger(value);
+    }
 
-	public IntegerValue(String stringValue) throws XPathException {
-		try {
-			value = new BigInteger(StringValue.trimWhitespace(stringValue)); // Long.parseLong(stringValue);
-		} catch (final NumberFormatException e) {
-				throw new XPathException(ErrorCodes.FORG0001,
-					"failed to convert '" + stringValue + "' to an integer: " + e.getMessage(), e);
+    public IntegerValue(long value, int type) throws XPathException {
+        this(value);
+        this.type = type;
+        if (!checkType(value, type)) {
+            throw new XPathException(
+                    "Value is not a valid integer for type " + Type.getTypeName(type));
+        }
+    }
+
+    public IntegerValue(String stringValue) throws XPathException {
+        try {
+            value = new BigInteger(StringValue.trimWhitespace(stringValue)); // Long.parseLong(stringValue);
+        } catch (final NumberFormatException e) {
+            throw new XPathException(ErrorCodes.FORG0001,
+                    "failed to convert '" + stringValue + "' to an integer: " + e.getMessage(), e);
 //			}
-		}
-	}
+        }
+    }
 
-	public IntegerValue(String stringValue, int requiredType) throws XPathException {
-		this.type = requiredType;
-		try {
-			value =  new BigInteger(StringValue.trimWhitespace(stringValue)); // Long.parseLong(stringValue);
-			if (!(checkType(value, type)))
-				{throw new XPathException(ErrorCodes.FORG0001, "can not convert '" + 
-						stringValue + "' to " + Type.getTypeName(type));}
-		} catch (final NumberFormatException e) {
-			throw new XPathException(ErrorCodes.FORG0001, "can not convert '" + 
-					stringValue + "' to " + Type.getTypeName(type));
-		}
-	}
-
-	/**
-	 * @param value
-	 * @param requiredType
-	 */
-	public IntegerValue(BigInteger value, int requiredType) {
-		this.value = value;
-		type = requiredType;
-	}
-
-	/**
-	 * @param integer
-	 */
-	public IntegerValue(BigInteger integer) {
-		this.value = integer;
-	}
-
-	/**
-	 * @param value2
-	 * @param type2
-	 * @throws XPathException
-	 */
-	private boolean checkType(BigInteger value2, int type2) throws XPathException {
-            switch (type) {
-		
-                case Type.LONG :
-                    // jmv: add test since now long is not the default implementation anymore:
-                    return value.compareTo(SMALLEST_LONG) >= 0 &&
-                            value.compareTo(LARGEST_LONG ) <= 0;
-                    
-                case Type.UNSIGNED_LONG :
-                    return value.compareTo(ZERO_BIGINTEGER) >= 0 &&
-                            value.compareTo(LARGEST_UNSIGNED_LONG ) <= 0;
-                    
-		case Type.INTEGER :
-		case Type.DECIMAL :
-			return true;
-		
-		case Type.POSITIVE_INTEGER :
-			return value.compareTo(ZERO_BIGINTEGER) == 1; // >0
-		case Type.NON_NEGATIVE_INTEGER :
-			return value.compareTo(MINUS_ONE_BIGINTEGER) == 1; // > -1
-		
-		case Type.NEGATIVE_INTEGER :
-			return value.compareTo(ZERO_BIGINTEGER) == -1 ; // <0
-		case Type.NON_POSITIVE_INTEGER :
-			return value.compareTo(ONE_BIGINTEGER) == -1; // <1
-		
-		case Type.INT :
-			return value.compareTo(SMALLEST_INT) >= 0 &&
-				value.compareTo(LARGEST_INT) <= 0;
-                    
-                case Type.UNSIGNED_INT:
-                    return value.compareTo(ZERO_BIGINTEGER) >= 0 &&
-                            value.compareTo(LARGEST_UNSIGNED_INT) <= 0;
-                        
-		case Type.SHORT :
-			return value.compareTo(SMALLEST_SHORT) >= 0 &&
-				value.compareTo(LARGEST_SHORT) <= 0;
-                    
-                case Type.UNSIGNED_SHORT :
-			return value.compareTo(ZERO_BIGINTEGER) >= 0 &&
-				value.compareTo(LARGEST_UNSIGNED_SHORT) <= 0;
-                    
-		case Type.BYTE :
-			return value.compareTo(SMALLEST_BYTE) >= 0 &&
-					value.compareTo(LARGEST_BYTE) <= 0;
-                    
-                case Type.UNSIGNED_BYTE :
-                        return value.compareTo(ZERO_BIGINTEGER) >= 0 &&
-				value.compareTo(LARGEST_UNSIGNED_BYTE) <= 0;
+    public IntegerValue(String stringValue, int requiredType) throws XPathException {
+        this.type = requiredType;
+        try {
+            value = new BigInteger(StringValue.trimWhitespace(stringValue)); // Long.parseLong(stringValue);
+            if (!(checkType(value, type))) {
+                throw new XPathException(ErrorCodes.FORG0001, "can not convert '" +
+                        stringValue + "' to " + Type.getTypeName(type));
             }
-            
-            throw new XPathException("Unknown type: " + Type.getTypeName(type));
-	}
+        } catch (final NumberFormatException e) {
+            throw new XPathException(ErrorCodes.FORG0001, "can not convert '" +
+                    stringValue + "' to " + Type.getTypeName(type));
+        }
+    }
 
-	private final static boolean checkType(long value, int type) throws XPathException {
-		switch (type) {
-			case Type.LONG :
-			case Type.INTEGER :
-			case Type.DECIMAL :
-				return true;
-			case Type.NON_POSITIVE_INTEGER :
-				return value < 1;
-			case Type.NEGATIVE_INTEGER :
-				return value < 0;
-			case Type.INT :
-				return value >= -4294967295L && value <= 4294967295L;
-			case Type.SHORT :
-				return value >= -65535 && value <= 65535;
-			case Type.BYTE :
-				return value >= -255 && value <= 255;
-			case Type.NON_NEGATIVE_INTEGER :
-				return value > -1;
-			case Type.UNSIGNED_LONG :
-				return value > -1;
-			case Type.UNSIGNED_INT:
-				return value > -1 && value <= 4294967295L;
-			case Type.UNSIGNED_SHORT :
-				return value > -1 && value <= 65535;
-			case Type.UNSIGNED_BYTE :
-				return value > -1 && value <= 255;
-			case Type.POSITIVE_INTEGER :
-				return value > 0; // jmv >= 0;
-		}
-		throw new XPathException("Unknown type: " + Type.getTypeName(type));
-	}
+    /**
+     * @param value
+     * @param requiredType
+     */
+    public IntegerValue(BigInteger value, int requiredType) {
+        this.value = value;
+        type = requiredType;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#getType()
-	 */
-	public int getType() {
-		return type;
-	}
+    /**
+     * @param integer
+     */
+    public IntegerValue(BigInteger integer) {
+        this.value = integer;
+    }
 
-	public boolean hasFractionalPart() {
-		return false;
-	}
+    private final static boolean checkType(long value, int type) throws XPathException {
+        switch (type) {
+            case Type.LONG:
+            case Type.INTEGER:
+            case Type.DECIMAL:
+                return true;
+            case Type.NON_POSITIVE_INTEGER:
+                return value < 1;
+            case Type.NEGATIVE_INTEGER:
+                return value < 0;
+            case Type.INT:
+                return value >= -4294967295L && value <= 4294967295L;
+            case Type.SHORT:
+                return value >= -65535 && value <= 65535;
+            case Type.BYTE:
+                return value >= -255 && value <= 255;
+            case Type.NON_NEGATIVE_INTEGER:
+                return value > -1;
+            case Type.UNSIGNED_LONG:
+                return value > -1;
+            case Type.UNSIGNED_INT:
+                return value > -1 && value <= 4294967295L;
+            case Type.UNSIGNED_SHORT:
+                return value > -1 && value <= 65535;
+            case Type.UNSIGNED_BYTE:
+                return value > -1 && value <= 255;
+            case Type.POSITIVE_INTEGER:
+                return value > 0; // jmv >= 0;
+        }
+        throw new XPathException("Unknown type: " + Type.getTypeName(type));
+    }
 
-	public Item itemAt(int pos) {
-		return pos == 0 ? this : null;
-	}
+    /**
+     * @param value2
+     * @param type2
+     * @throws XPathException
+     */
+    private boolean checkType(BigInteger value2, int type2) throws XPathException {
+        switch (type) {
 
-	public long getValue() {
-		return value.longValue();
-	}
+            case Type.LONG:
+                // jmv: add test since now long is not the default implementation anymore:
+                return value.compareTo(SMALLEST_LONG) >= 0 &&
+                        value.compareTo(LARGEST_LONG) <= 0;
 
-	public void setValue(long value) {
-		this.value = BigInteger.valueOf(value);
-	}
+            case Type.UNSIGNED_LONG:
+                return value.compareTo(ZERO_BIGINTEGER) >= 0 &&
+                        value.compareTo(LARGEST_UNSIGNED_LONG) <= 0;
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#getStringValue()
-	 */
-	public String getStringValue() {
-		return // Long.toString(value);
-		value.toString();
-	}
-	
-	public boolean isNaN() {
-		return false;
-	}
+            case Type.INTEGER:
+            case Type.DECIMAL:
+                return true;
 
-	public boolean isInfinite() {
-		return false;
-	}
+            case Type.POSITIVE_INTEGER:
+                return value.compareTo(ZERO_BIGINTEGER) == 1; // >0
+            case Type.NON_NEGATIVE_INTEGER:
+                return value.compareTo(MINUS_ONE_BIGINTEGER) == 1; // > -1
 
-	public boolean isZero() {
-		return value.signum() == 0;
-		//return value.compareTo(ZERO_BIGINTEGER) == Constants.EQUAL;
-	}
+            case Type.NEGATIVE_INTEGER:
+                return value.compareTo(ZERO_BIGINTEGER) == -1; // <0
+            case Type.NON_POSITIVE_INTEGER:
+                return value.compareTo(ONE_BIGINTEGER) == -1; // <1
 
-	public boolean isNegative() {
-        return value.signum()<0;
+            case Type.INT:
+                return value.compareTo(SMALLEST_INT) >= 0 &&
+                        value.compareTo(LARGEST_INT) <= 0;
+
+            case Type.UNSIGNED_INT:
+                return value.compareTo(ZERO_BIGINTEGER) >= 0 &&
+                        value.compareTo(LARGEST_UNSIGNED_INT) <= 0;
+
+            case Type.SHORT:
+                return value.compareTo(SMALLEST_SHORT) >= 0 &&
+                        value.compareTo(LARGEST_SHORT) <= 0;
+
+            case Type.UNSIGNED_SHORT:
+                return value.compareTo(ZERO_BIGINTEGER) >= 0 &&
+                        value.compareTo(LARGEST_UNSIGNED_SHORT) <= 0;
+
+            case Type.BYTE:
+                return value.compareTo(SMALLEST_BYTE) >= 0 &&
+                        value.compareTo(LARGEST_BYTE) <= 0;
+
+            case Type.UNSIGNED_BYTE:
+                return value.compareTo(ZERO_BIGINTEGER) >= 0 &&
+                        value.compareTo(LARGEST_UNSIGNED_BYTE) <= 0;
+        }
+
+        throw new XPathException("Unknown type: " + Type.getTypeName(type));
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#getType()
+     */
+    public int getType() {
+        return type;
+    }
+
+    public boolean hasFractionalPart() {
+        return false;
+    }
+
+    public Item itemAt(int pos) {
+        return pos == 0 ? this : null;
+    }
+
+    public long getValue() {
+        return value.longValue();
+    }
+
+    public void setValue(long value) {
+        this.value = BigInteger.valueOf(value);
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#getStringValue()
+     */
+    public String getStringValue() {
+        return // Long.toString(value);
+                value.toString();
+    }
+
+    public boolean isNaN() {
+        return false;
+    }
+
+    public boolean isInfinite() {
+        return false;
+    }
+
+    public boolean isZero() {
+        return value.signum() == 0;
+        //return value.compareTo(ZERO_BIGINTEGER) == Constants.EQUAL;
+    }
+
+    public boolean isNegative() {
+        return value.signum() < 0;
     }
 
     public boolean isPositive() {
-        return value.signum()>0;
+        return value.signum() > 0;
     }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#convertTo(int)
-	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		if (this.type == requiredType)
-			{return this;}
-		
-		switch (requiredType) {
-			case Type.ATOMIC :
-			case Type.ITEM :
-				return this;
-			case Type.DECIMAL :
-				return new DecimalValue(new BigDecimal(value));
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());				
-			case Type.NUMBER :
-			case Type.LONG :
-			case Type.INTEGER :
-			case Type.NON_POSITIVE_INTEGER :
-			case Type.NEGATIVE_INTEGER :
-			case Type.INT :
-			case Type.SHORT :
-			case Type.BYTE :
-			case Type.NON_NEGATIVE_INTEGER :
-			case Type.UNSIGNED_LONG :
-			case Type.UNSIGNED_INT :
-			case Type.UNSIGNED_SHORT :
-			case Type.UNSIGNED_BYTE :
-			case Type.POSITIVE_INTEGER :
-				return new IntegerValue(value, requiredType);
-			case Type.DOUBLE :
-				return new DoubleValue(value.doubleValue());
-			case Type.FLOAT:
-			    return new FloatValue(value.floatValue());
-			case Type.STRING :
-				return new StringValue(getStringValue());
-			case Type.BOOLEAN :
-				return (value.compareTo(ZERO_BIGINTEGER) == 0 ) ? BooleanValue.FALSE : BooleanValue.TRUE;
-			default :
-				throw new XPathException(ErrorCodes.FORG0001,
-					"cannot convert '" 
-                    +  Type.getTypeName(this.getType()) 
-                    + " (" 
-                    + value 
-                    + ")' into " 
-                    + Type.getTypeName(requiredType));
-		}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#convertTo(int)
+     */
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        if (this.type == requiredType) {
+            return this;
+        }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#getInt()
-	 */
-	public int getInt() throws XPathException {
-		return value.intValue(); // (int) value;
-	}
+        switch (requiredType) {
+            case Type.ATOMIC:
+            case Type.ITEM:
+                return this;
+            case Type.DECIMAL:
+                return new DecimalValue(new BigDecimal(value));
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            case Type.NUMBER:
+            case Type.LONG:
+            case Type.INTEGER:
+            case Type.NON_POSITIVE_INTEGER:
+            case Type.NEGATIVE_INTEGER:
+            case Type.INT:
+            case Type.SHORT:
+            case Type.BYTE:
+            case Type.NON_NEGATIVE_INTEGER:
+            case Type.UNSIGNED_LONG:
+            case Type.UNSIGNED_INT:
+            case Type.UNSIGNED_SHORT:
+            case Type.UNSIGNED_BYTE:
+            case Type.POSITIVE_INTEGER:
+                return new IntegerValue(value, requiredType);
+            case Type.DOUBLE:
+                return new DoubleValue(value.doubleValue());
+            case Type.FLOAT:
+                return new FloatValue(value.floatValue());
+            case Type.STRING:
+                return new StringValue(getStringValue());
+            case Type.BOOLEAN:
+                return (value.compareTo(ZERO_BIGINTEGER) == 0) ? BooleanValue.FALSE : BooleanValue.TRUE;
+            default:
+                throw new XPathException(ErrorCodes.FORG0001,
+                        "cannot convert '"
+                                + Type.getTypeName(this.getType())
+                                + " ("
+                                + value
+                                + ")' into "
+                                + Type.getTypeName(requiredType));
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#getLong()
-	 */
-	public long getLong() throws XPathException {
-		return value.longValue();
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#getInt()
+     */
+    public int getInt() throws XPathException {
+        return value.intValue(); // (int) value;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#getDouble()
-	 */
-	public double getDouble() throws XPathException {
-		return value.doubleValue(); // (double) value;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#getLong()
+     */
+    public long getLong() throws XPathException {
+        return value.longValue();
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#ceiling()
-	 */
-	public NumericValue ceiling() throws XPathException {
-		return this;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#getDouble()
+     */
+    public double getDouble() throws XPathException {
+        return value.doubleValue(); // (double) value;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#floor()
-	 */
-	public NumericValue floor() throws XPathException {
-		return this;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#ceiling()
+     */
+    public NumericValue ceiling() throws XPathException {
+        return this;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#round()
-	 */
-	public NumericValue round() throws XPathException {
-		return this;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#round(org.exist.xquery.IntegerValue)
-	 */
-	public NumericValue round(IntegerValue precision) throws XPathException {
-		if (precision == null) {return round();}
-		
-		if ( precision.getInt()<=0 )
-			{return (IntegerValue) ((DecimalValue) convertTo(Type.DECIMAL)).round(precision).convertTo(Type.INTEGER);}
-		else
-			{return this;}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#floor()
+     */
+    public NumericValue floor() throws XPathException {
+        return this;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#minus(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue minus(ComputableValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.INTEGER))
-			// return new IntegerValue(value - ((IntegerValue) other).value, type);
-			{return new IntegerValue( value.subtract( ((IntegerValue) other).value ), type );}
-		else
-			{return ((ComputableValue) convertTo(other.getType())).minus(other);}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#round()
+     */
+    public NumericValue round() throws XPathException {
+        return this;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#plus(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue plus(ComputableValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.INTEGER))
-			// return new IntegerValue(value + ((IntegerValue) other).value, type);
-			{return new IntegerValue( value.add( ((IntegerValue) other).value ), type );}
-		else
-			{return ((ComputableValue) convertTo(other.getType())).plus(other);}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#round(org.exist.xquery.IntegerValue)
+     */
+    public NumericValue round(IntegerValue precision) throws XPathException {
+        if (precision == null) {
+            return round();
+        }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#mult(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue mult(ComputableValue other) throws XPathException {
-		if(Type.subTypeOf(other.getType(), Type.INTEGER))
-		    {return new IntegerValue( value.multiply( ((IntegerValue) other).value ), type );}
-        else if(Type.subTypeOf(other.getType(), Type.DURATION))
-            {return other.mult(this);}
-        else
-            {return ((ComputableValue) convertTo(other.getType())).mult(other);}
-	}
+        if (precision.getInt() <= 0) {
+            return (IntegerValue) ((DecimalValue) convertTo(Type.DECIMAL)).round(precision).convertTo(Type.INTEGER);
+        } else {
+            return this;
+        }
+    }
 
-	/** The div operator performs floating-point division according to IEEE 754.
-	 * @see org.exist.xquery.value.NumericValue#idiv(org.exist.xquery.value.NumericValue)
-	 */
-	public ComputableValue div(ComputableValue other) throws XPathException {
-		if (other instanceof IntegerValue) {
-			if (((IntegerValue) other).isZero())
-				{throw new XPathException(ErrorCodes.FOAR0001, "division by zero");}
-			//http://www.w3.org/TR/xpath20/#mapping : numeric; but xs:decimal if both operands are xs:integer
-			final BigDecimal d = new BigDecimal(value);			 
-			final BigDecimal od = new BigDecimal(((IntegerValue) other).value);
-			final int scale = Math.max(18, Math.max(d.scale(), od.scale()));	
-			return new DecimalValue(d.divide(od, scale, BigDecimal.ROUND_HALF_DOWN));
-		} else
-			//TODO : review type promotion
-			{return ((ComputableValue) convertTo(other.getType())).div(other);}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#minus(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue minus(ComputableValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.INTEGER))
+        // return new IntegerValue(value - ((IntegerValue) other).value, type);
+        {
+            return new IntegerValue(value.subtract(((IntegerValue) other).value), type);
+        } else {
+            return ((ComputableValue) convertTo(other.getType())).minus(other);
+        }
+    }
 
-	public IntegerValue idiv(NumericValue other) throws XPathException {
-		if (other.isZero())
-			//If the divisor is (positive or negative) zero, then an error is raised [err:FOAR0001]
-		    {throw new XPathException(ErrorCodes.FOAR0001, "division by zero");}		
-		final ComputableValue result = div(other);
-		return new IntegerValue(((IntegerValue)result.convertTo(Type.INTEGER)).getLong());		
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#plus(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue plus(ComputableValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.INTEGER))
+        // return new IntegerValue(value + ((IntegerValue) other).value, type);
+        {
+            return new IntegerValue(value.add(((IntegerValue) other).value), type);
+        } else {
+            return ((ComputableValue) convertTo(other.getType())).plus(other);
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#mod(org.exist.xquery.value.NumericValue)
-	 */
-	public NumericValue mod(NumericValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.INTEGER)) {
-			if( other.isZero() )
-				{throw new XPathException(ErrorCodes.FOAR0001, "division by zero");}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#mult(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue mult(ComputableValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.INTEGER)) {
+            return new IntegerValue(value.multiply(((IntegerValue) other).value), type);
+        } else if (Type.subTypeOf(other.getType(), Type.DURATION)) {
+            return other.mult(this);
+        } else {
+            return ((ComputableValue) convertTo(other.getType())).mult(other);
+        }
+    }
 
-			// long ov = ((IntegerValue) other).value.longValue();
-			final BigInteger ov =  ((IntegerValue) other).value;
-			return new IntegerValue(value.remainder(ov), type);
-		} else
-			{return ((NumericValue) convertTo(other.getType())).mod(other);}
-	}
+    /**
+     * The div operator performs floating-point division according to IEEE 754.
+     *
+     * @see org.exist.xquery.value.NumericValue#idiv(org.exist.xquery.value.NumericValue)
+     */
+    public ComputableValue div(ComputableValue other) throws XPathException {
+        if (other instanceof IntegerValue) {
+            if (((IntegerValue) other).isZero()) {
+                throw new XPathException(ErrorCodes.FOAR0001, "division by zero");
+            }
+            //http://www.w3.org/TR/xpath20/#mapping : numeric; but xs:decimal if both operands are xs:integer
+            final BigDecimal d = new BigDecimal(value);
+            final BigDecimal od = new BigDecimal(((IntegerValue) other).value);
+            final int scale = Math.max(18, Math.max(d.scale(), od.scale()));
+            return new DecimalValue(d.divide(od, scale, BigDecimal.ROUND_HALF_DOWN));
+        } else
+        //TODO : review type promotion
+        {
+            return ((ComputableValue) convertTo(other.getType())).div(other);
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#unaryMinus()
-	 */
-	public NumericValue negate() throws XPathException {
-		return new IntegerValue(value.negate());
-	}
+    public IntegerValue idiv(NumericValue other) throws XPathException {
+        if (other.isZero())
+        //If the divisor is (positive or negative) zero, then an error is raised [err:FOAR0001]
+        {
+            throw new XPathException(ErrorCodes.FOAR0001, "division by zero");
+        }
+        final ComputableValue result = div(other);
+        return new IntegerValue(((IntegerValue) result.convertTo(Type.INTEGER)).getLong());
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#abs()
-	 */
-	public NumericValue abs() throws XPathException {
-		// return new IntegerValue(Math.abs(value), type);
-		return new IntegerValue( value.abs(), type);
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#mod(org.exist.xquery.value.NumericValue)
+     */
+    public NumericValue mod(NumericValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.INTEGER)) {
+            if (other.isZero()) {
+                throw new XPathException(ErrorCodes.FOAR0001, "division by zero");
+            }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.NumericValue#max(org.exist.xquery.value.AtomicValue)
-	 */
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		if(Type.subTypeOf(other.getType(), Type.INTEGER))
-			{return new IntegerValue( value.max( ((IntegerValue) other).value) );}
-		else
-			{return convertTo(other.getType()).max(collator, other);}
-	}
+            // long ov = ((IntegerValue) other).value.longValue();
+            final BigInteger ov = ((IntegerValue) other).value;
+            return new IntegerValue(value.remainder(ov), type);
+        } else {
+            return ((NumericValue) convertTo(other.getType())).mod(other);
+        }
+    }
 
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		if(Type.subTypeOf(other.getType(), Type.INTEGER))
-			{return new IntegerValue( value.min( ((IntegerValue) other).value) );}
-		else
-			{return convertTo(other.getType()).min(collator, other);}
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#unaryMinus()
+     */
+    public NumericValue negate() throws XPathException {
+        return new IntegerValue(value.negate());
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
-	 */
-	public int conversionPreference(Class<?> javaClass) {
-		if(javaClass.isAssignableFrom(IntegerValue.class)) {return 0;}
-		if(javaClass == Long.class || javaClass == long.class) {return 1;}
-		if(javaClass == Integer.class || javaClass == int.class) {return 2;}
-		if(javaClass == Short.class || javaClass == short.class) {return 3;}
-		if(javaClass == Byte.class || javaClass == byte.class) {return 4;}
-		if(javaClass == Double.class || javaClass == double.class) {return 5;}
-		if(javaClass == Float.class || javaClass == float.class) {return 6;}
-		if(javaClass == String.class) {return 7;}
-		if(javaClass == Boolean.class || javaClass == boolean.class) {return 8;}
-		if(javaClass == Object.class) {return 20;}
-		
-		return Integer.MAX_VALUE;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#abs()
+     */
+    public NumericValue abs() throws XPathException {
+        // return new IntegerValue(Math.abs(value), type);
+        return new IntegerValue(value.abs(), type);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
-	 */
-        @Override
-	public <T> T toJavaObject(final Class<T> target) throws XPathException {
-		if(target.isAssignableFrom(IntegerValue.class)) {
-			return (T)this;
-                } else if(target == Long.class || target == long.class) {
-			// ?? jmv: return new Long(value);
-			return (T)Long.valueOf(value.longValue());
-                } else if(target == Integer.class || target == int.class) {
-			final IntegerValue v = (IntegerValue)convertTo(Type.INT);
-			return (T)Integer.valueOf(v.value.intValue());
-		} else if(target == Short.class || target == short.class) {
-			final IntegerValue v = (IntegerValue)convertTo(Type.SHORT);
-			return (T)Short.valueOf(v.value.shortValue());
-		} else if(target == Byte.class || target == byte.class) {
-			final IntegerValue v = (IntegerValue)convertTo(Type.BYTE);
-			return (T)Byte.valueOf(v.value.byteValue());
-		} else if(target == Double.class || target == double.class) {
-			final DoubleValue v = (DoubleValue)convertTo(Type.DOUBLE);
-			return (T)Double.valueOf(v.getValue());
-		} else if(target == Float.class || target == float.class) {
-			final FloatValue v = (FloatValue)convertTo(Type.FLOAT);
-			return (T)Float.valueOf(v.value);
-		} else if(target == Boolean.class || target == boolean.class) {
-			return (T)new BooleanValue(effectiveBooleanValue());
-                } else if(target == String.class) {
-			return (T)value.toString();
-                } else if(target == BigInteger.class) {
-                    return (T)new BigInteger(value.toByteArray());
-                } else if(target == Object.class) {
-			return (T)value; // Long(value);
-                }
-		
-		throw new XPathException("cannot convert value of type " + Type.getTypeName(getType()) +
-			" to Java object of type " + target.getName());
-	}
-	
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.NumericValue#max(org.exist.xquery.value.AtomicValue)
+     */
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.INTEGER)) {
+            return new IntegerValue(value.max(((IntegerValue) other).value));
+        } else {
+            return convertTo(other.getType()).max(collator, other);
+        }
+    }
+
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.INTEGER)) {
+            return new IntegerValue(value.min(((IntegerValue) other).value));
+        } else {
+            return convertTo(other.getType()).min(collator, other);
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
+     */
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(IntegerValue.class)) {
+            return 0;
+        }
+        if (javaClass == Long.class || javaClass == long.class) {
+            return 1;
+        }
+        if (javaClass == Integer.class || javaClass == int.class) {
+            return 2;
+        }
+        if (javaClass == Short.class || javaClass == short.class) {
+            return 3;
+        }
+        if (javaClass == Byte.class || javaClass == byte.class) {
+            return 4;
+        }
+        if (javaClass == Double.class || javaClass == double.class) {
+            return 5;
+        }
+        if (javaClass == Float.class || javaClass == float.class) {
+            return 6;
+        }
+        if (javaClass == String.class) {
+            return 7;
+        }
+        if (javaClass == Boolean.class || javaClass == boolean.class) {
+            return 8;
+        }
+        if (javaClass == Object.class) {
+            return 20;
+        }
+
+        return Integer.MAX_VALUE;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
+     */
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target.isAssignableFrom(IntegerValue.class)) {
+            return (T) this;
+        } else if (target == Long.class || target == long.class) {
+            // ?? jmv: return new Long(value);
+            return (T) Long.valueOf(value.longValue());
+        } else if (target == Integer.class || target == int.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.INT);
+            return (T) Integer.valueOf(v.value.intValue());
+        } else if (target == Short.class || target == short.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.SHORT);
+            return (T) Short.valueOf(v.value.shortValue());
+        } else if (target == Byte.class || target == byte.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
+            return (T) Byte.valueOf(v.value.byteValue());
+        } else if (target == Double.class || target == double.class) {
+            final DoubleValue v = (DoubleValue) convertTo(Type.DOUBLE);
+            return (T) Double.valueOf(v.getValue());
+        } else if (target == Float.class || target == float.class) {
+            final FloatValue v = (FloatValue) convertTo(Type.FLOAT);
+            return (T) Float.valueOf(v.value);
+        } else if (target == Boolean.class || target == boolean.class) {
+            return (T) new BooleanValue(effectiveBooleanValue());
+        } else if (target == String.class) {
+            return (T) value.toString();
+        } else if (target == BigInteger.class) {
+            return (T) new BigInteger(value.toByteArray());
+        } else if (target == Object.class) {
+            return (T) value; // Long(value);
+        }
+
+        throw new XPathException("cannot convert value of type " + Type.getTypeName(getType()) +
+                " to Java object of type " + target.getName());
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     public int compareTo(Object o) {
-        final AtomicValue other = (AtomicValue)o;
-        if(Type.subTypeOf(other.getType(), Type.INTEGER))
-            {return value.compareTo(((IntegerValue)other).value);}
-        else
-            {return getType() > other.getType() ? 1 : -1;}
+        final AtomicValue other = (AtomicValue) o;
+        if (Type.subTypeOf(other.getType(), Type.INTEGER)) {
+            return value.compareTo(((IntegerValue) other).value);
+        } else {
+            return getType() > other.getType() ? 1 : -1;
+        }
     }
 
     @Override

--- a/src/org/exist/xquery/value/IntegerValue.java
+++ b/src/org/exist/xquery/value/IntegerValue.java
@@ -464,14 +464,14 @@ public class IntegerValue extends NumericValue {
 		if(Type.subTypeOf(other.getType(), Type.INTEGER))
 			{return new IntegerValue( value.max( ((IntegerValue) other).value) );}
 		else
-			{return ((NumericValue) convertTo(other.getType())).max(collator, other);}
+			{return convertTo(other.getType()).max(collator, other);}
 	}
 
 	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
 		if(Type.subTypeOf(other.getType(), Type.INTEGER))
 			{return new IntegerValue( value.min( ((IntegerValue) other).value) );}
 		else
-			{return ((NumericValue) convertTo(other.getType())).min(collator, other);}
+			{return convertTo(other.getType()).min(collator, other);}
 	}
 
 	/* (non-Javadoc)
@@ -504,13 +504,13 @@ public class IntegerValue extends NumericValue {
 			return (T)Long.valueOf(value.longValue());
                 } else if(target == Integer.class || target == int.class) {
 			final IntegerValue v = (IntegerValue)convertTo(Type.INT);
-			return (T)Integer.valueOf((int)v.value.intValue());
+			return (T)Integer.valueOf(v.value.intValue());
 		} else if(target == Short.class || target == short.class) {
 			final IntegerValue v = (IntegerValue)convertTo(Type.SHORT);
-			return (T)Short.valueOf((short)v.value.shortValue());
+			return (T)Short.valueOf(v.value.shortValue());
 		} else if(target == Byte.class || target == byte.class) {
 			final IntegerValue v = (IntegerValue)convertTo(Type.BYTE);
-			return (T)Byte.valueOf((byte)v.value.byteValue());
+			return (T)Byte.valueOf(v.value.byteValue());
 		} else if(target == Double.class || target == double.class) {
 			final DoubleValue v = (DoubleValue)convertTo(Type.DOUBLE);
 			return (T)Double.valueOf(v.getValue());

--- a/src/org/exist/xquery/value/IntegerValue.java
+++ b/src/org/exist/xquery/value/IntegerValue.java
@@ -21,12 +21,12 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.XPathException;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.Collator;
-
-import org.exist.xquery.ErrorCodes;
-import org.exist.xquery.XPathException;
 
 /** [Definition:]   integer is <i>derived</i> from decimal by fixing the value of <i>fractionDigits<i> to be 0. 
  * This results in the standard mathematical concept of the integer numbers. 

--- a/src/org/exist/xquery/value/Item.java
+++ b/src/org/exist/xquery/value/Item.java
@@ -45,19 +45,19 @@ public interface Item {
 	 * {@link Type}.
 	 * 
 	 */
-	public int getType();
+    int getType();
 	
 	/**
 	 * Return the string value of this item (see the definition of string value in XPath).
 	 * 
 	 */
-	public String getStringValue() throws XPathException;
+    String getStringValue() throws XPathException;
 	
 	/**
 	 * Convert this item into a sequence, containing only the item.
 	 *  
 	 */
-	public Sequence toSequence();
+    Sequence toSequence();
 
     /**
      * Clean up any resources used by the items in this sequence.
@@ -73,17 +73,17 @@ public interface Item {
 	 * @param requiredType
 	 * @throws XPathException
 	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException;
+    AtomicValue convertTo(int requiredType) throws XPathException;
 	
-	public AtomicValue atomize() throws XPathException;
+	AtomicValue atomize() throws XPathException;
 	
-	public void toSAX(DBBroker broker, ContentHandler handler, Properties properties) throws SAXException;
+	void toSAX(DBBroker broker, ContentHandler handler, Properties properties) throws SAXException;
 
-	public void copyTo(DBBroker broker, DocumentBuilderReceiver receiver) throws SAXException;
+	void copyTo(DBBroker broker, DocumentBuilderReceiver receiver) throws SAXException;
 	
-	public int conversionPreference(Class<?> javaClass);
+	int conversionPreference(Class<?> javaClass);
 	
-	public <T> T toJavaObject(Class<T> target) throws XPathException;
+	<T> T toJavaObject(Class<T> target) throws XPathException;
 
         /**
          * Nodes may implement this method to be informed of storage address

--- a/src/org/exist/xquery/value/Item.java
+++ b/src/org/exist/xquery/value/Item.java
@@ -20,8 +20,6 @@
  */
 package org.exist.xquery.value;
 
-import java.util.Properties;
-
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.persistent.NodeHandle;
 import org.exist.numbering.NodeId;
@@ -30,6 +28,8 @@ import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
+
+import java.util.Properties;
 
 /**
  * This class represents an item in a sequence as defined by the XPath 2.0 specification.

--- a/src/org/exist/xquery/value/Item.java
+++ b/src/org/exist/xquery/value/Item.java
@@ -35,28 +35,25 @@ import java.util.Properties;
  * This class represents an item in a sequence as defined by the XPath 2.0 specification.
  * Every item is either an {@link org.exist.xquery.value.AtomicValue atomic value} or
  * a {@link org.exist.dom.persistent.NodeProxy node}.
- * 
+ *
  * @author wolf
  */
 public interface Item {
 
-	/**
-	 * Return the type of this item according to the type constants defined in class
-	 * {@link Type}.
-	 * 
-	 */
+    /**
+     * Return the type of this item according to the type constants defined in class
+     * {@link Type}.
+     */
     int getType();
-	
-	/**
-	 * Return the string value of this item (see the definition of string value in XPath).
-	 * 
-	 */
+
+    /**
+     * Return the string value of this item (see the definition of string value in XPath).
+     */
     String getStringValue() throws XPathException;
-	
-	/**
-	 * Convert this item into a sequence, containing only the item.
-	 *  
-	 */
+
+    /**
+     * Convert this item into a sequence, containing only the item.
+     */
     Sequence toSequence();
 
     /**
@@ -64,35 +61,34 @@ public interface Item {
      */
     void destroy(XQueryContext context, Sequence contextSequence);
 
-	/**
-	 * Convert this item into an atomic value, whose type corresponds to
-	 * the specified target type. requiredType should be one of the type
-	 * constants defined in {@link Type}. An {@link XPathException} is thrown
-	 * if the conversion is impossible.
-	 * 
-	 * @param requiredType
-	 * @throws XPathException
-	 */
+    /**
+     * Convert this item into an atomic value, whose type corresponds to
+     * the specified target type. requiredType should be one of the type
+     * constants defined in {@link Type}. An {@link XPathException} is thrown
+     * if the conversion is impossible.
+     *
+     * @param requiredType
+     * @throws XPathException
+     */
     AtomicValue convertTo(int requiredType) throws XPathException;
-	
-	AtomicValue atomize() throws XPathException;
-	
-	void toSAX(DBBroker broker, ContentHandler handler, Properties properties) throws SAXException;
 
-	void copyTo(DBBroker broker, DocumentBuilderReceiver receiver) throws SAXException;
-	
-	int conversionPreference(Class<?> javaClass);
-	
-	<T> T toJavaObject(Class<T> target) throws XPathException;
+    AtomicValue atomize() throws XPathException;
 
-        /**
-         * Nodes may implement this method to be informed of storage address
-         * and node id changes after updates.
-         *
-         * @see org.exist.storage.UpdateListener
-         *
-         * @param oldNodeId
-         * @param newNode
-         */
-        void nodeMoved(NodeId oldNodeId, NodeHandle newNode);  //TODO why is this here, it only pertains to Peristent nodes and NOT also in-memory nodes
+    void toSAX(DBBroker broker, ContentHandler handler, Properties properties) throws SAXException;
+
+    void copyTo(DBBroker broker, DocumentBuilderReceiver receiver) throws SAXException;
+
+    int conversionPreference(Class<?> javaClass);
+
+    <T> T toJavaObject(Class<T> target) throws XPathException;
+
+    /**
+     * Nodes may implement this method to be informed of storage address
+     * and node id changes after updates.
+     *
+     * @param oldNodeId
+     * @param newNode
+     * @see org.exist.storage.UpdateListener
+     */
+    void nodeMoved(NodeId oldNodeId, NodeHandle newNode);  //TODO why is this here, it only pertains to Peristent nodes and NOT also in-memory nodes
 }

--- a/src/org/exist/xquery/value/ItemComparator.java
+++ b/src/org/exist/xquery/value/ItemComparator.java
@@ -40,14 +40,15 @@ public class ItemComparator implements Comparator<Item> {
 
     public final static ItemComparator INSTANCE = new ItemComparator();
 
-    private ItemComparator() {}
+    private ItemComparator() {
+    }
 
     @Override
     public int compare(final Item n1, final Item n2) {
-        if(n1 instanceof org.exist.dom.memtree.NodeImpl && (!(n2 instanceof org.exist.dom.memtree.NodeImpl))) {
+        if (n1 instanceof org.exist.dom.memtree.NodeImpl && (!(n2 instanceof org.exist.dom.memtree.NodeImpl))) {
             return Constants.INFERIOR;
-        } else if(n1 instanceof Comparable) {
-            return ((Comparable)n1).compareTo(n2);
+        } else if (n1 instanceof Comparable) {
+            return ((Comparable) n1).compareTo(n2);
         } else {
             return Constants.INFERIOR;
         }

--- a/src/org/exist/xquery/value/JavaObjectValue.java
+++ b/src/org/exist/xquery/value/JavaObjectValue.java
@@ -30,95 +30,97 @@ import java.text.Collator;
 /**
  * Represents a reference to an arbitrary Java object which is treated as an
  * atomic value.
- * 
+ *
  * @author wolf
  */
 public class JavaObjectValue extends AtomicValue {
 
-	private final Object object;
+    private final Object object;
 
-	public JavaObjectValue(Object object) {
-		this.object = object;
-	}
+    public JavaObjectValue(Object object) {
+        this.object = object;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#getType()
-	 */
-	public int getType() {
-		return Type.JAVA_OBJECT;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#getType()
+     */
+    public int getType() {
+        return Type.JAVA_OBJECT;
+    }
 
-	public Object getObject() {
-		return object;
-	}
+    public Object getObject() {
+        return object;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getStringValue()
-	 */
-	public String getStringValue() {
-		return String.valueOf(object);
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getStringValue()
+     */
+    public String getStringValue() {
+        return String.valueOf(object);
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#convertTo(int)
-	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		if (requiredType == Type.JAVA_OBJECT)
-			{return this;}
-		throw new XPathException(
-			"cannot convert Java object to " + Type.getTypeName(requiredType));
-	}
-	
-	public boolean effectiveBooleanValue() throws XPathException {
-		throw new XPathException("Called effectiveBooleanValue() on JavaObjectValue");
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#convertTo(int)
+     */
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        if (requiredType == Type.JAVA_OBJECT) {
+            return this;
+        }
+        throw new XPathException(
+                "cannot convert Java object to " + Type.getTypeName(requiredType));
+    }
 
-	@Override
-	public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
-		throw new XPathException(
-			"cannot compare Java object to " + Type.getTypeName(other.getType()));
-	}
+    public boolean effectiveBooleanValue() throws XPathException {
+        throw new XPathException("Called effectiveBooleanValue() on JavaObjectValue");
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#compareTo(org.exist.xquery.value.AtomicValue)
-	 */
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException(
-			"cannot compare Java object to " + Type.getTypeName(other.getType()));
-	}
+    @Override
+    public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
+        throw new XPathException(
+                "cannot compare Java object to " + Type.getTypeName(other.getType()));
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
-	 */
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException("Invalid argument to aggregate function: cannot compare Java objects");
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#compareTo(org.exist.xquery.value.AtomicValue)
+     */
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException(
+                "cannot compare Java object to " + Type.getTypeName(other.getType()));
+    }
 
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException("Invalid argument to aggregate function: cannot compare Java objects");
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
+     */
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException("Invalid argument to aggregate function: cannot compare Java objects");
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
-	 */
-	public int conversionPreference(Class<?> javaClass) {
-		if (javaClass.isAssignableFrom(object.getClass()))
-			{return 0;}
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException("Invalid argument to aggregate function: cannot compare Java objects");
+    }
 
-		return Integer.MAX_VALUE;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
+     */
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(object.getClass())) {
+            return 0;
+        }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
-	 */
-        @Override
-	public <T> T toJavaObject(final Class<T> target) throws XPathException {
-            if(target.isAssignableFrom(object.getClass())) {
-                return (T)object;
-            } else if (target == Object.class) {
-                return (T)object;
-            }
+        return Integer.MAX_VALUE;
+    }
 
-            throw new XPathException("cannot convert value of type " + Type.getTypeName(getType()) + " to Java object of type " + target.getName());
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
+     */
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target.isAssignableFrom(object.getClass())) {
+            return (T) object;
+        } else if (target == Object.class) {
+            return (T) object;
+        }
+
+        throw new XPathException("cannot convert value of type " + Type.getTypeName(getType()) + " to Java object of type " + target.getName());
+    }
 }

--- a/src/org/exist/xquery/value/JavaObjectValue.java
+++ b/src/org/exist/xquery/value/JavaObjectValue.java
@@ -35,7 +35,7 @@ import org.exist.xquery.XPathException;
  */
 public class JavaObjectValue extends AtomicValue {
 
-	private Object object;
+	private final Object object;
 
 	public JavaObjectValue(Object object) {
 		this.object = object;

--- a/src/org/exist/xquery/value/JavaObjectValue.java
+++ b/src/org/exist/xquery/value/JavaObjectValue.java
@@ -22,10 +22,10 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.XPathException;
+
+import java.text.Collator;
 
 /**
  * Represents a reference to an arbitrary Java object which is treated as an

--- a/src/org/exist/xquery/value/MemoryNodeSet.java
+++ b/src/org/exist/xquery/value/MemoryNodeSet.java
@@ -8,7 +8,7 @@ import org.exist.xquery.XPathException;
 public interface MemoryNodeSet extends Sequence {
 
     MemoryNodeSet EMPTY = new ValueSequence(1);
-    
+
     Sequence getAttributes(NodeTest test) throws XPathException;
 
     Sequence getDescendantAttributes(NodeTest test) throws XPathException;
@@ -28,7 +28,7 @@ public interface MemoryNodeSet extends Sequence {
     Sequence getPreceding(NodeTest test, int position) throws XPathException;
 
     Sequence getFollowingSiblings(NodeTest test) throws XPathException;
-    
+
     Sequence getFollowing(NodeTest test, int position) throws XPathException;
 
     Sequence getChildrenForParent(NodeImpl parent);
@@ -36,7 +36,7 @@ public interface MemoryNodeSet extends Sequence {
     Sequence selectDescendants(MemoryNodeSet descendants);
 
     Sequence selectChildren(MemoryNodeSet children);
-    
+
     int size();
 
     NodeImpl get(int which);

--- a/src/org/exist/xquery/value/MemoryNodeSet.java
+++ b/src/org/exist/xquery/value/MemoryNodeSet.java
@@ -7,45 +7,45 @@ import org.exist.dom.memtree.NodeImpl;
 
 public interface MemoryNodeSet extends Sequence {
 
-    public final static MemoryNodeSet EMPTY = new ValueSequence(1);
+    MemoryNodeSet EMPTY = new ValueSequence(1);
     
-    public Sequence getAttributes(NodeTest test) throws XPathException;
+    Sequence getAttributes(NodeTest test) throws XPathException;
 
-    public Sequence getDescendantAttributes(NodeTest test) throws XPathException;
+    Sequence getDescendantAttributes(NodeTest test) throws XPathException;
 
-    public Sequence getChildren(NodeTest test) throws XPathException;
+    Sequence getChildren(NodeTest test) throws XPathException;
 
-    public Sequence getDescendants(boolean includeSelf, NodeTest test) throws XPathException;
+    Sequence getDescendants(boolean includeSelf, NodeTest test) throws XPathException;
 
-    public Sequence getAncestors(boolean includeSelf, NodeTest test) throws XPathException;
+    Sequence getAncestors(boolean includeSelf, NodeTest test) throws XPathException;
 
-    public Sequence getParents(NodeTest test) throws XPathException;
+    Sequence getParents(NodeTest test) throws XPathException;
 
-    public Sequence getSelf(NodeTest test) throws XPathException;
+    Sequence getSelf(NodeTest test) throws XPathException;
 
-    public Sequence getPrecedingSiblings(NodeTest test) throws XPathException;
+    Sequence getPrecedingSiblings(NodeTest test) throws XPathException;
 
-    public Sequence getPreceding(NodeTest test, int position) throws XPathException;
+    Sequence getPreceding(NodeTest test, int position) throws XPathException;
 
-    public Sequence getFollowingSiblings(NodeTest test) throws XPathException;
+    Sequence getFollowingSiblings(NodeTest test) throws XPathException;
     
-    public Sequence getFollowing(NodeTest test, int position) throws XPathException;
+    Sequence getFollowing(NodeTest test, int position) throws XPathException;
 
-    public Sequence getChildrenForParent(NodeImpl parent);
+    Sequence getChildrenForParent(NodeImpl parent);
 
-    public Sequence selectDescendants(MemoryNodeSet descendants);
+    Sequence selectDescendants(MemoryNodeSet descendants);
 
-    public Sequence selectChildren(MemoryNodeSet children);
+    Sequence selectChildren(MemoryNodeSet children);
     
-    public int size();
+    int size();
 
-    public NodeImpl get(int which);
+    NodeImpl get(int which);
 
-    public boolean matchAttributes(NodeTest test) throws XPathException;
+    boolean matchAttributes(NodeTest test) throws XPathException;
 
-    public boolean matchDescendantAttributes(NodeTest test) throws XPathException;
+    boolean matchDescendantAttributes(NodeTest test) throws XPathException;
 
-    public boolean matchChildren(NodeTest test) throws XPathException;
+    boolean matchChildren(NodeTest test) throws XPathException;
 
 //    public Sequence matchDescendants(boolean includeSelf, NodeTest test) throws XPathException;
 //
@@ -53,7 +53,7 @@ public interface MemoryNodeSet extends Sequence {
 //
 //    public Sequence matchParents(NodeTest test) throws XPathException;
 
-    public boolean matchSelf(NodeTest test) throws XPathException;
+    boolean matchSelf(NodeTest test) throws XPathException;
 
 //    public Sequence matchPrecedingSiblings(NodeTest test) throws XPathException;
 //

--- a/src/org/exist/xquery/value/MemoryNodeSet.java
+++ b/src/org/exist/xquery/value/MemoryNodeSet.java
@@ -1,8 +1,8 @@
 package org.exist.xquery.value;
 
+import org.exist.dom.memtree.NodeImpl;
 import org.exist.xquery.NodeTest;
 import org.exist.xquery.XPathException;
-import org.exist.dom.memtree.NodeImpl;
 
 
 public interface MemoryNodeSet extends Sequence {

--- a/src/org/exist/xquery/value/MixedNodeValueComparator.java
+++ b/src/org/exist/xquery/value/MixedNodeValueComparator.java
@@ -21,8 +21,8 @@
  */
 package org.exist.xquery.value;
 
-import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.memtree.NodeImpl;
+import org.exist.dom.persistent.NodeProxy;
 
 import java.util.Comparator;
 

--- a/src/org/exist/xquery/value/MixedNodeValueComparator.java
+++ b/src/org/exist/xquery/value/MixedNodeValueComparator.java
@@ -38,15 +38,17 @@ public class MixedNodeValueComparator implements Comparator {
         final NodeValue n1 = (NodeValue) o1;
         final NodeValue n2 = (NodeValue) o2;
         if (n1.getImplementationType() == NodeValue.IN_MEMORY_NODE) {
-            if (n2.getImplementationType() == NodeValue.IN_MEMORY_NODE)
-                {return ((NodeImpl)n1).compareTo((NodeImpl)n2);}
-            else
-                {return -1;}
+            if (n2.getImplementationType() == NodeValue.IN_MEMORY_NODE) {
+                return ((NodeImpl) n1).compareTo((NodeImpl) n2);
+            } else {
+                return -1;
+            }
         } else {
-            if (n2.getImplementationType() == NodeValue.PERSISTENT_NODE)
-            	{return ((NodeProxy)o1).compareTo((NodeProxy)o2);}
-            else
-                {return 1;}
+            if (n2.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                return ((NodeProxy) o1).compareTo((NodeProxy) o2);
+            } else {
+                return 1;
+            }
         }
     }
 }

--- a/src/org/exist/xquery/value/NodeValue.java
+++ b/src/org/exist/xquery/value/NodeValue.java
@@ -31,61 +31,66 @@ import org.w3c.dom.Node;
 /**
  * Represents a node value. May either be an in-memory node
  * or a persistent node.
- * 
+ *
  * @author Wolfgang Meier (wolfgang@exist-db.org)
  */
 public interface NodeValue extends Item, Sequence {
-	
-	/** Node is a constructed in-memory node */
+
+    /**
+     * Node is a constructed in-memory node
+     */
     int IN_MEMORY_NODE = 0;
-	
-	/** Node is a persistent, i.e. stored in the database */
+
+    /**
+     * Node is a persistent, i.e. stored in the database
+     */
     int PERSISTENT_NODE = 1;
-	
-	/**
-	 * Returns true if this node has the same identity as another
-	 * node. Used to implement "is" and "isnot" comparisons.
-	 * 
-	 * @param other
-	 * @throws XPathException
-	 */
+
+    /**
+     * Returns true if this node has the same identity as another
+     * node. Used to implement "is" and "isnot" comparisons.
+     *
+     * @param other
+     * @throws XPathException
+     */
     boolean equals(NodeValue other) throws XPathException;
-	
-	/**
-	 * Returns true if this node comes before another node in
-	 * document order.
-	 * 
-	 * @param other
-	 * @throws XPathException
-	 */
+
+    /**
+     * Returns true if this node comes before another node in
+     * document order.
+     *
+     * @param other
+     * @throws XPathException
+     */
     boolean before(NodeValue other, boolean isPreceding) throws XPathException;
-	
-	/**
-	 * Returns true if this node comes after another node in
-	 * document order.
-	 * 
-	 * @param other
-	 * @throws XPathException
-	 */
+
+    /**
+     * Returns true if this node comes after another node in
+     * document order.
+     *
+     * @param other
+     * @throws XPathException
+     */
     boolean after(NodeValue other, boolean isFollowing) throws XPathException;
-	
-	/**
-	 * Returns the implementation-type of this node, i.e. either
-	 * {@link #IN_MEMORY_NODE} or {@link #PERSISTENT_NODE}.
-	 * 
-	 */
+
+    /**
+     * Returns the implementation-type of this node, i.e. either
+     * {@link #IN_MEMORY_NODE} or {@link #PERSISTENT_NODE}.
+     */
     int getImplementationType();
-	
+
     void addContextNode(int contextId, NodeValue node);
-    
+
     QName getQName();
 
-	/** Retrieve the actual node. This operation is <strong>expensive</strong>.
-	 * @return The actual node.
-	 */
+    /**
+     * Retrieve the actual node. This operation is <strong>expensive</strong>.
+     *
+     * @return The actual node.
+     */
     Node getNode();
-	
-	Document getOwnerDocument();
+
+    Document getOwnerDocument();
 
     NodeId getNodeId();
 }

--- a/src/org/exist/xquery/value/NodeValue.java
+++ b/src/org/exist/xquery/value/NodeValue.java
@@ -37,10 +37,10 @@ import org.w3c.dom.Node;
 public interface NodeValue extends Item, Sequence {
 	
 	/** Node is a constructed in-memory node */
-	public final static int IN_MEMORY_NODE = 0;
+    int IN_MEMORY_NODE = 0;
 	
 	/** Node is a persistent, i.e. stored in the database */
-	public final static int PERSISTENT_NODE = 1;
+    int PERSISTENT_NODE = 1;
 	
 	/**
 	 * Returns true if this node has the same identity as another
@@ -49,7 +49,7 @@ public interface NodeValue extends Item, Sequence {
 	 * @param other
 	 * @throws XPathException
 	 */
-	public boolean equals(NodeValue other) throws XPathException;
+    boolean equals(NodeValue other) throws XPathException;
 	
 	/**
 	 * Returns true if this node comes before another node in
@@ -58,7 +58,7 @@ public interface NodeValue extends Item, Sequence {
 	 * @param other
 	 * @throws XPathException
 	 */
-	public boolean before(NodeValue other, boolean isPreceding) throws XPathException;
+    boolean before(NodeValue other, boolean isPreceding) throws XPathException;
 	
 	/**
 	 * Returns true if this node comes after another node in
@@ -67,25 +67,25 @@ public interface NodeValue extends Item, Sequence {
 	 * @param other
 	 * @throws XPathException
 	 */
-	public boolean after(NodeValue other, boolean isFollowing) throws XPathException;
+    boolean after(NodeValue other, boolean isFollowing) throws XPathException;
 	
 	/**
 	 * Returns the implementation-type of this node, i.e. either
 	 * {@link #IN_MEMORY_NODE} or {@link #PERSISTENT_NODE}.
 	 * 
 	 */
-	public int getImplementationType();
+    int getImplementationType();
 	
-    public void addContextNode(int contextId, NodeValue node);
+    void addContextNode(int contextId, NodeValue node);
     
-    public QName getQName();
+    QName getQName();
 
 	/** Retrieve the actual node. This operation is <strong>expensive</strong>.
 	 * @return The actual node.
 	 */
-	public Node getNode();
+    Node getNode();
 	
-	public Document getOwnerDocument();
+	Document getOwnerDocument();
 
-    public NodeId getNodeId();
+    NodeId getNodeId();
 }

--- a/src/org/exist/xquery/value/NumericValue.java
+++ b/src/org/exist/xquery/value/NumericValue.java
@@ -1,10 +1,10 @@
 package org.exist.xquery.value;
 
-import java.text.Collator;
-
 import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.XPathException;
+
+import java.text.Collator;
 
 public abstract class NumericValue extends ComputableValue {
 

--- a/src/org/exist/xquery/value/NumericValue.java
+++ b/src/org/exist/xquery/value/NumericValue.java
@@ -8,107 +8,110 @@ import java.text.Collator;
 
 public abstract class NumericValue extends ComputableValue {
 
-	public abstract String getStringValue() throws XPathException;
+    public abstract String getStringValue() throws XPathException;
 
-	public abstract AtomicValue convertTo(int requiredType) throws XPathException;
-	
-	public double getDouble() throws XPathException {
-		return ((DoubleValue)convertTo(Type.DOUBLE)).getValue();
-	}
-	
-	public long getLong() throws XPathException {
-		return ((IntegerValue)convertTo(Type.INTEGER)).getValue();
-	}
-	
-	public int getInt() throws XPathException {
-		return (int)((IntegerValue)convertTo(Type.INTEGER)).getValue();
-	}
-	
-	public abstract boolean hasFractionalPart();
-	
-	public abstract boolean isNaN();
+    public abstract AtomicValue convertTo(int requiredType) throws XPathException;
 
-	public abstract boolean isInfinite();
+    public double getDouble() throws XPathException {
+        return ((DoubleValue) convertTo(Type.DOUBLE)).getValue();
+    }
 
-	public abstract boolean isZero();
-    
+    public long getLong() throws XPathException {
+        return ((IntegerValue) convertTo(Type.INTEGER)).getValue();
+    }
+
+    public int getInt() throws XPathException {
+        return (int) ((IntegerValue) convertTo(Type.INTEGER)).getValue();
+    }
+
+    public abstract boolean hasFractionalPart();
+
+    public abstract boolean isNaN();
+
+    public abstract boolean isInfinite();
+
+    public abstract boolean isZero();
+
     public abstract boolean isNegative();
-    
+
     public abstract boolean isPositive();
-	
-	public boolean effectiveBooleanValue() throws XPathException {
-		//If its operand is a singleton value of any numeric type or derived from a numeric type, 
-		//fn:boolean returns false if the operand value is NaN or is numerically equal to zero; 
-		//otherwise it returns true.		
-		return !(isNaN() || isZero());
-	}
-	
-	@Override
-	public boolean compareTo(Collator collator, Comparison operator, AtomicValue other)
-		throws XPathException {
-		if (other.isEmpty()) {
-			//Never equal, or inequal...
-			return false;
-		}		
-		if(Type.subTypeOf(other.getType(), Type.NUMBER)) {
-			if (isNaN()) {
-				//NaN does not equal itself.
-				if (((NumericValue)other).isNaN()) {
-					return operator == Comparison.NEQ;
-				}
-			}			
-			final double otherVal = ((NumericValue)other).getDouble();
-			final double val = getDouble();
-			switch(operator) {
-				case EQ:
-					return val == otherVal;
-				case NEQ:
-					return val != otherVal;
-				case GT:
-					return val > otherVal;
-				case GTEQ:
-					return val >= otherVal;
-				case LT:
-					return val < otherVal;
-				case LTEQ:
-					return val <= otherVal;
-				default:
-					throw new XPathException("Type error: cannot apply operator to numeric value");
-			}
-		}
-		throw new XPathException("Type error: cannot compare operands: " + 
-			Type.getTypeName(getType()) + " and " + 
-			Type.getTypeName(other.getType()));
-	}
-	
-	@Override
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		if(Type.subTypeOf(other.getType(), Type.NUMBER)) {
-			if (isNaN()) {
-				//NaN does not equal itself.
-				if (((NumericValue)other).isNaN())
-				{return Constants.INFERIOR;}
-			}
-			final double otherVal = ((NumericValue)other).getDouble();
-			final double val = getDouble();
-			if(val == otherVal)
-				{return Constants.EQUAL;}
-			else if(val > otherVal)
-				{return Constants.SUPERIOR;}
-			else
-				{return Constants.INFERIOR;}
-		} else {
-			throw new XPathException("cannot compare numeric value to non-numeric value");
-		}
-	}
+
+    public boolean effectiveBooleanValue() throws XPathException {
+        //If its operand is a singleton value of any numeric type or derived from a numeric type,
+        //fn:boolean returns false if the operand value is NaN or is numerically equal to zero;
+        //otherwise it returns true.
+        return !(isNaN() || isZero());
+    }
+
+    @Override
+    public boolean compareTo(Collator collator, Comparison operator, AtomicValue other)
+            throws XPathException {
+        if (other.isEmpty()) {
+            //Never equal, or inequal...
+            return false;
+        }
+        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+            if (isNaN()) {
+                //NaN does not equal itself.
+                if (((NumericValue) other).isNaN()) {
+                    return operator == Comparison.NEQ;
+                }
+            }
+            final double otherVal = ((NumericValue) other).getDouble();
+            final double val = getDouble();
+            switch (operator) {
+                case EQ:
+                    return val == otherVal;
+                case NEQ:
+                    return val != otherVal;
+                case GT:
+                    return val > otherVal;
+                case GTEQ:
+                    return val >= otherVal;
+                case LT:
+                    return val < otherVal;
+                case LTEQ:
+                    return val <= otherVal;
+                default:
+                    throw new XPathException("Type error: cannot apply operator to numeric value");
+            }
+        }
+        throw new XPathException("Type error: cannot compare operands: " +
+                Type.getTypeName(getType()) + " and " +
+                Type.getTypeName(other.getType()));
+    }
+
+    @Override
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+            if (isNaN()) {
+                //NaN does not equal itself.
+                if (((NumericValue) other).isNaN()) {
+                    return Constants.INFERIOR;
+                }
+            }
+            final double otherVal = ((NumericValue) other).getDouble();
+            final double val = getDouble();
+            if (val == otherVal) {
+                return Constants.EQUAL;
+            } else if (val > otherVal) {
+                return Constants.SUPERIOR;
+            } else {
+                return Constants.INFERIOR;
+            }
+        } else {
+            throw new XPathException("cannot compare numeric value to non-numeric value");
+        }
+    }
 
     @Override
     public boolean equals(Object obj) {
-		if (obj == null)
-			{return false;}
+        if (obj == null) {
+            return false;
+        }
         if (NumericValue.class.isAssignableFrom(obj.getClass()))
             try {
-                return compareTo(null, Comparison.EQ, (NumericValue)obj);
+                return compareTo(null, Comparison.EQ, (NumericValue) obj);
             } catch (final XPathException e) {
                 // should not be possible due to type check
             }
@@ -116,16 +119,25 @@ public abstract class NumericValue extends ComputableValue {
     }
 
     public abstract NumericValue negate() throws XPathException;
-	public abstract NumericValue ceiling() throws XPathException;
-	public abstract NumericValue floor() throws XPathException;
-	public abstract NumericValue round() throws XPathException;
-	public abstract NumericValue round(IntegerValue precision) throws XPathException;
-	public abstract NumericValue mod(NumericValue other) throws XPathException;
-	//TODO : implement here ?
-	public abstract	IntegerValue idiv(NumericValue other) throws XPathException;
-	public abstract NumericValue abs() throws XPathException;
-	public abstract AtomicValue max(Collator collator, AtomicValue other) throws XPathException;
-	public abstract AtomicValue min(Collator collator, AtomicValue other) throws XPathException;
 
-	
+    public abstract NumericValue ceiling() throws XPathException;
+
+    public abstract NumericValue floor() throws XPathException;
+
+    public abstract NumericValue round() throws XPathException;
+
+    public abstract NumericValue round(IntegerValue precision) throws XPathException;
+
+    public abstract NumericValue mod(NumericValue other) throws XPathException;
+
+    //TODO : implement here ?
+    public abstract IntegerValue idiv(NumericValue other) throws XPathException;
+
+    public abstract NumericValue abs() throws XPathException;
+
+    public abstract AtomicValue max(Collator collator, AtomicValue other) throws XPathException;
+
+    public abstract AtomicValue min(Collator collator, AtomicValue other) throws XPathException;
+
+
 }

--- a/src/org/exist/xquery/value/OrderedDurationValue.java
+++ b/src/org/exist/xquery/value/OrderedDurationValue.java
@@ -1,16 +1,15 @@
 package org.exist.xquery.value;
 
-import java.math.BigDecimal;
-import java.text.Collator;
-
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.Duration;
-import javax.xml.datatype.XMLGregorianCalendar;
-
 import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.Duration;
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.math.BigDecimal;
+import java.text.Collator;
 
 /**
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>

--- a/src/org/exist/xquery/value/OrderedDurationValue.java
+++ b/src/org/exist/xquery/value/OrderedDurationValue.java
@@ -66,8 +66,8 @@ abstract class OrderedDurationValue extends DurationValue {
 			final int r = duration.compare(((DurationValue) other).duration);
 			//compare fractional seconds to work around the JDK standard behaviour
 			if (r == DatatypeConstants.EQUAL &&
-					((BigDecimal)duration.getField(DatatypeConstants.SECONDS)) != null &&
-					((BigDecimal)(((DurationValue) other).duration).getField(DatatypeConstants.SECONDS)) != null) {
+					duration.getField(DatatypeConstants.SECONDS) != null &&
+					(((DurationValue) other).duration).getField(DatatypeConstants.SECONDS) != null) {
 				if (((BigDecimal)duration.getField(DatatypeConstants.SECONDS)).compareTo(
 						((BigDecimal)(((DurationValue) other).duration).getField(DatatypeConstants.SECONDS))) == DatatypeConstants.EQUAL)
 						{return Constants.EQUAL;}
@@ -189,7 +189,7 @@ abstract class OrderedDurationValue extends DurationValue {
                     throw new XPathException(exceptionMessagePrefix + Type.getTypeName(x.getType()));
 		}	
 		if (((NumericValue) x).isInfinite() || ((NumericValue) x).isNaN()) {
-                    throw new XPathException(ErrorCodes.XPTY0004, "Tried to convert '" + (NumericValue) x + "' to BigDecimal");	
+                    throw new XPathException(ErrorCodes.XPTY0004, "Tried to convert '" + x + "' to BigDecimal");
                 }
                 
 		if (x.conversionPreference(BigDecimal.class) < Integer.MAX_VALUE) {

--- a/src/org/exist/xquery/value/OrderedDurationValue.java
+++ b/src/org/exist/xquery/value/OrderedDurationValue.java
@@ -16,142 +16,163 @@ import java.text.Collator;
  */
 abstract class OrderedDurationValue extends DurationValue {
 
-	OrderedDurationValue(Duration duration) throws XPathException {
-		super(duration);
-	}
+    OrderedDurationValue(Duration duration) throws XPathException {
+        super(duration);
+    }
 
-	@Override
-	public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
-		if (other.isEmpty())
-			{return false;}
-		final int r = compareTo(collator, other);	
-		if (operator != Comparison.EQ && operator != Comparison.NEQ) {
-			if (getType() == Type.DURATION)
-				{throw new XPathException(ErrorCodes.XPTY0004, 
-						"cannot compare unordered " + Type.getTypeName(getType()) + " to "
-						+ Type.getTypeName(other.getType()));}
-			if (other.getType()== Type.DURATION) 
-				{throw new XPathException(ErrorCodes.XPTY0004, 
-					"cannot compare " + Type.getTypeName(getType()) + " to unordered "
-					+ Type.getTypeName(other.getType()));}
-			if (Type.getCommonSuperType(getType(), other.getType()) == Type.DURATION) 
-				{throw new XPathException(ErrorCodes.XPTY0004, 
-					"cannot compare " + Type.getTypeName(getType()) + " to "
-					+ Type.getTypeName(other.getType()));}
-		}
-		switch (operator) {
-			case EQ:
-				return r == DatatypeConstants.EQUAL;
-			case NEQ:
-				return r != DatatypeConstants.EQUAL;
-			case LT :
-				return r == DatatypeConstants.LESSER;
-			case LTEQ :
-				return r == DatatypeConstants.LESSER || r == DatatypeConstants.EQUAL;
-			case GT :
-				return r == DatatypeConstants.GREATER;
-			case GTEQ :
-				return r == DatatypeConstants.GREATER || r == DatatypeConstants.EQUAL;
-			default :
-				throw new XPathException("Unknown operator type in comparison");
-		}
-	}
+    @Override
+    public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
+        if (other.isEmpty()) {
+            return false;
+        }
+        final int r = compareTo(collator, other);
+        if (operator != Comparison.EQ && operator != Comparison.NEQ) {
+            if (getType() == Type.DURATION) {
+                throw new XPathException(ErrorCodes.XPTY0004,
+                        "cannot compare unordered " + Type.getTypeName(getType()) + " to "
+                                + Type.getTypeName(other.getType()));
+            }
+            if (other.getType() == Type.DURATION) {
+                throw new XPathException(ErrorCodes.XPTY0004,
+                        "cannot compare " + Type.getTypeName(getType()) + " to unordered "
+                                + Type.getTypeName(other.getType()));
+            }
+            if (Type.getCommonSuperType(getType(), other.getType()) == Type.DURATION) {
+                throw new XPathException(ErrorCodes.XPTY0004,
+                        "cannot compare " + Type.getTypeName(getType()) + " to "
+                                + Type.getTypeName(other.getType()));
+            }
+        }
+        switch (operator) {
+            case EQ:
+                return r == DatatypeConstants.EQUAL;
+            case NEQ:
+                return r != DatatypeConstants.EQUAL;
+            case LT:
+                return r == DatatypeConstants.LESSER;
+            case LTEQ:
+                return r == DatatypeConstants.LESSER || r == DatatypeConstants.EQUAL;
+            case GT:
+                return r == DatatypeConstants.GREATER;
+            case GTEQ:
+                return r == DatatypeConstants.GREATER || r == DatatypeConstants.EQUAL;
+            default:
+                throw new XPathException("Unknown operator type in comparison");
+        }
+    }
 
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		if (other.isEmpty())
-			{return Constants.INFERIOR;}
-		if (Type.subTypeOf(other.getType(), Type.DURATION)) {
-			//Take care : this method doesn't seem to take ms into account 
-			final int r = duration.compare(((DurationValue) other).duration);
-			//compare fractional seconds to work around the JDK standard behaviour
-			if (r == DatatypeConstants.EQUAL &&
-					duration.getField(DatatypeConstants.SECONDS) != null &&
-					(((DurationValue) other).duration).getField(DatatypeConstants.SECONDS) != null) {
-				if (((BigDecimal)duration.getField(DatatypeConstants.SECONDS)).compareTo(
-						((BigDecimal)(((DurationValue) other).duration).getField(DatatypeConstants.SECONDS))) == DatatypeConstants.EQUAL)
-						{return Constants.EQUAL;}
-				return (((BigDecimal)duration.getField(DatatypeConstants.SECONDS)).compareTo(
-						((BigDecimal)(((DurationValue) other).duration).getField(DatatypeConstants.SECONDS)))) == DatatypeConstants.LESSER ?
-						Constants.INFERIOR : Constants.SUPERIOR;
-			}
-			if (r == DatatypeConstants.INDETERMINATE) {throw new RuntimeException("indeterminate order between totally ordered duration values " + this + " and " + other);}
-			return r;		
-		}
-		throw new XPathException(
-				"Type error: cannot compare " + Type.getTypeName(getType()) + " to "
-				+ Type.getTypeName(other.getType()));
-	}
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        if (other.isEmpty()) {
+            return Constants.INFERIOR;
+        }
+        if (Type.subTypeOf(other.getType(), Type.DURATION)) {
+            //Take care : this method doesn't seem to take ms into account
+            final int r = duration.compare(((DurationValue) other).duration);
+            //compare fractional seconds to work around the JDK standard behaviour
+            if (r == DatatypeConstants.EQUAL &&
+                    duration.getField(DatatypeConstants.SECONDS) != null &&
+                    (((DurationValue) other).duration).getField(DatatypeConstants.SECONDS) != null) {
+                if (((BigDecimal) duration.getField(DatatypeConstants.SECONDS)).compareTo(
+                        ((BigDecimal) (((DurationValue) other).duration).getField(DatatypeConstants.SECONDS))) == DatatypeConstants.EQUAL) {
+                    return Constants.EQUAL;
+                }
+                return (((BigDecimal) duration.getField(DatatypeConstants.SECONDS)).compareTo(
+                        ((BigDecimal) (((DurationValue) other).duration).getField(DatatypeConstants.SECONDS)))) == DatatypeConstants.LESSER ?
+                        Constants.INFERIOR : Constants.SUPERIOR;
+            }
+            if (r == DatatypeConstants.INDETERMINATE) {
+                throw new RuntimeException("indeterminate order between totally ordered duration values " + this + " and " + other);
+            }
+            return r;
+        }
+        throw new XPathException(
+                "Type error: cannot compare " + Type.getTypeName(getType()) + " to "
+                        + Type.getTypeName(other.getType()));
+    }
 
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() != getType()) {throw new XPathException("cannot obtain maximum across different non-numeric data types");}
-		return compareTo(null, other) > 0 ? this : other;
-	}
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() != getType()) {
+            throw new XPathException("cannot obtain maximum across different non-numeric data types");
+        }
+        return compareTo(null, other) > 0 ? this : other;
+    }
 
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() != getType()) {throw new XPathException("cannot obtain minimum across different non-numeric data types");}
-		return compareTo(null, other) < 0 ? this : other;
-	}
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() != getType()) {
+            throw new XPathException("cannot obtain minimum across different non-numeric data types");
+        }
+        return compareTo(null, other) < 0 ? this : other;
+    }
 
-	public ComputableValue plus(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-			case Type.DAY_TIME_DURATION: {
-				//if (getType() != other.getType()) throw new IllegalArgumentException();	// not a match after all
-				final Duration a = getCanonicalDuration();
-				final Duration b = ((OrderedDurationValue) other).getCanonicalDuration();	
-				final Duration result = createSameKind(a.add(b)).getCanonicalDuration();
-				//TODO : move instantiation to the right place
-				return new DayTimeDurationValue(result); }			
-			case Type.YEAR_MONTH_DURATION: {
-				//if (getType() != other.getType()) throw new IllegalArgumentException();	// not a match after all
-				final Duration a = getCanonicalDuration();
-				final Duration b = ((OrderedDurationValue) other).getCanonicalDuration();	
-				final Duration result = createSameKind(a.add(b)).getCanonicalDuration();
-				//TODO : move instantiation to the right place
-				return new YearMonthDurationValue(result); }
-			case Type.DURATION: {
-				//if (getType() != other.getType()) throw new IllegalArgumentException();	// not a match after all
-				final Duration a = getCanonicalDuration();
-				final Duration b = ((DurationValue) other).getCanonicalDuration();	
-				final Duration result = createSameKind(a.add(b)).getCanonicalDuration();
-				//TODO : move instantiation to the right place
-				return new DurationValue(result); }
-			case Type.TIME:
-			case Type.DATE_TIME:
-			case Type.DATE:
-				final AbstractDateTimeValue date = (AbstractDateTimeValue) other;
-				final XMLGregorianCalendar gc = (XMLGregorianCalendar) date.calendar.clone();
-				gc.add(duration);
-				//Shift one year
-				if (gc.getYear() <0)
-					{gc.setYear(gc.getYear() - 1);}
-				return date.createSameKind(gc); 
-			default:
-				throw new XPathException(ErrorCodes.XPTY0004, "cannot add " + 
-						Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "') from " + 
-						Type.getTypeName(getType()) + "('" + getStringValue() + "')");		}
-	}
+    public ComputableValue plus(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.DAY_TIME_DURATION: {
+                //if (getType() != other.getType()) throw new IllegalArgumentException();	// not a match after all
+                final Duration a = getCanonicalDuration();
+                final Duration b = ((OrderedDurationValue) other).getCanonicalDuration();
+                final Duration result = createSameKind(a.add(b)).getCanonicalDuration();
+                //TODO : move instantiation to the right place
+                return new DayTimeDurationValue(result);
+            }
+            case Type.YEAR_MONTH_DURATION: {
+                //if (getType() != other.getType()) throw new IllegalArgumentException();	// not a match after all
+                final Duration a = getCanonicalDuration();
+                final Duration b = ((OrderedDurationValue) other).getCanonicalDuration();
+                final Duration result = createSameKind(a.add(b)).getCanonicalDuration();
+                //TODO : move instantiation to the right place
+                return new YearMonthDurationValue(result);
+            }
+            case Type.DURATION: {
+                //if (getType() != other.getType()) throw new IllegalArgumentException();	// not a match after all
+                final Duration a = getCanonicalDuration();
+                final Duration b = ((DurationValue) other).getCanonicalDuration();
+                final Duration result = createSameKind(a.add(b)).getCanonicalDuration();
+                //TODO : move instantiation to the right place
+                return new DurationValue(result);
+            }
+            case Type.TIME:
+            case Type.DATE_TIME:
+            case Type.DATE:
+                final AbstractDateTimeValue date = (AbstractDateTimeValue) other;
+                final XMLGregorianCalendar gc = (XMLGregorianCalendar) date.calendar.clone();
+                gc.add(duration);
+                //Shift one year
+                if (gc.getYear() < 0) {
+                    gc.setYear(gc.getYear() - 1);
+                }
+                return date.createSameKind(gc);
+            default:
+                throw new XPathException(ErrorCodes.XPTY0004, "cannot add " +
+                        Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "') from " +
+                        Type.getTypeName(getType()) + "('" + getStringValue() + "')");
+        }
+    }
 
-	public ComputableValue minus(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-		case Type.DAY_TIME_DURATION: {
-			if (getType() != other.getType()) 
-				{throw new XPathException(ErrorCodes.XPTY0004, "Tried to substract " + 
-						Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "') from " + 
-						Type.getTypeName(getType()) + "('" + getStringValue() + "')");}
-			final Duration a = getCanonicalDuration();
-			final Duration b = ((OrderedDurationValue) other).getCanonicalDuration();	
-			final Duration result = createSameKind(a.subtract(b)).getCanonicalDuration();
-			return new DayTimeDurationValue(result); }				
-		case Type.YEAR_MONTH_DURATION: {
-			if (getType() != other.getType()) 
-				{throw new XPathException(ErrorCodes.XPTY0004, "Tried to substract " + 
-						Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "') from " + 
-						Type.getTypeName(getType()) + "('" + getStringValue() + "')");}
-			final Duration a = getCanonicalDuration();
-			final Duration b = ((OrderedDurationValue) other).getCanonicalDuration();	
-			final Duration result = createSameKind(a.subtract(b)).getCanonicalDuration();
-			return new YearMonthDurationValue(result); }
-		/*
+    public ComputableValue minus(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.DAY_TIME_DURATION: {
+                if (getType() != other.getType()) {
+                    throw new XPathException(ErrorCodes.XPTY0004, "Tried to substract " +
+                            Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "') from " +
+                            Type.getTypeName(getType()) + "('" + getStringValue() + "')");
+                }
+                final Duration a = getCanonicalDuration();
+                final Duration b = ((OrderedDurationValue) other).getCanonicalDuration();
+                final Duration result = createSameKind(a.subtract(b)).getCanonicalDuration();
+                return new DayTimeDurationValue(result);
+            }
+            case Type.YEAR_MONTH_DURATION: {
+                if (getType() != other.getType()) {
+                    throw new XPathException(ErrorCodes.XPTY0004, "Tried to substract " +
+                            Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "') from " +
+                            Type.getTypeName(getType()) + "('" + getStringValue() + "')");
+                }
+                final Duration a = getCanonicalDuration();
+                final Duration b = ((OrderedDurationValue) other).getCanonicalDuration();
+                final Duration result = createSameKind(a.subtract(b)).getCanonicalDuration();
+                return new YearMonthDurationValue(result);
+            }
+        /*
 		case Type.TIME:
 		case Type.DATE_TIME:
 		case Type.DATE:
@@ -160,11 +181,11 @@ abstract class OrderedDurationValue extends DurationValue {
 			gc.substract(duration);
 			return date.createSameKind(gc);
 		*/
-		default:
-			throw new XPathException("err:XPTY0004: cannot substract " + 
-					Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "') from " + 
-					Type.getTypeName(getType()) + "('" + getStringValue() + "')");
-		}
+            default:
+                throw new XPathException("err:XPTY0004: cannot substract " +
+                        Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "') from " +
+                        Type.getTypeName(getType()) + "('" + getStringValue() + "')");
+        }
 		/*
 		if(other.getType() == getType()) {
 			return createSameKind(duration.subtract(((OrderedDurationValue)other).duration));
@@ -172,29 +193,29 @@ abstract class OrderedDurationValue extends DurationValue {
 		throw new XPathException("Operand to minus should be of type " + Type.getTypeName(getType()) + "; got: " +
 			Type.getTypeName(other.getType()));
 		*/
-	}
-	
-	/**
-	 * Convert the given value to a big decimal if it's a number, keeping as much precision
-	 * as possible.
-	 *
-	 * @param x a value to convert to a big decimal
-	 * @param exceptionMessagePrefix the beginning of the message to throw in an exception, will be suffixed with the type of the value given
-	 * @return the big decimal equivalent of the value
-	 * @throws XPathException if the value is not of a numeric type
-	 */
-	protected BigDecimal numberToBigDecimal(ComputableValue x, String exceptionMessagePrefix) throws XPathException {
-		if (!Type.subTypeOf(x.getType(), Type.NUMBER)) {
-                    throw new XPathException(exceptionMessagePrefix + Type.getTypeName(x.getType()));
-		}	
-		if (((NumericValue) x).isInfinite() || ((NumericValue) x).isNaN()) {
-                    throw new XPathException(ErrorCodes.XPTY0004, "Tried to convert '" + x + "' to BigDecimal");
-                }
-                
-		if (x.conversionPreference(BigDecimal.class) < Integer.MAX_VALUE) {
-                    return x.toJavaObject(BigDecimal.class);
-                } else {
-                    return new BigDecimal(((NumericValue) x).getDouble());		
-                }
-	}
+    }
+
+    /**
+     * Convert the given value to a big decimal if it's a number, keeping as much precision
+     * as possible.
+     *
+     * @param x                      a value to convert to a big decimal
+     * @param exceptionMessagePrefix the beginning of the message to throw in an exception, will be suffixed with the type of the value given
+     * @return the big decimal equivalent of the value
+     * @throws XPathException if the value is not of a numeric type
+     */
+    protected BigDecimal numberToBigDecimal(ComputableValue x, String exceptionMessagePrefix) throws XPathException {
+        if (!Type.subTypeOf(x.getType(), Type.NUMBER)) {
+            throw new XPathException(exceptionMessagePrefix + Type.getTypeName(x.getType()));
+        }
+        if (((NumericValue) x).isInfinite() || ((NumericValue) x).isNaN()) {
+            throw new XPathException(ErrorCodes.XPTY0004, "Tried to convert '" + x + "' to BigDecimal");
+        }
+
+        if (x.conversionPreference(BigDecimal.class) < Integer.MAX_VALUE) {
+            return x.toJavaObject(BigDecimal.class);
+        } else {
+            return new BigDecimal(((NumericValue) x).getDouble());
+        }
+    }
 }

--- a/src/org/exist/xquery/value/OrderedValueSequence.java
+++ b/src/org/exist/xquery/value/OrderedValueSequence.java
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
  */
 public class OrderedValueSequence extends AbstractSequence {
 
-    private OrderSpec orderSpecs[];
+    private final OrderSpec[] orderSpecs;
 	private Entry[] items = null;
 	private int count = 0;
 	private int state = 0;

--- a/src/org/exist/xquery/value/OrderedValueSequence.java
+++ b/src/org/exist/xquery/value/OrderedValueSequence.java
@@ -39,155 +39,165 @@ import java.util.stream.Stream;
 /**
  * A sequence that sorts its entries in the order specified by the order specs of
  * an "order by" clause. Used by {@link org.exist.xquery.ForExpr}.
- * 
+ * <p>
  * Contrary to class {@link org.exist.xquery.value.PreorderedValueSequence},
- * all order expressions are evaluated once for each item in the sequence 
+ * all order expressions are evaluated once for each item in the sequence
  * <b>while</b> items are added.
- * 
+ *
  * @author wolf
  */
 public class OrderedValueSequence extends AbstractSequence {
 
     private final OrderSpec[] orderSpecs;
-	private Entry[] items = null;
-	private int count = 0;
-	private int state = 0;
+    private Entry[] items = null;
+    private int count = 0;
+    private int state = 0;
 
     // used to keep track of the type of added items.
     private int itemType = Type.ANY_TYPE;
-    
-	public OrderedValueSequence(OrderSpec orderSpecs[], int size) {
-		this.orderSpecs = orderSpecs;
-        if (size == 0)
-            {size = 1;}
-		this.items = new Entry[size];
-	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#iterate()
-	 */
-	public SequenceIterator iterate() throws XPathException {
-		return new OrderedValueSequenceIterator();
-	}
-
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#unorderedIterator()
-	 */
-	public SequenceIterator unorderedIterator() throws XPathException {
-		return new OrderedValueSequenceIterator();
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getLength()
-	 */
-	public int getItemCount() {
-		return (items == null) ? 0 : count;
-	}
-	
-	public boolean isEmpty() {
-		return isEmpty;
-	}
-
-    public boolean hasOne() {
-    	return hasOne;
+    public OrderedValueSequence(OrderSpec orderSpecs[], int size) {
+        this.orderSpecs = orderSpecs;
+        if (size == 0) {
+            size = 1;
+        }
+        this.items = new Entry[size];
     }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#add(org.exist.xquery.value.Item)
-	 */
-	public void add(Item item) throws XPathException {
-		if (hasOne)
-			{hasOne = false;}
-		if (isEmpty)
-			{hasOne = true;}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#iterate()
+     */
+    public SequenceIterator iterate() throws XPathException {
+        return new OrderedValueSequenceIterator();
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#unorderedIterator()
+     */
+    public SequenceIterator unorderedIterator() throws XPathException {
+        return new OrderedValueSequenceIterator();
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getLength()
+     */
+    public int getItemCount() {
+        return (items == null) ? 0 : count;
+    }
+
+    public boolean isEmpty() {
+        return isEmpty;
+    }
+
+    public boolean hasOne() {
+        return hasOne;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#add(org.exist.xquery.value.Item)
+     */
+    public void add(Item item) throws XPathException {
+        if (hasOne) {
+            hasOne = false;
+        }
+        if (isEmpty) {
+            hasOne = true;
+        }
         isEmpty = false;
-		if(count == 0 && items.length == 1) {
-			items = new Entry[2];
-		} else if (count == items.length) {
-			Entry newItems[] = new Entry[count * 2];
-			System.arraycopy(items, 0, newItems, 0, count);
-			items = newItems;
-		}
-		items[count] = new Entry(item, count++);
-		checkItemType(item.getType());
+        if (count == 0 && items.length == 1) {
+            items = new Entry[2];
+        } else if (count == items.length) {
+            Entry newItems[] = new Entry[count * 2];
+            System.arraycopy(items, 0, newItems, 0, count);
+            items = newItems;
+        }
+        items[count] = new Entry(item, count++);
+        checkItemType(item.getType());
         setHasChanged();
     }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#addAll(org.exist.xquery.value.Sequence)
-	 */
-	public void addAll(Sequence other) throws XPathException {
-		if(other.hasOne())
-			{add(other.itemAt(0));}		
-		else if(!other.isEmpty()) {
-			for(final SequenceIterator i = other.iterate(); i.hasNext(); ) { 
-				final Item next = i.nextItem();
-				if(next != null)
-					{add(next);}
-			}
-		} 
-	}
-	
-	public void sort() {
-//		FastQSort.sort(items, 0, count - 1);
-		items =
-			Stream.of(items).filter(Objects::nonNull)
-					.parallel()
-					.sorted()
-					.map(entry -> { entry.clear(); return entry; })
-					.toArray(Entry[]::new);
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#itemAt(int)
-	 */
-	public Item itemAt(int pos) {
-		if(items != null && pos > -1 && pos < count)
-			{return items[pos].item;}
-		else
-			{return null;}
-	}
-
-	private void checkItemType(int type) {
-        if (itemType == type)
-            {return;}
-        else if (itemType == Type.ANY_TYPE)
-            {itemType = type;}
-        else
-            {itemType = Type.getCommonSuperType(type, itemType);}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#addAll(org.exist.xquery.value.Sequence)
+     */
+    public void addAll(Sequence other) throws XPathException {
+        if (other.hasOne()) {
+            add(other.itemAt(0));
+        } else if (!other.isEmpty()) {
+            for (final SequenceIterator i = other.iterate(); i.hasNext(); ) {
+                final Item next = i.nextItem();
+                if (next != null) {
+                    add(next);
+                }
+            }
+        }
     }
-    
+
+    public void sort() {
+//		FastQSort.sort(items, 0, count - 1);
+        items =
+                Stream.of(items).filter(Objects::nonNull)
+                        .parallel()
+                        .sorted()
+                        .map(entry -> {
+                            entry.clear();
+                            return entry;
+                        })
+                        .toArray(Entry[]::new);
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#itemAt(int)
+     */
+    public Item itemAt(int pos) {
+        if (items != null && pos > -1 && pos < count) {
+            return items[pos].item;
+        } else {
+            return null;
+        }
+    }
+
+    private void checkItemType(int type) {
+        if (itemType == type) {
+            return;
+        } else if (itemType == Type.ANY_TYPE) {
+            itemType = type;
+        } else {
+            itemType = Type.getCommonSuperType(type, itemType);
+        }
+    }
+
     /* (non-Javadoc)
      * @see org.exist.xquery.value.Sequence#getItemType()
      */
     public int getItemType() {
         return itemType;
     }
-    
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#toNodeSet()
-	 */
-	public NodeSet toNodeSet() throws XPathException {
-		//return early
-		if (isEmpty())
-			{return NodeSet.EMPTY_SET;}
-        // for this method to work, all items have to be nodes
-		if(itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
-			//Was ExtArrayNodeset() which orders the nodes in document order
-			//The order seems to change between different invocations !!!
-			final NodeSet set = new AVLTreeNodeSet();
-			//We can't make it from an ExtArrayNodeSet (probably because it is sorted ?)
-			//NodeSet set = new ArraySet(100);
-			for (int i = 0; i < items.length; i++) {
-				//TODO : investigate why we could have null here
-				if (items[i] != null) {
-				
-					NodeValue v = (NodeValue)items[i].item;
-					if(v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
 
-	                    // found an in-memory document
-	                    final org.exist.dom.memtree.DocumentImpl doc = ((NodeImpl)v).getOwnerDocument();
-                        if (doc==null) {
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#toNodeSet()
+     */
+    public NodeSet toNodeSet() throws XPathException {
+        //return early
+        if (isEmpty()) {
+            return NodeSet.EMPTY_SET;
+        }
+        // for this method to work, all items have to be nodes
+        if (itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
+            //Was ExtArrayNodeset() which orders the nodes in document order
+            //The order seems to change between different invocations !!!
+            final NodeSet set = new AVLTreeNodeSet();
+            //We can't make it from an ExtArrayNodeSet (probably because it is sorted ?)
+            //NodeSet set = new ArraySet(100);
+            for (int i = 0; i < items.length; i++) {
+                //TODO : investigate why we could have null here
+                if (items[i] != null) {
+
+                    NodeValue v = (NodeValue) items[i].item;
+                    if (v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
+
+                        // found an in-memory document
+                        final org.exist.dom.memtree.DocumentImpl doc = ((NodeImpl) v).getOwnerDocument();
+                        if (doc == null) {
                             continue;
                         }
                         // make this document persistent: doc.makePersistent()
@@ -200,17 +210,19 @@ public class OrderedValueSequence extends AbstractSequence {
                             NodeId rootId = newDoc.getBrokerPool().getNodeFactory().createInstance();
                             for (int j = i; j < count; j++) {
                                 v = (NodeValue) items[j].item;
-                                if(v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
+                                if (v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
                                     NodeImpl node = (NodeImpl) v;
                                     if (node.getOwnerDocument() == doc) {
                                         node = expandedDoc.getNode(node.getNodeNumber());
                                         NodeId nodeId = node.getNodeId();
-                                        if (nodeId == null)
-                                            {throw new XPathException("Internal error: nodeId == null");}
-                                        if (node.getNodeType() == Node.DOCUMENT_NODE)
-                                            {nodeId = rootId;}
-                                        else
-                                            {nodeId = rootId.append(nodeId);}
+                                        if (nodeId == null) {
+                                            throw new XPathException("Internal error: nodeId == null");
+                                        }
+                                        if (node.getNodeType() == Node.DOCUMENT_NODE) {
+                                            nodeId = rootId;
+                                        } else {
+                                            nodeId = rootId.append(nodeId);
+                                        }
                                         NodeProxy p = new NodeProxy(newDoc, nodeId, node.getNodeType());
                                         if (p != null) {
                                             // replace the node by the NodeProxy
@@ -221,29 +233,32 @@ public class OrderedValueSequence extends AbstractSequence {
                             }
                         }
                         set.add((NodeProxy) items[i].item);
-					} else {
-						set.add((NodeProxy)v);
-					}
-				}
-			}			
-			return set;
-		} else
-			{throw new XPathException("Type error: the sequence cannot be converted into" +
-				" a node set. Item type is " + Type.getTypeName(itemType));}
-	}
+                    } else {
+                        set.add((NodeProxy) v);
+                    }
+                }
+            }
+            return set;
+        } else {
+            throw new XPathException("Type error: the sequence cannot be converted into" +
+                    " a node set. Item type is " + Type.getTypeName(itemType));
+        }
+    }
 
     /* (non-Javadoc)
     * @see org.exist.xquery.value.Sequence#isPersistentSet()
     */
     public boolean isPersistentSet() {
-        if(count == 0)
-            {return true;}
-        if(itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
+        if (count == 0) {
+            return true;
+        }
+        if (itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
             NodeValue v;
             for (int i = 0; i < count; i++) {
-                v = (NodeValue)items[i].item;
-                if(v.getImplementationType() != NodeValue.PERSISTENT_NODE)
-                    {return false;}
+                v = (NodeValue) items[i].item;
+                if (v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
+                    return false;
+                }
             }
             return true;
         }
@@ -251,29 +266,31 @@ public class OrderedValueSequence extends AbstractSequence {
     }
 
     public MemoryNodeSet toMemNodeSet() throws XPathException {
-        if(count == 0)
-            {return MemoryNodeSet.EMPTY;}
-        if(itemType == Type.ANY_TYPE || !Type.subTypeOf(itemType, Type.NODE)) {
+        if (count == 0) {
+            return MemoryNodeSet.EMPTY;
+        }
+        if (itemType == Type.ANY_TYPE || !Type.subTypeOf(itemType, Type.NODE)) {
             throw new XPathException("Type error: the sequence cannot be converted into" +
-				" a node set. Item type is " + Type.getTypeName(itemType));
+                    " a node set. Item type is " + Type.getTypeName(itemType));
         }
         NodeValue v;
         for (int i = 0; i < count; i++) {
-            v = (NodeValue)items[i].item;
-            if(v.getImplementationType() == NodeValue.PERSISTENT_NODE)
-                {return null;}
+            v = (NodeValue) items[i].item;
+            if (v.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                return null;
+            }
         }
         return new ValueSequence(this);
     }
 
     public String toString() {
-    	final StringBuilder builder = new StringBuilder();
-    	for (int i = 0; i < count; i++) {
-    		builder.append(items[i].toString());
-    	}
-    	return builder.toString();
+        final StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            builder.append(items[i].toString());
+        }
+        return builder.toString();
     }
-    
+
     /* (non-Javadoc)
      * @see org.exist.xquery.value.Sequence#removeDuplicates()
      */
@@ -298,120 +315,131 @@ public class OrderedValueSequence extends AbstractSequence {
     }
 
     private class Entry implements Comparable<Entry> {
-		
-		Item item;
-		AtomicValue values[];
-		int pos;
-		
-		/**
-		 * @param item the item in the sequence
-		 * @param position the original position of the item in the result sequence
-		 * @throws XPathException
-		 */
-		public Entry(Item item, int position) throws XPathException {
-			this.item = item;
-			this.pos = position;
-			values = new AtomicValue[orderSpecs.length];
-			for(int i = 0; i < orderSpecs.length; i++) {
-				final Sequence seq = orderSpecs[i].getSortExpression().eval(null);
-				values[i] = AtomicValue.EMPTY_VALUE;
-				if(seq.hasOne()) {
-					values[i] = seq.itemAt(0).atomize();
-				} else if(seq.hasMany())
-					{throw new XPathException("expected a single value for order expression " +
-						ExpressionDumper.dump(orderSpecs[i].getSortExpression()) + 
-						" ; found: " + seq.getItemCount());}
-			}
-		}
 
-		/* (non-Javadoc)
-		 * @see java.lang.Comparable#compareTo(java.lang.Object)
-		 */
-		public int compareTo(Entry other) {
-			int cmp = 0;
-			AtomicValue a, b;
-			for(int i = 0; i < values.length; i++) {
-				try {
-					a = values[i];
-					b = other.values[i];
+        Item item;
+        AtomicValue values[];
+        int pos;
+
+        /**
+         * @param item     the item in the sequence
+         * @param position the original position of the item in the result sequence
+         * @throws XPathException
+         */
+        public Entry(Item item, int position) throws XPathException {
+            this.item = item;
+            this.pos = position;
+            values = new AtomicValue[orderSpecs.length];
+            for (int i = 0; i < orderSpecs.length; i++) {
+                final Sequence seq = orderSpecs[i].getSortExpression().eval(null);
+                values[i] = AtomicValue.EMPTY_VALUE;
+                if (seq.hasOne()) {
+                    values[i] = seq.itemAt(0).atomize();
+                } else if (seq.hasMany()) {
+                    throw new XPathException("expected a single value for order expression " +
+                            ExpressionDumper.dump(orderSpecs[i].getSortExpression()) +
+                            " ; found: " + seq.getItemCount());
+                }
+            }
+        }
+
+        /* (non-Javadoc)
+         * @see java.lang.Comparable#compareTo(java.lang.Object)
+         */
+        public int compareTo(Entry other) {
+            int cmp = 0;
+            AtomicValue a, b;
+            for (int i = 0; i < values.length; i++) {
+                try {
+                    a = values[i];
+                    b = other.values[i];
                     final boolean aIsEmpty = (a.isEmpty() || (Type.subTypeOf(a.getType(), Type.NUMBER) && ((NumericValue) a).isNaN()));
                     final boolean bIsEmpty = (b.isEmpty() || (Type.subTypeOf(b.getType(), Type.NUMBER) && ((NumericValue) b).isNaN()));
                     if (aIsEmpty) {
                         if (bIsEmpty)
-                            // both values are empty
-                            {return Constants.EQUAL;}
-                        else if ((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0)
-							{cmp = Constants.INFERIOR;}
-                        else
-                            {cmp = Constants.SUPERIOR;}
+                        // both values are empty
+                        {
+                            return Constants.EQUAL;
+                        } else if ((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0) {
+                            cmp = Constants.INFERIOR;
+                        } else {
+                            cmp = Constants.SUPERIOR;
+                        }
                     } else if (bIsEmpty) {
                         // we don't need to check for equality since we know a is not empty
-                        if ((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0)
-							{cmp = Constants.SUPERIOR;}
-						else
-							{cmp = Constants.INFERIOR;}
+                        if ((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0) {
+                            cmp = Constants.SUPERIOR;
+                        } else {
+                            cmp = Constants.INFERIOR;
+                        }
                     } else if (a == AtomicValue.EMPTY_VALUE && b != AtomicValue.EMPTY_VALUE) {
-						if((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0)
-							{cmp = Constants.INFERIOR;}
-						else
-							{cmp = Constants.SUPERIOR;}
-					} else if (b == AtomicValue.EMPTY_VALUE && a != AtomicValue.EMPTY_VALUE) {
-						if((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0)
-							{cmp = Constants.SUPERIOR;}
-						else
-							{cmp = Constants.INFERIOR;}
-					} else
-						{cmp = a.compareTo(orderSpecs[i].getCollator(), b);}
-					if((orderSpecs[i].getModifiers() & OrderSpec.DESCENDING_ORDER) != 0)
-						{cmp = cmp * -1;}
-					if(cmp != Constants.EQUAL)
-						{break;}
-				} catch (final XPathException e) {
-				}
-			}
-			// if the sort keys are equal, we need to order by the original position in the result sequence
-			if (cmp == Constants.EQUAL)
-				{cmp = (pos > other.pos ? Constants.SUPERIOR : (pos == other.pos ? Constants.EQUAL : Constants.INFERIOR));}
-			return cmp;
-		}
-		
-		public String toString() {
-			final StringBuilder builder = new StringBuilder();
-			builder.append(item);
-    		builder.append(" [");
-    		for (int i = 0; i < values.length; i++) {
-    			if (i > 0)
-    				{builder.append(", ");}
-    			builder.append(values[i].toString());
-    		}
-    		builder.append("]");
-    		return builder.toString();
-		}
+                        if ((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0) {
+                            cmp = Constants.INFERIOR;
+                        } else {
+                            cmp = Constants.SUPERIOR;
+                        }
+                    } else if (b == AtomicValue.EMPTY_VALUE && a != AtomicValue.EMPTY_VALUE) {
+                        if ((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0) {
+                            cmp = Constants.SUPERIOR;
+                        } else {
+                            cmp = Constants.INFERIOR;
+                        }
+                    } else {
+                        cmp = a.compareTo(orderSpecs[i].getCollator(), b);
+                    }
+                    if ((orderSpecs[i].getModifiers() & OrderSpec.DESCENDING_ORDER) != 0) {
+                        cmp = cmp * -1;
+                    }
+                    if (cmp != Constants.EQUAL) {
+                        break;
+                    }
+                } catch (final XPathException e) {
+                }
+            }
+            // if the sort keys are equal, we need to order by the original position in the result sequence
+            if (cmp == Constants.EQUAL) {
+                cmp = (pos > other.pos ? Constants.SUPERIOR : (pos == other.pos ? Constants.EQUAL : Constants.INFERIOR));
+            }
+            return cmp;
+        }
 
-		public void clear() {
-			values = null;
-		}
-	}
-	
-	private class OrderedValueSequenceIterator implements SequenceIterator {
-		
-		int pos = 0;
-		
-		/* (non-Javadoc)
-		 * @see org.exist.xquery.value.SequenceIterator#hasNext()
-		 */
-		public boolean hasNext() {
-			return pos < count;
-		}
-		
-		/* (non-Javadoc)
-		 * @see org.exist.xquery.value.SequenceIterator#nextItem()
-		 */
-		public Item nextItem() {
-			if(pos < count) {
-				return items[pos++].item;
-			}
-			return null;
-		}
-	}
+        public String toString() {
+            final StringBuilder builder = new StringBuilder();
+            builder.append(item);
+            builder.append(" [");
+            for (int i = 0; i < values.length; i++) {
+                if (i > 0) {
+                    builder.append(", ");
+                }
+                builder.append(values[i].toString());
+            }
+            builder.append("]");
+            return builder.toString();
+        }
+
+        public void clear() {
+            values = null;
+        }
+    }
+
+    private class OrderedValueSequenceIterator implements SequenceIterator {
+
+        int pos = 0;
+
+        /* (non-Javadoc)
+         * @see org.exist.xquery.value.SequenceIterator#hasNext()
+         */
+        public boolean hasNext() {
+            return pos < count;
+        }
+
+        /* (non-Javadoc)
+         * @see org.exist.xquery.value.SequenceIterator#nextItem()
+         */
+        public Item nextItem() {
+            if (pos < count) {
+                return items[pos++].item;
+            }
+            return null;
+        }
+    }
 }

--- a/src/org/exist/xquery/value/OrderedValueSequence.java
+++ b/src/org/exist/xquery/value/OrderedValueSequence.java
@@ -21,20 +21,18 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.dom.memtree.DocumentImpl;
+import org.exist.dom.memtree.NodeImpl;
 import org.exist.dom.persistent.AVLTreeNodeSet;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.persistent.NodeSet;
-import org.exist.dom.memtree.DocumentImpl;
-import org.exist.dom.memtree.NodeImpl;
 import org.exist.numbering.NodeId;
-import org.exist.util.FastQSort;
 import org.exist.xquery.Constants;
 import org.exist.xquery.OrderSpec;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.util.ExpressionDumper;
 import org.w3c.dom.Node;
 
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.stream.Stream;
 

--- a/src/org/exist/xquery/value/OrderedValueSequence.java
+++ b/src/org/exist/xquery/value/OrderedValueSequence.java
@@ -35,6 +35,7 @@ import org.exist.xquery.util.ExpressionDumper;
 import org.w3c.dom.Node;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -132,7 +133,7 @@ public class OrderedValueSequence extends AbstractSequence {
 	public void sort() {
 //		FastQSort.sort(items, 0, count - 1);
 		items =
-			Stream.of(items).filter(entry -> entry != null)
+			Stream.of(items).filter(Objects::nonNull)
 					.parallel()
 					.sorted()
 					.map(entry -> { entry.clear(); return entry; })

--- a/src/org/exist/xquery/value/PreorderedValueSequence.java
+++ b/src/org/exist/xquery/value/PreorderedValueSequence.java
@@ -31,7 +31,6 @@ import org.exist.xquery.XPathException;
 
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Iterator;
 
 /**
  * A sequence that sorts its items in the order specified by the order specs

--- a/src/org/exist/xquery/value/PreorderedValueSequence.java
+++ b/src/org/exist/xquery/value/PreorderedValueSequence.java
@@ -64,24 +64,23 @@ public class PreorderedValueSequence extends AbstractSequence {
 		for(int i = 0; i < orderSpecs.length; i++) {
 			final Expression expr = orderSpecs[i].getSortExpression();
 			final NodeSet result = expr.eval(null).toNodeSet();
-			for(final Iterator j = result.iterator(); j.hasNext(); ) {
-				final NodeProxy p = (NodeProxy)j.next();
-				ContextItem context = p.getContext();
-				//TODO : review to consider transverse context
-				while(context != null) {
-					if(context.getNode() instanceof OrderedNodeProxy) {
-						final OrderedNodeProxy cp = (OrderedNodeProxy)context.getNode();
-						cp.values[i] = p.atomize();
-					}
-					context = context.getNextDirect();
-				}
-			}
+            for (final NodeProxy p : result) {
+                ContextItem context = p.getContext();
+                //TODO : review to consider transverse context
+                while (context != null) {
+                    if (context.getNode() instanceof OrderedNodeProxy) {
+                        final OrderedNodeProxy cp = (OrderedNodeProxy) context.getNode();
+                        cp.values[i] = p.atomize();
+                    }
+                    context = context.getNextDirect();
+                }
+            }
 		}
 	}
 
     public void clearContext(int contextId) throws XPathException {
-        for (int i = 0; i < nodes.length; i++) {
-            nodes[i].clearContext(contextId);
+        for (OrderedNodeProxy node : nodes) {
+            node.clearContext(contextId);
         }
     }
     

--- a/src/org/exist/xquery/value/PreorderedValueSequence.java
+++ b/src/org/exist/xquery/value/PreorderedValueSequence.java
@@ -45,8 +45,8 @@ import java.util.Iterator;
  */
 public class PreorderedValueSequence extends AbstractSequence {
 	
-	private OrderSpec orderSpecs[];
-	private OrderedNodeProxy[] nodes;
+	private final OrderSpec[] orderSpecs;
+	private final OrderedNodeProxy[] nodes;
 	
 	public PreorderedValueSequence(OrderSpec specs[], Sequence input, int contextId) throws XPathException {
 		this.orderSpecs = specs;

--- a/src/org/exist/xquery/value/PreorderedValueSequence.java
+++ b/src/org/exist/xquery/value/PreorderedValueSequence.java
@@ -35,34 +35,34 @@ import java.util.Comparator;
 /**
  * A sequence that sorts its items in the order specified by the order specs
  * of an "order by" clause. Used by {@link org.exist.xquery.ForExpr}.
- * 
+ * <p>
  * For better performance, the whole input sequence is sorted in one single step.
  * However, this only works if every order expression returns a result of type
  * node.
- * 
+ *
  * @author wolf
  */
 public class PreorderedValueSequence extends AbstractSequence {
-	
-	private final OrderSpec[] orderSpecs;
-	private final OrderedNodeProxy[] nodes;
-	
-	public PreorderedValueSequence(OrderSpec specs[], Sequence input, int contextId) throws XPathException {
-		this.orderSpecs = specs;
-		nodes = new OrderedNodeProxy[input.getItemCount()];
-		int j = 0;
-		for(final SequenceIterator i = input.unorderedIterator(); i.hasNext(); j++) {
-			final NodeProxy p = (NodeProxy)i.nextItem();
-			nodes[j] = new OrderedNodeProxy(p);
-			p.addContextNode(contextId, nodes[j]);
-		}
-		processAll();
-	}
-	
-	private void processAll() throws XPathException {
-		for(int i = 0; i < orderSpecs.length; i++) {
-			final Expression expr = orderSpecs[i].getSortExpression();
-			final NodeSet result = expr.eval(null).toNodeSet();
+
+    private final OrderSpec[] orderSpecs;
+    private final OrderedNodeProxy[] nodes;
+
+    public PreorderedValueSequence(OrderSpec specs[], Sequence input, int contextId) throws XPathException {
+        this.orderSpecs = specs;
+        nodes = new OrderedNodeProxy[input.getItemCount()];
+        int j = 0;
+        for (final SequenceIterator i = input.unorderedIterator(); i.hasNext(); j++) {
+            final NodeProxy p = (NodeProxy) i.nextItem();
+            nodes[j] = new OrderedNodeProxy(p);
+            p.addContextNode(contextId, nodes[j]);
+        }
+        processAll();
+    }
+
+    private void processAll() throws XPathException {
+        for (int i = 0; i < orderSpecs.length; i++) {
+            final Expression expr = orderSpecs[i].getSortExpression();
+            final NodeSet result = expr.eval(null).toNodeSet();
             for (final NodeProxy p : result) {
                 ContextItem context = p.getContext();
                 //TODO : review to consider transverse context
@@ -74,71 +74,71 @@ public class PreorderedValueSequence extends AbstractSequence {
                     context = context.getNextDirect();
                 }
             }
-		}
-	}
+        }
+    }
 
     public void clearContext(int contextId) throws XPathException {
         for (OrderedNodeProxy node : nodes) {
             node.clearContext(contextId);
         }
     }
-    
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#getItemType()
-	 */
-	public int getItemType() {
-		return Type.NODE;
-	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#iterate()
-	 */
-	public SequenceIterator iterate() throws XPathException {
-		sort();
-		return new PreorderedValueSequenceIterator();
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#getItemType()
+     */
+    public int getItemType() {
+        return Type.NODE;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#unorderedIterator()
-	 */
-	public SequenceIterator unorderedIterator() throws XPathException{
-		return new PreorderedValueSequenceIterator();
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#iterate()
+     */
+    public SequenceIterator iterate() throws XPathException {
+        sort();
+        return new PreorderedValueSequenceIterator();
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#getLength()
-	 */
-	public int getItemCount() {
-		return nodes.length;
-	}
-	
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#unorderedIterator()
+     */
+    public SequenceIterator unorderedIterator() throws XPathException {
+        return new PreorderedValueSequenceIterator();
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#getLength()
+     */
+    public int getItemCount() {
+        return nodes.length;
+    }
+
     public boolean isEmpty() {
-    	return nodes.length == 0;
+        return nodes.length == 0;
     }
 
     public boolean hasOne() {
-    	return nodes.length == 1;
-    }    
+        return nodes.length == 1;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#add(org.exist.xquery.value.Item)
-	 */
-	public void add(Item item) throws XPathException {
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#add(org.exist.xquery.value.Item)
+     */
+    public void add(Item item) throws XPathException {
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#itemAt(int)
-	 */
-	public Item itemAt(int pos) {
-		return nodes[pos];
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#itemAt(int)
+     */
+    public Item itemAt(int pos) {
+        return nodes[pos];
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#toNodeSet()
-	 */
-	public NodeSet toNodeSet() throws XPathException {
-		return null;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#toNodeSet()
+     */
+    public NodeSet toNodeSet() throws XPathException {
+        return null;
+    }
 
     public MemoryNodeSet toMemNodeSet() throws XPathException {
         return null;
@@ -150,76 +150,82 @@ public class PreorderedValueSequence extends AbstractSequence {
     public void removeDuplicates() {
         // TODO: is this ever relevant?
     }
-    
-	private void sort() {
-		Arrays.sort(nodes, new OrderedComparator());
-	}
-	
-	private class OrderedComparator implements Comparator<OrderedNodeProxy> {
-		
-		/* (non-Javadoc)
-		 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
-		 */
-		public int compare(OrderedNodeProxy p1, OrderedNodeProxy p2) {
-			int cmp = 0;
-			AtomicValue a, b;
-			for(int i = 0; i < p1.values.length; i++) {
-				try {
-					a = p1.values[i];
-					b = p2.values[i];
-					if(a == AtomicValue.EMPTY_VALUE && b != AtomicValue.EMPTY_VALUE) {
-						if((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0)
-							{cmp = Constants.INFERIOR;}
-						else
-							{cmp = Constants.SUPERIOR;}
-					} else if(a != AtomicValue.EMPTY_VALUE && b == AtomicValue.EMPTY_VALUE) {
-						if((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0)
-							{cmp = Constants.SUPERIOR;}
-						else
-							{cmp = Constants.INFERIOR;}
-					} else
-						{cmp = a.compareTo(orderSpecs[i].getCollator(), b);}
-					if((orderSpecs[i].getModifiers() & OrderSpec.DESCENDING_ORDER) != 0)
-						{cmp = cmp * -1;}
-					if(cmp != Constants.EQUAL)
-						{break;}
-				} catch (final XPathException e) {
-				}
-			}
-			return cmp;
-		}
-	}
-	
-	private class OrderedNodeProxy extends NodeProxy {
-		
-		AtomicValue[] values;
-		
-		public OrderedNodeProxy(NodeProxy p) {
-			super(p);
-			values = new AtomicValue[orderSpecs.length];
-			for(int i = 0; i < values.length; i++)
-				values[i] = AtomicValue.EMPTY_VALUE;
-		}
-	}
-	
-	private class PreorderedValueSequenceIterator implements SequenceIterator {
-		
-		int pos = 0;
-		
-		/* (non-Javadoc)
-		 * @see org.exist.xquery.value.SequenceIterator#hasNext()
-		 */
-		public boolean hasNext() {
-			return pos < nodes.length;
-		}
-		
-		/* (non-Javadoc)
-		 * @see org.exist.xquery.value.SequenceIterator#nextItem()
-		 */
-		public Item nextItem() {
-			if(pos < nodes.length)
-				{return nodes[pos++];}
-			return null;
-		}
-	}
+
+    private void sort() {
+        Arrays.sort(nodes, new OrderedComparator());
+    }
+
+    private class OrderedComparator implements Comparator<OrderedNodeProxy> {
+
+        /* (non-Javadoc)
+         * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
+         */
+        public int compare(OrderedNodeProxy p1, OrderedNodeProxy p2) {
+            int cmp = 0;
+            AtomicValue a, b;
+            for (int i = 0; i < p1.values.length; i++) {
+                try {
+                    a = p1.values[i];
+                    b = p2.values[i];
+                    if (a == AtomicValue.EMPTY_VALUE && b != AtomicValue.EMPTY_VALUE) {
+                        if ((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0) {
+                            cmp = Constants.INFERIOR;
+                        } else {
+                            cmp = Constants.SUPERIOR;
+                        }
+                    } else if (a != AtomicValue.EMPTY_VALUE && b == AtomicValue.EMPTY_VALUE) {
+                        if ((orderSpecs[i].getModifiers() & OrderSpec.EMPTY_LEAST) != 0) {
+                            cmp = Constants.SUPERIOR;
+                        } else {
+                            cmp = Constants.INFERIOR;
+                        }
+                    } else {
+                        cmp = a.compareTo(orderSpecs[i].getCollator(), b);
+                    }
+                    if ((orderSpecs[i].getModifiers() & OrderSpec.DESCENDING_ORDER) != 0) {
+                        cmp = cmp * -1;
+                    }
+                    if (cmp != Constants.EQUAL) {
+                        break;
+                    }
+                } catch (final XPathException e) {
+                }
+            }
+            return cmp;
+        }
+    }
+
+    private class OrderedNodeProxy extends NodeProxy {
+
+        AtomicValue[] values;
+
+        public OrderedNodeProxy(NodeProxy p) {
+            super(p);
+            values = new AtomicValue[orderSpecs.length];
+            for (int i = 0; i < values.length; i++)
+                values[i] = AtomicValue.EMPTY_VALUE;
+        }
+    }
+
+    private class PreorderedValueSequenceIterator implements SequenceIterator {
+
+        int pos = 0;
+
+        /* (non-Javadoc)
+         * @see org.exist.xquery.value.SequenceIterator#hasNext()
+         */
+        public boolean hasNext() {
+            return pos < nodes.length;
+        }
+
+        /* (non-Javadoc)
+         * @see org.exist.xquery.value.SequenceIterator#nextItem()
+         */
+        public Item nextItem() {
+            if (pos < nodes.length) {
+                return nodes[pos++];
+            }
+            return null;
+        }
+    }
 }

--- a/src/org/exist/xquery/value/QNameValue.java
+++ b/src/org/exist/xquery/value/QNameValue.java
@@ -21,13 +21,13 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-
 import org.exist.dom.QName;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
+
+import java.text.Collator;
 
 /**
  * Wrapper class around a {@link org.exist.dom.QName} value which extends

--- a/src/org/exist/xquery/value/QNameValue.java
+++ b/src/org/exist/xquery/value/QNameValue.java
@@ -37,8 +37,8 @@ import org.exist.xquery.XQueryContext;
  */
 public class QNameValue extends AtomicValue {
 
-	private QName qname;
-	private String stringValue;
+	private final QName qname;
+	private final String stringValue;
 
     /**
      * Constructs a new QNameValue by parsing the given name using

--- a/src/org/exist/xquery/value/QNameValue.java
+++ b/src/org/exist/xquery/value/QNameValue.java
@@ -49,7 +49,7 @@ public class QNameValue extends AtomicValue {
      * @throws XPathException
      */
 	public QNameValue(XQueryContext context, String name) throws XPathException {
-        if (name.length() == 0)
+        if (name.isEmpty())
             {throw new XPathException(ErrorCodes.FORG0001, "An empty string is not a valid lexical representation of xs:QName.");}
 
     	qname = QName.parse(context, name, context.getURIForPrefix(""));
@@ -99,7 +99,7 @@ public class QNameValue extends AtomicValue {
 //
 //	    }
 	    //TODO : check that the prefix matches the URI in the current context ?
-		if (prefix != null && prefix.length() > 0)
+		if (prefix != null && !prefix.isEmpty())
 			{return prefix + ':' + qname.getLocalPart();}
 		else 
 			{return qname.getLocalPart();}

--- a/src/org/exist/xquery/value/QNameValue.java
+++ b/src/org/exist/xquery/value/QNameValue.java
@@ -32,61 +32,62 @@ import java.text.Collator;
 /**
  * Wrapper class around a {@link org.exist.dom.QName} value which extends
  * {@link org.exist.xquery.value.AtomicValue}.
- * 
+ *
  * @author wolf
  */
 public class QNameValue extends AtomicValue {
 
-	private final QName qname;
-	private final String stringValue;
+    private final QName qname;
+    private final String stringValue;
 
     /**
      * Constructs a new QNameValue by parsing the given name using
      * the namespace declarations in context.
-     * 
+     *
      * @param context
      * @param name
      * @throws XPathException
      */
-	public QNameValue(XQueryContext context, String name) throws XPathException {
-        if (name.isEmpty())
-            {throw new XPathException(ErrorCodes.FORG0001, "An empty string is not a valid lexical representation of xs:QName.");}
+    public QNameValue(XQueryContext context, String name) throws XPathException {
+        if (name.isEmpty()) {
+            throw new XPathException(ErrorCodes.FORG0001, "An empty string is not a valid lexical representation of xs:QName.");
+        }
 
-    	qname = QName.parse(context, name, context.getURIForPrefix(""));
-	    stringValue = computeStringValue();
+        qname = QName.parse(context, name, context.getURIForPrefix(""));
+        stringValue = computeStringValue();
     }
-    
-	public QNameValue(XQueryContext context, QName name) {
-		this.qname = name;
-		stringValue = computeStringValue();
-	}
 
-	/**
-	 * @see org.exist.xquery.value.AtomicValue#getType()
-	 */
-	public int getType() {
-		return Type.QNAME;
-	}
+    public QNameValue(XQueryContext context, QName name) {
+        this.qname = name;
+        stringValue = computeStringValue();
+    }
+
+    /**
+     * @see org.exist.xquery.value.AtomicValue#getType()
+     */
+    public int getType() {
+        return Type.QNAME;
+    }
 
     /**
      * Returns the wrapped QName object.
      */
-	public QName getQName() {
-		return qname;
-	}
-	
-	/**
-	 * @see org.exist.xquery.value.Sequence#getStringValue()
-	 */
-	public String getStringValue() throws XPathException {
-		//TODO : previous approach was to resolve the qname when needed. We now try to keep the original qname
-		return stringValue;
-	}
-		
-	private String computeStringValue() {
-		//TODO : previous approach was to resolve the qname when needed. We now try to keep the original qname
-		final String prefix = qname.getPrefix();
-		//Not clear what to work with here...
+    public QName getQName() {
+        return qname;
+    }
+
+    /**
+     * @see org.exist.xquery.value.Sequence#getStringValue()
+     */
+    public String getStringValue() throws XPathException {
+        //TODO : previous approach was to resolve the qname when needed. We now try to keep the original qname
+        return stringValue;
+    }
+
+    private String computeStringValue() {
+        //TODO : previous approach was to resolve the qname when needed. We now try to keep the original qname
+        final String prefix = qname.getPrefix();
+        //Not clear what to work with here...
         // WM: Changing the prefix is problematic (e.g. if a module
         // defines different prefixes than the main module). We should
         // keep the current in-scope prefix.
@@ -98,42 +99,43 @@ public class QNameValue extends AtomicValue {
 //				//	"namespace " + qname.getNamespaceURI() + " is not defined");
 //
 //	    }
-	    //TODO : check that the prefix matches the URI in the current context ?
-		if (prefix != null && !prefix.isEmpty())
-			{return prefix + ':' + qname.getLocalPart();}
-		else 
-			{return qname.getLocalPart();}
-	}
+        //TODO : check that the prefix matches the URI in the current context ?
+        if (prefix != null && !prefix.isEmpty()) {
+            return prefix + ':' + qname.getLocalPart();
+        } else {
+            return qname.getLocalPart();
+        }
+    }
 
-	/**
-	 * @see org.exist.xquery.value.Sequence#convertTo(int)
-	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.ATOMIC :
-			case Type.ITEM :
-			case Type.QNAME :
-				return this;
-			case Type.STRING :
-				return new StringValue( getStringValue() );
-            case Type.UNTYPED_ATOMIC :
+    /**
+     * @see org.exist.xquery.value.Sequence#convertTo(int)
+     */
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.ATOMIC:
+            case Type.ITEM:
+            case Type.QNAME:
+                return this;
+            case Type.STRING:
+                return new StringValue(getStringValue());
+            case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
-			default :
-				throw new XPathException(
-					"A QName cannot be converted to " + Type.getTypeName(requiredType));
-		}
-	}
+            default:
+                throw new XPathException(
+                        "A QName cannot be converted to " + Type.getTypeName(requiredType));
+        }
+    }
 
-	@Override
-	public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
-		if (other.getType() == Type.QNAME) {
-			final int cmp = qname.compareTo(((QNameValue) other).qname);
-			switch (operator) {
-				case EQ:
-					return cmp == 0;
-				case NEQ:
-					return cmp != 0;
-				/*
+    @Override
+    public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
+        if (other.getType() == Type.QNAME) {
+            final int cmp = qname.compareTo(((QNameValue) other).qname);
+            switch (operator) {
+                case EQ:
+                    return cmp == 0;
+                case NEQ:
+                    return cmp != 0;
+                /*
 				 * QNames are unordered
 				case GT :
 					return cmp > 0;
@@ -144,92 +146,99 @@ public class QNameValue extends AtomicValue {
 				case LTEQ :
 					return cmp >= 0;
 				*/
-				default :
-					throw new XPathException(ErrorCodes.XPTY0004, "cannot apply operator to QName");
-			}
-		} else
-			{throw new XPathException(
-				"Type error: cannot compare QName to "
-					+ Type.getTypeName(other.getType()));}
-	}
+                default:
+                    throw new XPathException(ErrorCodes.XPTY0004, "cannot apply operator to QName");
+            }
+        } else {
+            throw new XPathException(
+                    "Type error: cannot compare QName to "
+                            + Type.getTypeName(other.getType()));
+        }
+    }
 
-	/**
-	 * @see org.exist.xquery.value.AtomicValue#compareTo(Collator, AtomicValue)
-	 */
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		if (other.getType() == Type.QNAME) {
-			return qname.compareTo(((QNameValue) other).qname);
-		} else
-			{throw new XPathException(
-				"Type error: cannot compare QName to "
-					+ Type.getTypeName(other.getType()));}
-	}
+    /**
+     * @see org.exist.xquery.value.AtomicValue#compareTo(Collator, AtomicValue)
+     */
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        if (other.getType() == Type.QNAME) {
+            return qname.compareTo(((QNameValue) other).qname);
+        } else {
+            throw new XPathException(
+                    "Type error: cannot compare QName to "
+                            + Type.getTypeName(other.getType()));
+        }
+    }
 
-	/**
-	 * @see org.exist.xquery.value.AtomicValue#max(Collator, AtomicValue)
-	 */
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException("Invalid argument to aggregate function: QName");
-	}
+    /**
+     * @see org.exist.xquery.value.AtomicValue#max(Collator, AtomicValue)
+     */
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException("Invalid argument to aggregate function: QName");
+    }
 
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		throw new XPathException("Invalid argument to aggregate function: QName");
-	}
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        throw new XPathException("Invalid argument to aggregate function: QName");
+    }
 
-	/**
-	 * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
-	 */
-	public int conversionPreference(Class<?> javaClass) {
-		if (javaClass.isAssignableFrom(QNameValue.class))
-			{return 0;}
-		if (javaClass == String.class)
-			{return 1;}
-		if (javaClass == Object.class)
-			{return 20;}
+    /**
+     * @see org.exist.xquery.value.Item#conversionPreference(java.lang.Class)
+     */
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(QNameValue.class)) {
+            return 0;
+        }
+        if (javaClass == String.class) {
+            return 1;
+        }
+        if (javaClass == Object.class) {
+            return 20;
+        }
 
-		return Integer.MAX_VALUE;
-	}
+        return Integer.MAX_VALUE;
+    }
 
-	/**
-	 * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
-	 */
-        @Override
-	public <T> T toJavaObject(final Class<T> target) throws XPathException {
-		if (target.isAssignableFrom(QNameValue.class)) {
-			return (T)this;
-                } else if (target == String.class) {
-			return (T)getStringValue();
-                } else if (target == Object.class) {
-			return (T)qname;
-                }
+    /**
+     * @see org.exist.xquery.value.Item#toJavaObject(java.lang.Class)
+     */
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target.isAssignableFrom(QNameValue.class)) {
+            return (T) this;
+        } else if (target == String.class) {
+            return (T) getStringValue();
+        } else if (target == Object.class) {
+            return (T) qname;
+        }
 
-		throw new XPathException(
-			"cannot convert value of type "
-				+ Type.getTypeName(getType())
-				+ " to Java object of type "
-				+ target.getName());
-	}
-	
-	public String toString() {
-		try {
-			return this.getStringValue();
-		} catch (final XPathException e) {
-			return super.toString();
-		}			
-	}
-    
+        throw new XPathException(
+                "cannot convert value of type "
+                        + Type.getTypeName(getType())
+                        + " to Java object of type "
+                        + target.getName());
+    }
+
+    public String toString() {
+        try {
+            return this.getStringValue();
+        } catch (final XPathException e) {
+            return super.toString();
+        }
+    }
+
     public boolean effectiveBooleanValue() throws XPathException {
-        throw new XPathException(ErrorCodes.FORG0006, 
-        		"value of type " + Type.getTypeName(getType()) +
-        		" has no boolean value.");
+        throw new XPathException(ErrorCodes.FORG0006,
+                "value of type " + Type.getTypeName(getType()) +
+                        " has no boolean value.");
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
-            {return true;}
-        if (obj instanceof QNameValue)
-            {return ((QNameValue)obj).qname.equals(qname);}
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof QNameValue) {
+            return ((QNameValue) obj).qname.equals(qname);
+        }
         return false;
     }
 

--- a/src/org/exist/xquery/value/Sequence.java
+++ b/src/org/exist/xquery/value/Sequence.java
@@ -32,178 +32,175 @@ import java.util.Iterator;
 
 /**
  * This interface represents a sequence as defined in the XPath 2.0 specification.
- * 
+ * <p>
  * A sequence is a sequence of items. Each item is either an atomic value or a
- * node. A single item is also a sequence, containing only the item. The base classes for 
+ * node. A single item is also a sequence, containing only the item. The base classes for
  * {@link org.exist.xquery.value.AtomicValue atomic values} and {@link org.exist.dom.persistent.NodeProxy
  * nodes} thus implement the Sequence interface.
- * 
- * Also, a {@link org.exist.dom.persistent.NodeSet node set} is a special type of sequence, where all 
- * items are of type node.  
+ * <p>
+ * Also, a {@link org.exist.dom.persistent.NodeSet node set} is a special type of sequence, where all
+ * items are of type node.
  */
 public interface Sequence {
-	
-	/**
-	 * Constant representing an empty sequence, i.e. a sequence with no item.
-	 */
+
+    /**
+     * Constant representing an empty sequence, i.e. a sequence with no item.
+     */
     Sequence EMPTY_SEQUENCE = new EmptySequence();
-	
-	/**
-	 * The purpose of ordered and unordered flag is to set the ordering mode 
-	 * in the static context to ordered or unordered for a certain region in a query. 
-	 * 
-	 * @param flag
-	 */
+
+    /**
+     * The purpose of ordered and unordered flag is to set the ordering mode
+     * in the static context to ordered or unordered for a certain region in a query.
+     *
+     * @param flag
+     */
 //	public void keepUnOrdered(boolean flag);
-	
-	/**
-	 * Add an item to the current sequence. An {@link XPathException} may be thrown
-	 * if the item's type is incompatible with this type of sequence (e.g. if the sequence
-	 * is a node set).
-	 * 
-	 * The sequence may or may not allow duplicate values.
-	 * 
-	 * @param item
-	 * @throws XPathException
-	 */
+
+    /**
+     * Add an item to the current sequence. An {@link XPathException} may be thrown
+     * if the item's type is incompatible with this type of sequence (e.g. if the sequence
+     * is a node set).
+     * <p>
+     * The sequence may or may not allow duplicate values.
+     *
+     * @param item
+     * @throws XPathException
+     */
     void add(Item item) throws XPathException;
-	
-	/**
-	 * Add all items of the other sequence to this item. An {@link XPathException} may
-	 * be thrown if the type of the items in the other sequence is incompatible with
-	 * the primary type of this sequence.
-	 * 
-	 * @param other
-	 * @throws XPathException
-	 */
+
+    /**
+     * Add all items of the other sequence to this item. An {@link XPathException} may
+     * be thrown if the type of the items in the other sequence is incompatible with
+     * the primary type of this sequence.
+     *
+     * @param other
+     * @throws XPathException
+     */
     void addAll(Sequence other) throws XPathException;
-	
-	/**
-	 * Return the primary type to which all items in this sequence belong. This is
-	 * {@link org.exist.xquery.value.Type#NODE} for node sets, {@link Type#ITEM}
-	 * for other sequences with mixed items.
-	 * 
-	 * @return the primary type of the items in this sequence.
-	 */
+
+    /**
+     * Return the primary type to which all items in this sequence belong. This is
+     * {@link org.exist.xquery.value.Type#NODE} for node sets, {@link Type#ITEM}
+     * for other sequences with mixed items.
+     *
+     * @return the primary type of the items in this sequence.
+     */
     int getItemType();
-	
-	/**
-	 * Returns an iterator over all items in the sequence. The
-	 * items are returned in document order where applicable.
-	 * 
-	 * @throws XPathException TODO
-	 */
+
+    /**
+     * Returns an iterator over all items in the sequence. The
+     * items are returned in document order where applicable.
+     *
+     * @throws XPathException TODO
+     */
     SequenceIterator iterate() throws XPathException;
-	
-	/**
-	 * Returns an iterator over all items in the sequence. The returned
-	 * items may - but need not - to be in document order.
-	 * 
-	 */
+
+    /**
+     * Returns an iterator over all items in the sequence. The returned
+     * items may - but need not - to be in document order.
+     */
     SequenceIterator unorderedIterator() throws XPathException;
-	
-	/**
-	 * Returns the number of items contained in the sequence.
-     * Call this method <strong>only</strong> when necessary, 
-     * since it can be resource consuming. 
-	 * 
-	 * @return The number of items in the sequence
-	 */
+
+    /**
+     * Returns the number of items contained in the sequence.
+     * Call this method <strong>only</strong> when necessary,
+     * since it can be resource consuming.
+     *
+     * @return The number of items in the sequence
+     */
     int getItemCount();
 
-	/**
-	 * Returns whether the sequence is empty or not.
-	 * 
-	 * @return <code>true</code> is the sequence is empty
-	 */
+    /**
+     * Returns whether the sequence is empty or not.
+     *
+     * @return <code>true</code> is the sequence is empty
+     */
     boolean isEmpty();
-	
+
     /**
      * Returns whether the sequence has just one item or not.
-     * 
+     *
      * @return <code>true</code> is the sequence has just one item
      */
     boolean hasOne();
-	
+
     /**
      * Returns whether the sequence more than one item or not.
-     * 
+     *
      * @return <code>true</code> is the sequence more than one item
      */
     boolean hasMany();
-	
-	/**
-	 * Explicitely remove all duplicate nodes from this sequence.
-	 */
+
+    /**
+     * Explicitely remove all duplicate nodes from this sequence.
+     */
     void removeDuplicates();
-	
-	/**
-	 * Returns the cardinality of this sequence. The returned
-	 * value is a combination of flags as defined in
-	 * {@link org.exist.xquery.Cardinality}.
-	 * 
-	 * @see org.exist.xquery.Cardinality
-	 * 
-	 */
+
+    /**
+     * Returns the cardinality of this sequence. The returned
+     * value is a combination of flags as defined in
+     * {@link org.exist.xquery.Cardinality}.
+     *
+     * @see org.exist.xquery.Cardinality
+     */
     int getCardinality();
-	
-	/**
-	 * Returns the item located at the specified position within
-	 * this sequence. Items are counted beginning at 0.
-	 * 
-	 * @param pos
-	 */
+
+    /**
+     * Returns the item located at the specified position within
+     * this sequence. Items are counted beginning at 0.
+     *
+     * @param pos
+     */
     Item itemAt(int pos);
-	
-	Sequence tail() throws XPathException;
-	
-	/**
-	 * Try to convert the sequence into an atomic value. The target type should be specified by
-	 * using one of the constants defined in class {@link Type}. An {@link XPathException}
-	 * is thrown if the conversion is impossible.
-	 * 
-	 * @param requiredType one of the type constants defined in class {@link Type}
-	 * @throws XPathException
-	 */
+
+    Sequence tail() throws XPathException;
+
+    /**
+     * Try to convert the sequence into an atomic value. The target type should be specified by
+     * using one of the constants defined in class {@link Type}. An {@link XPathException}
+     * is thrown if the conversion is impossible.
+     *
+     * @param requiredType one of the type constants defined in class {@link Type}
+     * @throws XPathException
+     */
     AtomicValue convertTo(int requiredType) throws XPathException;
-	
-	/**
-	 * Convert the sequence to a string.
-	 * 
-	 */
+
+    /**
+     * Convert the sequence to a string.
+     */
     String getStringValue() throws XPathException;
-	
-	/**
-	 * Get the effective boolean value of this sequence. Will be false if the sequence is empty,
-	 * true otherwise.
-	 * 
-	 * @throws XPathException
-	 */
+
+    /**
+     * Get the effective boolean value of this sequence. Will be false if the sequence is empty,
+     * true otherwise.
+     *
+     * @throws XPathException
+     */
     boolean effectiveBooleanValue() throws XPathException;
-	
-	/**
-	 * Convert the sequence into a NodeSet. If the sequence contains items
-	 * which are not nodes, an XPathException is thrown.
-	 * @throws XPathException if the sequence contains items which are not nodes.
-	 */
+
+    /**
+     * Convert the sequence into a NodeSet. If the sequence contains items
+     * which are not nodes, an XPathException is thrown.
+     *
+     * @throws XPathException if the sequence contains items which are not nodes.
+     */
     NodeSet toNodeSet() throws XPathException;
 
     /**
      * Convert the sequence into an in-memory node set. If the sequence contains
      * items which are not nodes, an XPathException is thrown. For persistent
      * node sets, this method will return null. Call {@link #isPersistentSet()} to check
-     * if the sequence is a persistent node set. 
+     * if the sequence is a persistent node set.
      *
      * @throws XPathException if the sequence contains items which are not nodes or is
-     * a persistent node set
+     *                        a persistent node set
      */
     MemoryNodeSet toMemNodeSet() throws XPathException;
 
     /**
-	 * Returns the set of documents from which the node items in this sequence
-	 * have been selected. This is for internal use only.
-	 * 
-	 */
+     * Returns the set of documents from which the node items in this sequence
+     * have been selected. This is for internal use only.
+     */
     DocumentSet getDocumentSet();
 
     /**
@@ -213,63 +210,61 @@ public interface Sequence {
     Iterator<Collection> getCollectionIterator();
 
     /**
-	 * Returns a preference indicator, indicating the preference of
-	 * a value to be converted into the given Java class. Low numbers mean
-	 * that the value can be easily converted into the given class.
-	 * 
-	 * @param javaClass
-	 */
+     * Returns a preference indicator, indicating the preference of
+     * a value to be converted into the given Java class. Low numbers mean
+     * that the value can be easily converted into the given class.
+     *
+     * @param javaClass
+     */
     int conversionPreference(Class<?> javaClass);
-	
-	/**
-	 * Convert the value into an instance of the specified
-	 * Java class.
-	 * 
-	 * @param target
-	 * @throws XPathException
-	 */
+
+    /**
+     * Convert the value into an instance of the specified
+     * Java class.
+     *
+     * @param target
+     * @throws XPathException
+     */
     <T> T toJavaObject(Class<T> target) throws XPathException;
-	
-	/**
-	 * Returns true if the sequence is the result of a previous operation
-	 * and has been cached.
-	 * 
-	 */
+
+    /**
+     * Returns true if the sequence is the result of a previous operation
+     * and has been cached.
+     */
     boolean isCached();
-	
-	/**
-	 * Indicates that the sequence is the result of a previous operation
-	 * and has not been recomputed.
-	 *  
-	 * @param cached
-	 */
+
+    /**
+     * Indicates that the sequence is the result of a previous operation
+     * and has not been recomputed.
+     *
+     * @param cached
+     */
     void setIsCached(boolean cached);
-	
-	/**
-	 * For every item in the sequence, clear any context-dependant
-	 * information that is stored during query processing. This
-	 * feature is used for node sets, which may store information
-	 * about their context node.
-	 */
+
+    /**
+     * For every item in the sequence, clear any context-dependant
+     * information that is stored during query processing. This
+     * feature is used for node sets, which may store information
+     * about their context node.
+     */
     void clearContext(int contextId) throws XPathException;
-    
-	void setSelfAsContext(int contextId) throws XPathException;
-    
+
+    void setSelfAsContext(int contextId) throws XPathException;
+
     boolean isPersistentSet();
 
     /**
      * Node sets may implement this method to be informed of storage address
      * and node id changes after updates.
      *
-     * @see org.exist.storage.UpdateListener
-     * 
      * @param oldNodeId
      * @param newNode
+     * @see org.exist.storage.UpdateListener
      */
     void nodeMoved(NodeId oldNodeId, NodeHandle newNode);  //TODO why is this here, it only pertains to Peristent nodes and NOT also in-memory nodes
 
     boolean isCacheable();
-    
+
     int getState();
 
     boolean hasChanged(int previousState);

--- a/src/org/exist/xquery/value/Sequence.java
+++ b/src/org/exist/xquery/value/Sequence.java
@@ -46,7 +46,7 @@ public interface Sequence {
 	/**
 	 * Constant representing an empty sequence, i.e. a sequence with no item.
 	 */
-	public final static Sequence EMPTY_SEQUENCE = new EmptySequence();
+    Sequence EMPTY_SEQUENCE = new EmptySequence();
 	
 	/**
 	 * The purpose of ordered and unordered flag is to set the ordering mode 
@@ -66,7 +66,7 @@ public interface Sequence {
 	 * @param item
 	 * @throws XPathException
 	 */
-	public void add(Item item) throws XPathException;
+    void add(Item item) throws XPathException;
 	
 	/**
 	 * Add all items of the other sequence to this item. An {@link XPathException} may
@@ -76,7 +76,7 @@ public interface Sequence {
 	 * @param other
 	 * @throws XPathException
 	 */
-	public void addAll(Sequence other) throws XPathException;
+    void addAll(Sequence other) throws XPathException;
 	
 	/**
 	 * Return the primary type to which all items in this sequence belong. This is
@@ -85,7 +85,7 @@ public interface Sequence {
 	 * 
 	 * @return the primary type of the items in this sequence.
 	 */
-	public int getItemType();
+    int getItemType();
 	
 	/**
 	 * Returns an iterator over all items in the sequence. The
@@ -93,14 +93,14 @@ public interface Sequence {
 	 * 
 	 * @throws XPathException TODO
 	 */
-	public SequenceIterator iterate() throws XPathException;
+    SequenceIterator iterate() throws XPathException;
 	
 	/**
 	 * Returns an iterator over all items in the sequence. The returned
 	 * items may - but need not - to be in document order.
 	 * 
 	 */
-	public SequenceIterator unorderedIterator() throws XPathException;
+    SequenceIterator unorderedIterator() throws XPathException;
 	
 	/**
 	 * Returns the number of items contained in the sequence.
@@ -109,33 +109,33 @@ public interface Sequence {
 	 * 
 	 * @return The number of items in the sequence
 	 */
-	public int getItemCount();
+    int getItemCount();
 
 	/**
 	 * Returns whether the sequence is empty or not.
 	 * 
 	 * @return <code>true</code> is the sequence is empty
 	 */
-	public boolean isEmpty();
+    boolean isEmpty();
 	
     /**
      * Returns whether the sequence has just one item or not.
      * 
      * @return <code>true</code> is the sequence has just one item
-     */    
-	public boolean hasOne();
+     */
+    boolean hasOne();
 	
     /**
      * Returns whether the sequence more than one item or not.
      * 
      * @return <code>true</code> is the sequence more than one item
-     */    
-	public boolean hasMany();
+     */
+    boolean hasMany();
 	
 	/**
 	 * Explicitely remove all duplicate nodes from this sequence.
 	 */
-	public void removeDuplicates();
+    void removeDuplicates();
 	
 	/**
 	 * Returns the cardinality of this sequence. The returned
@@ -145,7 +145,7 @@ public interface Sequence {
 	 * @see org.exist.xquery.Cardinality
 	 * 
 	 */
-	public int getCardinality();
+    int getCardinality();
 	
 	/**
 	 * Returns the item located at the specified position within
@@ -153,9 +153,9 @@ public interface Sequence {
 	 * 
 	 * @param pos
 	 */
-	public Item itemAt(int pos);
+    Item itemAt(int pos);
 	
-	public Sequence tail() throws XPathException;
+	Sequence tail() throws XPathException;
 	
 	/**
 	 * Try to convert the sequence into an atomic value. The target type should be specified by
@@ -165,13 +165,13 @@ public interface Sequence {
 	 * @param requiredType one of the type constants defined in class {@link Type}
 	 * @throws XPathException
 	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException;
+    AtomicValue convertTo(int requiredType) throws XPathException;
 	
 	/**
 	 * Convert the sequence to a string.
 	 * 
 	 */
-	public String getStringValue() throws XPathException;
+    String getStringValue() throws XPathException;
 	
 	/**
 	 * Get the effective boolean value of this sequence. Will be false if the sequence is empty,
@@ -179,14 +179,14 @@ public interface Sequence {
 	 * 
 	 * @throws XPathException
 	 */
-	public boolean effectiveBooleanValue() throws XPathException;
+    boolean effectiveBooleanValue() throws XPathException;
 	
 	/**
 	 * Convert the sequence into a NodeSet. If the sequence contains items
 	 * which are not nodes, an XPathException is thrown.
 	 * @throws XPathException if the sequence contains items which are not nodes.
 	 */
-	public NodeSet toNodeSet() throws XPathException;
+    NodeSet toNodeSet() throws XPathException;
 
     /**
      * Convert the sequence into an in-memory node set. If the sequence contains
@@ -197,20 +197,20 @@ public interface Sequence {
      * @throws XPathException if the sequence contains items which are not nodes or is
      * a persistent node set
      */
-    public MemoryNodeSet toMemNodeSet() throws XPathException;
+    MemoryNodeSet toMemNodeSet() throws XPathException;
 
     /**
 	 * Returns the set of documents from which the node items in this sequence
 	 * have been selected. This is for internal use only.
 	 * 
 	 */
-	public DocumentSet getDocumentSet();
+    DocumentSet getDocumentSet();
 
     /**
      * Return an iterator on all collections referenced by documents
      * contained in this sequence..
      */
-    public Iterator<Collection> getCollectionIterator();
+    Iterator<Collection> getCollectionIterator();
 
     /**
 	 * Returns a preference indicator, indicating the preference of
@@ -219,7 +219,7 @@ public interface Sequence {
 	 * 
 	 * @param javaClass
 	 */
-	public int conversionPreference(Class<?> javaClass);
+    int conversionPreference(Class<?> javaClass);
 	
 	/**
 	 * Convert the value into an instance of the specified
@@ -228,14 +228,14 @@ public interface Sequence {
 	 * @param target
 	 * @throws XPathException
 	 */
-	public <T> T toJavaObject(Class<T> target) throws XPathException;
+    <T> T toJavaObject(Class<T> target) throws XPathException;
 	
 	/**
 	 * Returns true if the sequence is the result of a previous operation
 	 * and has been cached.
 	 * 
 	 */
-	public boolean isCached();
+    boolean isCached();
 	
 	/**
 	 * Indicates that the sequence is the result of a previous operation
@@ -243,7 +243,7 @@ public interface Sequence {
 	 *  
 	 * @param cached
 	 */
-	public void setIsCached(boolean cached);
+    void setIsCached(boolean cached);
 	
 	/**
 	 * For every item in the sequence, clear any context-dependant
@@ -251,11 +251,11 @@ public interface Sequence {
 	 * feature is used for node sets, which may store information
 	 * about their context node.
 	 */
-    public void clearContext(int contextId) throws XPathException;
+    void clearContext(int contextId) throws XPathException;
     
-	public void setSelfAsContext(int contextId) throws XPathException;
+	void setSelfAsContext(int contextId) throws XPathException;
     
-    public boolean isPersistentSet();
+    boolean isPersistentSet();
 
     /**
      * Node sets may implement this method to be informed of storage address
@@ -268,11 +268,11 @@ public interface Sequence {
      */
     void nodeMoved(NodeId oldNodeId, NodeHandle newNode);  //TODO why is this here, it only pertains to Peristent nodes and NOT also in-memory nodes
 
-    public boolean isCacheable();
+    boolean isCacheable();
     
-    public int getState();
+    int getState();
 
-    public boolean hasChanged(int previousState);
+    boolean hasChanged(int previousState);
 
     /**
      * Clean up any resources used by the items in this sequence.

--- a/src/org/exist/xquery/value/SequenceIterator.java
+++ b/src/org/exist/xquery/value/SequenceIterator.java
@@ -24,19 +24,19 @@ package org.exist.xquery.value;
 //TODO replace with extends Iterator<Item>
 public interface SequenceIterator {
 
-	public static final SequenceIterator EMPTY_ITERATOR = new EmptySequenceIterator();
+	SequenceIterator EMPTY_ITERATOR = new EmptySequenceIterator();
 
 	/**
 	 * Determines if there is a next item in the sequence
 	 *
 	 * @return true if there is another item available, false otherwise.
 	 */
-	public boolean hasNext();
+    boolean hasNext();
 
 	/**
 	 * Retrieves the next item from the Sequence
 	 *
 	 * @return The item, or null if there are no more items
 	 */
-	public Item nextItem();
+    Item nextItem();
 }

--- a/src/org/exist/xquery/value/SequenceIterator.java
+++ b/src/org/exist/xquery/value/SequenceIterator.java
@@ -18,25 +18,25 @@
  * 
  *  $Id$
  */
- 
+
 package org.exist.xquery.value;
 
 //TODO replace with extends Iterator<Item>
 public interface SequenceIterator {
 
-	SequenceIterator EMPTY_ITERATOR = new EmptySequenceIterator();
+    SequenceIterator EMPTY_ITERATOR = new EmptySequenceIterator();
 
-	/**
-	 * Determines if there is a next item in the sequence
-	 *
-	 * @return true if there is another item available, false otherwise.
-	 */
+    /**
+     * Determines if there is a next item in the sequence
+     *
+     * @return true if there is another item available, false otherwise.
+     */
     boolean hasNext();
 
-	/**
-	 * Retrieves the next item from the Sequence
-	 *
-	 * @return The item, or null if there are no more items
-	 */
+    /**
+     * Retrieves the next item from the Sequence
+     *
+     * @return The item, or null if there are no more items
+     */
     Item nextItem();
 }

--- a/src/org/exist/xquery/value/SequenceType.java
+++ b/src/org/exist/xquery/value/SequenceType.java
@@ -30,155 +30,163 @@ import org.w3c.dom.Node;
 /**
  * Represents an XQuery SequenceType and provides methods to check
  * sequences and items against this type.
- * 
+ *
  * @author wolf
  */
 public class SequenceType {
- 
-	private int primaryType = Type.ITEM;
-	private int cardinality = Cardinality.EXACTLY_ONE;
-	private QName nodeName = null;
-	
-	public SequenceType() {
-	}
+
+    private int primaryType = Type.ITEM;
+    private int cardinality = Cardinality.EXACTLY_ONE;
+    private QName nodeName = null;
+
+    public SequenceType() {
+    }
 
     /**
      * Construct a new SequenceType using the specified
      * primary type and cardinality constants.
-     * 
+     *
      * @param primaryType
      * @param cardinality
      */
-	public SequenceType(int primaryType, int cardinality) {
-		this.primaryType = primaryType;
-		this.cardinality = cardinality;
-	}
+    public SequenceType(int primaryType, int cardinality) {
+        this.primaryType = primaryType;
+        this.cardinality = cardinality;
+    }
 
     /**
      * Returns the primary type as one of the
      * constants defined in {@link Type}.
      */
-	public int getPrimaryType() {
-		return primaryType;
-	}
+    public int getPrimaryType() {
+        return primaryType;
+    }
 
-	public void setPrimaryType(int type) {
-		this.primaryType = type;
-	}
+    public void setPrimaryType(int type) {
+        this.primaryType = type;
+    }
 
     /**
-     * Returns the expected cardinality. See the constants 
+     * Returns the expected cardinality. See the constants
      * defined in {@link Cardinality}.
-     * 
      */
-	public int getCardinality() {
-		return cardinality;
-	}
+    public int getCardinality() {
+        return cardinality;
+    }
 
-	public void setCardinality(int cardinality) {
-		this.cardinality = cardinality;
-	}
+    public void setCardinality(int cardinality) {
+        this.cardinality = cardinality;
+    }
 
-	public QName getNodeName() {
-		return nodeName;
-	}
-	
-	public void setNodeName(QName qname) {
-		this.nodeName = qname;
-	}
+    public QName getNodeName() {
+        return nodeName;
+    }
+
+    public void setNodeName(QName qname) {
+        this.nodeName = qname;
+    }
 
     /**
      * Check the specified sequence against this SequenceType.
-     *  
+     *
      * @param seq
-     * @throws XPathException 
-     * @throws XPathException 
+     * @throws XPathException
+     * @throws XPathException
      */
     public boolean checkType(Sequence seq) throws XPathException {
         if (nodeName != null) {
             Item next;
             for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
                 next = i.nextItem();
-                if (!checkType(next))
-                    {return false;}
+                if (!checkType(next)) {
+                    return false;
+                }
             }
             return true;
         } else {
             return Type.subTypeOf(seq.getItemType(), primaryType);
         }
     }
-    
+
     /**
      * Check a single item against this SequenceType.
-     * 
+     *
      * @param item
      */
-	public boolean checkType(Item item) {
+    public boolean checkType(Item item) {
         Node realNode = null;
         int type = item.getType();
         if (type == Type.NODE) {
-            realNode = ((NodeValue)item).getNode();
+            realNode = ((NodeValue) item).getNode();
             type = realNode.getNodeType();
         }
-        if(!Type.subTypeOf(type, primaryType))
-			{return false;}
-		if(nodeName != null) {
-			//TODO : how to improve performance ?
-            final QName realName = ((NodeValue)item).getQName();
-			if (nodeName.getNamespaceURI() != null) {
-				if (!nodeName.getNamespaceURI().equals(realName.getNamespaceURI()))
-					{return false;}
-			}
-			if (nodeName.getLocalPart() != null) {
-				return nodeName.getLocalPart().equals(realName.getLocalPart());
-			}
-		}
-		return true;
-	}
-	
+        if (!Type.subTypeOf(type, primaryType)) {
+            return false;
+        }
+        if (nodeName != null) {
+            //TODO : how to improve performance ?
+            final QName realName = ((NodeValue) item).getQName();
+            if (nodeName.getNamespaceURI() != null) {
+                if (!nodeName.getNamespaceURI().equals(realName.getNamespaceURI())) {
+                    return false;
+                }
+            }
+            if (nodeName.getLocalPart() != null) {
+                return nodeName.getLocalPart().equals(realName.getLocalPart());
+            }
+        }
+        return true;
+    }
+
     /**
      * Check the given type against the primary type
      * declared in this SequenceType.
-     * 
+     *
      * @param type
      * @throws XPathException
      */
-	public void checkType(int type) throws XPathException {
-		if (type == Type.EMPTY || type == Type.ITEM)
-			{return;}
-		
-		//Although xs:anyURI is not a subtype of xs:string, both types are compatible
-		if (type ==	Type.ANY_URI && primaryType == Type.STRING)
-			{return;}
-        
-		if (!Type.subTypeOf(type, primaryType))
-			{throw new XPathException(
-				"Type error: expected type: "
-					+ Type.getTypeName(primaryType)
-					+ "; got: "
-					+ Type.getTypeName(type));}
-	}
+    public void checkType(int type) throws XPathException {
+        if (type == Type.EMPTY || type == Type.ITEM) {
+            return;
+        }
+
+        //Although xs:anyURI is not a subtype of xs:string, both types are compatible
+        if (type == Type.ANY_URI && primaryType == Type.STRING) {
+            return;
+        }
+
+        if (!Type.subTypeOf(type, primaryType)) {
+            throw new XPathException(
+                    "Type error: expected type: "
+                            + Type.getTypeName(primaryType)
+                            + "; got: "
+                            + Type.getTypeName(type));
+        }
+    }
 
     /**
      * Check if the given sequence has the cardinality required
      * by this sequence type.
-     * 
+     *
      * @param seq
      * @throws XPathException
      */
-	public void checkCardinality(Sequence seq) throws XPathException {
-		if (!seq.isEmpty() && cardinality == Cardinality.EMPTY)
-			{throw new XPathException("Empty sequence expected; got " + seq.getItemCount());}
-		if (seq.isEmpty() && (cardinality & Cardinality.ZERO) == 0)
-			{throw new XPathException("Empty sequence is not allowed here");}
-		else if (seq.hasMany() && (cardinality & Cardinality.MANY) == 0)
-			{throw new XPathException("Sequence with more than one item is not allowed here");}
-	}
+    public void checkCardinality(Sequence seq) throws XPathException {
+        if (!seq.isEmpty() && cardinality == Cardinality.EMPTY) {
+            throw new XPathException("Empty sequence expected; got " + seq.getItemCount());
+        }
+        if (seq.isEmpty() && (cardinality & Cardinality.ZERO) == 0) {
+            throw new XPathException("Empty sequence is not allowed here");
+        } else if (seq.hasMany() && (cardinality & Cardinality.MANY) == 0) {
+            throw new XPathException("Sequence with more than one item is not allowed here");
+        }
+    }
 
-	public String toString() {
-		if (cardinality == Cardinality.EMPTY)
-			{return Cardinality.toString(cardinality);}
-		return Type.getTypeName(primaryType) + Cardinality.toString(cardinality);
-	}
+    public String toString() {
+        if (cardinality == Cardinality.EMPTY) {
+            return Cardinality.toString(cardinality);
+        }
+        return Type.getTypeName(primaryType) + Cardinality.toString(cardinality);
+    }
 
 }

--- a/src/org/exist/xquery/value/SingleItemIterator.java
+++ b/src/org/exist/xquery/value/SingleItemIterator.java
@@ -22,28 +22,29 @@ package org.exist.xquery.value;
 
 public class SingleItemIterator implements SequenceIterator {
 
-	boolean more = true;
-	Item item;
+    boolean more = true;
+    Item item;
 
-	public SingleItemIterator(Item item) {
-		this.item = item;
-	}
+    public SingleItemIterator(Item item) {
+        this.item = item;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.SequenceIterator#hasNext()
-	 */
-	public boolean hasNext() {
-		return more;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.SequenceIterator#hasNext()
+     */
+    public boolean hasNext() {
+        return more;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.SequenceIterator#nextItem()
-	 */
-	public Item nextItem() {
-		if (!more)
-			{return null;}
-		more = false;
-		return item;
-	}
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.SequenceIterator#nextItem()
+     */
+    public Item nextItem() {
+        if (!more) {
+            return null;
+        }
+        more = false;
+        return item;
+    }
 
 }

--- a/src/org/exist/xquery/value/StringValue.java
+++ b/src/org/exist/xquery/value/StringValue.java
@@ -36,435 +36,130 @@ import java.util.regex.Pattern;
 
 public class StringValue extends AtomicValue {
 
-	public final static StringValue EMPTY_STRING = new StringValue("");
+    public final static StringValue EMPTY_STRING = new StringValue("");
 
     private final static String langRegex =
-    	//http://www.w3.org/TR/xmlschema-2/#language
-    	//The lexical space of language is the set of all strings that conform 
-    	//to the pattern [a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})* . 
-    	"[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*";
-    
-    	//Old definition : not sure where it comes from
-        //"/(([a-z]|[A-Z])([a-z]|[A-Z])|" // ISO639Code
-        //+ "([iI]-([a-z]|[A-Z])+)|"     // IanaCode
-        //+ "([xX]-([a-z]|[A-Z])+))"     // UserCode
-        //+ "(-([a-z]|[A-Z])+)*/";        // Subcode" 
-        
-    
-    private final static Pattern langPattern = Pattern.compile(langRegex);
-    
-	protected int type = Type.STRING;
+            //http://www.w3.org/TR/xmlschema-2/#language
+            //The lexical space of language is the set of all strings that conform
+            //to the pattern [a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})* .
+            "[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*";
 
-	protected String value;
+    //Old definition : not sure where it comes from
+    //"/(([a-z]|[A-Z])([a-z]|[A-Z])|" // ISO639Code
+    //+ "([iI]-([a-z]|[A-Z])+)|"     // IanaCode
+    //+ "([xX]-([a-z]|[A-Z])+))"     // UserCode
+    //+ "(-([a-z]|[A-Z])+)*/";        // Subcode"
+
+
+    private final static Pattern langPattern = Pattern.compile(langRegex);
+
+    protected int type = Type.STRING;
+
+    protected String value;
 
     public StringValue(String string, int type) throws XPathException {
         this(string, type, true);
     }
 
-	public StringValue(String string, int type, boolean expand) throws XPathException {
-		this.type = type;
-        if (expand)
-		    {string = StringValue.expand(string);} //Should we have character entities
-		if(type == Type.STRING)
-			{this.value = string;}
-		else if(type == Type.NORMALIZED_STRING)
-			{this.value = normalizeWhitespace(string);} 
-		else {
-			this.value = collapseWhitespace(string);
-			checkType();
-		}
- 	}
-
-	public StringValue(String string) {
-		//string = StringValue.expand(string); //Should we have character entities
-		value = string;
-	}
-
-    public void append(String toAppend) {
-        value += toAppend;
+    public StringValue(String string, int type, boolean expand) throws XPathException {
+        this.type = type;
+        if (expand) {
+            string = StringValue.expand(string);
+        } //Should we have character entities
+        if (type == Type.STRING) {
+            this.value = string;
+        } else if (type == Type.NORMALIZED_STRING) {
+            this.value = normalizeWhitespace(string);
+        } else {
+            this.value = collapseWhitespace(string);
+            checkType();
+        }
     }
 
-	public StringValue expand() throws XPathException {
-		value = expand(value);
-		return this;
-	}
-	
-	private void checkType() throws XPathException {
-		switch(type) {
-			case Type.NORMALIZED_STRING:
-			case Type.TOKEN:
-				return;
-			case Type.LANGUAGE:
-				final Matcher matcher = langPattern.matcher(value);				
-				if (!matcher.matches())
-					{throw new XPathException(
-						"Type error: string "
-						+ value
-						+ " is not valid for type xs:language");}
-				return;
-			case Type.NAME:
-				if(!QName.isQName(value))
-					{throw new XPathException("Type error: string " + value + " is not a valid xs:Name");}
-				return;
-			case Type.NCNAME:
-			case Type.ID:
-			case Type.IDREF:
-			case Type.ENTITY:
-				if(!XMLChar.isValidNCName(value))
-					{throw new XPathException("Type error: string " + value + " is not a valid " + Type.getTypeName(type));}
-			case Type.NMTOKEN:
-				if(!XMLChar.isValidNmtoken(value))
-					{throw new XPathException("Type error: string " + value + " is not a valid xs:NMTOKEN");}
-		}
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#getType()
-	 */
-	public int getType() {
-		return type;
-	}
+    public StringValue(String string) {
+        //string = StringValue.expand(string); //Should we have character entities
+        value = string;
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#getStringValue()
-	 */
-	public String getStringValue() {
-        return getStringValue(false);
-	}
-
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Item#getStringValue()
-	 */
-	public String getStringValue(boolean bmpCheck) {
-        if (bmpCheck) {
-            final StringBuilder buf = new StringBuilder(value.length());
-            char ch;
-            for (int i = 0; i < value.length(); i++) {
-                ch = value.charAt(i);
-                if (XMLChar.isSurrogate(ch)) {
-                    // Compose supplemental from high and low surrogate
-                    final int suppChar = XMLChar.supplemental(ch, value.charAt(++i));
-                        buf.append("&#");
-                        buf.append(Integer.toString(suppChar));
-                        buf.append(";");
-                } else {
-                    buf.append(ch);
-                }
-            }
-            
-            return buf.toString();
-        } else {
-        return value;
-        }
-	}
-    
-	public Item itemAt(int pos) {
-		return pos == 0 ? this : null;
-	}
-
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#convertTo(int)
-	 */
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			//TODO : should we allow these 2 type under-promotions ?
-			case Type.ATOMIC :
-			case Type.ITEM :
-			case Type.STRING :
-				return this;
-			case Type.NORMALIZED_STRING:
-			case Type.TOKEN:
-			case Type.LANGUAGE:
-			case Type.NMTOKEN:
-			case Type.NAME:
-			case Type.NCNAME:
-			case Type.ID:
-			case Type.IDREF:
-			case Type.ENTITY:
-				return new StringValue(value, requiredType);
-			case Type.ANY_URI :
-				return new AnyURIValue(value);
-			case Type.BOOLEAN :
-                final String trimmed = trimWhitespace(value);
-				if ("0".equals(trimmed) || "false".equals(trimmed))
-					{return BooleanValue.FALSE;}
-				else if ("1".equals(trimmed) || "true".equals(trimmed))
-					{return BooleanValue.TRUE;}
-				else
-					{throw new XPathException(
-						"cannot convert string '" + value + "' to boolean");}
-			case Type.FLOAT :
-				return new FloatValue(value); 
-			case Type.DOUBLE :
-			case Type.NUMBER :
-				return new DoubleValue(this);
-			case Type.DECIMAL :
-				return new DecimalValue(value);
-			case Type.INTEGER :
-			case Type.NON_POSITIVE_INTEGER :
-			case Type.NEGATIVE_INTEGER :
-			case Type.POSITIVE_INTEGER :
-			case Type.LONG :
-			case Type.INT :
-			case Type.SHORT :
-			case Type.BYTE :
-			case Type.NON_NEGATIVE_INTEGER :
-			case Type.UNSIGNED_LONG :
-			case Type.UNSIGNED_INT :
-			case Type.UNSIGNED_SHORT :
-			case Type.UNSIGNED_BYTE :
-				return new IntegerValue(value, requiredType);
-			case Type.BASE64_BINARY :
-				return new BinaryValueFromBinaryString(new Base64BinaryValueType(), value);
-            case Type.HEX_BINARY :
-                return new BinaryValueFromBinaryString(new HexBinaryValueType(), value);
-			case Type.DATE_TIME :
-				return new DateTimeValue(value);
-			case Type.TIME :
-				return new TimeValue(value);
-			case Type.DATE :
-            	return new DateValue(value);  
-			case Type.DURATION :
-				return new DurationValue(value);
-			case Type.YEAR_MONTH_DURATION : 
-				return new YearMonthDurationValue(value);
-			case Type.DAY_TIME_DURATION :	
-				return new DayTimeDurationValue(value);
-            case Type.GYEAR :
-            	return new GYearValue(value);  
-            case Type.GMONTH :
-        		return new GMonthValue(value);
-            case Type.GDAY :
-                return new GDayValue(value);
-            case Type.GYEARMONTH :
-            	return new GYearMonthValue(value);  
-            case Type.GMONTHDAY :
-                return new GMonthDayValue(value);
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());
-			case Type.QNAME :
-				return new QNameValue(null, new QName(value));
-			default :
-				throw new XPathException(ErrorCodes.FORG0001, "cannot cast '" + 
-						Type.getTypeName(this.getItemType()) + "(\"" + getStringValue() + "\")' to " +
-						Type.getTypeName(requiredType));
-		}
-	}
-
-	public int conversionPreference(Class<?> javaClass) {
-		if(javaClass.isAssignableFrom(StringValue.class)) {return 0;}
-		if(javaClass == String.class || javaClass == CharSequence.class) {return 1;}
-		if(javaClass == Character.class || javaClass == char.class) {return 2;}
-		if(javaClass == Double.class || javaClass == double.class) {return 10;}
-		if(javaClass == Float.class || javaClass == float.class) {return 11;}
-		if(javaClass == Long.class || javaClass == long.class) {return 12;}
-		if(javaClass == Integer.class || javaClass == int.class) {return 13;}
-		if(javaClass == Short.class || javaClass == short.class) {return 14;}
-		if(javaClass == Byte.class || javaClass == byte.class) {return 15;}
-		if(javaClass == Boolean.class || javaClass == boolean.class) {return 16;}
-		if(javaClass == Object.class) {return 20;}
-		
-		return Integer.MAX_VALUE;
-	}
-	
-        @Override
-	public <T> T toJavaObject(final Class<T> target) throws XPathException {
-		if(target.isAssignableFrom(StringValue.class)) {
-			return (T)this;
-                } else if(target == Object.class || target == String.class || target == CharSequence.class) {
-			return (T)value;
-                } else if(target == double.class || target == Double.class) {
-			final DoubleValue v = (DoubleValue)convertTo(Type.DOUBLE);
-			return (T)Double.valueOf(v.getValue());
-		} else if(target == float.class || target == Float.class) {
-			final FloatValue v = (FloatValue)convertTo(Type.FLOAT);
-			return (T)Float.valueOf(v.value);
-		} else if(target == long.class || target == Long.class) {
-			final IntegerValue v = (IntegerValue)convertTo(Type.LONG);
-			return (T)Long.valueOf(v.getInt());
-		} else if(target == int.class || target == Integer.class) {
-			final IntegerValue v = (IntegerValue)convertTo(Type.INT);
-			return (T)Integer.valueOf(v.getInt());
-		} else if(target == short.class || target == Short.class) {
-			final IntegerValue v = (IntegerValue)convertTo(Type.SHORT);
-			return (T)Short.valueOf((short)v.getInt());
-		} else if(target == byte.class || target == Byte.class) {
-			final IntegerValue v = (IntegerValue)convertTo(Type.BYTE);
-			return (T)Byte.valueOf((byte)v.getInt());
-		} else if(target == boolean.class || target == Boolean.class) {
-			return (T)Boolean.valueOf(effectiveBooleanValue());
-		} else if(target == char.class || target == Character.class) {
-                    if(value.length() > 1 || value.length() == 0) {
-                        throw new XPathException("cannot convert string with length = 0 or length > 1 to Java character");
-                    }
-                    return (T)Character.valueOf(value.charAt(0));
-		}
-		
-		throw new XPathException("cannot convert value of type " + Type.getTypeName(type) +
-			" to Java object of type " + target.getName());
-	}
-	
-	@Override
-	public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
-		if (other.isEmpty())
-			{return false;}
-		//A value of type xs:anyURI (or any type derived by restriction from xs:anyURI) 
-		//can be promoted to the type xs:string. 
-		//The result of this promotion is created by casting the original value to the type xs:string.
-		if (Type.subTypeOf(other.getType(), Type.ANY_URI)) 
-			{other = other.convertTo(Type.STRING);}
-		if (Type.subTypeOf(other.getType(), Type.STRING)) {
-			final int cmp = Collations.compare(collator, value, other.getStringValue());
-			switch (operator) {
-				case EQ:
-					return cmp == 0;
-				case NEQ:
-					return cmp != 0;
-				case LT :
-					return cmp < 0;
-				case LTEQ :
-					return cmp <= 0;
-				case GT :
-					return cmp > 0;
-				case GTEQ :
-					return cmp >= 0;
-				default :
-					throw new XPathException("Type error: cannot apply operand to string value");
-			}
-		}
-		throw new XPathException(ErrorCodes.XPTY0004, 
-			"can not compare xs:string('" + value + "') with " + 
-			Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "')");
-	}
-
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#compareTo(org.exist.xquery.value.AtomicValue)
-	 */
-	public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(),Type.NUMBER)) {
-			//No possible comparisons
-			if (((NumericValue)other).isNaN())
-				{return Constants.INFERIOR;}
-			if (((NumericValue)other).isInfinite())
-				{return Constants.INFERIOR;}
-		}			
-		return Collations.compare(collator, value, other.getStringValue());
-	}
-
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#startsWith(org.exist.xquery.value.AtomicValue)
-	 */
-	public boolean startsWith(Collator collator, AtomicValue other) throws XPathException {
-		return Collations.startsWith(collator, value, other.getStringValue());
-	}
-	
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#endsWith(org.exist.xquery.value.AtomicValue)
-	 */
-	public boolean endsWith(Collator collator, AtomicValue other) throws XPathException {
-		return Collations.endsWith(collator, value, other.getStringValue());
-	}
-	
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#contains(org.exist.xquery.value.AtomicValue)
-	 */
-	public boolean contains(Collator collator, AtomicValue other) throws XPathException {
-		return Collations.indexOf(collator, value, other.getStringValue()) != Constants.STRING_NOT_FOUND;
-	}
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#effectiveBooleanValue()
-	 */
-	public boolean effectiveBooleanValue() throws XPathException {
-		// If its operand is a singleton value of type xs:string, xs:anyURI, xs:untypedAtomic, 
-		//or a type derived from one of these, fn:boolean returns false if the operand value has zero length; otherwise it returns true.
-		return value.length() > 0;
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	public String toString() {
-		return value;
-	}
-
-	public final static String normalizeWhitespace(CharSequence seq) {
-        if (seq == null)
-            {return "";}
-        final StringBuilder copy = new StringBuilder(seq.length());
-		char ch;
-		for (int i = 0; i < seq.length(); i++) {
-			ch = seq.charAt(i);
-			switch (ch) {
-				case '\n' :
-				case '\r' :
-				case '\t' :
-					copy.append(' ');
-					break;
-				default :
-					copy.append(ch);
-			}
-		}
-		return copy.toString();
-	}
-
-	/**
-	 * Collapses all sequences of adjacent whitespace chars in the input string
-	 * into a single space.
-	 *  
-	 * @param in
-	 */
-	public static String collapseWhitespace(CharSequence in) {
-        if (in == null)
-            {return "";}
-        if (in.length() == 0) {
-			return in.toString();
-		}
-		int i = 0;
-		// this method is performance critical, so first test if we need to collapse at all
-		for (; i < in.length(); i++) {
-		    final char c = in.charAt(i);
-		    if(XMLChar.isSpace(c)) {
-		        if(i + 1 < in.length() && XMLChar.isSpace(in.charAt(i + 1)))
-		            {break;}
-		    }
-		}
-		if(i == in.length())
-		    // no whitespace to collapse, just return
-		    {return in.toString();}
-		
-		// start to collapse whitespace
-		final StringBuilder sb = new StringBuilder(in.length());
-		sb.append(in.subSequence(0, i + 1).toString());
-		boolean inWhitespace = true;
-		for (; i < in.length(); i++) {
-			final char c = in.charAt(i);
-			if(XMLChar.isSpace(c)) {
-				if (inWhitespace) {
-					// remove the whitespace
-				} else {
-					sb.append(' ');
-					inWhitespace = true;
-				}
-			} else {
-				sb.append(c);
-				inWhitespace = false;
-			}
-		}
-		if (sb.charAt(sb.length() - 1) == ' ') {
-			sb.deleteCharAt(sb.length() - 1);
-		}
-		return sb.toString();
-	}
-
-	public final static String trimWhitespace(String in) {
-		if (in == null) {
+    public final static String normalizeWhitespace(CharSequence seq) {
+        if (seq == null) {
             return "";
         }
-            if (in.length()==0) {
+        final StringBuilder copy = new StringBuilder(seq.length());
+        char ch;
+        for (int i = 0; i < seq.length(); i++) {
+            ch = seq.charAt(i);
+            switch (ch) {
+                case '\n':
+                case '\r':
+                case '\t':
+                    copy.append(' ');
+                    break;
+                default:
+                    copy.append(ch);
+            }
+        }
+        return copy.toString();
+    }
+
+    /**
+     * Collapses all sequences of adjacent whitespace chars in the input string
+     * into a single space.
+     *
+     * @param in
+     */
+    public static String collapseWhitespace(CharSequence in) {
+        if (in == null) {
+            return "";
+        }
+        if (in.length() == 0) {
+            return in.toString();
+        }
+        int i = 0;
+        // this method is performance critical, so first test if we need to collapse at all
+        for (; i < in.length(); i++) {
+            final char c = in.charAt(i);
+            if (XMLChar.isSpace(c)) {
+                if (i + 1 < in.length() && XMLChar.isSpace(in.charAt(i + 1))) {
+                    break;
+                }
+            }
+        }
+        if (i == in.length())
+        // no whitespace to collapse, just return
+        {
+            return in.toString();
+        }
+
+        // start to collapse whitespace
+        final StringBuilder sb = new StringBuilder(in.length());
+        sb.append(in.subSequence(0, i + 1).toString());
+        boolean inWhitespace = true;
+        for (; i < in.length(); i++) {
+            final char c = in.charAt(i);
+            if (XMLChar.isSpace(c)) {
+                if (inWhitespace) {
+                    // remove the whitespace
+                } else {
+                    sb.append(' ');
+                    inWhitespace = true;
+                }
+            } else {
+                sb.append(c);
+                inWhitespace = false;
+            }
+        }
+        if (sb.charAt(sb.length() - 1) == ' ') {
+            sb.deleteCharAt(sb.length() - 1);
+        }
+        return sb.toString();
+    }
+
+    public final static String trimWhitespace(String in) {
+        if (in == null) {
+            return "";
+        }
+        if (in.length() == 0) {
             return in;
         }
         int first = 0;
@@ -477,91 +172,93 @@ public class StringValue extends AtomicValue {
         while (in.charAt(last) <= 0x20) {
             last--;
         }
-        return in.substring(first, last+1);
-	}
-	
-	public final static String expand(CharSequence seq) throws XPathException {
-        if (seq == null)
-            {return "";}
+        return in.substring(first, last + 1);
+    }
+
+    public final static String expand(CharSequence seq) throws XPathException {
+        if (seq == null) {
+            return "";
+        }
         final StringBuilder buf = new StringBuilder(seq.length());
-	    StringBuilder entityRef = null;
-	    char ch;
-	    for (int i = 0; i < seq.length(); i++) {
-	        ch = seq.charAt(i);
-	        switch (ch) {
-	            case '&' :
-	                if (entityRef == null)
-	                    {entityRef = new StringBuilder();}
-	                else
-	                    {entityRef.setLength(0);}
-	                if ((i+1)==seq.length()) {
-	                    throw new XPathException(ErrorCodes.XPST0003, "Ampersands (&) must be escaped.");
-	                }
-	                if ((i+2)==seq.length()) {
-	                    throw new XPathException(ErrorCodes.XPST0003, "Ampersands (&) must be escaped (missing ;).");
-	                }
-	                ch = seq.charAt(i+1);
-	                if (ch!='#') {
-	                    if (!Character.isLetter(ch)) {
-	                        throw new XPathException(ErrorCodes.XPST0003, "Ampersands (&) must be escaped (following character was not a name start character).");
-	                    }
-	                    entityRef.append(ch);
-	                    boolean found = false;
-	                    for (int j = i + 2; j < seq.length(); j++) {
-	                        ch = seq.charAt(j);
-	                        if (ch != ';' && (ch=='.' || ch=='_' || ch=='-' || Character.isLetterOrDigit(ch))) {
-	                            entityRef.append(ch);
-	                        } else if (ch==';') {
-	                            found = true;
-	                            i = j;
-	                            break;
-	                        } else {
-	                            break;
-	                        }
-	                    }
-	                    if (found) {
-	                        buf.append((char) expandEntity(entityRef.toString()));
-	                    } else {
-	                        throw new XPathException(ErrorCodes.XPST0003, "Invalid character ("+ch+") in entity name ("+entityRef+") or missing ;");
-	                    }
-                        
-	                } else {
-	                    entityRef.append(ch);
-	                    ch = seq.charAt(i+2);
-	                    boolean found = false;
-	                    if (ch=='x') {
-	                        entityRef.append(ch);
-	                        // hex number
-	                        for (int j = i + 3; j < seq.length(); j++) {
-	                            ch = seq.charAt(j);
-	                            if (ch != ';' && (ch=='0' || ch=='1' || ch=='2' || ch=='3' || ch=='4' || ch=='5' || ch=='6' || ch=='7' || ch=='8' || ch=='9' ||
-	                                    ch=='a' || ch=='b' || ch=='c' || ch=='d' || ch=='e' || ch=='f' ||
-	                                    ch=='A' || ch=='B' || ch=='C' || ch=='D' || ch=='E' || ch=='F')) {
-	                                entityRef.append(ch);
-	                            } else if (ch==';') {
-	                                found = true;
-	                                i = j;
-	                                break;
-	                            } else {
-	                                break;
-	                            }
-	                        }
-	                    } else {
-	                        // decimal number
-	                        for (int j = i + 2; j < seq.length(); j++) {
-	                            ch = seq.charAt(j);
-	                            if (ch != ';' && (ch=='0' || ch=='1' || ch=='2' || ch=='3' || ch=='4' || ch=='5' || ch=='6' || ch=='7' || ch=='8' || ch=='9')) {
-	                                entityRef.append(ch);
-	                            } else if (ch==';') {
-	                                found = true;
-	                                i = j;
-	                                break;
-	                            } else {
-	                                break;
-	                            }
-	                        }
-	                    }
-	                    if (found) {
+        StringBuilder entityRef = null;
+        char ch;
+        for (int i = 0; i < seq.length(); i++) {
+            ch = seq.charAt(i);
+            switch (ch) {
+                case '&':
+                    if (entityRef == null) {
+                        entityRef = new StringBuilder();
+                    } else {
+                        entityRef.setLength(0);
+                    }
+                    if ((i + 1) == seq.length()) {
+                        throw new XPathException(ErrorCodes.XPST0003, "Ampersands (&) must be escaped.");
+                    }
+                    if ((i + 2) == seq.length()) {
+                        throw new XPathException(ErrorCodes.XPST0003, "Ampersands (&) must be escaped (missing ;).");
+                    }
+                    ch = seq.charAt(i + 1);
+                    if (ch != '#') {
+                        if (!Character.isLetter(ch)) {
+                            throw new XPathException(ErrorCodes.XPST0003, "Ampersands (&) must be escaped (following character was not a name start character).");
+                        }
+                        entityRef.append(ch);
+                        boolean found = false;
+                        for (int j = i + 2; j < seq.length(); j++) {
+                            ch = seq.charAt(j);
+                            if (ch != ';' && (ch == '.' || ch == '_' || ch == '-' || Character.isLetterOrDigit(ch))) {
+                                entityRef.append(ch);
+                            } else if (ch == ';') {
+                                found = true;
+                                i = j;
+                                break;
+                            } else {
+                                break;
+                            }
+                        }
+                        if (found) {
+                            buf.append((char) expandEntity(entityRef.toString()));
+                        } else {
+                            throw new XPathException(ErrorCodes.XPST0003, "Invalid character (" + ch + ") in entity name (" + entityRef + ") or missing ;");
+                        }
+
+                    } else {
+                        entityRef.append(ch);
+                        ch = seq.charAt(i + 2);
+                        boolean found = false;
+                        if (ch == 'x') {
+                            entityRef.append(ch);
+                            // hex number
+                            for (int j = i + 3; j < seq.length(); j++) {
+                                ch = seq.charAt(j);
+                                if (ch != ';' && (ch == '0' || ch == '1' || ch == '2' || ch == '3' || ch == '4' || ch == '5' || ch == '6' || ch == '7' || ch == '8' || ch == '9' ||
+                                        ch == 'a' || ch == 'b' || ch == 'c' || ch == 'd' || ch == 'e' || ch == 'f' ||
+                                        ch == 'A' || ch == 'B' || ch == 'C' || ch == 'D' || ch == 'E' || ch == 'F')) {
+                                    entityRef.append(ch);
+                                } else if (ch == ';') {
+                                    found = true;
+                                    i = j;
+                                    break;
+                                } else {
+                                    break;
+                                }
+                            }
+                        } else {
+                            // decimal number
+                            for (int j = i + 2; j < seq.length(); j++) {
+                                ch = seq.charAt(j);
+                                if (ch != ';' && (ch == '0' || ch == '1' || ch == '2' || ch == '3' || ch == '4' || ch == '5' || ch == '6' || ch == '7' || ch == '8' || ch == '9')) {
+                                    entityRef.append(ch);
+                                } else if (ch == ';') {
+                                    found = true;
+                                    i = j;
+                                    break;
+                                } else {
+                                    break;
+                                }
+                            }
+                        }
+                        if (found) {
                             final int charref = expandEntity(entityRef.toString());
                             if (XMLChar.isSupplemental(charref)) {
                                 buf.append(XMLChar.highSurrogate(charref));
@@ -569,120 +266,465 @@ public class StringValue extends AtomicValue {
                             } else {
                                 buf.append((char) charref);
                             }
-	                    } else {
-	                        throw new XPathException(ErrorCodes.XPST0003, "Invalid character in character reference ("+ch+") or missing ;");
-	                    }
+                        } else {
+                            throw new XPathException(ErrorCodes.XPST0003, "Invalid character in character reference (" + ch + ") or missing ;");
+                        }
 
-	                }
-	                break;
-	            case '\r':
-	                // drop carriage returns
-	                if ((i+1)!=seq.length()) {
-	                    ch = seq.charAt(i+1);
-	                    if (ch!='\n') {
-	                        buf.append('\n');
-	                    }
-	                }
-	                break;
-	            default :
-	                buf.append(ch);
-	        }
-	    }
-	    return buf.toString();
-	}
+                    }
+                    break;
+                case '\r':
+                    // drop carriage returns
+                    if ((i + 1) != seq.length()) {
+                        ch = seq.charAt(i + 1);
+                        if (ch != '\n') {
+                            buf.append('\n');
+                        }
+                    }
+                    break;
+                default:
+                    buf.append(ch);
+            }
+        }
+        return buf.toString();
+    }
 
-	/**
+    /**
      * The method <code>expandEntity</code>
      *
      * @param buf a <code>String</code> value
      * @return an <code>int</code> value
-     * @exception XPathException if an error occurs
+     * @throws XPathException if an error occurs
      */
     private final static int expandEntity(String buf) throws XPathException {
-		if ("amp".equals(buf))
-			{return '&';}
-		else if ("lt".equals(buf))
-			{return '<';}
-		else if ("gt".equals(buf))
-			{return '>';}
-		else if ("quot".equals(buf))
-			{return '"';}
-		else if ("apos".equals(buf))
-			{return '\'';}
-		else if (buf.length() > 1 && buf.charAt(0) == '#') {
+        if ("amp".equals(buf)) {
+            return '&';
+        } else if ("lt".equals(buf)) {
+            return '<';
+        } else if ("gt".equals(buf)) {
+            return '>';
+        } else if ("quot".equals(buf)) {
+            return '"';
+        } else if ("apos".equals(buf)) {
+            return '\'';
+        } else if (buf.length() > 1 && buf.charAt(0) == '#') {
             return expandCharRef(buf.substring(1));
-		} else
-			{throw new XPathException("Unknown entity reference: " + buf);}
-	}
+        } else {
+            throw new XPathException("Unknown entity reference: " + buf);
+        }
+    }
 
-	/**
+    /**
      * The method <code>expandCharRef</code>
      *
      * @param buf a <code>String</code> value
      * @return an <code>int</code> value
-     * @exception XPathException if an error occurs
+     * @throws XPathException if an error occurs
      */
     private final static int expandCharRef(String buf) throws XPathException {
-		try {
+        try {
             int charNumber;
-			if (buf.length() > 1 && buf.charAt(0) == 'x') {
-				// Hex
-				charNumber = Integer.parseInt(buf.substring(1), 16);
-			} else {
-				charNumber = Integer.parseInt(buf);
-                        }
-                   if (charNumber==0) {
-                      throw new XPathException(ErrorCodes.XQST0090, "Character number zero (0) is not allowed.");
-                   }
-                   return charNumber;
-		} catch (final NumberFormatException e) {
-			throw new XPathException("Unknown character reference: " + buf);
-		}
-	}
+            if (buf.length() > 1 && buf.charAt(0) == 'x') {
+                // Hex
+                charNumber = Integer.parseInt(buf.substring(1), 16);
+            } else {
+                charNumber = Integer.parseInt(buf);
+            }
+            if (charNumber == 0) {
+                throw new XPathException(ErrorCodes.XQST0090, "Character number zero (0) is not allowed.");
+            }
+            return charNumber;
+        } catch (final NumberFormatException e) {
+            throw new XPathException("Unknown character reference: " + buf);
+        }
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
-	 */
-	public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.STRING))
-			{return Collations.compare(collator, value, ((StringValue) other).value) > 0 ? this : other;}
-		else
-			{return Collations.compare(collator, value, ((StringValue) other.convertTo(getType())).value) > 0
-				? this
-				: other;}
-	}
+    public void append(String toAppend) {
+        value += toAppend;
+    }
 
-	public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-		if (Type.subTypeOf(other.getType(), Type.STRING))
-			{return Collations.compare(collator, value, ((StringValue) other).value) < 0 ? this : other;}
-		else
-			{return Collations.compare(collator, value, ((StringValue) other.convertTo(getType())).value) < 0
-				? this
-				: other;}
-	}
+    public StringValue expand() throws XPathException {
+        value = expand(value);
+        return this;
+    }
+
+    private void checkType() throws XPathException {
+        switch (type) {
+            case Type.NORMALIZED_STRING:
+            case Type.TOKEN:
+                return;
+            case Type.LANGUAGE:
+                final Matcher matcher = langPattern.matcher(value);
+                if (!matcher.matches()) {
+                    throw new XPathException(
+                            "Type error: string "
+                                    + value
+                                    + " is not valid for type xs:language");
+                }
+                return;
+            case Type.NAME:
+                if (!QName.isQName(value)) {
+                    throw new XPathException("Type error: string " + value + " is not a valid xs:Name");
+                }
+                return;
+            case Type.NCNAME:
+            case Type.ID:
+            case Type.IDREF:
+            case Type.ENTITY:
+                if (!XMLChar.isValidNCName(value)) {
+                    throw new XPathException("Type error: string " + value + " is not a valid " + Type.getTypeName(type));
+                }
+            case Type.NMTOKEN:
+                if (!XMLChar.isValidNmtoken(value)) {
+                    throw new XPathException("Type error: string " + value + " is not a valid xs:NMTOKEN");
+                }
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#getType()
+     */
+    public int getType() {
+        return type;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#getStringValue()
+     */
+    public String getStringValue() {
+        return getStringValue(false);
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Item#getStringValue()
+     */
+    public String getStringValue(boolean bmpCheck) {
+        if (bmpCheck) {
+            final StringBuilder buf = new StringBuilder(value.length());
+            char ch;
+            for (int i = 0; i < value.length(); i++) {
+                ch = value.charAt(i);
+                if (XMLChar.isSurrogate(ch)) {
+                    // Compose supplemental from high and low surrogate
+                    final int suppChar = XMLChar.supplemental(ch, value.charAt(++i));
+                    buf.append("&#");
+                    buf.append(Integer.toString(suppChar));
+                    buf.append(";");
+                } else {
+                    buf.append(ch);
+                }
+            }
+
+            return buf.toString();
+        } else {
+            return value;
+        }
+    }
+
+    public Item itemAt(int pos) {
+        return pos == 0 ? this : null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#convertTo(int)
+     */
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            //TODO : should we allow these 2 type under-promotions ?
+            case Type.ATOMIC:
+            case Type.ITEM:
+            case Type.STRING:
+                return this;
+            case Type.NORMALIZED_STRING:
+            case Type.TOKEN:
+            case Type.LANGUAGE:
+            case Type.NMTOKEN:
+            case Type.NAME:
+            case Type.NCNAME:
+            case Type.ID:
+            case Type.IDREF:
+            case Type.ENTITY:
+                return new StringValue(value, requiredType);
+            case Type.ANY_URI:
+                return new AnyURIValue(value);
+            case Type.BOOLEAN:
+                final String trimmed = trimWhitespace(value);
+                if ("0".equals(trimmed) || "false".equals(trimmed)) {
+                    return BooleanValue.FALSE;
+                } else if ("1".equals(trimmed) || "true".equals(trimmed)) {
+                    return BooleanValue.TRUE;
+                } else {
+                    throw new XPathException(
+                            "cannot convert string '" + value + "' to boolean");
+                }
+            case Type.FLOAT:
+                return new FloatValue(value);
+            case Type.DOUBLE:
+            case Type.NUMBER:
+                return new DoubleValue(this);
+            case Type.DECIMAL:
+                return new DecimalValue(value);
+            case Type.INTEGER:
+            case Type.NON_POSITIVE_INTEGER:
+            case Type.NEGATIVE_INTEGER:
+            case Type.POSITIVE_INTEGER:
+            case Type.LONG:
+            case Type.INT:
+            case Type.SHORT:
+            case Type.BYTE:
+            case Type.NON_NEGATIVE_INTEGER:
+            case Type.UNSIGNED_LONG:
+            case Type.UNSIGNED_INT:
+            case Type.UNSIGNED_SHORT:
+            case Type.UNSIGNED_BYTE:
+                return new IntegerValue(value, requiredType);
+            case Type.BASE64_BINARY:
+                return new BinaryValueFromBinaryString(new Base64BinaryValueType(), value);
+            case Type.HEX_BINARY:
+                return new BinaryValueFromBinaryString(new HexBinaryValueType(), value);
+            case Type.DATE_TIME:
+                return new DateTimeValue(value);
+            case Type.TIME:
+                return new TimeValue(value);
+            case Type.DATE:
+                return new DateValue(value);
+            case Type.DURATION:
+                return new DurationValue(value);
+            case Type.YEAR_MONTH_DURATION:
+                return new YearMonthDurationValue(value);
+            case Type.DAY_TIME_DURATION:
+                return new DayTimeDurationValue(value);
+            case Type.GYEAR:
+                return new GYearValue(value);
+            case Type.GMONTH:
+                return new GMonthValue(value);
+            case Type.GDAY:
+                return new GDayValue(value);
+            case Type.GYEARMONTH:
+                return new GYearMonthValue(value);
+            case Type.GMONTHDAY:
+                return new GMonthDayValue(value);
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            case Type.QNAME:
+                return new QNameValue(null, new QName(value));
+            default:
+                throw new XPathException(ErrorCodes.FORG0001, "cannot cast '" +
+                        Type.getTypeName(this.getItemType()) + "(\"" + getStringValue() + "\")' to " +
+                        Type.getTypeName(requiredType));
+        }
+    }
+
+    public int conversionPreference(Class<?> javaClass) {
+        if (javaClass.isAssignableFrom(StringValue.class)) {
+            return 0;
+        }
+        if (javaClass == String.class || javaClass == CharSequence.class) {
+            return 1;
+        }
+        if (javaClass == Character.class || javaClass == char.class) {
+            return 2;
+        }
+        if (javaClass == Double.class || javaClass == double.class) {
+            return 10;
+        }
+        if (javaClass == Float.class || javaClass == float.class) {
+            return 11;
+        }
+        if (javaClass == Long.class || javaClass == long.class) {
+            return 12;
+        }
+        if (javaClass == Integer.class || javaClass == int.class) {
+            return 13;
+        }
+        if (javaClass == Short.class || javaClass == short.class) {
+            return 14;
+        }
+        if (javaClass == Byte.class || javaClass == byte.class) {
+            return 15;
+        }
+        if (javaClass == Boolean.class || javaClass == boolean.class) {
+            return 16;
+        }
+        if (javaClass == Object.class) {
+            return 20;
+        }
+
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target.isAssignableFrom(StringValue.class)) {
+            return (T) this;
+        } else if (target == Object.class || target == String.class || target == CharSequence.class) {
+            return (T) value;
+        } else if (target == double.class || target == Double.class) {
+            final DoubleValue v = (DoubleValue) convertTo(Type.DOUBLE);
+            return (T) Double.valueOf(v.getValue());
+        } else if (target == float.class || target == Float.class) {
+            final FloatValue v = (FloatValue) convertTo(Type.FLOAT);
+            return (T) Float.valueOf(v.value);
+        } else if (target == long.class || target == Long.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.LONG);
+            return (T) Long.valueOf(v.getInt());
+        } else if (target == int.class || target == Integer.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.INT);
+            return (T) Integer.valueOf(v.getInt());
+        } else if (target == short.class || target == Short.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.SHORT);
+            return (T) Short.valueOf((short) v.getInt());
+        } else if (target == byte.class || target == Byte.class) {
+            final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
+            return (T) Byte.valueOf((byte) v.getInt());
+        } else if (target == boolean.class || target == Boolean.class) {
+            return (T) Boolean.valueOf(effectiveBooleanValue());
+        } else if (target == char.class || target == Character.class) {
+            if (value.length() > 1 || value.length() == 0) {
+                throw new XPathException("cannot convert string with length = 0 or length > 1 to Java character");
+            }
+            return (T) Character.valueOf(value.charAt(0));
+        }
+
+        throw new XPathException("cannot convert value of type " + Type.getTypeName(type) +
+                " to Java object of type " + target.getName());
+    }
+
+    @Override
+    public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
+        if (other.isEmpty()) {
+            return false;
+        }
+        //A value of type xs:anyURI (or any type derived by restriction from xs:anyURI)
+        //can be promoted to the type xs:string.
+        //The result of this promotion is created by casting the original value to the type xs:string.
+        if (Type.subTypeOf(other.getType(), Type.ANY_URI)) {
+            other = other.convertTo(Type.STRING);
+        }
+        if (Type.subTypeOf(other.getType(), Type.STRING)) {
+            final int cmp = Collations.compare(collator, value, other.getStringValue());
+            switch (operator) {
+                case EQ:
+                    return cmp == 0;
+                case NEQ:
+                    return cmp != 0;
+                case LT:
+                    return cmp < 0;
+                case LTEQ:
+                    return cmp <= 0;
+                case GT:
+                    return cmp > 0;
+                case GTEQ:
+                    return cmp >= 0;
+                default:
+                    throw new XPathException("Type error: cannot apply operand to string value");
+            }
+        }
+        throw new XPathException(ErrorCodes.XPTY0004,
+                "can not compare xs:string('" + value + "') with " +
+                        Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "')");
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#compareTo(org.exist.xquery.value.AtomicValue)
+     */
+    public int compareTo(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+            //No possible comparisons
+            if (((NumericValue) other).isNaN()) {
+                return Constants.INFERIOR;
+            }
+            if (((NumericValue) other).isInfinite()) {
+                return Constants.INFERIOR;
+            }
+        }
+        return Collations.compare(collator, value, other.getStringValue());
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#startsWith(org.exist.xquery.value.AtomicValue)
+     */
+    public boolean startsWith(Collator collator, AtomicValue other) throws XPathException {
+        return Collations.startsWith(collator, value, other.getStringValue());
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#endsWith(org.exist.xquery.value.AtomicValue)
+     */
+    public boolean endsWith(Collator collator, AtomicValue other) throws XPathException {
+        return Collations.endsWith(collator, value, other.getStringValue());
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#contains(org.exist.xquery.value.AtomicValue)
+     */
+    public boolean contains(Collator collator, AtomicValue other) throws XPathException {
+        return Collations.indexOf(collator, value, other.getStringValue()) != Constants.STRING_NOT_FOUND;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#effectiveBooleanValue()
+     */
+    public boolean effectiveBooleanValue() throws XPathException {
+        // If its operand is a singleton value of type xs:string, xs:anyURI, xs:untypedAtomic,
+        //or a type derived from one of these, fn:boolean returns false if the operand value has zero length; otherwise it returns true.
+        return value.length() > 0;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    public String toString() {
+        return value;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AtomicValue#max(org.exist.xquery.value.AtomicValue)
+     */
+    public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.STRING)) {
+            return Collations.compare(collator, value, ((StringValue) other).value) > 0 ? this : other;
+        } else {
+            return Collations.compare(collator, value, ((StringValue) other.convertTo(getType())).value) > 0
+                    ? this
+                    : other;
+        }
+    }
+
+    public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
+        if (Type.subTypeOf(other.getType(), Type.STRING)) {
+            return Collations.compare(collator, value, ((StringValue) other).value) < 0 ? this : other;
+        } else {
+            return Collations.compare(collator, value, ((StringValue) other.convertTo(getType())).value) < 0
+                    ? this
+                    : other;
+        }
+    }
 
     /* (non-Javadoc)
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     public int compareTo(Object o) {
-        final AtomicValue other = (AtomicValue)o;
+        final AtomicValue other = (AtomicValue) o;
 //        if(Type.subTypeOf(other.getType(), Type.STRING))
-        if (getType() == other.getType())
-            {return value.compareTo(((StringValue)other).value);}
-        else
-            {return getType() > other.getType() ? 1 : -1;}
+        if (getType() == other.getType()) {
+            return value.compareTo(((StringValue) other).value);
+        } else {
+            return getType() > other.getType() ? 1 : -1;
+        }
     }
-    
-    /** Serialize for the persistant storage 
+
+    /**
+     * Serialize for the persistant storage
+     *
      * @param offset
-     * */
-    public byte[] serializeValue( int offset, boolean caseSensitive) {
+     */
+    public byte[] serializeValue(int offset, boolean caseSensitive) {
         final String val = caseSensitive ? value : value.toLowerCase();
-		final byte[] data = new byte[ offset + 1 + UTF8.encoded(val) ];
-		data[offset] = (byte) type;	// TODO: cast to byte is not safe
-		UTF8.encode(val, data, offset+1);  
-		return data;
-	}
+        final byte[] data = new byte[offset + 1 + UTF8.encoded(val)];
+        data[offset] = (byte) type;    // TODO: cast to byte is not safe
+        UTF8.encode(val, data, offset + 1);
+        return data;
+    }
 
     @Override
     public int hashCode() {
@@ -691,10 +733,12 @@ public class StringValue extends AtomicValue {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
-            {return true;}
-        if (obj == null)
-            {return false;}
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
         return value.equals(obj.toString());
     }
 }

--- a/src/org/exist/xquery/value/StringValue.java
+++ b/src/org/exist/xquery/value/StringValue.java
@@ -21,10 +21,6 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.exist.dom.QName;
 import org.exist.util.Collations;
 import org.exist.util.UTF8;
@@ -33,6 +29,10 @@ import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import java.text.Collator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class StringValue extends AtomicValue {
 

--- a/src/org/exist/xquery/value/TimeUtils.java
+++ b/src/org/exist/xquery/value/TimeUtils.java
@@ -1,15 +1,14 @@
 package org.exist.xquery.value;
 
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.Duration;
+import javax.xml.datatype.XMLGregorianCalendar;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.Duration;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 /**
  * Centralizes access to time-related utility functions.  Mostly delegates to the

--- a/src/org/exist/xquery/value/TimeUtils.java
+++ b/src/org/exist/xquery/value/TimeUtils.java
@@ -20,66 +20,66 @@ import java.util.TimeZone;
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>
  */
 public class TimeUtils {
-	
-	private static final TimeUtils INSTANCE = new TimeUtils();
-	public static TimeUtils getInstance() {return INSTANCE;}
-	
-	public static final Duration ONE_DAY = INSTANCE.factory.newDuration(true, 0, 0, 1, 0, 0, 0);
 
-	// assume it's thread-safe, if not synchronize all access
-	private final DatatypeFactory factory;
-	private int timezoneOffset;
-	private boolean timezoneOverriden;
-	
-	private TimeUtils() {
-		// singleton, keep constructor private
-		try {
-			factory = DatatypeFactory.newInstance();
-		} catch (final DatatypeConfigurationException e) {
-			throw new RuntimeException("unable to instantiate an XML datatype factory", e);
-		}
-	}
-	
-	public DatatypeFactory getFactory() {
-		return factory;
-	}
-	
-	/**
-	 * Set the offset of the local timezone, ignoring the default provided by the OS.
-	 * Mainly useful for testing.
-	 *
-	 * @param millis the timezone offset in milliseconds, positive or negative
-	 */
-	public void overrideLocalTimezoneOffset(int millis) {
-		timezoneOffset = millis;
-		timezoneOverriden = true;
-	}
-	
-	/**
-	 * Cancel any timezone override that may be in effect, reverting back to the OS value.
-	 */
-	public void resetLocalTimezoneOffset() {
-		timezoneOverriden = false;
-	}
-	
-	public int getLocalTimezoneOffsetMillis() {
-		final int dstOffset = Calendar.getInstance(TimeZone.getDefault()).get(Calendar.DST_OFFSET);
-		return timezoneOverriden ? timezoneOffset : TimeZone.getDefault().getRawOffset() + dstOffset;
-	}
-	
-	public int getLocalTimezoneOffsetMinutes() {
-		return getLocalTimezoneOffsetMillis() / 60000;
-	}
-	
-	public Duration newDuration(long arg0) {
-		return factory.newDuration(arg0);
-	}
+    private static final TimeUtils INSTANCE = new TimeUtils();
+    public static final Duration ONE_DAY = INSTANCE.factory.newDuration(true, 0, 0, 1, 0, 0, 0);
+    // assume it's thread-safe, if not synchronize all access
+    private final DatatypeFactory factory;
+    private int timezoneOffset;
+    private boolean timezoneOverriden;
+    private TimeUtils() {
+        // singleton, keep constructor private
+        try {
+            factory = DatatypeFactory.newInstance();
+        } catch (final DatatypeConfigurationException e) {
+            throw new RuntimeException("unable to instantiate an XML datatype factory", e);
+        }
+    }
 
-	public Duration newDuration(String arg0) {
-		return factory.newDuration(arg0);
-	}
+    public static TimeUtils getInstance() {
+        return INSTANCE;
+    }
 
-	public Duration newDuration(
+    public DatatypeFactory getFactory() {
+        return factory;
+    }
+
+    /**
+     * Set the offset of the local timezone, ignoring the default provided by the OS.
+     * Mainly useful for testing.
+     *
+     * @param millis the timezone offset in milliseconds, positive or negative
+     */
+    public void overrideLocalTimezoneOffset(int millis) {
+        timezoneOffset = millis;
+        timezoneOverriden = true;
+    }
+
+    /**
+     * Cancel any timezone override that may be in effect, reverting back to the OS value.
+     */
+    public void resetLocalTimezoneOffset() {
+        timezoneOverriden = false;
+    }
+
+    public int getLocalTimezoneOffsetMillis() {
+        final int dstOffset = Calendar.getInstance(TimeZone.getDefault()).get(Calendar.DST_OFFSET);
+        return timezoneOverriden ? timezoneOffset : TimeZone.getDefault().getRawOffset() + dstOffset;
+    }
+
+    public int getLocalTimezoneOffsetMinutes() {
+        return getLocalTimezoneOffsetMillis() / 60000;
+    }
+
+    public Duration newDuration(long arg0) {
+        return factory.newDuration(arg0);
+    }
+
+    public Duration newDuration(String arg0) {
+        return factory.newDuration(arg0);
+    }
+
+    public Duration newDuration(
             final boolean isPositive,
             final int years,
             final int months,
@@ -88,80 +88,80 @@ public class TimeUtils {
             final int minutes,
             final int seconds) {
 
-		return factory.newDuration(isPositive, years, months, days, hours, minutes, seconds);
-	}
+        return factory.newDuration(isPositive, years, months, days, hours, minutes, seconds);
+    }
 
-	public Duration newDuration(boolean arg0, BigInteger arg1, BigInteger arg2, BigInteger arg3, BigInteger arg4, BigInteger arg5, BigDecimal arg6) {
-		return factory.newDuration(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
-	}
+    public Duration newDuration(boolean arg0, BigInteger arg1, BigInteger arg2, BigInteger arg3, BigInteger arg4, BigInteger arg5, BigDecimal arg6) {
+        return factory.newDuration(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+    }
 
-	public Duration newDurationDayTime(long arg0) {
-		return factory.newDurationDayTime(arg0);
-	}
+    public Duration newDurationDayTime(long arg0) {
+        return factory.newDurationDayTime(arg0);
+    }
 
-	public Duration newDurationDayTime(String arg0) {
-		return factory.newDurationDayTime(arg0);
-	}
+    public Duration newDurationDayTime(String arg0) {
+        return factory.newDurationDayTime(arg0);
+    }
 
-	public Duration newDurationDayTime(boolean arg0, int arg1, int arg2, int arg3, int arg4) {
-		return factory.newDurationDayTime(arg0, arg1, arg2, arg3, arg4);
-	}
+    public Duration newDurationDayTime(boolean arg0, int arg1, int arg2, int arg3, int arg4) {
+        return factory.newDurationDayTime(arg0, arg1, arg2, arg3, arg4);
+    }
 
-	public Duration newDurationDayTime(boolean arg0, BigInteger arg1, BigInteger arg2, BigInteger arg3, BigInteger arg4) {
-		return factory.newDurationDayTime(arg0, arg1, arg2, arg3, arg4);
-	}
+    public Duration newDurationDayTime(boolean arg0, BigInteger arg1, BigInteger arg2, BigInteger arg3, BigInteger arg4) {
+        return factory.newDurationDayTime(arg0, arg1, arg2, arg3, arg4);
+    }
 
-	public Duration newDurationYearMonth(long arg0) {
-		return factory.newDurationYearMonth(arg0);
-	}
+    public Duration newDurationYearMonth(long arg0) {
+        return factory.newDurationYearMonth(arg0);
+    }
 
-	public Duration newDurationYearMonth(String arg0) {
-		return factory.newDurationYearMonth(arg0);
-	}
+    public Duration newDurationYearMonth(String arg0) {
+        return factory.newDurationYearMonth(arg0);
+    }
 
-	public Duration newDurationYearMonth(boolean arg0, int arg1, int arg2) {
-		return factory.newDurationYearMonth(arg0, arg1, arg2);
-	}
+    public Duration newDurationYearMonth(boolean arg0, int arg1, int arg2) {
+        return factory.newDurationYearMonth(arg0, arg1, arg2);
+    }
 
-	public Duration newDurationYearMonth(boolean arg0, BigInteger arg1, BigInteger arg2) {
-		return factory.newDurationYearMonth(arg0, arg1, arg2);
-	}
+    public Duration newDurationYearMonth(boolean arg0, BigInteger arg1, BigInteger arg2) {
+        return factory.newDurationYearMonth(arg0, arg1, arg2);
+    }
 
-	public XMLGregorianCalendar newXMLGregorianCalendar() {
-		return factory.newXMLGregorianCalendar();
-	}
+    public XMLGregorianCalendar newXMLGregorianCalendar() {
+        return factory.newXMLGregorianCalendar();
+    }
 
-	public XMLGregorianCalendar newXMLGregorianCalendar(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7) {
-		return factory.newXMLGregorianCalendar(arg0, arg1, arg2, arg3, arg4, arg5,
-				arg6, arg7);
-	}
+    public XMLGregorianCalendar newXMLGregorianCalendar(int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7) {
+        return factory.newXMLGregorianCalendar(arg0, arg1, arg2, arg3, arg4, arg5,
+                arg6, arg7);
+    }
 
-	public XMLGregorianCalendar newXMLGregorianCalendar(String lexicalRepresentation) {
-		return factory.newXMLGregorianCalendar(lexicalRepresentation);
-	}
+    public XMLGregorianCalendar newXMLGregorianCalendar(String lexicalRepresentation) {
+        return factory.newXMLGregorianCalendar(lexicalRepresentation);
+    }
 
-	public XMLGregorianCalendar newXMLGregorianCalendar(BigInteger arg0, int arg1, int arg2, int arg3, int arg4, int arg5, BigDecimal arg6, int arg7) {
-		return factory.newXMLGregorianCalendar(arg0, arg1, arg2, arg3, arg4, arg5,
-				arg6, arg7);
-	}
+    public XMLGregorianCalendar newXMLGregorianCalendar(BigInteger arg0, int arg1, int arg2, int arg3, int arg4, int arg5, BigDecimal arg6, int arg7) {
+        return factory.newXMLGregorianCalendar(arg0, arg1, arg2, arg3, arg4, arg5,
+                arg6, arg7);
+    }
 
-	public XMLGregorianCalendar newXMLGregorianCalendar(GregorianCalendar arg0) {
-		return factory.newXMLGregorianCalendar(arg0);
-	}
+    public XMLGregorianCalendar newXMLGregorianCalendar(GregorianCalendar arg0) {
+        return factory.newXMLGregorianCalendar(arg0);
+    }
 
-	public XMLGregorianCalendar newXMLGregorianCalendarDate(int arg0, int arg1, int arg2, int arg3) {
-		return factory.newXMLGregorianCalendarDate(arg0, arg1, arg2, arg3);
-	}
+    public XMLGregorianCalendar newXMLGregorianCalendarDate(int arg0, int arg1, int arg2, int arg3) {
+        return factory.newXMLGregorianCalendarDate(arg0, arg1, arg2, arg3);
+    }
 
-	public XMLGregorianCalendar newXMLGregorianCalendarTime(int arg0, int arg1, int arg2, int arg3) {
-		return factory.newXMLGregorianCalendarTime(arg0, arg1, arg2, arg3);
-	}
+    public XMLGregorianCalendar newXMLGregorianCalendarTime(int arg0, int arg1, int arg2, int arg3) {
+        return factory.newXMLGregorianCalendarTime(arg0, arg1, arg2, arg3);
+    }
 
-	public XMLGregorianCalendar newXMLGregorianCalendarTime(int arg0, int arg1, int arg2, int arg3, int arg4) {
-		return factory.newXMLGregorianCalendarTime(arg0, arg1, arg2, arg3, arg4);
-	}
+    public XMLGregorianCalendar newXMLGregorianCalendarTime(int arg0, int arg1, int arg2, int arg3, int arg4) {
+        return factory.newXMLGregorianCalendarTime(arg0, arg1, arg2, arg3, arg4);
+    }
 
-	public XMLGregorianCalendar newXMLGregorianCalendarTime(int arg0, int arg1, int arg2, BigDecimal arg3, int arg4) {
-		return factory.newXMLGregorianCalendarTime(arg0, arg1, arg2, arg3, arg4);
-	}
+    public XMLGregorianCalendar newXMLGregorianCalendarTime(int arg0, int arg1, int arg2, BigDecimal arg3, int arg4) {
+        return factory.newXMLGregorianCalendarTime(arg0, arg1, arg2, arg3, arg4);
+    }
 }

--- a/src/org/exist/xquery/value/TimeValue.java
+++ b/src/org/exist/xquery/value/TimeValue.java
@@ -22,13 +22,12 @@
  */
 package org.exist.xquery.value;
 
-import java.util.GregorianCalendar;
+import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-
-import org.exist.xquery.XPathException;
+import java.util.GregorianCalendar;
 
 /**
  * @author Wolfgang Meier (wolfgang@exist-db.org)

--- a/src/org/exist/xquery/value/TimeValue.java
+++ b/src/org/exist/xquery/value/TimeValue.java
@@ -35,82 +35,84 @@ import java.util.GregorianCalendar;
  */
 public class TimeValue extends AbstractDateTimeValue {
 
-	public TimeValue() throws XPathException {
-		super(stripCalendar(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar())));
-	}
+    public TimeValue() throws XPathException {
+        super(stripCalendar(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar())));
+    }
 
-	public TimeValue(XMLGregorianCalendar calendar) throws XPathException {
-		super(stripCalendar((XMLGregorianCalendar) calendar.clone()));
-	}
+    public TimeValue(XMLGregorianCalendar calendar) throws XPathException {
+        super(stripCalendar((XMLGregorianCalendar) calendar.clone()));
+    }
 
-	public TimeValue(String timeValue) throws XPathException {
-		super(timeValue);
-		try {
-			if (calendar.getXMLSchemaType() != DatatypeConstants.TIME) {throw new IllegalStateException();}
-		} catch (final IllegalStateException e) {
-			throw new XPathException("xs:time instance must not have year, month or day fields set");
-		}
-	}
+    public TimeValue(String timeValue) throws XPathException {
+        super(timeValue);
+        try {
+            if (calendar.getXMLSchemaType() != DatatypeConstants.TIME) {
+                throw new IllegalStateException();
+            }
+        } catch (final IllegalStateException e) {
+            throw new XPathException("xs:time instance must not have year, month or day fields set");
+        }
+    }
 
-	private static XMLGregorianCalendar stripCalendar(XMLGregorianCalendar calendar) {
-		calendar = (XMLGregorianCalendar) calendar.clone();
-		calendar.setYear(DatatypeConstants.FIELD_UNDEFINED);
-		calendar.setMonth(DatatypeConstants.FIELD_UNDEFINED);
-		calendar.setDay(DatatypeConstants.FIELD_UNDEFINED);
-		return calendar;
-	}
+    private static XMLGregorianCalendar stripCalendar(XMLGregorianCalendar calendar) {
+        calendar = (XMLGregorianCalendar) calendar.clone();
+        calendar.setYear(DatatypeConstants.FIELD_UNDEFINED);
+        calendar.setMonth(DatatypeConstants.FIELD_UNDEFINED);
+        calendar.setDay(DatatypeConstants.FIELD_UNDEFINED);
+        return calendar;
+    }
 
-	protected AbstractDateTimeValue createSameKind(XMLGregorianCalendar cal) throws XPathException {
-		return new TimeValue(cal);
-	}
+    protected AbstractDateTimeValue createSameKind(XMLGregorianCalendar cal) throws XPathException {
+        return new TimeValue(cal);
+    }
 
-	protected QName getXMLSchemaType() {
-		return DatatypeConstants.TIME;
-	}
+    protected QName getXMLSchemaType() {
+        return DatatypeConstants.TIME;
+    }
 
-	public int getType() {
-		return Type.TIME;
-	}
+    public int getType() {
+        return Type.TIME;
+    }
 
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.TIME :
-			case Type.ATOMIC :
-			case Type.ITEM :
-				return this;
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.TIME:
+            case Type.ATOMIC:
+            case Type.ITEM:
+                return this;
 //		case Type.DATE_TIME :
 //			xs:time -> xs:dateTime conversion not defined in Funcs&Ops 17.1.5
-			case Type.STRING :
-				return new StringValue(getStringValue());
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());
-			default :
-				throw new XPathException(
-					"Type error: cannot cast xs:time to "
-						+ Type.getTypeName(requiredType));
-		}
-	}
+            case Type.STRING:
+                return new StringValue(getStringValue());
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            default:
+                throw new XPathException(
+                        "Type error: cannot cast xs:time to "
+                                + Type.getTypeName(requiredType));
+        }
+    }
 
-	public ComputableValue minus(ComputableValue other) throws XPathException {
-		switch(other.getType()) {
-			case Type.TIME:
-				return new DayTimeDurationValue(getTimeInMillis() - ((TimeValue) other).getTimeInMillis());
-			case Type.DAY_TIME_DURATION:
-				return ((DayTimeDurationValue) other).negate().plus(this);
-			default:
-				throw new XPathException(
-						"Operand to minus should be of type xs:time or xdt:dayTimeDuration; got: "
-							+ Type.getTypeName(other.getType()));
-		}
-	}
+    public ComputableValue minus(ComputableValue other) throws XPathException {
+        switch (other.getType()) {
+            case Type.TIME:
+                return new DayTimeDurationValue(getTimeInMillis() - ((TimeValue) other).getTimeInMillis());
+            case Type.DAY_TIME_DURATION:
+                return ((DayTimeDurationValue) other).negate().plus(this);
+            default:
+                throw new XPathException(
+                        "Operand to minus should be of type xs:time or xdt:dayTimeDuration; got: "
+                                + Type.getTypeName(other.getType()));
+        }
+    }
 
-	public ComputableValue plus(ComputableValue other) throws XPathException {
-		if (other.getType() == Type.DAY_TIME_DURATION) {
-			return other.plus(this);
-		}
-		throw new XPathException(
-			"Operand to plus should be of type xdt:dayTimeDuration; got: "
-				+ Type.getTypeName(other.getType()));
-	}
+    public ComputableValue plus(ComputableValue other) throws XPathException {
+        if (other.getType() == Type.DAY_TIME_DURATION) {
+            return other.plus(this);
+        }
+        throw new XPathException(
+                "Operand to plus should be of type xdt:dayTimeDuration; got: "
+                        + Type.getTypeName(other.getType()));
+    }
 
 }

--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -33,15 +33,12 @@ import java.util.HashSet;
 
 /**
  * Defines all built-in types and their relations.
- * 
+ *
  * @author Wolfgang Meier (wolfgang@exist-db.org)
  */
 public class Type {
 
-    private final static Logger LOG = LogManager.getLogger(Type.class);
-
     public static final int NODE = -1;
-
     public final static int ELEMENT = 1;
     public final static int ATTRIBUTE = 2;
     public final static int TEXT = 3;
@@ -50,16 +47,13 @@ public class Type {
     public final static int DOCUMENT = 6;
     public final static int NAMESPACE = 500;
     public final static int CDATA_SECTION = 501;
-
     public final static int EMPTY = 10;
     public final static int ITEM = 11;
     public final static int ANY_TYPE = 12;
     public final static int ANY_SIMPLE_TYPE = 13;
     public final static int UNTYPED = 14;
-
     public final static int ATOMIC = 20;
     public final static int UNTYPED_ATOMIC = 21;
-
     public final static int STRING = 22;
     public final static int BOOLEAN = 23;
     public final static int QNAME = 24;
@@ -67,13 +61,11 @@ public class Type {
     public final static int BASE64_BINARY = 26;
     public final static int HEX_BINARY = 27;
     public final static int NOTATION = 28;
-
     public final static int NUMBER = 30;
     public final static int INTEGER = 31;
     public final static int DECIMAL = 32;
     public final static int FLOAT = 33;
     public final static int DOUBLE = 34;
-
     public final static int NON_POSITIVE_INTEGER = 35;
     public final static int NEGATIVE_INTEGER = 36;
     public final static int LONG = 37;
@@ -86,7 +78,6 @@ public class Type {
     public final static int UNSIGNED_SHORT = 44;
     public final static int UNSIGNED_BYTE = 45;
     public final static int POSITIVE_INTEGER = 46;
-
     public final static int DATE_TIME = 50;
     public final static int DATE = 51;
     public final static int TIME = 52;
@@ -98,7 +89,6 @@ public class Type {
     public final static int GDAY = 58;
     public final static int GYEARMONTH = 59;
     public final static int GMONTHDAY = 71;
-
     public final static int TOKEN = 60;
     public final static int NORMALIZED_STRING = 61;
     public final static int LANGUAGE = 62;
@@ -108,13 +98,15 @@ public class Type {
     public final static int ID = 66;
     public final static int IDREF = 67;
     public final static int ENTITY = 68;
-
     public final static int JAVA_OBJECT = 100;
     public final static int FUNCTION_REFERENCE = 101;
     public final static int MAP = 102;
     public final static int ARRAY = 103;
-
+    private final static Logger LOG = LogManager.getLogger(Type.class);
     private final static int[] superTypes = new int[512];
+    private final static Int2ObjectHashMap<String[]> typeNames = new Int2ObjectHashMap<>(100);
+    //private final static Map<Integer, String[]> typeNames= new HashMap<Integer, String[]>(100);
+    private final static Object2IntHashMap<String> typeCodes = new Object2IntHashMap<>(100);
 
     static {
         defineSubType(ANY_TYPE, ANY_SIMPLE_TYPE);
@@ -192,10 +184,6 @@ public class Type {
         defineSubType(FUNCTION_REFERENCE, ARRAY);
     }
 
-    private final static Int2ObjectHashMap<String[]> typeNames = new Int2ObjectHashMap<>(100);
-    //private final static Map<Integer, String[]> typeNames= new HashMap<Integer, String[]>(100);
-    private final static Object2IntHashMap<String> typeCodes = new Object2IntHashMap<>(100);
-
     static {
         //TODO : use NODETYPES above ?
         //TODO use parentheses after the nodes name  ?
@@ -211,28 +199,28 @@ public class Type {
         defineBuiltInType(COMMENT, "comment()");
         defineBuiltInType(NAMESPACE, "namespace()");
         defineBuiltInType(CDATA_SECTION, "cdata-section()");
-        
+
         defineBuiltInType(JAVA_OBJECT, "object");
         defineBuiltInType(FUNCTION_REFERENCE, "function");
         defineBuiltInType(MAP, "map");
         defineBuiltInType(ARRAY, "array");
         defineBuiltInType(NUMBER, "numeric");
-        
+
         defineBuiltInType(ANY_TYPE, "xs:anyType");
         defineBuiltInType(ANY_SIMPLE_TYPE, "xs:anySimpleType");
         defineBuiltInType(UNTYPED, "xs:untyped");
-        
+
         //Duplicate definition : new one first
         defineBuiltInType(ATOMIC, "xs:anyAtomicType", "xdt:anyAtomicType");
 
         //Duplicate definition : new one first
         defineBuiltInType(UNTYPED_ATOMIC, "xs:untypedAtomic", "xdt:untypedAtomic");
-        
+
         defineBuiltInType(BOOLEAN, "xs:boolean");
         defineBuiltInType(DECIMAL, "xs:decimal");
         defineBuiltInType(FLOAT, "xs:float");
         defineBuiltInType(DOUBLE, "xs:double");
-        
+
         defineBuiltInType(INTEGER, "xs:integer");
         defineBuiltInType(NON_POSITIVE_INTEGER, "xs:nonPositiveInteger");
         defineBuiltInType(NEGATIVE_INTEGER, "xs:negativeInteger");
@@ -246,14 +234,14 @@ public class Type {
         defineBuiltInType(UNSIGNED_SHORT, "xs:unsignedShort");
         defineBuiltInType(UNSIGNED_BYTE, "xs:unsignedByte");
         defineBuiltInType(POSITIVE_INTEGER, "xs:positiveInteger");
-        
+
         defineBuiltInType(STRING, "xs:string");
         defineBuiltInType(QNAME, "xs:QName");
         defineBuiltInType(ANY_URI, "xs:anyURI");
         defineBuiltInType(BASE64_BINARY, "xs:base64Binary");
         defineBuiltInType(HEX_BINARY, "xs:hexBinary");
         defineBuiltInType(NOTATION, "xs:NOTATION");
-        
+
         defineBuiltInType(DATE_TIME, "xs:dateTime");
         defineBuiltInType(DATE, "xs:date");
         defineBuiltInType(TIME, "xs:time");
@@ -263,12 +251,12 @@ public class Type {
         defineBuiltInType(GDAY, "xs:gDay");
         defineBuiltInType(GYEARMONTH, "xs:gYearMonth");
         defineBuiltInType(GMONTHDAY, "xs:gMonthDay");
-        
+
         //Duplicate definition : new one first
-        defineBuiltInType(YEAR_MONTH_DURATION, "xs:yearMonthDuration", "xdt:yearMonthDuration");		
+        defineBuiltInType(YEAR_MONTH_DURATION, "xs:yearMonthDuration", "xdt:yearMonthDuration");
         //Duplicate definition : new one first
         defineBuiltInType(DAY_TIME_DURATION, "xs:dayTimeDuration", "xdt:dayTimeDuration");
-        
+
         defineBuiltInType(NORMALIZED_STRING, "xs:normalizedString");
         defineBuiltInType(TOKEN, "xs:token");
         defineBuiltInType(LANGUAGE, "xs:language");
@@ -285,28 +273,28 @@ public class Type {
      */
     public static void defineBuiltInType(int type, String... name) {
         typeNames.put(type, name);
-        for(final String n : name) {
+        for (final String n : name) {
             typeCodes.put(n, type);
         }
     }
 
     /**
      * Get the internal default name for the built-in type.
-     * 
+     *
      * @param type
      */
     public static String getTypeName(int type) {
         return typeNames.get(type)[0];
     }
-    
+
     /**
      * Get the internal aliases for the built-in type.
-     * 
+     *
      * @param type
      */
     public static String[] getTypeAliases(int type) {
         final String names[] = typeNames.get(type);
-        if(names != null && names.length > 1) {
+        if (names != null && names.length > 1) {
             final String aliases[] = new String[names.length - 1];
             System.arraycopy(names, 1, aliases, 0, names.length - 1);
             return aliases;
@@ -314,29 +302,30 @@ public class Type {
         return null;
     }
 
-	/**
-	 * Get the type code for a type identified by its internal name.
-	 * 
-	 * @param name
-	 * @throws XPathException
-	 */
-	public static int getType(String name) throws XPathException {
-		//if (name.equals("node"))
-		//	return NODE;
-		final int code = typeCodes.get(name);
-		if (code == Object2IntHashMap.UNKNOWN_KEY)
-			{throw new XPathException("Type: " + name + " is not defined");}
-		return code;
-	}
+    /**
+     * Get the type code for a type identified by its internal name.
+     *
+     * @param name
+     * @throws XPathException
+     */
+    public static int getType(String name) throws XPathException {
+        //if (name.equals("node"))
+        //	return NODE;
+        final int code = typeCodes.get(name);
+        if (code == Object2IntHashMap.UNKNOWN_KEY) {
+            throw new XPathException("Type: " + name + " is not defined");
+        }
+        return code;
+    }
 
-	/**
-	 * Get the type code for a type identified by its QName.
-	 * 
-	 * @param qname
-	 * @throws XPathException
-	 */
-	public static int getType(QName qname) throws XPathException {
-		final String uri = qname.getNamespaceURI();
+    /**
+     * Get the type code for a type identified by its QName.
+     *
+     * @param qname
+     * @throws XPathException
+     */
+    public static int getType(QName qname) throws XPathException {
+        final String uri = qname.getNamespaceURI();
         switch (uri) {
             case Namespaces.SCHEMA_NS:
                 return getType("xs:" + qname.getLocalPart());
@@ -345,101 +334,109 @@ public class Type {
             default:
                 return getType(qname.getLocalPart());
         }
-	}
+    }
 
-	/**
-	 * Define supertype/subtype relation.
-	 * 
-	 * @param supertype
-	 * @param subtype
-	 */
-	public static void defineSubType(int supertype, int subtype) {
+    /**
+     * Define supertype/subtype relation.
+     *
+     * @param supertype
+     * @param subtype
+     */
+    public static void defineSubType(int supertype, int subtype) {
         superTypes[subtype] = supertype;
-	}
+    }
 
-	/**
-	 * Check if the given type code is a subtype of the specified supertype.
-	 * 
-	 * @param subtype
-	 * @param supertype
-         *
-         * @throws IllegalArgumentException When the type is invalid
-	 */
-	public static boolean subTypeOf(int subtype, int supertype) {
-		if (subtype == supertype)
-			{return true;}
-		//Note that it will return true even if subtype == EMPTY
-		if (supertype == ITEM || supertype == ANY_TYPE)
-			//maybe return subtype != EMPTY ?
-			{return true;}
-		//Note that EMPTY is *not* a sub-type of anything else than itself
-		//EmptySequence has to take care of this when it checks its type
-		if (subtype == ITEM || subtype == EMPTY || subtype == ANY_TYPE || subtype == NODE)
-			{return false;}
+    /**
+     * Check if the given type code is a subtype of the specified supertype.
+     *
+     * @param subtype
+     * @param supertype
+     * @throws IllegalArgumentException When the type is invalid
+     */
+    public static boolean subTypeOf(int subtype, int supertype) {
+        if (subtype == supertype) {
+            return true;
+        }
+        //Note that it will return true even if subtype == EMPTY
+        if (supertype == ITEM || supertype == ANY_TYPE)
+        //maybe return subtype != EMPTY ?
+        {
+            return true;
+        }
+        //Note that EMPTY is *not* a sub-type of anything else than itself
+        //EmptySequence has to take care of this when it checks its type
+        if (subtype == ITEM || subtype == EMPTY || subtype == ANY_TYPE || subtype == NODE) {
+            return false;
+        }
         subtype = superTypes[subtype];
-		if (subtype == 0)
-			{throw new IllegalArgumentException(
-				"type " + subtype + " is not a valid type");}
-		return subTypeOf(subtype, supertype);
-	}
+        if (subtype == 0) {
+            throw new IllegalArgumentException(
+                    "type " + subtype + " is not a valid type");
+        }
+        return subTypeOf(subtype, supertype);
+    }
 
-	/**
-	 * Get the type code of the supertype of the specified subtype.
-	 * 
-	 * @param subtype
-	 */
-	public static int getSuperType(final int subtype) {
-            if(subtype == ITEM || subtype == NODE) {
-                return ITEM;
-            }
-            
-            final int supertype = superTypes[subtype];
-            if(supertype == 0) {
-                LOG.warn("eXist does not define a super-type for the sub-type {}", getTypeName(subtype), new Throwable());
-                return ITEM;
-            }
-            
-            return supertype;
-	}
+    /**
+     * Get the type code of the supertype of the specified subtype.
+     *
+     * @param subtype
+     */
+    public static int getSuperType(final int subtype) {
+        if (subtype == ITEM || subtype == NODE) {
+            return ITEM;
+        }
 
-	/**
-	 * Find a common supertype for two given type codes.
-	 * 
-	 * Type.ITEM is returned if no other common supertype
-	 * is found.
-	 *  
-	 * @param type1
-	 * @param type2
-	 */
-	public static int getCommonSuperType(int type1, int type2) {
-		//Super shortcut
-		if(type1 == type2)
-			{return type1;}
+        final int supertype = superTypes[subtype];
+        if (supertype == 0) {
+            LOG.warn("eXist does not define a super-type for the sub-type {}", getTypeName(subtype), new Throwable());
+            return ITEM;
+        }
+
+        return supertype;
+    }
+
+    /**
+     * Find a common supertype for two given type codes.
+     * <p>
+     * Type.ITEM is returned if no other common supertype
+     * is found.
+     *
+     * @param type1
+     * @param type2
+     */
+    public static int getCommonSuperType(int type1, int type2) {
+        //Super shortcut
+        if (type1 == type2) {
+            return type1;
+        }
         // if one of the types is empty(), return the other type: optimizer is free to choose
         // an optimization based on the more specific type.
-        if (type1 == Type.EMPTY)
-            {return type2;}
-        else if (type2 == Type.EMPTY)
-            {return type1;}
+        if (type1 == Type.EMPTY) {
+            return type2;
+        } else if (type2 == Type.EMPTY) {
+            return type1;
+        }
 
-		//TODO : optimize by swapping the arguments based on their numeric values ?
-		//Processing lower value first *should* reduce the size of the Set
-		//Collect type1's super-types
-		final HashSet<Integer> t1 = new HashSet<>();
-		//Don't introduce a shortcut (starting at getSuperType(type1) here
-		//type2 might be a super-type of type1
-		int t;
-		for(t = type1; t != ITEM; t = getSuperType(t)) {
-			//Shortcut
-			if (t == type2)
-				{return t;}
-			t1.add(t);
-		}
-		//Starting from type2's super type : the shortcut should have done its job
-		for(t = getSuperType(type2); t != ITEM ; t = getSuperType(t)) {
-			if (t1.contains(t))
-				{return t;}
-		}
-		return ITEM;
-	} 
+        //TODO : optimize by swapping the arguments based on their numeric values ?
+        //Processing lower value first *should* reduce the size of the Set
+        //Collect type1's super-types
+        final HashSet<Integer> t1 = new HashSet<>();
+        //Don't introduce a shortcut (starting at getSuperType(type1) here
+        //type2 might be a super-type of type1
+        int t;
+        for (t = type1; t != ITEM; t = getSuperType(t)) {
+            //Shortcut
+            if (t == type2) {
+                return t;
+            }
+            t1.add(t);
+        }
+        //Starting from type2's super type : the shortcut should have done its job
+        for (t = getSuperType(type2); t != ITEM; t = getSuperType(t)) {
+            if (t1.contains(t)) {
+                return t;
+            }
+        }
+        return ITEM;
+    }
 }

--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -395,7 +395,7 @@ public class Type {
             
             final int supertype = superTypes[subtype];
             if(supertype == 0) {
-                LOG.warn("eXist does not define a super-type for the sub-type " + getTypeName(subtype), new Throwable());
+                LOG.warn("eXist does not define a super-type for the sub-type {}", getTypeName(subtype), new Throwable());
                 return ITEM;
             }
             

--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -21,8 +21,6 @@
  */
 package org.exist.xquery.value;
 
-import java.util.HashSet;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Namespaces;
@@ -30,6 +28,8 @@ import org.exist.dom.QName;
 import org.exist.util.hashtable.Int2ObjectHashMap;
 import org.exist.util.hashtable.Object2IntHashMap;
 import org.exist.xquery.XPathException;
+
+import java.util.HashSet;
 
 /**
  * Defines all built-in types and their relations.

--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -192,9 +192,9 @@ public class Type {
         defineSubType(FUNCTION_REFERENCE, ARRAY);
     }
 
-    private final static Int2ObjectHashMap<String[]> typeNames = new Int2ObjectHashMap<String[]>(100);
+    private final static Int2ObjectHashMap<String[]> typeNames = new Int2ObjectHashMap<>(100);
     //private final static Map<Integer, String[]> typeNames= new HashMap<Integer, String[]>(100);
-    private final static Object2IntHashMap<String> typeCodes = new Object2IntHashMap<String>(100);
+    private final static Object2IntHashMap<String> typeCodes = new Object2IntHashMap<>(100);
 
     static {
         //TODO : use NODETYPES above ?
@@ -425,7 +425,7 @@ public class Type {
 		//TODO : optimize by swapping the arguments based on their numeric values ?
 		//Processing lower value first *should* reduce the size of the Set
 		//Collect type1's super-types
-		final HashSet<Integer> t1 = new HashSet<Integer>();
+		final HashSet<Integer> t1 = new HashSet<>();
 		//Don't introduce a shortcut (starting at getSuperType(type1) here
 		//type2 might be a super-type of type1
 		int t;
@@ -433,11 +433,11 @@ public class Type {
 			//Shortcut
 			if (t == type2)
 				{return t;}
-			t1.add(Integer.valueOf(t));
+			t1.add(t);
 		}
 		//Starting from type2's super type : the shortcut should have done its job
 		for(t = getSuperType(type2); t != ITEM ; t = getSuperType(t)) {
-			if (t1.contains(Integer.valueOf(t)))
+			if (t1.contains(t))
 				{return t;}
 		}
 		return ITEM;

--- a/src/org/exist/xquery/value/UntypedAtomicValue.java
+++ b/src/org/exist/xquery/value/UntypedAtomicValue.java
@@ -35,7 +35,7 @@ import org.exist.xquery.XPathException;
  */
 public class UntypedAtomicValue extends AtomicValue {
 
-    private String value;
+    private final String value;
 
     public UntypedAtomicValue(String value) {
         this.value = value;

--- a/src/org/exist/xquery/value/UntypedAtomicValue.java
+++ b/src/org/exist/xquery/value/UntypedAtomicValue.java
@@ -246,7 +246,7 @@ public class UntypedAtomicValue extends AtomicValue {
     public boolean effectiveBooleanValue() throws XPathException {
         // If its operand is a singleton value of type xs:string, xs:anyURI, xs:untypedAtomic, 
         //or a type derived from one of these, fn:boolean returns false if the operand value has zero length; otherwise it returns true.
-        return value.length() > 0;
+        return !value.isEmpty();
     }
 
     /* (non-Javadoc)
@@ -309,7 +309,7 @@ public class UntypedAtomicValue extends AtomicValue {
         } else if(target == boolean.class || target == Boolean.class) {
             return (T)Boolean.valueOf(effectiveBooleanValue());
         } else if(target == char.class || target == Character.class) {
-            if(value.length() > 1 || value.length() == 0) {
+            if(value.length() > 1 || value.isEmpty()) {
                 throw new XPathException("cannot convert string with length = 0 or length > 1 to Java character");
             }
             return (T)Character.valueOf(value.charAt(0));

--- a/src/org/exist/xquery/value/UntypedAtomicValue.java
+++ b/src/org/exist/xquery/value/UntypedAtomicValue.java
@@ -22,13 +22,13 @@
  */
 package org.exist.xquery.value;
 
-import java.text.Collator;
-
 import org.exist.util.Collations;
 import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import java.text.Collator;
 
 /**
  * @author Wolfgang Meier (wolfgang@exist-db.org)

--- a/src/org/exist/xquery/value/UntypedAtomicValue.java
+++ b/src/org/exist/xquery/value/UntypedAtomicValue.java
@@ -41,6 +41,101 @@ public class UntypedAtomicValue extends AtomicValue {
         this.value = value;
     }
 
+    public static AtomicValue convertTo(String value, int requiredType) throws XPathException {
+        return convertTo(null, value, requiredType);
+    }
+
+    public static AtomicValue convertTo(UntypedAtomicValue strVal, String value, int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.ATOMIC:
+            case Type.ITEM:
+            case Type.UNTYPED_ATOMIC:
+                return strVal == null ? new UntypedAtomicValue(value) : strVal;
+            case Type.STRING:
+                return new StringValue(value);
+            case Type.ANY_URI:
+                return new AnyURIValue(value);
+            case Type.BOOLEAN:
+                final String trimmed = StringValue.trimWhitespace(value);
+                if ("0".equals(trimmed) || "false".equals(trimmed)) {
+                    return BooleanValue.FALSE;
+                } else if ("1".equals(trimmed) || "true".equals(trimmed)) {
+                    return BooleanValue.TRUE;
+                } else {
+                    throw new XPathException(ErrorCodes.FORG0001, "cannot cast '" +
+                            Type.getTypeName(Type.ATOMIC) + "(\"" + value + "\")' to " +
+                            Type.getTypeName(requiredType));
+                }
+            case Type.FLOAT:
+                return new FloatValue(value);
+            case Type.DOUBLE:
+                return new DoubleValue(value);
+            case Type.NUMBER:
+                //TODO : more complicated
+                return new DoubleValue(value);
+            case Type.DECIMAL:
+                return new DecimalValue(value);
+            case Type.INTEGER:
+            case Type.POSITIVE_INTEGER:
+            case Type.NON_POSITIVE_INTEGER:
+            case Type.NEGATIVE_INTEGER:
+            case Type.LONG:
+            case Type.INT:
+            case Type.SHORT:
+            case Type.BYTE:
+            case Type.NON_NEGATIVE_INTEGER:
+            case Type.UNSIGNED_LONG:
+            case Type.UNSIGNED_INT:
+            case Type.UNSIGNED_SHORT:
+            case Type.UNSIGNED_BYTE:
+                return new IntegerValue(value, requiredType);
+
+
+        /*
+         The problem is that if this UntypedAtomicValue is constructed from a text() node
+         stored in the database, which contains base64 or hex encoded data, then the string value could be huge
+         and it has already been constructed and stored in memort by UntypedAtomicValue
+         this should be defered
+
+         TODO replace UntypedAtomicValue with something that can allow lazily reading text()
+         values from the database.
+         */
+            case Type.BASE64_BINARY:
+                return new BinaryValueFromBinaryString(new Base64BinaryValueType(), value);
+            case Type.HEX_BINARY:
+                return new BinaryValueFromBinaryString(new HexBinaryValueType(), value);
+
+
+            case Type.DATE_TIME:
+                return new DateTimeValue(value);
+            case Type.TIME:
+                return new TimeValue(value);
+            case Type.DATE:
+                return new DateValue(value);
+            case Type.GYEAR:
+                return new GYearValue(value);
+            case Type.GMONTH:
+                return new GMonthValue(value);
+            case Type.GDAY:
+                return new GDayValue(value);
+            case Type.GYEARMONTH:
+                return new GYearMonthValue(value);
+            case Type.GMONTHDAY:
+                return new GMonthDayValue(value);
+            case Type.DURATION:
+                return new DurationValue(value);
+            case Type.YEAR_MONTH_DURATION:
+                return new YearMonthDurationValue(value);
+            case Type.DAY_TIME_DURATION:
+                final DayTimeDurationValue dtdv = new DayTimeDurationValue(value);
+                return new DayTimeDurationValue(dtdv.getCanonicalDuration());
+            default:
+                throw new XPathException(ErrorCodes.FORG0001, "cannot cast '" +
+                        Type.getTypeName(Type.ATOMIC) + "(\"" + value + "\")' to " +
+                        Type.getTypeName(requiredType));
+        }
+    }
+
     /* (non-Javadoc)
      * @see org.exist.xquery.value.AtomicValue#getType()
      */
@@ -65,127 +160,34 @@ public class UntypedAtomicValue extends AtomicValue {
         return convertTo(this, value, requiredType);
     }
 
-    public static AtomicValue convertTo(String value, int requiredType) throws XPathException {
-        return convertTo(null, value, requiredType);
-    }
-
-    public static AtomicValue convertTo(UntypedAtomicValue strVal, String value, int requiredType) throws XPathException {
-        switch (requiredType) {
-        case Type.ATOMIC :
-        case Type.ITEM :
-        case Type.UNTYPED_ATOMIC :
-            return strVal == null ? new UntypedAtomicValue(value) : strVal;
-        case Type.STRING :
-            return new StringValue(value);
-        case Type.ANY_URI :
-            return new AnyURIValue(value);
-        case Type.BOOLEAN :
-            final String trimmed = StringValue.trimWhitespace(value);
-            if ("0".equals(trimmed) || "false".equals(trimmed))
-                {return BooleanValue.FALSE;}
-            else if ("1".equals(trimmed) || "true".equals(trimmed))
-                {return BooleanValue.TRUE;}
-            else
-                {throw new XPathException(ErrorCodes.FORG0001, "cannot cast '" + 
-                        Type.getTypeName(Type.ATOMIC) + "(\"" + value + "\")' to " +
-                        Type.getTypeName(requiredType));}
-        case Type.FLOAT :
-            return new FloatValue(value);
-        case Type.DOUBLE :
-            return new DoubleValue(value);
-        case Type.NUMBER :
-            //TODO : more complicated
-            return new DoubleValue(value);
-        case Type.DECIMAL :
-            return new DecimalValue(value);
-        case Type.INTEGER :
-        case Type.POSITIVE_INTEGER :
-        case Type.NON_POSITIVE_INTEGER :
-        case Type.NEGATIVE_INTEGER :
-        case Type.LONG :
-        case Type.INT :
-        case Type.SHORT :
-        case Type.BYTE :
-        case Type.NON_NEGATIVE_INTEGER :
-        case Type.UNSIGNED_LONG :
-        case Type.UNSIGNED_INT :
-        case Type.UNSIGNED_SHORT :
-        case Type.UNSIGNED_BYTE :
-            return new IntegerValue(value, requiredType);
-
-
-        /*
-         The problem is that if this UntypedAtomicValue is constructed from a text() node
-         stored in the database, which contains base64 or hex encoded data, then the string value could be huge
-         and it has already been constructed and stored in memort by UntypedAtomicValue
-         this should be defered
-
-         TODO replace UntypedAtomicValue with something that can allow lazily reading text()
-         values from the database.
-         */
-        case Type.BASE64_BINARY :
-            return new BinaryValueFromBinaryString(new Base64BinaryValueType(), value);
-        case Type.HEX_BINARY :
-            return new BinaryValueFromBinaryString(new HexBinaryValueType(), value);
-
-
-        case Type.DATE_TIME :
-            return new DateTimeValue(value);
-        case Type.TIME :
-            return new TimeValue(value);
-        case Type.DATE :
-            return new DateValue(value);
-        case Type.GYEAR :
-            return new GYearValue(value);
-        case Type.GMONTH :
-            return new GMonthValue(value);
-        case Type.GDAY :
-            return new GDayValue(value);
-        case Type.GYEARMONTH :
-            return new GYearMonthValue(value);
-        case Type.GMONTHDAY :
-            return new GMonthDayValue(value);
-        case Type.DURATION :
-        	return new DurationValue(value);
-        case Type.YEAR_MONTH_DURATION :
-        	return new YearMonthDurationValue(value);
-        case Type.DAY_TIME_DURATION :
-            final DayTimeDurationValue dtdv = new DayTimeDurationValue(value);
-            return new DayTimeDurationValue(dtdv.getCanonicalDuration());
-        default :
-            throw new XPathException(ErrorCodes.FORG0001, "cannot cast '" + 
-                Type.getTypeName(Type.ATOMIC) + "(\"" + value + "\")' to " +
-                Type.getTypeName(requiredType));
-        }
-    }
-
     @Override
     public boolean compareTo(Collator collator, Comparison operator, AtomicValue other) throws XPathException {
-        if (other.isEmpty())
-            {return false;}
+        if (other.isEmpty()) {
+            return false;
+        }
         if (Type.subTypeOf(other.getType(), Type.STRING) ||
                 Type.subTypeOf(other.getType(), Type.UNTYPED_ATOMIC)) {
             final int cmp = Collations.compare(collator, value, other.getStringValue());
             switch (operator) {
-            case EQ:
-                return cmp == 0;
-            case NEQ:
-                return cmp != 0;
-            case LT :
-                return cmp < 0;
-            case LTEQ :
-                return cmp <= 0;
-            case GT :
-                return cmp > 0;
-            case GTEQ :
-                return cmp >= 0;
-            default :
-                throw new XPathException("Type error: cannot apply operand to string value");
+                case EQ:
+                    return cmp == 0;
+                case NEQ:
+                    return cmp != 0;
+                case LT:
+                    return cmp < 0;
+                case LTEQ:
+                    return cmp <= 0;
+                case GT:
+                    return cmp > 0;
+                case GTEQ:
+                    return cmp >= 0;
+                default:
+                    throw new XPathException("Type error: cannot apply operand to string value");
             }
         }
         throw new XPathException(
                 "Type error: operands are not comparable; expected xdt:untypedAtomic; got "
-                + Type.getTypeName(other.getType()));
+                        + Type.getTypeName(other.getType()));
     }
 
     /* (non-Javadoc)
@@ -193,7 +195,7 @@ public class UntypedAtomicValue extends AtomicValue {
      */
     @Override
     public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-    	return Collations.compare(collator, value, other.getStringValue());
+        return Collations.compare(collator, value, other.getStringValue());
     }
 
     /* (non-Javadoc)
@@ -201,9 +203,10 @@ public class UntypedAtomicValue extends AtomicValue {
      */
     @Override
     public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {
-        if (Type.subTypeOf(other.getType(), Type.UNTYPED_ATOMIC))
-            {return Collations.compare(collator, value, ((UntypedAtomicValue) other).value) > 0 ?
-                this : other;}
+        if (Type.subTypeOf(other.getType(), Type.UNTYPED_ATOMIC)) {
+            return Collations.compare(collator, value, ((UntypedAtomicValue) other).value) > 0 ?
+                    this : other;
+        }
         return Collations.compare(collator, value, other.getStringValue()) > 0 ? this : other;
     }
 
@@ -212,8 +215,9 @@ public class UntypedAtomicValue extends AtomicValue {
      */
     @Override
     public AtomicValue min(Collator collator, AtomicValue other) throws XPathException {
-        if (Type.subTypeOf(other.getType(), Type.UNTYPED_ATOMIC))
-            {return Collations.compare(collator, value, ((UntypedAtomicValue) other).value) < 0 ? this : other;}
+        if (Type.subTypeOf(other.getType(), Type.UNTYPED_ATOMIC)) {
+            return Collations.compare(collator, value, ((UntypedAtomicValue) other).value) < 0 ? this : other;
+        }
         return Collations.compare(collator, value, other.getStringValue()) < 0 ?
                 this : other;
     }
@@ -254,29 +258,40 @@ public class UntypedAtomicValue extends AtomicValue {
      */
     @Override
     public int conversionPreference(Class<?> javaClass) {
-        if (javaClass.isAssignableFrom(StringValue.class))
-            {return 0;}
-        if (javaClass == String.class || javaClass == CharSequence.class)
-            {return 1;}
-        if (javaClass == Character.class || javaClass == char.class)
-            {return 2;}
-        if (javaClass == Double.class || javaClass == double.class)
-            {return 10;}
-        if (javaClass == Float.class || javaClass == float.class)
-            {return 11;}
-        if (javaClass == Long.class || javaClass == long.class)
-            {return 12;}
-        if (javaClass == Integer.class || javaClass == int.class)
-            {return 13;}
-        if (javaClass == Short.class || javaClass == short.class)
-            {return 14;}
-        if (javaClass == Byte.class || javaClass == byte.class)
-            {return 15;}
-        if (javaClass == Boolean.class || javaClass == boolean.class)
-            {return 16;}
-        if (javaClass == Object.class)
-            {return 20;}
-    	return Integer.MAX_VALUE;
+        if (javaClass.isAssignableFrom(StringValue.class)) {
+            return 0;
+        }
+        if (javaClass == String.class || javaClass == CharSequence.class) {
+            return 1;
+        }
+        if (javaClass == Character.class || javaClass == char.class) {
+            return 2;
+        }
+        if (javaClass == Double.class || javaClass == double.class) {
+            return 10;
+        }
+        if (javaClass == Float.class || javaClass == float.class) {
+            return 11;
+        }
+        if (javaClass == Long.class || javaClass == long.class) {
+            return 12;
+        }
+        if (javaClass == Integer.class || javaClass == int.class) {
+            return 13;
+        }
+        if (javaClass == Short.class || javaClass == short.class) {
+            return 14;
+        }
+        if (javaClass == Byte.class || javaClass == byte.class) {
+            return 15;
+        }
+        if (javaClass == Boolean.class || javaClass == boolean.class) {
+            return 16;
+        }
+        if (javaClass == Object.class) {
+            return 20;
+        }
+        return Integer.MAX_VALUE;
     }
 
     /* (non-Javadoc)
@@ -284,48 +299,49 @@ public class UntypedAtomicValue extends AtomicValue {
      */
     @Override
     public <T> T toJavaObject(final Class<T> target) throws XPathException {
-        if(target.isAssignableFrom(UntypedAtomicValue.class))
-            {return (T)this;}
-        else if(target == Object.class || target == String.class || target == CharSequence.class) {
-            return (T)value;
-        } else if(target == double.class || target == Double.class) {
+        if (target.isAssignableFrom(UntypedAtomicValue.class)) {
+            return (T) this;
+        } else if (target == Object.class || target == String.class || target == CharSequence.class) {
+            return (T) value;
+        } else if (target == double.class || target == Double.class) {
             final DoubleValue v = (DoubleValue) convertTo(Type.DOUBLE);
-            return (T)Double.valueOf(v.getValue());
-        } else if(target == float.class || target == Float.class) {
+            return (T) Double.valueOf(v.getValue());
+        } else if (target == float.class || target == Float.class) {
             final FloatValue v = (FloatValue) convertTo(Type.FLOAT);
-            return (T)Float.valueOf(v.value);
-        } else if(target == long.class || target == Long.class) {
+            return (T) Float.valueOf(v.value);
+        } else if (target == long.class || target == Long.class) {
             final IntegerValue v = (IntegerValue) convertTo(Type.LONG);
-            return (T)Long.valueOf(v.getInt());
-        } else if(target == int.class || target == Integer.class) {
+            return (T) Long.valueOf(v.getInt());
+        } else if (target == int.class || target == Integer.class) {
             final IntegerValue v = (IntegerValue) convertTo(Type.INT);
-            return (T)Integer.valueOf(v.getInt());
-        } else if(target == short.class || target == Short.class) {
+            return (T) Integer.valueOf(v.getInt());
+        } else if (target == short.class || target == Short.class) {
             final IntegerValue v = (IntegerValue) convertTo(Type.SHORT);
-            return (T)Short.valueOf((short) v.getInt());
-        } else if(target == byte.class || target == Byte.class) {
+            return (T) Short.valueOf((short) v.getInt());
+        } else if (target == byte.class || target == Byte.class) {
             final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
-            return (T)Byte.valueOf((byte) v.getInt());
-        } else if(target == boolean.class || target == Boolean.class) {
-            return (T)Boolean.valueOf(effectiveBooleanValue());
-        } else if(target == char.class || target == Character.class) {
-            if(value.length() > 1 || value.isEmpty()) {
+            return (T) Byte.valueOf((byte) v.getInt());
+        } else if (target == boolean.class || target == Boolean.class) {
+            return (T) Boolean.valueOf(effectiveBooleanValue());
+        } else if (target == char.class || target == Character.class) {
+            if (value.length() > 1 || value.isEmpty()) {
                 throw new XPathException("cannot convert string with length = 0 or length > 1 to Java character");
             }
-            return (T)Character.valueOf(value.charAt(0));
+            return (T) Character.valueOf(value.charAt(0));
         }
 
         throw new XPathException(
-            "cannot convert value of type "
-            + Type.getTypeName(getType())
-            + " to Java object of type "
-            + target.getName());
+                "cannot convert value of type "
+                        + Type.getTypeName(getType())
+                        + " to Java object of type "
+                        + target.getName());
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof UntypedAtomicValue)
-            {return value.equals(((UntypedAtomicValue)obj).value);}
+        if (obj instanceof UntypedAtomicValue) {
+            return value.equals(((UntypedAtomicValue) obj).value);
+        }
         return false;
     }
 

--- a/src/org/exist/xquery/value/ValueSequence.java
+++ b/src/org/exist/xquery/value/ValueSequence.java
@@ -23,27 +23,15 @@ package org.exist.xquery.value;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.collections.Collection;
-import org.exist.dom.persistent.DefaultDocumentSet;
-import org.exist.dom.persistent.DocumentSet;
-import org.exist.dom.persistent.MutableDocumentSet;
-import org.exist.dom.persistent.NewArrayNodeSet;
-import org.exist.dom.persistent.NodeProxy;
-import org.exist.dom.persistent.NodeSet;
-import org.exist.dom.persistent.StoredNode;
 import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.NodeImpl;
+import org.exist.dom.persistent.*;
 import org.exist.numbering.NodeId;
 import org.exist.util.FastQSort;
 import org.exist.xquery.*;
 import org.w3c.dom.Node;
 
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * A sequence that may contain a mixture of atomic values and nodes.

--- a/src/org/exist/xquery/value/ValueSequence.java
+++ b/src/org/exist/xquery/value/ValueSequence.java
@@ -35,33 +35,31 @@ import java.util.*;
 
 /**
  * A sequence that may contain a mixture of atomic values and nodes.
- * 
+ *
  * @author wolf
  */
 public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 
-	private final Logger LOG = LogManager.getLogger(ValueSequence.class);
-	
     //Do not change the -1 value since size computation relies on this start value
     private final static int UNSET_SIZE = -1;
     private final static int INITIAL_SIZE = 64;
-	
-	protected Item[] values;
-	protected int size = UNSET_SIZE;
-	
-	// used to keep track of the type of added items.
-	// will be Type.ANY_TYPE if the typlexe is unknown
-	// and Type.ITEM if there are items of mixed type.
-	protected int itemType = Type.ANY_TYPE;
-	
-	private boolean noDuplicates = false;
+    private final Logger LOG = LogManager.getLogger(ValueSequence.class);
+    protected Item[] values;
+    protected int size = UNSET_SIZE;
+
+    // used to keep track of the type of added items.
+    // will be Type.ANY_TYPE if the typlexe is unknown
+    // and Type.ITEM if there are items of mixed type.
+    protected int itemType = Type.ANY_TYPE;
+
+    private boolean noDuplicates = false;
 
     private boolean inMemNodeSet = false;
 
     private boolean isOrdered = false;
 
     private boolean enforceOrder = false;
-    
+
     private boolean keepUnOrdered = false;
 
     private Variable holderVar = null;
@@ -69,72 +67,75 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     private int state = 0;
 
     private NodeSet cachedSet = null;
-    
+
     public ValueSequence() {
-		this(false);
-	}
+        this(false);
+    }
 
     public ValueSequence(boolean ordered) {
         values = new Item[INITIAL_SIZE];
         enforceOrder = ordered;
     }
-	
-	public ValueSequence(int initialSize) {
-		values = new Item[initialSize];
-	}
+
+    public ValueSequence(int initialSize) {
+        values = new Item[initialSize];
+    }
 
     public ValueSequence(Sequence otherSequence) throws XPathException {
         this(otherSequence, false);
     }
 
     public ValueSequence(Sequence otherSequence, boolean ordered) throws XPathException {
-		values = new Item[otherSequence.getItemCount()];
-		addAll(otherSequence);
+        values = new Item[otherSequence.getItemCount()];
+        addAll(otherSequence);
         this.enforceOrder = ordered;
     }
-    
+
     public ValueSequence(final Item... items) throws XPathException {
         values = new Item[items.length];
-        for(final Item item : items) {
+        for (final Item item : items) {
             add(item);
         }
     }
 
     public void keepUnOrdered(boolean flag) {
-    	keepUnOrdered = flag;
+        keepUnOrdered = flag;
     }
-	
-	public void clear() {
-		Arrays.fill(values, null);
-		size = UNSET_SIZE;
-		itemType = Type.ANY_TYPE;
-		noDuplicates = false;
-	}
-	
+
+    public void clear() {
+        Arrays.fill(values, null);
+        size = UNSET_SIZE;
+        itemType = Type.ANY_TYPE;
+        noDuplicates = false;
+    }
+
     public boolean isEmpty() {
-    	return isEmpty;
+        return isEmpty;
     }
-    
+
     public boolean hasOne() {
-    	return hasOne;
+        return hasOne;
     }
-	
-	public void add(Item item) {
-        if (hasOne)
-            {hasOne = false;}
-        if (isEmpty)
-            {hasOne = true;}
+
+    public void add(Item item) {
+        if (hasOne) {
+            hasOne = false;
+        }
+        if (isEmpty) {
+            hasOne = true;
+        }
         cachedSet = null;
         isEmpty = false;
         ++size;
         ensureCapacity();
         values[size] = item;
-        if (itemType == item.getType())
-            {return;}
-        else if (itemType == Type.ANY_TYPE)
-            {itemType = item.getType();}
-        else
-            {itemType = Type.getCommonSuperType(item.getType(), itemType);}
+        if (itemType == item.getType()) {
+            return;
+        } else if (itemType == Type.ANY_TYPE) {
+            itemType = item.getType();
+        } else {
+            itemType = Type.getCommonSuperType(item.getType(), itemType);
+        }
         noDuplicates = false;
         isOrdered = false;
         setHasChanged();
@@ -150,40 +151,41 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 //    }
 
     public void addAll(Sequence otherSequence) throws XPathException {
-		if (otherSequence == null)
-			{return;}
+        if (otherSequence == null) {
+            return;
+        }
         final SequenceIterator iterator = otherSequence.iterate();
-		if (iterator == null) {
+        if (iterator == null) {
             LOG.warn("Iterator == null: {}", otherSequence.getClass().getName());
-		}
-		for(; iterator.hasNext(); )
-			add(iterator.nextItem());
+        }
+        for (; iterator.hasNext(); )
+            add(iterator.nextItem());
     }
-	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getItemType()
-	 */
-	public int getItemType() {
-		return itemType == Type.ANY_TYPE ? Type.ITEM : itemType;
-	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#iterate()
-	 */
-	@Override
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#getItemType()
+     */
+    public int getItemType() {
+        return itemType == Type.ANY_TYPE ? Type.ITEM : itemType;
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.Sequence#iterate()
+     */
+    @Override
     public SequenceIterator iterate() throws XPathException {
         sortInDocumentOrder();
-		return new ValueSequenceIterator();
-	}
+        return new ValueSequenceIterator();
+    }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.value.AbstractSequence#unorderedIterator()
-	 */
+    /* (non-Javadoc)
+     * @see org.exist.xquery.value.AbstractSequence#unorderedIterator()
+     */
     @Override
-	public SequenceIterator unorderedIterator() throws XPathException {
+    public SequenceIterator unorderedIterator() throws XPathException {
         sortInDocumentOrder();
         return new ValueSequenceIterator();
-	}
+    }
 
     public SequenceIterator iterateInReverse() throws XPathException {
         sortInDocumentOrder();
@@ -199,42 +201,43 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     }
 
     /* (non-Javadoc)
-	 * @see org.exist.xquery.value.Sequence#getLength()
+     * @see org.exist.xquery.value.Sequence#getLength()
 	 */
-	public int getItemCount() {
+    public int getItemCount() {
         sortInDocumentOrder();
-		return size + 1;
-	}
+        return size + 1;
+    }
 
-	public Item itemAt(int pos) {
+    public Item itemAt(int pos) {
         sortInDocumentOrder();
         return values[pos];
-	}
+    }
 
     public void setHolderVariable(Variable var) {
         this.holderVar = var;
     }
-    
+
     /**
      * Makes all in-memory nodes in this sequence persistent,
      * so they can be handled like other node sets.
-     * 
-	 * @see org.exist.xquery.value.Sequence#toNodeSet()
-	 */
-	public NodeSet toNodeSet() throws XPathException {
-		if(size == UNSET_SIZE)
-			{return NodeSet.EMPTY_SET;}
+     *
+     * @see org.exist.xquery.value.Sequence#toNodeSet()
+     */
+    public NodeSet toNodeSet() throws XPathException {
+        if (size == UNSET_SIZE) {
+            return NodeSet.EMPTY_SET;
+        }
         // for this method to work, all items have to be nodes
-		if(itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
-			final NodeSet set = new NewArrayNodeSet();
-			NodeValue v;
-			for (int i = 0; i <= size; i++) {
-				v = (NodeValue)values[i];
-				if(v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
+        if (itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
+            final NodeSet set = new NewArrayNodeSet();
+            NodeValue v;
+            for (int i = 0; i <= size; i++) {
+                v = (NodeValue) values[i];
+                if (v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
                     // found an in-memory document
-                    final DocumentImpl doc = ((NodeImpl)v).getOwnerDocument();
-                    if (doc==null) {
-                       continue;
+                    final DocumentImpl doc = ((NodeImpl) v).getOwnerDocument();
+                    if (doc == null) {
+                        continue;
                     }
                     // make this document persistent: doc.makePersistent()
                     // returns a map of all root node ids mapped to the corresponding
@@ -246,20 +249,23 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
                         NodeId rootId = newDoc.getBrokerPool().getNodeFactory().createInstance();
                         for (int j = i; j <= size; j++) {
                             v = (NodeValue) values[j];
-                            if(v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
+                            if (v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
                                 NodeImpl node = (NodeImpl) v;
                                 if (node.getOwnerDocument() == doc) {
-                                    if (node.getNodeType() == Node.ATTRIBUTE_NODE)
-                                        {node = expandedDoc.getAttribute(node.getNodeNumber());}
-                                    else
-                                        {node = expandedDoc.getNode(node.getNodeNumber());}
+                                    if (node.getNodeType() == Node.ATTRIBUTE_NODE) {
+                                        node = expandedDoc.getAttribute(node.getNodeNumber());
+                                    } else {
+                                        node = expandedDoc.getNode(node.getNodeNumber());
+                                    }
                                     NodeId nodeId = node.getNodeId();
-                                    if (nodeId == null)
-                                        {throw new XPathException("Internal error: nodeId == null");}
-                                    if (node.getNodeType() == Node.DOCUMENT_NODE)
-                                        {nodeId = rootId;}
-                                    else
-                                        {nodeId = rootId.append(nodeId);}
+                                    if (nodeId == null) {
+                                        throw new XPathException("Internal error: nodeId == null");
+                                    }
+                                    if (node.getNodeType() == Node.DOCUMENT_NODE) {
+                                        nodeId = rootId;
+                                    } else {
+                                        nodeId = rootId.append(nodeId);
+                                    }
                                     NodeProxy p = new NodeProxy(newDoc, nodeId, node.getNodeType());
                                     if (p != null) {
                                         // replace the node by the NodeProxy
@@ -271,30 +277,34 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
                         set.add((NodeProxy) values[i]);
                     }
                 } else {
-					set.add((NodeProxy)v);
-				}
-			}
-            if (holderVar != null)
-                {holderVar.setValue(set);}
+                    set.add((NodeProxy) v);
+                }
+            }
+            if (holderVar != null) {
+                holderVar.setValue(set);
+            }
             return set;
-		} else
-			{throw new XPathException("Type error: the sequence cannot be converted into" +
-				" a node set. Item type is " + Type.getTypeName(itemType));}
-	}
+        } else {
+            throw new XPathException("Type error: the sequence cannot be converted into" +
+                    " a node set. Item type is " + Type.getTypeName(itemType));
+        }
+    }
 
     public MemoryNodeSet toMemNodeSet() throws XPathException {
-        if(size == UNSET_SIZE)
-            {return MemoryNodeSet.EMPTY;}
-        if(itemType == Type.ANY_TYPE || !Type.subTypeOf(itemType, Type.NODE)) {
+        if (size == UNSET_SIZE) {
+            return MemoryNodeSet.EMPTY;
+        }
+        if (itemType == Type.ANY_TYPE || !Type.subTypeOf(itemType, Type.NODE)) {
             throw new XPathException("Type error: the sequence cannot be converted into" +
-				" a node set. Item type is " + Type.getTypeName(itemType));
+                    " a node set. Item type is " + Type.getTypeName(itemType));
         }
         NodeValue v;
         for (int i = 0; i <= size; i++) {
-            v = (NodeValue)values[i];
-            if(v.getImplementationType() == NodeValue.PERSISTENT_NODE)
-                {throw new XPathException("Type error: the sequence cannot be converted into" +
-				    " a MemoryNodeSet. It contains nodes from stored resources.");}
+            v = (NodeValue) values[i];
+            if (v.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                throw new XPathException("Type error: the sequence cannot be converted into" +
+                        " a MemoryNodeSet. It contains nodes from stored resources.");
+            }
         }
         expand();
         inMemNodeSet = true;
@@ -302,28 +312,33 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     }
 
     public boolean isInMemorySet() {
-        if(size == UNSET_SIZE)
-            {return true;}
-        if(itemType == Type.ANY_TYPE || !Type.subTypeOf(itemType, Type.NODE))
-            {return false;}
+        if (size == UNSET_SIZE) {
+            return true;
+        }
+        if (itemType == Type.ANY_TYPE || !Type.subTypeOf(itemType, Type.NODE)) {
+            return false;
+        }
         NodeValue v;
         for (int i = 0; i <= size; i++) {
-            v = (NodeValue)values[i];
-            if(v.getImplementationType() == NodeValue.PERSISTENT_NODE)
-                {return false;}
+            v = (NodeValue) values[i];
+            if (v.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                return false;
+            }
         }
         return true;
     }
 
     public boolean isPersistentSet() {
-        if(size == UNSET_SIZE)
-            {return true;}
-        if(itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
+        if (size == UNSET_SIZE) {
+            return true;
+        }
+        if (itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.NODE)) {
             NodeValue v;
             for (int i = 0; i <= size; i++) {
-                v = (NodeValue)values[i];
-                if(v.getImplementationType() != NodeValue.PERSISTENT_NODE)
-                    {return false;}
+                v = (NodeValue) values[i];
+                if (v.getImplementationType() != NodeValue.PERSISTENT_NODE) {
+                    return false;
+                }
             }
             return true;
         }
@@ -339,8 +354,9 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         final Set<DocumentImpl> docs = new HashSet<>();
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            if (node.getOwnerDocument().hasReferenceNodes())
-                {docs.add(node.getOwnerDocument());}
+            if (node.getOwnerDocument().hasReferenceNodes()) {
+                docs.add(node.getOwnerDocument());
+            }
         }
         for (final DocumentImpl doc : docs) {
             doc.expand();
@@ -357,21 +373,24 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 
     public boolean containsValue(AtomicValue value) {
         for (int i = 0; i <= size; i++) {
-            if (values[i] == value)
-                {return true;}
+            if (values[i] == value) {
+                return true;
+            }
         }
         return false;
     }
 
     public void sortInDocumentOrder() {
-        if (size == UNSET_SIZE)
-            {return;}
+        if (size == UNSET_SIZE) {
+            return;
+        }
         if (keepUnOrdered) {
             removeDuplicateNodes();
-        	return;
+            return;
         }
-        if (!enforceOrder || isOrdered)
-            {return;}
+        if (!enforceOrder || isOrdered) {
+            return;
+        }
         inMemNodeSet = inMemNodeSet || isInMemorySet();
         if (inMemNodeSet) {
             FastQSort.sort(values, new InMemoryNodeComparator(), 0, size);
@@ -387,17 +406,18 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     }
 
     private void ensureCapacity() {
-		if(size == values.length) {
-			final int newSize = (int)Math.round((size == 0 ? 1 : size * 3) / (double) 2);
-			Item newValues[] = new Item[newSize];
-			System.arraycopy(values, 0, newValues, 0, size);
-			values = newValues;
-		}
-	}
+        if (size == values.length) {
+            final int newSize = (int) Math.round((size == 0 ? 1 : size * 3) / (double) 2);
+            Item newValues[] = new Item[newSize];
+            System.arraycopy(values, 0, newValues, 0, size);
+            values = newValues;
+        }
+    }
 
-	private void removeDuplicateNodes() {
-        if(noDuplicates || size < 1)
-			{return;}
+    private void removeDuplicateNodes() {
+        if (noDuplicates || size < 1) {
+            return;
+        }
         if (inMemNodeSet) {
             int j = 0;
             for (int i = 1; i <= size; i++) {
@@ -409,42 +429,48 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
             }
             size = j;
         } else {
-            if(itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.ATOMIC))
-                {return;}
+            if (itemType != Type.ANY_TYPE && Type.subTypeOf(itemType, Type.ATOMIC)) {
+                return;
+            }
             // check if the sequence contains nodes
             boolean hasNodes = false;
-            for(int i = 0; i <= size; i++) {
-                if(Type.subTypeOf(values[i].getType(), Type.NODE))
-                    {hasNodes = true;}
+            for (int i = 0; i <= size; i++) {
+                if (Type.subTypeOf(values[i].getType(), Type.NODE)) {
+                    hasNodes = true;
+                }
             }
-            if(!hasNodes)
-            {return;}
+            if (!hasNodes) {
+                return;
+            }
             final Map<Item, Item> nodes = new TreeMap<>(ItemComparator.INSTANCE);
             int j = 0;
             for (int i = 0; i <= size; i++) {
-                if(Type.subTypeOf(values[i].getType(), Type.NODE)) {
-                	final Item found = nodes.get(values[i]);
-                    if(found == null) {
+                if (Type.subTypeOf(values[i].getType(), Type.NODE)) {
+                    final Item found = nodes.get(values[i]);
+                    if (found == null) {
                         Item item = values[i];
                         values[j++] = item;
                         nodes.put(item, item);
                     } else {
-                    	final NodeValue nv = (NodeValue) found;
-                    	if (nv.getImplementationType() == NodeValue.PERSISTENT_NODE)
-                    		{((NodeProxy) nv).addMatches((NodeProxy) values[i]);}
+                        final NodeValue nv = (NodeValue) found;
+                        if (nv.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                            ((NodeProxy) nv).addMatches((NodeProxy) values[i]);
+                        }
                     }
-                } else
-                    {values[j++] = values[i];}
+                } else {
+                    values[j++] = values[i];
+                }
             }
             size = j - 1;
         }
         noDuplicates = true;
-	}
-	
+    }
+
     public void clearContext(int contextId) throws XPathException {
         for (int i = 0; i <= size; i++) {
-            if (Type.subTypeOf(values[i].getType(), Type.NODE))
-                {((NodeValue) values[i]).clearContext(contextId);}
+            if (Type.subTypeOf(values[i].getType(), Type.NODE)) {
+                ((NodeValue) values[i]).clearContext(contextId);
+            }
         }
     }
 
@@ -475,8 +501,9 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     * @see org.exist.xquery.value.Sequence#getDocumentSet()
     */
     public DocumentSet getDocumentSet() {
-        if (cachedSet != null)
-            {return cachedSet.getDocumentSet();}
+        if (cachedSet != null) {
+            return cachedSet.getDocumentSet();
+        }
         try {
             boolean isPersistentSet = true;
             NodeValue node;
@@ -507,8 +534,9 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         for (int i = 0; i <= size; i++) {
             if (Type.subTypeOf(values[i].getType(), Type.NODE)) {
                 node = (NodeValue) values[i];
-                if (node.getImplementationType() == NodeValue.PERSISTENT_NODE)
-                    {docs.add((org.exist.dom.persistent.DocumentImpl) node.getOwnerDocument());}
+                if (node.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                    docs.add((org.exist.dom.persistent.DocumentImpl) node.getOwnerDocument());
+                }
             }
         }
         return docs;
@@ -555,8 +583,9 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         nodes.keepUnOrdered(keepUnOrdered);
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
-            if (node.getNodeId().isChildOf(parent.getNodeId()))
-                {nodes.add(node);}
+            if (node.getNodeId().isChildOf(parent.getNodeId())) {
+                nodes.add(node);
+            }
         }
         return nodes;
     }
@@ -590,8 +619,9 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
             final NodeImpl parent = (NodeImpl) node.selectParentNode();
-            if (parent != null && test.matches(parent))
-                {nodes.add(parent);}
+            if (parent != null && test.matches(parent)) {
+                nodes.add(parent);
+            }
         }
         return nodes;
     }
@@ -603,8 +633,9 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
             if ((test.getType() == Type.NODE && node.getNodeType() == Node.ATTRIBUTE_NODE) ||
-                    test.matches(node))
-                {nodes.add(node);}
+                    test.matches(node)) {
+                nodes.add(node);
+            }
         }
         return nodes;
     }
@@ -661,8 +692,9 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
             final NodeImpl node = (NodeImpl) values[i];
             for (int j = 0; j < descendants.size(); j++) {
                 final NodeImpl descendant = descendants.get(j);
-                if (descendant.getNodeId().isDescendantOrSelfOf(node.getNodeId()))
-                    {nodes.add(node);}
+                if (descendant.getNodeId().isDescendantOrSelfOf(node.getNodeId())) {
+                    nodes.add(node);
+                }
             }
         }
         return nodes;
@@ -676,8 +708,9 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
             final NodeImpl node = (NodeImpl) values[i];
             for (int j = 0; j < children.size(); j++) {
                 final NodeImpl descendant = children.get(j);
-                if (descendant.getNodeId().isChildOf(node.getNodeId()))
-                    {nodes.add(node);}
+                if (descendant.getNodeId().isChildOf(node.getNodeId())) {
+                    nodes.add(node);
+                }
             }
         }
         return nodes;
@@ -692,9 +725,94 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
     }
 
     /* END methods of MemoryNodeSet */
-    
+
     public Iterator<Collection> getCollectionIterator() {
         return new CollectionIterator();
+    }
+
+    public String toString() {
+        try {
+            final StringBuilder result = new StringBuilder();
+            result.append("(");
+            boolean moreThanOne = false;
+            for (final SequenceIterator i = iterate(); i.hasNext(); ) {
+                final Item next = i.nextItem();
+                if (moreThanOne) {
+                    result.append(", ");
+                }
+                moreThanOne = true;
+                result.append(next.toString());
+            }
+            result.append(")");
+            return result.toString();
+        } catch (final XPathException e) {
+            return "ValueSequence.toString() failed: " + e.getMessage();
+        }
+
+    }
+
+    public boolean matchSelf(NodeTest test) throws XPathException {
+        //UNDERSTAND: is it required? -shabanovd
+        sortInDocumentOrder();
+        for (int i = 0; i <= size; i++) {
+            final NodeImpl node = (NodeImpl) values[i];
+            if ((test.getType() == Type.NODE && node.getNodeType() == Node.ATTRIBUTE_NODE) ||
+                    test.matches(node)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean matchChildren(NodeTest test) throws XPathException {
+        //UNDERSTAND: is it required? -shabanovd
+        sortInDocumentOrder();
+        for (int i = 0; i <= size; i++) {
+            final NodeImpl node = (NodeImpl) values[i];
+            if (node.matchChildren(test)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean matchAttributes(NodeTest test) throws XPathException {
+        //UNDERSTAND: is it required? -shabanovd
+        sortInDocumentOrder();
+        for (int i = 0; i <= size; i++) {
+            final NodeImpl node = (NodeImpl) values[i];
+            if (node.matchAttributes(test)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean matchDescendantAttributes(NodeTest test) throws XPathException {
+        //UNDERSTAND: is it required? -shabanovd
+        sortInDocumentOrder();
+        for (int i = 0; i <= size; i++) {
+            final NodeImpl node = (NodeImpl) values[i];
+            if (node.matchDescendantAttributes(test)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static class InMemoryNodeComparator implements Comparator<Item> {
+
+        public int compare(Item o1, Item o2) {
+            final NodeImpl n1 = (NodeImpl) o1;
+            final NodeImpl n2 = (NodeImpl) o2;
+            final int docCmp = n1.getOwnerDocument().compareTo(n2.getOwnerDocument());
+            if (docCmp == 0) {
+                return n1.getNodeNumber() == n2.getNodeNumber() ? Constants.EQUAL :
+                        (n1.getNodeNumber() > n2.getNodeNumber() ? Constants.SUPERIOR : Constants.INFERIOR);
+            } else {
+                return docCmp;
+            }
+        }
     }
 
     private class CollectionIterator implements Iterator<Collection> {
@@ -730,54 +848,35 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         }
 
         public void remove() {
-             // not needed
+            // not needed
             throw new IllegalStateException();
         }
     }
-    
-    public String toString() {
-		try {
-			final StringBuilder result = new StringBuilder();
-			result.append("(");
-			boolean moreThanOne = false;
-			for (final SequenceIterator i = iterate(); i.hasNext(); ) {
-				final Item next = i.nextItem();
-				if (moreThanOne) {result.append(", ");}				
-				moreThanOne = true;
-				result.append(next.toString());						
-			}
-			result.append(")");
-			return result.toString();
-		} catch (final XPathException e) {
-			return "ValueSequence.toString() failed: " + e.getMessage();
-		}
-		
-	}
-	
-	private class ValueSequenceIterator implements SequenceIterator {
-		
-		private int pos = 0;
-		
-		public ValueSequenceIterator() {
-		}
-		
-		/* (non-Javadoc)
-		 * @see org.exist.xquery.value.SequenceIterator#hasNext()
-		 */
-		public boolean hasNext() {
-			return pos <= size;
-		}
-		
-		/* (non-Javadoc)
-		 * @see org.exist.xquery.value.SequenceIterator#nextItem()
-		 */
-		public Item nextItem() {
-			if(pos <= size) {
+
+    private class ValueSequenceIterator implements SequenceIterator {
+
+        private int pos = 0;
+
+        public ValueSequenceIterator() {
+        }
+
+        /* (non-Javadoc)
+         * @see org.exist.xquery.value.SequenceIterator#hasNext()
+         */
+        public boolean hasNext() {
+            return pos <= size;
+        }
+
+        /* (non-Javadoc)
+         * @see org.exist.xquery.value.SequenceIterator#nextItem()
+         */
+        public Item nextItem() {
+            if (pos <= size) {
                 return values[pos++];
             }
-			return null;
-		}
-	}
+            return null;
+        }
+    }
 
     private class ReverseValueSequenceIterator implements SequenceIterator {
 
@@ -797,69 +896,10 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
          * @see org.exist.xquery.value.SequenceIterator#nextItem()
          */
         public Item nextItem() {
-            if(pos >= 0) {
+            if (pos >= 0) {
                 return values[pos--];
             }
             return null;
         }
-    }
-
-    private static class InMemoryNodeComparator implements Comparator<Item> {
-
-        public int compare(Item o1, Item o2) {
-            final NodeImpl n1 = (NodeImpl) o1;
-            final NodeImpl n2 = (NodeImpl) o2;
-            final int docCmp = n1.getOwnerDocument().compareTo(n2.getOwnerDocument());
-            if (docCmp == 0) {
-                return n1.getNodeNumber() == n2.getNodeNumber() ? Constants.EQUAL :
-                    (n1.getNodeNumber() > n2.getNodeNumber() ? Constants.SUPERIOR : Constants.INFERIOR);
-            } else
-                {return docCmp;}
-        }
-    }
-
-	public boolean matchSelf(NodeTest test) throws XPathException {
-		//UNDERSTAND: is it required? -shabanovd
-		sortInDocumentOrder();
-		for (int i = 0; i <= size; i++) {
-			final NodeImpl node = (NodeImpl) values[i];
-			if ((test.getType() == Type.NODE && node.getNodeType() == Node.ATTRIBUTE_NODE) ||
-					test.matches(node))
-				{return true;}
-			}
-		return false;
-	}
-
-    public boolean matchChildren(NodeTest test) throws XPathException {
-		//UNDERSTAND: is it required? -shabanovd
-        sortInDocumentOrder();
-        for (int i = 0; i <= size; i++) {
-            final NodeImpl node = (NodeImpl) values[i];
-            if (node.matchChildren(test))
-            	{return true;}
-        }
-        return false;
-    }
-
-    public boolean matchAttributes(NodeTest test) throws XPathException {
-		//UNDERSTAND: is it required? -shabanovd
-        sortInDocumentOrder();
-        for (int i = 0; i <= size; i++) {
-            final NodeImpl node = (NodeImpl) values[i];
-            if (node.matchAttributes(test))
-            	{return true;}
-        }
-        return false;
-    }
-
-    public boolean matchDescendantAttributes(NodeTest test) throws XPathException {
-		//UNDERSTAND: is it required? -shabanovd
-        sortInDocumentOrder();
-        for (int i = 0; i <= size; i++) {
-            final NodeImpl node = (NodeImpl) values[i];
-            if (node.matchDescendantAttributes(test))
-            	{return true;}
-        }
-        return false;
     }
 }

--- a/src/org/exist/xquery/value/ValueSequence.java
+++ b/src/org/exist/xquery/value/ValueSequence.java
@@ -154,7 +154,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
 			{return;}
         final SequenceIterator iterator = otherSequence.iterate();
 		if (iterator == null) {
-			LOG.warn("Iterator == null: " + otherSequence.getClass().getName());
+            LOG.warn("Iterator == null: {}", otherSequence.getClass().getName());
 		}
 		for(; iterator.hasNext(); )
 			add(iterator.nextItem());

--- a/src/org/exist/xquery/value/ValueSequence.java
+++ b/src/org/exist/xquery/value/ValueSequence.java
@@ -348,7 +348,7 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
      * Expand those references to get a pure in-memory DOM tree.
      */
     private void expand() {
-        final Set<DocumentImpl> docs = new HashSet<DocumentImpl>();
+        final Set<DocumentImpl> docs = new HashSet<>();
         for (int i = 0; i <= size; i++) {
             final NodeImpl node = (NodeImpl) values[i];
             if (node.getOwnerDocument().hasReferenceNodes())

--- a/src/org/exist/xquery/value/YearMonthDurationValue.java
+++ b/src/org/exist/xquery/value/YearMonthDurationValue.java
@@ -37,53 +37,54 @@ import java.math.BigInteger;
  */
 public class YearMonthDurationValue extends OrderedDurationValue {
 
-	public static final Duration CANONICAL_ZERO_DURATION =
-		TimeUtils.getInstance().newDuration(true, null, BigInteger.ZERO, null, null, null, null);
-	
-	YearMonthDurationValue(Duration duration) throws XPathException {	
-		super(duration);
-		if (!duration.equals(DurationValue.CANONICAL_ZERO_DURATION)) {
-			if (duration.isSet(DatatypeConstants.DAYS) ||		
-				duration.isSet(DatatypeConstants.HOURS) ||
-				duration.isSet(DatatypeConstants.MINUTES) ||
-				//Always set !
-				//!duration.getField(DatatypeConstants.SECONDS).equals(BigInteger.ZERO))
-				duration.isSet(DatatypeConstants.SECONDS))
-				{throw new XPathException(ErrorCodes.XPTY0004, "The value '" + duration + "' is not an " + Type.getTypeName(getType()) + 
-						" since it specifies days, hours, minutes or seconds values");}
-		}		
-	}
+    public static final Duration CANONICAL_ZERO_DURATION =
+            TimeUtils.getInstance().newDuration(true, null, BigInteger.ZERO, null, null, null, null);
 
-	public YearMonthDurationValue(String str) throws XPathException {
-		this(createDurationYearMonth(str));		
-	}
-	
-	private static Duration createDurationYearMonth(String str) throws XPathException {
-		try {
-			return TimeUtils.getInstance().newDurationYearMonth(StringValue.trimWhitespace(str));
-		} catch (final IllegalArgumentException e) {
-			throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(Type.YEAR_MONTH_DURATION) +
-					" from \"" + str + "\"");            
-		}
-	}
-	
-	public DurationValue wrap() {
-		return this;
-	}
-	
-	protected Duration canonicalZeroDuration() {
-		return CANONICAL_ZERO_DURATION;
-	}
-	
-	public int getValue() {
-		return duration.getSign() * (duration.getYears() * 12 + duration.getMonths());
-	}
+    YearMonthDurationValue(Duration duration) throws XPathException {
+        super(duration);
+        if (!duration.equals(DurationValue.CANONICAL_ZERO_DURATION)) {
+            if (duration.isSet(DatatypeConstants.DAYS) ||
+                    duration.isSet(DatatypeConstants.HOURS) ||
+                    duration.isSet(DatatypeConstants.MINUTES) ||
+                    //Always set !
+                    //!duration.getField(DatatypeConstants.SECONDS).equals(BigInteger.ZERO))
+                    duration.isSet(DatatypeConstants.SECONDS)) {
+                throw new XPathException(ErrorCodes.XPTY0004, "The value '" + duration + "' is not an " + Type.getTypeName(getType()) +
+                        " since it specifies days, hours, minutes or seconds values");
+            }
+        }
+    }
 
-	public int getType() {
-		return Type.YEAR_MONTH_DURATION;
-	}
-	
-	public String getStringValue() {
+    public YearMonthDurationValue(String str) throws XPathException {
+        this(createDurationYearMonth(str));
+    }
+
+    private static Duration createDurationYearMonth(String str) throws XPathException {
+        try {
+            return TimeUtils.getInstance().newDurationYearMonth(StringValue.trimWhitespace(str));
+        } catch (final IllegalArgumentException e) {
+            throw new XPathException(ErrorCodes.FORG0001, "cannot construct " + Type.getTypeName(Type.YEAR_MONTH_DURATION) +
+                    " from \"" + str + "\"");
+        }
+    }
+
+    public DurationValue wrap() {
+        return this;
+    }
+
+    protected Duration canonicalZeroDuration() {
+        return CANONICAL_ZERO_DURATION;
+    }
+
+    public int getValue() {
+        return duration.getSign() * (duration.getYears() * 12 + duration.getMonths());
+    }
+
+    public int getType() {
+        return Type.YEAR_MONTH_DURATION;
+    }
+
+    public String getStringValue() {
         final FastStringBuffer sb = new FastStringBuffer(32);
         if (getCanonicalDuration().getSign() < 0) {
             sb.append('-');
@@ -92,124 +93,128 @@ public class YearMonthDurationValue extends OrderedDurationValue {
         if (getCanonicalDuration().getYears() != 0) {
             sb.append(getCanonicalDuration().getYears() + "Y");
         }
-        if (getCanonicalDuration().getMonths() !=0 || getCanonicalDuration().getYears() == 0) {
+        if (getCanonicalDuration().getMonths() != 0 || getCanonicalDuration().getYears() == 0) {
             sb.append(getCanonicalDuration().getMonths() + "M");
         }
         return sb.toString();
-	}	
+    }
 
-	public AtomicValue convertTo(int requiredType) throws XPathException {
-		switch (requiredType) {
-			case Type.ITEM :
-			case Type.ATOMIC :
-			case Type.YEAR_MONTH_DURATION :
-				return this;
-			case Type.STRING :
-				return new StringValue(getStringValue());
-			case Type.DURATION :
-				return new DurationValue(TimeUtils.getInstance().newDuration(
-						duration.getSign() >= 0,
-						(BigInteger) duration.getField(DatatypeConstants.YEARS),
-						(BigInteger) duration.getField(DatatypeConstants.MONTHS),
-						null, null, null, null
-				));
-			case Type.DAY_TIME_DURATION:
-				return new DayTimeDurationValue(DayTimeDurationValue.CANONICAL_ZERO_DURATION);
-			//case Type.DOUBLE:
-				//return new DoubleValue(monthsValueSigned().doubleValue());
-				//return new DoubleValue(Double.NaN);
-			//case Type.DECIMAL:
-				//return new DecimalValue(monthsValueSigned().doubleValue());
-			case Type.UNTYPED_ATOMIC :
-				return new UntypedAtomicValue(getStringValue());				
-			default :
-				throw new XPathException(ErrorCodes.XPTY0004, 
-					"cannot cast 'xs:yearMonthDuration(\"" + getStringValue() + 
-					"\")' to " + Type.getTypeName(requiredType));
-		}
-	}
+    public AtomicValue convertTo(int requiredType) throws XPathException {
+        switch (requiredType) {
+            case Type.ITEM:
+            case Type.ATOMIC:
+            case Type.YEAR_MONTH_DURATION:
+                return this;
+            case Type.STRING:
+                return new StringValue(getStringValue());
+            case Type.DURATION:
+                return new DurationValue(TimeUtils.getInstance().newDuration(
+                        duration.getSign() >= 0,
+                        (BigInteger) duration.getField(DatatypeConstants.YEARS),
+                        (BigInteger) duration.getField(DatatypeConstants.MONTHS),
+                        null, null, null, null
+                ));
+            case Type.DAY_TIME_DURATION:
+                return new DayTimeDurationValue(DayTimeDurationValue.CANONICAL_ZERO_DURATION);
+            //case Type.DOUBLE:
+            //return new DoubleValue(monthsValueSigned().doubleValue());
+            //return new DoubleValue(Double.NaN);
+            //case Type.DECIMAL:
+            //return new DecimalValue(monthsValueSigned().doubleValue());
+            case Type.UNTYPED_ATOMIC:
+                return new UntypedAtomicValue(getStringValue());
+            default:
+                throw new XPathException(ErrorCodes.XPTY0004,
+                        "cannot cast 'xs:yearMonthDuration(\"" + getStringValue() +
+                                "\")' to " + Type.getTypeName(requiredType));
+        }
+    }
 
-	protected DurationValue createSameKind(Duration dur) throws XPathException {
-		return new YearMonthDurationValue(dur);
-	}
-	
-	public ComputableValue plus(ComputableValue other) throws XPathException {
-		try {
-			if (other.getType() == Type.TIME) {throw new IllegalArgumentException();}
-			return super.plus(other);
-		} catch (final IllegalArgumentException e) {
-			throw new XPathException(
-					"Operand to plus should be of type xdt:yearMonthDuration, xs:date, "
-						+ "or xs:dateTime; got: "
-						+ Type.getTypeName(other.getType()));
-		}
-	}
-	
-	public ComputableValue mult(ComputableValue other) throws XPathException {
-		if (other instanceof NumericValue) {
-			//If $arg2 is NaN an error is raised [err:FOCA0005]
-			if (((NumericValue)other).isNaN()) {
-				throw new XPathException(ErrorCodes.FOCA0005, "Operand is not a number");				
-			}		
-			//If $arg2 is positive or negative infinity, the result overflows
-			if (((NumericValue)other).isInfinite()) {
-				throw new XPathException(ErrorCodes.FODT0002, "Multiplication by infinity overflow");		
-			}		
-		}
-		final BigDecimal factor = numberToBigDecimal(other, "Operand to mult should be of numeric type; got: ");
-		
-		final boolean isFactorNegative = factor.signum() < 0;		
-		
-		final YearMonthDurationValue product = fromDecimalMonths(
-			new BigDecimal(monthsValueSigned())
-			.multiply(factor.abs())
-			.setScale(0, (isFactorNegative)? BigDecimal.ROUND_HALF_DOWN : BigDecimal.ROUND_HALF_UP)
-		);
-		
-		if (isFactorNegative)
-			{return product.negate();}
-		
-		return product;
-	}
+    protected DurationValue createSameKind(Duration dur) throws XPathException {
+        return new YearMonthDurationValue(dur);
+    }
 
-	public ComputableValue div(ComputableValue other) throws XPathException {
-		if (other.getType() == Type.YEAR_MONTH_DURATION) {
-			return new IntegerValue(getValue()).div(new IntegerValue(((YearMonthDurationValue) other).getValue()));
-		}
-		if (other instanceof NumericValue) {
-			if (((NumericValue)other).isNaN()) {
-				throw new XPathException(ErrorCodes.FOCA0005, "Operand is not a number");				
-			}
-			if (((NumericValue)other).isInfinite()) {
-				return new YearMonthDurationValue("P0M");
-			}
-			//If $arg2 is positive or negative zero, the result overflows and is handled as discussed in 10.1.1 Limits and Precision
-			if (((NumericValue)other).isZero()) { 
-				throw new XPathException(ErrorCodes.FODT0002, "Division by zero overflow");
-			}			
-		}
-		final BigDecimal divisor = numberToBigDecimal(other, "Can not divide xdt:yearMonthDuration by '" + Type.getTypeName(other.getType())+ "'");
-		
-		final boolean isDivisorNegative = divisor.signum() < 0;
-		
-		final YearMonthDurationValue quotient = fromDecimalMonths(
-			new BigDecimal(monthsValueSigned())
-			.divide(divisor.abs(), 0, (isDivisorNegative)? BigDecimal.ROUND_HALF_DOWN : BigDecimal.ROUND_HALF_UP));		
-		
-		if (isDivisorNegative)
-			{return quotient.negate();}
-		
-		return new YearMonthDurationValue(quotient.getCanonicalDuration());	
-	}
-	
-	private YearMonthDurationValue fromDecimalMonths(BigDecimal x) throws XPathException {
-		return new YearMonthDurationValue(TimeUtils.getInstance().newDurationYearMonth(
-				x.signum() >= 0, null, x.toBigInteger()));
-	}
-	
+    public ComputableValue plus(ComputableValue other) throws XPathException {
+        try {
+            if (other.getType() == Type.TIME) {
+                throw new IllegalArgumentException();
+            }
+            return super.plus(other);
+        } catch (final IllegalArgumentException e) {
+            throw new XPathException(
+                    "Operand to plus should be of type xdt:yearMonthDuration, xs:date, "
+                            + "or xs:dateTime; got: "
+                            + Type.getTypeName(other.getType()));
+        }
+    }
+
+    public ComputableValue mult(ComputableValue other) throws XPathException {
+        if (other instanceof NumericValue) {
+            //If $arg2 is NaN an error is raised [err:FOCA0005]
+            if (((NumericValue) other).isNaN()) {
+                throw new XPathException(ErrorCodes.FOCA0005, "Operand is not a number");
+            }
+            //If $arg2 is positive or negative infinity, the result overflows
+            if (((NumericValue) other).isInfinite()) {
+                throw new XPathException(ErrorCodes.FODT0002, "Multiplication by infinity overflow");
+            }
+        }
+        final BigDecimal factor = numberToBigDecimal(other, "Operand to mult should be of numeric type; got: ");
+
+        final boolean isFactorNegative = factor.signum() < 0;
+
+        final YearMonthDurationValue product = fromDecimalMonths(
+                new BigDecimal(monthsValueSigned())
+                        .multiply(factor.abs())
+                        .setScale(0, (isFactorNegative) ? BigDecimal.ROUND_HALF_DOWN : BigDecimal.ROUND_HALF_UP)
+        );
+
+        if (isFactorNegative) {
+            return product.negate();
+        }
+
+        return product;
+    }
+
+    public ComputableValue div(ComputableValue other) throws XPathException {
+        if (other.getType() == Type.YEAR_MONTH_DURATION) {
+            return new IntegerValue(getValue()).div(new IntegerValue(((YearMonthDurationValue) other).getValue()));
+        }
+        if (other instanceof NumericValue) {
+            if (((NumericValue) other).isNaN()) {
+                throw new XPathException(ErrorCodes.FOCA0005, "Operand is not a number");
+            }
+            if (((NumericValue) other).isInfinite()) {
+                return new YearMonthDurationValue("P0M");
+            }
+            //If $arg2 is positive or negative zero, the result overflows and is handled as discussed in 10.1.1 Limits and Precision
+            if (((NumericValue) other).isZero()) {
+                throw new XPathException(ErrorCodes.FODT0002, "Division by zero overflow");
+            }
+        }
+        final BigDecimal divisor = numberToBigDecimal(other, "Can not divide xdt:yearMonthDuration by '" + Type.getTypeName(other.getType()) + "'");
+
+        final boolean isDivisorNegative = divisor.signum() < 0;
+
+        final YearMonthDurationValue quotient = fromDecimalMonths(
+                new BigDecimal(monthsValueSigned())
+                        .divide(divisor.abs(), 0, (isDivisorNegative) ? BigDecimal.ROUND_HALF_DOWN : BigDecimal.ROUND_HALF_UP));
+
+        if (isDivisorNegative) {
+            return quotient.negate();
+        }
+
+        return new YearMonthDurationValue(quotient.getCanonicalDuration());
+    }
+
+    private YearMonthDurationValue fromDecimalMonths(BigDecimal x) throws XPathException {
+        return new YearMonthDurationValue(TimeUtils.getInstance().newDurationYearMonth(
+                x.signum() >= 0, null, x.toBigInteger()));
+    }
+
     public boolean effectiveBooleanValue() throws XPathException {
-        throw new XPathException(ErrorCodes.FORG0006, 
-    		"value of type " + Type.getTypeName(getType()) +
-            " has no boolean value.");
+        throw new XPathException(ErrorCodes.FORG0006,
+                "value of type " + Type.getTypeName(getType()) +
+                        " has no boolean value.");
     }
 }

--- a/src/org/exist/xquery/value/YearMonthDurationValue.java
+++ b/src/org/exist/xquery/value/YearMonthDurationValue.java
@@ -23,15 +23,14 @@
 
 package org.exist.xquery.value;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.Duration;
-
 import org.exist.util.FastStringBuffer;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
+
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.Duration;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 /**
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>


### PR DESCRIPTION
### Description:

The current code in org.exist.xquery.value.* is of a rather low quality; Modern Java567 constructs are not used, indenting and order if not in line with standards, too many imports, redundant casting etc.

This PR is merely a mechanical repair of these items. For easy review there are about 8 smaller commits, and one (#4d5f770) larger commit containing the reformatting of al classes.

### Type of tests:

Run 'build.sh test' to run the unit tests.