### PR TITLE
Range index: include nested content by default

### DIFF
--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigElement.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexConfigElement.java
@@ -73,7 +73,7 @@ public class RangeIndexConfigElement {
             usesCollation = true;
         }
         String nested = node.getAttribute("nested");
-        includeNested = (nested == null || nested.equalsIgnoreCase("yes"));
+        includeNested = (nested == null || nested.length() == 0 || nested.equalsIgnoreCase("yes"));
 
         // normalize whitespace if whitespace="normalize"
         String whitespace = node.getAttribute("whitespace");

--- a/extensions/indexes/range/test/src/xquery/types.xql
+++ b/extensions/indexes/range/test/src/xquery/types.xql
@@ -9,6 +9,8 @@ declare variable $tt:COLLECTION_CONFIG :=
         <index xmlns:xs="http://www.w3.org/2001/XMLSchema"
             xmlns:tei="http://www.tei-c.org/ns/1.0">
             <range>
+                <create qname="word" type="xs:string"/>
+                <create qname="word2" type="xs:string" nested="no"/>
                 <create qname="date" type="xs:date"/>
                 <create qname="date4" type="xs:date" converter="org.exist.indexing.range.conversion.DateConverter"/>
                 <create qname="time" type="xs:time"/>
@@ -72,6 +74,14 @@ declare variable $tt:XML :=
         </entry>
     </test>;
 
+declare variable $tt:WORDS :=
+    <latin>
+        <!-- b -->
+        <word>b<stress>ee</stress>f</word>
+        <!-- c -->
+        <word2>ch<stress>i</stress>ld</word2>
+    </latin>;
+
 declare variable $tt:COLLECTION_NAME := "typestest";
 declare variable $tt:COLLECTION := "/db/" || $tt:COLLECTION_NAME;
 
@@ -81,7 +91,8 @@ function tt:setup() {
     xmldb:create-collection("/db/system/config/db", $tt:COLLECTION_NAME),
     xmldb:store("/db/system/config/db/" || $tt:COLLECTION_NAME, "collection.xconf", $tt:COLLECTION_CONFIG),
     xmldb:create-collection("/db", $tt:COLLECTION_NAME),
-    xmldb:store($tt:COLLECTION, "test.xml", $tt:XML)
+    xmldb:store($tt:COLLECTION, "test.xml", $tt:XML),
+    xmldb:store($tt:COLLECTION, "words.xml", $tt:WORDS)
 };
 
 declare
@@ -517,4 +528,16 @@ declare
     %test:assertEquals("E1")
 function tt:date-field-normalized-bc($date as xs:date) {
     collection($tt:COLLECTION)//entry[date6 = $date]/id/string()
+};
+
+declare 
+    %test:assertEquals("<word>b<stress>ee</stress>f</word>")
+function tt:include-nested() {
+    collection($tt:COLLECTION)/latin/word[. = 'beef']
+};
+
+declare 
+    %test:assertEquals("<word2>ch<stress>i</stress>ld</word2>")
+function tt:exclude-nested() {
+    collection($tt:COLLECTION)/latin/word2[. = 'chld']
 };


### PR DESCRIPTION
Range index should included nested content into index key by default - unless configured otherwise. This corresponds to the documented behaviour, but current version behaved the opposite way. See included test case.