### PR TITLE
Don't try and manually set a Jetty temp folder

### DIFF
--- a/tools/jetty/etc/jetty.xml
+++ b/tools/jetty/etc/jetty.xml
@@ -148,12 +148,4 @@
       </Call>
     </Ref -->
 
-    <!-- =========================================================== -->
-    <!-- change java.io.tmpdir default value                         -->
-    <!-- =========================================================== -->
-    <Call class="java.lang.System" name="setProperty">
-        <Arg>java.io.tmpdir</Arg>
-        <Arg><Property name="jetty.base" default="."/>/tmp</Arg>
-    </Call>
-
 </Configure>

--- a/tools/jetty/etc/standalone-jetty.xml
+++ b/tools/jetty/etc/standalone-jetty.xml
@@ -148,12 +148,4 @@
       </Call>
     </Ref -->
 
-    <!-- =========================================================== -->
-    <!-- change java.io.tmpdir default value                         -->
-    <!-- =========================================================== -->
-    <Call class="java.lang.System" name="setProperty">
-        <Arg>java.io.tmpdir</Arg>
-        <Arg><Property name="jetty.base" default="."/>/tmp</Arg>
-    </Call>
-
 </Configure>

--- a/tools/jetty/tmp/.DO_NOT_DELETE
+++ b/tools/jetty/tmp/.DO_NOT_DELETE
@@ -1,1 +1,0 @@
-Required for Jetty 9

--- a/tools/jetty/webapps/exist-webapp-context.xml
+++ b/tools/jetty/webapps/exist-webapp-context.xml
@@ -6,7 +6,6 @@
     <Set name="contextPath">/exist</Set>
     <Set name="war"><Property name="jetty.home" default="."/>/../../webapp/</Set>
     <Set name="defaultsDescriptor"><Property name="jetty.home" default="."/>/etc/webdefault.xml</Set>
-    <Set name="tempDirectory"><Property name="jetty.base" default="."/>/tmp</Set>
     <Set name="securityHandler">
         <New class="org.eclipse.jetty.security.ConstraintSecurityHandler">
             <Set name="loginService">


### PR DESCRIPTION
Jetty was creating the folder `$EXIST_HOME/file:/<$EXIST_HOME>/tools/jetty/etc` on some platforms. Note the recursive `$EXIST_HOME`!

I see no reason why we don't just allow Jetty to use Java's temp folder, which is the default for Jetty anyway.

As reported by @joewiz Can you test please?