### PR TITLE
Correct classpath an typos to compile with Eclipse.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -55,7 +55,7 @@
 	<classpathentry kind="lib" path="lib/core/log4j-core-2.8.2.jar"/>
 	<classpathentry kind="lib" path="lib/core/log4j-slf4j-impl-2.8.2.jar"/>
 	<classpathentry kind="lib" path="lib/core/log4j-jul-2.8.2.jar"/>
-	<classpathentry kind="lib" path="lib/core/jargo-0.4.2-SNAPSHOT-7fa1d04.jar" sourcepath="lib/core/jargo-src.zip"/>
+	<classpathentry kind="lib" path="lib/core/jargo-0.4.2-SNAPSHOT-7fa1d04.jar"/>
 	<classpathentry kind="lib" path="lib/core/xmldb.jar"/>
 	<classpathentry kind="lib" path="lib/optional/commons-httpclient-3.1.jar"/>
 	<classpathentry kind="lib" path="lib/core/commons-io-2.5.jar"/>

--- a/.classpath
+++ b/.classpath
@@ -11,11 +11,8 @@
 	<classpathentry kind="src" path="extensions/indexes/ngram/src"/>
 	<classpathentry kind="src" path="extensions/indexes/ngram/test/src"/>
 	<classpathentry excluding="org/exist/xquery/modules/cqlparser/**|org/exist/xquery/modules/jfreechart/**|org/exist/xquery/modules/memcached/**|org/exist/xquery/modules/oracle/**|org/exist/xquery/modules/xmlcalabash/**|org/exist/xquery/modules/xmpp/**|org/exist/xquery/modules/xslfo/**" kind="src" path="extensions/modules/src"/>
-	<classpathentry kind="src" path="extensions/xslt/src"/>
-	<classpathentry kind="src" path="extensions/xslt/test/src"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="test/src"/>
-	<classpathentry kind="src" path="tools/wrapper/src"/>
 	<classpathentry kind="src" path="samples/src"/>
 	<classpathentry kind="src" path="extensions/xqdoc/src"/>
 	<classpathentry kind="src" path="extensions/xqdoc/test/src"/>
@@ -25,8 +22,8 @@
 	<classpathentry kind="src" path="extensions/debuggee/test"/>
 	<classpathentry kind="src" path="extensions/webdav/src"/>
 	<classpathentry kind="src" path="extensions/commands/src"/>
-	<classpathentry kind="src" path="lib/core/j8fu-1.0.jar"/>
-	<classpathentry kind="lib" path="lib/core/pkg-repo.jar"/>
+	<classpathentry kind="lib" path="lib/core/j8fu-1.4.1.jar"/>
+	<classpathentry kind="lib" path="lib/core/pkg-java-fork.jar"/>
 	<classpathentry kind="lib" path="lib/core/caffeine-2.5.3.jar"/>
 	<classpathentry kind="lib" path="lib/core/rsyntaxtextarea-2.6.1.jar"/>
 	<classpathentry kind="lib" path="lib/endorsed/xml-apis-1.4.01.jar"/>
@@ -42,6 +39,7 @@
 	<classpathentry kind="lib" path="lib/core/xmlrpc-common-3.1.3.jar"/>
 	<classpathentry kind="lib" path="lib/core/xmlrpc-server-3.1.3.jar"/>
 	<classpathentry kind="lib" path="extensions/expath/lib/http-client-java-1.0-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="extensions/expath/lib/tools-java-1.0-SNAPSHOT.jar"/>
 	<classpathentry kind="lib" path="extensions/exquery/lib/exquery-common-1.0-SNAPSHOT.jar"/>
 	<classpathentry kind="lib" path="extensions/exquery/lib/exquery-annotations-common-api-1.0-SNAPSHOT.jar"/>
 	<classpathentry kind="lib" path="extensions/exquery/lib/exquery-annotations-common-1.0-SNAPSHOT.jar"/>
@@ -52,20 +50,18 @@
 	<classpathentry kind="lib" path="extensions/exquery/restxq/lib/exquery-restxq-1.0-SNAPSHOT.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="lib/core/antlr-2.7.7.jar"/>
