### PR TITLE
RESTXQ handle multipart/related request and response

### DIFF
--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
@@ -173,7 +173,7 @@ class RestXqServiceImpl extends AbstractRestXqService {
                     }
                     MimeType mimeType = MimeTable.getInstance().getContentType(contentType);
 
-                    if(contentType.toLowerCase().equals("multipart/related")){
+                    if(contentType.equalsIgnoreCase("multipart/related")){
                     	
                     	// multipart/related request
                     	String encoding = request.getCharacterEncoding();
@@ -472,7 +472,7 @@ class RestXqServiceImpl extends AbstractRestXqService {
      * 
      * @see <a href="http://expath.org/spec/http-client">HTTP Client Module</a>
      */
-    private String buildBodyPartAsXmlStr(final Pattern typePtn, final Pattern transEncPtn, final String headers, String content) throws RestXqServiceException{
+    private String buildBodyPartAsXmlStr(final Pattern typePtn, final Pattern transEncPtn, final String headers, final String content) throws RestXqServiceException{
     	// find content type
     	final Matcher typeMtc = typePtn.matcher(headers);
 		String contentType = null;
@@ -492,11 +492,11 @@ class RestXqServiceImpl extends AbstractRestXqService {
 		}
 		// if the transfer encoding is BASE64 then return the the content in a http:body node
 		// and declare the media-type as binary
-		if(transferEncodeing != null && transferEncodeing.toLowerCase().equals("base64")){
+		if(transferEncodeing != null && transferEncodeing.equalsIgnoreCase("base64")){
 			return String.format("<http:body media-type=\"%s\">%s</http:body>", contentType, content);
 		}else{
-			content = Base64.getEncoder().encodeToString(content.getBytes());
-			return String.format("<http:body media-type=\"%s\">%s</http:body>", contentType, content);
+			final String encodedContent = Base64.getEncoder().encodeToString(content.getBytes());
+			return String.format("<http:body media-type=\"%s\">%s</http:body>", contentType, encodedContent);
 		}
     }
     

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
@@ -26,17 +26,10 @@
  */
 package org.exist.extensions.exquery.restxq.impl;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.io.output.ByteArrayOutputStream;

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
@@ -28,8 +28,15 @@ package org.exist.extensions.exquery.restxq.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -164,9 +171,24 @@ class RestXqServiceImpl extends AbstractRestXqService {
                     if (contentType.contains(";")) {
                         contentType = contentType.substring(0, contentType.indexOf(";"));
                     }
-
                     MimeType mimeType = MimeTable.getInstance().getContentType(contentType);
-                    if (mimeType != null && !mimeType.isXMLType()) {
+
+                    if(contentType.toLowerCase().equals("multipart/related")){
+                    	
+                    	// multipart/related request
+                    	String encoding = request.getCharacterEncoding();
+                    	if (encoding == null) {
+                            encoding = "UTF-8";
+                        }
+                    	
+                    	final byte[] partsNodeAsBytes = extractBodyParts(request, is, encoding).getBytes(encoding);
+                		final InputStream partsNodeAsIs = new ByteArrayInputStream(partsNodeAsBytes);
+                		final DocumentImpl doc = parseAsXml(partsNodeAsIs);
+                		if(doc != null){
+                			result = new SequenceImpl<>(new DocumentTypedValue(doc));
+                		}
+                    	
+                    } else if (mimeType != null && !mimeType.isXMLType()) {
 
                         //binary data
                         try {
@@ -297,4 +319,185 @@ class RestXqServiceImpl extends AbstractRestXqService {
         final String s = new String(bos.toByteArray(), encoding);
         return new StringValue(s);
     }
+    
+    /**
+     * Extract parts from multipart/related request and build XML http:multipart Node as String including body parts and headers
+     * The first body element is the root part.
+	 * Body content is represented as BASE64
+	 * 
+     * <http:multipart>
+  	 * 		<http:header name="content-id" value="..." />
+  	 *		<http:body media-type="...">...</http:body>
+	 *		.
+	 *		. 
+	 * 	</http:multipart>
+	 * 
+     */
+    private String extractBodyParts(final HttpRequest request, final InputStream is, final String encoding) throws RestXqServiceException, IOException{
+    	
+    	final String requestContentType = request.getContentType();
+    	final String boundary = getMultiPartBoundary(requestContentType);
+    	final String rootId = getRootPartId(requestContentType);
+		final String content = getRequestContent(is, encoding);
+		
+		// build http:header and http:body for each body part within a http:mulitpart as XML String
+		// @see <a href="http://expath.org/spec/http-client">HTTP Client Module</a>
+		final StringBuilder xmlPartsAsStr = new StringBuilder();
+		
+		// compile part Content-Type pattern before going through the parts
+		final Pattern contentTypePtn = Pattern.compile("(?i:Content-Type): (.*?)(;|\\s|$)");
+		final Pattern contentIdPtn = Pattern.compile("(?i:Content-ID): (.*?)(;|\\s|$)");
+		final Pattern contTransEncPtn = Pattern.compile("(?i:Content-Transfer-Encoding): (.*?)(;|\\s|$)");
+		
+		// split the content by boundary and try to extract part headers for each split.
+		// Its a valid part if headers contain a content-type 
+		// and the are followed by an empty line then part contents
+		final String[] parts = content.split("--" + boundary);
+		boolean isRootFound = false;
+		for(int i = 0; i < parts.length; i++){
+			
+			final int seperatorIndex = parts[i].indexOf("\n\n");
+			// not a valid part
+			if(seperatorIndex <= 0){
+				continue;
+			}
+			final String partHeaders = parts[i].substring(0, seperatorIndex);
+			
+			// find content ID
+			final Matcher mtc = contentIdPtn.matcher(partHeaders);
+			String partContentId = "";
+			// leave content id empty if it is not present
+			// @see <a href="https://tools.ietf.org/html/rfc2387#section-6.1">RFC 2387</a>
+			if(mtc.find()){
+				partContentId = mtc.group(1);
+			}
+			
+			// determine whether current body part is a root part
+			boolean isRoot = false;
+			if(!isRootFound){
+				if(rootId != null && !rootId.isEmpty()){
+    				if(rootId.equals(partContentId)){
+    					isRoot = true;
+    					isRootFound = true;
+    				}
+    			}else{
+    				isRoot = true;
+					isRootFound = true;
+    			}
+			}
+			
+			// remove first and last <> from part content id
+			if(partContentId.startsWith("<") && partContentId.endsWith(">")){
+				partContentId = partContentId.substring(1, partContentId.length() - 1);
+			}
+			// content-id as part http:headers
+			// @see <a href="http://expath.org/spec/http-client">HTTP Client Module</a>
+			final String contIdAsHeaderElem = String.format("<http:header name=\"content-id\" value=\"%s\"/>", partContentId);
+			
+			// extract content and remove last character (line break)
+			// @see <a href="https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html">RFC 1341 (MIME)</a>
+			String partContent = parts[i].substring(seperatorIndex + 2);
+			partContent = partContent.substring(0, partContent.length() -1);
+			final String contAsBodyElem = buildBodyPartAsXmlStr(contentTypePtn, contTransEncPtn, partHeaders, partContent);
+			
+			// if current part is a root one then insert at the begin of the list
+			if(isRoot){
+				xmlPartsAsStr.insert(0, contAsBodyElem);
+				xmlPartsAsStr.insert(0, contIdAsHeaderElem); 
+			}else{
+				xmlPartsAsStr.append(contIdAsHeaderElem);
+				xmlPartsAsStr.append(contAsBodyElem);
+			}
+		}
+		
+		final String httpNs = "http://expath.org/ns/http-client";
+		xmlPartsAsStr.insert(0, String.format("<http:multipart xmlns:http=\"%s\">", httpNs));
+		xmlPartsAsStr.append("</http:multipart>");
+		
+		return xmlPartsAsStr.toString();
+    }
+    
+    /**
+     * Get Multipart Boundary from request content-type header
+     */
+    private String getMultiPartBoundary(final String contentType) throws RestXqServiceException{
+    	
+    	final String boundaryRegExp = "boundary=['\"]{0,1}(.*?)('|\"|;|\\s|$)";
+    	final Pattern ptn = Pattern.compile(boundaryRegExp);
+		final Matcher mtc = ptn.matcher(contentType);
+		String boundary = null;
+		if(mtc.find()){
+			boundary = mtc.group(1);
+		}
+		if(boundary == null || boundary.isEmpty()){
+			throw new RestXqServiceException("No multipart boundary could be found");
+		}
+		return boundary;
+    }
+    
+    /**
+     * Get root part ID
+     * If start parameter not present in Content-Type then
+     * the first body part is root part
+     * @see <a href="https://tools.ietf.org/html/rfc2387#section-3.2">RFC 2387</a>
+     */
+    private String getRootPartId(final String contentType){
+    	
+    	final String rootIdRegExp = "start=['\"]{0,1}(.*?)('|\"|;|\\s|$)";
+		final Pattern ptn = Pattern.compile(rootIdRegExp);
+		final Matcher mtc = ptn.matcher(contentType);
+		if(mtc.find()){
+			return mtc.group(1);
+		}else{
+			return null;
+		}
+    }
+    
+    /**
+     * Get request body as String from InputStream
+     */
+    private String getRequestContent(final InputStream is, final String encoding) throws RestXqServiceException, IOException{
+    	final String content;
+    	try (BufferedReader buffer = new BufferedReader(new InputStreamReader(is, encoding))) {
+    		content = buffer.lines().collect(Collectors.joining("\n"));
+    	}
+    	if(content == null || content.isEmpty()){
+    		throw new RestXqServiceException("Request content could not be readed");
+    	}
+    	return content;
+    }
+    
+    /**
+     * Build a http:body xml node as String including a media-type attribute 
+     * 
+     * @see <a href="http://expath.org/spec/http-client">HTTP Client Module</a>
+     */
+    private String buildBodyPartAsXmlStr(final Pattern typePtn, final Pattern transEncPtn, final String headers, String content) throws RestXqServiceException{
+    	// find content type
+    	final Matcher typeMtc = typePtn.matcher(headers);
+		String contentType = null;
+		if(typeMtc.find()){
+			contentType = typeMtc.group(1);
+		}
+		// not a valid part if content-type is not present
+		if(contentType == null || contentType.isEmpty()){
+			throw new RestXqServiceException("No body part Content-Type could be found");
+		}
+    	
+    	// find transfer encoding
+    	final Matcher transEncMtc = transEncPtn.matcher(headers);
+		String transferEncodeing = null;
+		if(transEncMtc.find()){
+			transferEncodeing = transEncMtc.group(1);
+		}
+		// if the transfer encoding is BASE64 then return the the content in a http:body node
+		// and declare the media-type as binary
+		if(transferEncodeing != null && transferEncodeing.toLowerCase().equals("base64")){
+			return String.format("<http:body media-type=\"%s\">%s</http:body>", contentType, content);
+		}else{
+			content = Base64.getEncoder().encodeToString(content.getBytes());
+			return String.format("<http:body media-type=\"%s\">%s</http:body>", contentType, content);
+		}
+    }
+    
 }

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceSerializerImpl.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceSerializerImpl.java
@@ -96,7 +96,7 @@ class RestXqServiceSerializerImpl extends AbstractRestXqServiceSerializer {
     		final SequenceAdapter sequence = (SequenceAdapter)result;
     		final org.exist.xquery.value.Sequence existSeq = sequence.getExistSequence();
     		
-    		if(existSeq.hasOne() && ((Node)existSeq.itemAt(0)).getLocalName().toLowerCase().equals("multipart")){
+    		if(existSeq.hasOne() && ((Node)existSeq.itemAt(0)).getLocalName().equalsIgnoreCase("multipart")){
     			// get boundary
     			final Node multipart = (Node)existSeq.itemAt(0);
     			final Node boundaryAttr = multipart.getAttributes().getNamedItem("boundary");
@@ -113,7 +113,7 @@ class RestXqServiceSerializerImpl extends AbstractRestXqServiceSerializer {
     			for(int i = 0; i < nodeList.getLength(); i++){
     				final Node node = nodeList.item(i);
     				final Node nameAttr = node.getAttributes().getNamedItem("name");
-    				if(nameAttr != null && nameAttr.getNodeValue().toLowerCase().equals("content-id")){
+    				if(nameAttr != null && nameAttr.getNodeValue().equalsIgnoreCase("content-id")){
     					rootId = node.getAttributes().getNamedItem("value").getNodeValue();
     					break;
     				}
@@ -201,6 +201,8 @@ class RestXqServiceSerializerImpl extends AbstractRestXqServiceSerializer {
  					case Node.TEXT_NODE:
  						strBuilder.append(pNode.getNodeValue());
  						break;
+					default:
+ 						throw new RestXqServiceException(pNode.getNodeType() + " node type is not supported");
  					}
  				}
  				strBuilder.append("\n");

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/xdm/type/impl/Multipart.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/xdm/type/impl/Multipart.java
@@ -1,0 +1,204 @@
+package org.exist.extensions.exquery.xdm.type.impl;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.exist.dom.QName;
+import org.exist.dom.memtree.DocumentImpl;
+import org.exist.dom.memtree.MemTreeBuilder;
+import org.exquery.restxq.RestXqServiceException;
+
+public class Multipart {
+	
+	private final String boundary;
+	
+	private final String rootId;
+	
+	private final String encoding;
+	
+	private final List<MultipartEntity> entities;
+	
+	private final MemTreeBuilder builder;
+	
+	private static final String NAME_SPACE_URI = "http://expath.org/ns/http-client";
+	private static final String ELEM_PREFIX = "http";
+	
+	private static final String CT_BOUNDARY_REGEX = "boundary=['\"]{0,1}(.*?)('|\"|;|\\s|$)";
+	private static final String CT_START_PARAM_REGEX = "start=['\"]{0,1}(.*?)('|\"|;|\\s|$)";
+	
+	public Multipart(final String contentTypeHeader, final InputStream is, final String encoding) throws RestXqServiceException, IOException{
+		this.boundary = getMultiPartBoundary(contentTypeHeader);
+		this.rootId = getRootPartId(contentTypeHeader);
+		this.encoding = encoding;
+		
+		this.builder = new MemTreeBuilder();
+		this.builder.startDocument();
+		this.builder.startElement(new QName("multipart", NAME_SPACE_URI, ELEM_PREFIX) , null);
+		
+		this.entities = new ArrayList<MultipartEntity>();
+		
+		final BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+		// move to the first boundary delimiter
+		String line;
+		while((line = reader.readLine()) != null){
+			if(line.equals("--" + this.boundary)){
+				break;
+			}
+		}
+		// get multipart entities
+        while (reader.ready()) {
+        	this.entities.add(new MultipartEntity(reader, this.boundary));
+        }
+        
+        moveRootEntityToHead();
+        
+        for(final MultipartEntity entity : this.entities){
+        	buildEntityHeaderElements(entity.getHeaders(), this.builder);
+    		buildEntityBodyElement(entity, this.builder);
+    	}
+        
+		this.builder.endElement();
+		this.builder.endDocument();
+		
+	}
+	
+	public String getBoundary() {
+		return this.boundary;
+	}
+
+	public String getRootId() {
+		return this.rootId;
+	}
+
+	public String getEncoding() {
+		return this.encoding;
+	}
+	
+	public List<MultipartEntity> getEntities(){
+		return this.entities;
+	}
+	
+	public DocumentImpl getDocument(){
+		return this.builder.getDocument();
+	}
+	
+	/**
+	 * Builds a http:header element for each entity header in a given builder.
+	 * This method ignores Content-Type and Content-Transfer-Encoding headers,
+	 * cause there information are present in entity http:body element.
+	 * 
+	 * @param headers entity headers map
+	 * @param builder {@link MemTreeBuilder}
+	 */
+	private void buildEntityHeaderElements(final TreeMap<String, String> headers, final MemTreeBuilder builder){
+		for(final Entry<String, String> entry: headers.entrySet()){
+			final String headerName = entry.getKey();
+			if(headerName.equalsIgnoreCase("Content-Type") || headerName.equalsIgnoreCase("Content-Transfer-Encoding")){
+				continue;
+			}
+			builder.startElement(new QName("header", NAME_SPACE_URI, ELEM_PREFIX), null);
+			builder.addAttribute(new QName("name", null), headerName);
+			builder.addAttribute(new QName("value", null), entry.getValue());
+			builder.endElement();
+		}
+	}
+	
+	/**
+	 * Builds a http:body element in a given builder.
+	 * The Content-Type is present as media-type element attribute and the body content is decoded as base64
+	 * if the Content-Transfer-Encoding is not base64.
+	 * 
+	 * @param entity {@link MultipartEntity}
+	 * @param builder {@link MemTreeBuilder}
+	 * @throws RestXqServiceException will be thrown if an entity does not have a Content-Type header
+	 */
+	private void buildEntityBodyElement(final MultipartEntity entity, final MemTreeBuilder builder) throws RestXqServiceException{
+		final String entityContentType = entity.getHeaders().get("Content-Type");
+		final String transferEncoding = entity.getHeaders().get("Content-Transfer-Encoding");
+		
+		if(entityContentType == null || entityContentType.isEmpty()){
+			throw new RestXqServiceException("No body part Content-Type could be found");
+		}
+		
+		final QName body = new QName("body", NAME_SPACE_URI, ELEM_PREFIX);
+		builder.startElement(body, null);
+		builder.addAttribute(new QName("media-type", null), entityContentType);
+		
+		final String content;
+		if(transferEncoding != null && transferEncoding.equalsIgnoreCase("base64")){
+			content = entity.getContent();
+		}else{
+			content = Base64.getEncoder().encodeToString(entity.getContent().getBytes());
+		}
+		
+		builder.characters(content);
+		builder.endElement();
+	}
+	
+	/**
+	 * Removes root entity if found to and insert it to head of the entities list by shifting next elements to right.
+	 * 
+	 * @throws RestXqServiceException will be thrown if start parameter is present in header and no root entity could be found 
+	 */
+	private void moveRootEntityToHead() throws RestXqServiceException{
+		boolean isRootFound = false;
+        if(this.rootId != null && !this.rootId.isEmpty()){
+        	for(int i = 0; i < this.entities.size(); i++){
+        		final MultipartEntity entity = this.entities.get(i);
+        		final String contentId = entity.getHeaders().get("content-id");
+        		if(this.rootId.equals(contentId)){
+        			this.entities.remove(i);
+        			this.entities.add(0, entity);
+        			isRootFound = true;
+        			break;
+        		}
+        	}
+        	if(!isRootFound){
+            	throw new RestXqServiceException("MUTLIPART ERROR: Start parameter is present but does not refer to any part");
+            }
+        }
+	}
+
+	/**
+     * Get Multipart Boundary from request content-type header
+     */
+    private String getMultiPartBoundary(final String contentType) throws RestXqServiceException{
+    	final String boundaryRegExp = CT_BOUNDARY_REGEX;
+    	final Pattern ptn = Pattern.compile(boundaryRegExp);
+		final Matcher mtc = ptn.matcher(contentType);
+		String boundary = null;
+		if(mtc.find()){
+			boundary = mtc.group(1);
+		}
+		if(boundary == null || boundary.isEmpty()){
+			throw new RestXqServiceException("No multipart boundary could be found");
+		}
+		return boundary;
+    }
+    
+    /**
+     * Get root part ID
+     * If start parameter not present in Content-Type then
+     * the first body part is root part
+     * @see <a href="https://tools.ietf.org/html/rfc2387#section-3.2">RFC 2387</a>
+     */
+    private String getRootPartId(final String contentType){
+    	final String rootIdRegExp = CT_START_PARAM_REGEX;
+		final Pattern ptn = Pattern.compile(rootIdRegExp);
+		final Matcher mtc = ptn.matcher(contentType);
+		if(mtc.find()){
+			return mtc.group(1);
+		}else{
+			return null;
+		}
+    }
+}

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/xdm/type/impl/MultipartEntity.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/xdm/type/impl/MultipartEntity.java
@@ -1,0 +1,52 @@
+package org.exist.extensions.exquery.xdm.type.impl;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.TreeMap;
+
+public class MultipartEntity{
+	
+	private final TreeMap<String, String> headers;
+
+	private final String content; 
+	
+	public MultipartEntity(final BufferedReader reader, final String boundary) throws IOException{
+		this.headers = getHeadersMap(reader);
+		this.content = getEntityContent(reader, boundary);
+	}
+
+	private TreeMap<String, String> getHeadersMap(final BufferedReader reader) throws IOException{
+		final TreeMap<String, String> headersMap = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+		String line;
+        while ((line = reader.readLine()) != null) {
+        	if(!line.equals("")){
+        		final String[] headerSplit = line.split(": ");
+        		headersMap.put(headerSplit[0], headerSplit[1]);
+        	}else{
+        		break;
+        	}
+        }
+        return headersMap;
+	}
+
+	public TreeMap<String, String> getHeaders() {
+		return headers;
+	}
+	
+	public String getEntityContent(final BufferedReader reader, final String boundary) throws IOException{
+		final StringBuffer strBuffer = new StringBuffer();
+		String line;
+        while ((line = reader.readLine()) != null) {
+        	if(!line.equals("--" + boundary) && !line.equals("--" + boundary + "--")){
+        		strBuffer.append(line);
+        	}else{
+        		break;
+        	}
+        }
+		return strBuffer.toString();
+	}
+
+	public String getContent() {
+		return content;
+	}
+}

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/xdm/type/impl/MultipartEntity.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/xdm/type/impl/MultipartEntity.java
@@ -19,7 +19,7 @@ public class MultipartEntity{
 		final TreeMap<String, String> headersMap = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
 		String line;
         while ((line = reader.readLine()) != null) {
-        	if(!line.equals("")){
+        	if(!line.isEmpty()){
         		final String[] headerSplit = line.split(": ");
         		headersMap.put(headerSplit[0], headerSplit[1]);
         	}else{

--- a/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartRelatedRequestTest.java
+++ b/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartRelatedRequestTest.java
@@ -126,15 +126,63 @@ public class MultipartRelatedRequestTest extends MultipartTest {
     	final Node multipartNode = getMultipartFromPostResponse(post);
     	assertEquals(200, post.getStatusCode());
     	
+    	/*
+    	 * Multipart childs
+    	 * 
+    	 * <http:header name="Content-ID" value="test1"/>
+    	 * <http:body media-type="text/plain">VEVTVCBDT05URU5UIDE=</http:body>
+    	 * <http:header name="Content-ID" value="test2"/>
+    	 * <http:body media-type="text/xml">PGRhdGE+VEVTVCBDT05URU5UIDI8L2RhdGE+</http:body>
+    	 */
 		final Node firstHeader = multipartNode.getChildNodes().item(0);
 		assertEquals(2, firstHeader.getAttributes().getLength());
 		assertEquals("name", firstHeader.getAttributes().item(0).getNodeName());
-		assertEquals("content-id", firstHeader.getAttributes().item(0).getNodeValue());
+		assertEquals("Content-ID", firstHeader.getAttributes().item(0).getNodeValue());
 		
 		final Node secondHeader = multipartNode.getChildNodes().item(2);
 		assertEquals(2, secondHeader.getAttributes().getLength());
 		assertEquals("name", secondHeader.getAttributes().item(0).getNodeName());
-		assertEquals("content-id", secondHeader.getAttributes().item(0).getNodeValue());
+		assertEquals("Content-ID", secondHeader.getAttributes().item(0).getNodeValue());
+    }
+    
+    @Test
+    public void partsAdditionalHeadersTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String contentTypeHeader = "multipart/related; boundary='TEST_BOUNDARY'";
+    	final String customHeader = "Custom-Header";
+    	final String customHeaderValue = "header-content";
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test1\n"+
+    			customHeader + ": " + customHeaderValue + "\n"+ 
+    			"\n"+
+    			"TEST CONTENT 1\n"+
+    			"--TEST_BOUNDARY--";
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	final Node multipartNode = getMultipartFromPostResponse(post);
+    	assertEquals(200, post.getStatusCode());
+    	
+    	/*
+    	 * Multipart childs
+    	 * 
+    	 * <http:header name="Content-ID" value="test1"/>
+    	 * <http:header name="Custom-Header" value="header-content"/>
+    	 * <http:body media-type="text/xml">VEVTVCBDT05URU5UIDE=</http:body>
+    	 */
+    	
+		final Node firstHeader = multipartNode.getChildNodes().item(0);
+		assertEquals(2, firstHeader.getAttributes().getLength());
+		assertEquals("name", firstHeader.getAttributes().item(0).getNodeName());
+		assertEquals("Content-ID", firstHeader.getAttributes().item(0).getNodeValue());
+		
+		final Node secondHeader = multipartNode.getChildNodes().item(1);
+		assertEquals(2, secondHeader.getAttributes().getLength());
+		assertEquals("name", secondHeader.getAttributes().item(0).getNodeName());
+		assertEquals(customHeader, secondHeader.getAttributes().item(0).getNodeValue());
+		assertEquals("value", secondHeader.getAttributes().item(1).getNodeName());
+		assertEquals(customHeaderValue, secondHeader.getAttributes().item(1).getNodeValue());
     }
     
     @Test

--- a/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartRelatedRequestTest.java
+++ b/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartRelatedRequestTest.java
@@ -1,0 +1,388 @@
+package org.exist.extensions.exquery.restxq.impl.multipart;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.exist.util.Base64Encoder;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Tests multipart/related requests in restXQ.
+ * 
+ * Send a multipart/related request to an restXQ endpoint, with post header in the following form:
+ * 
+ *  Content-Type: "multipart/related; start='ROOT_PART_CONTENT_ID'; boundary='TEST_BOUNDARY'"
+ * 
+ * and post request:
+ * 	--TEST_BOUNDARY
+ *	Content-Type: text/plain
+ *	Content-Transfer-Encoding: 8bit
+ *	Content-ID: test1
+ *
+ *	TEST CONTENT 1
+ *	--TEST_BOUNDARY
+ *	Content-Type: text/xml
+ *	Content-Transfer-Encoding: 8bit
+ *	 Content-ID: test2
+ *
+ *	TEST CONTENT 2
+ *	--TEST_BOUNDARY
+ *	Content-Type: text/plain
+ *	Content-Transfer-Encoding: base46
+ *	Content-ID: test3
+ *
+ *	VEVTVCBDT05URU5UIDM=
+ *	--TEST_BOUNDARY--
+ *
+ * If start parameter is not setted then the first part is a root part by default. 
+ * The expected results is a http:multipart element with a http:header for each http:body childs elements:
+ *
+ *	<http:multipart xmlns:http="http://expath.org/ns/http-client">
+ *    	<http:header name="content-id" value="test1"/>
+ *    	<http:body media-type="text/plain">VEVTVCBDT05URU5UIDE=</http:body>
+ *    	<http:header name="content-id" value="test2"/>
+ *    	<http:body media-type="text/xml">PGRhdGE+VEVTVCBDT05URU5UIDI8L2RhdGE+</http:body>
+ *    	<http:header name="content-id" value="test3"/>
+ *    	<http:body media-type="text/plain">VEVTVCBDT05URU5UIDM=</http:body>
+ *	</http:multipart>
+ *
+ * The first body element is the root part.
+ * If part header "Content-Transfer-Encoding" is setted to base64 then the part content will not be encoded,
+ * otherwise the content will be encoded to base64
+ * 
+ * 
+ * @author Maan Al Balkhi <maan.al.balkhi@gmail.com>
+ * 
+ */
+public class MultipartRelatedRequestTest extends MultipartTest {
+	
+	private static final String TEST_URL = REQUEST_URL + "/requestTest";
+	
+    @Test
+    public void multipartXMlTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String contentTypeHeader = "multipart/related; boundary='TEST_BOUNDARY'";
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test1\n"+
+    			"\n"+
+    			"TEST CONTENT 1\n"+
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/xml\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test2\n"+
+    			"\n"+
+    			"<data>TEST CONTENT 2</data>\n"+
+    			"--TEST_BOUNDARY--";
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	final Node multipartNode = getMultipartFromPostResponse(post);
+    	assertEquals(200, post.getStatusCode());
+    	
+		assertEquals("http:multipart", multipartNode.getNodeName());
+		assertEquals("http://expath.org/ns/http-client", multipartNode.getNamespaceURI());
+		
+		final NodeList childNodes = multipartNode.getChildNodes();
+		
+		assertEquals(4, childNodes.getLength());
+		assertEquals("http:header", childNodes.item(0).getNodeName());
+		assertEquals("http:body", childNodes.item(1).getNodeName());
+		assertEquals("http:header", childNodes.item(2).getNodeName());
+		assertEquals("http:body", childNodes.item(3).getNodeName());
+    }
+    
+    @Test
+    public void partsHeadersNameAttributeTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String contentTypeHeader = "multipart/related; boundary='TEST_BOUNDARY'";
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test1\n"+
+    			"\n"+
+    			"TEST CONTENT 1\n"+
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/xml\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test2\n"+
+    			"\n"+
+    			"<data>TEST CONTENT 2</data>\n"+
+    			"--TEST_BOUNDARY--";
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	final Node multipartNode = getMultipartFromPostResponse(post);
+    	assertEquals(200, post.getStatusCode());
+    	
+		final Node firstHeader = multipartNode.getChildNodes().item(0);
+		assertEquals(2, firstHeader.getAttributes().getLength());
+		assertEquals("name", firstHeader.getAttributes().item(0).getNodeName());
+		assertEquals("content-id", firstHeader.getAttributes().item(0).getNodeValue());
+		
+		final Node secondHeader = multipartNode.getChildNodes().item(2);
+		assertEquals(2, secondHeader.getAttributes().getLength());
+		assertEquals("name", secondHeader.getAttributes().item(0).getNodeName());
+		assertEquals("content-id", secondHeader.getAttributes().item(0).getNodeValue());
+    }
+    
+    @Test
+    public void partsHeadersValueAttributeTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String contentTypeHeader = "multipart/related; boundary='TEST_BOUNDARY'";
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test1\n"+
+    			"\n"+
+    			"TEST CONTENT 1\n"+
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/xml\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test2\n"+
+    			"\n"+
+    			"<data>TEST CONTENT 2</data>\n"+
+    			"--TEST_BOUNDARY--";
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	final Node multipartNode = getMultipartFromPostResponse(post);
+    	assertEquals(200, post.getStatusCode());
+    	
+		final Node firstHeader = multipartNode.getChildNodes().item(0);
+		assertEquals(2, firstHeader.getAttributes().getLength());
+		assertEquals("value", firstHeader.getAttributes().item(1).getNodeName());
+		assertEquals("test1", firstHeader.getAttributes().item(1).getNodeValue());
+		
+		final Node secondHeader = multipartNode.getChildNodes().item(2);
+		assertEquals(2, secondHeader.getAttributes().getLength());
+		assertEquals("value", secondHeader.getAttributes().item(1).getNodeName());
+		assertEquals("test2", secondHeader.getAttributes().item(1).getNodeValue());
+    }
+    
+    @Test
+    public void partsBodiesAttributeTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String contentTypeHeader = "multipart/related; boundary='TEST_BOUNDARY'";
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test1\n"+
+    			"\n"+
+    			"TEST CONTENT 1\n"+
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/xml\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test2\n"+
+    			"\n"+
+    			"<data>TEST CONTENT 2</data>\n"+
+    			"--TEST_BOUNDARY--";
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	final Node multipartNode = getMultipartFromPostResponse(post);
+    	assertEquals(200, post.getStatusCode());
+    	
+		final Node firstBody = multipartNode.getChildNodes().item(1);
+		assertEquals(1, firstBody.getAttributes().getLength());
+		assertEquals("media-type", firstBody.getAttributes().item(0).getNodeName());
+		
+		final Node secondBody = multipartNode.getChildNodes().item(3);
+		assertEquals(1, secondBody.getAttributes().getLength());
+		assertEquals("media-type", secondBody.getAttributes().item(0).getNodeName());
+    }
+    
+    @Test
+    public void partsBodiesMediaTypeTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String contentTypeHeader = "multipart/related; boundary='TEST_BOUNDARY'";
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test1\n"+
+    			"\n"+
+    			"TEST CONTENT 1\n"+
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/xml\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test2\n"+
+    			"\n"+
+    			"<data>TEST CONTENT 2</data>\n"+
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: application/pdf\n"+
+    			"Content-Transfer-Encoding: base64\n"+
+    			"Content-ID: test3\n"+
+    			"\n"+
+    			"VEVTVCBDT05URU5UIDM=\n"+
+    			"--TEST_BOUNDARY--";
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	final Node multipartNode = getMultipartFromPostResponse(post);
+    	assertEquals(200, post.getStatusCode());
+    	
+		final Node firstBody = multipartNode.getChildNodes().item(1);
+		assertEquals("text/plain", firstBody.getAttributes().item(0).getNodeValue());
+		
+		final Node secondBody = multipartNode.getChildNodes().item(3);
+		assertEquals("text/xml", secondBody.getAttributes().item(0).getNodeValue());
+		
+		final Node thirdBody = multipartNode.getChildNodes().item(5);
+		assertEquals("application/pdf", thirdBody.getAttributes().item(0).getNodeValue());
+    }
+    
+    @Test
+    public void partsBodiesContentTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String contentTypeHeader = "multipart/related; boundary='TEST_BOUNDARY'";
+    	
+    	final String content1 = "TEST CONTENT 1";
+    	final String content2 = "<data>TEST CONTENT 2</data>";
+    	final String content3 = "VEVTVCBDT05URU5UIDM=";
+    	
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test1\n"+
+    			"\n"+
+    			content1 + "\n"+
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/xml\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test2\n"+
+    			"\n"+
+    			content2 + "\n"+
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+    			"Content-Transfer-Encoding: base64\n"+
+    			"Content-ID: test3\n"+
+    			"\n"+
+    			content3 + "\n"+
+    			"--TEST_BOUNDARY--";	  		   
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	final Node multipartNode = getMultipartFromPostResponse(post);
+    	assertEquals(200, post.getStatusCode());
+    	
+		final Node firstBody = multipartNode.getChildNodes().item(1);
+		final Base64Encoder enc = new Base64Encoder();
+        enc.translate(content1.getBytes());
+		assertEquals(new String(enc.getCharArray()), firstBody.getTextContent());
+		
+		final Node secondBody = multipartNode.getChildNodes().item(3);
+		enc.reset();
+		enc.translate(content2.getBytes());
+		assertEquals(new String(enc.getCharArray()), secondBody.getTextContent());
+		
+		// if Content-Transfer-Encoding is base64 then it will be not encoded
+		final Node thirdBody = multipartNode.getChildNodes().item(5);
+		assertEquals(content3, thirdBody.getTextContent());
+    }
+    
+    @Test
+    public void rootPartTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String rootContentId = "test2";
+    	
+    	final String contentTypeHeader = "multipart/related; start='" + rootContentId + "'; boundary='TEST_BOUNDARY'";
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+				"Content-Transfer-Encoding: 8bit\n"+
+				"Content-ID: test1\n"+
+				"\n"+
+				"TEST CONTENT 1\n"+
+				"--TEST_BOUNDARY\n"+
+				"Content-Type: text/xml\n"+
+				"Content-Transfer-Encoding: 8bit\n"+
+				"Content-ID: test2\n"+
+				"\n"+
+				"<data>TEST CONTENT 2</data>\n"+
+				"--TEST_BOUNDARY\n"+
+				"Content-Type: application/pdf\n"+
+				"Content-Transfer-Encoding: base64\n"+
+				"Content-ID: test3\n"+
+				"\n"+
+				"VEVTVCBDT05URU5UIDM=\n"+
+				"--TEST_BOUNDARY--";
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	final Node multipartNode = getMultipartFromPostResponse(post);
+    	assertEquals(200, post.getStatusCode());
+    	
+		final Node header = multipartNode.getChildNodes().item(0);
+		assertEquals(rootContentId, header.getAttributes().item(1).getNodeValue());
+		
+		final Node body = multipartNode.getChildNodes().item(1);
+		final Base64Encoder enc = new Base64Encoder();
+        enc.translate("<data>TEST CONTENT 2</data>".getBytes());
+		
+		assertEquals("text/xml", body.getAttributes().item(0).getNodeValue());
+		assertEquals(new String(enc.getCharArray()), body.getTextContent());
+    }
+    
+    @Test
+    public void missingPartContentTypeHeaderExceptionTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String contentTypeHeader = "multipart/related; boundary='TEST_BOUNDARY'";
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test1\n"+
+    			"\n"+
+    			"TEST CONTENT 1\n"+
+    			"--TEST_BOUNDARY--";
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	
+    	assertEquals(500, post.getStatusCode());
+    	assertTrue(readResponse(post).contains("Caused by: javax.servlet.ServletException: No body part Content-Type could be found"));
+    }
+    
+    @Test
+    public void missingBoundaryParamInContentTypeHeaderExceptionTest() throws IOException, ParserConfigurationException, SAXException{
+    	final String contentTypeHeader = "multipart/related";
+    	final String request = 
+    			"--TEST_BOUNDARY\n"+
+    			"Content-Type: text/plain\n"+
+    			"Content-Transfer-Encoding: 8bit\n"+
+    			"Content-ID: test1\n"+
+    			"\n"+
+    			"TEST CONTENT 1\n"+
+    			"--TEST_BOUNDARY--";
+    	
+    	final PostMethod post = sendPostRequest(TEST_URL, request, contentTypeHeader);
+    	assertEquals(500, post.getStatusCode());
+    	assertTrue(readResponse(post).contains("javax.servlet.ServletException: No multipart boundary could be found"));
+    }
+    
+    private Node getMultipartFromPostResponse(final PostMethod post) throws IOException, ParserConfigurationException, SAXException{
+    	final String response = readResponse(post);
+		final Document responseDoc = parseToXML(response);
+		
+		final Node multipartNode = responseDoc.getFirstChild();
+		
+		// filter extra text nodes from whitespace between the child elements
+		final NodeList childNodes = multipartNode.getChildNodes();
+		for(int i = 0; i < childNodes.getLength() ; i++){
+			if(childNodes.item(i).getNodeType() == Node.TEXT_NODE){
+				multipartNode.removeChild(childNodes.item(i));
+			}
+		}
+		
+		return multipartNode;
+    }
+    
+    private Document parseToXML(final String xmlStr) throws ParserConfigurationException, SAXException, IOException{
+    	final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setNamespaceAware(true);
+		final DocumentBuilder builder = factory.newDocumentBuilder();
+		return builder.parse(new ByteArrayInputStream(xmlStr.getBytes()));
+    }
+}

--- a/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartRelatedResponseTest.java
+++ b/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartRelatedResponseTest.java
@@ -1,0 +1,361 @@
+package org.exist.extensions.exquery.restxq.impl.multipart;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.commons.httpclient.HttpException;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+
+/**
+ * Tests multipart/related response in restXQ.
+ * 
+ * Send a text/xml post request to an restXQ endpoint.
+ * The endpoint returns the sended xml data directly without any manipulation.
+ * The return media-type is multipart, that's will be serialized to multipart response.
+ * 
+ *
+ * 	The serilized XML:
+ * 
+ *	<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>
+ *		<http:header name='Content-Type' value='text/plain'/>
+ *		<http:header name='Content-ID' value='test_1'/>
+ *		<http:body>TEST CONTENT 1</http:body>
+ *		<http:header name='Content-Type' value='text/xml'/>
+ *		<http:header name='Content-ID' value='test_2'/>
+ *		<http:body><data>TEST CONTENT 2</data></http:body>
+ *		<http:header name='Content-Type' value='text/plain'/>
+ *		<http:header name='Content-ID' value='test_3'/>
+ *		<http:header name='Content-Transfer-Encoding' value='base64'/>
+ *		<http:body>VEVTVCBDT05URU5UIDM=</http:body>
+ *	</http:multipart>
+ *
+ * The expected response Content-Type header:
+ *	multipart/related; start=test_1; boundary=TEST_BOUNDARY; charset=utf-8
+ *
+ * The expected response:
+ * 
+ * 	--TEST_BOUNDARY
+ *	Content-Type: text/plain
+ *	Content-Transfer-Encoding: 8bit
+ *	Content-ID: test_1
+ *
+ *	TEST CONTENT 1
+ *	--TEST_BOUNDARY
+ *	Content-Type: text/xml
+ *	Content-Transfer-Encoding: 8bit
+ *	 Content-ID: test_2
+ *
+ *	TEST CONTENT 2
+ *	--TEST_BOUNDARY
+ *	Content-Type: text/plain
+ *	Content-Transfer-Encoding: base46
+ *	Content-ID: test_3
+ *
+ *	VEVTVCBDT05URU5UIDM=
+ *	--TEST_BOUNDARY--
+ *
+ * If start parameter is not setted then the first part is a root part by default. 
+ * The expected results is a http:multipart element with a http:header for each http:body childs elements:
+ *
+
+ *
+ * The first body element is the root part.
+ * If part header "Content-Transfer-Encoding" is setted to base64 then the part content will not be encoded,
+ * otherwise the content will be encoded to base64
+ * 
+ * 
+ * @author Maan Al Balkhi <maan.al.balkhi@gmail.com>
+ * 
+ */
+public class MultipartRelatedResponseTest extends MultipartTest {
+	
+	private static final String TEST_URL = REQUEST_URL + "/responseTest";
+	
+	@Test
+	public void responsePartsContentsTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>"+
+						"<http:header name='Content-Type' value='text/plain'/>"+
+						"<http:header name='Content-ID' value='test_1'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+						"<http:header name='Content-Type' value='text/xml'/>"+
+						"<http:header name='Content-ID' value='test_2'/>"+
+						"<http:body><data>TEST CONTENT 2</data></http:body>"+
+						"<http:header name='Content-Type' value='text/plain'/>"+
+						"<http:header name='Content-ID' value='test_3'/>"+
+						"<http:header name='Content-Transfer-Encoding' value='base64'/>"+
+						"<http:body>VEVTVCBDT05URU5UIDM=</http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		final String[] responseLines = readResponse(post).split("\n");
+		
+		assertEquals(200, post.getStatusCode());
+		assertEquals("First part Content: ", "TEST CONTENT 1", responseLines[4]);
+		assertEquals("Second part Content:", "<data>TEST CONTENT 2</data>", responseLines[9]);
+		assertEquals("Third part Content:", "VEVTVCBDT05URU5UIDM=", responseLines[15]);
+	}
+	
+	@Test
+	public void partsHeadersTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>"+
+						"<http:header name='Content-Type' value='text/plain'/>"+
+						"<http:header name='Content-ID' value='test_1'/>"+
+						"<http:header name='Content-Transfer-Encoding' value='8bit'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		final String[] responseLines = readResponse(post).split("\n");
+		
+		assertEquals(200, post.getStatusCode());
+		assertEquals("requiered header: Content-Type header", "Content-Type: text/plain", responseLines[1]);
+		assertEquals("optional header: Content-ID", "Content-ID: test_1", responseLines[2]);
+		assertEquals("optional header: Content-Transfer-Encodeing", "Content-Transfer-Encoding: 8bit", responseLines[3]);
+	}
+	
+	@Test
+	public void partsBoundaryTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>"+
+						"<http:header name='Content-Type' value='text/plain'/>"+
+						"<http:header name='Content-ID' value='test_1'/>"+
+						"<http:header name='Content-Transfer-Encoding' value='8bit'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+						"<http:header name='Content-Type' value='text/xml'/>"+
+						"<http:header name='Content-ID' value='test_2'/>"+
+						"<http:body><data>TEST CONTENT 2</data></http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		final String[] responseLines = readResponse(post).split("\n");
+		
+		assertEquals(200, post.getStatusCode());
+		assertEquals("boundary for first part", "--TEST_BOUNDARY", responseLines[0]);
+		assertEquals("boundary for second part", "--TEST_BOUNDARY", responseLines[6]);
+	}
+	
+	@Test
+	public void endingBoundaryTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>"+
+						"<http:header name='Content-Type' value='text/plain'/>"+
+						"<http:header name='Content-ID' value='test_1'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		
+		assertEquals(200, post.getStatusCode());
+		assertTrue("end boundary", readResponse(post).endsWith("--TEST_BOUNDARY--"));
+	}
+	
+	@Test
+	public void partHeaderAndContentDelimiterTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>"+
+						"<http:header name='Content-Type' value='text/plain'/>"+
+						"<http:header name='Content-ID' value='test_1'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		
+		assertEquals(200, post.getStatusCode());
+		assertTrue("Delimiter between part header and content ", readResponse(post).contains("Content-ID: test_1\n\nTEST CONTENT 1"));
+	}
+	
+	@Test
+	public void rootIdTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>"+
+						"<http:header name='content-type' value='text/plain'/>"+
+						"<http:header name='content-id' value='test_1'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</http:multipart>";
+
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		final String responseHeader = post.getResponseHeader("Content-Type").getValue();
+		
+		assertEquals(200, post.getStatusCode());
+		assertTrue("start parameter in header is not present ", responseHeader.contains("start=\"test_1\""));
+	}
+	
+	@Test
+	public void matchingBoundaryTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>"+
+						"<http:header name='Content-Type' value='text/plain'/>"+
+						"<http:header name='Content-ID' value='test_1'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+						"<http:header name='Content-Type' value='text/xml'/>"+
+						"<http:header name='Content-ID' value='test_2'/>"+
+						"<http:body><data>TEST CONTENT 2</data></http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		final String responseContentType = post.getResponseHeader("Content-Type").getValue();
+		
+		final String boundaryRegExp = "boundary=['\"]{0,1}(.*?)('|\"|;|\\s|$)";
+    	final Pattern ptn = Pattern.compile(boundaryRegExp);
+		final Matcher mtc = ptn.matcher(responseContentType);
+		final String boundary;
+		if(mtc.find()){
+			boundary = mtc.group(1);
+		}else{
+			boundary = "";
+		}
+		
+		final String[] responseLines = readResponse(post).split("\n");
+		
+		assertEquals(200, post.getStatusCode());
+		assertEquals("boundary for first part","--" + boundary, responseLines[0]);
+		assertEquals("boundary for second part","--" + boundary, responseLines[5]);
+		assertEquals("ending boundary","--" + boundary + "--", responseLines[10]);
+	}
+	
+	@Test
+	public void matchingRootIdTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>"+
+						"<http:header name='Content-Type' value='text/plain'/>"+
+						"<http:header name='Content-ID' value='test_1'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+						"<http:header name='Content-Type' value='text/xml'/>"+
+						"<http:header name='Content-ID' value='test_2'/>"+
+						"<http:body><data>TEST CONTENT 2</data></http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		final String responseContentType = post.getResponseHeader("Content-Type").getValue();
+		
+		final String rootIdRegExp = "start=['\"]{0,1}(.*?)('|\"|;|\\s|$)";
+    	final Pattern ptn = Pattern.compile(rootIdRegExp);
+		final Matcher mtc = ptn.matcher(responseContentType);
+		final String rootId;
+		if(mtc.find()){
+			rootId = mtc.group(1);
+		}else{
+			rootId = "";
+		}
+		
+		final String[] responseLines = readResponse(post).split("\n");
+		
+		assertEquals(200, post.getStatusCode());
+		assertEquals("first part content-id","Content-ID: " + rootId, responseLines[2]);
+		assertFalse("second part content-id",("Content-ID: " + rootId).equals(responseLines[7]));
+	}
+	
+	@Test
+	public void responseHeaderTest() throws ParserConfigurationException, SAXException, HttpException, IOException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client' boundary='TEST_BOUNDARY'>"+
+						"<http:header name='content-type' value='text/plain'/>"+
+						"<http:header name='content-id' value='test_1'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</http:multipart>";
+
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		
+		assertEquals(200, post.getStatusCode());
+		assertEquals("multipart/related; start=\"test_1\"; boundary=\"TEST_BOUNDARY\"; charset=UTF-8", post.getResponseHeader("Content-Type").getValue());
+	}
+	
+	@Test
+	public void missingBoundaryAttributeTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client'>"+
+						"<http:header name='content-type' value='text/plain'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		
+		assertEquals(500, post.getStatusCode());
+		assertTrue(readResponse(post).contains("org.exquery.restxq.RestXqServiceException: Multipart boundary could not be found"));
+	}
+	
+	@Test
+	public void nonMultipartResponseNodeTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<data xmlns:http='http://expath.org/ns/http-client'>"+
+						"<http:header name='content-type' value='text/plain'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</data>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		
+		assertEquals(500, post.getStatusCode());
+		assertTrue(readResponse(post).contains("org.exquery.restxq.RestXqServiceException: Multipart response must have a multipart root node"));
+	}
+	
+	@Test
+	public void invalidNameSpaceTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='some_name_space'>"+
+						"<http:header name='content-type' value='text/plain'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		
+		assertEquals(500, post.getStatusCode());
+		assertTrue(readResponse(post).contains("org.exquery.restxq.RestXqServiceException: Invalid namespace for multipart"));
+	}
+	
+	@Test
+	public void missingPartContentTypeHeaderTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client'>"+
+						"<http:header name='content-type' value='text/plain'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+						"<http:header name='content-id' value='test_2'/>"+
+						"<http:body>TEST CONTENT 2</http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		
+		assertEquals(500, post.getStatusCode());
+		assertTrue(readResponse(post).contains("org.exquery.restxq.RestXqServiceException: A multipart entity must have a Content-Type header"));
+	}
+	
+	@Test
+	public void missingPartHeaderNameAttrTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client'>"+
+						"<http:header  value='text/plain'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		
+		assertEquals(500, post.getStatusCode());
+		assertTrue(readResponse(post).contains("org.exquery.restxq.RestXqServiceException: Header musst include name and value attributes"));
+	}
+	
+	@Test
+	public void missingPartHeaderValueAttrTest() throws HttpException, IOException, ParserConfigurationException, SAXException{
+		final String request = 
+				"<http:multipart xmlns:http='http://expath.org/ns/http-client'>"+
+						"<http:header name='content-type'/>"+
+						"<http:body>TEST CONTENT 1</http:body>"+
+				"</http:multipart>";
+		
+		final PostMethod post = sendPostRequest(TEST_URL, request, "text/xml");
+		
+		assertEquals(500, post.getStatusCode());
+		assertTrue(readResponse(post).contains("org.exquery.restxq.RestXqServiceException: Header musst include name and value attributes"));
+	}
+	
+}

