### PR TITLE
Feature/xq31 fn serialize

### DIFF
--- a/src/org/exist/xquery/functions/util/Serialize.java
+++ b/src/org/exist/xquery/functions/util/Serialize.java
@@ -95,7 +95,8 @@ public class Serialize extends BasicFunction {
                                     "The serialization parameters: either a sequence of key=value pairs or an output:serialization-parameters " +
                                             "element as defined by the standard fn:serialize function.")
                     },
-                    new FunctionParameterSequenceType("result", Type.STRING, Cardinality.ZERO_OR_ONE, "the string containing the serialized node set.")
+                    new FunctionParameterSequenceType("result", Type.STRING, Cardinality.ZERO_OR_ONE, "the string containing the serialized node set."),
+                    "Use the fn:serialize() function instead!"
             )
     };
 

--- a/src/org/exist/xquery/util/SerializerUtils.java
+++ b/src/org/exist/xquery/util/SerializerUtils.java
@@ -21,24 +21,26 @@ public class SerializerUtils {
      * Parse output:serialization-parameters XML fragment into serialization
      * properties as defined by the fn:serialize function.
      *
-     * @param parent the parent expression calling this method
+     * @param parent     the parent expression calling this method
      * @param parameters root node of the XML fragment
      * @param properties parameters are added to the given properties
      */
-    public static void getSerializationOptions(Expression parent, NodeValue parameters, Properties properties) throws XPathException {
+    public static void getSerializationOptions(final Expression parent, final NodeValue parameters, final Properties properties) throws XPathException {
         try {
             final XMLStreamReader reader = parent.getContext().getXMLStreamReader(parameters);
             while (reader.hasNext() && (reader.next() != XMLStreamReader.START_ELEMENT)) {
             }
-            if (!reader.getNamespaceURI().equals(Namespaces.XSLT_XQUERY_SERIALIZATION_NS)) {
+            if (!Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(reader.getNamespaceURI())) {
                 throw new XPathException(parent, FnModule.SENR0001, "serialization parameter elements should be in the output namespace");
             }
+
             while (reader.hasNext()) {
                 final int status = reader.next();
                 if (status == XMLStreamReader.START_ELEMENT) {
                     final String key = reader.getLocalName();
-                    if (properties.contains(key))
-                    {throw new XPathException(parent, FnModule.SEPM0019, "serialization parameter specified twice: " + key);}
+                    if (properties.contains(key)) {
+                        throw new XPathException(parent, FnModule.SEPM0019, "serialization parameter specified twice: " + key);
+                    }
                     String value = reader.getAttributeValue("", "value");
                     if (value == null) {
                         // backwards compatibility: use element text as value

--- a/src/org/exist/xquery/util/SerializerUtils.java
+++ b/src/org/exist/xquery/util/SerializerUtils.java
@@ -1,21 +1,73 @@
 package org.exist.xquery.util;
 
 import org.exist.Namespaces;
+import org.exist.storage.serializers.EXistOutputKeys;
+import org.exist.xquery.Cardinality;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.functions.fn.FnModule;
-import org.exist.xquery.value.NodeValue;
+import org.exist.xquery.functions.map.MapType;
+import org.exist.xquery.value.*;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.OutputKeys;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
  * Serializer utilities used by several XQuery functions.
  */
 public class SerializerUtils {
+
+    /**
+     * See https://www.w3.org/TR/xpath-functions-31/#func-serialize
+     */
+    public enum ParameterConvention {
+        ALLOW_DUPLICATE_NAMES("allow-duplicate-names", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.FALSE),
+        BYTE_ORDER_MARK("byte-order-mark", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.FALSE),
+        CDATA_SECTION_ELEMENTS(OutputKeys.CDATA_SECTION_ELEMENTS, Type.QNAME, Cardinality.ZERO_OR_MORE, Sequence.EMPTY_SEQUENCE),
+        DOCTYPE_PUBLIC(OutputKeys.DOCTYPE_PUBLIC, Type.STRING, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),   //default: () means "absent"
+        DOCTYPE_SYSTEM(OutputKeys.DOCTYPE_SYSTEM, Type.STRING, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),   //default: () means "absent"
+        ENCODING(OutputKeys.ENCODING, Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("utf-8")),
+        ESCAPE_URI_ATTRIBUTES("escape-uri-attributes", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
+        HTML_VERSION(EXistOutputKeys.HTML_VERSION, Type.DECIMAL, Cardinality.ZERO_OR_ONE, new DecimalValue(5)),
+        INCLUDE_CONTENT_TYPE("include-content-type", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
+        INDENT(OutputKeys.INDENT, Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.FALSE),
+        ITEM_SEPARATOR(EXistOutputKeys.ITEM_SEPARATOR, Type.STRING, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),  //default: () means "absent"
+        JSON_NODE_OUTPUT_METHOD(EXistOutputKeys.JSON_NODE_OUTPUT_METHOD, Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("xml")),
+        MEDIA_TYPE(OutputKeys.MEDIA_TYPE, Type.STRING, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),    // default: a media type suitable for the chosen method
+        METHOD(OutputKeys.METHOD, Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("xml")),
+        NORMALIZATION_FORM("normalization-form", Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("none")),
+        OMIT_XML_DECLARATION(OutputKeys.OMIT_XML_DECLARATION, Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
+        STANDALONE(OutputKeys.STANDALONE, Type.BOOLEAN, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),   //default: () means "omit"
+        SUPPRESS_INDENTATION("suppress-indentation", Type.QNAME, Cardinality.ZERO_OR_MORE, Sequence.EMPTY_SEQUENCE),
+        UNDECLARE_PREFIXES("undeclare-prefixes", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.FALSE),
+        USE_CHARACTER_MAPS("use-character-maps", Type.MAP, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),
+        VERSION(OutputKeys.VERSION, Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("1.0"));
+
+        final String parameterName;
+        final int type;
+        final int cardinality;
+        final Sequence defaultValue;
+
+        ParameterConvention(final String parameterName, final int type, final int cardinality, final Sequence defaultValue) {
+            this.parameterName = parameterName;
+            this.type = type;
+            this.cardinality = cardinality;
+            this.defaultValue = defaultValue;
+        }
+    }
+
+    public final static Map<String, ParameterConvention> PARAMETER_CONVENTIONS_BY_NAME = new HashMap<>();
+    static {
+        for(final ParameterConvention parameterConvention : ParameterConvention.values()) {
+            PARAMETER_CONVENTIONS_BY_NAME.put(parameterConvention.parameterName, parameterConvention);
+        }
+    }
 
     /**
      * Parse output:serialization-parameters XML fragment into serialization
@@ -52,5 +104,169 @@ public class SerializerUtils {
         } catch (final XMLStreamException | IOException e) {
             throw new XPathException(parent, ErrorCodes.EXXQDY0001, e.getMessage());
         }
+    }
+
+    public static Properties getSerializationOptions(final Expression parent, final MapType entries) throws XPathException {
+        try {
+            final Properties properties = new Properties();
+
+            for (final ParameterConvention parameterConvention : ParameterConvention.values()) {
+                final Sequence providedParameterValue = entries.get(new StringValue(parameterConvention.parameterName));
+
+                final Sequence parameterValue;
+
+                // should we use the default value
+                if (providedParameterValue == null || providedParameterValue.isEmpty() || (parameterConvention.type == Type.STRING && isEmptyStringValue(providedParameterValue))) {
+                    // use default value
+
+                    if (ParameterConvention.MEDIA_TYPE == parameterConvention) {
+                        // the default value of MEDIA_TYPE is dependent on the METHOD
+                        parameterValue = getDefaultMediaType(entries.get(new StringValue(ParameterConvention.METHOD.parameterName)));
+
+                    } else {
+                        parameterValue = parameterConvention.defaultValue;
+                    }
+
+                } else {
+                    // use provided value
+
+                    if (checkTypes(parameterConvention, providedParameterValue)) {
+                        parameterValue = providedParameterValue;
+                    } else {
+                        throw new XPathException(parent, ErrorCodes.XPTY0004, "The supplied value is of the wrong type for the particular parameter: " + parameterConvention.parameterName);
+                    }
+                }
+
+                setPropertyForMap(properties, parameterConvention, parameterValue);
+            }
+
+            return properties;
+        } catch (final UnsupportedOperationException e) {
+            throw new XPathException(parent, FnModule.SENR0001, e.getMessage());
+        }
+    }
+
+    private static Sequence getDefaultMediaType(final Sequence providedMethod) throws XPathException {
+        final Sequence methodValue;
+
+        // should we use the default method
+        if(providedMethod == null || providedMethod.isEmpty()) {
+            //use default
+            methodValue = ParameterConvention.METHOD.defaultValue;
+
+        } else {
+            //use provided
+            methodValue = providedMethod;
+        }
+
+        final String method = methodValue.itemAt(0).getStringValue().toLowerCase();
+        switch(method) {
+            case "xml":
+            case "microxml":
+                return new StringValue("application/xml");
+
+            case "xhtml":
+                return new StringValue("application/xhtml+xml");
+
+            case "adaptive":
+                return new StringValue("text/plain");
+
+            case "json":
+                return new StringValue("application/json");
+
+            case "jsonp":
+                return new StringValue("application/javascript");
+
+            case "html":
+                return new StringValue("text/html");
+
+            case "text":
+                return new StringValue("text/plain");
+
+            case "binary":
+                return new StringValue("application/octet-stream");
+
+            default:
+                throw new UnsupportedOperationException("Unrecognised serialization method: " + method);
+
+        }
+    }
+
+    /**
+     * Checks that the types of the items in the sequence match the parameter convention.
+     *
+     * @param parameterConvention The parameter convention to check against
+     * @param sequence The sequence to check the types of
+     *
+     * @return true if the types are suitable, false otherwise
+     */
+    private static boolean checkTypes(final ParameterConvention parameterConvention, final Sequence sequence) throws XPathException {
+        if(Cardinality.checkCardinality(parameterConvention.cardinality, sequence.getCardinality())) {
+            final SequenceIterator iterator = sequence.iterate();
+            while(iterator.hasNext()) {
+                final Item item = iterator.nextItem();
+                if(parameterConvention.type != item.getType()) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void setPropertyForMap(final Properties properties, final ParameterConvention parameterConvention, final Sequence parameterValue) throws XPathException {
+        if(Type.BOOLEAN == parameterConvention.type) {
+            // ignore "admit" i.e. "standalone" empty sequence
+            if(!parameterValue.isEmpty()) {
+                if (((BooleanValue) parameterValue.itemAt(0)).getValue()) {
+                    properties.setProperty(parameterConvention.parameterName, "yes");
+                } else {
+                    properties.setProperty(parameterConvention.parameterName, "no");
+                }
+            }
+        } else if(Type.STRING == parameterConvention.type) {
+            // ignore "absent" i.e. empty sequence
+            if(!parameterValue.isEmpty()) {
+                properties.setProperty(parameterConvention.parameterName, ((StringValue) parameterValue.itemAt(0)).getStringValue());
+            }
+        } else if(Type.DECIMAL == parameterConvention.type) {
+            properties.setProperty(parameterConvention.parameterName, ((DecimalValue) parameterValue.itemAt(0)).getStringValue());
+        } else if(Type.QNAME == parameterConvention.type) {
+            if(!parameterValue.isEmpty()) {
+                if (Cardinality.checkCardinality(Cardinality.MANY, parameterConvention.cardinality)) {
+                    final String existingValue = (String) properties.get(parameterConvention.parameterName);
+                    if (existingValue == null || existingValue.isEmpty()) {
+                        properties.setProperty(parameterConvention.parameterName, ((QNameValue) parameterValue.itemAt(0)).getStringValue());
+                    } else {
+                        properties.setProperty(parameterConvention.parameterName, existingValue + " " + ((QNameValue) parameterValue.itemAt(0)).getStringValue());
+                    }
+                } else {
+                    properties.setProperty(parameterConvention.parameterName, ((QNameValue) parameterValue.itemAt(0)).getStringValue());
+                }
+            }
+        } else if(Type.MAP == parameterConvention.type) {
+            if(!parameterValue.isEmpty()) {
+                //TODO(AR) implement `use-character-maps`
+                throw new UnsupportedOperationException("Not yet implemented support for the map serialization parameter: " + parameterConvention.parameterName);
+            }
+        }
+    }
+
+    /**
+     * Determines if the provided sequence contains a single empty string
+     *
+     * @param sequence The sequence to test
+     *
+     * @return if the sequence is a single empty string
+     */
+    private static boolean isEmptyStringValue(final Sequence sequence) {
+        if(sequence != null && sequence.getItemCount() == 1) {
+            final Item firstItem = sequence.itemAt(0);
+            return Type.STRING == firstItem.getType() && ((StringValue)firstItem).getStringValue().isEmpty();
+        }
+
+        return false;
     }
 }

--- a/test/src/xquery/xquery3/serialize.xql
+++ b/test/src/xquery/xquery3/serialize.xql
@@ -18,11 +18,26 @@ declare %private function ser:adaptive($data, $itemSep as xs:string?) {
             }
         </output:serialization-parameters>
     return
-        serialize($data, $options)
+        fn:serialize($data, $options)
+};
+
+declare %private function ser:adaptive-map-params($data, $itemSep as xs:string?) {
+    let $options :=
+        map {
+            "method": "adaptive",
+            "indent": false(),
+            "item-separator": $itemSep
+        }
+    return
+        fn:serialize($data, $options)
 };
 
 declare %private function ser:adaptive($data) {
     ser:adaptive($data, ())
+};
+
+declare %private function ser:adaptive-map-params($data) {
+    ser:adaptive-map-params($data, ())
 };
 
 declare variable $ser:atomic :=
@@ -92,13 +107,13 @@ function ser:teardown() {
 declare
     %test:assertXPath("contains($result,'atomic')")
 function ser:serialize-element() {
-    serialize($ser:atomic)
+    fn:serialize($ser:atomic)
 };
 
 declare
     %test:assertError
 function ser:serialize-attribute() {
-    serialize(($ser:atomic//@*)[1])
+    fn:serialize(($ser:atomic//@*)[1])
 };
 
 declare
@@ -110,7 +125,18 @@ function ser:serialize-with-params() {
         <output:method value="xml"/>
         <output:indent value="yes"/>
       </output:serialization-parameters>
-    return serialize($ser:atomic, $params)
+    return fn:serialize($ser:atomic, $params)
+};
+
+declare
+    %test:assertXPath("contains($result,'atomic')")
+function ser:serialize-with-params-map-params() {
+    let $params :=
+      map {
+        "method": "xml",
+        "indent": true()
+      }
+    return fn:serialize($ser:atomic, $params)
 };
 
 declare
@@ -120,14 +146,24 @@ function ser:serialize-no-method() {
         <output:serialization-parameters xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
             <output:indent value="yes"/>
         </output:serialization-parameters>
-    return serialize($ser:atomic, $params)
+    return fn:serialize($ser:atomic, $params)
+};
+
+declare
+    %test:assertXPath("contains($result,'atomic')")
+function ser:serialize-no-method-map-params() {
+    let $params :=
+        map {
+            "indent": true()
+        }
+    return fn:serialize($ser:atomic, $params)
 };
 
 declare
     %test:assertXPath("contains($result,'atomic')")
 function ser:serialize-empty-params() {
     let $params := ()
-    return serialize($ser:atomic, $params)
+    return fn:serialize($ser:atomic, $params)
 };
 
 declare
@@ -135,7 +171,7 @@ declare
 function ser:serialize-atomic() {
     let $nodes := ("aaa", "bbb")
     return
-        serialize($nodes)
+        fn:serialize($nodes)
 };
 
 declare
@@ -143,7 +179,7 @@ declare
 function ser:serialize-empty-sequence() {
     let $nodes := ()
     return
-        serialize($nodes)
+        fn:serialize($nodes)
 };
 
 declare
@@ -153,6 +189,15 @@ declare
     %test:assertEquals('"Hello ""world""!"')
 function ser:adaptive-simple-atomic($atomic as xs:anyAtomicType) {
     ser:adaptive($atomic)
+};
+
+declare
+    %test:args(1234)
+    %test:assertEquals('"1234"')
+    %test:args('Hello "world"!')
+    %test:assertEquals('"Hello ""world""!"')
+function ser:adaptive-simple-atomic-map-params($atomic as xs:anyAtomicType) {
+    ser:adaptive-map-params($atomic)
 };
 
 declare
@@ -176,6 +221,26 @@ function ser:adaptive-function-item() {
 };
 
 declare
+    %test:assertEquals("fn:substring#3
+math:pi#0
+fn:exists#1
+Q{http://exist-db.org/xquery/lucene}query#2
+(anonymous-function)#1
+Q{http://exist-db.org/xquery/test/serialize}adaptive-simple-atomic#1")
+function ser:adaptive-function-item-map-params() {
+    let $input := (
+        substring#3,
+        math:pi#0,
+        Q{http://www.w3.org/2005/xpath-functions}exists#1,
+        ft:query#2,
+        function ($a) { $a },
+        ser:adaptive-simple-atomic#1
+    )
+    return
+        ser:adaptive-map-params($input)
+};
+
+declare
     %test:assertEquals('<?pi?><elem a="abc"><!--comment--><b>123</b></elem>
 <elem a="abc"><!--comment--><b>123</b></elem>
 a="abc"
@@ -191,11 +256,34 @@ declare
 <elem a="abc"><!--comment--><b>123</b></elem>
 a="abc"
 <!--comment-->')
+function ser:adaptive-xml-map-params() {
+    let $input := ($ser:test-xml, $ser:test-xml/elem, $ser:test-xml/elem/@a, $ser:test-xml/elem/comment())
+    return
+        ser:adaptive-map-params($input)
+};
+
+declare
+    %test:assertEquals('<?pi?><elem a="abc"><!--comment--><b>123</b></elem>
+<elem a="abc"><!--comment--><b>123</b></elem>
+a="abc"
+<!--comment-->')
 function ser:adaptive-xml-stored() {
     let $doc := doc($ser:collection || "/test.xml")
     let $input := ($doc, $doc/elem, $doc/elem/@a, $doc/elem/comment())
     return
         ser:adaptive($input)
+};
+
+declare
+    %test:assertEquals('<?pi?><elem a="abc"><!--comment--><b>123</b></elem>
+<elem a="abc"><!--comment--><b>123</b></elem>
+a="abc"
+<!--comment-->')
+function ser:adaptive-xml-stored-map-params() {
+    let $doc := doc($ser:collection || "/test.xml")
+    let $input := ($doc, $doc/elem, $doc/elem/@a, $doc/elem/comment())
+    return
+        ser:adaptive-map-params($input)
 };
 
 declare
@@ -207,9 +295,23 @@ function ser:adaptive-xml-namespace() {
 };
 
 declare
+    %test:assertEquals('xmlns:foo="http://exist-db.org/foo"')
+function ser:adaptive-xml-namespace-map-params() {
+    let $input := namespace foo { "http://exist-db.org/foo" }
+    return
+        ser:adaptive-map-params($input)
+};
+
+declare
     %test:assertEquals("Q{http://exist.sourceforge.net/NS/exist}test")
 function ser:adaptive-qname() {
     ser:adaptive(xs:QName("exist:test"))
+};
+
+declare
+    %test:assertEquals("Q{http://exist.sourceforge.net/NS/exist}test")
+function ser:adaptive-qname-map-params() {
+    ser:adaptive-map-params(xs:QName("exist:test"))
 };
 
 declare
@@ -218,6 +320,14 @@ function ser:adaptive-array() {
     let $input := [(1 to 3), 'hello "world"!', true(), 1 = 0]
     return
         ser:adaptive($input)
+};
+
+declare
+    %test:assertEquals('[(1,2,3),"hello ""world""!",true(),false()]')
+function ser:adaptive-array-map-params() {
+    let $input := [(1 to 3), 'hello "world"!', true(), 1 = 0]
+    return
+        ser:adaptive-map-params($input)
 };
 
 declare
@@ -232,6 +342,17 @@ function ser:adaptive-map() {
 };
 
 declare
+    %test:assertEquals('map{"k1":(1,2,3),"k2":map{"k3":a="abc","k4":[1,2]}}')
+function ser:adaptive-map-map-params() {
+    let $input := map {
+        "k1": 1 to 3,
+        "k2": map { "k3": $ser:test-xml/elem/@a, "k4": array { 1 to 2 } }
+    }
+    return
+        ser:adaptive-map-params($input)
+};
+
+declare
     %test:assertEquals('1.0e0
 3.141592653589793e0
 2.543e1')
@@ -239,6 +360,16 @@ function ser:adaptive-double() {
     let $input := (xs:double(1), xs:double(math:pi()), xs:double(2.543e1))
     return
         ser:adaptive($input)
+};
+
+declare
+    %test:assertEquals('1.0e0
+3.141592653589793e0
+2.543e1')
+function ser:adaptive-double-map-params() {
+    let $input := (xs:double(1), xs:double(math:pi()), xs:double(2.543e1))
+    return
+        ser:adaptive-map-params($input)
 };
 
 declare
@@ -266,9 +397,39 @@ function ser:adaptive-mixed() {
 };
 
 declare
+    %test:assertEquals('a="abc"
+["a",2,&lt;b&gt;123&lt;/b&gt;,()]
+3.141592653589793e0
+math:pi#0
+"hello"
+"""quoted"""
+true()
+map{"k":()}')
+function ser:adaptive-mixed-map-params() {
+    let $input := (
+        $ser:test-xml/elem/@a,
+        ["a", 2, $ser:test-xml/elem/b, ()],
+        xs:double(math:pi()),
+        math:pi#0,
+        "hello",
+        '"quoted"',
+        2 = 1+1,
+        map:entry("k", ())
+    )
+    return
+        ser:adaptive-map-params($input)
+};
+
+declare
     %test:assertEquals("[]")
 function ser:adaptive-empty-array() {
     ser:adaptive([])
+};
+
+declare
+    %test:assertEquals("[]")
+function ser:adaptive-empty-array-map-params() {
+    ser:adaptive-map-params([])
 };
 
 declare
@@ -278,9 +439,21 @@ function ser:adaptive-empty-map() {
 };
 
 declare
+    %test:assertEquals("map{}")
+function ser:adaptive-empty-map-map-params() {
+    ser:adaptive-map-params(map { })
+};
+
+declare
     %test:assertEquals("")
 function ser:adaptive-empty-seq() {
     ser:adaptive(())
+};
+
+declare
+    %test:assertEquals("")
+function ser:adaptive-empty-seq-map-params() {
+    ser:adaptive-map-params(())
 };
 
 declare
@@ -290,9 +463,21 @@ function ser:adaptive-text-node() {
 };
 
 declare
+    %test:assertEquals("content")
+function ser:adaptive-text-node-map-params() {
+    ser:adaptive-map-params(<test>content</test>/text())
+};
+
+declare
     %test:assertEquals("<!--comment-->")
 function ser:adaptive-comment-node() {
     ser:adaptive(<!--comment-->)
+};
+
+declare
+    %test:assertEquals("<!--comment-->")
+function ser:adaptive-comment-node-map-params() {
+    ser:adaptive-map-params(<!--comment-->)
 };
 
 declare
@@ -302,12 +487,24 @@ function ser:adaptive-processing-instr() {
 };
 
 declare
+    %test:assertEquals("<?target instruction ?>")
+function ser:adaptive-processing-instr-map-params() {
+    ser:adaptive-map-params(<?target instruction ?>)
+};
+
+declare
     %test:assertEquals('att-name="att-value"')
 function ser:adaptive-attribute-node() {
     ser:adaptive(attribute att-name { "att-value" })
 };
 
 declare
+    %test:assertEquals('att-name="att-value"')
+function ser:adaptive-attribute-node-map-params() {
+    ser:adaptive-map-params(attribute att-name { "att-value" })
+};
+
+declare
     %test:assertEquals('[xs:float("NaN")]')
 function ser:adaptive-array-with-NaN() {
     ser:adaptive([ xs:float("NaN") ])
@@ -315,8 +512,20 @@ function ser:adaptive-array-with-NaN() {
 
 declare
     %test:assertEquals('[xs:float("NaN")]')
+function ser:adaptive-array-with-NaN-map-params() {
+    ser:adaptive-map-params([ xs:float("NaN") ])
+};
+
+declare
+    %test:assertEquals('[xs:float("NaN")]')
 function ser:adaptive-array-with-NaN() {
     ser:adaptive([ xs:float("NaN") ])
+};
+
+declare
+    %test:assertEquals('[xs:float("NaN")]')
+function ser:adaptive-array-with-NaN-map-params() {
+    ser:adaptive-map-params([ xs:float("NaN") ])
 };
 
 declare
@@ -326,9 +535,21 @@ function ser:adaptive-seq-with-item-separator() {
 };
 
 declare
+    %test:assertEquals('1-2-3-4-5')
+function ser:adaptive-seq-with-item-separator-map-params() {
+    ser:adaptive-map-params(1 to 5, "-")
+};
+
+declare
     %test:assertEquals('"the quick", "brown fox"')
 function ser:adaptive-seq-with-item-separator2() {
     ser:adaptive(("the quick", "brown fox"), ", ")
+};
+
+declare
+    %test:assertEquals('"the quick", "brown fox"')
+function ser:adaptive-seq-with-item-separator2-map-params() {
+    ser:adaptive-map-params(("the quick", "brown fox"), ", ")
 };
 
 declare
@@ -340,9 +561,23 @@ function ser:adaptive-map-with-itemsep-no-quotes() {
 };
 
 declare
+    %test:assertEquals('map{"a":("quotes ("")","apos (&apos;)")}')
+function ser:adaptive-map-with-itemsep-no-quotes-map-params() {
+    let $input := map{ "a":("quotes ("")", "apos (')") }
+    return
+        ser:adaptive-map-params($input, ",")
+};
+
+declare
     %test:assertEquals('xs:dateTime("1999-05-31T13:20:00-05:00")')
 function ser:adaptive-xs-date-time() {
     ser:adaptive(xs:dateTime('1999-05-31T13:20:00-05:00'))
+};
+
+declare
+    %test:assertEquals('xs:dateTime("1999-05-31T13:20:00-05:00")')
+function ser:adaptive-xs-date-time-map-params() {
+    ser:adaptive-map-params(xs:dateTime('1999-05-31T13:20:00-05:00'))
 };
 
 declare
@@ -352,9 +587,21 @@ function ser:adaptive-xs-duration() {
 };
 
 declare
+    %test:assertEquals('xs:duration("P1Y2M3DT10H30M23S")')
+function ser:adaptive-xs-duration-map-params() {
+    ser:adaptive-map-params(xs:duration("P1Y2M3DT10H30M23S"))
+};
+
+declare
     %test:assertEquals('xs:float("1")')
 function ser:adaptive-xs-float() {
     ser:adaptive(xs:float("1e0"))
+};
+
+declare
+    %test:assertEquals('xs:float("1")')
+function ser:adaptive-xs-float-map-params() {
+    ser:adaptive-map-params(xs:float("1e0"))
 };
 
 declare
@@ -363,6 +610,14 @@ function ser:adaptive-xs-double() {
     let $input := xs:double(1e0)
     return
         ser:adaptive($input, ",")
+};
+
+declare
+    %test:assertEquals('1.0e0')
+function ser:adaptive-xs-double-map-params() {
+    let $input := xs:double(1e0)
+    return
+        ser:adaptive-map-params($input, ",")
 };
 
 declare
@@ -375,6 +630,15 @@ function ser:adaptive-xs-integers() {
 };
 
 declare
+    %test:assertEquals('1.2,1,0,-1,0,0')
+function ser:adaptive-xs-integers-map-params() {
+    let $input := (xs:decimal(1.2), xs:integer(1), xs:nonPositiveInteger("0"),
+        xs:negativeInteger(-1), xs:long(0), xs:int(0))
+    return
+        ser:adaptive-map-params($input, ",")
+};
+
+declare
     %test:assertEquals('"""","""",""""')
 function ser:adaptive-string-escaping() {
     let $input := ('"', xs:untypedAtomic('"'), xs:anyURI('"'))
@@ -383,9 +647,25 @@ function ser:adaptive-string-escaping() {
 };
 
 declare
+    %test:assertEquals('"""","""",""""')
+function ser:adaptive-string-escaping-map-params() {
+    let $input := ('"', xs:untypedAtomic('"'), xs:anyURI('"'))
+    return
+        ser:adaptive-map-params($input, ",")
+};
+
+declare
     %test:assertEquals('"en","en","en","en","en"')
 function ser:adaptive-xs-strings() {
     let $input := (xs:normalizedString("en"), xs:token("en"), xs:language("en"), xs:ID("en"), xs:NCName("en"))
     return
         ser:adaptive($input, ",")
+};
+
+declare
+    %test:assertEquals('"en","en","en","en","en"')
+function ser:adaptive-xs-strings-map-params() {
+    let $input := (xs:normalizedString("en"), xs:token("en"), xs:language("en"), xs:ID("en"), xs:NCName("en"))
+    return
+        ser:adaptive-map-params($input, ",")
 };


### PR DESCRIPTION
Allows `fn:serialize#2` to accept a map as the second parameter as per the F&O 3.1 specification.

Implements #1568