### PR TITLE
[bugfix] Fix various Windows batch file issues

### DIFF
--- a/bin/backup.bat
+++ b/bin/backup.bat
@@ -1,23 +1,12 @@
 @echo off
 
-rem $Id$
-
 ::remove any quotes from JAVA_HOME and EXIST_HOME env vars if present
 for /f "delims=" %%G IN ("%JAVA_HOME%") DO SET "JAVA_HOME=%%~G"
 for /f "delims=" %%G IN ("%EXIST_HOME%") DO SET "EXIST_HOME=%%~G"
 
-rem Slurp the command line arguments. This loop allows for an unlimited number
-rem of arguments (up to the command line limit, anyway).
-
-set CMD_LINE_ARGS=%1
-if ""%1""=="""" goto doneStart
-shift
-:setupArgs
-if ""%1""=="""" goto doneStart
-set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
-shift
-goto setupArgs
-
+:: copy the command line args preserving equals chars etc. for things like -ouri=http://something
+for /f "tokens=*" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
+ 
 rem This label provides a place for the argument list loop to break out
 rem and for NT handling to skip to.
 

--- a/bin/backup.bat
+++ b/bin/backup.bat
@@ -2,9 +2,9 @@
 
 rem $Id$
 
-::remove any quotes from JAVA_HOME and EXIST_HOME env var, will be re-added below
-for /f "delims=" %%G IN (%JAVA_HOME%) DO SET JAVA_HOME=%%G
-for /f "delims=" %%G IN (%EXIST_HOME%) DO SET EXIST_HOME=%%G
+::remove any quotes from JAVA_HOME and EXIST_HOME env vars if present
+for /f "delims=" %%G IN ("%JAVA_HOME%") DO SET "JAVA_HOME=%%~G"
+for /f "delims=" %%G IN ("%EXIST_HOME%") DO SET "EXIST_HOME=%%~G"
 
 rem Slurp the command line arguments. This loop allows for an unlimited number
 rem of arguments (up to the command line limit, anyway).

--- a/bin/batch.d/get_opts.bat
+++ b/bin/batch.d/get_opts.bat
@@ -1,84 +1,90 @@
-rem $Id$
 @echo off
 
 set CHECK_PORT=0 
 
-:CHECK_ARG
-    set ARG=%1
+for /f "tokens=*" %%x IN ("%*") DO SET "SUB_CMD_LINE_ARGS=%%x"
 
-    if %ARG%x == x goto :EOF
+:EXTRACT_ARG
+    if "%SUB_CMD_LINE_ARGS%" == "" goto :eof
+
+    for /f "tokens=1* delims= " %%x in ("%SUB_CMD_LINE_ARGS%") DO (
+       set "SUB_CMD_LINE_ARG=%%x"
+       set "SUB_CMD_LINE_ARGS=%%y"    :: shift to the next tag
+       goto CHECK_ARG
+    )
+    if not "%SUB_CMD_LINE_ARGS%" == "" goto EXTRACT_ARG    :: loop to process the next arg
+    goto :eof    :: finished processing all args 
+
+:CHECK_ARG
+
+    :: if "%SUB_CMD_LINE_ARG%" == "" goto :EOF
 
     if %CHECK_PORT% == 1 goto CHECK_IS_PORT
 
-    if %ARG% == "-j" goto JMX_CHECK_PORT
+    if not "x%SUB_CMD_LINE_ARG:-j=%" == "x%SUB_CMD_LINE_ARG%" goto JMX_CHECK_PORT
 
-    if %ARG% == "--jmx" goto JMX_CHECK_PORT
+    if not "x%SUB_CMD_LINE_ARG:--jmx=%" == "x%SUB_CMD_LINE_ARG%" goto JMX_CHECK_PORT
 
     set OPTNAME=--jmx=
-    if %ARG:~0,6% == %OPTNAME% goto JMX_6_PORT_SET
+    if "%SUB_CMD_LINE_ARG:~0,6%" == %OPTNAME% goto JMX_6_PORT_SET
 
     set OPTNAME=-j=
