### PR TITLE
Ensure math functions report their ns prefix

### DIFF
--- a/src/org/exist/xquery/functions/math/NoParamFunctions.java
+++ b/src/org/exist/xquery/functions/math/NoParamFunctions.java
@@ -46,7 +46,7 @@ public class NoParamFunctions extends BasicFunction {
     public static final String PI = "pi";
 
     public final static FunctionSignature FNS_PI = new FunctionSignature(
-        new QName(PI, MathModule.NAMESPACE_URI),
+        new QName(PI, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the value of pi.",
         null,
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the value of pi")

--- a/src/org/exist/xquery/functions/math/OneParamFunctions.java
+++ b/src/org/exist/xquery/functions/math/OneParamFunctions.java
@@ -59,77 +59,77 @@ public class OneParamFunctions extends BasicFunction {
     public static final String TAN = "tan";
     
     public final static FunctionSignature FNS_ACOS = new FunctionSignature(
-        new QName(ACOS, MathModule.NAMESPACE_URI),
+        new QName(ACOS, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the arc cosine of the argument, the result being in the range zero to +π radians.",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the result")
     );
                         
     public final static FunctionSignature FNS_ASIN = new FunctionSignature(
-        new QName(ASIN, MathModule.NAMESPACE_URI),
+        new QName(ASIN, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the arc sine of the argument, the result being in the range -π/2 to +π/2 radians.",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "result")
     );
     
     public final static FunctionSignature FNS_ATAN = new FunctionSignature(
-        new QName(ATAN, MathModule.NAMESPACE_URI),
+        new QName(ATAN, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the arc tangent of the argument, the result being in the range -π/2 to +π/2 radians.",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the result")
     );
     
     public final static FunctionSignature FNS_COS = new FunctionSignature(
-        new QName(COS, MathModule.NAMESPACE_URI),
+        new QName(COS, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the cosine of the argument, expressed in radians.",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the cosine")
     );
     
     public final static FunctionSignature FNS_EXP = new FunctionSignature(
-        new QName(EXP, MathModule.NAMESPACE_URI),
+        new QName(EXP, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Calculates e (the Euler Constant) raised to the power of $arg",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "e (the Euler Constant) raised to the power of a value or expression")
     );
                 
     public final static FunctionSignature FNS_EXP10 = new FunctionSignature( // NEW
-        new QName(EXP10, MathModule.NAMESPACE_URI),
+        new QName(EXP10, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Calculates 10 raised to the power of $arg",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "e (the Euler Constant) raised to the power of a value or expression")
     );
         
     public final static FunctionSignature FNS_LOG = new FunctionSignature(
-        new QName(LOG, MathModule.NAMESPACE_URI),
+        new QName(LOG, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the natural logarithm of the argument.",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the log")
     );
         
     public final static FunctionSignature FNS_LOG10 = new FunctionSignature( // NEW
-        new QName(LOG10, MathModule.NAMESPACE_URI),
+        new QName(LOG10, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the base-ten logarithm of the argument.",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the log")
     );
         
     public final static FunctionSignature FNS_SIN = new FunctionSignature(
-        new QName(SIN, MathModule.NAMESPACE_URI),
+        new QName(SIN, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the sine of the argument, expressed in radians.",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the sine")
     );
         
     public final static FunctionSignature FNS_SQRT = new FunctionSignature(
-        new QName(SQRT, MathModule.NAMESPACE_URI),
+        new QName(SQRT, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the non-negative square root of the argument.",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the square root of $x")
     );
     
     public final static FunctionSignature FNS_TAN = new FunctionSignature(
-        new QName(TAN, MathModule.NAMESPACE_URI),
+        new QName(TAN, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the tangent of the argument, expressed in radians.",
         new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The radians") },
         new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the tangent")

--- a/src/org/exist/xquery/functions/math/TwoParamFunctions.java
+++ b/src/org/exist/xquery/functions/math/TwoParamFunctions.java
@@ -54,7 +54,7 @@ public class TwoParamFunctions extends BasicFunction {
     
     
     public final static FunctionSignature FNS_ATAN2 = new FunctionSignature(
-        new QName(ATAN2, MathModule.NAMESPACE_URI),
+        new QName(ATAN2, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the angle in radians subtended at the origin by the point on a "
         + "plane with coordinates (x, y) and the positive x-axis, the result being in the range -π to +π.",
         new SequenceType[] {
@@ -65,7 +65,7 @@ public class TwoParamFunctions extends BasicFunction {
     );
         
     public final static FunctionSignature FNS_POW = new FunctionSignature(
-        new QName(POW, MathModule.NAMESPACE_URI),
+        new QName(POW, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the result of raising the first argument to the power of the second.",
         new SequenceType[] {
             new FunctionParameterSequenceType("value", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The value"),


### PR DESCRIPTION
### Description:

This PR fixes a problem with functions in the math module: they did not identify their namespace prefix to functions like `inspect:inspect-function`. 

For example, `inspect:inspect-function(math:pi#0)` would return `@name="pi"` instead of `@name="math:pi"`. In contrast, all modules (other than the default function namespace) module would return, e.g., `@name="array:size"`, `"map:merge"`, etc.

With this PR, math module functions now correctly report their namespace prefix to `inspect:inspect-function`, returning `@name="math:pi"`.

### Reference:

- https://www.w3.org/TR/xpath-functions-31/#namespace-prefixes
- https://www.w3.org/TR/xpath-functions-31/#trigonometry

### Type of tests:

- Well, the math module currently has none of its own tests whatsoever besides the QT3 tests which probably wouldn't test introspectability. I suppose some new test suite could be created, ensuring that `inspect:inspect-function` would include the prefix for functions in the `math`, `map`, and `array` modules. I'm open to suggestions here. I only know about how these functions should report themselves from XQuery and don't know how they should from a Java perspective.