### PR TITLE
[feature] Provide an extension mechanism for extension modules to provide valid XPath/XQuery error codes

### DIFF
--- a/src/org/exist/xquery/XPathErrorProvider.java
+++ b/src/org/exist/xquery/XPathErrorProvider.java
@@ -1,0 +1,35 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+/**
+ * An interface for providing XPath Error Codes
+ *
+ * @author Adam Retter <adam@exist-db.org>
+ */
+public interface XPathErrorProvider {
+
+    /**
+     * Gets the XPath Error code
+     *
+     * @return The error code or {@link ErrorCodes#ERROR} if there is no defined error code
+     */
+    ErrorCodes.ErrorCode getErrorCode();
+}

--- a/src/org/exist/xquery/XPathException.java
+++ b/src/org/exist/xquery/XPathException.java
@@ -30,7 +30,7 @@ import org.exist.xquery.value.Sequence;
 /**
  *  Class for representing a generic XPath exception.
  */
-public class XPathException extends Exception {
+public class XPathException extends Exception implements XPathErrorProvider {
 
     private static final long serialVersionUID = 212844692232650666L;
     private int line = 0;
@@ -147,36 +147,42 @@ public class XPathException extends Exception {
      * @deprecated Use a constructor with errorCode
      */
     @Deprecated
-    public XPathException(Throwable cause) {
+    public XPathException(final Throwable cause) {
         super(cause);
+        if(cause instanceof XPathErrorProvider) {
+            this.errorCode = ((XPathErrorProvider)cause).getErrorCode();
+        }
     }
 
     /**
      * @deprecated Use a constructor with errorCode
      */
     @Deprecated
-    public XPathException(String message, Throwable cause) {
+    public XPathException(final String message, final Throwable cause) {
         super(cause);
         this.message = message;
+        if(cause instanceof XPathErrorProvider) {
+            this.errorCode = ((XPathErrorProvider)cause).getErrorCode();
+        }
     }
 
     /**
      * @deprecated Use a constructor with errorCode
      */
     @Deprecated
-    public XPathException(Expression expr, Throwable cause) {
-        this(expr, ErrorCodes.ERROR, cause.getMessage(), null, cause);
+    public XPathException(final Expression expr, final Throwable cause) {
+        this(expr, cause instanceof  XPathErrorProvider ? ((XPathErrorProvider)cause).getErrorCode() : ErrorCodes.ERROR, cause.getMessage(), null, cause);
     }
 
     /**
      * @deprecated Use a constructor with errorCode
      */
     @Deprecated
-    public XPathException(Expression expr, String message, Throwable cause) {
-        this(expr, ErrorCodes.ERROR, message, null, cause);
+    public XPathException(final Expression expr, final String message, final Throwable cause) {
+        this(expr, cause instanceof  XPathErrorProvider ? ((XPathErrorProvider)cause).getErrorCode() : ErrorCodes.ERROR, message, null, cause);
     }
 
-    public XPathException(Expression expr, ErrorCode errorCode, String errorDesc, Sequence errorVal, Throwable cause) {
+    public XPathException(final Expression expr, final ErrorCode errorCode, final String errorDesc, final Sequence errorVal, final Throwable cause) {
         this(expr.getLine(), expr.getColumn(), errorDesc, cause);
         this.errorCode = errorCode;
         this.errorVal = errorVal;
@@ -224,21 +230,27 @@ public class XPathException extends Exception {
      * @deprecated Use a constructor with errorCode
      */
     @Deprecated
-    protected XPathException(int line, int column, String message, Throwable cause) {
+    protected XPathException(final int line, final int column, final String message, final Throwable cause) {
         super(cause);
         this.message = message;
         this.line = line;
         this.column = column;
+        if(cause instanceof XPathErrorProvider) {
+            this.errorCode = ((XPathErrorProvider)cause).getErrorCode();
+        }
     }
 
     /**
      * @deprecated Use a constructor with errorCode
      */
     @Deprecated
-    public XPathException(int line, int column, Throwable cause) {
+    public XPathException(final int line, final int column, final Throwable cause) {
         super(cause);
         this.line = line;
         this.column = column;
+        if(cause instanceof XPathErrorProvider) {
+            this.errorCode = ((XPathErrorProvider)cause).getErrorCode();
+        }
     }
 
     public void setLocation(int line, int column) {
@@ -261,9 +273,11 @@ public class XPathException extends Exception {
     }
 
     /**
-     *  Get the xquery error code. Use getErroCode instead.
+     * Get the xquery error code. Use getErroCode instead.
      * 
      * @return The error code or ErrorCode#Error when not available.
+     *
+     * @deprecated Use {@link #getErrorCode()}
      */
     @Deprecated
     public ErrorCode getCode() {
@@ -388,12 +402,7 @@ public class XPathException extends Exception {
         return buf.toString();
     }
 
-
-    /**
-     *  Get the xquery error code.
-     * 
-     * @return The errorcode or ErrorCode#Error when not available.
-     */
+    @Override
     public ErrorCode getErrorCode() {
         return errorCode;
     }


### PR DESCRIPTION
Exceptions thrown by XQuery functions are eventually wrapped up into an `XPathException` which has an `ErrorCodes.ErrorCode`, this change allows the originating exception to provide an `ErrorCode` if one is not otherwise explicitly provided.

Such a mechanism allows extension modules to provide correct error codes. An example usage is the `expath-bin-module` extension, you can see it in use here: https://github.com/eXist-db/expath-bin-module/blob/master/src/main/java/org/exist/xquery/modules/expath/bin/RegionFilterInputStream.java#L166