-    if %ARG:~0,3% == %OPTNAME% goto JMX_3_PORT_SET
+    if "%SUB_CMD_LINE_ARG:~0,3%" == %OPTNAME% goto JMX_3_PORT_SET
 
     set OPTNAME=--jmx
-    if %ARG:~0,5% == %OPTNAME% goto JMX_5_PORT_SET
+    if "%SUB_CMD_LINE_ARG:~0,5%" == %OPTNAME% goto JMX_5_PORT_SET
 
     set OPTNAME=-j
-    if %ARG:~0,2% == %OPTNAME% goto JMX_2_PORT_SET
+    if "%SUB_CMD_LINE_ARG:~0,2%" == %OPTNAME% goto JMX_2_PORT_SET
 
     set OPTNAME=--j
-    if %ARG:~0,3% == %OPTNAME% goto JMX_3_PORT_SET
+    if "%SUB_CMD_LINE_ARG:~0,3%" == %OPTNAME% goto JMX_3_PORT_SET
 
     goto ADD_TO_JAVA_ARGS 
 
 
 :CHECK_IS_PORT
- echo Check if is port %ARG%
+ echo Check if is port %SUB_CMD_LINE_ARG%
  set CHECK_PORT=0
- if %ARG:~0,1% == "-" goto ADD_TO_JAVA_ARGS
- set JMX_PORT=%ARG%
+ if "%SUB_CMD_LINE_ARG:~0,1%" == "-" goto ADD_TO_JAVA_ARGS
+ set JMX_PORT=%SUB_CMD_LINE_ARG%
  echo JMX_PORT=%JMX_PORT%
- shift
- goto CHECK_ARG
+ goto EXTRACT_ARG
 
 :JMX_CHECK_PORT
  echo "JMX enabled"
  set JMX_ENABLED=1
  set CHECK_PORT=1
  echo CHECK_PORT=%CHECK_PORT%
- shift
- goto CHECK_ARG
+ goto EXTRACT_ARG
 
 :JMX_2_PORT_SET
  set JMX_ENABLED=1
- set JMX_PORT=%ARG:~2%
+ set JMX_PORT=%SUB_CMD_LINE_ARG:~2%
  echo JMX_PORT=%JMX_PORT%
- shift
- goto CHECK_ARG
+ goto EXTRACT_ARG
 
 :JMX_3_PORT_SET
  set JMX_ENABLED=1
- set JMX_PORT=%ARG:~3%
+ set JMX_PORT=%SUB_CMD_LINE_ARG:~3%
  echo JMX_PORT=%JMX_PORT%
- shift
- goto CHECK_ARG
+ goto EXTRACT_ARG
 
 :JMX_5_PORT_SET
  set JMX_ENABLED=1
- set JMX_PORT=%ARG:~5%
+ set JMX_PORT=%SUB_CMD_LINE_ARG:~5%
  echo JMX_PORT=%JMX_PORT%
- shift
- goto CHECK_ARG
+ goto EXTRACT_ARG
 
 :JMX_6_PORT_SET
  set JMX_ENABLED=1
- set JMX_PORT=%ARG:~6%
+ set JMX_PORT=%SUB_CMD_LINE_ARG:~6%
  echo JMX_PORT=%JMX_PORT%
- shift
- goto CHECK_ARG
+ goto EXTRACT_ARG
 
 :ADD_TO_JAVA_ARGS
- echo Adding %ARG% to JAVA_ARGS
- set JAVA_ARGS=%JAVA_ARGS% %ARG%
- shift
- goto CHECK_ARG
+ echo Adding "%SUB_CMD_LINE_ARG%" to JAVA_ARGS...
+ for /f "delims=" %%G IN ("%JAVA_ARGS%") DO SET "JAVA_ARGS=%%~G"
+ set "JAVA_ARGS=%JAVA_ARGS% %SUB_CMD_LINE_ARG%"
+ goto EXTRACT_ARG
+

--- a/bin/client.bat
+++ b/bin/client.bat
@@ -1,5 +1,5 @@
 @echo off
