### PR TITLE
Bug fix and optimise in DefaultDocumentSet

### DIFF
--- a/src/org/exist/dom/persistent/DefaultDocumentSet.java
+++ b/src/org/exist/dom/persistent/DefaultDocumentSet.java
@@ -188,12 +188,11 @@ public class DefaultDocumentSet extends Int2ObjectHashMap implements MutableDocu
         if (other.getDocumentCount() > size()) {
             return false;
         }
-        for (int idx = 0; idx < tabSize; idx++) {
-            if (values[idx] == null || values[idx] == REMOVED) {
-                continue;
-            }
-            final DocumentImpl d = (DocumentImpl)values[idx];
-            if (!contains(d.getDocId())) {
+
+        final Iterator<DocumentImpl> otherDocumentIterator = other.getDocumentIterator();
+        while (otherDocumentIterator.hasNext()) {
+            final DocumentImpl otherDocument = otherDocumentIterator.next();
+            if (!contains(otherDocument.getDocId())) {
                 return false;
             }
         }

--- a/src/org/exist/dom/persistent/DefaultDocumentSet.java
+++ b/src/org/exist/dom/persistent/DefaultDocumentSet.java
@@ -189,14 +189,24 @@ public class DefaultDocumentSet extends Int2ObjectHashMap implements MutableDocu
             return false;
         }
 
-        final Iterator<DocumentImpl> otherDocumentIterator = other.getDocumentIterator();
-        while (otherDocumentIterator.hasNext()) {
-            final DocumentImpl otherDocument = otherDocumentIterator.next();
-            if (!contains(otherDocument.getDocId())) {
-                return false;
+        if(other instanceof DefaultDocumentSet) {
+            // optimization for fast comparison when other is also a DefaultDocumentSet
+            final DefaultDocumentSet otherDDS = (DefaultDocumentSet)other;
+            final BitSet compare = new BitSet();
+            compare.or(docIds);
+            compare.and(otherDDS.docIds);
+            return compare.equals(otherDDS.docIds);
+        } else {
+            // otherwise, fallback to general comparison
+            final Iterator<DocumentImpl> otherDocumentIterator = other.getDocumentIterator();
+            while (otherDocumentIterator.hasNext()) {
+                final DocumentImpl otherDocument = otherDocumentIterator.next();
+                if (!contains(otherDocument.getDocId())) {
+                    return false;
+                }
             }
+            return true;
         }
-        return true;
     }
 
     @Override

--- a/src/org/exist/dom/persistent/DefaultDocumentSet.java
+++ b/src/org/exist/dom/persistent/DefaultDocumentSet.java
@@ -46,6 +46,7 @@ import java.util.TreeSet;
  * belong to.
  *
  * @author wolf
+ * @author aretter
  */
 @NotThreadSafe
 public class DefaultDocumentSet extends Int2ObjectHashMap implements MutableDocumentSet {
@@ -257,19 +258,25 @@ public class DefaultDocumentSet extends Int2ObjectHashMap implements MutableDocu
             return true;
         }
 
-        if (size() != other.getDocumentCount()) {
+        if (getDocumentCount() != other.getDocumentCount()) {
             return false;
         }
 
-        for (int idx = 0; idx < tabSize; idx++) {
-            if (values[idx] == null || values[idx] == REMOVED) {
-                continue;
+        if(other instanceof DefaultDocumentSet) {
+            // optimization for fast comparison when other is also a DefaultDocumentSet
+            final DefaultDocumentSet otherDDS = (DefaultDocumentSet)other;
+            return docIds.equals(otherDDS.docIds);
+        } else {
+            // otherwise, fallback to general comparison
+            final Iterator<DocumentImpl> otherDocumentIterator = other.getDocumentIterator();
+            while (otherDocumentIterator.hasNext()) {
+                final DocumentImpl otherDocument = otherDocumentIterator.next();
+                if (!contains(otherDocument.getDocId())) {
+                    return false;
+                }
             }
-            if (!other.contains(keys[idx])) {
-                return false;
-            }
+            return true;
         }
-        return true;
     }
 
     @Override

--- a/src/org/exist/dom/persistent/DefaultDocumentSet.java
+++ b/src/org/exist/dom/persistent/DefaultDocumentSet.java
@@ -320,7 +320,9 @@ public class DefaultDocumentSet extends Int2ObjectHashMap implements MutableDocu
         final StringBuilder result = new StringBuilder();
         for (final Iterator<DocumentImpl> i = getDocumentIterator(); i.hasNext(); ) {
             result.append(i.next());
-            result.append(", ");
+            if(i.hasNext()) {
+                result.append(", ");
+            }
         }
         return result.toString();
     }

--- a/src/org/exist/dom/persistent/DefaultDocumentSet.java
+++ b/src/org/exist/dom/persistent/DefaultDocumentSet.java
@@ -32,11 +32,7 @@ import org.exist.util.hashtable.Int2ObjectHashMap;
 import org.exist.xmldb.XmldbURI;
 import org.w3c.dom.Node;
 
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 /**
  * Manages a set of documents.
@@ -301,7 +297,8 @@ public class DefaultDocumentSet extends Int2ObjectHashMap implements MutableDocu
     @Override
     public void unlock(final boolean exclusive) {
         final Thread thread = Thread.currentThread();
-        for (int idx = 0; idx < tabSize; idx++) {
+        // NOTE: locks should be released in the reverse order that they were acquired
+        for (int idx = tabSize - 1; idx >= 0; idx--) {
             if (values[idx] == null || values[idx] == REMOVED) {
                 continue;
             }

--- a/src/org/exist/dom/persistent/DocumentSet.java
+++ b/src/org/exist/dom/persistent/DocumentSet.java
@@ -31,7 +31,7 @@ import java.util.Iterator;
 
 public interface DocumentSet {
 
-    public static final DocumentSet EMPTY_DOCUMENT_SET = new DefaultDocumentSet(9);
+    DocumentSet EMPTY_DOCUMENT_SET = new EmptyDocumentSet();
 
     public Iterator<DocumentImpl> getDocumentIterator();
 

--- a/src/org/exist/dom/persistent/DocumentSet.java
+++ b/src/org/exist/dom/persistent/DocumentSet.java
@@ -33,28 +33,27 @@ public interface DocumentSet {
 
     DocumentSet EMPTY_DOCUMENT_SET = new EmptyDocumentSet();
 
-    public Iterator<DocumentImpl> getDocumentIterator();
+    Iterator<DocumentImpl> getDocumentIterator();
 
-    public Iterator<Collection> getCollectionIterator();
+    Iterator<Collection> getCollectionIterator();
 
-    public int getDocumentCount();
+    int getDocumentCount();
 
-    public DocumentImpl getDoc(int docId);
+    DocumentImpl getDoc(int docId);
 
-    public XmldbURI[] getNames();
+    XmldbURI[] getNames();
 
-    public DocumentSet intersection(DocumentSet other);
+    DocumentSet intersection(DocumentSet other);
 
-    public boolean contains(DocumentSet other);
+    boolean contains(DocumentSet other);
 
-    public boolean contains(int id);
+    boolean contains(int id);
 
-    public NodeSet docsToNodeSet();
+    NodeSet docsToNodeSet();
 
-    public void lock(DBBroker broker, boolean exclusive, boolean checkExisting) throws LockException;
+    void lock(DBBroker broker, boolean exclusive, boolean checkExisting) throws LockException;
 
-    public void unlock(boolean exclusive);
+    void unlock(boolean exclusive);
 
-    public boolean equalDocs(DocumentSet other);
-
+    boolean equalDocs(DocumentSet other);
 }

--- a/src/org/exist/dom/persistent/EmptyDocumentSet.java
+++ b/src/org/exist/dom/persistent/EmptyDocumentSet.java
@@ -1,0 +1,103 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.dom.persistent;
+
+import org.exist.collections.Collection;
+import org.exist.storage.DBBroker;
+import org.exist.util.LockException;
+import org.exist.xmldb.XmldbURI;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+/**
+ * An Empty DocumentSet
+ *
+ * @author aretter
+ */
+public class EmptyDocumentSet implements DocumentSet {
+
+    /**
+     * Use {@link DocumentSet#EMPTY_DOCUMENT_SET}
+     */
+    EmptyDocumentSet() {
+    }
+
+    @Override
+    public Iterator<DocumentImpl> getDocumentIterator() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public Iterator<Collection> getCollectionIterator() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public int getDocumentCount() {
+        return 0;
+    }
+
+    @Override
+    public DocumentImpl getDoc(final int docId) {
+        return null;
+    }
+
+    private final XmldbURI[] NO_NAMES = new XmldbURI[0];
+
+    @Override
+    public XmldbURI[] getNames() {
+        return NO_NAMES;
+    }
+
+    @Override
+    public DocumentSet intersection(final DocumentSet other) {
+        return DocumentSet.EMPTY_DOCUMENT_SET;
+    }
+
+    @Override
+    public boolean contains(final DocumentSet other) {
+        return false;
+    }
+
+    @Override
+    public boolean contains(final int id) {
+        return false;
+    }
+
+    @Override
+    public NodeSet docsToNodeSet() {
+        return NodeSet.EMPTY_SET;
+    }
+
+    @Override
+    public void lock(final DBBroker broker, final boolean exclusive, final boolean checkExisting) throws
+            LockException {
+    }
+
+    @Override
+    public void unlock(final boolean exclusive) {
+    }
+
+    @Override
+    public boolean equalDocs(final DocumentSet other) {
+        return false;
+    }
+}

--- a/test/src/org/exist/dom/persistent/DefaultDocumentSetTest.java
+++ b/test/src/org/exist/dom/persistent/DefaultDocumentSetTest.java
@@ -224,6 +224,149 @@ public class DefaultDocumentSetTest {
         verify(col, doc1, doc6, doc9, doc15, doc34);
     }
 
+    @Test
+    public void equalDocs() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        replay(col, doc1, doc6, doc9, doc15, doc34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+        set1.add(doc1);
+        set1.add(doc6);
+        set1.add(doc9);
+        set1.add(doc15);
+        set1.add(doc34);
+
+        final DefaultDocumentSet set2 = new DefaultDocumentSet();
+        set2.add(doc1);
+        set2.add(doc6);
+        set2.add(doc9);
+        set2.add(doc15);
+        set2.add(doc34);
+
+        // functions under test
+        assertTrue(set1.equalDocs(set2));
+        assertTrue(set2.equalDocs(set1));
+
+        verify(col, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
+    public void equalDocs_noMatch() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        replay(col, doc1, doc6, doc9, doc15, doc34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+        set1.add(doc1);
+        set1.add(doc6);
+        set1.add(doc9);
+        set1.add(doc15);
+        set1.add(doc34);
+
+        final DefaultDocumentSet set2 = new DefaultDocumentSet();
+        set2.add(doc1);
+        set2.add(doc6);
+        set2.add(doc9);
+
+        // functions under test
+        assertFalse(set1.equalDocs(set2));
+        assertFalse(set2.equalDocs(set1));
+
+        verify(col, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
+    public void equalDocs_nonOptimized() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+
+        final DocumentSet set2 = testableDocumentSet(doc1, doc6, doc9, doc15, doc34);
+
+        replay(col, set2, doc1, doc6, doc9, doc15, doc34);
+
+        set1.add(doc1);
+        set1.add(doc6);
+        set1.add(doc9);
+        set1.add(doc15);
+        set1.add(doc34);
+
+        // functions under test
+        assertTrue(set1.equalDocs(set2));
+
+        verify(col, set2, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
+    public void equalDocs_nonOptimized_noMatch() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+
+        final DocumentSet set2 = testableDocumentSet(doc1, doc6, doc9, doc15, doc34);
+
+        replay(col, set2, doc1, doc6, doc9, doc15, doc34);
+
+        set1.add(doc1);
+        set1.add(doc6);
+        set1.add(doc9);
+
+        // functions under test
+        assertFalse(set1.equalDocs(set2));
+
+        verify(col, set2, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
+    public void equalDocs_emptySet() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        replay(col, doc1, doc6, doc9, doc15, doc34);
+
+        final DocumentSet set1 = DocumentSet.EMPTY_DOCUMENT_SET;
+
+        final DefaultDocumentSet set2 = new DefaultDocumentSet();
+        set2.add(doc15);
+        set2.add(doc34);
+
+        // functions under test
+        assertFalse(set2.equalDocs(set1));
+        assertFalse(set1.equalDocs(set2));
+
+        verify(col, doc1, doc6, doc9, doc15, doc34);
+    }
+
     private final Collection mockCollection(final int colId) {
         final Collection col = createMock(Collection.class);
         expect(col.compareTo(col)).andReturn(0).anyTimes();

--- a/test/src/org/exist/dom/persistent/DefaultDocumentSetTest.java
+++ b/test/src/org/exist/dom/persistent/DefaultDocumentSetTest.java
@@ -1,0 +1,159 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.dom.persistent;
+
+import org.exist.collections.Collection;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
+public class DefaultDocumentSetTest {
+
+    @Test
+    public void contains_leftRight() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        replay(col, doc1, doc6, doc9, doc15, doc34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+        set1.add(doc1);
+        set1.add(doc6);
+        set1.add(doc9);
+
+        final DefaultDocumentSet set2 = new DefaultDocumentSet();
+        set2.add(doc1);
+        set2.add(doc6);
+        set2.add(doc9);
+        set2.add(doc15);
+        set2.add(doc34);
+
+        // functions under test
+        assertTrue(set2.contains(set1));
+        assertFalse(set1.contains(set2));
+
+        verify(col, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
+    public void contains_noMatch() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        replay(col, doc1, doc6, doc9, doc15, doc34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+        set1.add(doc1);
+        set1.add(doc6);
+        set1.add(doc9);
+
+        final DefaultDocumentSet set2 = new DefaultDocumentSet();
+        set2.add(doc15);
+        set2.add(doc34);
+
+        // functions under test
+        assertFalse(set2.contains(set1));
+        assertFalse(set1.contains(set2));
+
+        verify(col, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
+    public void contains_emptySet() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        replay(col, doc1, doc6, doc9, doc15, doc34);
+
+        final DocumentSet set1 = DocumentSet.EMPTY_DOCUMENT_SET;
+
+        final DefaultDocumentSet set2 = new DefaultDocumentSet();
+        set2.add(doc15);
+        set2.add(doc34);
+
+        // functions under test
+        assertTrue(set2.contains(set1));
+        assertFalse(set1.contains(set2));
+
+        verify(col, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    private final Collection mockCollection(final int colId) {
+        final Collection col = createMock(Collection.class);
+        expect(col.compareTo(col)).andReturn(0).anyTimes();
+        expect(col.getId()).andReturn(colId).anyTimes();
+        return col;
+    }
+
+    private final DocumentImpl mockDoc(final Collection collection, final int docId) {
+        final DocumentImpl doc = createMock(DocumentImpl.class);
+        expect(doc.getCollection()).andReturn(collection).anyTimes();
+        expect(doc.getDocId()).andReturn(docId).anyTimes();
+        return doc;
+    }
+
+    private final DocumentSet testableDocumentSet(final DocumentImpl... docs) {
+        final DocumentSet documentSet = createMock(DocumentSet.class);
+
+        expect(documentSet.getDocumentCount()).andReturn(docs.length);
+
+        expect(documentSet.getDocumentIterator()).andReturn(new Iterator<DocumentImpl>(){
+            private int idx = 0;
+
+            @Override
+            public boolean hasNext() {
+                return idx < docs.length;
+            }
+
+            @Override
+            public DocumentImpl next() {
+                return docs[idx++];
+            }
+        }).anyTimes();
+
+        return documentSet;
+    }
+}

--- a/test/src/org/exist/dom/persistent/DefaultDocumentSetTest.java
+++ b/test/src/org/exist/dom/persistent/DefaultDocumentSetTest.java
@@ -69,6 +69,60 @@ public class DefaultDocumentSetTest {
     }
 
     @Test
+    public void contains_nonOptimized_leftRight() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+
+        final DocumentSet set2 = testableDocumentSet(doc1, doc6, doc9, doc15, doc34);
+
+        replay(col, set2, doc1, doc6, doc9, doc15, doc34);
+
+        set1.add(doc1);
+        set1.add(doc6);
+        set1.add(doc9);
+
+        // functions under test
+        assertFalse(set1.contains(set2));
+
+        verify(col, set2, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
+    public void contains_nonOptimized_rightLeft() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+
+        final DocumentSet set2 = testableDocumentSet(doc1, doc6, doc9);
+
+        replay(col, set2, doc1, doc6, doc9, doc15, doc34);
+
+        set1.add(doc1);
+        set1.add(doc6);
+        set1.add(doc9);
+        set1.add(doc15);
+        set1.add(doc34);
+
+        // functions under test
+        assertTrue(set1.contains(set2));
+
+        verify(col, set2, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
     public void contains_noMatch() {
         final Collection col = mockCollection(1);
 
@@ -94,6 +148,55 @@ public class DefaultDocumentSetTest {
         assertFalse(set1.contains(set2));
 
         verify(col, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
+    public void contains_nonOptimized_noMatch_leftRight() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+        final DocumentSet set2 = testableDocumentSet(doc15, doc34);
+
+        replay(col, set2, doc1, doc6, doc9, doc15, doc34);
+
+        set1.add(doc1);
+        set1.add(doc6);
+        set1.add(doc9);
+
+        // functions under test
+        assertFalse(set1.contains(set2));
+
+        verify(col, set2, doc1, doc6, doc9, doc15, doc34);
+    }
+
+    @Test
+    public void contains_nonOptimized_noMatch_rightLeft() {
+        final Collection col = mockCollection(1);
+
+        final DocumentImpl doc1 = mockDoc(col, 1);
+        final DocumentImpl doc6 = mockDoc(col, 6);
+        final DocumentImpl doc9 = mockDoc(col, 9);
+        final DocumentImpl doc15 = mockDoc(col, 15);
+        final DocumentImpl doc34 = mockDoc(col, 34);
+
+        final DefaultDocumentSet set1 = new DefaultDocumentSet();
+        final DocumentSet set2 = testableDocumentSet(doc1, doc6, doc9);
+
+        replay(col, set2, doc1, doc6, doc9, doc15, doc34);
+
+        set1.add(doc15);
+        set1.add(doc34);
+
+        // functions under test
+        assertFalse(set1.contains(set2));
+
+        verify(col, set2, doc1, doc6, doc9, doc15, doc34);
     }
 
     @Test


### PR DESCRIPTION
1. Fixes a bug in `DefaultDocumentSet#contains`, see https://github.com/eXist-db/exist/issues/1406
2. Optimises `contains` between two `DeafultDocumentSets`
2. Optimises `equalDocs` between two `DeafultDocumentSets`

@wolfgangmm I would like your thoughts on why we have not encountered this bug in `DefaultDocumentSet#contains` before in XQuery.