-	<classpathentry kind="lib" path="lib/core/excalibur-cli-1.0.jar"/>
 	<classpathentry kind="lib" path="lib/core/jline-0.9.94.jar"/>
 	<classpathentry kind="lib" path="lib/core/log4j-api-2.8.2.jar"/>
 	<classpathentry kind="lib" path="lib/core/log4j-core-2.8.2.jar"/>
 	<classpathentry kind="lib" path="lib/core/log4j-slf4j-impl-2.8.2.jar"/>
 	<classpathentry kind="lib" path="lib/core/log4j-jul-2.8.2.jar"/>
+	<classpathentry kind="lib" path="lib/core/jargo-0.4.2-SNAPSHOT-7fa1d04.jar" sourcepath="lib/core/jargo-src.zip"/>
 	<classpathentry kind="lib" path="lib/core/xmldb.jar"/>
 	<classpathentry kind="lib" path="lib/optional/commons-httpclient-3.1.jar"/>
-	<classpathentry kind="lib" path="lib/core/commons-io-2.4.jar"/>
+	<classpathentry kind="lib" path="lib/core/commons-io-2.5.jar"/>
 	<classpathentry kind="lib" path="lib/optional/jaxrpc-1.1.jar"/>
 	<classpathentry kind="lib" path="lib/optional/saaj-1.2.jar"/>
 	<classpathentry kind="lib" path="lib/optional/wsdl4j-1.5.1.jar"/>
-	<classpathentry kind="lib" path="tools/ircbot/lib/pircbot.jar"/>
-	<classpathentry kind="lib" path="tools/wrapper/lib/wrapper.jar"/>
 	<classpathentry kind="lib" path="lib/core/jta-1.1.jar"/>
 	<classpathentry kind="lib" path="lib/core/commons-collections-3.2.2.jar"/>
         <classpathentry kind="lib" path="lib/core/commons-configuration2-2.0.jar"/>
@@ -73,13 +69,12 @@
 	<classpathentry kind="lib" path="lib/optional/jing-20091111.jar"/>
 	<classpathentry kind="lib" path="extensions/xqdoc/lib/xqdoc_conv.jar"/>
 	<classpathentry kind="lib" path="lib/user/activation-1.1.1.jar"/>
-	<classpathentry kind="lib" path="lib/test/easymock-3.2.jar"/>
-	<classpathentry kind="lib" path="lib/test/easymockclassextension-3.2.jar"/>
+	<classpathentry kind="lib" path="lib/test/easymock-3.4.jar"/>
 	<classpathentry kind="lib" path="extensions/webdav/lib/jdom-1.1.jar"/>
 	<classpathentry kind="lib" path="extensions/webdav/lib/mime-util-2.1.3.jar"/>
 	<classpathentry kind="lib" path="lib/optional/isorelax-20041111.jar"/>
 	<classpathentry kind="lib" path="lib/optional/xqjapi-1.0-fr.jar"/>
-	<classpathentry kind="lib" path="lib/core/gnu-crypto-2.0.1-min.jar"/>
+	<classpathentry kind="lib" path="lib/core/gnu-crypto-2.0.1.jar"/>
 	<classpathentry kind="lib" path="tools/jetty/lib/existdb-favicon.jar"/>
     <classpathentry kind="lib" path="tools/jetty/lib/asm-5.1.jar"/>
     <classpathentry kind="lib" path="tools/jetty/lib/asm-commons-5.1.jar"/>
@@ -105,8 +100,8 @@
 	<classpathentry kind="lib" path="extensions/webdav/lib/milton-servlet-1.8.1.3.jar"/>
 	<classpathentry kind="lib" path="extensions/exquery/lib/exquery-xquery3-1.0-SNAPSHOT.jar"/>
 	<classpathentry kind="lib" path="extensions/debuggee/lib/mina-core-2.0.5.jar"/>
