### PR TITLE
Some further test fixes

### DIFF
--- a/extensions/indexes/range/test/src/xquery/field-type.xql
+++ b/extensions/indexes/range/test/src/xquery/field-type.xql
@@ -52,8 +52,7 @@ declare
 function rt:cleanup() {
     xmldb:remove($rt:INDEXED_COLLECTION_NAME),
     xmldb:remove("/db/system/config/db/" || $rt:INDEXED_COLLECTION_NAME),
-    xmldb:remove($rt:NON_INDEXED_COLLECTION_NAME),
-    xmldb:remove("/db/system/config/db/" || $rt:NON_INDEXED_COLLECTION_NAME)
+    xmldb:remove($rt:NON_INDEXED_COLLECTION_NAME)
 };
 
 declare function rt:get-note($div as element(div)) as element(note)  {

--- a/extensions/indexes/range/test/src/xquery/index-keys.xql
+++ b/extensions/indexes/range/test/src/xquery/index-keys.xql
@@ -67,7 +67,7 @@ declare
 %test:tearDown
 function rtik:cleanup() {
     xmldb:remove($rtik:COLLECTION),
-    xmldb:remove("/db/system/config/db/" || $rtik:COLLECTION_NAME)()
+    xmldb:remove("/db/system/config/db/" || $rtik:COLLECTION_NAME)
 };
 
 

--- a/src/org/exist/xquery/functions/map/AbstractMapType.java
+++ b/src/org/exist/xquery/functions/map/AbstractMapType.java
@@ -1,6 +1,8 @@
 package org.exist.xquery.functions.map;
 
 import com.ibm.icu.text.Collator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.fn.FunDistinctValues;
@@ -20,6 +22,8 @@ import java.util.Map;
 public abstract class AbstractMapType extends FunctionReference
         implements Map.Entry<AtomicValue, Sequence>, Iterable<Map.Entry<AtomicValue, Sequence>>,
         Lookup.LookupSupport {
+
+    private final static Logger LOG = LogManager.getLogger(AbstractMapType.class);
 
     private static final Comparator<AtomicValue> DEFAULT_COMPARATOR = new FunDistinctValues.ValueComparator(null);
 
@@ -98,6 +102,56 @@ public abstract class AbstractMapType extends FunctionReference
             return new FunDistinctValues.ValueComparator(collator);
         }
         return DEFAULT_COMPARATOR;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder("map {");
+
+        boolean first = true;
+        final Sequence keys = keys();
+        if(keys != null && !keys.isEmpty()) {
+            try {
+                final SequenceIterator iterator = keys.iterate();
+                while (iterator.hasNext()) {
+                    final Item key = iterator.nextItem();
+
+                    if (!first) {
+                        buf.append(", ");
+                    }
+
+                    if(key instanceof StringValue) {
+                        buf.append('\"');
+                    }
+
+                    buf.append(key);
+
+                    if(key instanceof StringValue) {
+                        buf.append('\"');
+                    }
+
+                    buf.append(": ");
+                    final Sequence value = get((AtomicValue) key);
+
+                    if(value != null && value.hasOne() && value instanceof StringValue) {
+                        buf.append('\"');
+                    }
+
+                    buf.append(value);
+                    if(value != null && value.hasOne() && value instanceof StringValue) {
+                        buf.append('\"');
+                    }
+
+                    first = false;
+                }
+            } catch (final XPathException e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+
+        buf.append('}');
+
+        return buf.toString();
     }
 
     /**

--- a/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -236,17 +236,15 @@ declare %private function test:test($func as function(*), $meta as element(funct
                     if(not(empty($test-error-function))) then
                         $test-error-function(test:get-test-name($meta),
                                 map {
-                                    "error": map {
-                                        "code": $err:code,
-                                        "description": $err:description,
-                                        "value": $err:value,
-                                        "module": $err:module,
-                                        "line-number": $err:line-number,
-                                        "column-number": $err:column-number,
-                                        "additional": $err:additional,
-                                        "xquery-stack-trace": $exerr:xquery-stack-trace,
-                                        "java-stack-trace": $exerr:java-stack-trace
-                                    }
+                                    "code": $err:code,
+                                    "description": $err:description,
+                                    "value": $err:value,
+                                    "module": $err:module,
+                                    "line-number": $err:line-number,
+                                    "column-number": $err:column-number,
+                                    "additional": $err:additional,
+                                    "xquery-stack-trace": $exerr:xquery-stack-trace,
+                                    "java-stack-trace": $exerr:java-stack-trace
                                 }
                         )
                     else ()

--- a/test/src/org/exist/test/runner/ExtTestErrorFunction.java
+++ b/test/src/org/exist/test/runner/ExtTestErrorFunction.java
@@ -40,7 +40,7 @@ public class ExtTestErrorFunction extends JUnitIntegrationFunction {
         super("ext-test-error-function",
                 params(
                         param("name", Type.STRING, "name of the test"),
-                        optParam("error", Type.MAP, "error detail of the test")
+                        optParam("error", Type.MAP, "error detail of the test. e.g. map { \"code\": $err:code, \"description\": $err:description, \"value\": $err:value, \"module\": $err:module, \"line-number\": $err:line-number, \"column-number\": $err:column-number, \"additional\": $err:additional, \"xquery-stack-trace\": $exerr:xquery-stack-trace, \"java-stack-trace\": $exerr:java-stack-trace}")
                 ), context, parentName, notifier);
     }
 


### PR DESCRIPTION
I saw some strange things with the Range Index tests written in XQuery and realised that XSuite (and previously TestRunner) were not reporting errors that occurred during `%test:setUp` or `%test:tearDown` to JUnit, in fact the tests appeared to pass fine.

I have now fixed that, and also that showed some problems with the cleanup of some tests written in XQuery, so I fixed that too!

Cheers.