### PR TITLE
Enabled JDK 9 on AppVeyor Ubuntu

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,8 @@ environment:
       JAVA_HOME: C:\Program Files\Java\jdk9
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-# Disabled Ubuntu OpenJDK due to AspectJ bug - https://bugs.eclipse.org/bugs/show_bug.cgi?id=534801
-#    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-#      JAVA_HOME: /usr/lib/jvm/java-9-openjdk-amd64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      JAVA_HOME: /usr/lib/jvm/java-9-openjdk-amd64
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       JAVA_HOME: /usr/lib/jvm/java-10-openjdk-amd64
 


### PR DESCRIPTION
Okay this one is now fixed and ready to land.