### PR TITLE
Previously Mixed-Content was not correctly serialized to JSON

### DIFF
--- a/src/org/exist/util/serializer/json/JSONObject.java
+++ b/src/org/exist/util/serializer/json/JSONObject.java
@@ -144,8 +144,8 @@ public class JSONObject extends JSONNode {
             }
 
             JSONNode next = firstChild;
-            boolean allowText = false;
-            boolean skipMixedContentText = false;
+//            boolean allowText = false;
+//            boolean skipMixedContentText = false;
             while(next != null) {
                 if(next.getType() == Type.VALUE_TYPE) {
                     /*
@@ -153,7 +153,7 @@ public class JSONObject extends JSONNode {
                      node is serialized as property "#text". 
                      Text in mixed content nodes is ignored though.
                     */
-                    if(allowText) {
+//                    if(allowText) {
                         writer.write("\"" + next.getName() + "\"");     // next.getName() returns "#text"
                         if(isIndent()) {
                             writer.write(' ');
@@ -163,29 +163,29 @@ public class JSONObject extends JSONNode {
                             writer.write(' ');
                         }
                         next.serialize(writer, false);
-                        allowText = false;
-                    } else {
-                        //writer.write("\"#mixed-content-text\" : ");
-                        skipMixedContentText = true;
-                    }
+//                        allowText = false;
+//                    } else {
+//                        //writer.write("\"#mixed-content-text\" : ");
+//                        skipMixedContentText = true;
+//                    }
                 } else {
                     next.serialize(writer, false);
                 }
 
-                if(next.getType() == Type.SIMPLE_PROPERTY_TYPE) {
-                    allowText = true;
-                }
+//                if(next.getType() == Type.SIMPLE_PROPERTY_TYPE) {
+//                    allowText = true;
+//                }
 
                 next = next.getNext();
 
-                if(next != null && !skipMixedContentText && !isMixedContentTextLast(next, allowText)) {
+                if(next != null /*&& !skipMixedContentText && !isMixedContentTextLast(next, allowText)*/) {
                     writer.write(',');
                     if(isIndent()) {
                         writer.write(' ');
                     }
                 }
 
-                skipMixedContentText = false;
+//                skipMixedContentText = false;
             }
             if(isIndent()) {
                 writer.write(' ');
@@ -194,9 +194,9 @@ public class JSONObject extends JSONNode {
         }
     }
  
-    private boolean isMixedContentTextLast(final JSONNode node, final boolean allowText) {
-        return node.getType() == Type.VALUE_TYPE && !allowText && node.equals(getLastChild());
-    }
+//    private boolean isMixedContentTextLast(final JSONNode node, final boolean allowText) {
+//        return node.getType() == Type.VALUE_TYPE && !allowText && node.equals(getLastChild());
+//    }
 
     @Override
     public String toString() {

--- a/test/src/org/exist/util/serializer/json/JSONWriterTest.java
+++ b/test/src/org/exist/util/serializer/json/JSONWriterTest.java
@@ -111,6 +111,58 @@ public class JSONWriterTest {
         }
     }
 
+    @Test
+    public void serializesMixedContent_whenAttrsPresent() throws IOException, TransformerException, ParserConfigurationException, SAXException {
+        final Node xmlDoc = parseXml(
+                "<a x='y' xx='yy'>" + EOL +
+                            "\tbefore-b" + EOL +
+                            "\t<b y='z'>before-c <c>c-value</c> after-c</b>" + EOL +
+                            "\tafter-b" + EOL +
+                        "</a>");
+
+        final Properties properties = new Properties();
+        properties.setProperty(OutputKeys.METHOD, "json");
+        properties.setProperty(OutputKeys.INDENT, "no");
+
+        final SAXSerializer serializer = new SAXSerializer();
+        try(final StringWriter writer = new StringWriter()) {
+            serializer.setOutput(writer, properties);
+            final Transformer transformer = transformerFactory.newTransformer();
+            final SAXResult saxResult = new SAXResult(serializer);
+            transformer.transform(new DOMSource(xmlDoc), saxResult);
+
+            final String result = writer.toString();
+
+            assertEquals("{\"x\":\"y\",\"xx\":\"yy\",\"#text\":[\"\\n\\tbefore-b\\n\\t\",\"\\n\\tafter-b\\n\"],\"b\":{\"y\":\"z\",\"#text\":[\"before-c \",\" after-c\"],\"c\":\"c-value\"}}", result);
+        }
+    }
+
+    @Test
+    public void serializesMixedContent() throws IOException, TransformerException, ParserConfigurationException, SAXException {
+        final Node xmlDoc = parseXml(
+                "<a>" + EOL +
+                            "\tbefore-b" + EOL +
+                            "\t<b>before-c <c>c-value</c> after-c</b>" + EOL +
+                            "\tafter-b" + EOL +
+                        "</a>");
+
+        final Properties properties = new Properties();
+        properties.setProperty(OutputKeys.METHOD, "json");
+        properties.setProperty(OutputKeys.INDENT, "no");
+
+        final SAXSerializer serializer = new SAXSerializer();
+        try(final StringWriter writer = new StringWriter()) {
+            serializer.setOutput(writer, properties);
+            final Transformer transformer = transformerFactory.newTransformer();
+            final SAXResult saxResult = new SAXResult(serializer);
+            transformer.transform(new DOMSource(xmlDoc), saxResult);
+
+            final String result = writer.toString();
+
+            assertEquals("{\"#text\":[\"\\n\\tbefore-b\\n\\t\",\"\\n\\tafter-b\\n\"],\"b\":{\"#text\":[\"before-c \",\" after-c\"],\"c\":\"c-value\"}}", result);
+        }
+    }
+
     private Document parseXml(final String xmlStr) throws ParserConfigurationException, IOException, SAXException {
         final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
         try(final InputStream is = new ByteArrayInputStream(xmlStr.getBytes(UTF_8))) {


### PR DESCRIPTION
The tests added in `test/src/org/exist/util/serializer/json/JSONWriterTest.java` show that `JSONWriterTest#serializesMixedContent_whenAttrsPresent()` would previously correctly serialize mixed content, but if you removed the attributes from the elemnents, as in `JSONWriterTest#serializesMixedContent`, then the text nodes would be incorrectly skipped. This bugfix fixes that issue.