### PR TITLE
Fix random crashes on Mac

### DIFF
--- a/log4j2.xml
+++ b/log4j2.xml
@@ -118,6 +118,14 @@
             <PatternLayout pattern="${exist.file.pattern}"/>
         </RollingRandomAccessFile>
         
+        <RollingRandomAccessFile name="exist.launcher" filePattern="${logs}/launcher.${rollover.file.pattern}.log.gz" fileName="${logs}/launcher.log">
+            <Policies>
+                <SizeBasedTriggeringPolicy size="${rollover.max.size}"/>
+            </Policies>
+            <DefaultRolloverStrategy max="${rollover.max}"/>
+            <PatternLayout pattern="${exist.file.pattern}"/>
+        </RollingRandomAccessFile>
+        
     </Appenders>
     
     <Loggers>
@@ -213,6 +221,9 @@
         </Logger>
         <Logger name="org.exist.repo" additivity="false" level="trace">
             <AppenderRef ref="expath.repo"/>
+        </Logger>
+        <Logger name="org.exist.launcher" additivity="false" level="warn">
+            <AppenderRef ref="exist.launcher"/>
         </Logger>
         
         <Root level="info">

--- a/src/org/exist/launcher/Launcher.java
+++ b/src/org/exist/launcher/Launcher.java
@@ -327,9 +327,18 @@ public class Launcher extends Observable implements Observer {
             }
 
             popup.addSeparator();
-            quitItem = new MenuItem("Quit (and stop server)");
+            quitItem = new MenuItem("Quit");
             popup.add(quitItem);
-            quitItem.addActionListener(actionEvent -> shutdown(false));
+            quitItem.addActionListener(actionEvent -> {
+                if (serviceManager.isInstalled()) {
+                    if (tray != null) {
+                        tray.remove(trayIcon);
+                    }
+                    System.exit(SystemExitCodes.OK_EXIT_CODE);
+                } else {
+                    shutdown(false);
+                }
+            });
         }
         return popup;
     }
