### PR TITLE
Fix java.lang.IllegalArgumentException thrown by FastByteArrayOutputStream

### DIFF
--- a/extensions/modules/src/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -432,7 +432,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 		} else if (doc.getResourceType() == DocumentImpl.BINARY_FILE) {
 			// binary file
             try (final InputStream is = context.getBroker().getBinaryResource((BinaryDocument)doc);
-                 final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
+                 final FastByteArrayOutputStream baos = new FastByteArrayOutputStream(doc.getContentLength() == -1 ? 1024 : (int)doc.getContentLength())) {
                 baos.write(is);
                 value = baos.toByteArray();
             }

--- a/extensions/modules/src/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -432,7 +432,7 @@ public abstract class AbstractCompressFunction extends BasicFunction
 		} else if (doc.getResourceType() == DocumentImpl.BINARY_FILE) {
 			// binary file
             try (final InputStream is = context.getBroker().getBinaryResource((BinaryDocument)doc);
-                 final FastByteArrayOutputStream baos = new FastByteArrayOutputStream((int)doc.getContentLength())) {
+                 final FastByteArrayOutputStream baos = new FastByteArrayOutputStream()) {
                 baos.write(is);
                 value = baos.toByteArray();
             }


### PR DESCRIPTION
Fix exception in compression module: size of binary resource might be reported as -1 if unknown and should thus not be passed on the FastByteArrayOutputStream.