### PR TITLE
Update map -> map(*) and empty() -> empty-sequence() according to spec.

### DIFF
--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -191,7 +191,7 @@ public class Type {
         defineBuiltInType(ITEM, "item()");
         defineBuiltInType(EMPTY, "empty-sequence()","empty()"); // keep empty() for backward compatibility
 
-        defineBuiltInType(ELEMENT, "element(*)","element()");
+        defineBuiltInType(ELEMENT, "element()");
         defineBuiltInType(DOCUMENT, "document-node()");
         defineBuiltInType(ATTRIBUTE, "attribute()");
         defineBuiltInType(TEXT, "text()");

--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -189,7 +189,7 @@ public class Type {
         //TODO use parentheses after the nodes name  ?
         defineBuiltInType(NODE, "node()");
         defineBuiltInType(ITEM, "item()");
-        defineBuiltInType(EMPTY, "empty()");
+        defineBuiltInType(EMPTY, "empty-sequence()","empty");
 
         defineBuiltInType(ELEMENT, "element()");
         defineBuiltInType(DOCUMENT, "document-node()");
@@ -202,7 +202,7 @@ public class Type {
 
         defineBuiltInType(JAVA_OBJECT, "object");
         defineBuiltInType(FUNCTION_REFERENCE, "function");
-        defineBuiltInType(MAP, "map");
+        defineBuiltInType(MAP, "map(*)", "map");
         defineBuiltInType(ARRAY, "array");
         defineBuiltInType(NUMBER, "numeric");
 

--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -189,7 +189,7 @@ public class Type {
         //TODO use parentheses after the nodes name  ?
         defineBuiltInType(NODE, "node()");
         defineBuiltInType(ITEM, "item()");
-        defineBuiltInType(EMPTY, "empty-sequence()","empty");
+        defineBuiltInType(EMPTY, "empty-sequence()","empty()"); // keep empty() for backward compatibility
 
         defineBuiltInType(ELEMENT, "element()");
         defineBuiltInType(DOCUMENT, "document-node()");
@@ -202,7 +202,7 @@ public class Type {
 
         defineBuiltInType(JAVA_OBJECT, "object");
         defineBuiltInType(FUNCTION_REFERENCE, "function");
-        defineBuiltInType(MAP, "map(*)", "map");
+        defineBuiltInType(MAP, "map(*)", "map"); // keep map for backward compatibility
         defineBuiltInType(ARRAY, "array");
         defineBuiltInType(NUMBER, "numeric");
 

--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -191,7 +191,7 @@ public class Type {
         defineBuiltInType(ITEM, "item()");
         defineBuiltInType(EMPTY, "empty-sequence()","empty()"); // keep empty() for backward compatibility
 
-        defineBuiltInType(ELEMENT, "element()");
+        defineBuiltInType(ELEMENT, "element(*)","element()");
         defineBuiltInType(DOCUMENT, "document-node()");
         defineBuiltInType(ATTRIBUTE, "attribute()");
         defineBuiltInType(TEXT, "text()");
@@ -201,9 +201,9 @@ public class Type {
         defineBuiltInType(CDATA_SECTION, "cdata-section()");
 
         defineBuiltInType(JAVA_OBJECT, "object");
-        defineBuiltInType(FUNCTION_REFERENCE, "function");
+        defineBuiltInType(FUNCTION_REFERENCE, "function(*)", "function");
         defineBuiltInType(MAP, "map(*)", "map"); // keep map for backward compatibility
-        defineBuiltInType(ARRAY, "array");
+        defineBuiltInType(ARRAY, "array(*)","array");
         defineBuiltInType(NUMBER, "numeric");
 
         defineBuiltInType(ANY_TYPE, "xs:anyType");

--- a/test/src/xquery/suite.xql
+++ b/test/src/xquery/suite.xql
@@ -13,5 +13,6 @@ test:suite((
     inspect:module-functions(xs:anyURI("fn.xql")),
     inspect:module-functions(xs:anyURI("errors.xql")),
     inspect:module-functions(xs:anyURI("nill.xql")),
-    inspect:module-functions(xs:anyURI("ft-match.xql"))
+    inspect:module-functions(xs:anyURI("ft-match.xql")),
+    inspect:module-functions(xs:anyURI("types.xql"))
 ))

--- a/test/src/xquery/types.xql
+++ b/test/src/xquery/types.xql
@@ -1,0 +1,53 @@
+xquery version "3.0";
+
+(:~
+ : Tests textual representation of datatypes
+ :)
+module namespace tps="http://exist-db.org/test/types";
+
+import module namespace inspect="http://exist-db.org/xquery/inspection" at "java:org.exist.xquery.functions.inspect.InspectionModule";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:assertEquals("map(*)")
+function tps:map_type() {
+    data(inspect:inspect-function(map:entry#2)//returns/@type)
+};
+
+declare
+    %test:assertEquals("empty-sequence()")
+function tps:empty_sequence() {
+    data(inspect:inspect-function(fn:error#2)//returns/@type)
+};
+
+declare
+    %test:assertEquals("document-node()")
+function tps:document_node() {
+    data(inspect:inspect-function(fn:doc#1)//returns/@type)
+};
+
+declare
+    %test:assertEquals("xs:string")
+function tps:string() {
+    data(inspect:inspect-function(fn:format-date#2)//returns/@type)
+};
+
+declare
+    %test:assertEquals("xs:integer")
+function tps:integer() {
+    data(inspect:inspect-function(fn:function-arity#1)//returns/@type)
+};
+
+declare
+    %test:assertEquals("function(*)")
+function tps:function() {
+    data(inspect:inspect-function(fn:function-lookup#2)//returns/@type)
+};
+
+declare
+    %test:assertEquals("xs:QName")
+function tps:xqname() {
+    data(inspect:inspect-function(fn:function-name#1)//returns/@type)
+};
+

--- a/test/src/xquery/types.xql
+++ b/test/src/xquery/types.xql
@@ -51,3 +51,9 @@ function tps:xqname() {
     data(inspect:inspect-function(fn:function-name#1)//returns/@type)
 };
 
+declare
+    %test:assertEquals("array(*)")
+function tps:array() {
+    data(inspect:inspect-function(array:append#2)//returns/@type)
+};
+


### PR DESCRIPTION
### Description:

Update `map -> map(*)` and `empty() -> empty-sequence()` according to spec.
and: `element(*)`, `function(*)` and `array(*)`

### Reference:

https://www.w3.org/TR/xquery-31/#doc-xquery31-SequenceType
https://www.w3.org/TR/xquery-31/#doc-xquery31-MapTest

### Type of tests:

- existing tets suite --> OK
- pending: additional test to show progression

@wolfgangmm is this a correct approach?