### PR TITLE
[bugfix] fn:replace with arrow operator

### DIFF
--- a/src/org/exist/xquery/functions/fn/FunReplace.java
+++ b/src/org/exist/xquery/functions/fn/FunReplace.java
@@ -112,6 +112,7 @@ public class FunReplace extends FunMatches {
 	 * @see org.exist.xquery.Function#setArguments(java.util.List)
 	 */
 	public void setArguments(List<Expression> arguments) throws XPathException {
+	    steps.clear();
         Expression arg = arguments.get(0);
         arg = new DynamicCardinalityCheck(context, Cardinality.ZERO_OR_ONE, arg,
                 new Error(Error.FUNC_PARAM_CARDINALITY, "1", mySignature));    

--- a/test/src/xquery/xquery3/arrowop.xql
+++ b/test/src/xquery/xquery3/arrowop.xql
@@ -17,6 +17,12 @@ function ao:func-by-name2() {
 };
 
 declare
+    %test:assertEquals("hey")
+function ao:func-by-name3() {
+    "hello" => replace("llo", "y")
+};
+
+declare
     %test:assertEquals(3)
 function ao:func-inline() {
     ('A', 'B', 'C') => (function($sequence) { count($sequence)})()


### PR DESCRIPTION
[bugfix] fn:replace arguments not cleared when dynamically called. Closes #1357