### PR TITLE
[bugfix] Align xml:id handling with saxon and basex

### DIFF
--- a/src/org/exist/Indexer.java
+++ b/src/org/exist/Indexer.java
@@ -653,10 +653,6 @@ public class Indexer extends Observable implements ContentHandler, LexicalHandle
                     // type to ID
                     attr.setValue(StringValue.trimWhitespace(StringValue.collapseWhitespace(attr.getValue())));
 
-                    if (!XMLChar.isValidNCName(attr.getValue())) {
-                        throw new SAXException("Value of xml:id attribute is not a valid NCName: " + attr.getValue());
-                    }
-
                     attr.setType(AttrImpl.ID);
                 } else if (attr.getQName().equals(Namespaces.XML_SPACE_QNAME)) {
                     node.setPreserveSpace("preserve".equals(attr.getValue()));

--- a/src/org/exist/xquery/DynamicAttributeConstructor.java
+++ b/src/org/exist/xquery/DynamicAttributeConstructor.java
@@ -167,8 +167,6 @@ public class DynamicAttributeConstructor extends NodeConstructor {
         //normalize xml:id
     	if (qn.equals(Namespaces.XML_ID_QNAME)) {
     		value = StringValue.trimWhitespace(StringValue.collapseWhitespace(value));
-            if (!XMLChar.isValidNCName(value))
-                {throw new XPathException(expr, ErrorCodes.XQDY0091, "Value of xml:id attribute is not a valid NCName: " + value);}
     	}
     	return value;
     }

--- a/test/src/xquery/xmlid.xql
+++ b/test/src/xquery/xmlid.xql
@@ -1,0 +1,75 @@
+xquery version "3.1";
+
+(:~ Additional tests for the fn:count function :)
+module namespace xid="http://exist-db.org/xquery/test/xmlid";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $xid:COLLECTION_NAME := "test-xmlid";
+
+declare variable $xid:XML :=
+    ``[<test>
+        <item xml:id="nym_Ͷαναξιμοῦς"/>
+        <item xml:id="123"/>
+    </test>]``;
+
+declare
+%test:setUp
+function xid:setup() {
+    xmldb:create-collection("/db", $xid:COLLECTION_NAME)
+};
+
+declare
+%test:tearDown
+function xid:cleanup() {
+    xmldb:remove($xid:COLLECTION_NAME)
+};
+
+declare
+    %test:assertEquals("<item xml:id='nym_Ͷαναξιμοῦς'/>")
+function xid:stored-xml() {
+    xmldb:store($xid:COLLECTION_NAME, "test.xml", $xid:XML),
+    doc($xid:COLLECTION_NAME || "/test.xml")/id("nym_Ͷαναξιμοῦς"),
+    (: not a valid ncname and thus ignored, c.f. https://www.w3.org/TR/xpath-functions-31/#func-id :)
+    doc($xid:COLLECTION_NAME || "/test.xml")/id("123")
+};
+
+declare
+%test:assertEquals("<item xml:id='nym_Ͷαναξιμοῦς'/>")
+function xid:parse-xml() {
+    let $test := fn:parse-xml($xid:XML)
+    return (
+        $test/id("nym_Ͷαναξιμοῦς"),
+        (: not a valid ncname and thus ignored, c.f. https://www.w3.org/TR/xpath-functions-31/#func-id :)
+        $test/id("123")
+    )
+
+};
+
+declare
+    %test:assertEquals("<item xml:id='nym_Ͷαναξιμοῦς'/>")
+function xid:constructed-xml() {
+    let $test :=
+        <test>
+            <item xml:id="nym_Ͷαναξιμοῦς"/>
+        </test>
+    return (
+        $test/id("nym_Ͷαναξιμοῦς"),
+        (: not a valid ncname and thus ignored, c.f. https://www.w3.org/TR/xpath-functions-31/#func-id :)
+        $test/id("123")
+    )
+};
+
+declare
+%test:assertEquals("<item xml:id='nym_Ͷαναξιμοῦς'/>")
+function xid:constructed-attribute() {
+    let $test :=
+        <test>
+            <item>
+                { attribute xml:id { "nym_Ͷαναξιμοῦς"} }
+            </item>
+        </test>
+    return (
+        $test/id("nym_Ͷαναξιμοῦς")
+    )
+};


### PR DESCRIPTION
Improves #1360 and addresses #540. Testing against saxon and basex showed that both are much more permissive about xml:id in constructed documents, which makes sense because it is quite common e.g. when writing XSLT stylesheets to declare an xml:id whose value is not strictly a valid NCName. Storing documents like this in eXist resulted in an error, causing trouble for XSLT users. Also, the check in eXist (based on xerces code), did not allow some unicode characters which were added in later versions of the spec.

The XQuery spec says an implementation MAY trigger an error on an invalid xml:id when constructing a document, but does not require it. Included tests have been run against saxon and basex to make sure we see the same behaviour on all implementations.