### PR TITLE
[feature] Display the exact Java version whilst building

### DIFF
--- a/build/scripts/build-impl.xml
+++ b/build/scripts/build-impl.xml
@@ -29,8 +29,8 @@
     <property name="dist" value="./dist"/>
     <property name="webapp.dir" value="${dist}/webapp"/>
     <property name="build.compiler" value="modern"/>
-    <property name="build.compiler.source" value="1.5"/>
-    <property name="build.compiler.target" value="1.5"/>
+    <property name="build.compiler.source" value="1.8"/>
+    <property name="build.compiler.target" value="1.8"/>
     <property name="build.debug" value="on"/>
     <property name="build.optimize" value="on"/>
     <property name="build.deprecation" value="on"/>
@@ -153,6 +153,9 @@
             </else>
         </if>
         <echo message=""/>
+        <echo message="Java Vendor: ${java.vendor}"/>
+        <echo message="Java Version: ${java.runtime.version}"/>
+        <echo message="Java VM: ${java.vm.name} ${java.vm.version}"/>
         <echo message="${ant.version}"/>
         <echo message="---------------------------------------------"/>
         <echo/>


### PR DESCRIPTION
Just prints out the exact JVM version during the build. Useful for reproducing issues shown on CI where we didn't before exactly which JVM versions are running.