### PR TITLE
Fix for XQuery regex flags `q` and `x`

### DIFF
--- a/src/org/exist/xquery/functions/fn/FunMatches.java
+++ b/src/org/exist/xquery/functions/fn/FunMatches.java
@@ -225,9 +225,15 @@ public class FunMatches extends Function implements Optimizable, IndexUseReporte
 		if(isCalledAs("matches-regex")) {
 			pattern = getArgument(1).eval(contextSequence).getStringValue();
 		} else {
-            final boolean ignoreWhitespace = hasIgnoreWhitespace(flags);
-            final boolean caseBlind = !caseSensitive;
-			pattern = translateRegexp(getArgument(1).eval(contextSequence).getStringValue(), ignoreWhitespace, caseBlind);
+            final boolean literal = hasLiteral(flags);
+            if(literal) {
+                // no need to change anything
+                pattern = getArgument(1).eval(contextSequence).getStringValue();
+            } else {
+                final boolean ignoreWhitespace = hasIgnoreWhitespace(flags);
+                final boolean caseBlind = !caseSensitive;
+                pattern = translateRegexp(getArgument(1).eval(contextSequence).getStringValue(), ignoreWhitespace, caseBlind);
+            }
 		}
 
         try {
@@ -242,6 +248,10 @@ public class FunMatches extends Function implements Optimizable, IndexUseReporte
             {context.getProfiler().traceIndexUsage(context, PerformanceStats.RANGE_IDX_TYPE, this,
                 PerformanceStats.OPTIMIZED_INDEX, System.currentTimeMillis() - start);}
         return preselectResult;
+    }
+
+    protected boolean hasLiteral(final int flags) {
+        return (flags & Pattern.LITERAL) != 0;
     }
 
     protected boolean hasCaseInsensitive(final int flags) {
@@ -389,9 +399,15 @@ public class FunMatches extends Function implements Optimizable, IndexUseReporte
 		if(isCalledAs("matches-regex")) {
 			pattern = getArgument(1).eval(contextSequence, contextItem).getStringValue();
 		} else {
-            final boolean ignoreWhitespace = hasIgnoreWhitespace(flags);
-            final boolean caseBlind = !caseSensitive;
-			pattern = translateRegexp(getArgument(1).eval(contextSequence, contextItem).getStringValue(), ignoreWhitespace, caseBlind);
+            final boolean literal = hasLiteral(flags);
+            if(literal) {
+                // no need to change anything
+                pattern = getArgument(1).eval(contextSequence, contextItem).getStringValue();
+            } else {
+                final boolean ignoreWhitespace = hasIgnoreWhitespace(flags);
+                final boolean caseBlind = !caseSensitive;
+                pattern = translateRegexp(getArgument(1).eval(contextSequence, contextItem).getStringValue(), ignoreWhitespace, caseBlind);
+            }
 		}
 		
         final NodeSet nodes = input.toNodeSet();
@@ -506,9 +522,15 @@ public class FunMatches extends Function implements Optimizable, IndexUseReporte
 		if( isCalledAs( "matches-regex" ) ) {
 			pattern = getArgument(1).eval(contextSequence, contextItem).getStringValue();
 		} else {
-            final boolean ignoreWhitespace = hasIgnoreWhitespace(flags);
-            final boolean caseBlind = hasCaseInsensitive(flags);
-			pattern = translateRegexp(getArgument(1).eval(contextSequence, contextItem).getStringValue(), ignoreWhitespace, caseBlind);
+            final boolean literal = hasLiteral(flags);
+            if(literal) {
+                // no need to change anything
+                pattern = getArgument(1).eval(contextSequence, contextItem).getStringValue();
+            } else {
+                final boolean ignoreWhitespace = hasIgnoreWhitespace(flags);
+                final boolean caseBlind = hasCaseInsensitive(flags);
+                pattern = translateRegexp(getArgument(1).eval(contextSequence, contextItem).getStringValue(), ignoreWhitespace, caseBlind);
+            }
 		}
         
 		return BooleanValue.valueOf(match(string, pattern, flags));
@@ -554,6 +576,9 @@ public class FunMatches extends Function implements Optimizable, IndexUseReporte
                     break;
                 case 's':
                     flags |= Pattern.DOTALL;
+                    break;
+                case 'q' :
+                    flags |= Pattern.LITERAL;
                     break;
 				default:
 					throw new XPathException("err:FORX0001: Invalid regular expression flag: " + ch);

--- a/src/org/exist/xquery/functions/fn/FunReplace.java
+++ b/src/org/exist/xquery/functions/fn/FunReplace.java
@@ -173,12 +173,25 @@ public class FunReplace extends FunMatches {
 
     		final String string = stringArg.getStringValue();
     		final Sequence patternSeq = getArgument(1).eval(contextSequence, contextItem);
-			final String pattern = translateRegexp(patternSeq.getStringValue(), hasIgnoreWhitespace(flags), hasCaseInsensitive(flags));
 
 			final Sequence replaceSeq = getArgument(2).eval(contextSequence, contextItem);
-			final String replace = replaceSeq.getStringValue();
+			String replace = replaceSeq.getStringValue();
+
+    		final String pattern;
+			if(hasLiteral(flags)) {
+				// no need to change anything in the pattern
+				pattern = patternSeq.getStringValue();
+
+				// however, $ and \ now have no special significance
+				replace = replace
+						.replace("\\", "\\\\")
+						.replace("$", "\\$");
+			} else {
+				pattern = translateRegexp(patternSeq.getStringValue(), hasIgnoreWhitespace(flags), hasCaseInsensitive(flags));
+			}
+
             //An error is raised [err:FORX0004] if the value of $replacement contains a "$" character that is not immediately followed by a digit 0-9 and not immediately preceded by a "\".
-            //An error is raised [err:FORX0004] if the value of $replacement contains a "\" character that is not part of a "\\" pair, unless it is immediately followed by a "$" character.            
+            //An error is raised [err:FORX0004] if the value of $replacement contains a "\" character that is not part of a "\\" pair, unless it is immediately followed by a "$" character.
             for (int i = 0 ; i < replace.length() ; i++) {
             	//Commented out : this seems to be a total non sense
             	/*
@@ -194,8 +207,9 @@ public class FunReplace extends FunMatches {
             	*/
             	if (replace.charAt(i) == '\\') {
             		try {
-            			if (!(replace.charAt(i + 1) == '\\' || replace.charAt(i + 1) == '$'))
-            				{throw new XPathException(this, ErrorCodes.FORX0004, "The value of $replacement contains a '\\' character that is not part of a '\\\\' pair, unless it is immediately followed by a '$' character.", replaceSeq);}
+            			if (!(replace.charAt(i + 1) == '\\' || replace.charAt(i + 1) == '$')) {
+            				throw new XPathException(this, ErrorCodes.FORX0004, "The value of $replacement contains a '\\' character that is not part of a '\\\\' pair, unless it is immediately followed by a '$' character.", replaceSeq);
+            			}
             			i++;
             		//Handle index exceptions
             		} catch (final Exception e){

--- a/src/org/exist/xquery/functions/fn/FunTokenize.java
+++ b/src/org/exist/xquery/functions/fn/FunTokenize.java
@@ -111,9 +111,14 @@ public class FunTokenize extends FunMatches {
                     pattern = " ";
                     string = FunNormalizeSpace.normalize(string);
                 } else {
-                    final boolean ignoreWhitespace = hasIgnoreWhitespace(flags);
-                    final boolean caseBlind = !hasCaseInsensitive(flags);
-                    pattern = translateRegexp(getArgument(1).eval(contextSequence, contextItem).getStringValue(), ignoreWhitespace, caseBlind);
+                    if(hasLiteral(flags)) {
+                        // no need to change anything
+                        pattern = getArgument(1).eval(contextSequence, contextItem).getStringValue();
+                    } else {
+                        final boolean ignoreWhitespace = hasIgnoreWhitespace(flags);
+                        final boolean caseBlind = !hasCaseInsensitive(flags);
+                        pattern = translateRegexp(getArgument(1).eval(contextSequence, contextItem).getStringValue(), ignoreWhitespace, caseBlind);
+                    }
                 }
 
                 try {

--- a/src/org/exist/xquery/functions/fn/FunTokenize.java
+++ b/src/org/exist/xquery/functions/fn/FunTokenize.java
@@ -98,19 +98,24 @@ public class FunTokenize extends FunMatches {
             if (string.isEmpty()) {
                 result = Sequence.EMPTY_SEQUENCE;
             } else {
+                final int flags;
+                if (getSignature().getArgumentCount() == 3) {
+                    flags = parseFlags(getArgument(2).eval(contextSequence, contextItem)
+                            .getStringValue());
+                } else {
+                    flags = 0;
+                }
+
                 final String pattern;
                 if(getArgumentCount() == 1) {
                     pattern = " ";
                     string = FunNormalizeSpace.normalize(string);
                 } else {
-                    pattern = translateRegexp(getArgument(1).eval(contextSequence, contextItem).getStringValue());
+                    final boolean ignoreWhitespace = hasIgnoreWhitespace(flags);
+                    final boolean caseBlind = !hasCaseInsensitive(flags);
+                    pattern = translateRegexp(getArgument(1).eval(contextSequence, contextItem).getStringValue(), ignoreWhitespace, caseBlind);
                 }
 
-                int flags = 0;
-                if (getSignature().getArgumentCount() == 3) {
-                    flags = parseFlags(getArgument(2).eval(contextSequence, contextItem)
-                            .getStringValue());
-                }
                 try {
                     if (pat == null || (!pattern.equals(pat.pattern())) || flags != pat.flags()) {
                         pat = PatternFactory.getInstance().getPattern(pattern, flags);

--- a/test/src/xquery/regex.xml
+++ b/test/src/xquery/regex.xml
@@ -26,6 +26,26 @@
         <code>fn:matches('exist', '[a-z]{5}')</code>
         <expected>true</expected>
     </test>
+    <test output="text">
+        <task>fn:matches-xflag-1</task>
+        <code>fn:matches('helloworld', 'hello world', 'x')</code>
+        <expected>true</expected>
+    </test>
+    <test output="text">
+        <task>fn:matches-xflag-2</task>
+        <code>fn:matches('helloworld', 'hello[ ]world', 'x')</code>
+        <expected>false</expected>
+    </test>
+    <test output="text">
+        <task>fn:matches-xflag-3</task>
+        <code>fn:matches('hello world', 'hello\ sworld', 'x')</code>
+        <expected>true</expected>
+    </test>
+    <test output="text">
+        <task>fn:matches-xflag-4</task>
+        <code>fn:matches('hello world', 'hello world', 'x')</code>
+        <expected>false</expected>
+    </test>
 
     <test output="text">
         <task>fn:replace1</task>

--- a/test/src/xquery/regex.xml
+++ b/test/src/xquery/regex.xml
@@ -46,17 +46,42 @@
         <code>fn:matches('hello world', 'hello world', 'x')</code>
         <expected>false</expected>
     </test>
+    <test output="text">
+        <task>fn:matches-qflag-1</task>
+        <code>fn:matches("abcd", ".*", "q")</code>
+        <expected>false</expected>
+    </test>
+    <test output="text">
+        <task>fn:matches-iqflags-1</task>
+        <code>fn:matches("Mr. B. Obama", "B. OBAMA", "iq")</code>
+        <expected>true</expected>
+    </test>
 
     <test output="text">
         <task>fn:replace1</task>
         <code>fn:replace('eximtdb', 'm', 's')</code>
         <expected>existdb</expected>
     </test>
-
     <test output="text">
-        <task>fn:replac2</task>
+        <task>fn:replace2</task>
         <code>fn:replace('aaaah', 'a{2,3}?', 'X')</code>
         <expected>XXh</expected>
+    </test>
+    <test output="text">
+        <task>fn:replace-qflag-1</task>
+        <code>fn:replace("a\b\c", "\", "\\", "q")</code>
+        <expected>a\\b\\c</expected>
+    </test>
+    <test output="text">
+        <task>fn:replace-qflag-2</task>
+        <code>fn:replace("a/b/c", "/", "$", "q")</code>
+        <expected>a$b$c</expected>
+    </test>
+
+    <test output="text">
+        <task>fn:tokenize-qflag-1</task>
+        <code>fn:tokenize("12.3.5.6", ".", "q")</code>
+        <expected>12 3 5 6</expected>
     </test>
 
 </TestSet>


### PR DESCRIPTION
Previouisly we did not correctly implement the `x` flag for various XQuery regular expression functions, and we did not implement `q` at all. This now implements both, hopefully correctly.

Reported by @joewiz https://github.com/eXist-db/exist/pull/1530#issuecomment-325690846