### PR TITLE
Performance improvements

### DIFF
--- a/extensions/debuggee/src/org/exist/debuggee/dbgp/packets/Eval.java
+++ b/extensions/debuggee/src/org/exist/debuggee/dbgp/packets/Eval.java
@@ -21,12 +21,12 @@
  */
 package org.exist.debuggee.dbgp.packets;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import java.io.IOException;
 
 import org.apache.mina.core.session.IoSession;
 import org.exist.debuggee.dbgp.Errors;
 import org.exist.util.Base64Encoder;
+import org.exist.util.io.FastByteArrayOutputStream;
 
 /**
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
@@ -77,7 +77,7 @@ public class Eval extends Command {
 			Base64Encoder enc = new Base64Encoder();
 			enc.translate(result.getBytes());
 	
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			FastByteArrayOutputStream baos = new FastByteArrayOutputStream(head.length() + ((result.length() / 100) * 33) + tail.length());
 			try {
 				baos.write(head.getBytes());
 				baos.write(new String(enc.getCharArray()).getBytes());

--- a/extensions/debuggee/src/org/exist/debuggee/dbgp/packets/Source.java
+++ b/extensions/debuggee/src/org/exist/debuggee/dbgp/packets/Source.java
@@ -31,6 +31,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.Base64Encoder;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 
 import java.net.URL;
@@ -38,7 +39,6 @@ import java.net.MalformedURLException;
 import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.io.InputStream;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -127,7 +127,7 @@ public class Source extends Command {
         		URLConnection conn = url.openConnection();
         		is = conn.getInputStream();
         	}
-    		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    		FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
     		byte[] buf = new byte[256];
     		int c;
     		while ((c = is.read(buf)) > -1) {
@@ -180,7 +180,7 @@ public class Source extends Command {
     				Base64Encoder enc = new Base64Encoder();
     				enc.translate(source);
 
-    				ByteArrayOutputStream baos = new ByteArrayOutputStream();
+					FastByteArrayOutputStream baos = new FastByteArrayOutputStream(head.length() + ((source.length / 100) * 33) + tail.length());
     				baos.write(head.getBytes());
     				baos.write(new String(enc.getCharArray()).getBytes());
     				baos.write(tail.getBytes());

--- a/extensions/exiftool/src/org/exist/exiftool/xquery/MetadataFunctions.java
+++ b/extensions/exiftool/src/org/exist/exiftool/xquery/MetadataFunctions.java
@@ -1,7 +1,5 @@
 package org.exist.exiftool.xquery;
 
-import java.io.ByteArrayInputStream;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.io.IOException;
@@ -19,6 +17,7 @@ import org.exist.source.Source;
 import org.exist.source.SourceFactory;
 import org.exist.storage.NativeBroker;
 import org.exist.storage.lock.Lock.LockMode;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -131,14 +130,10 @@ public class MetadataFunctions extends BasicFunction {
         try {
             final Process p = Runtime.getRuntime().exec(module.getPerlPath() + " " + module.getExiftoolPath() + " -X -struct " + binaryFile.toAbsolutePath().toString());
             try(final InputStream stdIn = p.getInputStream();
-                    final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                    final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
 
                 //buffer stdin
-                int read = -1;
-                byte buf[] = new byte[4096];
-                while ((read = stdIn.read(buf)) > -1) {
-                    baos.write(buf, 0, read);
-                }
+                baos.write(stdIn);
 
                 //make sure process is complete
                 p.waitFor();
@@ -160,7 +155,7 @@ public class MetadataFunctions extends BasicFunction {
             final Process p = Runtime.getRuntime().exec(module.getExiftoolPath()+" -fast -X -");
 
             try(final InputStream stdIn = p.getInputStream();
-                    final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                    final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
 
                 try(final OutputStream stdOut = p.getOutputStream()) {
                     final Source src = SourceFactory.getSource(context.getBroker(), null, uri.toString(), false);
@@ -176,11 +171,7 @@ public class MetadataFunctions extends BasicFunction {
                 }
 
                 //read stdin to buffer
-                int read = -1;
-                byte buf[] = new byte[4096];
-                while ((read = stdIn.read(buf)) > -1) {
-                    baos.write(buf, 0, read);
-                }
+                baos.write(stdIn);
 
                 //make sure process is complete
                 p.waitFor();

--- a/extensions/expath/src/org/expath/exist/ZipFileFunctions.java
+++ b/extensions/expath/src/org/expath/exist/ZipFileFunctions.java
@@ -1,6 +1,5 @@
 package org.expath.exist;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.persistent.BinaryDocument;
@@ -8,12 +7,12 @@ import org.exist.dom.QName;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.security.PermissionDeniedException;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 import org.exist.storage.lock.Lock.LockMode;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -111,14 +110,12 @@ public class ZipFileFunctions extends BasicFunction {
         ZipFileSource zipFileSource =  new ZipFileFromDb(uri);
         ZipInputStream zis = null;
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        HashMap<String, BinaryValue> binariesTable = new HashMap<String, BinaryValue>(paths.length);
+        Map<String, BinaryValue> binariesTable = new HashMap<>(paths.length);
         for (int i = 0; i < paths.length; i++) {
             binariesTable.put(paths[i], binaries[i]);
         }
 
-        try
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream();)
         {
             zis = zipFileSource.getStream();
             ZipOutputStream zos = new ZipOutputStream(baos); // zos is the output - the result

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.Logger;
 import org.exist.extensions.exquery.xdm.type.impl.BinaryTypedValue;
 import org.exist.extensions.exquery.xdm.type.impl.DocumentTypedValue;
 import org.exist.extensions.exquery.xdm.type.impl.StringTypedValue;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.MemTreeBuilder;
@@ -47,6 +46,7 @@ import org.exist.util.Configuration;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
 import org.exist.util.io.CachingFilterInputStream;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.util.io.FilterInputStreamCache;
 import org.exist.util.io.FilterInputStreamCacheFactory;
 import org.exist.xquery.XPathException;
@@ -292,13 +292,11 @@ class RestXqServiceImpl extends AbstractRestXqService {
     }
 
     private static StringValue parseAsString(final InputStream is, final String encoding) throws IOException {
-        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        byte[] buf = new byte[4096];
-        int read = -1;
-        while ((read = is.read(buf)) > -1) {
-            bos.write(buf, 0, read);
+        final String s;
+        try (final FastByteArrayOutputStream bos = new FastByteArrayOutputStream(4096)) {
+            bos.write(is);
+            s = new String(bos.toByteArray(), encoding);
         }
-        final String s = new String(bos.toByteArray(), encoding);
         return new StringValue(s);
     }
 }

--- a/extensions/fluent/test/src/org/exist/fluent/XMLDocumentTest.java
+++ b/extensions/fluent/test/src/org/exist/fluent/XMLDocumentTest.java
@@ -3,7 +3,7 @@ package org.exist.fluent;
 import static org.junit.Assert.*;
 
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -118,10 +118,11 @@ public class XMLDocumentTest extends DatabaseTestCase {
 	
 	@Test public void writeToOutputStream() throws IOException {
 		XMLDocument doc = db.createFolder("/top").documents().load(Name.create(db,"foo"), Source.xml("<root/>"));
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		doc.write(out);
-		out.close();
-		assertEquals("<root/>", out.toString());
+		try (final FastByteArrayOutputStream out = new FastByteArrayOutputStream()) {
+			doc.write(out);
+			out.close();
+			assertEquals("<root/>", out.toString());
+		}
 	}
 
 }

--- a/extensions/modules/src/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -21,7 +21,6 @@
  */
 package org.exist.xquery.modules.compression;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.collections.Collection;
@@ -33,7 +32,9 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.Base64Decoder;
+import org.exist.util.FileUtils;
 import org.exist.util.LockException;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
@@ -46,6 +47,9 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.zip.CRC32;
 import java.util.zip.DeflaterOutputStream;
@@ -115,7 +119,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                 encoding = StandardCharsets.UTF_8;
             }
 
-            try(final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
                     OutputStream os = stream(baos, encoding)) {
 
                 // iterate through the argument sequence
@@ -155,7 +159,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
                     }
 
                     // got a file
