### PR TITLE
[bugfix] Close input stream in fn:json-doc

### DIFF
--- a/src/org/exist/xquery/functions/fn/JSON.java
+++ b/src/org/exist/xquery/functions/fn/JSON.java
@@ -144,10 +144,11 @@ public class JSON extends BasicFunction {
             if (source == null) {
                 throw new XPathException(this, ErrorCodes.FOUT1170, "failed to load json doc from URI " + url);
             }
-            final InputStream is = source.getInputStream();
-            final JsonParser parser = factory.createParser(is);
-            final Item result = readValue(context, parser, handleDuplicates);
-            return result == null ? Sequence.EMPTY_SEQUENCE : result.toSequence();
+            try (final InputStream is = source.getInputStream()) {
+                final JsonParser parser = factory.createParser(is);
+                final Item result = readValue(context, parser, handleDuplicates);
+                return result == null ? Sequence.EMPTY_SEQUENCE : result.toSequence();
+            }
         } catch (IOException | PermissionDeniedException e) {
             throw new XPathException(this, ErrorCodes.FOUT1170, e.getMessage());
         }

--- a/src/org/exist/xquery/functions/fn/JSON.java
+++ b/src/org/exist/xquery/functions/fn/JSON.java
@@ -1,7 +1,6 @@
 package org.exist.xquery.functions.fn;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import org.exist.dom.QName;
@@ -119,8 +118,7 @@ public class JSON extends BasicFunction {
         if (json.isEmpty()) {
             return Sequence.EMPTY_SEQUENCE;
         }
-        try {
-            final JsonParser parser = factory.createParser(json.itemAt(0).getStringValue());
+        try (final JsonParser parser = factory.createParser(json.itemAt(0).getStringValue())) {
             final Item result = readValue(context, parser, handleDuplicates);
             return result == null ? Sequence.EMPTY_SEQUENCE : result.toSequence();
         } catch (IOException e) {
@@ -144,8 +142,9 @@ public class JSON extends BasicFunction {
             if (source == null) {
                 throw new XPathException(this, ErrorCodes.FOUT1170, "failed to load json doc from URI " + url);
             }
-            try (final InputStream is = source.getInputStream()) {
-                final JsonParser parser = factory.createParser(is);
+            try (final InputStream is = source.getInputStream();
+                 final JsonParser parser = factory.createParser(is)) {
+
                 final Item result = readValue(context, parser, handleDuplicates);
                 return result == null ? Sequence.EMPTY_SEQUENCE : result.toSequence();
             }


### PR DESCRIPTION
While investigating test suite failures on windows, I found json-doc does not properly close the input stream on the resource after reading.