### PR TITLE
[refactor] Switched away from Weak References for values in the Regex Pattern Cache

### DIFF
--- a/src/org/exist/util/PatternFactory.java
+++ b/src/org/exist/util/PatternFactory.java
@@ -40,7 +40,6 @@ public class PatternFactory {
     private PatternFactory() {
         this.cache = Caffeine.newBuilder()
                 .maximumSize(1_000)
-                .weakValues()
                 .build();
     }
 


### PR DESCRIPTION
As suggested by @ben-manes. See https://github.com/eXist-db/exist/pull/1508#issuecomment-323216121
