### PR TITLE
Fix link to "quick start" docs

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ eXist Native XML Database
 =========================
 
 For instructions on how to install and start eXist, please
-refer to http://exist-db.org/quickstart.html. Alternatively 
+refer to https://exist-db.org/exist/apps/doc/quickstart.xml. Alternatively 
 you may directly start the database with the included Jetty 
 webserver and read the documentation which will be available at
 


### PR DESCRIPTION
### Description:

Spotted a typo.

### Reference:

- The URL http://exist-db.org/quickstart.html returns a 404
- The correct URL is https://exist-db.org/exist/apps/doc/quickstart.xml

### Type of tests:

n/a