-	<classpathentry kind="lib" path="lib/optional/commons-lang3-3.1.jar"/>
-	<classpathentry kind="lib" path="lib/core/quartz-2.2.1.jar"/>
+	<classpathentry kind="lib" path="lib/optional/commons-lang3-3.5.jar"/>
+	<classpathentry kind="lib" path="lib/core/quartz-2.2.3.jar"/>
 	<classpathentry kind="lib" path="extensions/indexes/lucene/lib/lucene-analyzers-common-4.10.4.jar"/>
 	<classpathentry kind="lib" path="extensions/indexes/lucene/lib/lucene-core-4.10.4.jar"/>
 	<classpathentry kind="lib" path="extensions/indexes/lucene/lib/lucene-queries-4.10.4.jar"/>
@@ -115,28 +110,28 @@
 	<classpathentry kind="lib" path="tools/ant/lib/ant-antunit-1.3.jar"/>
 	<classpathentry kind="lib" path="tools/ant/lib/ant-launcher-1.10.1.jar"/>
 	<classpathentry kind="lib" path="tools/aspectj/lib/aspectjrt-1.8.9.jar"/>
-	<classpathentry kind="lib" path="lib/core/cglib-nodep-2.2.2.jar"/>
+	<classpathentry kind="lib" path="lib/core/cglib-nodep-3.1.jar"/>
 	<classpathentry kind="lib" path="lib/core/clj-ds-0.0.4.jar"/>
 	<classpathentry kind="lib" path="lib/core/commons-codec-1.10.jar"/>
 	<classpathentry kind="lib" path="lib/core/commons-logging-1.2.jar"/>
-	<classpathentry kind="lib" path="lib/core/slf4j-api-1.7.12.jar"/>
+	<classpathentry kind="lib" path="lib/core/slf4j-api-1.7.21.jar"/>
 	<classpathentry kind="lib" path="lib/optional/commons-compress-1.14.jar"/>
-	<classpathentry kind="lib" path="lib/optional/commons-fileupload-1.3.1.jar"/>
-	<classpathentry kind="lib" path="lib/optional/commons-net-3.3.jar"/>
+	<classpathentry kind="lib" path="lib/optional/commons-fileupload-1.3.2.jar"/>
+	<classpathentry kind="lib" path="lib/optional/commons-net-3.5.jar"/>
 	<classpathentry kind="lib" path="lib/optional/fluent-hc-4.5.3.jar"/>
 	<classpathentry kind="lib" path="lib/optional/httpclient-4.5.3.jar"/>
 	<classpathentry kind="lib" path="lib/optional/httpclient-cache-4.5.3.jar"/>
 	<classpathentry kind="lib" path="lib/optional/httpcore-4.4.6.jar"/>
 	<classpathentry kind="lib" path="lib/optional/httpmime-4.5.3.jar"/>
-	<classpathentry kind="lib" path="lib/core/jackson-core-2.5.0.jar"/>
-	<classpathentry kind="lib" path="lib/endorsed/saxonhe-9.4.0.7.jar"/>
+	<classpathentry kind="lib" path="lib/core/jackson-core-2.7.4.jar"/>
+	<classpathentry kind="lib" path="lib/endorsed/Saxon-HE-9.6.0-7.jar"/>
 	<classpathentry kind="lib" path="lib/endorsed/serializer-2.7.2.jar"/>
 	<classpathentry kind="lib" path="lib/endorsed/xalan-2.7.2.jar"/>
 	<classpathentry kind="lib" path="lib/test/junit-4.12.jar"/>
-	<classpathentry kind="lib" path="lib/test/objenesis-1.2.jar"/>
+	<classpathentry kind="lib" path="lib/test/objenesis-2.2.jar"/>
 	<classpathentry kind="lib" path="lib/user/exificient-0.9.3.jar"/>
 	<classpathentry kind="lib" path="lib/user/mail-1.4.7.jar"/>
-	<classpathentry kind="lib" path="lib/user/nekohtml-1.9.21.jar"/>
+	<classpathentry kind="lib" path="lib/user/nekohtml-1.9.22.jar"/>
 	<classpathentry kind="lib" path="tools/ant/lib/xmlunit-1.6.jar"/>
 	<classpathentry kind="output" path="test/classes"/>
 	<classpathentry kind="lib" path="lib/core/jcip-annotations-1.0.jar"/>

