### PR TITLE
[bugfix] When copying a Collection we only need a READ_LOCK on the source collection

### DIFF
--- a/src/org/exist/xmldb/LocalCollectionManagementService.java
+++ b/src/org/exist/xmldb/LocalCollectionManagementService.java
@@ -192,7 +192,7 @@ public class LocalCollectionManagementService extends AbstractLocalService imple
         }
 
         withDb((broker, transaction) ->
-                modify(broker, transaction, srcPath).apply((source, b1, t1) ->
+                read(broker, transaction, srcPath).apply((source, b1, t1) ->
                         modify(b1, t1, destPath).apply((destination, b2, t2) -> {
                             try {
                                 b2.copyCollection(t2, source, destination, newName);


### PR DESCRIPTION
Relaxes the WRITE_LOCK to a READ_LOCK when copying a local collection with XML:DB API