### PR TITLE
Implement fn:unparsed-text and related functions

### DIFF
--- a/src/org/exist/source/AbstractSource.java
+++ b/src/org/exist/source/AbstractSource.java
@@ -25,6 +25,7 @@ package org.exist.source;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 
 import org.exist.dom.QName;
 import org.exist.xquery.XPathException;
@@ -42,10 +43,14 @@ public abstract class AbstractSource implements Source {
 
     private long cacheTime = 0;
 
-    
+    @Override
+    public Charset getEncoding() throws IOException {
+        return null;
+    }
+
     /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
+         * @see java.lang.Object#equals(java.lang.Object)
+         */
     @Override
     public boolean equals(Object obj) {
     	if (obj != null && obj instanceof Source) {

--- a/src/org/exist/source/FileSource.java
+++ b/src/org/exist/source/FileSource.java
@@ -120,7 +120,13 @@ public class FileSource extends AbstractSource {
         checkEncoding();
         return new String(Files.readAllBytes(path), encoding);
     }
-    
+
+    @Override
+    public Charset getEncoding() throws IOException {
+        checkEncoding();
+        return encoding;
+    }
+
     private void checkEncoding() throws IOException {
         if (checkEncoding) {
             try(final InputStream is = Files.newInputStream(path)) {

--- a/src/org/exist/source/Source.java
+++ b/src/org/exist/source/Source.java
@@ -25,6 +25,7 @@ package org.exist.source;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
@@ -96,7 +97,15 @@ public interface Source {
     InputStream getInputStream() throws IOException;
 
     String getContent() throws IOException;
-    
+
+    /**
+     * Returns the character encoding of the underlying source or null if unknown.
+     *
+     * @return the character encoding
+     * @throws IOException
+     */
+    Charset getEncoding() throws IOException;
+
     /**
      * Set a timestamp for this source. This is used
      * by {@link org.exist.storage.XQueryPool} to

--- a/src/org/exist/source/Source.java
+++ b/src/org/exist/source/Source.java
@@ -32,6 +32,8 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.security.Subject;
 import org.exist.storage.DBBroker;
 
+import javax.annotation.Nullable;
+
 
 /**
  * A general interface for access to external or internal sources.
@@ -104,7 +106,7 @@ public interface Source {
      * @return the character encoding
      * @throws IOException
      */
-    Charset getEncoding() throws IOException;
+    @Nullable Charset getEncoding() throws IOException;
 
     /**
      * Set a timestamp for this source. This is used

--- a/src/org/exist/xquery/ErrorCodes.java
+++ b/src/org/exist/xquery/ErrorCodes.java
@@ -214,6 +214,8 @@ public class ErrorCodes {
     public static final ErrorCode FOJS0003 = new W3CErrorCode("FOJS0003", "JSON duplicate keys.");
 
     public static final ErrorCode FOUT1170 = new W3CErrorCode("FOUT1170", "Invalid $href argument to fn:unparsed-text() (etc.)");
+    public static final ErrorCode FOUT1190 = new W3CErrorCode("FOUT1190", "Cannot decode resource retrieved by fn:unparsed-text() (etc.)");
+    public static final ErrorCode FOUT1200 = new W3CErrorCode("FOUT1200", "Cannot infer encoding of resource retrieved by fn:unparsed-text() (etc.)");
     public static final ErrorCode FOQM0001 = new W3CErrorCode("FOQM0001", "Module URI is a zero-length string");
     public static final ErrorCode FOQM0002 = new W3CErrorCode("FOQM0002", "Module URI not found.");
     public static final ErrorCode FOQM0003 = new W3CErrorCode("FOQM0003", "Static error in dynamically-loaded XQuery module.");

--- a/src/org/exist/xquery/functions/fn/FnModule.java
+++ b/src/org/exist/xquery/functions/fn/FnModule.java
@@ -246,7 +246,9 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT[0], FunUnparsedText.class),
         new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT[1], FunUnparsedText.class),
         new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT_LINES[0], FunUnparsedText.class),
-        new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT_LINES[1], FunUnparsedText.class)
+        new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT_LINES[1], FunUnparsedText.class),
+        new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT_AVAILABLE[0], FunUnparsedText.class),
+        new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT_AVAILABLE[1], FunUnparsedText.class)
     };
 
     static {

--- a/src/org/exist/xquery/functions/fn/FnModule.java
+++ b/src/org/exist/xquery/functions/fn/FnModule.java
@@ -242,7 +242,11 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(LoadXQueryModule.LOAD_XQUERY_MODULE_2, LoadXQueryModule.class),
         new FunctionDef(FunSort.signatures[0], FunSort.class),
         new FunctionDef(FunSort.signatures[1], FunSort.class),
-        new FunctionDef(FunSort.signatures[2], FunSort.class)
+        new FunctionDef(FunSort.signatures[2], FunSort.class),
+        new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT[0], FunUnparsedText.class),
+        new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT[1], FunUnparsedText.class),
+        new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT_LINES[0], FunUnparsedText.class),
+        new FunctionDef(FunUnparsedText.FS_UNPARSED_TEXT_LINES[1], FunUnparsedText.class)
     };
 
     static {

--- a/src/org/exist/xquery/functions/fn/FunUnparsedText.java
+++ b/src/org/exist/xquery/functions/fn/FunUnparsedText.java
@@ -66,6 +66,15 @@ public class FunUnparsedText extends BasicFunction {
                 arity(PARAM_HREF, PARAM_ENCODING)
         ));
 
+    static final FunctionSignature [] FS_UNPARSED_TEXT_AVAILABLE = functionSignatures(
+        new QName("unparsed-text-available", Function.BUILTIN_FUNCTION_NS),
+        "determines whether a call on the fn:unparsed-text function with identical arguments would return a string",
+        returnsOpt(Type.STRING),
+        arities(
+                arity(PARAM_HREF),
+                arity(PARAM_HREF, PARAM_ENCODING)
+        ));
+
     public FunUnparsedText(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
@@ -74,7 +83,18 @@ public class FunUnparsedText extends BasicFunction {
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
         final String encoding = args.length == 2 ? args[1].getStringValue() : null;
         if (!args[0].isEmpty()) {
-            final String content = readContent(args[0].getStringValue(), encoding);
+            final String content;
+            try {
+                content = readContent(args[0].getStringValue(), encoding);
+            } catch (XPathException e) {
+                if (isCalledAs("unparsed-text-available")) {
+                    return BooleanValue.FALSE;
+                }
+                throw e;
+            }
+            if (isCalledAs("unparsed-text-available")) {
+                return BooleanValue.TRUE;
+            }
             if (isCalledAs("unparsed-text-lines")) {
                 final Pattern pattern = PatternFactory.getInstance().getPattern(LINE_REGEX);
                 final String[] lines = pattern.split(content);

--- a/src/org/exist/xquery/functions/fn/FunUnparsedText.java
+++ b/src/org/exist/xquery/functions/fn/FunUnparsedText.java
@@ -1,0 +1,129 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2017 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.xquery.functions.fn;
+
+import org.apache.commons.io.IOUtils;
+import org.exist.dom.QName;
+import org.exist.security.PermissionDeniedException;
+import org.exist.source.Source;
+import org.exist.source.SourceFactory;
+import org.exist.util.PatternFactory;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+import static org.exist.xquery.FunctionDSL.*;
+
+public class FunUnparsedText extends BasicFunction {
+
+    private final static String LINE_REGEX = "\\r\\n|\\r|\\n";
+
+    private final static FunctionParameterSequenceType PARAM_HREF = optParam("href", Type.STRING, "the URI to load text from");
+    private final static FunctionParameterSequenceType PARAM_ENCODING = param("encoding", Type.STRING, "character encoding of the resource");
+
+    static final FunctionSignature [] FS_UNPARSED_TEXT = functionSignatures(
+        new QName("unparsed-text", Function.BUILTIN_FUNCTION_NS),
+        "reads an external resource (for example, a file) and returns a string representation of the resource",
+        returnsOpt(Type.STRING),
+        arities(
+                arity(PARAM_HREF),
+                arity(PARAM_HREF, PARAM_ENCODING)
+        ));
+
+    static final FunctionSignature[] FS_UNPARSED_TEXT_LINES = functionSignatures(
+        new QName("unparsed-text-lines", Function.BUILTIN_FUNCTION_NS),
+        "reads an external resource (for example, a file) and returns its contents as a sequence of strings, one for each line of text in the string representation of the resource",
+        returnsOptMany(Type.STRING),
+        arities(
+                arity(PARAM_HREF),
+                arity(PARAM_HREF, PARAM_ENCODING)
+        ));
+
+    public FunUnparsedText(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
+        final String encoding = args.length == 2 ? args[1].getStringValue() : null;
+        if (!args[0].isEmpty()) {
+            final String content = readContent(args[0].getStringValue(), encoding);
+            if (isCalledAs("unparsed-text-lines")) {
+                final Pattern pattern = PatternFactory.getInstance().getPattern(LINE_REGEX);
+                final String[] lines = pattern.split(content);
+                int limit = lines.length;
+                if (lines[limit - 1].length() == 0) {
+                    --limit;
+                }
+                final Sequence result = new ValueSequence();
+                for (int i = 0; i < limit; i++) {
+                    result.add(new StringValue(lines[i]));
+                }
+                return result;
+            } else {
+                return new StringValue(content);
+            }
+        }
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    private String readContent(String uriParam, String encoding) throws XPathException {
+        try {
+            URI uri = new URI(uriParam);
+            if (uri.getScheme() == null) {
+                uri = new URI(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + uriParam);
+            }
+            if (uri.getFragment() != null) {
+                throw new XPathException(this, ErrorCodes.FOUT1170, "href argument may not contain fragment identifier");
+            }
+            final StringWriter output = new StringWriter();
+            final Source source = SourceFactory.getSource(context.getBroker(), null, uri.toASCIIString(), false);
+            Charset charset;
+            if (encoding == null) {
+                charset = source.getEncoding();
+                if (charset == null) {
+                    charset = StandardCharsets.UTF_8;
+                }
+            } else {
+                try {
+                    charset = Charset.forName(encoding);
+                } catch (IllegalArgumentException e) {
+                    throw new XPathException(this, ErrorCodes.FOUT1190, e.getMessage());
+                }
+            }
+            try (final InputStream is = source.getInputStream()) {
+                IOUtils.copy(is, output, charset);
+            }
+            return output.toString();
+        } catch (IOException | PermissionDeniedException | URISyntaxException e) {
+            throw new XPathException(this, ErrorCodes.FOUT1170, e.getMessage());
+        }
+    }
+}

--- a/src/org/exist/xquery/functions/fn/FunUnparsedText.java
+++ b/src/org/exist/xquery/functions/fn/FunUnparsedText.java
@@ -30,9 +30,7 @@ import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringWriter;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -42,8 +40,6 @@ import java.util.regex.Pattern;
 import static org.exist.xquery.FunctionDSL.*;
 
 public class FunUnparsedText extends BasicFunction {
-
-    private final static String LINE_REGEX = "\\r\\n|\\r|\\n";
 
     private final static FunctionParameterSequenceType PARAM_HREF = optParam("href", Type.STRING, "the URI to load text from");
     private final static FunctionParameterSequenceType PARAM_ENCODING = param("encoding", Type.STRING, "character encoding of the resource");
@@ -83,38 +79,81 @@ public class FunUnparsedText extends BasicFunction {
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
         final String encoding = args.length == 2 ? args[1].getStringValue() : null;
         if (!args[0].isEmpty()) {
-            final String content;
-            try {
-                content = readContent(args[0].getStringValue(), encoding);
-            } catch (XPathException e) {
-                if (isCalledAs("unparsed-text-available")) {
-                    return BooleanValue.FALSE;
-                }
-                throw e;
-            }
-            if (isCalledAs("unparsed-text-available")) {
-                return BooleanValue.TRUE;
-            }
             if (isCalledAs("unparsed-text-lines")) {
-                final Pattern pattern = PatternFactory.getInstance().getPattern(LINE_REGEX);
-                final String[] lines = pattern.split(content);
-                int limit = lines.length;
-                if (lines[limit - 1].length() == 0) {
-                    --limit;
-                }
-                final Sequence result = new ValueSequence();
-                for (int i = 0; i < limit; i++) {
-                    result.add(new StringValue(lines[i]));
-                }
-                return result;
+                return readLines(args[0].getStringValue(), encoding);
             } else {
+                final String content;
+                try {
+                    content = readContent(args[0].getStringValue(), encoding);
+                } catch (XPathException e) {
+                    if (isCalledAs("unparsed-text-available")) {
+                        return BooleanValue.FALSE;
+                    }
+                    throw e;
+                }
+                if (isCalledAs("unparsed-text-available")) {
+                    return BooleanValue.TRUE;
+                }
                 return new StringValue(content);
             }
         }
         return Sequence.EMPTY_SEQUENCE;
     }
 
-    private String readContent(String uriParam, String encoding) throws XPathException {
+    private String readContent(final String uriParam, final String encoding) throws XPathException {
+        try {
+            final Source source = getSource(uriParam);
+            Charset charset = getCharset(encoding, source);
+            final StringWriter output = new StringWriter();
+            try (final InputStream is = source.getInputStream()) {
+                IOUtils.copy(is, output, charset);
+            }
+            return output.toString();
+        } catch (IOException e) {
+            throw new XPathException(this, ErrorCodes.FOUT1170, e.getMessage());
+        }
+    }
+
+    private Sequence readLines(final String uriParam, final String encoding) throws XPathException {
+        try {
+            final Sequence result = new ValueSequence();
+            final Source source = getSource(uriParam);
+            final Charset charset = getCharset(encoding, source);
+
+            try (final BufferedReader reader = new BufferedReader(new InputStreamReader(source.getInputStream(), charset))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    result.add(new StringValue(line));
+                }
+            }
+            return result;
+        } catch (IOException e) {
+            throw new XPathException(this, ErrorCodes.FOUT1170, e.getMessage());
+        }
+    }
+
+    private Charset getCharset(final String encoding, final Source source) throws XPathException {
+        Charset charset;
+        if (encoding == null) {
+            try {
+                charset = source.getEncoding();
+            } catch (IOException e) {
+                throw new XPathException(this, ErrorCodes.FOUT1170, e.getMessage());
+            }
+            if (charset == null) {
+                charset = StandardCharsets.UTF_8;
+            }
+        } else {
+            try {
+                charset = Charset.forName(encoding);
+            } catch (IllegalArgumentException e) {
+                throw new XPathException(this, ErrorCodes.FOUT1190, e.getMessage());
+            }
+        }
+        return charset;
+    }
+
+    private Source getSource(final String uriParam) throws XPathException {
         try {
             URI uri = new URI(uriParam);
             if (uri.getScheme() == null) {
@@ -123,25 +162,11 @@ public class FunUnparsedText extends BasicFunction {
             if (uri.getFragment() != null) {
                 throw new XPathException(this, ErrorCodes.FOUT1170, "href argument may not contain fragment identifier");
             }
-            final StringWriter output = new StringWriter();
-            final Source source = SourceFactory.getSource(context.getBroker(), null, uri.toASCIIString(), false);
-            Charset charset;
-            if (encoding == null) {
-                charset = source.getEncoding();
-                if (charset == null) {
-                    charset = StandardCharsets.UTF_8;
-                }
-            } else {
-                try {
-                    charset = Charset.forName(encoding);
-                } catch (IllegalArgumentException e) {
-                    throw new XPathException(this, ErrorCodes.FOUT1190, e.getMessage());
-                }
+            final Source source = SourceFactory.getSource(context.getBroker(), "", uri.toASCIIString(), false);
+            if (!context.getBroker().getCurrentSubject().hasDbaRole()) {
+                throw new XPathException(this, ErrorCodes.FOUT1170, "non-dba user not allowed to read from file system");
             }
-            try (final InputStream is = source.getInputStream()) {
-                IOUtils.copy(is, output, charset);
-            }
-            return output.toString();
+            return source;
         } catch (IOException | PermissionDeniedException | URISyntaxException e) {
             throw new XPathException(this, ErrorCodes.FOUT1170, e.getMessage());
         }

--- a/test/src/xquery/arrays/unparsed-text.xql
+++ b/test/src/xquery/arrays/unparsed-text.xql
@@ -1,0 +1,106 @@
+xquery version "3.1";
+
+(:~
+ : Test fn:unparsed-text and friends
+ :)
+module namespace upt="http://exist-db.org/xquery/test/unparsed-text";
+
+import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+declare
+    %test:setUp
+function upt:store() {
+    let $col := xmldb:create-collection("/db", "test-unparsed-text")
+    return
+        xmldb:store($col, "test.txt", "Hello&#10;world!", "application/octet-stream")
+};
+
+declare
+    %test:tearDown
+function upt:cleanup() {
+    xmldb:remove("/db/test-unparsed-text")
+};
+
+declare 
+    %test:assertXPath("contains($result, 'eXist')")
+function upt:unparsed-text-from-url() {
+    unparsed-text("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README")
+};
+
+declare 
+    %test:assertXPath("contains($result, '----')")
+function upt:unparsed-text-lines-from-url() {
+    unparsed-text-lines("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README")[2]
+};
+
+declare 
+    %test:assertEquals(6)
+function upt:unparsed-text-lines-from-url-count() {
+    count(unparsed-text-lines("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README"))
+};
+
+declare 
+    %test:assertXPath("contains($result, 'eXist')")
+function upt:unparsed-text-from-url-encoding() {
+    unparsed-text("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README", "UTF-8")
+};
+
+declare 
+    %test:assertEquals("Hello&#10;world!")
+function upt:unparsed-text-from-db() {
+    unparsed-text("/db/test-unparsed-text/test.txt")
+};
+
+declare 
+    %test:assertEquals("Hello&#10;world!")
+function upt:unparsed-text-from-db-full() {
+    unparsed-text("xmldb:exist:///db/test-unparsed-text/test.txt")
+};
+
+declare 
+    %test:assertEquals("Hello", "world!")
+function upt:unparsed-text-lines-from-db() {
+    unparsed-text-lines("/db/test-unparsed-text/test.txt")
+};
+
+declare 
+    %test:assertError("FOUT1170")
+function upt:fragment-identifier() {
+    unparsed-text-lines("http://www.example.org/#fragment")
+};
+
+declare 
+    %test:assertError("FOUT1170")
+function upt:fragment-identifier-encoding() {
+    unparsed-text("http://www.example.org/#fragment", "UTF-8")
+};
+
+declare 
+    %test:assertError("FOUT1170")
+function upt:invalid-uri() {
+    unparsed-text-lines("http://www.example.org/%gg")
+};
+
+declare 
+    %test:assertError("FOUT1170")
+function upt:invalid-uri2() {
+    unparsed-text-lines(":/")
+};
+
+declare 
+    %test:assertError("FOUT1170")
+function upt:non-existant() {
+    unparsed-text-lines("http://www.w3.org/fots/unparsed-text/does-not-exist.txt")
+};
+
+declare 
+    %test:assertError("FOUT1170")
+function upt:unsupported-scheme() {
+    fn:unparsed-text-lines("surely-nobody-supports-this:/path.txt")
+};
+
+declare 
+    %test:assertError("FOUT1170")
+function upt:windows-path() {
+    unparsed-text-lines("C:\file-might-exist.txt", "utf-8")
+};

--- a/test/src/xquery/suite.xql
+++ b/test/src/xquery/suite.xql
@@ -14,5 +14,6 @@ test:suite((
     inspect:module-functions(xs:anyURI("errors.xql")),
     inspect:module-functions(xs:anyURI("nill.xql")),
     inspect:module-functions(xs:anyURI("ft-match.xql")),
-    inspect:module-functions(xs:anyURI("types.xql"))
+    inspect:module-functions(xs:anyURI("types.xql")),
+    inspect:module-functions(xs:anyURI("unparsed-text.xql"))
 ))

--- a/test/src/xquery/unparsed-text.xql
+++ b/test/src/xquery/unparsed-text.xql
@@ -71,6 +71,30 @@ function upt:unparsed-text-from-db-xml() {
     unparsed-text("/db/test-unparsed-text/test.xml")
 };
 
+declare
+    %test:assertEquals(26436)
+function upt:unparsed-text-from-file-dba() {
+    let $home := system:get-exist-home()
+    let $url := "file:" || $home || "/LICENSE"
+    return
+        string-length(unparsed-text($url))
+};
+
+declare
+    %test:assertEquals(504)
+function upt:unparsed-text-lines-from-file-dba() {
+    let $home := system:get-exist-home()
+    let $url := "file:" || $home || "/LICENSE"
+    return
+        count(unparsed-text-lines($url))
+};
+
+declare
+    %test:assertError("FOUT1170")
+function upt:unparsed-text-from-file-not-allowed() {
+    system:as-user("guest", "guest", unparsed-text("file:///etc/passwd"))
+};
+
 declare 
     %test:assertError("FOUT1170")
 function upt:fragment-identifier() {

--- a/test/src/xquery/unparsed-text.xql
+++ b/test/src/xquery/unparsed-text.xql
@@ -74,8 +74,8 @@ function upt:unparsed-text-from-db-xml() {
 declare
     %test:assertEquals(26436)
 function upt:unparsed-text-from-file-dba() {
-    let $home := system:get-exist-home()
-    let $url := "file:" || $home || "/LICENSE"
+    let $home := translate(system:get-exist-home(), "\", "/")
+    let $url := ``[file://`{$home}`/LICENSE]``
     return
         string-length(unparsed-text($url))
 };
@@ -83,8 +83,8 @@ function upt:unparsed-text-from-file-dba() {
 declare
     %test:assertEquals(504)
 function upt:unparsed-text-lines-from-file-dba() {
-    let $home := system:get-exist-home()
-    let $url := "file:" || $home || "/LICENSE"
+    let $home := translate(system:get-exist-home(), "\", "/")
+    let $url := ``[file://`{$home}`/LICENSE]``
     return
         count(unparsed-text-lines($url))
 };

--- a/test/src/xquery/unparsed-text.xql
+++ b/test/src/xquery/unparsed-text.xql
@@ -11,8 +11,10 @@ declare
     %test:setUp
 function upt:store() {
     let $col := xmldb:create-collection("/db", "test-unparsed-text")
-    return
-        xmldb:store($col, "test.txt", "Hello&#10;world!", "application/octet-stream")
+    return (
+        xmldb:store($col, "test.txt", "Hello&#10;world!&#xD;Hello&#xD;&#xA;world!", "application/octet-stream"),
+        xmldb:store($col, "test.xml", "<p>Hello world!</p>", "application/xml")
+    )
 };
 
 declare
@@ -46,21 +48,27 @@ function upt:unparsed-text-from-url-encoding() {
 };
 
 declare 
-    %test:assertEquals("Hello&#10;world!")
+    %test:assertEquals("Hello&#10;world!&#xD;Hello&#xD;&#xA;world!")
 function upt:unparsed-text-from-db() {
     unparsed-text("/db/test-unparsed-text/test.txt")
 };
 
 declare 
-    %test:assertEquals("Hello&#10;world!")
+    %test:assertEquals("Hello&#10;world!&#xD;Hello&#xD;&#xA;world!")
 function upt:unparsed-text-from-db-full() {
     unparsed-text("xmldb:exist:///db/test-unparsed-text/test.txt")
 };
 
 declare 
-    %test:assertEquals("Hello", "world!")
+    %test:assertEquals("Hello", "world!", "Hello", "world!")
 function upt:unparsed-text-lines-from-db() {
     unparsed-text-lines("/db/test-unparsed-text/test.txt")
+};
+
+declare 
+    %test:assertEquals("<p>Hello world!</p>")
+function upt:unparsed-text-from-db-xml() {
+    unparsed-text("/db/test-unparsed-text/test.xml")
 };
 
 declare 
@@ -103,4 +111,70 @@ declare
     %test:assertError("FOUT1170")
 function upt:windows-path() {
     unparsed-text-lines("C:\file-might-exist.txt", "utf-8")
+};
+
+declare 
+    %test:assertTrue
+function upt:unparsed-text-available-from-url() {
+    unparsed-text-available("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README")
+};
+
+declare 
+    %test:assertTrue
+function upt:unparsed-text-available-from-url-encoding() {
+    unparsed-text-available("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README", "UTF-8")
+};
+
+declare 
+    %test:assertTrue
+function upt:unparsed-text-available-from-db() {
+    unparsed-text-available("/db/test-unparsed-text/test.txt")
+};
+
+declare 
+    %test:assertTrue
+function upt:unparsed-text-available-from-db-full() {
+    unparsed-text-available("xmldb:exist:///db/test-unparsed-text/test.txt")
+};
+
+declare 
+    %test:assertTrue
+function upt:unparsed-text-available-from-db-xml() {
+    unparsed-text-available("/db/test-unparsed-text/test.xml")
+};
+
+declare 
+    %test:assertFalse
+function upt:unparsed-text-available-fragment-identifier() {
+    unparsed-text-available("http://www.example.org/#fragment")
+};
+
+declare 
+    %test:assertFalse
+function upt:fragment-identifier-encoding() {
+    unparsed-text-available("http://www.example.org/#fragment", "UTF-8")
+};
+
+declare 
+    %test:assertFalse
+function upt:unparsed-text-available-invalid-uri() {
+    unparsed-text-available("http://www.example.org/%gg")
+};
+
+declare 
+    %test:assertFalse
+function upt:unparsed-text-available-invalid-uri2() {
+    unparsed-text-available(":/")
+};
+
+declare 
+    %test:assertFalse
+function upt:unparsed-text-available-non-existant() {
+    unparsed-text-available("http://www.w3.org/fots/unparsed-text/does-not-exist.txt")
+};
+
+declare 
+    %test:assertFalse
+function upt:unparsed-text-available-unsupported-scheme() {
+    fn:unparsed-text-available("surely-nobody-supports-this:/path.txt")
 };


### PR DESCRIPTION
Implements `fn:unparsed-text`, `fn:unparsed-text-lines` and `fn:unparsed-text-available` for resources stored in the db as well as retrieved from external URIs.