--- a/build/scripts/installer.xml
+++ b/build/scripts/installer.xml
@@ -103,7 +103,7 @@
         </fetch>
     </target>
 
-    <target name="xars" description="Scan apps directory and include all .xar files into installer">
+    <target name="xars" depends="download-xars" description="Scan apps directory and include all .xar files into installer">
         <echo message="Processing xar packages ..."/>
         <foreach target="process-xar" param="app">
             <path>

--- a/build/scripts/installer.xml
+++ b/build/scripts/installer.xml
@@ -103,7 +103,7 @@
         </fetch>
     </target>
 
-    <target name="xars" depends="download-xars" description="Scan apps directory and include all .xar files into installer">
+    <target name="xars" description="Scan apps directory and include all .xar files into installer">
         <echo message="Processing xar packages ..."/>
         <foreach target="process-xar" param="app">
             <path>

--- a/src/org/exist/launcher/ServiceManager.java
+++ b/src/org/exist/launcher/ServiceManager.java
@@ -21,7 +21,8 @@
 package org.exist.launcher;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.util.ConfigurationHelper;
 
 import javax.swing.*;
@@ -42,7 +43,7 @@ import java.util.regex.Pattern;
 
 public class ServiceManager {
 
-    private final static Logger LOG = Logger.getLogger(ServiceManager.class);
+    private final static Logger LOG = LogManager.getLogger(ServiceManager.class);
 
     private final static Pattern STATUS_REGEX = Pattern.compile("Installed\\s*:\\s*(.*)\n\\s*Running\\s*:\\s*(.*)\n", Pattern.MULTILINE);
 

--- a/src/org/exist/util/HtmlToXmlParser.java
+++ b/src/org/exist/util/HtmlToXmlParser.java
@@ -19,8 +19,8 @@
  */
 package org.exist.util;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import com.evolvedbinary.j8fu.Either;
 import org.xml.sax.*;
 

--- a/src/org/exist/xquery/functions/xmldb/XMLDBStore.java
+++ b/src/org/exist/xquery/functions/xmldb/XMLDBStore.java
@@ -22,7 +22,7 @@
 package org.exist.xquery.functions.xmldb;
 
 import java.io.IOException;
-import java.io.InputStream;;
+import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URI;

--- a/src/org/exist/xquery/value/ValueSequence.java
+++ b/src/org/exist/xquery/value/ValueSequence.java
@@ -29,6 +29,7 @@ import org.exist.dom.persistent.*;
 import org.exist.numbering.NodeId;
 import org.exist.util.FastQSort;
 import org.exist.xquery.*;
+import org.exist.xquery.NodeTest; // Needed by Eclipse to disambiguate
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 


### PR DESCRIPTION
To compile with Eclipse

1. Correct .classpath :
replace 'lib/core/cglib-nodep-**2.2.2**.jar' with "lib/core/cglib-nodep-**3.1**.jar"/>
replace 'lib/core/commons-io-**2.4**.jar' with "lib/core/commons-io-**2.5**.jar"/> ...
replace kind="**src**" path="lib/core/j8fu-**1.0**.jar" with kind="**lib**" path="lib/core/j8fu-1.4.1.jar"..
Then Eclipse complains about typos :

2. Logger cannot be resolved to a type /eXist/src/org/exist/util/HtmlToXmlParser.java
   Replace `import org.apache.log4j.LogManager;` by `import org.apache.**logging**.log4j.LogManager;`

3. Logger cannot be resolved to a type /exist/launcher/ServiceManager.java
   Replace `import org.apache.log4j.LogManager;` by `import org.apache.**logging**.log4j.LogManager;`

4. The type NodeTest is ambiguous /eXist/src/org/exist/xquery/value/ValueSequence.java    line 563
   Add `import org.exist.xquery.NodeTest; // Needed by Eclipse` to disambiguate

5. Syntax error on token ";", delete this token /eXist/src/org/exist/xquery/functions/xmldb/XMLDBStore.java
   Replace ;; by ;
Now Eclipse reports only warnings. 