### PR TITLE
[bugfix] Fix util:eval-with-context#4

### DIFF
--- a/src/org/exist/xquery/functions/util/Eval.java
+++ b/src/org/exist/xquery/functions/util/Eval.java
@@ -370,7 +370,7 @@ public class Eval extends BasicFunction {
         try {
 
             if(this.getArgumentCount() == 4) {
-                final NodeValue contextItem = (NodeValue)args[3].itemAt(0);
+                final Item contextItem = (Item)args[3].itemAt(0);
                 if (contextItem != null) {
                     //TODO : sort this out
                     if (exprContext != null) {

--- a/test/src/org/exist/xquery/functions/util/EvalTest.java
+++ b/test/src/org/exist/xquery/functions/util/EvalTest.java
@@ -139,6 +139,17 @@ public class EvalTest {
     }
     
     @Test
+    public void testEvalSupplyingContextItem() throws XPathException, XMLDBException {
+        final String query = "let $context := 'London'\n" +
+                "let $query := '.'\n" +
+                "return\n" +
+                "util:eval-with-context($query, (), false(), $context)";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertEquals("London", r);
+    }
+    
+    @Test
     public void evalInContextWithPreDeclaredNamespace() throws XMLDBException {
         createCollection("testEvalInContextWithPreDeclaredNamespace");
         final String query =


### PR DESCRIPTION
### Description:

The final parameter of the 4-arity version of `util:eval-with-context()` is typed as `item()`, but in practice, errors are raised if anything but a `node()` is supplied. This PR fixes this problem and adds a test.

The motivation is to be able to run QT3 tests that require a context item to be set as part of the query environment, e.g., https://github.com/LeoWoerteler/QT3TS/blob/master/prod/ContextItemDecl.xml#L98-L108. To run this test via an XQuery test suite runner, we'd need to be able to run queries like this:

```xquery
util:eval-with-context(".", (), false(), "London")
```

Before this PR, eXist would return this error:

> org.exist.xquery.value.StringValue cannot be cast to org.exist.xquery.value.NodeValue

But, of course, a string value is a valid `item()`.

### Reference:

See http://exist-db.org/exist/apps/fundocs/view.html?uri=http://exist-db.org/xquery/util#eval-with-context.4.

### Type of tests:

JUnit. 