### PR TITLE
Make XML RPC Query Result Cache thread-safe

### DIFF
--- a/src/org/exist/xmlrpc/XmldbRequestProcessorFactory.java
+++ b/src/org/exist/xmlrpc/XmldbRequestProcessorFactory.java
@@ -45,8 +45,6 @@ public class XmldbRequestProcessorFactory implements RequestProcessorFactoryFact
     private final BrokerPool brokerPool;
     protected final QueryResultCache resultSets = new QueryResultCache();
 
-    private long lastCheck = System.currentTimeMillis();
-
     /**
      * id of the database registered against the BrokerPool
      */
@@ -62,7 +60,6 @@ public class XmldbRequestProcessorFactory implements RequestProcessorFactoryFact
 
     @Override
     public Object getRequestProcessor(final XmlRpcRequest pRequest) throws XmlRpcException {
-        checkResultSets();
         final XmlRpcHttpRequestConfig config = (XmlRpcHttpRequestConfig) pRequest.getConfig();
         final Subject user = authenticate(config.getBasicUserName(), config.getBasicPassword());
         return new RpcConnection(this, user);
@@ -92,13 +89,6 @@ public class XmldbRequestProcessorFactory implements RequestProcessorFactoryFact
 
     protected BrokerPool getBrokerPool() {
         return brokerPool;
-    }
-
-    protected void checkResultSets() {
-        if (System.currentTimeMillis() - lastCheck > CHECK_INTERVAL) {
-            resultSets.checkTimestamps();
-            lastCheck = System.currentTimeMillis();
-        }
     }
 
     public synchronized void shutdown() {


### PR DESCRIPTION
Previously the  cache of `XmldbRequestProcessorFactory` which cached query results for the XML RPC Server was not thread-safe.
This PR both fixed the concurrency issues, and also simplifies the implementation.

Very similar to https://github.com/eXist-db/exist/pull/1580