@@ -384,7 +393,7 @@ public class Launcher extends Observable implements Observer {
     protected void shutdown(final boolean restart) {
         utilityPanel.setStatus("Shutting down ...");
         SwingUtilities.invokeLater(() -> {
-            if (serviceManager.isRunning()) {
+            if (serviceManager.isRunning() && restart) {
                 if (serviceManager.stop()) {
                     serviceManager.start();
                     trayIcon.displayMessage(null, "Database stopped", TrayIcon.MessageType.INFO);

--- a/src/org/exist/launcher/LauncherWrapper.java
+++ b/src/org/exist/launcher/LauncherWrapper.java
@@ -25,10 +25,6 @@ import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.SystemUtils;
 import org.exist.util.ConfigurationHelper;
-import org.rzo.yajsw.os.OperatingSystem;
-import org.rzo.yajsw.os.Process;
-import org.rzo.yajsw.os.ProcessManager;
-import org.rzo.yajsw.os.ms.win.w32.WindowsXPProcess;
 
 import java.io.File;
 import java.io.IOException;
@@ -80,9 +76,6 @@ public class LauncherWrapper {
         final String debugLauncher = System.getProperty("exist.debug.launcher", "false");
         final PropertiesConfiguration vmProperties = getVMProperties();
 
-        final OperatingSystem os = OperatingSystem.instance();
-        final ProcessManager pm = os.processManagerInstance();
-        final Process process = pm.createProcess();
         final List<String> args = new ArrayList<>();
         args.add(getJavaCmd());
         getJavaOpts(args, home, vmProperties);
@@ -95,17 +88,7 @@ public class LauncherWrapper {
         args.add("start.jar");
         args.add(command);
 
-        process.setWorkingDir(home);
-        process.setVisible(false);
-        process.setPipeStreams(false, false);
-        System.out.println(String.join(" ", args));
-        process.setCommand(args.toArray(new String[args.size()]));
-
-        if (process instanceof WindowsXPProcess) {
-            ((WindowsXPProcess)process).startElevated();
-        } else {
-            process.start();
-        }
+        ServiceManager.run(args, null);
     }
 
     protected String getJavaCmd() {

--- a/src/org/exist/launcher/ServiceManager.java
+++ b/src/org/exist/launcher/ServiceManager.java
@@ -1,0 +1,274 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.launcher;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.log4j.Logger;
+import org.exist.util.ConfigurationHelper;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ServiceManager {
+
+    private final static Logger LOG = Logger.getLogger(ServiceManager.class);
+
+    private Launcher launcher;
+    private final Properties wrapperProperties;
+    private boolean canUseServices;
+    private boolean inServiceInstall = false;
+    private boolean isInstalled = false;
+    private boolean isRunning = false;
+
+    public ServiceManager(Launcher launcher) {
+        this.launcher = launcher;
+
+        if (SystemUtils.IS_OS_WINDOWS) {
+            canUseServices = true;
+        } else {
+            isRoot((root) -> canUseServices = root);
+        }
+
+        final Optional<Path> eXistHome = ConfigurationHelper.getExistHome();
+        final Path wrapperConfig;
+        if (eXistHome.isPresent()) {
+            wrapperConfig = eXistHome.get().resolve("tools/yajsw/conf/wrapper.conf");
+        } else {
+            wrapperConfig = Paths.get("tools/yajsw/conf/wrapper.conf");
+        }
+
+        System.setProperty("wrapper.config", wrapperConfig.toString());
+
+        wrapperProperties = new Properties();
+        wrapperProperties.setProperty("wrapper.working.dir", eXistHome.orElse(Paths.get(".")).toString());
+        wrapperProperties.setProperty("wrapper.config", wrapperConfig.toString());
+
+        installedAsService();
+    }
+
+    public boolean isInstallingService() {
+        return inServiceInstall;
+    }
+
+    public boolean isInstalled() {
+        return isInstalled;
+    }
+
+    public boolean isRunning() {
+        return isRunning;
+    }
+
+    public boolean canUseServices() {
+        return canUseServices;
+    }
+
+    private void installedAsService() {
+        if (canUseServices) {
+            final String cmd;
+            if (SystemUtils.IS_OS_UNIX) {
+                cmd = "tools/yajsw/bin/queryDaemon.sh";
+            } else {
+                cmd = "tools/yajsw/bin/queryService.bat";
+            }
+
+            runWrapperCmd(cmd, (code, output) -> {
+                if (code == 0) {
+                    Pattern statusRegex = Pattern.compile("^Installed\\s*:\\s*(.*)$|^Running\\s*:\\s*(.*)$", Pattern.MULTILINE);
+                    Matcher m = statusRegex.matcher(output);
+                    if (m.find()) {
+                        isInstalled = Boolean.valueOf(m.group(1));
+                        isRunning = Boolean.valueOf(m.group(2));
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("isInstalled: " + isInstalled + "; isRunning: " + isRunning);
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    protected void installAsService() {
+        launcher.showTrayMessage("Installing service and starting eXistdb ...", TrayIcon.MessageType.INFO);
+
+        inServiceInstall = true;
+
+        if (canUseServices) {
+            final String cmd;
+            if (SystemUtils.IS_OS_UNIX) {
+                cmd = "tools/yajsw/bin/installDaemon.sh";
+            } else {
+                cmd = "tools/yajsw/bin/installService.bat";
+            }
+
+            runWrapperCmd(cmd, (code, output) -> {
+                if (code == 0) {
+                    isInstalled = true;
+                    start();
+                    launcher.showTrayMessage("Service installed and started", TrayIcon.MessageType.INFO);
+                } else {
+                    JOptionPane.showMessageDialog(null, "Failed to install service. ", "Install Service Failed", JOptionPane.ERROR_MESSAGE);
+                    isInstalled = false;
+                    isRunning = false;
+                }
+            });
+        }
+        inServiceInstall = false;
+    }
+
+    protected boolean uninstall() {
+        if (isInstalled) {
+            final String cmd;
+            if (SystemUtils.IS_OS_MAC) {
+                cmd = "tools/yajsw/bin/uninstallDaemon.sh";
+            } else {
+                cmd = "tools/yajsw/bin/uninstallService.bat";
+            }
+
+            runWrapperCmd(cmd, (code, output) -> {
+                if (code == 0) {
+                    isInstalled = false;
+                    isRunning = false;
+                    launcher.showTrayMessage("Service stopped and uninstalled", TrayIcon.MessageType.INFO);
+                } else {
+                    JOptionPane.showMessageDialog(null, "Failed to uninstall service. ", "Uninstalling Service Failed", JOptionPane.ERROR_MESSAGE);
+                    isInstalled = true;
+                    isRunning = true;
+                }
+                launcher.setServiceState();
+            });
+        }
+        return false;
+    }
+
+    protected boolean start() {
+        if (!isRunning) {
+            final String cmd;
+            if (SystemUtils.IS_OS_MAC) {
+                cmd = "tools/yajsw/bin/startDaemon.sh";
+            } else {
+                cmd = "tools/yajsw/bin/startService.bat";
+            }
+            runWrapperCmd(cmd, (code, output) -> {
+                if (code == 0) {
+                    isRunning = true;
+                    launcher.showTrayMessage("Service started", TrayIcon.MessageType.INFO);
+                } else {
+                    JOptionPane.showMessageDialog(null, "Failed to start service. ", "Starting Service Failed", JOptionPane.ERROR_MESSAGE);
+                    isRunning = false;
+                }
+                launcher.setServiceState();
+            });
+        }
+        return isRunning;
+    }
+
+    protected boolean stop() {
+        if (isRunning) {
+            final String cmd;
+            if (SystemUtils.IS_OS_MAC) {
+                cmd = "tools/yajsw/bin/stopDaemon.sh";
+            } else {
+                cmd = "tools/yajsw/bin/stopService.bat";
+            }
+            runWrapperCmd(cmd, (code, output) -> {
+                if (code == 0) {
+                    isRunning = false;
+                    launcher.showTrayMessage("Service stopped", TrayIcon.MessageType.INFO);
+                } else {
+                    JOptionPane.showMessageDialog(null, "Failed to stop service. ", "Stopping Service Failed", JOptionPane.ERROR_MESSAGE);
+                    isRunning = true;
+                }
+                launcher.setServiceState();
+            });
+        }
+        return false;
+    }
+
+    private void isRoot(Consumer<Boolean> consumer) {
+        final List<String> args = new ArrayList<>(2);
+        args.add("id");
+        args.add("-u");
+        run(args, (code, output) -> {
+            consumer.accept("0".equals(output.trim()));
+        });
+    }
+
+    public void showServicesConsole() {
+        final List<String> args = new ArrayList<>(2);
+        args.add("cmd");
+        args.add("/c");
+        args.add("services.msc");
+
+        run(args, null);
+    }
+
+    private static void runWrapperCmd(final String cmd, final BiConsumer<Integer, String> consumer) {
+        final List<String> args = new ArrayList<>(1);
+        args.add(cmd);
+        run(args, (code, output) -> {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(output);
+            }
+            consumer.accept(code, output);
+        });
+    }
+
+    public static void run(List<String> args, BiConsumer<Integer, String> consumer) {
+        final ProcessBuilder pb = new ProcessBuilder(args);
+        final Optional<Path> home = ConfigurationHelper.getExistHome();
+
+        pb.directory(home.orElse(Paths.get(".")).toFile());
+        pb.redirectErrorStream(true);
+        if (consumer == null) {
+            pb.inheritIO();
+        }
+        try {
+            final Process process = pb.start();
+            if (consumer != null) {
+                final StringBuilder output = new StringBuilder();
+                try (final BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(),
+                        "UTF-8"))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        output.append('\n').append(line);
+                    }
+                }
+                final int exitValue = process.waitFor();
+                consumer.accept(exitValue, output.toString());
+            }
+        } catch (IOException | InterruptedException e) {
+            JOptionPane.showMessageDialog(null, e.getMessage(), "Error Running Process", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+}

--- a/src/org/exist/launcher/ServiceManager.java
+++ b/src/org/exist/launcher/ServiceManager.java
@@ -44,6 +44,8 @@ public class ServiceManager {
 
     private final static Logger LOG = Logger.getLogger(ServiceManager.class);
 
+    private final static Pattern STATUS_REGEX = Pattern.compile("Installed\\s*:\\s*(.*)\n\\s*Running\\s*:\\s*(.*)\n", Pattern.MULTILINE);
+
     private Launcher launcher;
     private final Properties wrapperProperties;
     private final Path wrapperDir;
@@ -93,8 +95,8 @@ public class ServiceManager {
         if (canUseServices) {
             runWrapperCmd("query", (code, output) -> {
                 if (code == 0) {
-                    Pattern statusRegex = Pattern.compile("^Installed\\s*:\\s*(.*)$|^Running\\s*:\\s*(.*)$", Pattern.MULTILINE);
-                    Matcher m = statusRegex.matcher(output);
+
+                    final Matcher m = STATUS_REGEX.matcher(output);
                     if (m.find()) {
                         isInstalled = Boolean.valueOf(m.group(1));
                         isRunning = Boolean.valueOf(m.group(2));
@@ -219,7 +221,7 @@ public class ServiceManager {
         });
     }
 
-    public static void run(List<String> args, BiConsumer<Integer, String> consumer) {
+    static void run(List<String> args, BiConsumer<Integer, String> consumer) {
         final ProcessBuilder pb = new ProcessBuilder(args);
         final Optional<Path> home = ConfigurationHelper.getExistHome();
 

--- a/src/org/exist/start/start.config
+++ b/src/org/exist/start/start.config
@@ -104,10 +104,4 @@ tools/jetty/lib/*                                  mode == standalone
 tools/jetty/lib/*                                  mode == other
 tools/ircbot/lib/*                                 mode == jetty
 tools/aspectj/lib/*                                always
-tools/yajsw/wrapperApp.jar                         mode == other
-tools/yajsw/wrapper.jar                            mode == other
-tools/yajsw/lib/extended/velocity/velocity-%latest%.jar         mode == other
 tools/yajsw/lib/core/commons/commons-configuration2-%latest%.jar mode == other
-tools/yajsw/lib/core/commons/commons-lang3-%latest%.jar          mode == other
-tools/yajsw/lib/core/netty/netty-all-4.0.35.Final.jar           mode == other
-tools/yajsw/lib/core/jna/jna-platform-%latest%.jar              mode == other

--- a/tools/yajsw/bin/installDaemon.sh
+++ b/tools/yajsw/bin/installDaemon.sh
@@ -36,7 +36,11 @@ fi
 if [ -z "${JAVA_HOME}" ]; then
   echo -e "\nNo JAVA_HOME environment variable found!"
   echo "Attempting to determine JAVA_HOME (if this fails you must manually set it)..."
-  java_bin=$(readlink `which java`)
+  if [ "$(uname -s)" == "Darwin" ]; then
+      java_bin=$(readlink `which java`)
+  else
+      java_bin=$(readlink -f `which java`)
+  fi
   java_bin_dir=$(dirname "${java_bin}")
   JAVA_HOME=$(dirname "${java_bin_dir}")
   echo -e "Found JAVA_HOME=${JAVA_HOME}\n"

--- a/tools/yajsw/bin/installDaemon.sh
+++ b/tools/yajsw/bin/installDaemon.sh
@@ -36,7 +36,7 @@ fi
 if [ -z "${JAVA_HOME}" ]; then
   echo -e "\nNo JAVA_HOME environment variable found!"
   echo "Attempting to determine JAVA_HOME (if this fails you must manually set it)..."
-  java_bin=$(readlink -f `which java`)
+  java_bin=$(readlink `which java`)
   java_bin_dir=$(dirname "${java_bin}")
   JAVA_HOME=$(dirname "${java_bin_dir}")
   echo -e "Found JAVA_HOME=${JAVA_HOME}\n"

--- a/vm.properties
+++ b/vm.properties
@@ -3,8 +3,8 @@
 # "java -jar start.jar" without parameters on the shell).
 
 # Minimum and maximum memory
-memory.max=4096
-memory.min=192
+memory.max=2048
+memory.min=128
 
 # General vm options
 vmoptions=-Dfile.encoding=UTF-8

--- a/vm.properties
+++ b/vm.properties
@@ -3,8 +3,8 @@
 # "java -jar start.jar" without parameters on the shell).
 
 # Minimum and maximum memory
-memory.max=2048
-memory.min=64
+memory.max=4096
+memory.min=192
 
 # General vm options
 vmoptions=-Dfile.encoding=UTF-8


### PR DESCRIPTION
eXist's system tray launcher used the yajsw Java libraries to control eXist as a service. On a Mac this led to random crashes of the Java VM, likely due to library dependencies required by yajsw.  The .dmg install was thus plain unusable for most Mac users (for the last two releases of eXist).

This PR refactors the launcher to not rely on yajsw directly and thus avoid any jar dependencies on it. Instead it manages services by calling the external shell/bat scripts. Removing the yajsw dependency fixed the instability on Mac.