-rem $Id$
+
 rem
 rem In addition to the other parameter options for the interactive client 
 rem pass -j or --jmx to enable JMX agent.  The port for it can be specified 
@@ -53,9 +53,11 @@ rem @WINDOWS_INSTALLER_3@
 set JAVA_ENDORSED_DIRS="%EXIST_HOME%\lib\endorsed"
 set JAVA_OPTS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8 -Djava.endorsed.dirs=%JAVA_ENDORSED_DIRS%"
 
-set BATCH.D="%EXIST_HOME%\bin\batch.d"
-call %BATCH.D%\get_opts.bat %*
+:: copy the command line args preserving equals chars etc. for things like -ouri=http://something
+for /f "tokens=*" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
+set BATCH.D=%EXIST_HOME%\bin\batch.d
+call %BATCH.D%\get_opts.bat %CMD_LINE_ARGS%
 call %BATCH.D%\check_jmx_status.bat
 
-%JAVA_RUN% "%JAVA_OPTS%"  -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" client %JAVA_ARGS%
+%JAVA_RUN% "%JAVA_OPTS%" -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" client %JAVA_ARGS%
 :eof

--- a/bin/client.bat
+++ b/bin/client.bat
@@ -10,9 +10,9 @@ set JMX_ENABLED=0
 set JMX_PORT=1099
 set JAVA_ARGS=
 
-::remove any quotes from JAVA_HOME and EXIST_HOME env var, will be re-added below
-for /f "delims=" %%G IN (%JAVA_HOME%) DO SET JAVA_HOME=%%G
-for /f "delims=" %%G IN (%EXIST_HOME%) DO SET EXIST_HOME=%%G
+::remove any quotes from JAVA_HOME and EXIST_HOME env vars if present
+for /f "delims=" %%G IN ("%JAVA_HOME%") DO SET "JAVA_HOME=%%~G"
+for /f "delims=" %%G IN ("%EXIST_HOME%") DO SET "EXIST_HOME=%%~G"
 
 set JAVA_RUN="java"
 

--- a/bin/server.bat
+++ b/bin/server.bat
@@ -11,9 +11,9 @@ set JMX_ENABLED=0
 set JMX_PORT=1099
 set JAVA_ARGS=
 
-::remove any quotes from JAVA_HOME and EXIST_HOME env var, will be re-added below
-for /f "delims=" %%G IN (%JAVA_HOME%) DO SET JAVA_HOME=%%G
-for /f "delims=" %%G IN (%EXIST_HOME%) DO SET EXIST_HOME=%%G
+::remove any quotes from JAVA_HOME and EXIST_HOME env vars if present
+for /f "delims=" %%G IN ("%JAVA_HOME%") DO SET "JAVA_HOME=%%~G"
+for /f "delims=" %%G IN ("%EXIST_HOME%") DO SET "EXIST_HOME=%%~G"
 
 set JAVA_RUN="java"
 

--- a/bin/server.bat
+++ b/bin/server.bat
@@ -1,6 +1,5 @@
 @echo off
 
-rem $Id$
 rem
 rem In addition to the other parameter options for the standalone server 
 rem pass -j or --jmx to enable JMX agent.  The port for it can be specified 
@@ -54,8 +53,10 @@ rem @WINDOWS_INSTALLER_3@
 set JAVA_ENDORSED_DIRS="%EXIST_HOME%\lib\endorsed"
 set JAVA_OPTS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8 -Djava.endorsed.dirs=%JAVA_ENDORSED_DIRS%"
 
+:: copy the command line args preserving equals chars etc. for thinks like -ouri=http://something
+for /f "tokens=*" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
 set BATCH.D="%EXIST_HOME%\bin\batch.d"
-call %BATCH.D%\get_opts.bat %*
+call %BATCH.D%\get_opts.bat %CMD_LINE_ARGS%
 call %BATCH.D%\check_jmx_status.bat
 
 %JAVA_RUN% "%JAVA_OPTS%" -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" standalone %JAVA_ARGS%

--- a/bin/shutdown.bat
+++ b/bin/shutdown.bat
@@ -1,22 +1,11 @@
 @echo off
 
