### PR TITLE
Fix two regressions introduced by memory leak PR

### DIFF
--- a/src/org/exist/xquery/AbstractInternalModule.java
+++ b/src/org/exist/xquery/AbstractInternalModule.java
@@ -211,5 +211,8 @@ public abstract class AbstractInternalModule implements InternalModule {
     public void reset(XQueryContext xqueryContext, boolean keepGlobals) {
         // call deprecated method for backwards compatibility
         reset(xqueryContext);
+        if (!keepGlobals) {
+            mGlobalVariables.clear();
+        }
     }
 }

--- a/src/org/exist/xquery/ExternalModuleImpl.java
+++ b/src/org/exist/xquery/ExternalModuleImpl.java
@@ -285,8 +285,6 @@ public class ExternalModuleImpl implements ExternalModule {
                 // reset state of variable declarations
                 mGlobalVariables.values().forEach(v -> v.resetState(true));
             }
-            // reset state of declared functions
-            mFunctionMap.values().forEach(f -> f.resetState(true));
             needsReset = true;
         }
     }

--- a/src/org/exist/xquery/functions/request/RequestModule.java
+++ b/src/org/exist/xquery/functions/request/RequestModule.java
@@ -79,12 +79,8 @@ public class RequestModule extends AbstractInternalModule {
         Arrays.sort(functions, new FunctionComparator());
     }
 
-    private final Variable requestVar;
-
     public RequestModule(Map<String, List<? extends Object>> parameters) throws XPathException {
         super(functions, parameters, true);
-        // predefined module global variables:
-        this.requestVar = declareVariable(REQUEST_VAR, null);
     }
 
     /* (non-Javadoc)
@@ -115,8 +111,5 @@ public class RequestModule extends AbstractInternalModule {
     @Override
     public void reset(XQueryContext xqueryContext, boolean keepGlobals) {
         super.reset(xqueryContext, keepGlobals);
-        if (!keepGlobals) {
-            requestVar.setValue(null);
-        }
     }
 }

--- a/src/org/exist/xquery/functions/response/ResponseModule.java
+++ b/src/org/exist/xquery/functions/response/ResponseModule.java
@@ -56,14 +56,9 @@ public class ResponseModule extends AbstractInternalModule
         new FunctionDef( GetExists.signature, GetExists.class )
     };
 
-    private final Variable responseVar;
-
     public ResponseModule(Map<String, List<? extends Object>> parameters) throws XPathException
     {
         super(functions, parameters);
-
-        // predefined module global variables:
-        this.responseVar = declareVariable( RESPONSE_VAR, null );
     }
 
     /* (non-Javadoc)
@@ -101,8 +96,5 @@ public class ResponseModule extends AbstractInternalModule
     @Override
     public void reset(XQueryContext xqueryContext, boolean keepGlobals) {
         super.reset(xqueryContext, keepGlobals);
-        if (!keepGlobals) {
-            responseVar.setValue(null);
-        }
     }
 }

--- a/src/org/exist/xquery/functions/session/SessionModule.java
+++ b/src/org/exist/xquery/functions/session/SessionModule.java
@@ -66,13 +66,9 @@ public class SessionModule extends AbstractInternalModule
 		new FunctionDef( GetExists.signature, GetExists.class )
 	};
 
-	private final Variable sessionVar;
-
 	public SessionModule(Map<String, List<? extends Object>> parameters) throws XPathException
 	{
 		super(functions,  parameters);
-		// predefined module global variables:
-		this.sessionVar = declareVariable( SESSION_VAR, null );
 	}
 
 	/* (non-Javadoc)
@@ -143,8 +139,5 @@ public class SessionModule extends AbstractInternalModule
     @Override
     public void reset(XQueryContext xqueryContext, boolean keepGlobals) {
         super.reset(xqueryContext, keepGlobals);
-        if (!keepGlobals) {
-            sessionVar.setValue(null);
-        }
     }
 }

--- a/src/org/exist/xquery/functions/util/Eval.java
+++ b/src/org/exist/xquery/functions/util/Eval.java
@@ -404,7 +404,7 @@ public class Eval extends BasicFunction {
 
     private void cleanup(XQueryContext evalContext, XQueryContext innerContext, DocumentSet oldDocs, LocalVariable mark, Item expr, Sequence resultSequence) {
         if(innerContext != evalContext) {
-           innerContext.reset();
+           innerContext.reset(true);
         }
 
         if(oldDocs != null) {


### PR DESCRIPTION
This PR fixes two regressions introduced by #1477:

1. in certain scenarios, the HTTP request, response and session variables were cleared before an XQuery was completed, thus causing errors. This mainly applies to the use of `util:eval`. This PR solves the issue and chooses a more general approach, by cleaning up *any* global variable declared in an internal module, thus making sure variables are always cleared (even if the module author did not think of it).
2. the changes to module cleanup in #1477 result in `resetState` being repeatedly called on module functions, which turned out to be very expensive (for complex queries there is now a measurable delay between finishing the query and returning the HTTP response). Further investigations showed that explicitely calling `resetState` on all module functions is actually unnecessary, because all used functions are already cleared via the call chain. The corresponding line in `AbstractInternalModule#resetState` can thus be removed. Module *variables* are still reset and need to be to avoid the memory leak.