### PR TITLE
Replaced reflective construction with Constructor functions

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/AnalyzerConfig.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/AnalyzerConfig.java
@@ -20,9 +20,8 @@
 package org.exist.indexing.lucene;
 
 import java.io.Reader;
-import java.lang.reflect.Constructor;
+import java.lang.invoke.*;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -46,6 +45,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import static java.lang.invoke.MethodType.methodType;
 
 public class AnalyzerConfig {
 
@@ -82,6 +83,7 @@ public class AnalyzerConfig {
 
      */
     private static final Logger LOG = LogManager.getLogger(AnalyzerConfig.class);
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
     private static final String ID_ATTRIBUTE = "id";
 
@@ -250,25 +252,19 @@ public class AnalyzerConfig {
     private static Analyzer createInstance(final Class<?> clazz, final Class<?>[] vcParamClasses,
         final Object[] vcParamValues, final boolean warnOnError) {
 
-        String className = clazz.getName();
+        final String className = clazz.getName();
+
+        MethodType constructorType = methodType(void.class);
+        for (final Class<?> vcParamClazz : vcParamClasses) {
+            constructorType = constructorType.appendParameterTypes(vcParamClazz);
+        }
 
         try {
-            final Constructor<?> cstr = clazz.getDeclaredConstructor(vcParamClasses);
-            cstr.setAccessible(true);
-
+            final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, constructorType);
             if (LOG.isDebugEnabled()) {
                 LOG.debug(String.format("Using analyzer %s", className));
             }
-
-            return (Analyzer) cstr.newInstance(vcParamValues);
-
-        } catch (final IllegalArgumentException | IllegalAccessException | InstantiationException | InvocationTargetException | SecurityException e) {
-            final String message = String.format("Exception while instantiating analyzer class %s: %s", className, e.getMessage());
-            if (warnOnError) {
-                LOG.warn(message + ". Will retry...");
-            } else {
-                LOG.error(message, e);
-            }
+            return (Analyzer)methodHandle.invokeWithArguments(vcParamValues);
         } catch (final NoSuchMethodException e) {
             final String message = String.format("Could not find matching analyzer class constructor%s: %s", className, e.getMessage());
             if (warnOnError) {
@@ -276,8 +272,14 @@ public class AnalyzerConfig {
             } else {
                 LOG.error(message, e);
             }
+        } catch (final Throwable e) {
+            final String message = String.format("Exception while instantiating analyzer class %s: %s", className, e.getMessage());
+            if (warnOnError) {
+                LOG.warn(message + ". Will retry...");
+            } else {
+                LOG.error(message, e);
+            }
         }
-
         return null;
     }
 

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/AnalyzerConfig.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/AnalyzerConfig.java
@@ -266,13 +266,18 @@ public class AnalyzerConfig {
             }
             return (Analyzer)methodHandle.invokeWithArguments(vcParamValues);
         } catch (final NoSuchMethodException e) {
-            final String message = String.format("Could not find matching analyzer class constructor%s: %s", className, e.getMessage());
+            final String message = String.format("Could not find matching analyzer class constructor %s: %s", className, e.getMessage());
             if (warnOnError) {
                 LOG.warn(message + ". Will retry...");
             } else {
                 LOG.error(message, e);
             }
         } catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             final String message = String.format("Exception while instantiating analyzer class %s: %s", className, e.getMessage());
             if (warnOnError) {
                 LOG.warn(message + ". Will retry...");

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/ClassicQueryParserWrapper.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/ClassicQueryParserWrapper.java
@@ -64,7 +64,13 @@ public class ClassicQueryParserWrapper extends QueryParserWrapper {
 
                 parser = constructor.apply(LuceneIndex.LUCENE_VERSION_IN_USE, field, analyzer);
             }
+
         } catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             LOG.warn("Failed to instantiate lucene query parser class: " + className + ": " + e.getMessage(), e);
         }
     }

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/ClassicQueryParserWrapper.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/ClassicQueryParserWrapper.java
@@ -19,6 +19,7 @@
  */
 package org.exist.indexing.lucene;
 
