### PR TITLE
Several small fixes

### DIFF
--- a/extensions/indexes/sort/test/src/xquery/sort/tests.xml
+++ b/extensions/indexes/sort/test/src/xquery/sort/tests.xml
@@ -35,7 +35,7 @@
             $node/name/text()
 		};
 
-		declare function local:create-index($options as element()?) as empty() {
+		declare function local:create-index($options as element()?) as empty-sequence() {
 			let $fn := util:function(xs:QName("local:cb"), 1)
             return
                 sort:create-index-callback("names", doc("/db/test/sort1.xml")//item, $fn, 

--- a/src/org/exist/xquery/functions/fn/FnHasChildren.java
+++ b/src/org/exist/xquery/functions/fn/FnHasChildren.java
@@ -56,11 +56,13 @@ public class FnHasChildren extends Function {
         if(getArgumentCount() == 0) {
             // default to the context item
 
-            if(contextItem == null) {
-                throw new XPathException(this, ErrorCodes.XPDY0002, "Context item is absent");
-            }
+            if(contextSequence == null) {
 
-            contextSequence = contextItem.toSequence();
+                if (contextItem == null) {
+                    throw new XPathException(this, ErrorCodes.XPDY0002, "Context item is absent");
+                }
+                contextSequence = contextItem.toSequence();
+            }
 
             if(contextSequence.isEmpty()) {
                 return BooleanValue.FALSE;

--- a/src/org/exist/xquery/functions/inspect/ModuleFunctions.java
+++ b/src/org/exist/xquery/functions/inspect/ModuleFunctions.java
@@ -1,6 +1,7 @@
 package org.exist.xquery.functions.inspect;
 
 import org.exist.dom.QName;
+import org.exist.source.FileSource;
 import org.exist.xquery.*;
 import org.exist.xquery.Module;
 import org.exist.xquery.functions.fn.FunOnFunctions;
@@ -8,6 +9,7 @@ import org.exist.xquery.functions.fn.LoadXQueryModule;
 import org.exist.xquery.parser.XQueryAST;
 import org.exist.xquery.value.*;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -64,6 +66,7 @@ public class ModuleFunctions extends BasicFunction {
                 if (isCalledAs("module-functions-by-uri")) {
                     module = tempContext.importModule(args[0].getStringValue(), null, null);
                 } else {
+                    tempContext.setSource(new FileSource(Paths.get(args[0].getStringValue()), false));
                     module = tempContext.importModule(null, null, args[0].getStringValue());
                 }
                 

--- a/test/src/org/exist/test/ExistEmbeddedServer.java
+++ b/test/src/org/exist/test/ExistEmbeddedServer.java
@@ -111,7 +111,7 @@ public class ExistEmbeddedServer extends ExternalResource {
             if(useTemporaryStorage) {
                 this.temporaryStorage = Optional.of(Files.createTempDirectory("org.exist.test.ExistEmbeddedServer"));
                 config.setProperty(BrokerPool.PROPERTY_DATA_DIR, temporaryStorage.get());
-                config.setProperty(Journal.RECOVERY_JOURNAL_DIR_ATTRIBUTE, temporaryStorage.get());
+                config.setProperty(Journal.PROPERTY_RECOVERY_JOURNAL_DIR, temporaryStorage.get());
                 System.out.println("Using temporary storage location: " + temporaryStorage.get().toAbsolutePath().toString());
             }
 

--- a/test/src/xquery/xquery3/fn.xql
+++ b/test/src/xquery/xquery3/fn.xql
@@ -89,7 +89,7 @@ function fnt:innermost() {
         </a>
     } return
         string-join(
-            for $inner in fn:innermost($doc/a/b, $doc/a/c, $doc/a/c/e, $doc/a/f, $doc/a/f/g/h, $doc/a/b)
+            for $inner in fn:innermost(($doc/a/b, $doc/a/c, $doc/a/c/e, $doc/a/f, $doc/a/f/g/h, $doc/a/b))
             return
                 local-name($inner)
             ,
@@ -115,9 +115,9 @@ function fnt:outermost() {
         </a>
     } return
         string-join(
-            for $inner in fn:outermost($doc/a/b, $doc/a/c, $doc/a/c/e, $doc/a/f, $doc/a/f/g/h, $doc/a/b)
+            for $outer in fn:outermost(($doc/a/b, $doc/a/c, $doc/a/c/e, $doc/a/f, $doc/a/f/g/h, $doc/a/b))
             return
-                local-name($inner)
+                local-name($outer)
             ,
             ","
         )

--- a/test/src/xquery/xquery3/fn.xql
+++ b/test/src/xquery/xquery3/fn.xql
@@ -47,7 +47,7 @@ function fnt:has-children-contextItem-absent() {
 };
 
 declare
-    %test:assertError("XPTY0004")
+    %test:assertError("XPTY0019")
 function fnt:has-children-contextItem-notNode() {
     "str1"/has-children()
 };


### PR DESCRIPTION
1. Fixed the tests for `fn:inner-most` and `fn:outer-most`. The functions only accept a sequence!
2. Fixed `fn:has-children§`:
    1. `()/has-children()` now correctly returns `false`.
    2. `has-children()` on a non-node item, now returns the correct error code.
3. ExistEmbeddedServer now correctly sets the journal-dir for temporary storage. Previously set the wrong property.
4. `insepect:module-functions` now correctly sets the source, which is needed for system trace functions.