### PR TITLE
Some minor improvements ; reducing nr of compile warnings

### DIFF
--- a/test/src/org/exist/test/ExistEmbeddedServer.java
+++ b/test/src/org/exist/test/ExistEmbeddedServer.java
@@ -102,11 +102,11 @@ public class ExistEmbeddedServer extends ExternalResource {
             }
 
             // override any specified config properties
-            if(configProperties.isPresent()) {
-                for(final Map.Entry<Object, Object> configProperty : configProperties.get().entrySet()) {
+            configProperties.ifPresent(properties -> {
+                for (final Map.Entry<Object, Object> configProperty : properties.entrySet()) {
                     config.setProperty(configProperty.getKey().toString(), configProperty.getValue());
                 }
-            }
+            });
 
             if(useTemporaryStorage) {
                 this.temporaryStorage = Optional.of(Files.createTempDirectory("org.exist.test.ExistEmbeddedServer"));

--- a/test/src/org/exist/test/ExistXmldbEmbeddedServer.java
+++ b/test/src/org/exist/test/ExistXmldbEmbeddedServer.java
@@ -87,8 +87,7 @@ public class ExistXmldbEmbeddedServer extends ExternalResource {
 
     public ResourceSet executeQuery(final String query) throws XMLDBException {
         final CompiledExpression compiledQuery = xpathQueryService.compile(query);
-        final ResourceSet result = xpathQueryService.execute(compiledQuery);
-        return result;
+        return xpathQueryService.execute(compiledQuery);
     }
 
     public ResourceSet executeQuery(final String query, final Map<String, Object> externalVariables)

--- a/test/src/org/exist/test/TransactionTestDSL.java
+++ b/test/src/org/exist/test/TransactionTestDSL.java
@@ -484,31 +484,23 @@ public interface TransactionTestDSL {
 
             // submit t1
             final ExecutorService t1ExecutorService = Executors.newSingleThreadExecutor(r -> new Thread(transactionsThreadGroup, r, "Transaction-1 Schedule"));
-            final Future<U1> t1Result = t1ExecutorService.submit(new Callable<U1>() {
-
-                @Override
-                public U1 call() throws EXistException, XPathException, PermissionDeniedException, LockException, TriggerException, IOException, InterruptedException {
-                    try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
-                         final Txn txn = brokerPool.getTransactionManager().beginTransaction()) {
-                        final U1 result = lastOperation.t1_state.apply(broker, txn, executionListener, null);
-                        txn.commit();
-                        return result;
-                    }
+            final Future<U1> t1Result = t1ExecutorService.submit(() -> {
+                try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+                     final Txn txn = brokerPool.getTransactionManager().beginTransaction()) {
+                    final U1 result = lastOperation.t1_state.apply(broker, txn, executionListener, null);
+                    txn.commit();
+                    return result;
                 }
             });
 
             // submit t2
             final ExecutorService t2ExecutorService = Executors.newSingleThreadExecutor(r -> new Thread(transactionsThreadGroup, r, "Transaction-2 Schedule"));
-            final Future<U2> t2Result = t2ExecutorService.submit(new Callable<U2>() {
-
-                @Override
-                public U2 call() throws EXistException, XPathException, PermissionDeniedException, LockException, TriggerException, IOException, InterruptedException {
-                    try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
-                         final Txn txn = brokerPool.getTransactionManager().beginTransaction()) {
-                        final U2 result = lastOperation.t2_state.apply(broker, txn, executionListener, null);
-                        txn.commit();
-                        return result;
-                    }
+            final Future<U2> t2Result = t2ExecutorService.submit(() -> {
+                try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+                     final Txn txn = brokerPool.getTransactionManager().beginTransaction()) {
+                    final U2 result = lastOperation.t2_state.apply(broker, txn, executionListener, null);
+                    txn.commit();
+                    return result;
                 }
             });
 

--- a/test/src/org/exist/test/runner/XMLTestRunner.java
+++ b/test/src/org/exist/test/runner/XMLTestRunner.java
@@ -108,6 +108,9 @@ public class XMLTestRunner extends AbstractTestRunner {
                             }
                         }
                         break;
+                    default:
+                        // ignored
+                        break;
                 }
             }
         }

--- a/test/src/org/exist/test/runner/XMLTestRunner.java
+++ b/test/src/org/exist/test/runner/XMLTestRunner.java
@@ -90,20 +90,24 @@ public class XMLTestRunner extends AbstractTestRunner {
         for(int i = 0; i < children.getLength(); i++) {
             final Node child = children.item(i);
             if(child.getNodeType() == Node.ELEMENT_NODE && child.getNamespaceURI() == null) {
-                if (child.getLocalName().equals("testName")) {
-                    testName = child.getTextContent().trim();
-                } else if (child.getLocalName().equals("description")) {
-                    description = child.getTextContent().trim();
-                } else if (child.getLocalName().equals("test")) {
-                    final NodeList testChildren = child.getChildNodes();
-                    for (int j = 0; j < testChildren.getLength(); j++) {
-                        final Node testChild = testChildren.item(j);
-                        if (testChild.getNodeType() == Node.ELEMENT_NODE && testChild.getNamespaceURI() == null) {
-                            if (testChild.getLocalName().equals("task")) {
-                                childNames.add(testChild.getTextContent().trim());
+                switch (child.getLocalName()) {
+                    case "testName":
+                        testName = child.getTextContent().trim();
+                        break;
+                    case "description":
+                        description = child.getTextContent().trim();
+                        break;
+                    case "test":
+                        final NodeList testChildren = child.getChildNodes();
+                        for (int j = 0; j < testChildren.getLength(); j++) {
+                            final Node testChild = testChildren.item(j);
+                            if (testChild.getNodeType() == Node.ELEMENT_NODE && testChild.getNamespaceURI() == null) {
+                                if (testChild.getLocalName().equals("task")) {
+                                    childNames.add(testChild.getTextContent().trim());
+                                }
                             }
                         }
-                    }
+                        break;
                 }
             }
         }
@@ -121,9 +125,9 @@ public class XMLTestRunner extends AbstractTestRunner {
 
     @Override
     public Description getDescription() {
-        final Description description = Description.createSuiteDescription(getSuiteName(), null);
+        final Description description = Description.createSuiteDescription(getSuiteName(), (java.lang.annotation.Annotation[]) null);
         for (final String childName : info.getChildNames()) {
-            description.addChild(Description.createTestDescription(getSuiteName(), childName, null));
+            description.addChild(Description.createTestDescription(getSuiteName(), childName, (java.lang.annotation.Annotation[]) null));
         }
         return description;
     }

--- a/test/src/org/exist/test/runner/XQueryTestRunner.java
+++ b/test/src/org/exist/test/runner/XQueryTestRunner.java
@@ -41,7 +41,6 @@ import org.w3c.dom.NodeList;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -148,9 +147,9 @@ public class XQueryTestRunner extends AbstractTestRunner {
 
     @Override
     public Description getDescription() {
-        final Description description = Description.createSuiteDescription(getSuiteName(), null);
+        final Description description = Description.createSuiteDescription(getSuiteName(), (java.lang.annotation.Annotation[]) null);
         for (final XQueryTestInfo.TestFunctionDef testFunctionDef : info.getTestFunctions()) {
-            description.addChild(Description.createTestDescription(getSuiteName(), testFunctionDef.getLocalName(), null));
+            description.addChild(Description.createTestDescription(getSuiteName(), testFunctionDef.getLocalName(), (java.lang.annotation.Annotation) null));
         }
         return description;
     }


### PR DESCRIPTION
Get rid of compiler warnings:

```
compile-testkit:
    [mkdir] Created dir: /....../exist/test/classes
     [echo] Compiling with Java 1.8 from 1.8 source to 1.8 target, debug on, optimize on, deprecation off
    [javac] Compiling 17 source files to /....../exist/test/classes
    [javac] /....../exist/test/src/org/exist/test/runner/XMLTestRunner.java:124: warning: non-varargs call of varargs method with inexact argument type for last parameter;
    [javac]         final Description description = Description.createSuiteDescription(getSuiteName(), null);
    [javac]                                                                                            ^
    [javac]   cast to Annotation for a varargs call
    [javac]   cast to Annotation[] for a non-varargs call and to suppress this warning
    [javac] /....../exist/test/src/org/exist/test/runner/XMLTestRunner.java:126: warning: non-varargs call of varargs method with inexact argument type for last parameter;
    [javac]             description.addChild(Description.createTestDescription(getSuiteName(), childName, null));
    [javac]                                                                                               ^
    [javac]   cast to Annotation for a varargs call
    [javac]   cast to Annotation[] for a non-varargs call and to suppress this warning
    [javac] /....../exist/test/src/org/exist/test/runner/XQueryTestRunner.java:151: warning: non-varargs call of varargs method with inexact argument type for last parameter;
    [javac]         final Description description = Description.createSuiteDescription(getSuiteName(), null);
    [javac]                                                                                            ^
    [javac]   cast to Annotation for a varargs call
    [javac]   cast to Annotation[] for a non-varargs call and to suppress this warning
    [javac] /....../exist/test/src/org/exist/test/runner/XQueryTestRunner.java:153: warning: non-varargs call of varargs method with inexact argument type for last parameter;
    [javac]             description.addChild(Description.createTestDescription(getSuiteName(), testFunctionDef.getLocalName(), null));
    [javac]                                                                                                                    ^
    [javac]   cast to Annotation for a varargs call
    [javac]   cast to Annotation[] for a non-varargs call and to suppress this warning
    [javac] Note: /....../exist/test/src/org/exist/TestUtils.java uses or overrides a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] 4 warnings

```