-rem $Id$
-
 ::remove any quotes from JAVA_HOME and EXIST_HOME env vars if present
 for /f "delims=" %%G IN ("%JAVA_HOME%") DO SET "JAVA_HOME=%%~G"
 for /f "delims=" %%G IN ("%EXIST_HOME%") DO SET "EXIST_HOME=%%~G"
 
-rem Slurp the command line arguments. This loop allows for an unlimited number
-rem of arguments (up to the command line limit, anyway).
-
-set CMD_LINE_ARGS=%1
-if ""%1""=="""" goto doneStart
-shift
-:setupArgs
-if ""%1""=="""" goto doneStart
-set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
-shift
-goto setupArgs
+:: copy the command line args preserving equals chars etc. for things like -ouri=http://something
+for /f "tokens=" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
 
 rem This label provides a place for the argument list loop to break out
 rem and for NT handling to skip to.

--- a/bin/shutdown.bat
+++ b/bin/shutdown.bat
@@ -2,9 +2,9 @@
 
 rem $Id$
 
-::remove any quotes from JAVA_HOME and EXIST_HOME env var, will be re-added below
-for /f "delims=" %%G IN (%JAVA_HOME%) DO SET JAVA_HOME=%%G
-for /f "delims=" %%G IN (%EXIST_HOME%) DO SET EXIST_HOME=%%G
+::remove any quotes from JAVA_HOME and EXIST_HOME env vars if present
+for /f "delims=" %%G IN ("%JAVA_HOME%") DO SET "JAVA_HOME=%%~G"
+for /f "delims=" %%G IN ("%EXIST_HOME%") DO SET "EXIST_HOME=%%~G"
 
 rem Slurp the command line arguments. This loop allows for an unlimited number
 rem of arguments (up to the command line limit, anyway).

--- a/bin/startup.bat
+++ b/bin/startup.bat
@@ -1,6 +1,5 @@
 @echo off
 
-rem $Id$
 rem
 rem In addition to the other parameter options for the Jetty container 
 rem pass -j or --jmx to enable JMX agent.  The port for it can be specified 
@@ -55,8 +54,10 @@ rem @WINDOWS_INSTALLER_3@
 set JAVA_ENDORSED_DIRS="%EXIST_HOME%\lib\endorsed"
 set JAVA_OPTS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8 -Djava.endorsed.dirs=%JAVA_ENDORSED_DIRS%"
 
+:: copy the command line args preserving equals chars etc. for things like --ouri=http://something
+for /f "tokens=*" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
 set BATCH.D="%EXIST_HOME%\bin\batch.d"
-call %BATCH.D%\get_opts.bat %*
+call %BATCH.D%\get_opts.bat %CMD_LINE_ARGS%
 call %BATCH.D%\check_jmx_status.bat
 
 %JAVA_RUN% "%JAVA_OPTS%"  -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" jetty %JAVA_ARGS%

--- a/bin/startup.bat
+++ b/bin/startup.bat
@@ -11,9 +11,9 @@ set JMX_ENABLED=0
 set JMX_PORT=1099
 set JAVA_ARGS=
 
-::remove any quotes from JAVA_HOME and EXIST_HOME env var, will be re-added below
-for /f "delims=" %%G IN (%JAVA_HOME%) DO SET JAVA_HOME=%%G
-for /f "delims=" %%G IN (%EXIST_HOME%) DO SET EXIST_HOME=%%G
+::remove any quotes from JAVA_HOME and EXIST_HOME env vars if present
+for /f "delims=" %%G IN ("%JAVA_HOME%") DO SET "JAVA_HOME=%%~G"
+for /f "delims=" %%G IN ("%EXIST_HOME%") DO SET "EXIST_HOME=%%~G"
 
 set JAVA_RUN="java"
 


### PR DESCRIPTION
Previously unquoting a quoted environment variable would cause errors like: `The system cannot find the file C:\Programs`.  This now correctly unquotes the variables.

Closes: https://github.com/eXist-db/exist/issues/1504