### PR TITLE
Bugfix/1639 fix empty sequence comparison

### DIFF
--- a/src/org/exist/xquery/GeneralComparison.java
+++ b/src/org/exist/xquery/GeneralComparison.java
@@ -1090,7 +1090,8 @@ public class GeneralComparison extends BinaryOp implements Optimizable, IndexUse
                 }
 
                 default: {
-                    return( lv.compareTo( collator, relation, rv ) );
+                    // If right value is () always return false
+                    return( rv.isEmpty() ? false : lv.compareTo( collator, relation, rv ) );
                 }
             }
         }

--- a/src/org/exist/xquery/value/AbstractDateTimeValue.java
+++ b/src/org/exist/xquery/value/AbstractDateTimeValue.java
@@ -359,9 +359,8 @@ public abstract class AbstractDateTimeValue extends ComputableValue {
             }
             return r;
         }
-        throw new XPathException(
-                "Type error: cannot compare " + Type.getTypeName(getType()) + " to "
-                        + Type.getTypeName(other.getType()));
+        throw new XPathException(ErrorCodes.XPTY0004, "Type error: cannot compare " + Type.getTypeName(getType())
+                + " to " + Type.getTypeName(other.getType()));
     }
 
     public AtomicValue max(Collator collator, AtomicValue other) throws XPathException {

--- a/src/org/exist/xquery/value/AnyURIValue.java
+++ b/src/org/exist/xquery/value/AnyURIValue.java
@@ -37,7 +37,7 @@ import java.util.BitSet;
 /**
  * @author Wolfgang Meier (wolfgang@exist-db.org)
  */
-public class AnyURIValue extends AtomicValue {
+public class    AnyURIValue extends AtomicValue {
 
     public static final AnyURIValue EMPTY_URI = new AnyURIValue();
     static final int caseDiff = ('a' - 'A');
@@ -288,13 +288,24 @@ public class AnyURIValue extends AtomicValue {
                 case LTEQ:
                     return cmp <= 0;
                 default:
-                    throw new XPathException(
-                            "XPTY0004: cannot apply operator "
-                                    + operator.generalComparisonSymbol
-                                    + " to xs:anyURI");
+                    throw new XPathException(ErrorCodes.XPTY0004,
+                            "cannot apply operator " + operator.generalComparisonSymbol + " to xs:anyURI");
             }
         } else {
-            return compareTo(collator, operator, other.convertTo(Type.ANY_URI));
+            AtomicValue atomicValue = null;
+
+            try {
+                atomicValue = other.convertTo(Type.ANY_URI);
+
+            } catch (XPathException ex) {
+
+                if (ex.getErrorCode() == ErrorCodes.FORG0001) {
+                    throw new XPathException(ErrorCodes.XPTY0004, "cannot apply operator " + operator.generalComparisonSymbol + " to xs:anyURI");
+                }
+                throw ex;
+            }
+
+            return compareTo(collator, operator, atomicValue);
         }
     }
 

--- a/src/org/exist/xquery/value/NumericValue.java
+++ b/src/org/exist/xquery/value/NumericValue.java
@@ -3,6 +3,7 @@ package org.exist.xquery.value;
 import com.ibm.icu.text.Collator;
 import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 public abstract class NumericValue extends ComputableValue {
@@ -75,7 +76,7 @@ public abstract class NumericValue extends ComputableValue {
                     throw new XPathException("Type error: cannot apply operator to numeric value");
             }
         }
-        throw new XPathException("Type error: cannot compare operands: " +
+        throw new XPathException(ErrorCodes.XPTY0004, "Type error: cannot compare operands: " +
                 Type.getTypeName(getType()) + " and " +
                 Type.getTypeName(other.getType()));
     }

--- a/test/src/xquery/namespaces.xql
+++ b/test/src/xquery/namespaces.xql
@@ -272,3 +272,27 @@ declare
 function nt:qname-lhs-compare() {
     xs:QName('test') eq 'test'
 };
+
+declare
+    %test:assertError("XPTY0004")
+function nt:int-string-compare() {
+    5 eq 'five'
+};
+
+declare
+    %test:assertError("XPTY0004")
+function nt:string-int-compare() {
+    'five' eq 5
+};
+
+declare
+    %test:assertError("XPTY0004")
+function nt:uri-int-compare() {
+    xs:anyURI('5') eq 5
+};
+
+declare
+    %test:assertError("XPTY0004")
+function nt:int-uri-compare() {
+    5 eq xs:anyURI('5')
+};

--- a/test/src/xquery/namespaces.xql
+++ b/test/src/xquery/namespaces.xql
@@ -274,6 +274,18 @@ function nt:qname-lhs-compare() {
 };
 
 declare
+    %test:assertEquals("false")
+function nt:right_empty_sequence-date() {
+    current-date() = ()
+};
+
+declare
+    %test:assertEquals("false")
+function nt:right_empty_sequence-boolean() {
+    false() = ()
+};
+
+declare
     %test:assertError("XPTY0004")
 function nt:int-string-compare() {
     5 eq 'five'


### PR DESCRIPTION
Fix for #1639 : In general comparison when the right value is the empty sequence, always false() should be returned. (checked with Saxon)