### PR TITLE
[bugfix] Lucene match highlighting of ignored nodes

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneMatchListener.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneMatchListener.java
@@ -183,11 +183,17 @@ public class LuceneMatchListener extends AbstractMatchListener {
                         if (--level < 0) {
                             break;
                         }
-                        textOffset += extractor.endElement(reader.getQName());
+                        // call extractor.endElement unless this is the root of the current fragment
+                        if (level > 0) {
+                            textOffset += extractor.endElement(reader.getQName());
+                        }
                         break;
                     case XMLStreamConstants.START_ELEMENT:
+                        // call extractor.startElement unless this is the root of the current fragment
+                        if (level > 0) {
+                            textOffset += extractor.startElement(reader.getQName());
+                        }
                         ++level;
-                        textOffset += extractor.startElement(reader.getQName());
                         break;
                     case XMLStreamConstants.CHARACTERS:
                         NodeId nodeId = (NodeId) reader.getProperty(ExtendedXMLStreamReader.PROPERTY_NODE_ID);

--- a/test/src/xquery/ft-match.xql
+++ b/test/src/xquery/ft-match.xql
@@ -1,0 +1,62 @@
+xquery version "3.1";
+
+module namespace ftt="http://exist-db.org/xquery/ft-match/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace stats="http://exist-db.org/xquery/profiling";
+
+declare variable $ftt:COLLECTION_CONFIG := 
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene>
+                <text qname="div">
+                    <ignore qname="div"/>
+                    <ignore qname="hi"/>
+                </text>
+            </lucene>
+        </index>
+    </collection>;
+
+declare variable $ftt:DATA :=
+    <body>
+        <div>
+            <p>Introduction text</p>
+            <div>
+                <p>text in nested div and more <hi>text</hi>.</p>
+            </div>
+        </div>
+    </body>;
+    
+declare variable $ftt:COLLECTION_NAME := "matchestest";
+declare variable $ftt:COLLECTION := "/db/" || $ftt:COLLECTION_NAME;
+
+declare
+    %test:setUp
+function ftt:setup() {
+    xmldb:create-collection("/db/system/config/db", $ftt:COLLECTION_NAME),
+    xmldb:store("/db/system/config/db/" || $ftt:COLLECTION_NAME, "collection.xconf", $ftt:COLLECTION_CONFIG),
+    xmldb:create-collection("/db", $ftt:COLLECTION_NAME),
+    xmldb:store($ftt:COLLECTION, "test.xml", $ftt:DATA)
+};
+
+declare
+    %test:tearDown
+function ftt:cleanup() {
+    xmldb:remove($ftt:COLLECTION),
+    xmldb:remove("/db/system/config/db/" || $ftt:COLLECTION_NAME)
+};
+
+(:~
+ : Check match highlighting: because the inner div is set to "ignore" in the Lucene index,
+ : the matching string "text" should not be highlighted.
+ : 
+ : It should be highlighted though if we look at the second result, which is the inner div.
+ : The nested <hi> should never be highlighted.
+ :)
+declare
+    %test:args("text")
+    %test:assertEquals(1, 1)
+function ftt:highlight($query as xs:string) {
+    count(util:expand(collection($ftt:COLLECTION)//div[ft:query(., $query)][1])//exist:match),
+    count(util:expand(collection($ftt:COLLECTION)//div[ft:query(., $query)][2])//exist:match)
+};

--- a/test/src/xquery/suite.xql
+++ b/test/src/xquery/suite.xql
@@ -12,5 +12,6 @@ test:suite((
     inspect:module-functions(xs:anyURI("comments.xql")),
     inspect:module-functions(xs:anyURI("fn.xql")),
     inspect:module-functions(xs:anyURI("errors.xql")),
-    inspect:module-functions(xs:anyURI("nill.xql"))
+    inspect:module-functions(xs:anyURI("nill.xql")),
+    inspect:module-functions(xs:anyURI("ft-match.xql"))
 ))


### PR DESCRIPTION
When using "ignore" in a Lucene index definition, an empty string was returned by the match highlighter if the name of the ignored element happened to be the same as that of the root element indexed. 

Using "ignore" on nested structures is a common use case, e.g. in TEI where `div` elements tend to be nested. So an index definition like

```xml
<text qname="div">
  <ignore qname="div"/>
</text>
```

makes sense. One only wants content in the top-level div to be queried, while content in nested divs will produce separate matches. This approach failed though as the match highlighter did ignore the entire outer div, returning an empty string.

Note that the indexer does correctly ignore the nested divs.