### PR TITLE
Removes unused JETTYCONTAINER_OPTS

### DIFF
--- a/bin/functions.d/getopt-settings.sh
+++ b/bin/functions.d/getopt-settings.sh
@@ -10,8 +10,6 @@ PROCESS_OPTS="|--forking|--pidfile|"
 # defaults:
 FORKING=0
 
-JETTYCONTAINER_OPTS=""
-
 BACKUP_OPTS="|-u|--user|-p|--password|-P|--dba-password|-b|--backup|-d|--dir|-r|--restore|-o|--option|"
 
 JMX_OPTS="|-j|--jmx|"


### PR DESCRIPTION
i was looking for a way to provide Jetty configuration per cli-options. this variable seemed to point into the right direction, but leads nowhere.