### PR TITLE
fix consistency check report

### DIFF
--- a/src/org/exist/backup/ConsistencyCheck.java
+++ b/src/org/exist/backup/ConsistencyCheck.java
@@ -289,7 +289,7 @@ public class ConsistencyCheck
                 try {
                     final ElementImpl root = (ElementImpl)doc.getDocumentElement();
                     if (root == null) {
-                        return new ErrorReport.ResourceError(ErrorReport.RESOURCE_ACCESS_FAILED, "Failed to access document data");
+                        return new ErrorReport.ResourceError(ErrorReport.RESOURCE_ACCESS_FAILED, "Failed to access data of document " + doc.getDocumentURI() );
                     }
                 } catch( final Exception e ) {
                     e.printStackTrace();
@@ -324,6 +324,10 @@ public class ConsistencyCheck
                         EmbeddedXMLStreamReader reader = null;
                         try {
                             final ElementImpl             root            = (ElementImpl)doc.getDocumentElement();
+                            if (root == null) {
+                                return new ErrorReport.ResourceError(ErrorReport.RESOURCE_ACCESS_FAILED, "Failed to access data of document " + doc.getDocumentURI() );
+                            }
+
                             reader = (EmbeddedXMLStreamReader)broker.getXMLStreamReader( root, true );
                             NodeId                  nodeId;
                             boolean                 attribsAllowed  = false;


### PR DESCRIPTION
### Description:

If a DB instance contains an XML document without any children running sanity-check on the command line will crash with an NPE.
This fix will prevent the app from crashing and report the name of the XML file.

### Reference:

None

### Type of tests:

None