### PR TITLE
put db settings in build.properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -7,8 +7,8 @@ project.name = eXist-db
 project.version = 3.5.0-SNAPSHOT
 
 # db settings
-dataDir = webapp/WEB-INF/data
-cacheSize = 256
+config.dataDir = webapp/WEB-INF/data
+config.cacheSize = 256
 
 # build settings
 build.debug = on

--- a/build.properties
+++ b/build.properties
@@ -6,6 +6,10 @@
 project.name = eXist-db
 project.version = 3.5.0-SNAPSHOT
 
+# db settings
+dataDir = webapp/WEB-INF/data
+cacheSize = 256
+
 # build settings
 build.debug = on
 build.optimize = on

--- a/build/scripts/build-impl.xml
+++ b/build/scripts/build-impl.xml
@@ -37,8 +37,8 @@
     <property name="jvmarg" value="-Xmx128000k -Xms32000k -Djetty.home=${jetty.dir} -Dexist.home=${basedir}"/>
     <property name="xmldb.src" value="undefined"/>
     <property name="dist.dir" value="${dist}/${project.name}-${project.version}"/>
-    
-   
+
+
 
     <!-- import common targets -->
     <!-- <import file="../../build.xml"/> -->
@@ -150,13 +150,13 @@
 
         <copy file="${basedir}/conf.xml.tmpl" tofile="${basedir}/conf.xml" filtering="true">
 			<filterset>
-				<filter token="dataDir" value="webapp/WEB-INF/data"/>
-                <filter token="cacheSize" value="256"/>
+                <filter token="dataDir" value="${dataDir}"/>
+                <filter token="cacheSize" value="${cacheSize}"/>
 			</filterset>
 		</copy>
         <copy file="${basedir}/conf.xml.tmpl" tofile="${basedir}/installer/conf.xml" filtering="true">
 			<filterset>
-				<filter token="dataDir" value="$dataDir"/>
+				<filter token="dataDir" value="${dataDir}"/>
                 <filter token="cacheSize" value="${cacheSize}"/>
 			</filterset>
 		</copy>

--- a/build/scripts/build-impl.xml
+++ b/build/scripts/build-impl.xml
@@ -149,17 +149,17 @@
             filtering="true" failonerror="false"/>
 
         <copy file="${basedir}/conf.xml.tmpl" tofile="${basedir}/conf.xml" filtering="true">
-			<filterset>
-                <filter token="dataDir" value="${dataDir}"/>
-                <filter token="cacheSize" value="${cacheSize}"/>
-			</filterset>
-		</copy>
+		<filterset>
+			<filter token="dataDir" value="${config.dataDir}"/>
+			<filter token="cacheSize" value="${config.cacheSize}"/>
+		</filterset>
+	</copy>
         <copy file="${basedir}/conf.xml.tmpl" tofile="${basedir}/installer/conf.xml" filtering="true">
-			<filterset>
-				<filter token="dataDir" value="${dataDir}"/>
-                <filter token="cacheSize" value="${cacheSize}"/>
-			</filterset>
-		</copy>
+		<filterset>
+			<filter token="dataDir" value="${config.dataDir}"/>
+			<filter token="cacheSize" value="${config.cacheSize}"/>
+		</filterset>
+	</copy>
         <copy file="${basedir}/client.properties.tmpl" tofile="${basedir}/client.properties"
             filtering="true"/>
         <copy file="${basedir}/descriptor.xml.tmpl" tofile="${basedir}/descriptor.xml"

--- a/build/scripts/macosx.xml
+++ b/build/scripts/macosx.xml
@@ -186,8 +186,8 @@
         </copy>
         <copy file="${basedir}/conf.xml.tmpl" tofile="${app.exist}/conf.xml" filtering="true">
             <filterset>
-                <filter token="dataDir" value="${dataDir}"/>
-                <filter token="cacheSize" value="${cacheSize}"/>
+                <filter token="dataDir" value="${config.dataDir}"/>
+                <filter token="cacheSize" value="${config.cacheSize}"/>
             </filterset>
         </copy>
         <chmod perm="+x">

--- a/build/scripts/macosx.xml
+++ b/build/scripts/macosx.xml
@@ -186,8 +186,8 @@
         </copy>
         <copy file="${basedir}/conf.xml.tmpl" tofile="${app.exist}/conf.xml" filtering="true">
             <filterset>
-                <filter token="dataDir" value="webapp/WEB-INF/data"/>
-                <filter token="cacheSize" value="256"/>
+                <filter token="dataDir" value="${dataDir}"/>
+                <filter token="cacheSize" value="${cacheSize}"/>
             </filterset>
         </copy>
         <chmod perm="+x">


### PR DESCRIPTION
I put the database settings for `conf.xml` (in some locations) in the `build.properties file`. This is probably a good idea, and would've saved me the time to find out how this works.