### PR TITLE
Fix missing build.properties in jarsigner.xml

### DIFF
--- a/build/scripts/jarsigner.xml
+++ b/build/scripts/jarsigner.xml
@@ -19,6 +19,8 @@
     $Id$
 -->
 <project name="Sign eXist jarfiles" default="jnlp-all" basedir="../..">
+
+    <property file="${basedir}/build.properties" />
     
     <description>Sign jarfiles for eXist webstart application</description>
     


### PR DESCRIPTION
Thank you for your contribution to the eXist-db codebase! We will review your changes and pull them in when the project agrees with them and if the project benefits from it, content and quality wise.

To be able to judge the Pull Request (PR) please be sure the following is present

- A (short) description of the content of changes.
- A context reference to e.g. a [Github Issue](https://github.com/eXist-db/exist/issues), a message in the  [eXist-open mailinglist](http://exist-open.markmail.org) or a [specification](https://www.w3.org/TR/xquery-3/).

Additionally please add a few tests to the PR. The [XQSuite - Annotation-based Test Framework for XQuery](http://exist-db.org/exist/apps/doc/xqsuite.xml) makes it very easy for you to create tests. These tests can be executed from the [eXide editor](http://exist-db.org/exist/apps/eXide/index.html) (XQuery - Run as Test)

> When the PR is filed, the complete PR will be tested using [travis-ci](https://travis-ci.org/eXist-db/exist), the build status is visible in the PR. Note that only a limited number of tests are executed (smoketest).

Please run the *full* junit testsuite before filing the PR! This can be done with `build.sh test` which generates a HTML report.

------

### Description:

### Reference:

### Type of tests:
