### PR TITLE
Fix module cleanup performance

### DIFF
--- a/src/org/exist/xquery/ModuleContext.java
+++ b/src/org/exist/xquery/ModuleContext.java
@@ -226,7 +226,6 @@ public class ModuleContext extends XQueryContext {
 	}
 	
 	protected void setRootModule(String namespaceURI, Module module) {
-		allModules.put(namespaceURI, module);
 		parentContext.setRootModule(namespaceURI, module);
 	}
 
@@ -235,46 +234,12 @@ public class ModuleContext extends XQueryContext {
 	}
 	
 	public Iterator<Module> getAllModules() {
-		return allModules.values().iterator();
+		return parentContext.getAllModules();
 	}
 	
 	public Module getRootModule(String namespaceURI) {
 		return parentContext.getRootModule(namespaceURI);
 	}
-	
-    /**
-     * Overwritten method: the module will be loaded by the parent context, but
-     * we need to declare its namespace in the module context. 
-     */
-    public Module loadBuiltInModule(String namespaceURI, String moduleClass) {
-        Module module = getModule(namespaceURI);
-        if (module == null)
-            {module = initBuiltInModule(namespaceURI, moduleClass);}
-        if (module != null) {
-            try {
-            	final String defaultPrefix = module.getDefaultPrefix();
-            	if (!"".equals(defaultPrefix))
-            		{declareNamespace(defaultPrefix, module.getNamespaceURI());}
-            } catch (final XPathException e) {
-                LOG.warn("error while loading builtin module class " + moduleClass, e);
-            }
-        }
-        return module;
-    }
-
-    public void updateModuleRefs(XQueryContext rootContext) {
-        HashMap<String, Module> newModules = new HashMap<String, Module>(modules.size());
-        for (Module module : modules.values()) {
-            if (module.isInternalModule()) {
-                Module updated = rootContext.getModule(module.getNamespaceURI());
-                if (updated == null)
-                    {updated = module;}
-                newModules.put(module.getNamespaceURI(), updated);
-            } else
-                {newModules.put(module.getNamespaceURI(), module);}
-        }
-        modules = newModules;
-    }
     
     @Override
     final protected XPathException moduleLoadException(final String message, final String moduleLocation) throws XPathException {

--- a/test/src/org/exist/xquery/TestModule.java
+++ b/test/src/org/exist/xquery/TestModule.java
@@ -1,0 +1,101 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.xquery;
+
+import org.exist.dom.QName;
+import org.exist.xquery.value.FunctionReturnSequenceType;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.SequenceType;
+import org.exist.xquery.value.Type;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Used by {@link CleanupTest}.
+ */
+public class TestModule extends AbstractInternalModule {
+
+    private final static String MODULE_NS = "http://exist-db.org/test";
+
+    private final static FunctionDef[] functions = {
+            new FunctionDef(TestFunction.signature, TestFunction.class)
+    };
+
+    public TestModule(Map<String, List<?>> parameters) throws XPathException {
+        super(functions, parameters);
+    }
+
+    @Override
+    public String getNamespaceURI() {
+        return MODULE_NS;
+    }
+
+    @Override
+    public String getDefaultPrefix() {
+        return "t";
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public String getReleaseVersion() {
+        return null;
+    }
+
+    public static class TestFunction extends BasicFunction {
+
+        public final static FunctionSignature signature =
+                new FunctionSignature(
+                        new QName("test", MODULE_NS),
+                        "Test function",
+                        new SequenceType[] {
+                        },
+                        new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_ONE,
+                                "return value")
+                );
+
+        // used to check if resetState is called on the function
+        public boolean dummyProperty = false;
+
+        public TestFunction(XQueryContext context) {
+            super(context, signature);
+        }
+
+        @Override
+        public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
+            dummyProperty = true;
+            final Variable var = context.resolveVariable(new QName("VAR", MODULE_NS, "t"));
+            return var.getValue();
+        }
+
+        @Override
+        public void resetState(boolean postOptimization) {
+            super.resetState(postOptimization);
+            if (!postOptimization) {
+                dummyProperty = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a follow up on #1512 and #1477: imported modules are now cleaned up properly, which resulted in a performance deterioration visible on some apps making heavy use of modules. The root cause of this could be tracked down to old, unnecessary code in `ModuleContext`, resulting in every module being cleaned up several times, thus slowing down queries by up to factor 2. Modules should only track the modules they actually import, not every module available to the root context.

I carefully removed the relevant code, trying to not touch unrelated sections. Test cases have been extended to cover the corresponding cases. There are also additional tests missing in #1512.