### PR TITLE
Random 0-byte XML docs in db

### DIFF
--- a/src/org/exist/Indexer.java
+++ b/src/org/exist/Indexer.java
@@ -398,7 +398,6 @@ public class Indexer extends Observable implements ContentHandler, LexicalHandle
     @Override
     public void endElement(final String namespace, final String name, final String qname) {
         final ElementImpl last = stack.peek();
-        if (last.getNodeName().equals(qname)) {
             processText(last, ProcessTextParent.ELEMENT_END);
             stack.pop();
             XMLString elemContent = null;
@@ -424,7 +423,6 @@ public class Indexer extends Observable implements ContentHandler, LexicalHandle
             currentPath.removeLastComponent();
             setPrevious(last);
             level--;
-        }
     }
 
     /**


### PR DESCRIPTION
A long standing bug in `Indexer` caused 0-byte documents to appear in database collections. The bug occurs rather randomly and is hard to reproduce. As I finally figured out, the 0-byte document was created due to the element stack used by Indexer being messed up. Closer inspection revealed a weird if condition checking the element qname in endElement (and only there) in a wrong way. This (probably very old) code seems to be completely unnecessary if we assume that a document with incorrect element hierarchy should be rejected by the parser. I thus vote for removing it completely.

The PR also fixes a small issue in package deployment which unfortunately did hide the 0-byte bug during deployment. The code for handling HTML5 documents catched all exceptions.