### PR TITLE
Make SessionManager thread-safe

### DIFF
--- a/src/org/exist/http/RESTServer.java
+++ b/src/org/exist/http/RESTServer.java
@@ -186,7 +186,7 @@ public class RESTServer {
         this.containerEncoding = containerEncoding;
         this.useDynamicContentType = useDynamicContentType;
         this.safeMode = safeMode;
-        this.sessionManager = new SessionManager(pool);
+        this.sessionManager = new SessionManager();
         this.xquerySubmission = xquerySubmission;
         this.xupdateSubmission = xupdateSubmission;
         


### PR DESCRIPTION
Previously the Session Manager which cached query results for the REST Server was not thread-safe, yet was accessed from at least two concurrent threads, and possibly more if there was more than one concurrent user. This PR both fixed the concurrency issues, and also simplifies the implementation.