### PR TITLE
Add new user manager to distribution

### DIFF
--- a/installer/apps.properties
+++ b/installer/apps.properties
@@ -1,2 +1,2 @@
 apps.repo=http://demo.exist-db.org/exist/apps/public-repo
-apps=shared,dashboard,eXide,monex,doc,fundocs,markdown
+apps=shared,dashboard,usermanager,eXide,monex,doc,fundocs,markdown


### PR DESCRIPTION
Version 0.4.9 of the dashboard drops the non-functional usermanager. As discussed during last teleconf, the new working usermanager has to be added to the distribution instead.