### PR TITLE
reload index controller when index configuration changed

### DIFF
--- a/src/org/exist/indexing/IndexManager.java
+++ b/src/org/exist/indexing/IndexManager.java
@@ -132,6 +132,9 @@ public class IndexManager implements BrokerPoolService {
         if (LOG.isInfoEnabled()) {
             LOG.info("Registered index " + index.getClass() + " as " + index.getIndexId());
         }
+
+        pool.configurationChanged();
+
         return index;
     }
 
@@ -140,6 +143,8 @@ public class IndexManager implements BrokerPoolService {
         if (LOG.isInfoEnabled()) {
             LOG.info("Unregistered index " + index.getClass() + " as " + index.getIndexId());
         }
+
+        pool.configurationChanged();
     }
 
     /**

--- a/src/org/exist/indexing/IndexManager.java
+++ b/src/org/exist/indexing/IndexManager.java
@@ -57,11 +57,22 @@ public class IndexManager implements BrokerPoolService {
     private Configuration.IndexModuleConfig modConfigs[];
     private Path dataDir;
 
+    long config_timestamp = 0;
+
     /**
      * @param pool   the BrokerPool representing the current database instance
      */
     public IndexManager(final BrokerPool pool) {
         this.pool = pool;
+        configurationChanged();
+    }
+
+    private void configurationChanged() {
+        config_timestamp = System.currentTimeMillis();
+    }
+
+    public long getConfigurationTimestamp() {
+        return config_timestamp;
     }
 
     @Override
@@ -69,6 +80,7 @@ public class IndexManager implements BrokerPoolService {
         this.modConfigs = (Configuration.IndexModuleConfig[])
                 configuration.getProperty(PROPERTY_INDEXER_MODULES);
         this.dataDir = (Path) configuration.getProperty(BrokerPool.PROPERTY_DATA_DIR);
+        configurationChanged();
     }
 
     /**
@@ -100,6 +112,8 @@ public class IndexManager implements BrokerPoolService {
             }
         } catch(final DatabaseConfigurationException e) {
             throw new BrokerPoolServiceException(e);
+        } finally {
+            configurationChanged();
         }
     }
 
@@ -133,7 +147,7 @@ public class IndexManager implements BrokerPoolService {
             LOG.info("Registered index " + index.getClass() + " as " + index.getIndexId());
         }
 
-        pool.configurationChanged();
+        configurationChanged();
 
         return index;
     }
@@ -144,7 +158,7 @@ public class IndexManager implements BrokerPoolService {
             LOG.info("Unregistered index " + index.getClass() + " as " + index.getIndexId());
         }
 
-        pool.configurationChanged();
+        configurationChanged();
     }
 
     /**

--- a/src/org/exist/storage/BrokerPool.java
+++ b/src/org/exist/storage/BrokerPool.java
@@ -1042,6 +1042,11 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
         return globalXUpdateLock;
     }
 
+    long config_ts = 0;
+    public void configurationChanged() {
+        config_ts = System.currentTimeMillis();
+    }
+
     /**
      * Creates an inactive broker for the database instance.
      *
@@ -1187,6 +1192,12 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
                     }
             }
             broker = inactiveBrokers.pop();
+
+            if (broker.config_ts != config_ts) {
+                broker.config_ts = config_ts;
+                broker.initIndexModules();
+            }
+
             //activate the broker
             activeBrokers.put(Thread.currentThread(), broker);
 

--- a/src/org/exist/storage/BrokerPool.java
+++ b/src/org/exist/storage/BrokerPool.java
@@ -52,7 +52,6 @@ import org.exist.scheduler.impl.SystemTaskJobImpl;
 import org.exist.security.*;
 import org.exist.security.SecurityManager;
 import org.exist.security.internal.SecurityManagerImpl;
-import org.exist.storage.btree.DBException;
 import org.exist.storage.journal.JournalManager;
 import org.exist.storage.lock.DeadlockDetection;
 import org.exist.storage.lock.FileLockService;
@@ -1042,11 +1041,6 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
         return globalXUpdateLock;
     }
 
-    long config_ts = 0;
-    public void configurationChanged() {
-        config_ts = System.currentTimeMillis();
-    }
-
     /**
      * Creates an inactive broker for the database instance.
      *
@@ -1192,11 +1186,7 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
                     }
             }
             broker = inactiveBrokers.pop();
-
-            if (broker.config_ts != config_ts) {
-                broker.config_ts = config_ts;
-                broker.initIndexModules();
-            }
+            broker.initIndexModules();
 
             //activate the broker
             activeBrokers.put(Thread.currentThread(), broker);

--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -116,6 +116,8 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
 
     protected IndexController indexController;
 
+    long config_ts = 0;
+
     public DBBroker(final BrokerPool pool, final Configuration config) {
         this.config = config;
         final Boolean temp = (Boolean) config.getProperty(NativeValueIndex.PROPERTY_INDEX_CASE_SENSITIVE);

--- a/src/org/exist/storage/DBBroker.java
+++ b/src/org/exist/storage/DBBroker.java
@@ -116,7 +116,7 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
 
     protected IndexController indexController;
 
-    long config_ts = 0;
+    long config_timestamp = 0;
 
     public DBBroker(final BrokerPool pool, final Configuration config) {
         this.config = config;
@@ -129,7 +129,11 @@ public abstract class DBBroker extends Observable implements AutoCloseable {
     }
 
     public void initIndexModules() {
-        indexController = new IndexController(this);
+        if (indexController == null
+            || getBrokerPool().getIndexManager().getConfigurationTimestamp() != config_timestamp) {
+
+            indexController = new IndexController(this);
+        }
     }
 
     /**


### PR DESCRIPTION
Use `System.currentTimeMillis()` to detect that  `IndexManager` configuration change and reinit `IndexController` at broker

(port 3ab8ac96dc444477839b17d023e728f47d9cf675)