### PR TITLE
Correct param name in array:for-each-pair

### DIFF
--- a/src/org/exist/xquery/functions/array/ArrayFunction.java
+++ b/src/org/exist/xquery/functions/array/ArrayFunction.java
@@ -196,7 +196,7 @@ public class ArrayFunction extends BasicFunction {
                     "supplied arrays.",
                     new SequenceType[] {
                             new FunctionParameterSequenceType("array1", Type.ARRAY, Cardinality.EXACTLY_ONE, "The first array to process"),
-                            new FunctionParameterSequenceType("array1", Type.ARRAY, Cardinality.EXACTLY_ONE, "The second array to process"),
+                            new FunctionParameterSequenceType("array2", Type.ARRAY, Cardinality.EXACTLY_ONE, "The second array to process"),
                             new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function to call for each pair")
                     },
                     new FunctionReturnSequenceType(Type.ARRAY, Cardinality.EXACTLY_ONE, "The resulting array")


### PR DESCRIPTION
### Description:

The function doc for `array:for-each-pair()` contained a simple typo: the 2nd parameter, "The second array to process", was called "array1" instead of "array2." This commit fixes the typo, renaming this parameter "array2."

### Reference:

n/a

### Type of tests:

n/a