### PR TITLE
[bugfix] Switch to reference counting for caches shared between binary values

### DIFF
--- a/src/org/exist/util/io/CachingFilterInputStream.java
+++ b/src/org/exist/util/io/CachingFilterInputStream.java
@@ -79,7 +79,7 @@ public class CachingFilterInputStream extends FilterInputStream {
     /**
      * Gets the cache implementation
      */
-    private FilterInputStreamCache getCache() {
+    FilterInputStreamCache getCache() {
         return cache;
     }
 
@@ -175,6 +175,10 @@ public class CachingFilterInputStream extends FilterInputStream {
 
             return actualLen;
         }
+    }
+
+    public boolean isClosed() {
+        return getCache().isSrcClosed();
     }
 
     /**
@@ -292,12 +296,18 @@ public class CachingFilterInputStream extends FilterInputStream {
         //If cache hasRead and srcOffset is still in cache useCache
         return getCache().getSrcOffset() > 0 && getCache().getLength() > srcOffset;
     }
-    
-    public void register(InputStream inputStream) {
-        getCache().register(inputStream);
+
+    /**
+     * Increments the number of shared references to the cache.
+     */
+    public void incrementSharedReferences() {
+        getCache().incrementSharedReferences();
     }
-    
-    public void deregister(InputStream inputStream) {
-        getCache().deregister(inputStream);
+
+    /**
+     * Decrements the number of shared references to the cache.
+     */
+    public void decrementSharedReferences() {
+        getCache().decrementSharedReferences();
     }
 }

--- a/src/org/exist/util/io/FilterInputStreamCache.java
+++ b/src/org/exist/util/io/FilterInputStreamCache.java
@@ -27,7 +27,6 @@
 package org.exist.util.io;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * Interface for Cache Implementations for use by the CachingFilterInputStream
@@ -165,8 +164,14 @@ public interface FilterInputStreamCache {
     public boolean isSrcClosed();
     
     public boolean srcIsFilterInputStreamCache();
-    
-    public void register(InputStream inputStream);
-    
-    public void deregister(InputStream inputStream);
+
+    /**
+     * Increments the number of shared references to the cache.
+     */
+    void incrementSharedReferences();
+
+    /**
+     * Decrements the number of shared references to the cache.
+     */
+    void decrementSharedReferences();
 }

--- a/src/org/exist/xquery/value/BinaryValue.java
+++ b/src/org/exist/xquery/value/BinaryValue.java
@@ -28,10 +28,7 @@ import org.apache.logging.log4j.Logger;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.XPathException;
 
-import java.io.FilterOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.text.Collator;
 
 /**
@@ -264,6 +261,8 @@ public abstract class BinaryValue extends AtomicValue {
     }
 
     public abstract InputStream getInputStream();
+
+    public abstract boolean isClosed();
 
     public abstract void close() throws IOException;
 }

--- a/src/org/exist/xquery/value/BinaryValueFromBinaryString.java
+++ b/src/org/exist/xquery/value/BinaryValueFromBinaryString.java
@@ -22,6 +22,7 @@ public class BinaryValueFromBinaryString extends BinaryValue {
     private final static Logger LOG = LogManager.getLogger(BinaryValueFromBinaryString.class);
 
     private final String value;
+    private boolean closed = false;
 
     public BinaryValueFromBinaryString(BinaryValueType binaryValueType, String value) throws XPathException {
         super(null, binaryValueType);
@@ -88,7 +89,7 @@ public class BinaryValueFromBinaryString extends BinaryValue {
     @Override
     public void streamTo(OutputStream os) throws IOException {
         //write
-        final byte data[] = value.getBytes(); //TODO consider a more efficient approach for writting large strings
+        final byte data[] = value.getBytes(); //TODO consider a more efficient approach for writing large strings
         os.write(data);
     }
 
@@ -108,6 +109,12 @@ public class BinaryValueFromBinaryString extends BinaryValue {
     }
 
     @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
     public void close() throws IOException {
+        closed = true;
     }
 }

--- a/src/org/exist/xquery/value/BinaryValueFromFile.java
+++ b/src/org/exist/xquery/value/BinaryValueFromFile.java
@@ -73,6 +73,11 @@ public class BinaryValueFromFile extends BinaryValue {
     }
 
     @Override
+    public boolean isClosed() {
+        return !channel.isOpen();
+    }
+
+    @Override
     public void close() throws IOException {
         channel.close();
     }

--- a/src/org/exist/xquery/value/BinaryValueFromInputStream.java
+++ b/src/org/exist/xquery/value/BinaryValueFromInputStream.java
@@ -88,6 +88,11 @@ public class BinaryValueFromInputStream extends BinaryValue {
     }
 
     @Override
+    public boolean isClosed() {
+        return is.isClosed();
+    }
+
+    @Override
     public void close() throws IOException {
         is.close();
     }

--- a/test/src/org/exist/xquery/value/BinaryValueFromInputStreamTest.java
+++ b/test/src/org/exist/xquery/value/BinaryValueFromInputStreamTest.java
@@ -5,9 +5,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+
+import org.exist.util.io.CachingFilterInputStream;
 import org.exist.xquery.XPathException;
 import org.junit.Test;
-import static org.junit.Assert.assertArrayEquals;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -44,6 +47,373 @@ public class BinaryValueFromInputStreamTest {
             assertArrayEquals(testData, baos.toByteArray());
         } finally {
             binaryValueManager.runCleanupTasks();
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void filter_withoutIncrementReferenceCountFails() throws IOException, XPathException {
+        final BinaryValueManager binaryValueManager = new MockBinaryValueManager();
+
+        final byte[] testData = "test data".getBytes();
+
+        try (final InputStream bais = new ByteArrayInputStream(testData)) {
+            final BinaryValue binaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), bais);
+            final InputStream bvis = binaryValue.getInputStream();
+
+            // create a filter over the first BinaryValue, with no reference count increment
+            final InputStream fis = new BinaryValueFilteringInputStream(bvis, false);
+            final BinaryValue filteredBinaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis);
+
+            // we now destroy the filtered binary value, just as it would be if it went out of scope from popLocalVariables#popLocalVariables.
+            // It should close the original binary value, as we have not incremented the reference count!
+            filteredBinaryValue.close();
+            assertTrue(filteredBinaryValue.isClosed());
+            assertTrue(binaryValue.isClosed());
+
+            // we should not be able to read from the origin binary value!
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+
+                // this should throw an IOException
+                binaryValue.streamBinaryTo(baos);
+            }
+
+        } finally {
+            binaryValueManager.runCleanupTasks();
+        }
+    }
+
+    @Test
+    public void filter_withIncrementReferenceCount() throws IOException, XPathException {
+        final BinaryValueManager binaryValueManager = new MockBinaryValueManager();
+
+        final byte[] testData = "test data".getBytes();
+
+        try (final InputStream bais = new ByteArrayInputStream(testData)) {
+            final BinaryValue binaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), bais);
+            final InputStream bvis = binaryValue.getInputStream();
+
+            // create a filter over the first BinaryValue, and reference count increment
+            final InputStream fis = new BinaryValueFilteringInputStream(bvis, true);
+            final BinaryValue filteredBinaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis);
+
+            // we now destroy the filtered binary value, just as it would if it went out of scope from popLocalVariables#popLocalVariables.
+            // It should not close the original binary value, as BinaryValueFilteringInputStream increased the reference count.
+            filteredBinaryValue.close();
+            assertTrue(filteredBinaryValue.isClosed());
+            assertFalse(binaryValue.isClosed());
+
+            // we should still be able to read from the origin binary value!
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                binaryValue.streamBinaryTo(baos);
+
+                assertArrayEquals(testData, baos.toByteArray());
+            }
+
+            // finally close the original binary value
+            binaryValue.close();
+            assertTrue(binaryValue.isClosed());
+
+        } finally {
+            binaryValueManager.runCleanupTasks();
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void multiFilter_withoutIncrementReferenceCountFails() throws IOException, XPathException {
+        final BinaryValueManager binaryValueManager = new MockBinaryValueManager();
+
+        final byte[] testData = "test data".getBytes();
+
+        try (final InputStream bais = new ByteArrayInputStream(testData)) {
+            final BinaryValue binaryValue1 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), bais);
+            final InputStream bvis1 = binaryValue1.getInputStream();
+
+            final BinaryValue binaryValue2 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), bais);
+            final InputStream bvis2 = binaryValue2.getInputStream();
+
+            // create a filter over both BinaryValues, with no reference count increment
+            final InputStream fis = new MultiBinaryValueFilteringInputStream(new InputStream[]{bvis1, bvis2}, false);
+            final BinaryValue filteredBinaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis);
+
+            // we now destroy the filtered binary value, just as it would be if it went out of scope from popLocalVariables#popLocalVariables.
+            // It should close the original binary values, as we have not incremented the reference counts!
+            filteredBinaryValue.close();
+            assertTrue(filteredBinaryValue.isClosed());
+            assertTrue(binaryValue2.isClosed());
+            assertTrue(binaryValue1.isClosed());
+
+            // we should not be able to read from the origin binary value!
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+
+                // this should throw an IOException
+                binaryValue1.streamBinaryTo(baos);
+            }
+
+        } finally {
+            binaryValueManager.runCleanupTasks();
+        }
+    }
+
+    @Test
+    public void multiFilter_withIncrementReferenceCount() throws IOException, XPathException {
+        final BinaryValueManager binaryValueManager = new MockBinaryValueManager();
+
+        final byte[] testData1 = "test data".getBytes();
+        final byte[] testData2 = "second test data".getBytes();
+
+        try (final InputStream bais1 = new ByteArrayInputStream(testData1);
+                final InputStream bais2 = new ByteArrayInputStream(testData2)) {
+
+            final BinaryValue binaryValue1 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), bais1);
+            final InputStream bvis1 = binaryValue1.getInputStream();
+
+            final BinaryValue binaryValue2 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), bais2);
+            final InputStream bvis2 = binaryValue2.getInputStream();
+
+            // create a filter over both BinaryValues, and reference count increment
+            final InputStream fis = new MultiBinaryValueFilteringInputStream(new InputStream[]{bvis1, bvis2}, true);
+            final BinaryValue filteredBinaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis);
+
+            // we now destroy the filtered binary value, just as it would be if it went out of scope from popLocalVariables#popLocalVariables.
+            // It should not close the original binary values, as MultiBinaryValueFilteringInputStream increased the reference count.
+            filteredBinaryValue.close();
+            assertTrue(filteredBinaryValue.isClosed());
+            assertFalse(binaryValue2.isClosed());
+            assertFalse(binaryValue1.isClosed());
+
+            // we should still be able to read from the origin binary value2!
+            try (final ByteArrayOutputStream baos2 = new ByteArrayOutputStream()) {
+                binaryValue2.streamBinaryTo(baos2);
+
+                assertArrayEquals(testData2, baos2.toByteArray());
+            }
+
+            // we should still be able to read from the original binary value1!
+            try (final ByteArrayOutputStream baos1 = new ByteArrayOutputStream()) {
+                binaryValue1.streamBinaryTo(baos1);
+
+                assertArrayEquals(testData1, baos1.toByteArray());
+            }
+
+            // finally close the original binary values
+            binaryValue2.close();
+            assertTrue(binaryValue2.isClosed());
+            binaryValue1.close();
+            assertTrue(binaryValue1.isClosed());
+
+        } finally {
+            binaryValueManager.runCleanupTasks();
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void filterFilter_withoutIncrementReferenceCountFails() throws IOException, XPathException {
+        final BinaryValueManager binaryValueManager = new MockBinaryValueManager();
+
+        final byte[] testData = "test data".getBytes();
+
+        try (final InputStream bais = new ByteArrayInputStream(testData)) {
+            final BinaryValue binaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), bais);
+            final InputStream bvis = binaryValue.getInputStream();
+
+            // create a filter over the first BinaryValue, with no reference count increment
+            final InputStream fis1 = new BinaryValueFilteringInputStream(bvis, false);
+            final BinaryValue filteredBinaryValue1 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis1);
+
+            // create a second filter over the first filter, with no reference count increment
+            final InputStream fbvis = filteredBinaryValue1.getInputStream();
+            final InputStream fis2 = new BinaryValueFilteringInputStream(fbvis, false);
+            final BinaryValue filteredBinaryValue2 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis2);
+
+            // we now destroy the second filtered binary value, just as it would if it went out of scope from popLocalVariables#popLocalVariables.
+            // It should close the first filtered binary value and original binary value, as we have not incremented the reference counts!
+            filteredBinaryValue2.close();
+            assertTrue(filteredBinaryValue2.isClosed());
+            assertTrue(filteredBinaryValue1.isClosed());
+            assertTrue(binaryValue.isClosed());
+
+            // we should not be able to read from the first filtered binary value!
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+
+                // this should throw an IOException
+                filteredBinaryValue1.streamBinaryTo(baos);
+            }
+
+        } finally {
+            binaryValueManager.runCleanupTasks();
+        }
+    }
+
+    @Test
+    public void filterFilter_withIncrementReferenceCount() throws IOException, XPathException {
+        final BinaryValueManager binaryValueManager = new MockBinaryValueManager();
+
+        final byte[] testData = "test data".getBytes();
+
+        try (final InputStream bais = new ByteArrayInputStream(testData)) {
+            final BinaryValue binaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), bais);
+            final InputStream bvis = binaryValue.getInputStream();
+
+            // create a filter over the first BinaryValue, and reference count increment
+            final InputStream fis1 = new BinaryValueFilteringInputStream(bvis, true);
+            final BinaryValue filteredBinaryValue1 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis1);
+
+            // create a second filter over the first filter, and reference count increment
+            final InputStream fbvis = filteredBinaryValue1.getInputStream();
+            final InputStream fis2 = new BinaryValueFilteringInputStream(fbvis, true);
+            final BinaryValue filteredBinaryValue2 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis2);
+
+            // we now destroy the second filtered binary value, just as it would if it went out of scope from popLocalVariables#popLocalVariables.
+            // It should not close the filtered binary value or original binary value, as BinaryValueFilteringInputStream increased the reference count.
+            filteredBinaryValue2.close();
+            assertTrue(filteredBinaryValue2.isClosed());
+            assertFalse(filteredBinaryValue1.isClosed());
+            assertFalse(binaryValue.isClosed());
+
+            // we should still be able to read from the filtered binary value!
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                filteredBinaryValue1.streamBinaryTo(baos);
+
+                assertArrayEquals(testData, baos.toByteArray());
+            }
+
+            // we now destroy the first filtered binary value, just as it would if it went out of scope from popLocalVariables#popLocalVariables.
+            // It should not close the original binary value, as BinaryValueFilteringInputStream increased the reference count.
+            filteredBinaryValue1.close();
+            assertTrue(filteredBinaryValue1.isClosed());
+
+            // we should still be able to read from the origin binary value!
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                binaryValue.streamBinaryTo(baos);
+
+                assertArrayEquals(testData, baos.toByteArray());
+            }
+
+            // finally close the original binary value
+            binaryValue.close();
+            assertTrue(binaryValue.isClosed());
+
+        } finally {
+            binaryValueManager.runCleanupTasks();
+        }
+    }
+
+    @Test
+    public void multiFilterFilter_withIncrementReferenceCount() throws IOException, XPathException {
+        final BinaryValueManager binaryValueManager = new MockBinaryValueManager();
+
+        final byte[] testData = "test data".getBytes();
+
+        try (final InputStream bais = new ByteArrayInputStream(testData)) {
+
+            final BinaryValue binaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), bais);
+
+            // create a first filter over the first BinaryValue, and reference count increment
+            final InputStream fis1 = new BinaryValueFilteringInputStream(binaryValue.getInputStream(), true);
+            final BinaryValue filteredBinaryValue1 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis1);
+
+            // create a second filter over the first BinaryValue, and reference count increment
+            final InputStream fis2 = new BinaryValueFilteringInputStream(binaryValue.getInputStream(), true);
+            final BinaryValue filteredBinaryValue2 = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), fis2);
+
+
+            // create a multi filter over both filters
+            final InputStream mfis = new MultiBinaryValueFilteringInputStream(new InputStream[]{filteredBinaryValue1.getInputStream(), filteredBinaryValue2.getInputStream()}, true);
+            final BinaryValue multiFilteredBinaryValue = BinaryValueFromInputStream.getInstance(binaryValueManager, new Base64BinaryValueType(), mfis);
+
+            // we now destroy the multi filtered binary value, just as it would be if it went out of scope from popLocalVariables#popLocalVariables.
+            // It should not close the filtered or original binary values, as MultiBinaryValueFilteringInputStream increased the reference count.
+            multiFilteredBinaryValue.close();
+            assertTrue(multiFilteredBinaryValue.isClosed());
+            assertFalse(filteredBinaryValue2.isClosed());
+            assertFalse(filteredBinaryValue1.isClosed());
+            assertFalse(binaryValue.isClosed());
+
+
+            // we should still be able to read from the filtered binary value2!
+            try (final ByteArrayOutputStream baos2 = new ByteArrayOutputStream()) {
+                filteredBinaryValue2.streamBinaryTo(baos2);
+
+                assertArrayEquals(testData, baos2.toByteArray());
+            }
+
+            filteredBinaryValue2.close();
+            assertTrue(filteredBinaryValue2.isClosed());
+
+            // we should still be able to read from the filtered binary value1!
+            try (final ByteArrayOutputStream baos1 = new ByteArrayOutputStream()) {
+                filteredBinaryValue1.streamBinaryTo(baos1);
+
+                assertArrayEquals(testData, baos1.toByteArray());
+            }
+
+            filteredBinaryValue1.close();
+            assertTrue(filteredBinaryValue1.isClosed());
+
+            // we should still be able to read from the original binary value!
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                binaryValue.streamBinaryTo(baos);
+
+                assertArrayEquals(testData, baos.toByteArray());
+            }
+
+            // finally close the original binary value
+            binaryValue.close();
+            assertTrue(binaryValue.isClosed());
+
+        } finally {
+            binaryValueManager.runCleanupTasks();
+        }
+    }
+
+
+    private static class BinaryValueFilteringInputStream extends FilterInputStream {
+        public BinaryValueFilteringInputStream(final InputStream inputStream, final boolean incrementReferenceCount) {
+            super(inputStream);
+            if(incrementReferenceCount && inputStream instanceof CachingFilterInputStream) {
+                final CachingFilterInputStream cfis = ((CachingFilterInputStream)inputStream);
+
+                // increment shared references by one, as this filter is sharing the underlying input stream of the cache
+                cfis.incrementSharedReferences();
+            }
+        }
+    }
+
+    private static class MultiBinaryValueFilteringInputStream extends FilterInputStream {
+        final InputStream[] inputStreams;
+
+        public MultiBinaryValueFilteringInputStream(final InputStream[] inputStreams, final boolean incrementReferenceCount) {
+            super(inputStreams[0]);
+            this.inputStreams = inputStreams;
+            if(incrementReferenceCount) {
+                for(final InputStream inputStream : inputStreams) {
+                    if (inputStream instanceof  CachingFilterInputStream) {
+                        final CachingFilterInputStream cfis = ((CachingFilterInputStream)inputStream);
+
+                        // increment shared references by one, as this filter is sharing the underlying input stream of the cache
+                        cfis.incrementSharedReferences();
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            IOException firstException = null;
+
+            for(int i = inputStreams.length - 1; i > -1; i--) {
+                try {
+                    inputStreams[i].close();
+                } catch(final IOException e) {
+                    if(firstException == null) {
+                        firstException = e;
+                    }
+                }
+            }
+
+            if(firstException != null) {
+                throw new IOException("first exception on close", firstException);
+            }
         }
     }
 }


### PR DESCRIPTION
This is an alternative fix for to https://github.com/eXist-db/exist/pull/1470.

Rather than navigating the query AST to determine when values are out of scope as in #1470, we instead reference count the number of `BinaryValueInputStreams` that are sharing the same underlying cache. The underlying cache is then only closed when the reference count finally reaches zero i.e., when the last `XQueryContext#popLocalVariable` occurs which references the shared cache.