### PR TITLE
Added %test:assumeInternetAccess to XQSuite

### DIFF
--- a/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/src/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -18,6 +18,7 @@ xquery version "3.0";
  :)
 module namespace test="http://exist-db.org/xquery/xqsuite";
 
+import module namespace http = "http://expath.org/ns/http-client";
 import module namespace map = "http://www.w3.org/2005/xpath-functions/map";
 import module namespace util = "http://exist-db.org/xquery/util";
 import module namespace system = "http://exist-db.org/xquery/system";
@@ -178,12 +179,74 @@ declare %private function test:run-tests($func as function(*), $meta as element(
           }</report>)
       )
     else
-      let $argsAnnot := $meta/annotation[matches(@name, ":args?")][not(preceding-sibling::annotation[1][matches(@name, ":args?")])]
-      return
-          if ($argsAnnot) then
-              $argsAnnot ! test:test($func, $meta, ., $test-started-function, $test-failure-function, $test-assumption-failed-function, $test-error-function, $test-finished-function)
-          else
-              test:test($func, $meta, (), $test-started-function, $test-failure-function, $test-assumption-failed-function, $test-error-function, $test-finished-function)
+        let $failed-assumptions := test:test-assumptions($meta, $test-assumption-failed-function)
+        return
+            if(not(empty($failed-assumptions)))then
+                test:print-result($meta, (), <report>{
+                element assumptions {
+                  for $failed-assumption in $failed-assumptions
+                  return
+                      element assumption {
+                        attribute name { replace($failed-assumption/@name, "[^:]+:(.+)", "$1") },
+                        $failed-assumption/value/text()
+                      }
+                }
+              }</report>)
+            else
+              let $argsAnnot := $meta/annotation[matches(@name, ":args?")][not(preceding-sibling::annotation[1][matches(@name, ":args?")])]
+              return
+                  if ($argsAnnot) then
+                      $argsAnnot ! test:test($func, $meta, ., $test-started-function, $test-failure-function, $test-error-function, $test-finished-function)
+                  else
+                      test:test($func, $meta, (), $test-started-function, $test-failure-function, $test-error-function, $test-finished-function)
+};
+
+(:~
+ : Tests the assumptions on the (test) function
+ :
+ : @param $meta the function description
+ : @param $test-assumption-failed-function A callback for reporting the failure of assumptions
+ :
+ : @return Any assumption annotations where the asusmption did not hold true
+ :)
+declare
+    %private
+function test:test-assumptions($meta as element(function), $test-assumption-failed-function as (function(xs:string, map(xs:string, item()?)?) as empty-sequence())?) as element(annotation)* {
+    let $assumption-annotations := $meta/annotation[matches(@name,  "[^:]+:assume.+")]
+    return
+        let $failed-assumption-annotations := $assumption-annotations ! test:test-assumption(., $test-assumption-failed-function)
+        return
+            (
+                if(not(empty($test-assumption-failed-function))) then
+                    $failed-assumption-annotations ! $test-assumption-failed-function(
+                            test:get-test-name($meta),
+                            map {
+                                "name": ./string(@name),
+                                "value": ./value/string()
+                            }
+                    )
+                else ()
+                ,
+                $failed-assumption-annotations
+            )
+};
+
+declare
+    %private
+function test:test-assumption($assumption-annotation as element(annotation), $test-assumption-failed-function as (function(xs:string, map(xs:string, item()?)?) as empty-sequence())?) as element(annotation)? {
+    if(ends-with($assumption-annotation/@name, ":assumeInternetAccess"))then
+        (: check for internet access :)
+         try {
+            let $uri := $assumption-annotation/value/text()
+            return
+                (: set a timeout of 3 seconds :)
+                let $response := http:send-request(<http:request method="head" href="{$uri}" timeout="3"/>)[1]
+                return
+                    () (: nothing failed :)
+         } catch * {
+            $assumption-annotation (: return the annotation as failed :)
+         }
+    else()
 };
 
 (:~
@@ -193,7 +256,6 @@ declare %private function test:run-tests($func as function(*), $meta as element(
 declare %private function test:test($func as function(*), $meta as element(function), $firstArg as element(annotation)?,
         $test-started-function as (function(xs:string) as empty-sequence())?,
         $test-failure-function as (function(xs:string, map(xs:string, item()?), map(xs:string, item()?)) as empty-sequence())?,
-        $test-assumption-failed-function as (function(xs:string, map(xs:string, item()?)?) as empty-sequence())?,
         $test-error-function as (function(xs:string, map(xs:string, item()?)?) as empty-sequence())?,
         $test-finished-function as (function(xs:string) as empty-sequence())?) {
     let $args := test:get-run-args($firstArg)

--- a/test/src/xquery/unparsed-text.xql
+++ b/test/src/xquery/unparsed-text.xql
@@ -5,7 +5,9 @@ xquery version "3.1";
  :)
 module namespace upt="http://exist-db.org/xquery/test/unparsed-text";
 
+import module namespace system="http://exist-db.org/xquery/system";
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
 
 declare
     %test:setUp
@@ -23,25 +25,29 @@ function upt:cleanup() {
     xmldb:remove("/db/test-unparsed-text")
 };
 
-declare 
+declare
+    %test:assumeInternetAccess("https://raw.githubusercontent.com")
     %test:assertXPath("contains($result, 'eXist')")
 function upt:unparsed-text-from-url() {
     unparsed-text("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README")
 };
 
-declare 
+declare
+    %test:assumeInternetAccess("https://raw.githubusercontent.com")
     %test:assertXPath("contains($result, '----')")
 function upt:unparsed-text-lines-from-url() {
     unparsed-text-lines("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README")[2]
 };
 
-declare 
+declare
+    %test:assumeInternetAccess("https://raw.githubusercontent.com")
     %test:assertEquals(6)
 function upt:unparsed-text-lines-from-url-count() {
     count(unparsed-text-lines("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README"))
 };
 
-declare 
+declare
+    %test:assumeInternetAccess("https://raw.githubusercontent.com")
     %test:assertXPath("contains($result, 'eXist')")
 function upt:unparsed-text-from-url-encoding() {
     unparsed-text("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README", "UTF-8")
@@ -137,13 +143,15 @@ function upt:windows-path() {
     unparsed-text-lines("C:\file-might-exist.txt", "utf-8")
 };
 
-declare 
+declare
+    %test:assumeInternetAccess("https://raw.githubusercontent.com")
     %test:assertTrue
 function upt:unparsed-text-available-from-url() {
     unparsed-text-available("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README")
 };
 
-declare 
+declare
+    %test:assumeInternetAccess("https://raw.githubusercontent.com")
     %test:assertTrue
 function upt:unparsed-text-available-from-url-encoding() {
     unparsed-text-available("https://raw.githubusercontent.com/eXist-db/exist/develop/test/src/xquery/README", "UTF-8")


### PR DESCRIPTION
Some XQuery tests previously depended on various websites. Unfortunately that then causes those tests to fail when you don't have any internet access. I have now implemented an annotation `%test:assumeInternetAccess` which allows you to make sure that your test is only run when Internet Access is available.