### PR TITLE
Fixes a couple bugs in fn:format-number

### DIFF
--- a/src/org/exist/xquery/ErrorCodes.java
+++ b/src/org/exist/xquery/ErrorCodes.java
@@ -197,7 +197,7 @@ public class ErrorCodes {
     public static final ErrorCode FOFD1340 = new W3CErrorCode("FOFD1340", "Invalid date/time formatting picture string");
     public static final ErrorCode FOFD1350 = new W3CErrorCode("FOFD1350", " Invalid date/time formatting component");
 
-    public static final ErrorCode XTDE1310 = new W3CErrorCode("XTDE1310", " Invalid decimal format picture string.");
+    public static final ErrorCode FODF1310 = new W3CErrorCode("FODF1310", " Invalid decimal format picture string.");
 	public static final ErrorCode FTDY0020 = new W3CErrorCode("FTDY0020", "");
 	
 	public static final ErrorCode FODC0006 = new W3CErrorCode("FODC0006", "String passed to fn:parse-xml is not a well-formed XML document.");

--- a/src/org/exist/xquery/functions/fn/FnFormatNumbers.java
+++ b/src/org/exist/xquery/functions/fn/FnFormatNumbers.java
@@ -168,7 +168,7 @@ public class FnFormatNumbers extends BasicFunction {
         sb.append(number);
         if (f.flMIN > 0) {
             sb.append(".");
-            for (int i = 0; i < f.mlMIN; i++) {
+            for (int i = 0; i < f.flMIN; i++) {
                 sb.append('0');
             }
         }

--- a/src/org/exist/xquery/functions/fn/FnFormatNumbers.java
+++ b/src/org/exist/xquery/functions/fn/FnFormatNumbers.java
@@ -176,7 +176,7 @@ public class FnFormatNumbers extends BasicFunction {
 
     private Formatter[] prepare(final String picture) throws XPathException {
         if (picture.length() == 0) {
-            throw new XPathException(this, ErrorCodes.XTDE1310, "format-number() picture is zero-length");
+            throw new XPathException(this, ErrorCodes.FODF1310, "format-number() picture is zero-length");
         }
 
         final String[] pics = picture.split(String.valueOf(PATTERN_SEPARATOR_SIGN));
@@ -224,7 +224,7 @@ public class FnFormatNumbers extends BasicFunction {
 
         public void format() throws XPathException {
             if (!(picture.contains(String.valueOf(OPTIONAL_DIGIT_SIGN)) || picture.contains(String.valueOf(MANDATORY_DIGIT_SIGN)))) {
-                throw new XPathException(xqueryExpr, ErrorCodes.XTDE1310,
+                throw new XPathException(xqueryExpr, ErrorCodes.FODF1310,
                         "A sub-picture must contain at least one character that is an optional-digit-sign or a member of the decimal-digit-family.");
             }
 
@@ -246,7 +246,7 @@ public class FnFormatNumbers extends BasicFunction {
                                 break;
 
                             case ZERO_SIGNS:
-                                throw new XPathException(xqueryExpr, ErrorCodes.XTDE1310,
+                                throw new XPathException(xqueryExpr, ErrorCodes.FODF1310,
                                         "");
 
                             case FRACTIONAL_ZERO_SIGNS:
@@ -256,7 +256,7 @@ public class FnFormatNumbers extends BasicFunction {
                                 break;
 
                             case ENDING_PASSIVE_CHARS:
-                                throw new XPathException(xqueryExpr, ErrorCodes.XTDE1310,
+                                throw new XPathException(xqueryExpr, ErrorCodes.FODF1310,
                                         "A sub-picture must not contain a passive character that is preceded by an active character and that is followed by another active character. " +
                                                 "Found at optional-digit-sign.");
                         }
@@ -280,11 +280,11 @@ public class FnFormatNumbers extends BasicFunction {
                                 break;
 
                             case FRACTIONAL_DIGIT_SIGNS:
-                                throw new XPathException(xqueryExpr, ErrorCodes.XTDE1310,
+                                throw new XPathException(xqueryExpr, ErrorCodes.FODF1310,
                                         "");
 
                             case ENDING_PASSIVE_CHARS:
-                                throw new XPathException(xqueryExpr, ErrorCodes.XTDE1310,
+                                throw new XPathException(xqueryExpr, ErrorCodes.FODF1310,
                                         "A sub-picture must not contain a passive character that is preceded by an active character and that is followed by another active character. " +
                                                 "Found at mandatory-digit-sign.");
                         }
@@ -316,7 +316,7 @@ public class FnFormatNumbers extends BasicFunction {
                                 break;
 
                             case ENDING_PASSIVE_CHARS:
-                                throw new XPathException(xqueryExpr, ErrorCodes.XTDE1310,
+                                throw new XPathException(xqueryExpr, ErrorCodes.FODF1310,
                                         "A sub-picture must not contain a passive character that is preceded by an active character and that is followed by another active character. " +
                                                 "Found at grouping-separator-sign.");
                         }
@@ -341,11 +341,11 @@ public class FnFormatNumbers extends BasicFunction {
                             case FRACTIONAL_DIGIT_SIGNS:
                             case ENDING_PASSIVE_CHARS:
                                 if (ds) {
-                                    throw new XPathException(xqueryExpr, ErrorCodes.XTDE1310,
+                                    throw new XPathException(xqueryExpr, ErrorCodes.FODF1310,
                                             "A sub-picture must not contain more than one decimal-separator-sign.");
                                 }
 
-                                throw new XPathException(xqueryExpr, ErrorCodes.XTDE1310,
+                                throw new XPathException(xqueryExpr, ErrorCodes.FODF1310,
                                         "A sub-picture must not contain a passive character that is preceded by an active character and that is followed by another active character. " +
                                                 "Found at decimal-separator-sign.");
                         }
@@ -355,7 +355,7 @@ public class FnFormatNumbers extends BasicFunction {
                     case PERCENT_SIGN:
                     case PER_MILLE_SIGN:
                         if (isPercent || isPerMille) {
-                            throw new XPathException(xqueryExpr, ErrorCodes.XTDE1310,
+                            throw new XPathException(xqueryExpr, ErrorCodes.FODF1310,
                                     "A sub-picture must not contain more than one percent-sign or per-mille-sign, and it must not contain one of each.");
                         }
 

--- a/test/src/xquery/numbers/format-numbers.xql
+++ b/test/src/xquery/numbers/format-numbers.xql
@@ -18,3 +18,18 @@ declare
 function fd:simple-number($number as numeric) {
     format-number($number, "#,###.##")
 };
+
+declare
+    %test:args("#0")
+    %test:assertEquals("0")
+    %test:args("#0.0")
+    %test:assertEquals("0.0")
+    %test:args("#0.00")
+    %test:assertEquals("0.00")
+    %test:args("#0.000")
+    %test:assertEquals("0.000")
+    %test:args("#0.0#")
+    %test:assertEquals("0.0")
+function fd:decimal-zeros($picture as xs:string) {
+    format-number(0, $picture)
+};

--- a/test/src/xquery/numbers/format-numbers.xql
+++ b/test/src/xquery/numbers/format-numbers.xql
@@ -4,14 +4,13 @@ module namespace fd="http://exist-db.org/xquery/test/format-numbers";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
-(:
+
 declare
     %test:args("12345.6")
-    %test:assertEquals("12.345,00")
-function fd:simple-number($number as numeric) {
+    %test:assertError("FODF1310")
+function fd:invalid-picture($number as numeric) {
     format-number($number, "#.###,00")
 };
-:)
 
 declare
     %test:args("12345.6")


### PR DESCRIPTION
1. Corrects the F&O XQuery error code 
2. Fixes an issue with decimal formatting reported by David Birnbaum, i.e.: `format-number(0,'#0.00')`