+import com.evolvedbinary.j8fu.function.TriFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
@@ -30,8 +31,11 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.Version;
 import org.exist.xquery.XPathException;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+import static java.lang.invoke.MethodType.methodType;
 
 /**
  * Wrapper around Lucene parsers which are based on
@@ -41,24 +45,26 @@ import java.lang.reflect.InvocationTargetException;
  */
 public class ClassicQueryParserWrapper extends QueryParserWrapper {
 
-    private final static Logger LOG = LogManager.getLogger(ClassicQueryParserWrapper.class);
+    private static final Logger LOG = LogManager.getLogger(ClassicQueryParserWrapper.class);
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
     private QueryParserBase parser = null;
 
-    public ClassicQueryParserWrapper(String className, String field, Analyzer analyzer) {
+    public ClassicQueryParserWrapper(final String className, final String field, final Analyzer analyzer) {
         super(field, analyzer);
         try {
-            Class<?> clazz = Class.forName(className);
+            final Class<?> clazz = Class.forName(className);
             if (QueryParserBase.class.isAssignableFrom(clazz)) {
-                final Class<?> cParamClasses[] = new Class<?>[] {
-                        Version.class, String.class, Analyzer.class
-                };
-                final Constructor<?> cstr = clazz.getDeclaredConstructor(cParamClasses);
-                parser = (QueryParserBase) cstr.newInstance(LuceneIndex.LUCENE_VERSION_IN_USE, field, analyzer);
+
+                final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, methodType(void.class, Version.class, String.class, Analyzer.class));
+                final TriFunction<Version, String, Analyzer, QueryParserBase> constructor = (TriFunction<Version, String, Analyzer, QueryParserBase>)
+                        LambdaMetafactory.metafactory(
+                                LOOKUP, "apply", methodType(TriFunction.class),
+                                methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
+
+                parser = constructor.apply(LuceneIndex.LUCENE_VERSION_IN_USE, field, analyzer);
             }
-        } catch (ClassNotFoundException | IllegalAccessException | InvocationTargetException e) {
-            LOG.warn("Failed to instantiate lucene query parser class: " + className, e);
-        } catch (NoSuchMethodException | InstantiationException e) {
+        } catch (final Throwable e) {
             LOG.warn("Failed to instantiate lucene query parser class: " + className + ": " + e.getMessage(), e);
         }
     }

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/QueryParserWrapper.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/QueryParserWrapper.java
@@ -64,7 +64,13 @@ public abstract class QueryParserWrapper {
 
                 return constructor.apply(field, analyzer);
             }
+
         } catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             LOG.warn("Failed to instantiate lucene query parser wrapper class: " + className, e);
         }
         return null;

--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/QueryParserWrapper.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/QueryParserWrapper.java
@@ -19,6 +19,7 @@
  */
 package org.exist.indexing.lucene;
 
+import com.evolvedbinary.j8fu.function.TriFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
@@ -26,8 +27,12 @@ import org.apache.lucene.queryparser.flexible.standard.CommonQueryParserConfigur
 import org.apache.lucene.search.Query;
 import org.exist.xquery.XPathException;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.function.BiFunction;
