### PR TITLE
Ensure that we unlock the same documents we lock

### DIFF
--- a/extensions/fluent/src/org/exist/fluent/QueryService.java
+++ b/extensions/fluent/src/org/exist/fluent/QueryService.java
@@ -322,11 +322,11 @@ public class QueryService implements Cloneable {
 					compiledQuery = xquery.compile(broker, context, source);
 					t3 = System.currentTimeMillis();
 				}
-				docsToLock.lock(broker, false, false);
+				docsToLock.lock(broker, false);
 				try {
 					return new ItemList(xquery.execute(broker, wrap(compiledQuery, wrapperFactory, context), base), namespaceBindings.extend(), db);
 				} finally {
-					docsToLock.unlock(false);
+					docsToLock.unlock();
 					t4 = System.currentTimeMillis();
 				}
 			} finally {

--- a/src/org/exist/dom/persistent/DocumentSet.java
+++ b/src/org/exist/dom/persistent/DocumentSet.java
@@ -51,9 +51,17 @@ public interface DocumentSet {
 
     NodeSet docsToNodeSet();
 
-    void lock(DBBroker broker, boolean exclusive, boolean checkExisting) throws LockException;
+    /**
+     * Locks all of the documents currently in the document set.
+     *
+     * @param exclusive true if a WRITE_LOCK is required, false if a READ_LOCK is required
+     */
+    void lock(final DBBroker broker, final boolean exclusive) throws LockException;
 
-    void unlock(boolean exclusive);
+    /**
+     * Unlocks all of the documents which were locked by the previous call(s) to {@link #lock(DBBroker, boolean)}.
+     */
+    void unlock();
 
     boolean equalDocs(DocumentSet other);
 }

--- a/src/org/exist/dom/persistent/EmptyDocumentSet.java
+++ b/src/org/exist/dom/persistent/EmptyDocumentSet.java
@@ -88,12 +88,12 @@ public class EmptyDocumentSet implements DocumentSet {
     }
 
     @Override
-    public void lock(final DBBroker broker, final boolean exclusive, final boolean checkExisting) throws
+    public void lock(final DBBroker broker, final boolean exclusive) throws
             LockException {
     }
 
     @Override
-    public void unlock(final boolean exclusive) {
+    public void unlock() {
     }
 
     @Override

--- a/src/org/exist/xquery/RootNode.java
+++ b/src/org/exist/xquery/RootNode.java
@@ -83,7 +83,7 @@ public class RootNode extends Step {
         try {
             // wait for pending updates
             if (!context.inProtectedMode())
-                {ds.lock(context.getBroker(), false, true);}
+                {ds.lock(context.getBroker(), false);}
 	        DocumentImpl doc;
 	        for (final Iterator<DocumentImpl> i = ds.getDocumentIterator(); i.hasNext();) {
 	            doc = i.next();
@@ -100,7 +100,7 @@ public class RootNode extends Step {
         } finally {
             // release all locks
             if (!context.inProtectedMode())
-                {ds.unlock(false);}
+                {ds.unlock();}
         }
 //        result.updateNoSort();
         if (context.getProfiler().isEnabled()) 

--- a/src/org/exist/xquery/functions/util/LockFunction.java
+++ b/src/org/exist/xquery/functions/util/LockFunction.java
@@ -54,12 +54,12 @@ public abstract class LockFunction extends Function {
         final Sequence docsArg = getArgument(0).eval(contextSequence, contextItem);
         final DocumentSet docs = docsArg.getDocumentSet();
         try {
-            docs.lock(context.getBroker(), exclusive, false);
+            docs.lock(context.getBroker(), exclusive);
             return getArgument(1).eval(contextSequence, contextItem);
         } catch (final LockException e) {
             throw new XPathException(this, "Could not lock document set", e);
         } finally {
-            docs.unlock(exclusive);
+            docs.unlock();
         }
     }
     

--- a/src/org/exist/xquery/functions/xmldb/XMLDBDocument.java
+++ b/src/org/exist/xquery/functions/xmldb/XMLDBDocument.java
@@ -172,7 +172,7 @@ public class XMLDBDocument extends Function {
 	try {
             if(!cacheIsValid)
                 // wait for pending updates
-                {docs.lock(context.getBroker(), lockOnLoad, true);}
+                {docs.lock(context.getBroker(), lockOnLoad);}
 	    // wait for pending updates
 	    if(result == null) {
 		result = new ExtArrayNodeSet(docs.getDocumentCount(), 1);
@@ -192,7 +192,7 @@ public class XMLDBDocument extends Function {
         } finally {
             if(!(cacheIsValid || lockOnLoad))
                 // release all locks
-                {docs.unlock(lockOnLoad);}
+                {docs.unlock();}
 	}
 	cached = result;
 	cachedDocs = docs;

--- a/src/org/exist/xquery/update/Modification.java
+++ b/src/org/exist/xquery/update/Modification.java
@@ -144,7 +144,7 @@ public abstract class Modification extends AbstractExpression
             // acquire a lock on all documents
             // we have to avoid that node positions change
             // during the modification
-            lockedDocuments.lock(context.getBroker(), true, false);
+            lockedDocuments.lock(context.getBroker(), true);
 
             final StoredNode ql[] = new StoredNode[nodes.getItemCount()];
             for (int i = 0; i < ql.length; i++) {
@@ -238,7 +238,7 @@ public abstract class Modification extends AbstractExpression
         modifiedDocuments.clear();
 
         //unlock documents
-        lockedDocuments.unlock(true);
+        lockedDocuments.unlock();
         lockedDocuments = null;
     }
 

--- a/src/org/exist/xupdate/Modification.java
+++ b/src/org/exist/xupdate/Modification.java
@@ -220,7 +220,7 @@ public abstract class Modification {
 		    // acquire a lock on all documents
 	        // we have to avoid that node positions change
 	        // during the modification
-	        lockedDocuments.lock(broker, true, false);
+	        lockedDocuments.lock(broker, true);
 	        
 		    final StoredNode ql[] = new StoredNode[nl.getLength()];		    
 			for (int i = 0; i < ql.length; i++) {
@@ -246,10 +246,11 @@ public abstract class Modification {
 	 * database modification to call the eventual triggers
 	 * @throws TriggerException 
 	 */
-	protected final void unlockDocuments(Txn transaction) throws TriggerException
+	protected final void unlockDocuments(final Txn transaction) throws TriggerException
 	{
-		if(lockedDocuments == null)
-			{return;}
+		if(lockedDocuments == null) {
+			return;
+		}
 		
 		//finish Trigger
 		final Iterator<DocumentImpl> iterator = modifiedDocuments.getDocumentIterator();
@@ -260,7 +261,7 @@ public abstract class Modification {
         modifiedDocuments.clear();
 		
 		//unlock documents
-	    lockedDocuments.unlock(true);
+	    lockedDocuments.unlock();
 	    lockedDocuments = null;
 	}
 	

--- a/src/org/exist/xupdate/Modification.java
+++ b/src/org/exist/xupdate/Modification.java
@@ -251,18 +251,21 @@ public abstract class Modification {
 		if(lockedDocuments == null) {
 			return;
 		}
-		
-		//finish Trigger
-		final Iterator<DocumentImpl> iterator = modifiedDocuments.getDocumentIterator();
-		while (iterator.hasNext()) {
-			finishTrigger(transaction, iterator.next());
+
+		try {
+			//finish Trigger
+			final Iterator<DocumentImpl> iterator = modifiedDocuments.getDocumentIterator();
+			while (iterator.hasNext()) {
+				finishTrigger(transaction, iterator.next());
+			}
+		} finally {
+			triggers.clear();
+			modifiedDocuments.clear();
+
+			//unlock documents
+			lockedDocuments.unlock();
+			lockedDocuments = null;
 		}
-        triggers.clear();
-        modifiedDocuments.clear();
-		
-		//unlock documents
-	    lockedDocuments.unlock();
-	    lockedDocuments = null;
 	}
 	
 	/**


### PR DESCRIPTION
`DocumentSet#lock` can throw a lock exception. If that occurs, it may have only locked some of the documents within the document set, the corresponding call to `DocumentSet#unlock` would attempt to release locks on all documents; that is incorrect as it could release locks that it doesn't own!

We now record the actual locks taken, and only release those that we acquired.