### PR TITLE
Fix xqsuite results

### DIFF
--- a/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -640,7 +640,7 @@ declare %private function test:assertEmpty($result as item()*) as element(report
     else
         <report>
             <failure message="assertEmpty failed."
-                type="failure-error-code-1"/>,
+                type="failure-error-code-1"/>
             <output>{ $result }</output>
         </report>
 };
@@ -654,7 +654,7 @@ declare %private function test:assertExists($result as item()*) as element(repor
     else
         <report>
             <failure message="assertExists failed."
-                type="failure-error-code-1"/>,
+                type="failure-error-code-1"/>
             <output>{ $result }</output>
         </report>
 };
@@ -668,7 +668,7 @@ declare %private function test:assertTrue($result as item()*) as element(report)
     else
         <report>
             <failure message="assertExists failed."
-                type="failure-error-code-1"/>,
+                type="failure-error-code-1"/>
             <output>{ $result }</output>
         </report>
 };
@@ -682,7 +682,7 @@ declare %private function test:assertError($value as xs:string, $result as item(
     else
         <report>
             <failure message="assertError failed. Expected error {$value}"
-                type="failure-error-code-1"/>,
+                type="failure-error-code-1"/>
             <output>{ $result }</output>
         </report>
 };
@@ -696,7 +696,7 @@ declare %private function test:assertFalse($result as item()*) as element(report
     else
         <report>
             <failure message="assertExists failed."
-                type="failure-error-code-1"/>,
+                type="failure-error-code-1"/>
             <output>{ $result }</output>
         </report>
 };
@@ -746,7 +746,7 @@ declare %private function test:assertXPath($annotation as element(annotation), $
         else
             <report>
                 <failure message="assertXPath failed."
-                    type="failure-error-code-1">{ $expr }</failure>,
+                    type="failure-error-code-1">{ $expr }</failure>
                 <output>{ $result }</output>
             </report>
 };

--- a/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -667,7 +667,7 @@ declare %private function test:assertTrue($result as item()*) as element(report)
         ()
     else
         <report>
-            <failure message="assertExists failed."
+            <failure message="assertTrue failed."
                 type="failure-error-code-1"/>
             <output>{ $result }</output>
         </report>
@@ -695,7 +695,7 @@ declare %private function test:assertFalse($result as item()*) as element(report
         ()
     else
         <report>
-            <failure message="assertExists failed."
+            <failure message="assertFalse failed."
                 type="failure-error-code-1"/>
             <output>{ $result }</output>
         </report>

--- a/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -212,6 +212,7 @@ declare %private function test:test($func as function(*), $meta as element(funct
                             <report>
                                 <failure message="Expected error {$assertError/value/string()}."
                                     type="failure-error-code-1"/>
+                                <output>{ $result }</output>
                             </report>
                         )
                     else


### PR DESCRIPTION
### Description:

- `assertTrue` and `assertFalse` failures were reported as `assertExists` failures
- `assertError` failures did not show the actual result

### Reference:

n/a

### Type of tests:

Before, the following test:

```xquery
xquery version "3.1";

module namespace xqst = "xqsuite-tests";
 
declare namespace test = "http://exist-db.org/xquery/xqsuite";

declare 
    %test:assertFalse 
function xqst:true() {
    true()
};

declare 
    %test:assertTrue 
function xqst:false() {
    false()
};

declare 
    %test:assertError("exerr:ERROR")
function xqst:valid() {
    1
};
```

would return this (notice how the `failure/@message` for the first 2 tests are wrong and how the 3rd case tells us what was expected but not the actual result):

```xml
<testsuites>
    <testsuite package="xqsuite-tests" timestamp="2018-05-02T00:14:33.219-04:00" failures="3" pending="0" tests="3" time="PT0.003S">
        <testcase name="false" class="xqst:false">
            <failure message="assertExists failed." type="failure-error-code-1"/>
            <output>false</output>
        </testcase>
        <testcase name="true" class="xqst:true">
            <failure message="assertExists failed." type="failure-error-code-1"/>
            <output>true</output>
        </testcase>
        <testcase name="valid" class="xqst:valid">
            <failure message="Expected error exerr:ERROR." type="failure-error-code-1"/>
        </testcase>
    </testsuite>
</testsuites>
```

With this PR, the test returns this (notice how the `failure/@message` for the first 2 tests are correct and how the 3rd case tells us both what was expected and what the actual result was):

```xml
<testsuites>
    <testsuite package="xqsuite-tests" timestamp="2018-05-02T00:15:50.309-04:00" failures="3" pending="0" tests="3" time="PT0.004S">
        <testcase name="false" class="xqst:false">
            <failure message="assertTrue failed." type="failure-error-code-1"/>
            <output>false</output>
        </testcase>
        <testcase name="true" class="xqst:true">
            <failure message="assertFalse failed." type="failure-error-code-1"/>
            <output>true</output>
        </testcase>
        <testcase name="valid" class="xqst:valid">
            <failure message="Expected error exerr:ERROR." type="failure-error-code-1"/>
            <output>1</output>
        </testcase>
    </testsuite>
</testsuites>
```