### PR TITLE
fix lucene inline elements in case of not yet applied whitespaces

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/DefaultTextExtractor.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/DefaultTextExtractor.java
@@ -28,6 +28,10 @@ public class DefaultTextExtractor extends AbstractTextExtractor {
     private boolean addSpaceBeforeNext = false;
     
     public int startElement(QName name) {
+        if(isInlineNode(name)) {
+            // discard not yet applied whitespaces
+            addSpaceBeforeNext = false;
+        }
         if (config.isIgnoredNode(name) || (idxConfig != null && idxConfig.isIgnoredNode(name)))
             stack++;
         else if (!isInlineNode(name) && buffer.length() > 0 && buffer.charAt(buffer.length() - 1) != ' ') {


### PR DESCRIPTION
### Description:
The inline element configuration for lucene fails if an empty element is before the element to be inlined. 

For elements like this:
```xml
        <p><em>trampel</em>tier</p>
        <p><a name="1"></a><em>trampel</em>tier</p>
```
with a config like this:
```xml
            <lucene>
                <text qname="p">
                    <inline qname="em"/>
                </text>
            </lucene>
```

Only one match for the query `//p[ft:query(., $query)]` will be found.

This happens because in the DefaultTextExtractor the whitespace is not applied before, but in the middle of the word. 

This patch fixes this behaviour by resetting the variable "adSpaceBeforeNext" when an inline element starts.

### Reference:

https://github.com/eXist-db/exist/issues/1439

### Type of tests:

```xquery
xquery version "3.1";

module namespace fti="http://exist-db.org/xquery/ft-inline/test";

declare namespace test="http://exist-db.org/xquery/xqsuite";
declare namespace stats="http://exist-db.org/xquery/profiling";

declare variable $fti:COLLECTION_CONFIG := 
    <collection xmlns="http://exist-db.org/collection-config/1.0">
        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
            <lucene>
                <text qname="p">
                    <inline qname="em"/>
                </text>
            </lucene>
        </index>
    </collection>;

declare variable $fti:DATA :=
    <root>
        <p>trampeltier</p>
        <p><em>trampel</em>tier</p>
        <p><a name="1"></a><em>trampel</em>tier</p>
    </root>;
    
declare variable $fti:COLLECTION_NAME := "inlinetest";
declare variable $fti:COLLECTION := "/db/" || $fti:COLLECTION_NAME;

declare
    %test:setUp
function fti:setup() {
    xmldb:create-collection("/db/system/config/db", $fti:COLLECTION_NAME),
    xmldb:store("/db/system/config/db/" || $fti:COLLECTION_NAME, "collection.xconf", $fti:COLLECTION_CONFIG),
    xmldb:create-collection("/db", $fti:COLLECTION_NAME),
    xmldb:store($fti:COLLECTION, "test.xml", $fti:DATA)
};

declare
    %test:tearDown
function fti:cleanup() {
    xmldb:remove($fti:COLLECTION),
    xmldb:remove("/db/system/config/db/" || $fti:COLLECTION_NAME)
};

(:~
 : Check lucene inline configuration. As the <em> element is configured to be inlined.
 : this query should return 3 matching elements. 
 :)
declare
    %test:args("trampeltier")
    %test:assertEquals(3)
function fti:test-inline($query as xs:string) {
    count(collection($fti:COLLECTION)//p[ft:query(., $query)])
};
```
