### PR TITLE
Enhancement to the noDiacriticsAnalyzer for Lucene.

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/analyzers/NoDiacriticsStandardAnalyzer.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/analyzers/NoDiacriticsStandardAnalyzer.java
@@ -20,6 +20,7 @@
 package org.exist.indexing.lucene.analyzers;
 
 import org.apache.lucene.analysis.*;
+import org.apache.lucene.analysis.icu.*;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.core.StopFilter;
@@ -129,7 +130,7 @@ public class NoDiacriticsStandardAnalyzer extends StopwordAnalyzerBase {
         src.setMaxTokenLength(maxTokenLength);
 //        src.setReplaceInvalidAcronym(replaceInvalidAcronym);
         TokenStream tok = new StandardFilter(getVersion(), src);
-        tok = new ASCIIFoldingFilter(tok);
+        tok = new ICUFoldingFilter(tok);
         tok = new LowerCaseFilter(getVersion(), tok);
         tok = new StopFilter(getVersion(), tok, stopwords);
         return new TokenStreamComponents(src, tok);

--- a/extensions/indexes/lucene/test/src/xquery/lucene/analyzers.xql
+++ b/extensions/indexes/lucene/test/src/xquery/lucene/analyzers.xql
@@ -46,6 +46,21 @@ function analyze:setup() {
                 <p>Russelsheim</p>
                 <p>Māori</p>
                 <p>Maori</p>
+                <!--Syriac, eastern, western and no vowels. -->
+                <p>ܦܘܼܪܫܵܢܵܐ</p>    
+                <p>ܦܘܽܪܫܳܢܳܐ</p>
+                <p>ܦܘܪܫܢܐ</p>
+                <!-- Hebrew with and without vowels -->
+                <p>פָּעַל</p>
+                <p>פעל</p>  
+                <!-- Arabic with and without vowels -->
+                <p>بَردَيصان</p>
+                <p>برديصان</p>     
+                <!-- Pinyin tone marks -->
+                <p>nǚ</p>   
+                <p>nu</p>   
+                <p>zìyóu</p>
+                <p>ziyou</p>                
             </test>
         ),
         xmldb:store($confCol2, "collection.xconf", $analyze:XCONF2),
@@ -55,6 +70,21 @@ function analyze:setup() {
                 <p>Russelsheim</p>
                 <p>Māori</p>
                 <p>Maori</p>
+                <!--Syriac, eastern, western and no vowels. -->
+                <p>ܦܘܼܪܫܵܢܵܐ</p>    
+                <p>ܦܘܽܪܫܳܢܳܐ</p>
+                <p>ܦܘܪܫܢܐ</p>  
+                <!-- Hebrew with and without vowels-->
+                <p>פָּעַל</p>
+                <p>פעל</p> 
+                <!-- Arabic with and without vowels -->
+                <p>بَردَيصان</p>
+                <p>برديصان</p>  
+                <!-- Pinyin tone marks -->
+                <p>nǚ</p>   
+                <p>nu</p> 
+                <p>zìyóu</p>
+                <p>ziyou</p>
             </test>
         )
     )
@@ -76,6 +106,28 @@ declare
     %test:assertEquals(2)
     %test:args("Māori")
     %test:assertEquals(2)
+    %test:args("ܦܘܼܪܫܵܢܵܐ")
+    %test:assertEquals(3)
+    %test:args("ܦܘܽܪܫܳܢܳܐ")
+    %test:assertEquals(3)
+    %test:args("ܦܘܪܫܢܐ")
+    %test:assertEquals(3)
+    %test:args("פָּעַל")
+    %test:assertEquals(2)
+    %test:args("פעל")
+    %test:assertEquals(2)
+    %test:args("بَردَيصان")
+    %test:assertEquals(2)
+    %test:args("برديصان")
+    %test:assertEquals(2)
+    %test:args("nǚ")
+    %test:assertEquals(2)
+    %test:args("nu")
+    %test:assertEquals(2)
+    %test:args("zìyóu")
+    %test:assertEquals(2)
+    %test:args("ziyou")
+    %test:assertEquals(2)     
 function analyze:no-diacrictics($term as xs:string) {
     count(collection("/db/lucenetest/test1")//p[ft:query(., $term)])
 };
@@ -89,6 +141,28 @@ declare
     %test:assertEquals(1)
     %test:args("Māori")
     %test:assertEquals(1)
+    %test:args("ܦܘܼܪܫܵܢܵܐ")
+    %test:assertEquals(1)
+    %test:args("ܦܘܽܪܫܳܢܳܐ")
+    %test:assertEquals(1)
+    %test:args("ܦܘܪܫܢܐ")
+    %test:assertEquals(1)    
+    %test:args("פָּעַל")
+    %test:assertEquals(1)
+    %test:args("פעל")
+    %test:assertEquals(1)  
+    %test:args("بَردَيصان")
+    %test:assertEquals(1)
+    %test:args("برديصان")
+    %test:assertEquals(1)  
+    %test:args("nǚ")
+    %test:assertEquals(1)
+    %test:args("nu")
+    %test:assertEquals(1)
+    %test:args("zìyóu")
+    %test:assertEquals(1)
+    %test:args("ziyou")
+    %test:assertEquals(1)       
 function analyze:diacrictics($term as xs:string) {
     count(collection("/db/lucenetest/test2")//p[ft:query(., $term)])
 };
@@ -102,6 +176,12 @@ declare
     %test:assertEquals(2)
     %test:args("Māor*")
     %test:assertEquals(2)
+    %test:args("ܦܘܪ*")
+    %test:assertEquals(3)
+    %test:args("פע*")
+    %test:assertEquals(2)
+    %test:args("بردي*")
+    %test:assertEquals(2)    
 function analyze:query-parser($term as xs:string) {
     count(collection("/db/lucenetest/test1")//p[ft:query(., $term)])
 };


### PR DESCRIPTION
### Description:
Enhancement to the noDiacriticsAnalyzer for Lucene to filter out vowels in languages such as Syriac, Hebrew, and Arabic. It also strips some additional diacritic characters not handled by the ASCIIFoldingFilter, see Pinyin test cases for examples. 

Change swaps in ICUFoldingFilter in place of the ASCIIFoldingFilter. Test cases for Syriac, Hebrew, Arabic and Pinyin added to the analyzers.xql tests. 


### Reference:
See discussion here: http://exist-open.markmail.org/message/recx6njwbqt6sshd?q=ICU4j+for+the+No+Diacritics+Analyzer

And related issue here: https://github.com/srophe/syriac-corpus-app/issues/36

### Type of tests:
Tests added to $EXIST_HOME/extensions/indexes/lucene/test/src/xquery/lucene/analyzers.xql

Results of junit testsuite 
   
Tests | Failures | Errors | Skipped | Success rate | Time
-- | -- | -- | -- | -- | --
2706 | 0 | 0 | 59 | 100.00% | 693.683


