### PR TITLE
adopt XQuery 3.1 xs:numeric union datatype

### DIFF
--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -204,7 +204,7 @@ public class Type {
         defineBuiltInType(FUNCTION_REFERENCE, "function(*)", "function");
         defineBuiltInType(MAP, "map(*)", "map"); // keep map for backward compatibility
         defineBuiltInType(ARRAY, "array(*)","array");
-        defineBuiltInType(NUMBER, "numeric");
+        defineBuiltInType(NUMBER, "xs:numeric", "numeric"); // keep numeric for backward compatibility
 
         defineBuiltInType(ANY_TYPE, "xs:anyType");
         defineBuiltInType(ANY_SIMPLE_TYPE, "xs:anySimpleType");


### PR DESCRIPTION
### Description:

In XQuery 3.1, the previously "numeric" datatype was renamed to "xs:numeric":

> The type `xs:numeric` is defined as a union type whose member types are (in order) `xs:double`, `xs:float`, and `xs:decimal`. 

This PR adopts the new name, while preserving the old one for backward compatibility. (For example, the test at https://github.com/eXist-db/exist/blob/develop/test/src/xquery/numbers/format-numbers.xql#L11, which still references `numeric` as a datatype, still passes after this PR. Running `inspect:inspect-function` on this function, its return type is now reported as `<argument type="xs:numeric" cardinality="exactly one" var="number"/>` rather than `@type="numeric"`.)

Fixing this will help align eXist's function documentation with the XQuery F&O 3.1 spec. 

### Reference:

- XQuery 3.1: https://www.w3.org/TR/xpath-functions-31/#numeric-types
- XQuery 3.0: https://www.w3.org/TR/xpath-functions-30/#numeric-types
- XQuery 1.0: https://www.w3.org/TR/xquery-operators/#numeric-types

### Type of tests:

- As with #1712, I'm open to suggestions for the best type of test for this. I could see an xqsuite test that uses both syntax in a function signature and then calls inspect:inspect-function on each to ensure they both work and return `xs:numeric`. 