-                    File file = new File(uri.getPath());
+                    Path file = Paths.get(uri.getPath());
                     compressFile(os, file, useHierarchy, stripOffset, method, resourceName);
 
                 } else {
@@ -216,49 +220,40 @@ public abstract class AbstractCompressFunction extends BasicFunction
      *            Whether to use a folder hierarchy in the archive file that
      *            reflects the collection hierarchy
      */
-    private void compressFile(OutputStream os, File file, boolean useHierarchy, String stripOffset, String method, String name) throws IOException {
+    private void compressFile(final OutputStream os, final Path file, boolean useHierarchy, String stripOffset, String method, String name) throws IOException {
 
-        if (file.isFile()) {
+        if (!Files.isDirectory(file)) {
 
             // create an entry in the Tar for the document
-            Object entry = null;
-            CRC32 chksum = new CRC32();
-            try(final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-
-                if (name != null) {
-                    entry = newEntry(name);
-                } else if (useHierarchy) {
-                    entry = newEntry(removeLeadingOffset(file.getPath(), stripOffset));
-                } else {
-                    entry = newEntry(file.getName());
-                }
-
-                try (final InputStream is = new FileInputStream(file)) {
-                    byte[] data = new byte[16384];
-                    int len = -1;
-                    while ((len = is.read(data, 0, data.length)) > 0) {
-                        baos.write(data, 0, len);
-                    }
-                }
-                final byte[] value = baos.toByteArray();
-                // close the entry
-                if (entry instanceof ZipEntry &&
-                        "store".equals(method)) {
-                    ((ZipEntry) entry).setMethod(ZipOutputStream.STORED);
-                    chksum.update(value);
-                    ((ZipEntry) entry).setCrc(chksum.getValue());
-                    ((ZipEntry) entry).setSize(value.length);
-                }
-
-                putEntry(os, entry);
-                os.write(value);
-                closeEntry(os);
+            final Object entry;
+            if (name != null) {
+                entry = newEntry(name);
+            } else if (useHierarchy) {
+                entry = newEntry(removeLeadingOffset(file.toAbsolutePath().toString(), stripOffset));
+            } else {
+                entry = newEntry(file.getFileName().toString());
             }
+
+            final byte[] value = Files.readAllBytes(file);
+
+            // close the entry
+            final CRC32 chksum = new CRC32();
+            if (entry instanceof ZipEntry &&
+                    "store".equals(method)) {
+                ((ZipEntry) entry).setMethod(ZipOutputStream.STORED);
+                chksum.update(value);
+                ((ZipEntry) entry).setCrc(chksum.getValue());
+                ((ZipEntry) entry).setSize(value.length);
+            }
+
+            putEntry(os, entry);
+            os.write(value);
+            closeEntry(os);
 
         } else {
 
-            for (String i : file.list()) {
-                compressFile(os, new File(file, i), useHierarchy, stripOffset, method, null);
+            for (final Path child : FileUtils.list(file)) {
+                compressFile(os, file.resolve(child), useHierarchy, stripOffset, method, null);
             }
 
         }
@@ -413,16 +408,10 @@ public abstract class AbstractCompressFunction extends BasicFunction
 	 */
 	private void compressResource(OutputStream os, DocumentImpl doc, boolean useHierarchy, String stripOffset, String method, String name) throws IOException, SAXException {
 		// create an entry in the Tar for the document
-		Object entry = null;
-        byte[] value = new byte[0];
-        CRC32 chksum = new CRC32();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(); 
-
-                if(name != null)
-                {
-                    entry = newEntry(name);
-                }
-                else if (useHierarchy) {
+        final Object entry;
+        if(name != null) {
+            entry = newEntry(name);
+        } else if (useHierarchy) {
 			String docCollection = doc.getCollection().getURI().toString();
 			XmldbURI collection = XmldbURI.create(removeLeadingOffset(docCollection, stripOffset));
 			entry = newEntry(collection.append(doc.getFileURI()).toString());
@@ -430,6 +419,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 			entry = newEntry(doc.getFileURI().toString());
 		}
 
+        final byte[] value;
 		if (doc.getResourceType() == DocumentImpl.XML_FILE) {
 			// xml file
 			Serializer serializer = context.getBroker().getSerializer();
@@ -440,16 +430,17 @@ public abstract class AbstractCompressFunction extends BasicFunction
             value = strDoc.getBytes();            
 		} else if (doc.getResourceType() == DocumentImpl.BINARY_FILE) {
 			// binary file
-            InputStream is = context.getBroker().getBinaryResource((BinaryDocument)doc);
-			byte[] data = new byte[16384];
-            int len = 0;
-            while ((len=is.read(data,0,data.length))>0) {
-            	baos.write(data,0,len);
+            try (final InputStream is = context.getBroker().getBinaryResource((BinaryDocument)doc);
+                 final FastByteArrayOutputStream baos = new FastByteArrayOutputStream((int)doc.getContentLength())) {
+                baos.write(is);
+                value = baos.toByteArray();
             }
-            is.close();
-            value = baos.toByteArray();
-		}
+		} else {
+		    value = new byte[0];
+        }
+
 		// close the entry
+        final CRC32 chksum = new CRC32();
         if (entry instanceof ZipEntry &&
             "store".equals(method)) {
             ((ZipEntry) entry).setMethod(ZipOutputStream.STORED);
@@ -498,7 +489,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 		}
 	}
 	
-	protected abstract OutputStream stream(ByteArrayOutputStream baos, Charset encoding);
+	protected abstract OutputStream stream(FastByteArrayOutputStream baos, Charset encoding);
 	
 	protected abstract Object newEntry(String name);
 	

--- a/extensions/modules/src/org/exist/xquery/modules/compression/GZipFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/GZipFunction.java
@@ -21,13 +21,11 @@
  */
 package org.exist.xquery.modules.compression;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.zip.GZIPOutputStream;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
-
 import org.exist.dom.QName;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -78,15 +76,15 @@ public class GZipFunction extends BasicFunction
         BinaryValue bin = (BinaryValue) args[0].itemAt(0);
 
         // gzip the data
-        try(final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                GZIPOutputStream gzos = new GZIPOutputStream(baos)) {
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
+                final GZIPOutputStream gzos = new GZIPOutputStream(baos)) {
             bin.streamBinaryTo(gzos);
             
             gzos.flush();
             gzos.finish();
             
             return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), baos.toInputStream());
-        } catch(IOException ioe) {
+        } catch (final IOException ioe) {
             throw new XPathException(this, ioe.getMessage(), ioe);
         }
     }

--- a/extensions/modules/src/org/exist/xquery/modules/compression/TarFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/TarFunction.java
@@ -25,11 +25,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 
 import org.exist.dom.QName;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XQueryContext;
@@ -106,8 +106,8 @@ public class TarFunction extends AbstractCompressFunction
     }
 
     @Override
-    protected OutputStream stream(final ByteArrayOutputStream baos, final Charset encoding)
+    protected OutputStream stream(final FastByteArrayOutputStream baos, final Charset encoding)
     {
-            return new TarArchiveOutputStream(baos, encoding.name());
+        return new TarArchiveOutputStream(baos, encoding.name());
     }	
 }

--- a/extensions/modules/src/org/exist/xquery/modules/compression/UnGZipFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/UnGZipFunction.java
@@ -24,9 +24,8 @@ package org.exist.xquery.modules.compression;
 import java.io.IOException;
 import java.util.zip.GZIPInputStream;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
-
 import org.exist.dom.QName;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -78,13 +77,8 @@ public class UnGZipFunction extends BasicFunction
         //TODO(AR) just pass the GZIPInputStream straight into BinaryValueFromInputStream.getInstance
         // ungzip the data
         try(final GZIPInputStream gzis = new GZIPInputStream(bin.getInputStream());
-                final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            int read = -1;
-            final byte[] b = new byte[4096];
-            while ((read = gzis.read(b)) != -1) {
-                baos.write(b, 0, read);
-            }
-
+                final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
+            baos.write(gzis);
             return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), baos.toInputStream());
         } catch(final IOException ioe) {
             throw new XPathException(this, ioe.getMessage(), ioe);

--- a/extensions/modules/src/org/exist/xquery/modules/compression/ZipFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/ZipFunction.java
@@ -21,8 +21,6 @@
  */
 package org.exist.xquery.modules.compression;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
@@ -30,6 +28,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.exist.dom.QName;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XQueryContext;
@@ -108,7 +107,7 @@ public class ZipFunction extends AbstractCompressFunction {
     }
 
     @Override
-    protected OutputStream stream(final ByteArrayOutputStream baos, final Charset encoding)
+    protected OutputStream stream(final FastByteArrayOutputStream baos, final Charset encoding)
     {
         return new ZipOutputStream(baos, encoding);
     }

--- a/extensions/modules/src/org/exist/xquery/modules/exi/EncodeExiFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/exi/EncodeExiFunction.java
@@ -19,12 +19,12 @@
  */
 package org.exist.xquery.modules.exi;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
 import org.exist.dom.QName;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.util.serializer.EXISerializer;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -85,8 +85,7 @@ public class EncodeExiFunction extends BasicFunction {
 		if(args[0].isEmpty()) {
             return Sequence.EMPTY_SEQUENCE;
         }
-		try {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
 			EXISerializer exiSerializer;
 			if(args.length > 1) {
 				if(!args[1].isEmpty()) {

--- a/extensions/modules/src/org/exist/xquery/modules/file/FileRead.java
+++ b/extensions/modules/src/org/exist/xquery/modules/file/FileRead.java
@@ -27,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -106,9 +105,8 @@ public class FileRead extends BasicFunction {
 			encoding = StandardCharsets.UTF_8;
 		}
 
-		try(final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-			Files.copy(file, os);
-            return new StringValue(new String(os.toByteArray(), encoding));
+		try {
+            return new StringValue(new String(Files.readAllBytes(file), encoding));
 		} catch(final IOException e ) {
 			throw new XPathException(this, e);	
 		}

--- a/extensions/modules/src/org/exist/xquery/modules/image/CropFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/image/CropFunction.java
@@ -24,7 +24,6 @@ package org.exist.xquery.modules.image;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import java.awt.Toolkit;
 import java.awt.Graphics2D;
@@ -32,11 +31,11 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.awt.image.CropImageFilter;
 import java.awt.image.FilteredImageSource;
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import javax.imageio.ImageIO;
 
 import org.exist.dom.QName;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -160,11 +159,12 @@ public class CropFunction extends BasicFunction {
                 g.dispose();
             }
 
-            ByteArrayOutputStream os = new ByteArrayOutputStream();
-            ImageIO.write(bImage, formatName, os);
+            try (final FastByteArrayOutputStream os = new FastByteArrayOutputStream()) {
+                ImageIO.write(bImage, formatName, os);
 
-            //return the new croped image data
-            return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), os.toInputStream());
+                //return the new croped image data
+                return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), os.toInputStream());
+            }
 
         } catch(Exception e) {
             throw new XPathException(this, e.getMessage());

--- a/extensions/modules/src/org/exist/xquery/modules/image/GetThumbnailsFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/image/GetThumbnailsFunction.java
@@ -23,7 +23,6 @@ package org.exist.xquery.modules.image;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import java.awt.Image;
 import java.awt.image.BufferedImage;
@@ -51,6 +50,7 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -236,7 +236,7 @@ public class GetThumbnailsFunction extends BasicFunction {
             @SuppressWarnings("unused")
             byte[] imgData = null;
             Image image = null;
-            ByteArrayOutputStream os = null;
+            FastByteArrayOutputStream os = null;
 
             try {
                 Iterator<DocumentImpl> i = allPictures.iterator(dbbroker);
@@ -270,7 +270,7 @@ public class GetThumbnailsFunction extends BasicFunction {
                                 }
 
                                 if (isSaveToDataBase) {
-                                    os = new ByteArrayOutputStream();
+                                    os = new FastByteArrayOutputStream();
                                     try {
                                         ImageIO.write(bImage, "jpg", os);
                                     } catch (Exception e) {

--- a/extensions/modules/src/org/exist/xquery/modules/image/ScaleFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/image/ScaleFunction.java
@@ -24,15 +24,14 @@ package org.exist.xquery.modules.image;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import java.awt.Image;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import javax.imageio.ImageIO;
 
 import org.exist.dom.QName;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -139,11 +138,12 @@ public class ScaleFunction extends BasicFunction
 			bImage = ImageModule.createThumb(image, maxHeight, maxWidth);
 		
 			//get the new scaled image
-			ByteArrayOutputStream os = new ByteArrayOutputStream();
-			ImageIO.write(bImage, formatName, os);
-			
-			//return the new scaled image data
-			return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), os.toInputStream());
+			try (final FastByteArrayOutputStream os = new FastByteArrayOutputStream()) {
+				ImageIO.write(bImage, formatName, os);
+
+				//return the new scaled image data
+				return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), os.toInputStream());
+			}
 		}
 		catch(Exception e)
 		{

--- a/extensions/xqdoc/src/org/exist/xqdoc/xquery/Scan.java
+++ b/extensions/xqdoc/src/org/exist/xqdoc/xquery/Scan.java
@@ -1,6 +1,5 @@
 package org.exist.xqdoc.xquery;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.regex.Matcher;
@@ -13,6 +12,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.source.*;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.util.LockException;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xqdoc.XQDocHelper;
 import org.exist.xquery.*;
@@ -67,9 +67,10 @@ public class Scan extends BasicFunction {
 
     //TODO ideally should be replaced by changing BinarySource to a streaming approach
     private byte[] binaryValueToByteArray(BinaryValue binaryValue) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        binaryValue.streamBinaryTo(baos);
-        return baos.toByteArray();
+        try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
+            binaryValue.streamBinaryTo(baos);
+            return baos.toByteArray();
+        }
     }
 
     @Override

--- a/src/org/exist/dom/persistent/ElementImpl.java
+++ b/src/org/exist/dom/persistent/ElementImpl.java
@@ -20,7 +20,6 @@
  */
 package org.exist.dom.persistent;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.EXistException;
 import org.exist.Namespaces;
 import org.exist.dom.NamedNodeMapImpl;
@@ -41,6 +40,7 @@ import org.exist.storage.txn.Txn;
 import org.exist.util.ByteArrayPool;
 import org.exist.util.ByteConversion;
 import org.exist.util.UTF8;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.util.pool.NodePool;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.Constants;
@@ -224,7 +224,7 @@ public class ElementImpl extends NamedNode implements Element {
             final byte[] prefixData;
             // serialize namespace prefixes declared in this element
             if(declaresNamespacePrefixes()) {
-                try(final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+                try(final FastByteArrayOutputStream bout = new FastByteArrayOutputStream(64);
                     final DataOutputStream out = new DataOutputStream(bout)) {
                     out.writeShort(namespaceMappings.size());
                     for (final Map.Entry<String, String> namespaceMapping : namespaceMappings.entrySet()) {

--- a/src/org/exist/dom/persistent/XMLUtil.java
+++ b/src/org/exist/dom/persistent/XMLUtil.java
@@ -20,9 +20,9 @@
  */
 package org.exist.dom.persistent;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.util.serializer.DOMSerializer;
 import org.exist.xquery.Constants;
 import org.w3c.dom.DocumentFragment;
@@ -196,7 +196,7 @@ public final class XMLUtil {
 
                 {
 
-                    final ByteArrayOutputStream out = new ByteArrayOutputStream(150);
+                    final FastByteArrayOutputStream out = new FastByteArrayOutputStream(150);
 
                     out.write('<');
                     out.write(declString, 0, 4);
@@ -248,14 +248,9 @@ public final class XMLUtil {
     @Deprecated
     public static String readFile(final InputSource inSrc) throws IOException {
         // read the file into a string
-        try(final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+        try(final FastByteArrayOutputStream os = new FastByteArrayOutputStream()) {
             try(final InputStream is = inSrc.getByteStream()) {
-
-                final byte[] buf = new byte[2048];
-                int read = -1;
-                while ((read = is.read(buf)) != -1) {
-                    os.write(buf, 0, read);
-                }
+                os.write(is);
             }
             return readFile(os.toByteArray(), Charset.forName(inSrc.getEncoding()));
         }

--- a/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/src/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -40,6 +40,7 @@ import org.exist.source.Source;
 import org.exist.source.DBSource;
 import org.exist.source.SourceFactory;
 import org.exist.source.FileSource;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.util.serializer.XQuerySerializer;
 import org.exist.xquery.functions.request.RequestModule;
 import org.exist.xquery.functions.response.ResponseModule;
@@ -65,8 +66,6 @@ import org.exist.util.MimeType;
 import org.exist.http.servlets.HttpRequestWrapper;
 import org.exist.http.servlets.HttpResponseWrapper;
 import org.exist.http.Descriptor;
-
-import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import org.w3c.dom.Node;
 import org.w3c.dom.Document;
@@ -1433,7 +1432,7 @@ public class XQueryURLRewrite extends HttpServlet {
 
     private static class CachingServletOutputStream extends ServletOutputStream {
 
-        protected ByteArrayOutputStream ostream = new ByteArrayOutputStream(512);
+        protected FastByteArrayOutputStream ostream = new FastByteArrayOutputStream(512);
 
         protected byte[] getData() {
             return ostream.toByteArray();

--- a/src/org/exist/protocolhandler/embedded/InMemoryOutputStream.java
+++ b/src/org/exist/protocolhandler/embedded/InMemoryOutputStream.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
@@ -39,13 +38,14 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 import org.xml.sax.InputSource;
 
 /**
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
  */
-public class InMemoryOutputStream extends ByteArrayOutputStream {
+public class InMemoryOutputStream extends FastByteArrayOutputStream {
 
   private final static Logger LOG = LogManager.getLogger(InMemoryOutputStream.class);
 

--- a/src/org/exist/storage/index/BFile.java
+++ b/src/org/exist/storage/index/BFile.java
@@ -50,11 +50,10 @@ import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.lock.ReentrantReadWriteLock;
 import org.exist.storage.txn.Txn;
 import org.exist.util.*;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.util.sanity.SanityCheck;
 import org.exist.xquery.Constants;
 import org.exist.xquery.TerminatedException;
-
-import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -1971,7 +1970,7 @@ public class BFile extends BTree {
             byte[] temp;
             int len;
 
-            try(final ByteArrayOutputStream os = new ByteArrayOutputStream(page.getPageHeader().getDataLength())) {
+            try(final FastByteArrayOutputStream os = new FastByteArrayOutputStream(page.getPageHeader().getDataLength())) {
                 do {
                     temp = page.getData();
                     next = page.getPageHeader().getNextInChain();

--- a/src/org/exist/util/Base64Decoder.java
+++ b/src/org/exist/util/Base64Decoder.java
@@ -21,7 +21,7 @@
  */
 package org.exist.util;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.exist.util.io.FastByteArrayOutputStream;
 
 /**
  * Base 64 text to byte decoder. To produce the binary  array from
@@ -33,7 +33,7 @@ import org.apache.commons.io.output.ByteArrayOutputStream;
  */
 
 public final class Base64Decoder {
-    private ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private FastByteArrayOutputStream out = new FastByteArrayOutputStream();
 
     private byte token[] = new byte[4];      // input buffer
 

--- a/src/org/exist/util/VirtualTempFile.java
+++ b/src/org/exist/util/VirtualTempFile.java
@@ -33,8 +33,8 @@ import java.io.RandomAccessFile;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.util.io.FastByteArrayOutputStream;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 
 /**
  * 
@@ -59,7 +59,7 @@ public class VirtualTempFile
 	
 	protected File tempFile;
 	protected boolean deleteTempFile;
-	protected ByteArrayOutputStream baBuffer;
+	protected FastByteArrayOutputStream baBuffer;
 	protected FileOutputStream strBuffer;
 	protected OutputStream os;
 	
@@ -91,7 +91,7 @@ public class VirtualTempFile
 		
 		vLength = -1L;
 		
-		baBuffer = new ByteArrayOutputStream(maxMemorySize);
+		baBuffer = new FastByteArrayOutputStream(maxMemorySize);
 		strBuffer = null;
 		
 		tempFile = null;

--- a/src/org/exist/util/io/FastByteArrayOutputStream.java
+++ b/src/org/exist/util/io/FastByteArrayOutputStream.java
@@ -1,0 +1,431 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.exist.util.io;
+
+import static org.apache.commons.io.IOUtils.EOF;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.SequenceInputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import net.jcip.annotations.NotThreadSafe;
+import org.apache.commons.io.input.ClosedInputStream;
+
+/**
+ * NOTE this is a modified version of Apache
+ * Commons IO 2.6 {@link org.apache.commons.io.output.ByteArrayOutputStream}
+ * which removes the synchronization overhead for non-concurrent
+ * access; as such this class is not thread-safe.
+ *
+ * Modified by Adam Retter <adam@exist-db.org>.
+ * Original Apache class header continues below:
+ *
+ *
+ * This class implements an output stream in which the data is
+ * written into a byte array. The buffer automatically grows as data
+ * is written to it.
+ * <p>
+ * The data can be retrieved using <code>toByteArray()</code> and
+ * <code>toString()</code>.
+ * <p>
+ * Closing a {@code ByteArrayOutputStream} has no effect. The methods in
+ * this class can be called after the stream has been closed without
+ * generating an {@code IOException}.
+ * <p>
+ * This is an alternative implementation of the {@link java.io.ByteArrayOutputStream}
+ * class. The original implementation only allocates 32 bytes at the beginning.
+ * As this class is designed for heavy duty it starts at 1024 bytes. In contrast
+ * to the original it doesn't reallocate the whole memory block but allocates
+ * additional buffers. This way no buffers need to be garbage collected and
+ * the contents don't have to be copied to the new buffer. This class is
+ * designed to behave exactly like the original. The only exception is the
+ * deprecated toString(int) method that has been ignored.
+ */
+@NotThreadSafe
+public class FastByteArrayOutputStream extends OutputStream {
+
+    static final int DEFAULT_SIZE = 1024;
+
+    /** A singleton empty byte array. */
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
+    /** The list of buffers, which grows and never reduces. */
+    private final List<byte[]> buffers = new ArrayList<>();
+    /** The index of the current buffer. */
+    private int currentBufferIndex;
+    /** The total count of bytes in all the filled buffers. */
+    private int filledBufferSum;
+    /** The current buffer. */
+    private byte[] currentBuffer;
+    /** The total count of bytes written. */
+    private int count;
+    /** Flag to indicate if the buffers can be reused after reset */
+    private boolean reuseBuffers = true;
+
+    /**
+     * Creates a new byte array output stream. The buffer capacity is
+     * initially 1024 bytes, though its size increases if necessary.
+     */
+    public FastByteArrayOutputStream() {
+        this(DEFAULT_SIZE);
+    }
+
+    /**
+     * Creates a new byte array output stream, with a buffer capacity of
+     * the specified size, in bytes.
+     *
+     * @param size  the initial size
+     * @throws IllegalArgumentException if size is negative
+     */
+    public FastByteArrayOutputStream(final int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException(
+                "Negative initial size: " + size);
+        }
+//        synchronized (this) {
+            needNewBuffer(size);
+//        }
+    }
+
+    /**
+     * Makes a new buffer available either by allocating
+     * a new one or re-cycling an existing one.
+     *
+     * @param newcount  the size of the buffer if one is created
+     */
+    private void needNewBuffer(final int newcount) {
+        if (currentBufferIndex < buffers.size() - 1) {
+            //Recycling old buffer
+            filledBufferSum += currentBuffer.length;
+
+            currentBufferIndex++;
+            currentBuffer = buffers.get(currentBufferIndex);
+        } else {
+            //Creating new buffer
+            int newBufferSize;
+            if (currentBuffer == null) {
+                newBufferSize = newcount;
+                filledBufferSum = 0;
+            } else {
+                newBufferSize = Math.max(
+                    currentBuffer.length << 1,
+                    newcount - filledBufferSum);
+                filledBufferSum += currentBuffer.length;
+            }
+
+            currentBufferIndex++;
+            currentBuffer = new byte[newBufferSize];
+            buffers.add(currentBuffer);
+        }
+    }
+
+    /**
+     * Write the bytes to byte array.
+     * @param b the bytes to write
+     * @param off The start offset
+     * @param len The number of bytes to write
+     */
+    @Override
+    public void write(final byte[] b, final int off, final int len) {
+        if ((off < 0)
+                || (off > b.length)
+                || (len < 0)
+                || ((off + len) > b.length)
+                || ((off + len) < 0)) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return;
+        }
+//        synchronized (this) {
+            final int newcount = count + len;
+            int remaining = len;
+            int inBufferPos = count - filledBufferSum;
+            while (remaining > 0) {
+                final int part = Math.min(remaining, currentBuffer.length - inBufferPos);
+                System.arraycopy(b, off + len - remaining, currentBuffer, inBufferPos, part);
+                remaining -= part;
+                if (remaining > 0) {
+                    needNewBuffer(newcount);
+                    inBufferPos = 0;
+                }
+            }
+            count = newcount;
+//        }
+    }
+
+    /**
+     * Write a byte to byte array.
+     * @param b the byte to write
+     */
+    @Override
+    public /*synchronized*/ void write(final int b) {
+        int inBufferPos = count - filledBufferSum;
+        if (inBufferPos == currentBuffer.length) {
+            needNewBuffer(count + 1);
+            inBufferPos = 0;
+        }
+        currentBuffer[inBufferPos] = (byte) b;
+        count++;
+    }
+
+    /**
+     * Writes the entire contents of the specified input stream to this
+     * byte stream. Bytes from the input stream are read directly into the
+     * internal buffers of this streams.
+     *
+     * @param in the input stream to read from
+     * @return total number of bytes read from the input stream
+     *         (and written to this stream)
+     * @throws IOException if an I/O error occurs while reading the input stream
+     * @since 1.4
+     */
+    public /*synchronized*/ int write(final InputStream in) throws IOException {
+        int readCount = 0;
+        int inBufferPos = count - filledBufferSum;
+        int n = in.read(currentBuffer, inBufferPos, currentBuffer.length - inBufferPos);
+        while (n != EOF) {
+            readCount += n;
+            inBufferPos += n;
+            count += n;
+            if (inBufferPos == currentBuffer.length) {
+                needNewBuffer(currentBuffer.length);
+                inBufferPos = 0;
+            }
+            n = in.read(currentBuffer, inBufferPos, currentBuffer.length - inBufferPos);
+        }
+        return readCount;
+    }
+
+    /**
+     * Return the current size of the byte array.
+     * @return the current size of the byte array
+     */
+    public /*synchronized*/ int size() {
+        return count;
+    }
+
+    /**
+     * Closing a {@code ByteArrayOutputStream} has no effect. The methods in
+     * this class can be called after the stream has been closed without
+     * generating an {@code IOException}.
+     *
+     * @throws IOException never (this method should not declare this exception
+     * but it has to now due to backwards compatibility)
+     */
+    @Override
+    public void close() throws IOException {
+        //nop
+    }
+
+    /**
+     * @see java.io.ByteArrayOutputStream#reset()
+     */
+    public /*synchronized*/ void reset() {
+        count = 0;
+        filledBufferSum = 0;
+        currentBufferIndex = 0;
+        if (reuseBuffers) {
+            currentBuffer = buffers.get(currentBufferIndex);
+        } else {
+            //Throw away old buffers
+            currentBuffer = null;
+            final int size = buffers.get(0).length;
+            buffers.clear();
+            needNewBuffer(size);
+            reuseBuffers = true;
+        }
+    }
+
+    /**
+     * Writes the entire contents of this byte stream to the
+     * specified output stream.
+     *
+     * @param out  the output stream to write to
+     * @throws IOException if an I/O error occurs, such as if the stream is closed
+     * @see java.io.ByteArrayOutputStream#writeTo(OutputStream)
+     */
+    public /*synchronized*/ void writeTo(final OutputStream out) throws IOException {
+        int remaining = count;
+        for (final byte[] buf : buffers) {
+            final int c = Math.min(buf.length, remaining);
+            out.write(buf, 0, c);
+            remaining -= c;
+            if (remaining == 0) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Fetches entire contents of an <code>InputStream</code> and represent
+     * same data as result InputStream.
+     * <p>
+     * This method is useful where,
+     * <ul>
+     * <li>Source InputStream is slow.</li>
+     * <li>It has network resources associated, so we cannot keep it open for
+     * long time.</li>
+     * <li>It has network timeout associated.</li>
+     * </ul>
+     * It can be used in favor of {@link #toByteArray()}, since it
+     * avoids unnecessary allocation and copy of byte[].<br>
+     * This method buffers the input internally, so there is no need to use a
+     * <code>BufferedInputStream</code>.
+     *
+     * @param input Stream to be fully buffered.
+     * @return A fully buffered stream.
+     * @throws IOException if an I/O error occurs
+     * @since 2.0
+     */
+    public static InputStream toBufferedInputStream(final InputStream input)
+            throws IOException {
+        return toBufferedInputStream(input, 1024);
+    }
+
+    /**
+     * Fetches entire contents of an <code>InputStream</code> and represent
+     * same data as result InputStream.
+     * <p>
+     * This method is useful where,
+     * <ul>
+     * <li>Source InputStream is slow.</li>
+     * <li>It has network resources associated, so we cannot keep it open for
+     * long time.</li>
+     * <li>It has network timeout associated.</li>
+     * </ul>
+     * It can be used in favor of {@link #toByteArray()}, since it
+     * avoids unnecessary allocation and copy of byte[].<br>
+     * This method buffers the input internally, so there is no need to use a
+     * <code>BufferedInputStream</code>.
+     *
+     * @param input Stream to be fully buffered.
+     * @param size the initial buffer size
+     * @return A fully buffered stream.
+     * @throws IOException if an I/O error occurs
+     * @since 2.5
+     */
+    public static InputStream toBufferedInputStream(final InputStream input, final int size)
+            throws IOException {
+        // It does not matter if a ByteArrayOutputStream is not closed as close() is a no-op
+        @SuppressWarnings("resource")
+        final FastByteArrayOutputStream output = new FastByteArrayOutputStream(size);
+        output.write(input);
+        return output.toInputStream();
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a Input Stream. The
+     * returned stream is backed by buffers of <code>this</code> stream,
+     * avoiding memory allocation and copy, thus saving space and time.<br>
+     *
+     * @return the current contents of this output stream.
+     * @see java.io.ByteArrayOutputStream#toByteArray()
+     * @see #reset()
+     * @since 2.5
+     */
+    public /*synchronized*/ InputStream toInputStream() {
+        int remaining = count;
+        if (remaining == 0) {
+            return new ClosedInputStream();
+        }
+        final List<ByteArrayInputStream> list = new ArrayList<>(buffers.size());
+        for (final byte[] buf : buffers) {
+            final int c = Math.min(buf.length, remaining);
+            list.add(new ByteArrayInputStream(buf, 0, c));
+            remaining -= c;
+            if (remaining == 0) {
+                break;
+            }
+        }
+        reuseBuffers = false;
+        return new SequenceInputStream(Collections.enumeration(list));
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a byte array.
+     * The result is independent of this stream.
+     *
+     * @return the current contents of this output stream, as a byte array
+     * @see java.io.ByteArrayOutputStream#toByteArray()
+     */
+    public /*synchronized*/ byte[] toByteArray() {
+        int remaining = count;
+        if (remaining == 0) {
+            return EMPTY_BYTE_ARRAY;
+        }
+        final byte newbuf[] = new byte[remaining];
+        int pos = 0;
+        for (final byte[] buf : buffers) {
+            final int c = Math.min(buf.length, remaining);
+            System.arraycopy(buf, 0, newbuf, pos, c);
+            pos += c;
+            remaining -= c;
+            if (remaining == 0) {
+                break;
+            }
+        }
+        return newbuf;
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a string
+     * using the platform default charset.
+     * @return the contents of the byte array as a String
+     * @see java.io.ByteArrayOutputStream#toString()
+     * @deprecated 2.5 use {@link #toString(String)} instead
+     */
+    @Override
+    @Deprecated
+    public String toString() {
+        // make explicit the use of the default charset
+        return new String(toByteArray(), Charset.defaultCharset());
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a string
+     * using the specified encoding.
+     *
+     * @param enc  the name of the character encoding
+     * @return the string converted from the byte array
+     * @throws UnsupportedEncodingException if the encoding is not supported
+     * @see java.io.ByteArrayOutputStream#toString(String)
+     */
+    public String toString(final String enc) throws UnsupportedEncodingException {
+        return new String(toByteArray(), enc);
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a string
+     * using the specified encoding.
+     *
+     * @param charset  the character encoding
+     * @return the string converted from the byte array
+     * @see java.io.ByteArrayOutputStream#toString(String)
+     * @since 2.5
+     */
+    public String toString(final Charset charset) {
+        return new String(toByteArray(), charset);
+    }
+
+}

--- a/src/org/exist/util/io/MemoryFilterInputStreamCache.java
+++ b/src/org/exist/util/io/MemoryFilterInputStreamCache.java
@@ -26,8 +26,6 @@
  */
 package org.exist.util.io;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
-
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -42,7 +40,7 @@ import java.io.InputStream;
  */
 public class MemoryFilterInputStreamCache extends AbstractFilterInputStreamCache {
 
-    private ByteArrayOutputStream cache = new ByteArrayOutputStream();
+    private FastByteArrayOutputStream cache = new FastByteArrayOutputStream();
 
     public MemoryFilterInputStreamCache(InputStream src) {
         super(src);

--- a/src/org/exist/validation/ValidationReport.java
+++ b/src/org/exist/validation/ValidationReport.java
@@ -25,10 +25,13 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.io.output.ByteArrayOutputStream;
+
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Report containing all validation info (errors, warnings).
@@ -215,10 +218,9 @@ public class ValidationReport implements ErrorHandler {
             return null;
         }
 
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
         final PrintStream ps = new PrintStream(baos);
         throwed.printStackTrace(ps);
-
-        return baos.toString();
+        return baos.toString(UTF_8);
     }
 }

--- a/src/org/exist/xmldb/AbstractRemoteResource.java
+++ b/src/org/exist/xmldb/AbstractRemoteResource.java
@@ -30,12 +30,12 @@ import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
 import org.apache.xmlrpc.XmlRpcException;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import org.exist.security.Permission;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.util.EXistInputSource;
 import org.exist.util.VirtualTempFile;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.xml.sax.InputSource;
 import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.ErrorCodes;
@@ -521,9 +521,8 @@ public abstract class AbstractRemoteResource extends AbstractRemote
 
     protected byte[] readFile(final Path file)
             throws XMLDBException {
-        try(final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-            Files.copy(file, os);
-            return os.toByteArray();
+        try {
+            return Files.readAllBytes(file);
         } catch (final IOException e) {
             throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
         }
@@ -550,8 +549,8 @@ public abstract class AbstractRemoteResource extends AbstractRemote
 
     private byte[] readFile(final InputStream is)
             throws XMLDBException {
-        try(final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            copy(is, bos);
+        try(final FastByteArrayOutputStream bos = new FastByteArrayOutputStream()) {
+            bos.write(is);
             return bos.toByteArray();
         } catch (final IOException e) {
             throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);

--- a/src/org/exist/xquery/functions/request/GetData.java
+++ b/src/org/exist/xquery/functions/request/GetData.java
@@ -29,7 +29,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Namespaces;
 import org.exist.dom.QName;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.http.servlets.RequestWrapper;
 import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.MemTreeBuilder;
@@ -37,6 +36,7 @@ import org.exist.util.Configuration;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
 import org.exist.util.io.CachingFilterInputStream;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.util.io.FilterInputStreamCache;
 import org.exist.util.io.FilterInputStreamCacheFactory;
 import org.exist.util.io.FilterInputStreamCacheFactory.FilterInputStreamCacheConfiguration;
@@ -239,13 +239,9 @@ public class GetData extends BasicFunction {
     }
 
     private Sequence parseAsString(InputStream is, String encoding) throws IOException {
-        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        final byte[] buf = new byte[4096];
-        int read = -1;
-        while ((read = is.read(buf)) > -1) {
-            bos.write(buf, 0, read);
+        try (final FastByteArrayOutputStream bos = new FastByteArrayOutputStream()) {
+            bos.write(is);
+            return new StringValue(bos.toString(encoding));
         }
-        final String s = new String(bos.toByteArray(), encoding);
-        return new StringValue(s);
     }
 }

--- a/src/org/exist/xquery/functions/util/BinaryToString.java
+++ b/src/org/exist/xquery/functions/util/BinaryToString.java
@@ -30,7 +30,7 @@ import java.io.UnsupportedEncodingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
-import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -113,17 +113,11 @@ public class BinaryToString extends BasicFunction {
     }
 
     protected StringValue binaryToString(BinaryValue binary, String encoding) throws XPathException {
-        final ByteArrayOutputStream os = new ByteArrayOutputStream();
-        try {
+        try (final FastByteArrayOutputStream os = new FastByteArrayOutputStream()) {
             binary.streamBinaryTo(os);
-            return new StringValue(new String(os.toByteArray(), encoding));
+            return new StringValue(os.toString(encoding));
         } catch(final IOException ioe) {
             throw new XPathException(this, ioe);
-        } finally {
-            try {
-                os.close();
-            } catch(final IOException ex) {
-            }
         }
     }
 

--- a/src/org/exist/xquery/functions/util/Serialize.java
+++ b/src/org/exist/xquery/functions/util/Serialize.java
@@ -23,7 +23,6 @@ package org.exist.xquery.functions.util;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -38,6 +37,7 @@ import javax.xml.transform.OutputKeys;
 
 import org.exist.dom.QName;
 import org.exist.storage.serializers.Serializer;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.serializer.SerializerPool;
 import org.exist.xquery.BasicFunction;
@@ -147,13 +147,13 @@ public class Serialize extends BasicFunction {
             //parse serialization options from second argument to function
             outputProperties = parseSerializationOptions(args[1]);
 
-            try(final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream os = new FastByteArrayOutputStream()) {
                 //do the serialization
                 serialize(args[0].iterate(), outputProperties, os);
 
 
                 final String encoding = outputProperties.getProperty(OutputKeys.ENCODING, UTF_8.name());
-                return new StringValue(new String(os.toByteArray(), encoding));
+                return new StringValue(os.toString(encoding));
             } catch (final IOException  e) {
                 throw new XPathException(this, "A problem occurred while serializing the node set: " + e.getMessage(), e);
             }

--- a/src/org/exist/xquery/value/BinaryValue.java
+++ b/src/org/exist/xquery/value/BinaryValue.java
@@ -22,14 +22,16 @@
 package org.exist.xquery.value;
 
 import com.ibm.icu.text.Collator;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.XPathException;
 
 import java.io.*;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author Adam Retter <adam@existsolutions.com>
@@ -134,8 +136,7 @@ public abstract class BinaryValue extends AtomicValue implements Closeable {
         }
 
         if (target == byte[].class) {
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
                 streamBinaryTo(baos);
                 return (T) baos.toByteArray();
             } catch (final IOException ioe) {
@@ -213,8 +214,7 @@ public abstract class BinaryValue extends AtomicValue implements Closeable {
     //TODO ideally this should be moved out into serialization where we can stream the output from the buf/channel by calling streamTo()
     @Override
     public String getStringValue() throws XPathException {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
+        final FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
         try {
             streamTo(baos);
         } catch (final IOException ex) {
@@ -226,8 +226,7 @@ public abstract class BinaryValue extends AtomicValue implements Closeable {
                 LOG.error("Unable to close stream: {}", ioe.getMessage(), ioe);
             }
         }
-
-        return new String(baos.toByteArray());
+        return baos.toString(UTF_8);
     }
 
     /**

--- a/src/org/exist/xquery/value/BinaryValueFromBinaryString.java
+++ b/src/org/exist/xquery/value/BinaryValueFromBinaryString.java
@@ -1,12 +1,14 @@
 package org.exist.xquery.value;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.XPathException;
 
 import java.io.*;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Representation of an XSD binary value e.g. (xs:base64Binary or xs:hexBinary)
@@ -34,7 +36,7 @@ public class BinaryValueFromBinaryString extends BinaryValue {
         //TODO temporary approach, consider implementing a TranscodingBinaryValueFromBinaryString(BinaryValueFromBinaryString) class
         //that only does the transncoding lazily
 
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
         FilterOutputStream fos = null;
         try {
 
@@ -60,7 +62,7 @@ public class BinaryValueFromBinaryString extends BinaryValue {
             }
         }
 
-        return new BinaryValueFromBinaryString(binaryValueType, new String(baos.toByteArray()));
+        return new BinaryValueFromBinaryString(binaryValueType, baos.toString(UTF_8));
     }
 
     @Override
@@ -95,16 +97,13 @@ public class BinaryValueFromBinaryString extends BinaryValue {
 
     @Override
     public InputStream getInputStream() {
-
         //TODO consider a more efficient approach for writting large strings
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
+        final FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
         try {
             streamBinaryTo(baos);
         } catch (final IOException ioe) {
             LOG.error("Unable to get read only buffer: {}", ioe.getMessage(), ioe);
         }
-
         return baos.toInputStream();
     }
 

--- a/test/src/org/exist/security/RestApiSecurityTest.java
+++ b/test/src/org/exist/security/RestApiSecurityTest.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -33,6 +32,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.exist.test.ExistWebServer;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.junit.ClassRule;
 
 /**
@@ -189,8 +189,9 @@ public class RestApiSecurityTest extends AbstractApiSecurityTest {
     }
     
     private String getResponseBody(final HttpEntity entity) throws IOException {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        entity.writeTo(baos);
-        return new String(baos.toByteArray());
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream(256)) {
+            entity.writeTo(baos);
+            return new String(baos.toByteArray());
+        }
     }
 }

--- a/test/src/org/exist/storage/RecoverBinaryTest.java
+++ b/test/src/org/exist/storage/RecoverBinaryTest.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
@@ -78,12 +77,11 @@ public class RecoverBinaryTest {
 	            final String existHome = System.getProperty("exist.home");
                 Path existDir = existHome == null ? Paths.get(".") : Paths.get(existHome);
                 existDir = existDir.normalize();
-        	    try(final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-                    Files.copy(existDir.resolve("LICENSE"), os);
-                	BinaryDocument doc =
-                    	root.addBinaryResource(transaction, broker, TestConstants.TEST_BINARY_URI, os.toByteArray(), "text/text");
-	                assertNotNull(doc);
-    	        }
+
+                final byte[] bin = Files.readAllBytes(existDir.resolve("LICENSE"));
+                BinaryDocument doc =
+                    root.addBinaryResource(transaction, broker, TestConstants.TEST_BINARY_URI, bin, "text/text");
+                assertNotNull(doc);
 
 				transact.commit(transaction);
 			}

--- a/test/src/org/exist/util/VirtualTempFileTest.java
+++ b/test/src/org/exist/util/VirtualTempFileTest.java
@@ -21,9 +21,10 @@
 package org.exist.util;
 
 import com.googlecode.junittoolbox.ParallelRunner;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.junit.Test;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
@@ -118,23 +119,21 @@ public class VirtualTempFileTest {
 		vtempFile.write(testString,0,testStringLength);
 		vtempFile.close();
 		
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		vtempFile.writeToStream(baos);
-		baos.close();
-		
-		Assert.assertArrayEquals("Written content must match",testString,baos.toByteArray());
+		try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
+			vtempFile.writeToStream(baos);
+			Assert.assertArrayEquals("Written content must match",testString,baos.toByteArray());
+		}
 		
 		// Test2, temp file
 		vtempFile = new VirtualTempFile(testStringLength-3,testStringLength-3);
 		
 		vtempFile.write(testString,0,testStringLength);
 		vtempFile.close();
-		
-		baos = new ByteArrayOutputStream();
-		vtempFile.writeToStream(baos);
-		baos.close();
-		
-		Assert.assertArrayEquals("Written content must match",testString,baos.toByteArray());
+
+		try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
+			vtempFile.writeToStream(baos);
+			Assert.assertArrayEquals("Written content must match",testString,baos.toByteArray());
+		}
 		
 		// Test3, several writes
 		vtempFile = new VirtualTempFile(testStringLength,testStringLength);
@@ -142,15 +141,13 @@ public class VirtualTempFileTest {
 		vtempFile.write(testString,0,testStringLength);
 		vtempFile.write(testString2,0,testString2.length);
 		vtempFile.close();
-		
-		baos = new ByteArrayOutputStream();
-		vtempFile.writeToStream(baos);
-		baos.close();
-		
-		byte[] joinedTestString = new byte[testStringLength+testString2.length];
-		System.arraycopy(testString,0,joinedTestString,0,testStringLength);
-		System.arraycopy(testString2,0,joinedTestString,testStringLength,testString2.length);
-		
-		Assert.assertArrayEquals("Written content must match",joinedTestString,baos.toByteArray());
+
+		try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
+			vtempFile.writeToStream(baos);
+			final byte[] joinedTestString = new byte[testStringLength+testString2.length];
+			System.arraycopy(testString,0,joinedTestString,0,testStringLength);
+			System.arraycopy(testString2,0,joinedTestString,testStringLength,testString2.length);
+			Assert.assertArrayEquals("Written content must match",joinedTestString,baos.toByteArray());
+		}
 	}
 }

--- a/test/src/org/exist/util/io/CachingFilterInputStreamTest_NonMarkableByteArrayInputStream.java
+++ b/test/src/org/exist/util/io/CachingFilterInputStreamTest_NonMarkableByteArrayInputStream.java
@@ -25,7 +25,6 @@
 package org.exist.util.io;
 
 import com.googlecode.junittoolbox.ParallelParameterized;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 import java.util.Arrays;
@@ -52,7 +51,7 @@ import static org.junit.Assert.assertArrayEquals;
 public class CachingFilterInputStreamTest_NonMarkableByteArrayInputStream {
 
     @Parameters
-    public static Collection data() throws IOException {
+    public static Collection data() {
         Object[][] data = new Object[][]{
             {MemoryFilterInputStreamCache.class},
             {MemoryMappedFileFilterInputStreamCache.class},
@@ -878,16 +877,9 @@ public class CachingFilterInputStreamTest_NonMarkableByteArrayInputStream {
     }
 
     private byte[] consumeInputStream(final CachingFilterInputStream is) throws IOException {
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try {
-            int read = -1;
-            final byte buf[] = new byte[_4KB];
-            while ((read = is.read(buf)) > -1) {
-                baos.write(buf, 0, read);
-            }
+        try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
+            baos.write(is);
             return baos.toByteArray();
-        } finally {
-            baos.close();
         }
     }
 

--- a/test/src/org/exist/xmldb/CreateCollectionsTest.java
+++ b/test/src/org/exist/xmldb/CreateCollectionsTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.TestUtils;
 import org.exist.dom.persistent.XMLUtil;
 import org.exist.security.Account;
@@ -190,13 +189,10 @@ public class CreateCollectionsTest  {
         final Resource res = testCollection.createResource(file.getFileName().toString(), "BinaryResource");
         assertNotNull("store binary Resource From File", res);
         // Get an array of bytes from the file:
-        try(final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
-            Files.copy(file, os);
-            final byte[] data = os.toByteArray();
-            res.setContent(data);
-            testCollection.storeResource(res);
-            return data;
-        }
+        final byte[] data = Files.readAllBytes(file);
+        res.setContent(data);
+        testCollection.storeResource(res);
+        return data;
     }
 
     @Test

--- a/test/src/org/exist/xmldb/TestEXistXMLSerialize.java
+++ b/test/src/org/exist/xmldb/TestEXistXMLSerialize.java
@@ -23,6 +23,7 @@ package org.exist.xmldb;
 
 import org.exist.security.Account;
 import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.junit.ClassRule;
 import org.xmldb.api.modules.CollectionManagementService;
 import java.io.IOException;
@@ -41,7 +42,6 @@ import javax.xml.transform.stream.StreamResult;
 
 import org.apache.xml.serialize.OutputFormat;
 import org.apache.xml.serialize.XMLSerializer;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import org.exist.util.serializer.DOMSerializer;
 import org.exist.util.serializer.SAXSerializer;
@@ -124,11 +124,12 @@ public class TestEXistXMLSerialize {
 
         //Attempting serialization
         DOMSource source = new DOMSource(node);
-        ByteArrayOutputStream out = new ByteArrayOutputStream( );
-        StreamResult result = new StreamResult(out);
+        try (final FastByteArrayOutputStream out = new FastByteArrayOutputStream()) {
+            StreamResult result = new StreamResult(out);
 
-        Transformer xformer = TransformerFactory.newInstance().newTransformer();
-        xformer.transform(source, result);
+            Transformer xformer = TransformerFactory.newInstance().newTransformer();
+            xformer.transform(source, result);
+        }
     }
 
     @Test
@@ -147,15 +148,16 @@ public class TestEXistXMLSerialize {
         format.setLineWidth(0);
         format.setIndent(5);
         format.setPreserveSpace(true);
-        ByteArrayOutputStream out = new ByteArrayOutputStream( );
-        XMLSerializer serializer = new XMLSerializer(out, format);
+        try (final FastByteArrayOutputStream out = new FastByteArrayOutputStream()) {
+            XMLSerializer serializer = new XMLSerializer(out, format);
 
-        if(node instanceof Document){
-            serializer.serialize((Document) node);
-        }else if(node instanceof Element){
-            serializer.serialize((Element) node);
-        }else{
-            fail("Can't serialize node type: "+node);
+            if (node instanceof Document) {
+                serializer.serialize((Document) node);
+            } else if (node instanceof Element) {
+                serializer.serialize((Element) node);
+            } else {
+                fail("Can't serialize node type: " + node);
+            }
         }
     }
 

--- a/test/src/org/exist/xmlrpc/XmlRpcTest.java
+++ b/test/src/org/exist/xmlrpc/XmlRpcTest.java
@@ -24,12 +24,12 @@ import org.apache.xmlrpc.XmlRpcException;
 import org.apache.xmlrpc.client.XmlRpcClient;
 import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.security.MessageDigester;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.test.ExistWebServer;
 import org.exist.test.TestConstants;
 import org.exist.util.MimeType;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -157,7 +157,7 @@ public class XmlRpcTest {
         params.add(options);
         Map table = (Map) xmlrpc.execute("getDocumentData", params);
 
-        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+        try (final FastByteArrayOutputStream os = new FastByteArrayOutputStream()) {
             int offset = (int) table.get("offset");
             data = (byte[]) table.get("data");
             os.write(data);

--- a/test/src/org/exist/xquery/EmbeddedBinariesTest.java
+++ b/test/src/org/exist/xquery/EmbeddedBinariesTest.java
@@ -20,7 +20,6 @@
 
 package org.exist.xquery;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.collections.Collection;
 import org.exist.source.Source;
 import org.exist.source.StringSource;
@@ -30,6 +29,7 @@ import org.exist.storage.XQueryPool;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.value.*;
 import org.junit.ClassRule;
@@ -149,13 +149,13 @@ public class EmbeddedBinariesTest extends AbstractBinariesTest<Sequence, Item, I
     protected byte[] getBytes(final Item item) throws IOException {
         if (item instanceof Base64BinaryDocument) {
             final Base64BinaryDocument doc = (Base64BinaryDocument) item;
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
                 doc.streamBinaryTo(baos);
                 return baos.toByteArray();
             }
         } else {
             final BinaryValueFromFile file = (BinaryValueFromFile) item;
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
                 file.streamBinaryTo(baos);
                 return baos.toByteArray();
             }

--- a/test/src/org/exist/xquery/RestBinariesTest.java
+++ b/test/src/org/exist/xquery/RestBinariesTest.java
@@ -22,7 +22,6 @@ package org.exist.xquery;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -32,6 +31,7 @@ import org.apache.http.entity.ContentType;
 import org.exist.http.jaxb.Query;
 import org.exist.http.jaxb.Result;
 import org.exist.test.ExistWebServer;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xmldb.XmldbURI;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -84,7 +84,7 @@ public class RestBinariesTest extends AbstractBinariesTest<Result, Result.Value,
         final HttpResponse response = postXquery(query);
 
         final HttpEntity entity = response.getEntity();
-        try(final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
             entity.writeTo(baos);
 
             assertArrayEquals(BIN1_CONTENT, Base64.decodeBase64(baos.toByteArray()));
@@ -106,7 +106,7 @@ public class RestBinariesTest extends AbstractBinariesTest<Result, Result.Value,
         final HttpResponse response = postXquery(query);
 
         final HttpEntity entity = response.getEntity();
-        try(final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
             entity.writeTo(baos);
 
             assertArrayEquals(BIN1_CONTENT, baos.toByteArray());
@@ -131,7 +131,7 @@ public class RestBinariesTest extends AbstractBinariesTest<Result, Result.Value,
         final HttpResponse response = postXquery(query);
 
         final HttpEntity entity = response.getEntity();
-        try(final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
             entity.writeTo(baos);
 
             assertArrayEquals(Files.readAllBytes(tmpInFile), Base64.decodeBase64(baos.toByteArray()));
@@ -156,7 +156,7 @@ public class RestBinariesTest extends AbstractBinariesTest<Result, Result.Value,
         final HttpResponse response = postXquery(query);
 
         final HttpEntity entity = response.getEntity();
-        try(final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
             entity.writeTo(baos);
 
             assertArrayEquals(Files.readAllBytes(tmpInFile), baos.toByteArray());
@@ -211,7 +211,7 @@ public class RestBinariesTest extends AbstractBinariesTest<Result, Result.Value,
         final Marshaller marshaller = jaxbContext.createMarshaller();
 
         final HttpResponse response;
-        try(final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
             marshaller.marshal(query, baos);
             response = executor.execute(Request.Post(getRestUrl() + "/db/")
                     .bodyByteArray(baos.toByteArray(), ContentType.APPLICATION_XML)

--- a/test/src/org/exist/xquery/value/Base64BinaryValueTypeTest.java
+++ b/test/src/org/exist/xquery/value/Base64BinaryValueTypeTest.java
@@ -9,12 +9,12 @@ import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.apache.commons.codec.binary.Base64InputStream;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.util.ConfigurationHelper;
-import org.exist.util.FileUtils;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.XPathException;
 import org.junit.Test;
 import static org.junit.Assert.assertNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  *
@@ -57,16 +57,11 @@ public class Base64BinaryValueTypeTest {
         Optional<Path> home = ConfigurationHelper.getExistHome();
         Path binaryFile = Paths.get(getClass().getResource("logo.jpg").toURI());
 
-        String base64data = null;
+        final String base64data;
         try(final InputStream is = new Base64InputStream(Files.newInputStream(binaryFile), true, -1, null);
-                final ByteArrayOutputStream baos  = new ByteArrayOutputStream()) {
-
-            byte buf[] = new byte[1024];
-            int read = -1;
-            while((read = is.read(buf)) > -1) {
-                baos.write(buf, 0, read);
-            }
-            base64data = new String(baos.toByteArray());
+                final FastByteArrayOutputStream baos  = new FastByteArrayOutputStream()) {
+            baos.write(is);
+            base64data = baos.toString(UTF_8);
         }
 
         assertNotNull(base64data);

--- a/test/src/org/exist/xquery/value/BinaryValueFromBinaryStringTest.java
+++ b/test/src/org/exist/xquery/value/BinaryValueFromBinaryStringTest.java
@@ -3,7 +3,7 @@ package org.exist.xquery.value;
 import org.apache.commons.codec.binary.Hex;
 import java.io.InputStream;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.XPathException;
 import java.io.IOException;
 import org.junit.Test;
@@ -24,16 +24,12 @@ public class BinaryValueFromBinaryStringTest {
 
         BinaryValue binaryValue = new BinaryValueFromBinaryString(new Base64BinaryValueType(), base64TestData);
 
-        InputStream is = binaryValue.getInputStream();
 
-        int read = -1;
-        byte buf[] = new byte[1024];
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        while((read = is.read(buf)) > -1) {
-            baos.write(buf, 0, read);
+        try (final InputStream is = binaryValue.getInputStream();
+             final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
+            baos.write(is);
+            assertArrayEquals(testData.getBytes(), baos.toByteArray());
         }
-
-        assertArrayEquals(testData.getBytes(), baos.toByteArray());
     }
 
     @Test

--- a/test/src/org/exist/xquery/value/BinaryValueFromInputStreamTest.java
+++ b/test/src/org/exist/xquery/value/BinaryValueFromInputStreamTest.java
@@ -6,8 +6,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.googlecode.junittoolbox.ParallelRunner;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.exist.util.io.CachingFilterInputStream;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.XPathException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -103,7 +103,7 @@ public class BinaryValueFromInputStreamTest {
             assertTrue(binaryValue.isClosed());
 
             // we should not be able to read from the origin binary value!
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
 
                 // this should throw an IOException
                 binaryValue.streamBinaryTo(baos);
@@ -135,7 +135,7 @@ public class BinaryValueFromInputStreamTest {
             assertFalse(binaryValue.isClosed());
 
             // we should still be able to read from the origin binary value!
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
                 binaryValue.streamBinaryTo(baos);
 
                 assertArrayEquals(testData, baos.toByteArray());
@@ -180,7 +180,7 @@ public class BinaryValueFromInputStreamTest {
             assertTrue(binaryValue1.isClosed());
 
             // we should not be able to read from the origin binary value!
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
 
                 // this should throw an IOException
                 binaryValue1.streamBinaryTo(baos);
@@ -219,14 +219,14 @@ public class BinaryValueFromInputStreamTest {
             assertFalse(binaryValue1.isClosed());
 
             // we should still be able to read from the origin binary value2!
-            try (final ByteArrayOutputStream baos2 = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos2 = new FastByteArrayOutputStream()) {
                 binaryValue2.streamBinaryTo(baos2);
 
                 assertArrayEquals(testData2, baos2.toByteArray());
             }
 
             // we should still be able to read from the original binary value1!
-            try (final ByteArrayOutputStream baos1 = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos1 = new FastByteArrayOutputStream()) {
                 binaryValue1.streamBinaryTo(baos1);
 
                 assertArrayEquals(testData1, baos1.toByteArray());
@@ -279,7 +279,7 @@ public class BinaryValueFromInputStreamTest {
             assertTrue(binaryValue.isClosed());
 
             // we should not be able to read from the first filtered binary value!
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
 
                 // this should throw an IOException
                 filteredBinaryValue1.streamBinaryTo(baos);
@@ -317,7 +317,7 @@ public class BinaryValueFromInputStreamTest {
             assertFalse(binaryValue.isClosed());
 
             // we should still be able to read from the filtered binary value!
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
                 filteredBinaryValue1.streamBinaryTo(baos);
 
                 assertArrayEquals(testData, baos.toByteArray());
@@ -330,7 +330,7 @@ public class BinaryValueFromInputStreamTest {
             assertTrue(filteredBinaryValue1.isClosed());
 
             // we should still be able to read from the origin binary value!
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
                 binaryValue.streamBinaryTo(baos);
 
                 assertArrayEquals(testData, baos.toByteArray());
@@ -379,7 +379,7 @@ public class BinaryValueFromInputStreamTest {
 
 
             // we should still be able to read from the filtered binary value2!
-            try (final ByteArrayOutputStream baos2 = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos2 = new FastByteArrayOutputStream()) {
                 filteredBinaryValue2.streamBinaryTo(baos2);
 
                 assertArrayEquals(testData, baos2.toByteArray());
@@ -390,7 +390,7 @@ public class BinaryValueFromInputStreamTest {
             assertTrue(filteredBinaryValue2.isClosed());
 
             // we should still be able to read from the filtered binary value1!
-            try (final ByteArrayOutputStream baos1 = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos1 = new FastByteArrayOutputStream()) {
                 filteredBinaryValue1.streamBinaryTo(baos1);
 
                 assertArrayEquals(testData, baos1.toByteArray());
@@ -400,7 +400,7 @@ public class BinaryValueFromInputStreamTest {
             assertTrue(filteredBinaryValue1.isClosed());
 
             // we should still be able to read from the original binary value!
-            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
                 binaryValue.streamBinaryTo(baos);
 
                 assertArrayEquals(testData, baos.toByteArray());
@@ -418,13 +418,8 @@ public class BinaryValueFromInputStreamTest {
     }
 
     private static byte[] readAll(final InputStream is) throws IOException {
-        try(final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            int read = -1;
-            final byte buf[] = new byte[1024];
-            while ((read = is.read(buf)) > -1) {
-                baos.write(buf, 0, read);
-            }
-
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
+            baos.write(is);
             return baos.toByteArray();
         }
     }


### PR DESCRIPTION
@dizzzz Here we go! :-)

**TODO(AR)** have `FastByteArrayOutputStream` return an unsycnhronized `FastByteArrayInputStream` when calling `toInputStream`...

# Rules

1. Prefer `org.apache.commons.io.output.ByteArrayOutputStream` over `java.io.ByteArrayOutputStream`.
	
2. When possible provide a size hint to `ByteArrayOutputStream(size)`
     1. Pay attention to difference in initial sizing: `commons.io.output.ByteArrayOutputStream(1024)` vs `java.io.ByteArrayOutputStream(32)`
	
3. Note that `commons.io.output.ByteArrayOutputStream` and `java.io.ByteArrayOutputStream` are thread-safe, when writing non-concurrent code, instead prefer `org.exist.util.io.FastByteArrayOutputStream` which is a non-thread safe port of `commons.io.output.ByteArrayOutputStream`.

4. Note that calling `toByteArray` on either `org.exist.util.io.FastByteArrayOutputStream`, `commons.io.output.ByteArrayOutputStream`, or `java.io.ByteArrayOutputStream` will result in a copy of the data, so the size requirement is 2x the content of the `OutputStream`.
    1. If the follow-on destination for the data is another `OutputStream`, consider calling `writeTo(OutputStream)` instead of `toByteArray()`.
    2. If the follow-on destination for the data is an `InputStream`, `FastByteArrayOutputStream` and `commons.io.output.ByteArrayOutputStream` also provide `toInputStream()` and `toBufferedInputStream()` methods.

5. When reading from an `InputStream` to a `ByteArrayOutputStream`, consider the method `write(InputStream)` on either `FastByteArrayOutputStream` or `commons.io.output.ByteArrayOutputStream`.

6. Avoid `org.apache.commons.io.IOUtils.copy(...)`.

7. When the size is known in advance, don't use a `ByteArrayOutputStream`, use a `ByteBuffer` or `sun.misc.Unsafe`.