### PR TITLE
Arrow operator fails to find function

### DIFF
--- a/src/org/exist/xquery/ArrowOperator.java
+++ b/src/org/exist/xquery/ArrowOperator.java
@@ -29,6 +29,7 @@ import org.exist.xquery.value.Type;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Implements the XQuery 3.1 arrow operator.
@@ -37,6 +38,7 @@ import java.util.List;
  */
 public class ArrowOperator extends AbstractExpression {
 
+    private QName qname = null;
     private Expression leftExpr;
     private FunctionCall fcall = null;
     private Expression funcSpec = null;
@@ -51,9 +53,9 @@ public class ArrowOperator extends AbstractExpression {
 
     public void setArrowFunction(final String fname, final List<Expression> params) throws XPathException {
         try {
-            final QName name = QName.parse(context, fname, context.getDefaultFunctionNamespace());
-            this.fcall = NamedFunctionReference.lookupFunction(this, context, name, params.size() + 1);
+            this.qname = QName.parse(context, fname, context.getDefaultFunctionNamespace());
             this.parameters = params;
+            // defer resolving the function to analyze to make sure all functions are known
         } catch (final IllegalQNameException e) {
             throw new XPathException(ErrorCodes.XPST0081, "No namespace defined for prefix " + fname);
         }
@@ -70,6 +72,9 @@ public class ArrowOperator extends AbstractExpression {
             throw new XPathException(this,
                 ErrorCodes.EXXQDY0003,
                 "arrow operator is not available before XQuery 3.1");
+        }
+        if (qname != null) {
+            fcall = NamedFunctionReference.lookupFunction(this, context, qname, parameters.size() + 1);
         }
         this.cachedContextInfo = contextInfo;
         leftExpr.analyze(contextInfo);

--- a/test/src/xquery/xquery3/arrowop.xql
+++ b/test/src/xquery/xquery3/arrowop.xql
@@ -133,3 +133,19 @@ declare
 function ao:type-checks-user-func() {
     (1, 2, 3) => ao:string-join("-")
 };
+
+declare function ao:A($x) { 
+    let $y := $x || $x 
+    return 
+        $y => ao:B()
+};
+
+declare function ao:B($x) {
+    string-length($x)
+};
+
+declare 
+    %test:assertEquals(10)
+function ao:function-declared-later() {
+    ao:A("hello")
+};


### PR DESCRIPTION
Defer function lookup until query has been parsed entirely. Fixes #1622.