### PR TITLE
Load XSuite resources from classpath

### DIFF
--- a/test/src/org/exist/test/runner/XMLTestRunner.java
+++ b/test/src/org/exist/test/runner/XMLTestRunner.java
@@ -141,7 +141,7 @@ public class XMLTestRunner extends AbstractTestRunner {
             final Source query = new ClassLoaderSource(pkgName + "/xml-test-runner.xq");
 
             final List<java.util.function.Function<XQueryContext, Tuple2<String, Object>>> externalVariableDeclarations = Arrays.asList(
-                context -> new Tuple2<String, Object>("doc", doc),
+                context -> new Tuple2<>("doc", doc),
                 context -> new Tuple2<>("id", Sequence.EMPTY_SEQUENCE),
 
                 // set callback functions for notifying junit!

--- a/test/src/org/exist/test/runner/XMLTestRunner.java
+++ b/test/src/org/exist/test/runner/XMLTestRunner.java
@@ -25,7 +25,7 @@ import org.exist.EXistException;
 import org.exist.Namespaces;
 import org.exist.dom.memtree.SAXAdapter;
 import org.exist.security.PermissionDeniedException;
-import org.exist.source.FileSource;
+import org.exist.source.ClassLoaderSource;
 import org.exist.source.Source;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.xquery.*;
@@ -44,7 +44,6 @@ import javax.annotation.Nullable;
 import javax.xml.parsers.*;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 
 /**
@@ -138,7 +137,8 @@ public class XMLTestRunner extends AbstractTestRunner {
     @Override
     public void run(final RunNotifier notifier) {
         try {
-            final Source query = new FileSource(Paths.get("test/src/org/exist/test/runner/xml-test-runner.xq"), false);
+            final String pkgName = getClass().getPackage().getName().replace('.', '/');
+            final Source query = new ClassLoaderSource(pkgName + "/xml-test-runner.xq");
 
             final List<java.util.function.Function<XQueryContext, Tuple2<String, Object>>> externalVariableDeclarations = Arrays.asList(
                 context -> new Tuple2<String, Object>("doc", doc),

--- a/test/src/org/exist/test/runner/XQueryTestRunner.java
+++ b/test/src/org/exist/test/runner/XQueryTestRunner.java
@@ -161,7 +161,7 @@ public class XQueryTestRunner extends AbstractTestRunner {
             final URI testModuleUri = path.toAbsolutePath().toUri();
 
             final List<java.util.function.Function<XQueryContext, Tuple2<String, Object>>> externalVariableDeclarations = Arrays.asList(
-                    context -> new Tuple2<String, Object>("test-module-uri", new AnyURIValue(testModuleUri)),
+                    context -> new Tuple2<>("test-module-uri", new AnyURIValue(testModuleUri)),
 
                     // set callback functions for notifying junit!
                     context -> new Tuple2<>("test-ignored-function", new FunctionReference(new FunctionCall(context, new ExtTestIgnoredFunction(context, getSuiteName(), notifier)))),

--- a/test/src/org/exist/test/runner/XQueryTestRunner.java
+++ b/test/src/org/exist/test/runner/XQueryTestRunner.java
@@ -23,7 +23,7 @@ package org.exist.test.runner;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.security.PermissionDeniedException;
-import org.exist.source.FileSource;
+import org.exist.source.ClassLoaderSource;
 import org.exist.source.Source;
 import org.exist.source.StringSource;
 import org.exist.util.DatabaseConfigurationException;
@@ -42,7 +42,6 @@ import org.w3c.dom.NodeList;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -157,7 +156,8 @@ public class XQueryTestRunner extends AbstractTestRunner {
     @Override
     public void run(final RunNotifier notifier) {
         try {
-            final Source query = new FileSource(Paths.get("test/src/org/exist/test/runner/xquery-test-runner.xq"), false);
+            final String pkgName = getClass().getPackage().getName().replace('.', '/');
+            final Source query = new ClassLoaderSource(pkgName + "/xquery-test-runner.xq");
             final URI testModuleUri = path.toAbsolutePath().toUri();
 
             final List<java.util.function.Function<XQueryContext, Tuple2<String, Object>>> externalVariableDeclarations = Arrays.asList(


### PR DESCRIPTION
This eases the cases where `exist-testkit.jar` is used from other eXist-db based Java projects for executing XQuery and XML tests against eXist-db used XQSuite etc.