### PR TITLE
[bugfix] Check the extensions folder exists before signing, fails on clean checkout otherwise

### DIFF
--- a/build/scripts/jarsigner.xml
+++ b/build/scripts/jarsigner.xml
@@ -116,7 +116,7 @@
             <fileset dir="lib/core">
                 <include name="*.jar"/>
             </fileset>
-            <fileset dir="lib/extensions">
+            <fileset dir="lib/extensions" erroronmissingdir="false">
                 <include name="exist-netedit.jar"/>
             </fileset>
             <fileset dir="lib/optional">


### PR DESCRIPTION
This is needed to be able to produce a release on a clean checkout.