### PR TITLE
Fix fn:doc return type

### DIFF
--- a/src/org/exist/xquery/functions/fn/FunDoc.java
+++ b/src/org/exist/xquery/functions/fn/FunDoc.java
@@ -60,7 +60,7 @@ public class FunDoc extends Function {
                 new FunctionParameterSequenceType("document-uri", Type.STRING,
                     Cardinality.ZERO_OR_ONE, "The document URI")
             },
-            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_ONE,
+            new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ZERO_OR_ONE,
                 "the document node of $document-uri")
         );
 

--- a/test/src/xquery/fn.xql
+++ b/test/src/xquery/fn.xql
@@ -16,7 +16,7 @@ function fnt:store() {
     let $col := xmldb:create-collection("/db", "fn-test")
     return
         (
-            xmldb:store($col, "test.xml", <something/>),
+            xmldb:store($col, "test.xml", <books><book/></books>),
             xmldb:store($col, "test.bin", "some binary", "application/octet-stream")
         )
 };
@@ -54,6 +54,20 @@ declare
     %test:assertEquals("false")
 function fnt:doc-available($filename as xs:string) {
     fn:doc-available("/db/fn-test/" || $filename)
+};
+
+declare
+    %test:args("test.xml")
+    %test:assertEquals("true")
+function fnt:doc($filename as xs:string) {
+    fn:doc("/db/fn-test/" || $filename) instance of document-node()
+};
+
+declare
+    %test:args("test.xml")
+    %test:assertEmpty
+function fnt:doc($filename as xs:string) {
+    fn:doc("/db/fn-test/" || $filename)/book
 };
 
 declare


### PR DESCRIPTION
### Description:

The return type of `fn:doc()` should be `document-node()?`. This PR corrects the return type in eXist, which was `node()?` - and could lead people to mistakenly believe that the function return other kinds of nodes, such as elements.

### Reference:

- https://www.w3.org/TR/xpath-functions/#func-doc
- https://www.w3.org/TR/xpath-functions-30/#func-doc
- https://www.w3.org/TR/xpath-functions-31/#func-doc

### Type of tests:

XQSuite