### PR TITLE
WIP fix: prevent error in util:get-document-by-absolute-id

### DIFF
--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -2021,6 +2021,9 @@ public class NativeBroker extends DBBroker {
             //get the resource uri
             final Value key = new CollectionStore.DocumentKey(collectionId, resourceType, documentId);
             final VariableByteInput vbi = collectionsDb.getAsStream(key);
+            if (vbi == null) {
+                return null;
+            }
             vbi.readInt(); //skip doc id
             final String resourceUri = vbi.readUTF();
 

--- a/src/org/exist/xquery/functions/util/DocumentNameOrId.java
+++ b/src/org/exist/xquery/functions/util/DocumentNameOrId.java
@@ -163,6 +163,9 @@ public class DocumentNameOrId extends BasicFunction {
                     final int collectionId = absoluteId.and(BigInteger.valueOf(0xFFFFFFFF)).intValue();
                     
                     doc = context.getBroker().getResourceById(collectionId, resourceType, documentId);
+                    if (doc == null) {
+                        return Sequence.EMPTY_SEQUENCE;
+                    }
                     if(doc instanceof BinaryDocument) {
                         final BinaryDocument bin = (BinaryDocument) doc;
                         final InputStream is = context.getBroker().getBinaryResource(bin);


### PR DESCRIPTION
### Description:

`util:get-document-by-absolute-id` returns an empty sequence if document was not found instead of throwing an error.

### Reference:

none

### Type of tests:

TBD
