### PR TITLE
Provide unique names for XQSuite tests

### DIFF
--- a/test/src/xquery/fn.xql
+++ b/test/src/xquery/fn.xql
@@ -59,14 +59,14 @@ function fnt:doc-available($filename as xs:string) {
 declare
     %test:args("test.xml")
     %test:assertEquals("true")
-function fnt:doc($filename as xs:string) {
+function fnt:doc-returns-document-node($filename as xs:string) {
     fn:doc("/db/fn-test/" || $filename) instance of document-node()
 };
 
 declare
     %test:args("test.xml")
     %test:assertEmpty
-function fnt:doc($filename as xs:string) {
+function fnt:doc-does-not-return-element-node($filename as xs:string) {
     fn:doc("/db/fn-test/" || $filename)/book
 };
 


### PR DESCRIPTION
### Description:

PR #1593 included two new XQSuite tests for the `fn:doc` function. Mistakenly, I gave these two tests the same name. This PR gives each test a unique name.

### Reference:

#1593.

### Type of tests:

n/a