### PR TITLE
Add support for building on OSX (as well as Linux) on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
-sudo: false
 language: java
+matrix:
+  include:
+    - os: linux
+      sudo: false
+      jdk: oraclejdk8
+    - os: osx
+      osx_image: xcode9.1
+      env: JAVA_HOME=$(/usr/libexec/java_home)
+script: ./build.sh -Dexist.autodeploy=off -Dtest.haltonerror=true -Dtest.haltonfailure=true travis
 notifications:
   hipchat: ec8fcfa661addc56a361a8ef536320@integrations
-jdk:
- - oraclejdk8
-script: ./build.sh -Dexist.autodeploy=off -Dtest.haltonerror=true -Dtest.haltonfailure=true travis


### PR DESCRIPTION
As well as building on Linux on Travis CI, we can also build on Mac OSX to ensure correct cross-platform behaviour.