+
+import static java.lang.invoke.MethodType.methodType;
 
 /**
  * Wrapper around Lucene's parser classes, which unfortunately do not all inherit
@@ -37,7 +42,8 @@ import java.lang.reflect.InvocationTargetException;
  */
 public abstract class QueryParserWrapper {
 
-    private final static Logger LOG = LogManager.getLogger(QueryParserWrapper.class);
+    private static final Logger LOG = LogManager.getLogger(QueryParserWrapper.class);
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
     public QueryParserWrapper(String field, Analyzer analyzer) {
     }
@@ -46,17 +52,19 @@ public abstract class QueryParserWrapper {
 
     public abstract Query parse(String query) throws XPathException;
 
-    public static QueryParserWrapper create(String className, String field, Analyzer analyzer) {
+    public static QueryParserWrapper create(final String className, final String field, final Analyzer analyzer) {
         try {
-            Class<?> clazz = Class.forName(className);
+            final Class<?> clazz = Class.forName(className);
             if (QueryParserWrapper.class.isAssignableFrom(clazz)) {
-                final Class<?> cParamClasses[] = new Class<?>[] {
-                    String.class, Analyzer.class
-                };
-                final Constructor<?> cstr = clazz.getDeclaredConstructor(cParamClasses);
-                return (QueryParserWrapper) cstr.newInstance(field, analyzer);
+                final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, methodType(void.class, String.class, Analyzer.class));
+                final BiFunction<String, Analyzer, QueryParserWrapper> constructor = (BiFunction<String, Analyzer, QueryParserWrapper>)
+                        LambdaMetafactory.metafactory(
+                                LOOKUP, "apply", methodType(TriFunction.class),
+                                methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
+
+                return constructor.apply(field, analyzer);
             }
-        } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        } catch (final Throwable e) {
             LOG.warn("Failed to instantiate lucene query parser wrapper class: " + className, e);
         }
         return null;

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexAnalyzer.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexAnalyzer.java
@@ -1,7 +1,6 @@
 package org.exist.indexing.range;
 
 import com.ibm.icu.text.Collator;
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
@@ -11,7 +10,6 @@ import org.apache.lucene.collation.ICUCollationAttributeFactory;
 import org.apache.lucene.util.AttributeFactory;
 import org.exist.util.Collations;
 import org.exist.util.DatabaseConfigurationException;
-import org.apache.logging.log4j.Logger;
 import org.exist.xquery.XPathException;
 import org.w3c.dom.Element;
 
@@ -32,12 +30,10 @@ import static java.lang.invoke.MethodType.methodType;
  */
 public class RangeIndexAnalyzer extends Analyzer {
 
-    private final static Logger LOG = LogManager.getLogger(RangeIndexAnalyzer.class);
-
     private static class FilterConfig {
-        Function<TokenStream, TokenStream> constructor;
+        private Function<TokenStream, TokenStream> constructor;
 
-        FilterConfig(Element config) throws DatabaseConfigurationException {
+        FilterConfig(final Element config) throws DatabaseConfigurationException {
             final String className = config.getAttribute("class");
             if (className == null) {
                 throw new DatabaseConfigurationException("No class specified for filter");

--- a/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexAnalyzer.java
+++ b/extensions/indexes/range/src/org/exist/indexing/range/RangeIndexAnalyzer.java
@@ -51,7 +51,13 @@ public class RangeIndexAnalyzer extends Analyzer {
                         LambdaMetafactory.metafactory(
                                 lookup, "apply", methodType(Function.class),
                                 methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
+
             } catch (final Throwable e) {
+                if (e instanceof InterruptedException) {
+                    // NOTE: must set interrupted flag
+                    Thread.currentThread().interrupt();
+                }
+
                 throw new DatabaseConfigurationException("Filter not found: " + className, e);
             }
         }

--- a/src/org/exist/config/Configurator.java
+++ b/src/org/exist/config/Configurator.java
@@ -21,12 +21,10 @@ package org.exist.config;
 
 import java.io.*;
 import java.lang.annotation.Annotation;
-import java.lang.invoke.LambdaConversionException;
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/src/org/exist/config/mapper/Constructor.java
+++ b/src/org/exist/config/mapper/Constructor.java
@@ -147,6 +147,11 @@ public class Constructor {
                 return obj;
 
             } catch (final Throwable e) {
+                if (e instanceof InterruptedException) {
+                    // NOTE: must set interrupted flag
+                    Thread.currentThread().interrupt();
+                }
+
                 Configurator.LOG.error(e);
             }
             return null;

--- a/src/org/exist/config/mapper/Constructor.java
+++ b/src/org/exist/config/mapper/Constructor.java
@@ -25,7 +25,6 @@ import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.util.*;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.xml.stream.XMLInputFactory;
@@ -53,7 +52,8 @@ public class Constructor {
     /**
      * Create new java object by mapping instructions.
      */
-    public static Object load(final NewClass newClazz, final Configurable instance, final Configuration conf) {
+    public static Object load(final NewClass newClazz,
+            final Configurable instance, final Configuration conf) {
 
         final String url = newClazz.mapper();
         if (url == null) {

--- a/src/org/exist/config/mapper/Constructor.java
+++ b/src/org/exist/config/mapper/Constructor.java
@@ -20,9 +20,7 @@
 package org.exist.config.mapper;
 
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Stack;
+import java.util.*;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
@@ -69,8 +67,8 @@ public class Constructor {
             final XMLStreamReader reader = inputFactory.createXMLStreamReader(is);
 
             Object obj = null;
-            final Stack<Object> objs = new Stack<>();
-            final Stack<CallMethod> instructions = new Stack<>();
+            final Deque<Object> objs = new ArrayDeque<>();
+            final Deque<CallMethod> instructions = new ArrayDeque<>();
 
             int eventType;
             while (reader.hasNext()) {
@@ -94,16 +92,16 @@ public class Constructor {
                             if (obj == null) {
                                 obj = newInstance;
                             }
-                            objs.add(newInstance);
+                            objs.push(newInstance);
 
-                            if (!instructions.empty()) {
+                            if (!instructions.isEmpty()) {
                                 instructions.peek().setValue(newInstance);
                             }
 
                         } else if ("callMethod".equals(localName)) {
 
                             Configuration _conf_ = conf;
-                            if (!instructions.empty()) {
+                            if (!instructions.isEmpty()) {
                                 _conf_ = instructions.peek().getConfiguration();
                             }
 
@@ -113,7 +111,7 @@ public class Constructor {
                                 call.set(reader.getAttributeLocalName(i), reader.getAttributeValue(i));
                             }
 
-                            instructions.add(call);
+                            instructions.push(call);
                         }
                         break;
                     case XMLEvent.END_ELEMENT:

--- a/src/org/exist/http/RESTServer.java
+++ b/src/org/exist/http/RESTServer.java
@@ -222,6 +222,11 @@ public class RESTServer {
                 }
             }
         } catch(final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             if(LOG.isDebugEnabled()) {
                 LOG.debug("EXQuery Request Module is not present: " + e.getMessage(), e);
             }

--- a/src/org/exist/plugin/PluginsManagerImpl.java
+++ b/src/org/exist/plugin/PluginsManagerImpl.java
@@ -108,53 +108,60 @@ public class PluginsManagerImpl implements Configurable, BrokerPoolService, Plug
 	public void start(DBBroker broker) throws EXistException {
         final TransactionManager transaction = broker.getBrokerPool().getTransactionManager();
 
-        try (final Txn txn = transaction.beginTransaction()) {
-            collection = broker.getCollection(COLLETION_URI);
-            if (collection == null) {
-                collection = broker.getOrCreateCollection(txn, COLLETION_URI);
-                if (collection == null) {
-                    return;
-                }
-                //if db corrupted it can lead to unrunnable issue
-                //throw new ConfigurationException("Collection '/db/system/plugins' can't be created.");
-
-                collection.setPermissions(Permission.DEFAULT_SYSTEM_SECURITY_COLLECTION_PERM);
-                broker.saveCollection(txn, collection);
-            }
-
-            transaction.commit(txn);
-        } catch (final Exception e) {
-            e.printStackTrace();
-            LOG.debug("loading configuration failed: " + e.getMessage());
-        }
-
-        final Configuration _config_ = Configurator.parse(this, broker, collection, CONFIG_FILE_URI);
-        configuration = Configurator.configure(this, _config_);
-
-        //load plugins by META-INF/services/
+        boolean interrupted = false;
         try {
+            try (final Txn txn = transaction.beginTransaction()) {
+                collection = broker.getCollection(COLLETION_URI);
+                if (collection == null) {
+                    collection = broker.getOrCreateCollection(txn, COLLETION_URI);
+                    if (collection == null) {
+                        return;
+                    }
+                    //if db corrupted it can lead to unrunnable issue
+                    //throw new ConfigurationException("Collection '/db/system/plugins' can't be created.");
 
-            final MethodHandles.Lookup lookup = MethodHandles.lookup();
-
-            for (final Class<? extends Plug> pluginClazz : listServices(Plug.class)) {
-                try {
-                    final MethodHandle methodHandle = lookup.findConstructor(pluginClazz, methodType(void.class, PluginsManager.class));
-                    final Function<PluginsManager, Plug> ctor = (Function<PluginsManager, Plug>)
-                            LambdaMetafactory.metafactory(
-                                    lookup, "apply", methodType(Function.class),
-                                    methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
-
-                    final Plug plgn = ctor.apply(this);
-
-                    jacks.put(pluginClazz.getName(), plgn);
-                } catch (final Throwable e) {
-                    e.printStackTrace();
+                    collection.setPermissions(Permission.DEFAULT_SYSTEM_SECURITY_COLLECTION_PERM);
+                    broker.saveCollection(txn, collection);
                 }
+
+                transaction.commit(txn);
+            } catch (final Exception e) {
+                e.printStackTrace();
+                LOG.debug("loading configuration failed: " + e.getMessage());
             }
-        } catch (final Throwable e) {
-            e.printStackTrace();
-        }
-        //UNDERSTAND: call save?
+
+            final Configuration _config_ = Configurator.parse(this, broker, collection, CONFIG_FILE_URI);
+            configuration = Configurator.configure(this, _config_);
+
+            //load plugins by META-INF/services/
+            try {
+
+                final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+                for (final Class<? extends Plug> pluginClazz : listServices(Plug.class)) {
+                    try {
+                        final MethodHandle methodHandle = lookup.findConstructor(pluginClazz, methodType(void.class, PluginsManager.class));
+                        final Function<PluginsManager, Plug> ctor = (Function<PluginsManager, Plug>)
+                                LambdaMetafactory.metafactory(
+                                        lookup, "apply", methodType(Function.class),
+                                        methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
+
+                        final Plug plgn = ctor.apply(this);
+
+                        jacks.put(pluginClazz.getName(), plgn);
+                    } catch (final Throwable e) {
+                        if (e instanceof InterruptedException) {
+                            // NOTE: must set interrupted flag
+                            interrupted = true;
+                        }
+
+                        e.printStackTrace();
+                    }
+                }
+            } catch (final Throwable e) {
+                e.printStackTrace();
+            }
+            //UNDERSTAND: call save?
 
 //		try {
 //			configuration.save(broker);
@@ -162,8 +169,14 @@ public class PluginsManagerImpl implements Configurable, BrokerPoolService, Plug
 //			//LOG?
 //		}
 
-        for (final Plug jack : jacks.values()) {
-            jack.start(broker);
+            for (final Plug jack : jacks.values()) {
+                jack.start(broker);
+            }
+        } finally {
+            if (interrupted) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
         }
     }
 
@@ -222,6 +235,10 @@ public class PluginsManagerImpl implements Configurable, BrokerPoolService, Plug
 			
 			//TODO: if (jack instanceof Startable) { ((Startable) jack).startUp(broker); }
 		} catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
 //			e.printStackTrace();
 		}
 	}

--- a/src/org/exist/repo/ExistRepository.java
+++ b/src/org/exist/repo/ExistRepository.java
@@ -10,8 +10,9 @@
 package org.exist.repo;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -19,12 +20,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.exist.start.EXistClassLoader;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.BrokerPoolService;
 import org.exist.storage.BrokerPoolServiceException;
@@ -42,6 +43,8 @@ import org.expath.pkg.repo.PackageException;
 import org.expath.pkg.repo.Repository;
 import org.expath.pkg.repo.URISpace;
 
+import static java.lang.invoke.MethodType.methodType;
+
 /**
  * A repository as viewed by eXist.
  *
@@ -53,6 +56,7 @@ import org.expath.pkg.repo.URISpace;
 public class ExistRepository extends Observable implements BrokerPoolService {
 
     private final static Logger LOG = LogManager.getLogger(ExistRepository.class);
+    private final static MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
     public final static String EXPATH_REPO_DIR = "expathrepo";
     public final static String EXPATH_REPO_DEFAULT = "webapp/WEB-INF/" + EXPATH_REPO_DIR;
 
@@ -133,8 +137,6 @@ public class ExistRepository extends Observable implements BrokerPoolService {
             return ctxt.loadBuiltInModule(namespace, name);
         } catch (final ClassNotFoundException ex) {
             throw new XPathException("Cannot find module class from EXPath repository: " + name, ex);
-        } catch (final InstantiationException | InvocationTargetException | IllegalAccessException ex) {
-            throw new XPathException("Problem instantiating module class from EXPath repository: " + name, ex);
         } catch (final ClassCastException ex) {
             throw new XPathException("The class configured in EXPath repository is not a Module: " + name, ex);
         } catch (final IllegalArgumentException ex) {
@@ -146,20 +148,32 @@ public class ExistRepository extends Observable implements BrokerPoolService {
      * Try to instantiate the class using the constructor with a Map parameter, 
      * or the default constructor.
      */
-    private Module instantiateModule(final Class<Module> clazz) throws XPathException,
-        InstantiationException, IllegalAccessException, InvocationTargetException {
+    private Module instantiateModule(final Class<Module> clazz) throws XPathException {
         try {
-            final Constructor<Module> ctor = clazz.getConstructor(Map.class);
-            return ctor.newInstance(Collections.emptyMap());
-        } catch (final NoSuchMethodException ex) {
             try {
-                final Constructor<Module> ctor = clazz.getConstructor();
-                return ctor.newInstance();
+                // attempt for a constructor that takes 1 argument
+                final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, methodType(void.class, Map.class));
+                final Function<Map, Module> ctor = (Function<Map, Module>)
+                        LambdaMetafactory.metafactory(
+                                LOOKUP, "apply", methodType(Function.class),
+                                methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
+                return ctor.apply(Collections.emptyMap());
+
+            } catch (final NoSuchMethodException nsme) {
+                // attempt for a constructor that takes 0 arguments
+                final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, methodType(void.class, Map.class));
+                final Supplier<Module> ctor = (Supplier<Module>)
+                        LambdaMetafactory.metafactory(
+                                LOOKUP, "apply", methodType(Supplier.class),
+                                methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
+                return ctor.get();
             }
-            catch (final NoSuchMethodException exx) {
-                throw new XPathException("Cannot find suitable constructor " +
-                    "for module from expath repository", exx);
-            }
+        } catch (final NoSuchMethodException nsme) {
+            throw new XPathException("Cannot find suitable constructor " +
+                "for module from EXPath repository: " + clazz.getName(), nsme);
+        } catch (final Throwable lce) {
+            throw new XPathException("Unable to instantiate module from EXPath" +
+                    "repository: " + clazz.getName());
         }
     }
 

--- a/src/org/exist/repo/ExistRepository.java
+++ b/src/org/exist/repo/ExistRepository.java
@@ -171,7 +171,12 @@ public class ExistRepository extends Observable implements BrokerPoolService {
         } catch (final NoSuchMethodException nsme) {
             throw new XPathException("Cannot find suitable constructor " +
                 "for module from EXPath repository: " + clazz.getName(), nsme);
-        } catch (final Throwable lce) {
+        } catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             throw new XPathException("Unable to instantiate module from EXPath" +
                     "repository: " + clazz.getName());
         }

--- a/src/org/exist/storage/BrokerFactory.java
+++ b/src/org/exist/storage/BrokerFactory.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2010 The eXist Project
+ *  Copyright (C) 2001-2018 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -16,8 +16,6 @@
  *  You should have received a copy of the GNU Lesser General Public
  *  License along with this library; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
  */
 package org.exist.storage;
 
@@ -35,7 +33,7 @@ public class BrokerFactory {
 
     private static Class<?> constructorArgs[] = { BrokerPool.class, Configuration.class };
 
-    private static Map<String, Class<? extends DBBroker>> objClasses =  new HashMap<String, Class<? extends DBBroker>>();
+    private static Map<String, Class<? extends DBBroker>> objClasses =  new HashMap<>();
 
     public static void plug(String id, Class<? extends DBBroker> clazz) {
         objClasses.put(id.toUpperCase(Locale.ENGLISH), clazz);
@@ -45,25 +43,25 @@ public class BrokerFactory {
         plug("NATIVE", NativeBroker.class);
     }
 
-    public static DBBroker getInstance(BrokerPool database, Configuration conf) throws EXistException {
+    public static DBBroker getInstance(final BrokerPool database, final Configuration conf) throws EXistException {
         String brokerID = (String) conf.getProperty(PROPERTY_DATABASE);
         if (brokerID == null) {
-            throw new RuntimeException("no database defined");
+            throw new RuntimeException("No database defined");
         }
         
         // Repair name ; https://sourceforge.net/p/exist/bugs/810/
         brokerID = brokerID.toUpperCase(Locale.ENGLISH);
         if (!objClasses.containsKey(brokerID)) {
-            throw new RuntimeException("no database backend found for " + brokerID);
+            throw new RuntimeException("No database backend found for " + brokerID);
         }
-        
+
         try {
             final Class<? extends DBBroker> clazz = objClasses.get(brokerID);
             final Constructor<? extends DBBroker> constructor = clazz.getConstructor(constructorArgs);
             return constructor.newInstance(database, conf);
             
         } catch (final Exception e) {
-            throw new RuntimeException("can't get database backend " + brokerID, e);
+            throw new RuntimeException("Can't get database backend " + brokerID, e);
         }
     }
 }

--- a/src/org/exist/storage/BrokerFactory.java
+++ b/src/org/exist/storage/BrokerFactory.java
@@ -107,7 +107,13 @@ public class BrokerFactory {
                     methodType(BiFunction.class),
                     methodHandle.type().erase(), methodHandle, methodHandle.type()
             ).getTarget().invokeExact());
+
         } catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             return Left(new RuntimeException("Can't get database backend: " + brokerId, e));
         }
     }

--- a/src/org/exist/storage/BrokerFactory.java
+++ b/src/org/exist/storage/BrokerFactory.java
@@ -20,73 +20,125 @@
 package org.exist.storage;
 
 import java.lang.invoke.*;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 
+import com.evolvedbinary.j8fu.Either;
+import com.evolvedbinary.j8fu.lazy.LazyValE;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.util.Configuration;
 
+import static com.evolvedbinary.j8fu.Either.Left;
+import static com.evolvedbinary.j8fu.Either.Right;
 import static java.lang.invoke.MethodType.methodType;
 
+/**
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
 public class BrokerFactory {
 
-    private final static Logger LOG = LogManager.getLogger(BrokerFactory.class);
+    private static final Logger LOG = LogManager.getLogger(BrokerFactory.class);
+    private static final ConcurrentMap<String, LazyValE<BiFunction<BrokerPool, Configuration, DBBroker>, RuntimeException>> CONSTRUCTORS = new ConcurrentHashMap<>();
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
     public static final String PROPERTY_DATABASE = "database";
 
-    private static Class<?> constructorArgs[] = { BrokerPool.class, Configuration.class };
-
-    private static Map<String, Class<? extends DBBroker>> objClasses =  new HashMap<>();
-    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-
-    public static void plug(String id, Class<? extends DBBroker> clazz) {
-        objClasses.put(id.toUpperCase(Locale.ENGLISH), clazz);
+    public static void plug(final String brokerId, final Class<? extends DBBroker> clazz) {
+        CONSTRUCTORS.computeIfAbsent(formatBrokerId(brokerId), key -> new LazyValE<>(() -> getConstructor(key, clazz)));
     }
 
     static {
-        plug("NATIVE", NativeBroker.class);
+        plug(formatBrokerId("NATIVE"), NativeBroker.class);
     }
 
-    public static DBBroker getInstance(final BrokerPool database, final Configuration conf) throws EXistException {
-        String brokerID = (String) conf.getProperty(PROPERTY_DATABASE);
-        if (brokerID == null) {
-            throw new RuntimeException("No database defined");
-        }
-        
-        // Repair name ; https://sourceforge.net/p/exist/bugs/810/
-        brokerID = brokerID.toUpperCase(Locale.ENGLISH);
-        if (!objClasses.containsKey(brokerID)) {
-            throw new RuntimeException("No database backend found for " + brokerID);
+    /**
+     * Constructs a DBBroker instance.
+     *
+     * @param brokerPool the database's broker pool.
+     * @param configuration the database's configuration.
+     *
+     * @return DBBroker an instance of a sub-class of {@link DBBroker}.
+     *
+     * @throws IllegalArgumentException if the configuration does not define a broker ID.
+     * @throws IllegalStateException if there is no database backend defined for the broker ID.
+     * @throws RuntimeException if the database backend cannot be constructed.
+     */
+    public static DBBroker getInstance(final BrokerPool brokerPool, final Configuration configuration) throws RuntimeException, EXistException {
+        final long start = System.currentTimeMillis();
+
+        final String brokerId = getBrokerId(configuration);
+        final LazyValE<BiFunction<BrokerPool, Configuration, DBBroker>, RuntimeException> constructor
+                = CONSTRUCTORS.get(brokerId);
+        if (constructor == null) {
+            throw new IllegalStateException("No database backend found for: " + brokerId);
         }
 
+        final DBBroker broker = constructor.get().apply(brokerPool, configuration);
+
+        if (LOG.isTraceEnabled()) {
+            final long end = System.currentTimeMillis();
+            LOG.trace("Constructed DBBroker in: " + (end - start) + " ms");
+        }
+
+        return broker;
+    }
+
+    /**
+     * Creates a constructor function for a sub-class of DBBroker.
+     *
+     * @param brokerId the id of the DBBroker.
+     * @param clazz the sub-class of DBBroker.
+     *
+     * @return Either a constructor function, or a RuntimeException.
+     */
+    @SuppressWarnings("unchecked")
+    private static Either<RuntimeException, BiFunction<BrokerPool, Configuration, DBBroker>> getConstructor(final String brokerId, final Class<? extends DBBroker> clazz) {
         try {
-            final long start = System.currentTimeMillis();
-            final Class<? extends DBBroker> clazz = objClasses.get(brokerID);
-            final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, methodType(void.class, constructorArgs));
+            final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, methodType(void.class, BrokerPool.class, Configuration.class));
 
             // see https://stackoverflow.com/questions/50211216/how-to-invoke-constructor-using-lambdametafactory#50211536
-            final BiFunction<BrokerPool, Configuration, DBBroker> constructor =
-                    (BiFunction<BrokerPool, Configuration, DBBroker>)
-                            LambdaMetafactory.metafactory(
-                                    LOOKUP, "apply", methodType(BiFunction.class),
-                                    methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
-
-            // TODO(AR) ideally we want to cache the constructor for re-use on subsequent calls to further reduce overhead
-
-            final DBBroker broker = constructor.apply(database, conf);
-
-            if (LOG.isTraceEnabled()) {
-                final long end = System.currentTimeMillis();
-                LOG.trace("Constructed DBBroker in : " + (end - start) + " ms");
-            }
-
-            return broker;
+            return Right((BiFunction<BrokerPool, Configuration, DBBroker>) LambdaMetafactory.metafactory(
+                    LOOKUP,
+                    "apply",
+                    methodType(BiFunction.class),
+                    methodHandle.type().erase(), methodHandle, methodHandle.type()
+            ).getTarget().invokeExact());
         } catch (final Throwable e) {
-            throw new RuntimeException("Can't get database backend " + brokerID, e);
+            return Left(new RuntimeException("Can't get database backend: " + brokerId, e));
         }
+    }
+
+    /**
+     * Gets the Broker ID from a Configuration.
+     *
+     * @param configuration the configuration.
+     * @return the broker ID.
+     *
+     * @throws IllegalArgumentException if the configuration does not define a broker ID.
+     */
+    private static String getBrokerId(final Configuration configuration) throws IllegalArgumentException {
+        final String brokerId = (String) configuration.getProperty(PROPERTY_DATABASE);
+        if (brokerId == null) {
+            throw new IllegalArgumentException("No database defined in: " + configuration.getConfigFilePath());
+        }
+
+        return formatBrokerId(brokerId);
+    }
+
+    /**
+     * Ensures consistent formatting fo the Broker ID.
+     *
+     * Repair name {@see https://sourceforge.net/p/exist/bugs/810/}.
+     *
+     * @param brokerId the broker id to be formatted.
+     *
+     * @return consistently formatted broker id.
+     */
+    private static String formatBrokerId(final String brokerId) {
+        return brokerId.toUpperCase(Locale.ENGLISH);
     }
 }

--- a/src/org/exist/util/io/FilterInputStreamCacheFactory.java
+++ b/src/org/exist/util/io/FilterInputStreamCacheFactory.java
@@ -80,6 +80,11 @@ public class FilterInputStreamCacheFactory {
                             methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
             return constructor.apply(is);
         } catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             LOG.error(e.getMessage(), e);
             return null;
         }

--- a/src/org/exist/util/io/FilterInputStreamCacheFactory.java
+++ b/src/org/exist/util/io/FilterInputStreamCacheFactory.java
@@ -28,11 +28,15 @@ package org.exist.util.io;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.function.Function;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import static java.lang.invoke.MethodType.methodType;
 
 /**
  * Factory to instantiate a cache object
@@ -42,6 +46,7 @@ import org.apache.logging.log4j.Logger;
 public class FilterInputStreamCacheFactory {
 
     private static final Logger LOG = LogManager.getLogger(FilterInputStreamCacheFactory.class);
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
     public interface FilterInputStreamCacheConfiguration {
         String getCacheClass();
@@ -66,18 +71,16 @@ public class FilterInputStreamCacheFactory {
     private FilterInputStreamCache instantiate(final FilterInputStreamCacheConfiguration cacheConfiguration, final InputStream is) {
         try {
             final Class clazz = Class.forName(cacheConfiguration.getCacheClass());
-            final Constructor ctor = clazz.getDeclaredConstructor(InputStream.class);
-            ctor.setAccessible(true);
-            final Object obj = ctor.newInstance(is);
 
-            if (!(obj instanceof FilterInputStreamCache)) {
-                LOG.error("Invalid cache class: " + clazz.getName());
-                return null;
-            }
+            final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, methodType(void.class, InputStream.class));
 
-            return (FilterInputStreamCache) obj;
-        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException | ClassNotFoundException ex) {
-            LOG.error(ex.getMessage(), ex);
+            final Function<InputStream, FilterInputStreamCache> constructor = (Function<InputStream, FilterInputStreamCache>)
+                    LambdaMetafactory.metafactory(
+                            LOOKUP, "apply", methodType(Function.class),
+                            methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
+            return constructor.apply(is);
+        } catch (final Throwable e) {
+            LOG.error(e.getMessage(), e);
             return null;
         }
     }

--- a/src/org/exist/xquery/Function.java
+++ b/src/org/exist/xquery/Function.java
@@ -160,6 +160,11 @@ public abstract class Function extends PathExpr {
             return function;
 
         } catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             LOG.debug(e.getMessage(), e);
             throw new XPathException(ast.getLine(), ast.getColumn(),
                     "Function implementation class " + fclazz.getName() + " not found", e);

--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -1713,6 +1713,11 @@ public class XQueryContext implements BinaryValueManager, Context
             modules.put(module.getNamespaceURI(), module);
             allModules.put(module.getNamespaceURI(), module);
         } catch(final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             LOG.warn("error while instantiating module class " + mClazz.getName(), e);
         }
         

--- a/src/org/exist/xquery/util/NumberFormatter.java
+++ b/src/org/exist/xquery/util/NumberFormatter.java
@@ -2,12 +2,16 @@ package org.exist.xquery.util;
 
 import org.exist.xquery.XPathException;
 
-import java.lang.reflect.Constructor;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.text.DateFormatSymbols;
 import java.time.DayOfWeek;
 import java.time.Month;
 import java.time.format.TextStyle;
 import java.util.Locale;
+
+import static java.lang.invoke.MethodType.methodType;
 
 /**
  * Formatter for numbers and dates. Concrete implementations are language-dependant.
@@ -141,14 +145,19 @@ public abstract class NumberFormatter {
         return count;
     }
 
-    public static NumberFormatter getInstance(String language) {
+    public static NumberFormatter getInstance(final String language) {
         final String className = NumberFormatter.class.getName() + "_" + language;
         final Locale locale = new Locale(language);
         try {
-            final Class langClass = Class.forName(className);
-            final Constructor constructor = langClass.getConstructor(Locale.class);
-            return (NumberFormatter) constructor.newInstance(locale);
-        } catch (final Exception e) {
+            final Class langClazz = Class.forName(className);
+            final MethodHandles.Lookup lookup = MethodHandles.lookup();
+            final MethodHandle methodHandle = lookup.findConstructor(langClazz, methodType(void.class, Locale.class));
+            final java.util.function.Function<Locale, NumberFormatter> constructor = (java.util.function.Function<Locale, NumberFormatter>)
+                    LambdaMetafactory.metafactory(
+                            lookup, "apply", methodType(java.util.function.Function.class),
+                            methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
+            return constructor.apply(locale);
+        } catch (final Throwable e) {
             return new NumberFormatter_en(locale);
         }
     }

--- a/src/org/exist/xquery/util/NumberFormatter.java
+++ b/src/org/exist/xquery/util/NumberFormatter.java
@@ -158,6 +158,11 @@ public abstract class NumberFormatter {
                             methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
             return constructor.apply(locale);
         } catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             return new NumberFormatter_en(locale);
         }
     }

--- a/src/org/exist/xquery/value/BinaryValueType.java
+++ b/src/org/exist/xquery/value/BinaryValueType.java
@@ -5,13 +5,19 @@ import org.exist.xquery.XPathException;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.function.BiFunction;
+
+import static java.lang.invoke.MethodType.methodType;
 
 /**
  * @author Adam Retter <adam@existsolutions.com>
  */
 public abstract class BinaryValueType<T extends FilterOutputStream> {
+
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
     private final int xqueryType;
     private final Class<T> coder;
@@ -35,11 +41,21 @@ public abstract class BinaryValueType<T extends FilterOutputStream> {
 
     private T instantiateCoder(OutputStream stream, boolean encoder) throws IOException {
         try {
-            final Constructor<T> c = coder.getConstructor(OutputStream.class, boolean.class);
-            final T f = c.newInstance(stream, encoder);
+            final MethodHandle methodHandle = LOOKUP.findConstructor(coder, methodType(void.class, OutputStream.class, boolean.class));
+            // NOTE we have to explicitly replace boolean.class with Boolean.class for the implementation
+            final BiFunction<OutputStream, Boolean, T> c = (BiFunction<OutputStream, Boolean, T>)
+                    LambdaMetafactory.metafactory(
+                            LOOKUP,
+                            "apply",
+                            methodType(BiFunction.class),
+                            methodHandle.type().changeParameterType(1, Boolean.class).erase(),
+                            methodHandle,
+                            methodHandle.type().changeParameterType(1, Boolean.class)
+                    ).getTarget().invokeExact();
+            final T f = c.apply(stream, encoder);
             return f;
-        } catch (final NoSuchMethodException | InvocationTargetException | IllegalAccessException | IllegalArgumentException | InstantiationException nsme) {
-            throw new IOException("Unable to get binary coder '" + coder.getName() + "': " + nsme.getMessage(), nsme);
+        } catch (final Throwable e) {
+            throw new IOException("Unable to get binary coder '" + coder.getName() + "': " + e.getMessage(), e);
         }
     }
 

--- a/src/org/exist/xquery/value/BinaryValueType.java
+++ b/src/org/exist/xquery/value/BinaryValueType.java
@@ -55,6 +55,11 @@ public abstract class BinaryValueType<T extends FilterOutputStream> {
             final T f = c.apply(stream, encoder);
             return f;
         } catch (final Throwable e) {
+            if (e instanceof InterruptedException) {
+                // NOTE: must set interrupted flag
+                Thread.currentThread().interrupt();
+            }
+
             throw new IOException("Unable to get binary coder '" + coder.getName() + "': " + e.getMessage(), e);
         }
     }


### PR DESCRIPTION
Rather than using reflection to construct objects, since Java 8+ we have several more options available to us, which can be more performant (and possibly safer). For a basic performance comparison see: https://stackoverflow.com/questions/19557829/faster-alternatives-to-javas-reflection#19563000

I have opted to use the `LambdaMetaFactory` approach as much as possible. Apart from direct construction, it is suggested to offer the best performance.

These changes also seem to reduce the:
```
WARNING: An illegal reflective access operation has occurred
```
warnings on JDK 9+.