### PR TITLE
[bugfix] Fix NPE when updating an attribute

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -75,6 +75,8 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.NamedNodeMap;
 import org.xml.sax.helpers.AttributesImpl;
 
+import javax.xml.XMLConstants;
+
 
 /**
  * Class for handling all Lucene operations.
@@ -241,6 +243,9 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             NamedNodeMap attributes = parentStoredNode.getAttributes();
             for (int i = 0; i < attributes.getLength(); ++i) {
                 IStoredNode<?> attr = (IStoredNode<?>) attributes.item(i);
+                if (attr.getPrefix() != null && XMLConstants.XMLNS_ATTRIBUTE.equals(attr.getPrefix())) {
+                    continue;
+                }
                 configIt = config.getConfig(attr.getPath());
                 while (configIt.hasNext()) {
                     LuceneIndexConfig idxConfig = configIt.next();

--- a/test/src/org/exist/xquery/update/UpdateValueTest.java
+++ b/test/src/org/exist/xquery/update/UpdateValueTest.java
@@ -23,4 +23,15 @@ public class UpdateValueTest extends AbstractTestUpdate {
         queryResource(service, docName, "//t[@xml:id eq 'id2']", 1);
         queryResource(service, docName, "id('id2', /test)", 1);
     }
+
+    @Test
+    public void updateAttributeInNamespacedElement() throws XMLDBException {
+        final String docName = "docNs.xml";
+        final XQueryService service =
+            storeXMLStringAndGetQueryService(docName, "<test xmlns=\"http://test.com\" id=\"id1\"/>");
+
+        queryResource(service, docName, "declare namespace t=\"http://test.com\"; update value /t:test/@id with " +
+                "'id2'", 0);
+        queryResource(service, docName, "declare namespace t=\"http://test.com\"; /t:test[@id = 'id2']", 1);
+    }
 }


### PR DESCRIPTION
Fix NPE when updating an attribute on a namespaced element which has a lucene index defined. See test case for details.