### PR TITLE
set timeout via util:eval-with-context

### DIFF
--- a/src/org/exist/xquery/functions/util/Eval.java
+++ b/src/org/exist/xquery/functions/util/Eval.java
@@ -552,6 +552,10 @@ public class Eval extends BasicFunction {
 				final Element elem = (Element) child;
 				//TODO : error check
 				innerContext.getWatchDog().setMaxNodes(Integer.parseInt(elem.getAttribute("value")));
+			} else if (child.getNodeType() == Node.ELEMENT_NODE &&	"timeout".equals(child.getLocalName())) {
+				final Element elem = (Element) child;
+				//TODO : error check
+				innerContext.getWatchDog().setTimeout(Long.parseLong(elem.getAttribute("value")));
 			} else if (child.getNodeType() == Node.ELEMENT_NODE &&	"current-dateTime".equals(child.getLocalName())) {
 				final Element elem = (Element) child;
 				//TODO : error check

--- a/test/src/xquery/util/eval-with-context.xql
+++ b/test/src/xquery/util/eval-with-context.xql
@@ -1,0 +1,16 @@
+xquery version "3.1";
+
+module namespace ut = "http://exist-db.org/xquery/test/util-eval-with-context";
+ 
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare 
+    %test:assertError("exerr:ERROR")
+function ut:timeout() {
+    let $context :=
+        <static-context>
+            <timeout value="1"/>
+        </static-context>
+    return
+        util:eval-with-context("util:wait(2), <ok/>", $context, false() )
+};


### PR DESCRIPTION
### Description:

Enables setting the timeout option via `util:eval-with-context` to kill a query after the timeout has been reached. 

Before this PR, the following query would not time out. 

```xquery
xquery version "3.1";

let $context :=
    <static-context>
        <timeout value="1"/>
    </static-context>
return
    util:eval-with-context("sum(1 to 10000000)", $context, false() )
```

With this PR, the query correctly times out, with the following error:

> exerr:ERROR Error while evaluating expression: sum(1 to 10000000). The query exceeded the predefined timeout and has been killed. [at line 8, column 5]

### Reference:

- The function documentation for util:eval-with-context http://exist-db.org/exist/apps/fundocs/view.html?uri=http://exist-db.org/xquery/util#eval-with-context.3 indicates the method for setting static context options
- Some options are listed at https://exist-db.org/exist/apps/doc/xquery.xml#other-options
- All options supported under the hood are listed at https://github.com/eXist-db/exist/blob/develop/src/org/exist/xquery/Option.java#L38-L44 

### Type of tests:

See the test above. I'm not quite sure what the best way is to integrate this into the test suite, but I'm open to suggestions?