### PR TITLE
Allow anyone with a valid certificate to create a signed package for MacOS

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -76,3 +76,8 @@ antlr.traceTreeWalker = false
 # https://java.net/projects/appbundler (store in IzPack/lib)
 izpack.dir = /Applications/IzPack/
 
+# If you wish to sign .app applications and .DMG packages for MacOS
+# then a "Developer ID Application" certificate is required
+# the name of that certificate should be set
+# via this property:
+mac.codesign.identity=Developer ID Application: eXist-db.org

--- a/build/scripts/macosx.xml
+++ b/build/scripts/macosx.xml
@@ -17,15 +17,25 @@
     <property name="app.resources" value="${app.dir}/Contents/Resources"/>
     <property name="app.exist" value="${app.resources}/eXist-db"/>
     <property name="app.icon" value="installer/scripts/icon.icns"/>
-    <property name="codesign.identity" value="Lars Windauer"/>
     <property name="appbundler.jar" value="${tools.ant}/lib/appbundler-1.0.jar"/>
     <property name="appbundler.url" value="http://java.net/downloads/appbundler/appbundler-1.0.jar"/>
 
     <available property="appbundler.available" file="${appbundler.jar}"/>
 
+    <condition property="isMacOS">
+        <and>
+            <os family="mac"/>
+            <os family="unix"/>
+        </and>
+    </condition>
+
     <target name="app" description="Build Mac OS X dmg (unsigned)" depends="all,bundle,copy-all,dmg"/>
 
-    <target name="app-signed" description="Build Mac OS X dmg (signed)" depends="all,bundle,copy-all,codesign,dmg"/>
+    <target name="app-signed" description="Build Mac OS X dmg (signed)" xmlns:unless="ant:unless" depends="all,bundle,copy-all,codesign-app,dmg,codesign-dmg">
+        <echo unless:set="isMacOS">
+            *** WARNING: There are no tools for signing Mac applications on non-Mac platforms. The resultant .app and .dmg are not signed!
+        </echo>
+    </target>
 
     <target name="install-appbundler" unless="appbundler.available">
         <taskdef name="fetch" classname="nl.ow.dilemma.ant.fetch.FetchTask">
@@ -186,11 +196,13 @@
         </chmod>
     </target>
 
-    <target name="codesign" description="Codesign .app">
+    <!-- NOTE: there are currently no tools available to code sign Mac .app files on Linux :-( -->
+    <target name="codesign-app" description="Codesign .app" depends="copy-all" if="isMacOS">
+        <echo message="Signing '${app.dir}' as '${mac.codesign.identity}'..."/>
         <exec executable="/usr/bin/codesign" os="Mac OS X" failonerror="true">
-            <arg value="-f"/>
-            <arg value="-s"/>
-            <arg value="${codesign.identity}"/>
+            <arg value="--force"/>
+            <arg value="--sign"/>
+            <arg value="${mac.codesign.identity}"/>
             <arg value="${app.dir}"/>
         </exec>
     </target>
@@ -350,5 +362,16 @@
             <fileset dir="${mountdir}" includes="**/*"/>
         </delete>
 
+    </target>
+
+    <!-- NOTE: there are currently no tools available to code sign Mac .dmg files on Linux :-( -->
+    <target name="codesign-dmg" description="Codesign .dmg" depends="dmg" if="isMacOS">
+        <echo message="Signing '${dist}/${dmg.name}' as '${mac.codesign.identity}'..."/>
+        <exec executable="/usr/bin/codesign" os="Mac OS X" failonerror="true">
+            <arg value="--force"/>
+            <arg value="--sign"/>
+            <arg value="${mac.codesign.identity}"/>
+            <arg value="${dist}/${dmg.name}"/>
+        </exec>
     </target>
 </project>


### PR DESCRIPTION
Assuming you have a "Developer ID Application" certificate from Apple for MacOS. You can now create a signed .app/.dmg package by:

1) Ensure that `$EXIST_HOME/local.build.properties` contains a line like:

```
mac.codesign.identity=Developer ID Application: Your Megacorp Here
```

but replace `Your Megacorp Here` with the identity of your certificate.

2) Run `./build.sh app-signed`. Note the signing will only take place on a MacOS system, as there are currently no 3rd party tools for signing Mac packages on other platforms.