### PR TITLE
DocumentImpl metadata should not be lazy-loaded.

### DIFF
--- a/src/org/exist/backup/SystemExport.java
+++ b/src/org/exist/backup/SystemExport.java
@@ -840,7 +840,7 @@ public class SystemExport {
                     } else {
                         doc = new DocumentImpl(broker.getBrokerPool());
                     }
-                    doc.readWithMetadata(istream);
+                    doc.read(istream);
                     reportError("Found an orphaned document: " + doc.getFileURI().toString(), null);
 
                     if (writtenDocs != null) {

--- a/src/org/exist/collections/MutableCollection.java
+++ b/src/org/exist/collections/MutableCollection.java
@@ -1553,12 +1553,13 @@ public class MutableCollection implements Collection {
      * @param document The current/new document
      */
     private void manageDocumentInformation(final DocumentImpl oldDoc, final DocumentImpl document) {
-        DocumentMetadata metadata = new DocumentMetadata();
+        final DocumentMetadata metadata;
         if (oldDoc != null) {
             metadata = oldDoc.getMetadata();
             metadata.setCreated(oldDoc.getMetadata().getCreated());
             document.setPermissions(oldDoc.getPermissions());
         } else {
+            metadata = new DocumentMetadata();
             metadata.setCreated(System.currentTimeMillis());
         }
         document.setMetadata(metadata);

--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -606,8 +606,6 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
 
     public abstract long getBinaryResourceSize(final BinaryDocument blob)
            throws IOException;
-
-    public abstract void getResourceMetadata(DocumentImpl doc);
     
     /**
      * Completely delete this binary document (descriptor and binary data).

--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -2409,26 +2409,6 @@ public class NativeBroker extends DBBroker {
         }
     }
 
-    //TODO : consider a better cooperation with Collection -pb
-    @Override
-    public void getResourceMetadata(final DocumentImpl document) {
-        final Lock lock = collectionsDb.getLock();
-        try {
-            lock.acquire(LockMode.READ_LOCK);
-            final Value key = new CollectionStore.DocumentKey(document.getCollection().getId(), document.getResourceType(), document.getDocId());
-            final VariableByteInput is = collectionsDb.getAsStream(key);
-            if(is != null) {
-                document.readDocumentMeta(is);
-            }
-        } catch(final LockException e) {
-            LOG.warn("Failed to acquire lock on " + FileUtils.fileName(collectionsDb.getFile()));
-        } catch(final IOException e) {
-            LOG.warn("IOException while reading document data", e);
-        } finally {
-            lock.release(LockMode.READ_LOCK);
-        }
-    }
-
     /**
      * @param doc         src document
      * @param destination destination collection


### PR DESCRIPTION
Previously, `DocumentImpl#getMetadata()` would lazy-load metadata from `collections.dbx` using code like the following:

```java
    public DocumentMetadata getMetadata() {
        if(metadata == null) {

            // require a WRITE_LOCK as we are going to modify our state
            try(final ManagedDocumentLock docLock = pool.getLockManager().acquireDocumentWriteLock_BAK(getURI());
                    final DBBroker broker = pool.getBroker()) {

                // double-check now under lock!
                if(metadata == null) {
                    broker.getResourceMetadata(this);
                }
            } catch(final EXistException | LockException e) {
                LOG.error("Error while loading document metadata: " + e.getMessage(), e);
            }
        }

        return metadata;
    }
```

`Broker#getResourceMetadata(Collection)` after opening `collections.dbx` would then call `DocumentImpl#readDocumentmeta(VariableByteInput)`:

```java
    public void readDocumentMeta(final VariableByteInput istream) {
        // skip over already known document data
        try {
            istream.skip(1); //docId
            istream.readUTF(); //fileURI.toString()

            //istream.skip(2 + 2); //uid, gid, mode, children count
            istream.skip(1); //unix style permission uses a single long
            if(permissions instanceof ACLPermission) {
                final int aceCount = istream.read();
                istream.skip(aceCount);
            }

            istream.skip(1); //children size
            istream.skip(children * 2); //actual children

            metadata = new DocumentMetadata();
            metadata.read(pool.getSymbols(), istream);

        } catch(final IOException e) {
            LOG.error("IO error while reading document metadata for {}", fileURI, e);
            //TODO : raise exception ?
        }
    }
```

The problem is that `DocumentImpl#getMetadata()` is often called with only a `READ_LOCK` on the document, however if the metadata needs to be lazy loaded it will result in writes to the state of the `DocumentImpl` object. This lack of correct synchronization means that the metadata of a document (size, permissions, created, modified, doctype, etc.) is quite unpredictable when there are concurrent reads on the same document.

One such example of this problematic use is the calls to `DocumentImpl#getDocType()` which can be seen in the XML-RPC and XML:DB APIs:

`LocalXMLResource#getDocType()`:
```java
    public  DocumentType getDocType() throws XMLDBException {
        return read((document, broker, transaction) -> document.getDoctype());
    }
```

`RpcConnection#getDocType(XmldbURI)`:
```java
    private List<String> getDocType(final XmldbURI docUri)
            throws PermissionDeniedException, EXistException {
        return this.<List<String>>readDocument(docUri).apply((document, broker, transaction) -> {
            final List<String> list = new ArrayList<>(3);

            if (document.getDoctype() != null) {
                list.add(document.getDoctype().getName());

                if (document.getDoctype().getPublicId() != null) {
                    list.add(document.getDoctype().getPublicId());
                } else {
                    list.add("");
                }

                if (document.getDoctype().getSystemId() != null) {
                    list.add(document.getDoctype().getSystemId());
                } else {
                    list.add("");
                }
            } else {
                list.add("");
                list.add("");
                list.add("");
            }
            return list;
        });
    }
```

There are other such examples which are easily discoverable in the code base. There are also a few instances where calls to `DocumentImpl#getMetadata()` are undertaken without either a `READ_LOCK` or `WRITE_LOCK`, which will likely compound the issue discussed above.
 
This PR removes the lazy-loading in `DocumentImpl#getMetadata()`, instead loading the metadata at the same time as the other persisted state of the `DocumentImpl`.