--- a/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartTest.java
+++ b/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartTest.java
@@ -30,7 +30,7 @@ public abstract class MultipartTest extends RESTTest {
     protected static final String DRIVER = "org.exist.xmldb.DatabaseImpl";
     
     protected static final String USER = "admin";
-    protected static final String PW = "admin";
+    protected static final String PW = "";
     
     protected static final String RESTXQ_TEST_FOLDER = "extensions/exquery/restxq/src/test";
     protected static final String MULTIPART_IMPL_FOLDER = "java/org/exist/extensions/exquery/restxq/impl/multipart";

--- a/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartTest.java
+++ b/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartTest.java
@@ -1,0 +1,103 @@
+package org.exist.extensions.exquery.restxq.impl.multipart;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.apache.commons.httpclient.HttpException;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.RequestEntity;
+import org.apache.commons.httpclient.methods.StringRequestEntity;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.exist.http.RESTTest;
+import org.exist.util.Base64Encoder;
+import org.exist.xmldb.EXistResource;
+import org.exist.xmldb.UserManagementService;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.xml.sax.SAXException;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.Database;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.BinaryResource;
+
+public abstract class MultipartTest extends RESTTest {
+	
+    protected static final String DRIVER = "org.exist.xmldb.DatabaseImpl";
+    
+    protected static final String USER = "admin";
+    protected static final String PW = "admin";
+    
+    protected static final String RESTXQ_TEST_FOLDER = "extensions/exquery/restxq/src/test";
+    protected static final String MULTIPART_IMPL_FOLDER = "java/org/exist/extensions/exquery/restxq/impl/multipart";
+    protected static final String XQUERY_FILENAME = "MultipartTestEndpoint.xql";
+    
+    protected static final String XQUERY_PATH = RESTXQ_TEST_FOLDER + "/" + MULTIPART_IMPL_FOLDER + "/" + XQUERY_FILENAME;
+    
+    protected static final String REQUEST_URL = "http://localhost:8080/exist/restxq";
+    
+    protected static Collection root;
+    
+    protected static BinaryResource res;
+    
+
+    @BeforeClass
+	public static void beforeCalss() throws ClassNotFoundException, InstantiationException, IllegalAccessException, XMLDBException, IOException {
+    	final Class<?> cl = Class.forName(DRIVER);
+        final Database database = (Database) cl.newInstance();
+        database.setProperty("create-database", "true");
+        DatabaseManager.registerDatabase(database);
+        
+        root = DatabaseManager.getCollection("xmldb:exist://localhost:" + existWebServer.getPort() + "/exist/xmlrpc/db", USER, PW);
+		
+		final File xqueryFile = new File(XQUERY_PATH);
+		if(!xqueryFile.canRead()){
+			throw new IOException("cannot read file: " + XQUERY_PATH);
+		}
+		
+		res = (BinaryResource)root.createResource(XQUERY_PATH, "BinaryResource");
+        ((EXistResource) res).setMimeType("application/xquery");
+        res.setContent(xqueryFile);
+        root.storeResource(res);
+        UserManagementService ums = (UserManagementService)root.getService("UserManagementService", "1.0");
+        ums.chmod(res, 0777);
+    }
+    
+    @AfterClass
+    public static void afterClass() throws XMLDBException {
+        root.removeResource(res);
+    }
+    
+	protected PostMethod sendPostRequest(final String url, final String request, final String contentTypeHeader) throws HttpException, IOException, ParserConfigurationException, SAXException{
+        final PostMethod post = new PostMethod(url);
+        final Base64Encoder enc = new Base64Encoder();
+        enc.translate((USER + ":" + PW).getBytes());
+        post.addRequestHeader("Authorization", "Basic " + new String(enc.getCharArray()));
+        post.addRequestHeader("Content-Type", contentTypeHeader);
+        
+        final RequestEntity requestEntity = new StringRequestEntity(request, "multipart/related; boundary='TEST_BOUNDARY'", "UTF-8");
+		post.setRequestEntity(requestEntity);
+		client.executeMethod(post);
+		
+		return post;
+    }
+    
+    protected String readResponse(final HttpMethod methode) throws IOException{
+    	final byte buf[] = new byte[1024];
+        int read = -1;
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final InputStream is = methode.getResponseBodyAsStream();
+        while((read = is.read(buf)) > -1) {
+            baos.write(buf, 0, read);
+        }
+        final byte actualResponse[] = baos.toByteArray();
+		baos.close();
+        
+        return new String(actualResponse);
+    }
+
+}

--- a/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartTestEndpoint.xql
+++ b/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/multipart/MultipartTestEndpoint.xql
@@ -1,0 +1,22 @@
+xquery version "3.0";
+
+module namespace endpoint="http://exist-db.org/exquery/restxq/multipart_related/test/endpoint";
+
+declare namespace http = "http://expath.org/ns/http-client";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+
+declare
+    %rest:POST('{$request}')
+    %rest:path("/requestTest")
+    %rest:consumes("multipart/related")
+    %rest:produces("application/xml")
+    %output:media-type("application/xml")
+function endpoint:requestTest($request){$request};
+
+declare
+    %rest:POST('{$request}')
+    %rest:path("/responseTest")
+    %rest:consumes("text/xml")
+    %rest:produces("multipart/related")
+    %output:media-type("multipart/related")
+function endpoint:responsePostTest($request){$request};


### PR DESCRIPTION
### Description:
- Accept multipart/related http requests and convert to multi http:body and http:header nodes in a http:multipart element like:
`<http:multipart>
    <http:header name="content-id" value="..." />
    <http:body media-type="...">...</http:body>
    .
    . 
</http:multipart>`
Body content is represented as BASE64

- Serialize http:multipart element as response to a multipart response with a body part for each http:body element.

Multipart/related content type is mostly used for MTOM/XOP requests and responses
### Reference:
[ MIME Multipart/Related RFC 2387](https://tools.ietf.org/html/rfc2387#section-6.1)
[  The Multipart Content-Type RFC 1341 (MIME)](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html)
[ HTTP Client Module](http://expath.org/spec/http-client)
### Type of tests:
