### PR TITLE
Fix the Windows Ant build

### DIFF
--- a/build/scripts/dist.xml
+++ b/build/scripts/dist.xml
@@ -29,8 +29,22 @@
         <mkdir dir="webapp/WEB-INF/logs"/>
 
         <!-- create war specific configuration files -->
-        <xslt in="conf.xml"  out="webapp/WEB-INF/conf.xml"  style="${build.scripts}/dist-war-conf.xsl"/>
-        <xslt in="log4j2.xml" out="webapp/WEB-INF/log4j2.xml" style="${build.scripts}/dist-war-log4j.xsl"/>
+        <xslt in="conf.xml"  out="webapp/WEB-INF/conf.xml"  style="${build.scripts}/dist-war-conf.xsl" classpathref="classpath.core">
+            <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+            <classpath>
+                <fileset dir="lib/endorsed">
+                    <include name="Saxon*.jar"/>
+                </fileset>
+            </classpath>
+        </xslt>
+        <xslt in="log4j2.xml" out="webapp/WEB-INF/log4j2.xml" style="${build.scripts}/dist-war-log4j.xsl" classpathref="classpath.core">
+        <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+            <classpath>
+                <fileset dir="lib/endorsed">
+                    <include name="Saxon*.jar"/>
+                </fileset>
+            </classpath>
+        </xslt>
         
         <!-- fetch war specific libs -->
         <path id="log4j2.core.path">

--- a/build/scripts/installer.xml
+++ b/build/scripts/installer.xml
@@ -123,12 +123,11 @@
         <delete file="installer/install.xml" failonerror="false"/>
         <xslt basedir="installer" in="installer/install.xml.tmpl"
             out="installer/install.xml"
-            style="installer/install.xsl" classpathref="classpath.core"
-            processor="trax">
+            style="installer/install.xsl" classpathref="classpath.core">
             <factory name="net.sf.saxon.TransformerFactoryImpl"/>
             <classpath>
                 <fileset dir="lib/endorsed">
-                    <include name="saxon*.jar"/>
+                    <include name="Saxon*.jar"/>
                 </fileset>
             </classpath>
             <param name="apps" expression="${apps.list}"/>

--- a/build/scripts/junit.xml
+++ b/build/scripts/junit.xml
@@ -109,7 +109,14 @@
         <mkdir dir="${junit.reports.html}"/>
 
         <!-- create a log4j config for running the tests -->
-        <xslt in="${basedir}/log4j2.xml" out="${basedir}/test/classes/log4j2-test.xml" style="${build.scripts}/log4j2-test.xsl"/>
+        <xslt in="${basedir}/log4j2.xml" out="${basedir}/test/classes/log4j2-test.xml" style="${build.scripts}/log4j2-test.xsl" classpathref="classpath.core">
+            <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+            <classpath>
+                <fileset dir="lib/endorsed">
+                    <include name="Saxon*.jar"/>
+                </fileset>
+            </classpath>
+        </xslt>
 
     </target>
 
@@ -122,7 +129,17 @@
             <fileset dir="${junit.reports.dat}">
                 <include name="TEST-*.xml"/>
             </fileset>
-            <report format="frames" todir="${junit.reports.html}"/>
+            <report format="frames" todir="${junit.reports.html}">
+                <classpath>
+                    <fileset dir="lib/endorsed">
+                        <include name="xalan*.jar"/>
+                        <include name="xml-apis*.jar"/>
+                        <include name="xercesImpl*.jar"/>
+                        <include name="serializer*.jar"/>
+                    </fileset>
+                </classpath>
+                <factory name="org.apache.xalan.processor.TransformerFactoryImpl"/>
+            </report>
         </junitreport>
     </target>
 

--- a/build/scripts/minimal.xml
+++ b/build/scripts/minimal.xml
@@ -50,12 +50,26 @@ expand-xincludes=yes
 highlight-matches=none
 
 </echo>
-  <xslt in="${src.dir}/conf.xml" out="${dist.minimal}/conf.xml" style="${build.scripts}/minimal-fix-conf.xsl"/>
+  <xslt in="${src.dir}/conf.xml" out="${dist.minimal}/conf.xml" style="${build.scripts}/minimal-fix-conf.xsl" classpathref="classpath.core">
+    <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+    <classpath>
+      <fileset dir="lib/endorsed">
+        <include name="Saxon*.jar"/>
+      </fileset>
+    </classpath>
+  </xslt>
   <copy file="${src.dir}/descriptor.xml" todir="${dist.minimal}"/>
   <copy file="${src.dir}/exist.jar" todir="${dist.minimal}"/>
   <copy file="${src.dir}/exist-optional.jar" todir="${dist.minimal}"/>
   <copy file="${src.dir}/LICENSE" todir="${dist.minimal}"/>
-  <xslt in="${src.dir}/log4j2.xml" out="${dist.minimal}/log4j2.xml" style="${build.scripts}/minimal-fix-log4j.xsl"/>
+  <xslt in="${src.dir}/log4j2.xml" out="${dist.minimal}/log4j2.xml" style="${build.scripts}/minimal-fix-log4j.xsl" classpathref="classpath.core">
+    <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+    <classpath>
+      <fileset dir="lib/endorsed">
+        <include name="Saxon*.jar"/>
+      </fileset>
+    </classpath>
+  </xslt>
   <copy file="${src.dir}/mime-types.xml" todir="${dist.minimal}"/>
   <copy file="${src.dir}/server.xml" todir="${dist.minimal}"/>
   <!-- copy file="${src.dir}/atom-services.xml" todir="${dist.minimal}"/ -->

--- a/tools/yajsw/build.xml
+++ b/tools/yajsw/build.xml
@@ -30,6 +30,12 @@
     	<pathelement path="${server.dir}/exist.jar"/>
     </path>
 
+    <path id="classpath.saxon">
+        <fileset dir="${env.EXIST_HOME}/lib/endorsed">
+            <include name="Saxon*.jar"/>
+        </fileset>
+    </path>
+
     <available file="${conf}/wrapper.conf" property="conf.available"/>
 
     <!-- =================================================================== -->
@@ -62,7 +68,9 @@
     <!-- Prepare the build                                                   -->
     <!-- =================================================================== -->
     <target name="prepare" depends="create-conf">
-    	<echo message="--------------------------------------------------"/>
+        <fail unless="env.EXIST_HOME" message="EXIST_HOME environment variable not set. Please set it and start the build again. If run from commandline just prepend it."/>
+
+        <echo message="--------------------------------------------------"/>
         <echo message="Setting up Java Service Wrapper"/>
         <echo message="--------------------------------------------------"/>
        
@@ -74,7 +82,14 @@
         <tstamp/>
 
         <!-- Create log4j config based on general config file -->
-        <xslt in="${server.dir}/log4j2.xml" out="${conf}/log4j2.xml" style="${wrapper.dir}/wrapper-log4j.xsl"/>
+        <xslt in="${server.dir}/log4j2.xml" out="${conf}/log4j2.xml" style="${wrapper.dir}/wrapper-log4j.xsl" classpathref="classpath.saxon">
+            <factory name="net.sf.saxon.TransformerFactoryImpl"/>
+            <classpath>
+                <fileset dir="${env.EXIST_HOME}/lib/endorsed">
+                    <include name="Saxon*.jar"/>
+                </fileset>
+            </classpath>
+        </xslt>
     </target>
 
     <!-- =================================================================== -->


### PR DESCRIPTION
Ant seems to work a little differently on Windows. Fixes an issue introduced when we removed `-Djava.endorsed.dir`