### PR TITLE
Increases the DMG image size when building on Linux

### DIFF
--- a/build/scripts/macosx.xml
+++ b/build/scripts/macosx.xml
@@ -259,7 +259,7 @@
                     regexp="([0-9]+).+"
                     select="\1"
                     casesensitive="false"/>
-                <math result="dmg.size" operand1="${du.size}" operation="add" operand2="2" datatype="int"/>
+                <math result="dmg.size" operand1="${du.size}" operation="add" operand2="10" datatype="int"/>
             </then>
         </if>
 


### PR DESCRIPTION
Nightly builds had stopped as there was not enough space pre-allocated in the DMG