### PR TITLE
Fix security issues with doc/collection mode/owner during copy

### DIFF
--- a/src/org/exist/collections/MutableCollection.java
+++ b/src/org/exist/collections/MutableCollection.java
@@ -1460,7 +1460,7 @@ public class MutableCollection implements Collection {
                 } else {
                     //TODO : use a more elaborated method ? No triggers...
                     broker.removeXMLResource(transaction, oldDoc, false);
-                    oldDoc.copyOf(document, true);
+                    oldDoc.copyOf(broker, document, oldDoc);
                     indexer.setDocumentObject(oldDoc);
                     //old has become new at this point
                     document = oldDoc;

--- a/src/org/exist/dom/persistent/BinaryDocument.java
+++ b/src/org/exist/dom/persistent/BinaryDocument.java
@@ -48,8 +48,24 @@ public class BinaryDocument extends DocumentImpl {
         super(pool);
     }
 
+    /**
+     * Creates a new persistent binary Document instance.
+     *
+     * @param pool The broker pool
+     * @param collection The Collection which holds this document
+     * @param fileURI The name of the document
+     */
     public BinaryDocument(final BrokerPool pool, final Collection collection, final XmldbURI fileURI) {
         super(pool, collection, fileURI);
+    }
+
+    /**
+     * Creates a new persistent binary Document instance to replace an existing document instance.
+     *
+     * @param prevDoc The previous binary Document object that we are overwriting
+     */
+    public BinaryDocument(final DocumentImpl prevDoc) {
+        super(prevDoc);
     }
 
     @Override

--- a/src/org/exist/dom/persistent/BinaryDocument.java
+++ b/src/org/exist/dom/persistent/BinaryDocument.java
@@ -68,6 +68,17 @@ public class BinaryDocument extends DocumentImpl {
         super(prevDoc);
     }
 
+    /**
+     * Creates a new persistent binary Document instance to replace an existing document instance.
+     *
+     * @param collection The Collection which holds this document
+     * @param prevDoc The previous Document object that we are overwriting
+     * @param prevDoc The previous binary Document object that we are overwriting
+     */
+    public BinaryDocument(final BrokerPool pool, final Collection collection, final Collection.CollectionEntry prevDoc) {
+        super(pool, collection, prevDoc);
+    }
+
     @Override
     public byte getResourceType() {
         return BINARY_FILE;

--- a/src/org/exist/dom/persistent/DocumentImpl.java
+++ b/src/org/exist/dom/persistent/DocumentImpl.java
@@ -145,6 +145,17 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
         this(prevDoc.pool, prevDoc.collection, prevDoc.fileURI, prevDoc.permissions.copy());
     }
 
+    /**
+     * Creates a new persistent Document instance to replace an existing document instance.
+     *
+     * @param pool The broker pool
+     * @param collection The Collection which holds this document
+     * @param prevDoc The previous Document object that we are overwriting
+     */
+    public DocumentImpl(final BrokerPool pool, final Collection collection, final Collection.CollectionEntry prevDoc) {
+        this(pool, collection, prevDoc.getUri().lastSegment(), prevDoc.getPermissions().copy());
+    }
+
     private DocumentImpl(final BrokerPool pool, final Collection collection, final XmldbURI fileURI, final Permission permissions) {
         this.pool = pool;
         this.collection = collection;

--- a/src/org/exist/dom/persistent/DocumentImpl.java
+++ b/src/org/exist/dom/persistent/DocumentImpl.java
@@ -21,6 +21,7 @@
  */
 package org.exist.dom.persistent;
 
+import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.Resource;
 import org.exist.dom.QName;
@@ -29,13 +30,8 @@ import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfiguration;
 import org.exist.dom.memtree.DocumentFragmentImpl;
 import org.exist.numbering.NodeId;
-import org.exist.security.ACLPermission;
-import org.exist.security.Account;
-import org.exist.security.Permission;
-import org.exist.security.PermissionDeniedException;
-import org.exist.security.PermissionFactory;
+import org.exist.security.*;
 import org.exist.security.SecurityManager;
-import org.exist.security.UnixStylePermission;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.ElementValue;
@@ -65,6 +61,7 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.ProcessingInstruction;
 import org.w3c.dom.Text;
 
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 import java.io.EOFException;
 import java.io.IOException;
@@ -125,23 +122,34 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
      * @param pool a <code>BrokerPool</code> instance representing the db
      */
     public DocumentImpl(final BrokerPool pool) {
-        this(pool, null, null);
+        this(pool, null, (XmldbURI)null);
     }
 
     /**
-     * Creates a new <code>DocumentImpl</code> instance.
+     * Creates a new persistent Document instance.
      *
-     * @param pool       a <code>BrokerPool</code> instance representing the db
-     * @param collection a <code>Collection</code> value
-     * @param fileURI    a <code>XmldbURI</code> value
+     * @param pool The broker pool
+     * @param collection The Collection which holds this document
+     * @param fileURI The name of the document
      */
     public DocumentImpl(final BrokerPool pool, final Collection collection, final XmldbURI fileURI) {
+        this(pool, collection, fileURI, PermissionFactory.getDefaultResourcePermission(pool.getSecurityManager()));
+    }
+
+    /**
+     * Creates a new persistent Document instance to replace an existing document instance.
+     *
+     * @param prevDoc The previous Document object that we are overwriting
+     */
+    public DocumentImpl(final DocumentImpl prevDoc) {
+        this(prevDoc.pool, prevDoc.collection, prevDoc.fileURI, prevDoc.permissions.copy());
+    }
+
+    private DocumentImpl(final BrokerPool pool, final Collection collection, final XmldbURI fileURI, final Permission permissions) {
         this.pool = pool;
         this.collection = collection;
         this.fileURI = fileURI;
-
-        // the permissions assigned to this document
-        this.permissions = PermissionFactory.getDefaultResourcePermission(pool.getSecurityManager());
+        this.permissions = permissions;
 
         //inherit the group to the resource if current collection is setGid
         if(collection != null && collection.getPermissions().isSetGid()) {
@@ -285,40 +293,88 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
      * This is called by {@link Collection} when replacing a document.
      *
      * @param other    a <code>DocumentImpl</code> value
-     * @param preserve Cause copyOf to preserve the following attributes of
-     *                 each source file in the copy: modification time,
-     *                 access time, file mode, user ID, and group ID,
-     *                 as allowed by permissions and  Access Control
-     *                 Lists (ACLs)
+     * @param prev if there was an existing document which we are replacing,
+     *     we will copy the mode, ACL, and birth time from the existing document.
      */
-    public void copyOf(final DocumentImpl other, final boolean preserve) {
+    public void copyOf(final DBBroker broker, final DocumentImpl other, @Nullable final DocumentImpl prev) throws PermissionDeniedException {
+        copyOf(broker, other, prev == null ? null : new Tuple2<>(prev.getPermissions(), prev.getMetadata().getCreated()));
+    }
+
+    /**
+     * Copy the relevant internal fields from the specified document object.
+     * This is called by {@link Collection} when replacing a document.
+     *
+     * @param other a <code>DocumentImpl</code> value
+     * @param prev if there was an existing document which we are replacing,
+     *     we will copy the mode, ACL, and birth time from the existing document.
+     */
+    public void copyOf(final DBBroker broker, final DocumentImpl other, @Nullable final Collection.CollectionEntry prev) throws PermissionDeniedException {
+        copyOf(broker, other, prev == null ? null : new Tuple2<>(prev.getPermissions(), prev.getCreated()));
+    }
+
+    /**
+     * Copy the relevant internal fields from the specified document object.
+     * This is called by {@link Collection} when replacing a document.
+     *
+     * @param other    a <code>DocumentImpl</code> value
+     * @param prev A tuple, containing the permissions and birth time of any
+     *     previous document that we are replacing; We will copy the mode, ACL,
+     *     and birth time from the existing document.
+     */
+    private void copyOf(final DBBroker broker, final DocumentImpl other, @Nullable final Tuple2<Permission, Long> prev) throws PermissionDeniedException {
         childAddress = null;
         children = 0;
 
-        //XXX: why reusing? better to create new instance? -shabanovd
         metadata = getMetadata();
-        if(metadata == null) {
+        if (metadata == null) {
             metadata = new DocumentMetadata();
         }
 
         //copy metadata
         metadata.copyOf(other.getMetadata());
 
-        if(preserve) {
-            //copy permission
-            permissions = ((UnixStylePermission) other.permissions).copy();
-            //created and last modified are done by metadata.copyOf
-            //metadata.setCreated(other.getMetadata().getCreated());
-            //metadata.setLastModified(other.getMetadata().getLastModified());
+        final long timestamp = System.currentTimeMillis();
+        if(prev != null) {
+            // replaced file should have same owner user:group as prev file
+            if (permissions.getOwner().getId() != prev._1.getOwner().getId()) {
+                permissions.setOwner(prev.get_1().getOwner());
+            }
+            if (permissions.getGroup().getId() != prev._1.getGroup().getId()) {
+                permissions.setGroup(prev.get_1().getGroup());
+            }
+
+            //copy mode and acl from prev file
+            copyModeAcl(prev._1, permissions);
+
+            // set birth time to same as prev file
+            metadata.setCreated(prev._2);
+
         } else {
-            //update timestamp
-            final long timestamp = System.currentTimeMillis();
+            // copy mode and acl from source file
+            copyModeAcl(other.getPermissions(), permissions);
+
+            // set birth time to the current timestamp
             metadata.setCreated(timestamp);
-            metadata.setLastModified(timestamp);
         }
+
+        // always set mtime
+        metadata.setLastModified(timestamp);
 
         // reset pageCount: will be updated during storage
         metadata.setPageCount(0);
+    }
+
+    private void copyModeAcl(final Permission srcPermissions, final Permission destPermissions) throws PermissionDeniedException {
+        if (destPermissions.getMode() != srcPermissions.getMode()) {
+            destPermissions.setMode(srcPermissions.getMode());
+        }
+        if (srcPermissions instanceof SimpleACLPermission && destPermissions instanceof SimpleACLPermission) {
+            final SimpleACLPermission srcAclPermissions = (SimpleACLPermission)srcPermissions;
+            final SimpleACLPermission destAclPermissions = (SimpleACLPermission)destPermissions;
+            if (!destAclPermissions.equalsAcl(srcAclPermissions)) {
+                destAclPermissions.copyAclOf(srcAclPermissions);
+            }
+        }
     }
 
     /**

--- a/src/org/exist/security/Permission.java
+++ b/src/org/exist/security/Permission.java
@@ -239,4 +239,6 @@ public interface Permission {
     boolean isCurrentSubjectInGroup();
 
     boolean isCurrentSubjectInGroup(int groupId);
+
+    Permission copy();
 }

--- a/src/org/exist/security/SimpleACLPermission.java
+++ b/src/org/exist/security/SimpleACLPermission.java
@@ -381,6 +381,32 @@ public class SimpleACLPermission extends UnixStylePermission implements ACLPermi
         return prm;
     }
 
+    /**
+     * Determines if this permisisons ACL is equal to that
+     * of another permissions ACL.
+     *
+     * @param other the other ACL to check equality against.
+     *
+     * @return true if the ACLs are equal
+     */
+    public boolean equalsAcl(final SimpleACLPermission other) {
+        if (other == null || other.getACECount() != getACECount()) {
+            return false;
+        }
+
+        for (int i = 0; i < getACECount(); i++) {
+
+            if(getACEAccessType(i) != other.getACEAccessType(i)
+                    || getACETarget(i) != other.getACETarget(i)
+                    || (!getACEWho(i).equals(other.getACEWho(i)))
+                    || getACEMode(i) != other.getACEMode(i)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     @PermissionRequired(user = IS_DBA | IS_OWNER, mode = ACL_WRITE)
     public void copyAclOf(final SimpleACLPermission simpleACLPermission) {
         this.acl = Arrays.copyOf(simpleACLPermission.acl, simpleACLPermission.acl.length);

--- a/src/org/exist/security/UnixStylePermission.java
+++ b/src/org/exist/security/UnixStylePermission.java
@@ -511,6 +511,7 @@ public class UnixStylePermission extends AbstractUnixStylePermission implements 
         return false;
     }
 
+    @Override
     public UnixStylePermission copy() {
         return new UnixStylePermission(sm, vector);
     }

--- a/src/org/exist/security/internal/aider/UnixStylePermissionAider.java
+++ b/src/org/exist/security/internal/aider/UnixStylePermissionAider.java
@@ -22,14 +22,10 @@
 package org.exist.security.internal.aider;
 
 import java.io.IOException;
-import org.exist.security.AbstractUnixStylePermission;
 
-import org.exist.security.Group;
+import org.exist.security.*;
+
 import org.exist.security.SecurityManager;
-import org.exist.security.Account;
-import org.exist.security.Permission;
-import org.exist.security.PermissionDeniedException;
-import org.exist.security.Subject;
 import org.exist.storage.io.VariableByteInput;
 import org.exist.storage.io.VariableByteOutputStream;
 import org.exist.util.SyntaxException;
@@ -381,5 +377,10 @@ public class UnixStylePermissionAider extends AbstractUnixStylePermission implem
     @Override
     public boolean isCurrentSubjectInGroup(final int groupId) {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Permission copy() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/org/exist/storage/NativeBroker.java
+++ b/src/org/exist/storage/NativeBroker.java
@@ -778,7 +778,7 @@ public class NativeBroker extends DBBroker {
 
                         sub = new MutableCollection(this, path);
                         //inherit the group to the sub-collection if current collection is setGid
-                        if(current.getPermissions().isSetGid()) {
+                        if (current.getPermissions().isSetGid()) {
                             sub.getPermissions().setGroupFrom(current.getPermissions()); //inherit group
                             sub.getPermissions().setSetGid(true); //inherit setGid bit
                         }
@@ -1099,7 +1099,7 @@ public class NativeBroker extends DBBroker {
 
                 final DocumentTrigger docTrigger = new DocumentTriggers(this);
 
-                final Collection newCollection = doCopyCollection(transaction, docTrigger, collection, destination, newName, false);
+                final Collection newCollection = doCopyCollection(transaction, docTrigger, collection, destination, newName, true);
 
                 trigger.afterCopyCollection(this, transaction, newCollection, srcURI);
             } finally {
@@ -1123,10 +1123,16 @@ public class NativeBroker extends DBBroker {
         final Tuple2<Boolean, Collection> destCollection = getOrCreateCollectionExplicit(transaction, newName);
 
         //if required, copy just the mode and acl of the permissions to the dest collection
-        if(copyCollectionMode && destCollection._1) {
+        if (copyCollectionMode && destCollection._1) {
             final Permission srcPerms = collection.getPermissions();
             final Permission destPerms = destCollection._2.getPermissions();
             copyModeAndAcl(srcPerms, destPerms);
+        }
+
+        // inherit the group to the destCollection if destination is setGid
+        if (destination.getPermissions().isSetGid()) {
+            destCollection._2.getPermissions().setGroupFrom(destination.getPermissions()); //inherit group
+            destCollection._2.getPermissions().setSetGid(true); //inherit setGid bit
         }
 
         for(final Iterator<DocumentImpl> i = collection.iterator(this); i.hasNext(); ) {
@@ -1136,8 +1142,7 @@ public class NativeBroker extends DBBroker {
                 LOG.debug("Copying resource: '" + child.getURI() + "'");
             }
 
-            //TODO The code below seems quite different to that in NativeBroker#copyResource presumably should be the same?
-
+            // TODO(AR) The code below seems quite different to that in NativeBroker#copyResource presumably should be the same?
 
             final XmldbURI newUri = destCollection._2.getURI().append(child.getFileURI());
             trigger.beforeCopyDocument(this, transaction, child, newUri);
@@ -1153,18 +1158,13 @@ public class NativeBroker extends DBBroker {
             DocumentImpl createdDoc;
             if(child.getResourceType() == DocumentImpl.XML_FILE) {
                 //TODO : put a lock on newDoc ?
-                final DocumentImpl newDoc = new DocumentImpl(pool, destCollection._2, child.getFileURI());
-                newDoc.copyOf(this, child, oldDoc);
-                if(oldDoc != null) {
-                    //preserve permissions from existing doc we are replacing
-                    newDoc.setPermissions(oldDoc.getPermissions()); //TODO use newDoc.copyOf(oldDoc) ideally, but we cannot currently access oldDoc without READ access to it, which we may not have (and should not need for this)!
+                final DocumentImpl newDoc;
+                if (oldDoc != null) {
+                    newDoc = new DocumentImpl(pool, destCollection._2, oldDoc);
                 } else {
-                    //copy just the mode and acl of the permissions to the dest document
-                    final Permission srcPerm = child.getPermissions();
-                    final Permission destPerm = newDoc.getPermissions();
-                    copyModeAndAcl(srcPerm, destPerm);
+                    newDoc = new DocumentImpl(pool, destCollection._2, child.getFileURI());
                 }
-
+                newDoc.copyOf(this, child, oldDoc);
                 newDoc.setDocId(getNextResourceId(transaction, destination));
                 copyXMLResource(transaction, child, newDoc);
                 storeXMLResource(transaction, newDoc);
@@ -1172,12 +1172,13 @@ public class NativeBroker extends DBBroker {
 
                 createdDoc = newDoc;
             } else {
-                final BinaryDocument newDoc = new BinaryDocument(pool, destCollection._2, child.getFileURI());
-                newDoc.copyOf(this, child, oldDoc);
-                if(oldDoc != null) {
-                    //preserve permissions from existing doc we are replacing
-                    newDoc.setPermissions(oldDoc.getPermissions()); //TODO use newDoc.copyOf(oldDoc) ideally, but we cannot currently access oldDoc without READ access to it, which we may not have (and should not need for this)!
+                final BinaryDocument newDoc;
+                if (oldDoc != null) {
+                    newDoc = new BinaryDocument(pool, destCollection._2, oldDoc);
+                } else {
+                    newDoc = new BinaryDocument(pool, destCollection._2, child.getFileURI());
                 }
+                newDoc.copyOf(this, child, oldDoc);
                 newDoc.setDocId(getNextResourceId(transaction, destination));
 
                 try(final InputStream is = getBinaryResource((BinaryDocument) child)) {

--- a/test/src/org/exist/dom/persistent/DocumentImplTest.java
+++ b/test/src/org/exist/dom/persistent/DocumentImplTest.java
@@ -2,16 +2,15 @@ package org.exist.dom.persistent;
 
 import com.googlecode.junittoolbox.ParallelRunner;
 import org.exist.Database;
-import org.exist.security.Group;
+import org.exist.security.*;
+import org.exist.security.SecurityManager;
 import org.exist.security.internal.RealmImpl;
-import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.exist.security.SecurityManager;
 import org.easymock.EasyMock;
-import org.exist.security.Permission;
+
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.easymock.EasyMock.expect;
@@ -28,7 +27,7 @@ import org.junit.runner.RunWith;
 public class DocumentImplTest {
 
     @Test
-    public void copyOf_calls_getMetadata() {
+    public void copyOf_calls_getMetadata() throws PermissionDeniedException {
 
         BrokerPool mockBrokerPool = EasyMock.createMock(BrokerPool.class);
         Database mockDatabase = EasyMock.createMock(Database.class);
@@ -58,7 +57,7 @@ public class DocumentImplTest {
         other.setMetadata(otherMetadata);
 
         //actions
-        doc.copyOf(other, false);
+        doc.copyOf(mockBroker, other, (DocumentImpl)null);
 
         verify(mockBrokerPool, mockDatabase, mockBroker, mockCurrentSubject, mockCurrentSubjectGroup, mockSecurityManager);
 
@@ -67,7 +66,7 @@ public class DocumentImplTest {
     }
 
     @Test
-    public void copyOf_calls_metadata_copyOf() {
+    public void copyOf_calls_metadata_copyOf() throws PermissionDeniedException {
         BrokerPool mockBrokerPool = EasyMock.createMock(BrokerPool.class);
         Database mockDatabase = EasyMock.createMock(Database.class);
         DBBroker mockBroker = EasyMock.createMock(DBBroker.class);
@@ -98,7 +97,7 @@ public class DocumentImplTest {
         other.setMetadata(otherMetadata);
 
         //actions
-        doc.copyOf(other, false);
+        doc.copyOf(mockBroker, other, (DocumentImpl)null);
 
         verify(mockBrokerPool, mockDatabase, mockBroker, mockCurrentSubject, mockCurrentSubjectGroup, mockSecurityManager);
 
@@ -107,7 +106,7 @@ public class DocumentImplTest {
     }
 
     @Test
-    public void copyOf_updates_metadata_created_and_lastModified() {
+    public void copyOf_updates_metadata_created_and_lastModified() throws PermissionDeniedException {
         BrokerPool mockBrokerPool = EasyMock.createMock(BrokerPool.class);
         Database mockDatabase = EasyMock.createMock(Database.class);
         DBBroker mockBroker = EasyMock.createMock(DBBroker.class);
@@ -140,7 +139,7 @@ public class DocumentImplTest {
         other.setMetadata(otherMetadata);
 
         //actions
-        doc.copyOf(other, false);
+        doc.copyOf(mockBroker, other, (DocumentImpl)null);
 
         verify(mockBrokerPool, mockDatabase, mockBroker, mockCurrentSubject, mockCurrentSubjectGroup, mockSecurityManager);
 
@@ -297,5 +296,5 @@ public class DocumentImplTest {
         public void describeTo(Description description) {
             description.appendText("Less than");
         }
-    };
+    }
 }

--- a/test/src/org/exist/storage/AllStorageTests.java
+++ b/test/src/org/exist/storage/AllStorageTests.java
@@ -31,6 +31,7 @@ import org.junit.runners.Suite;
         ReindexTest.class,
         ShutdownTest.class,
         CollectionTest.class,
+        CopyResourceTest.class,
         CopyResourceRecoveryTest.class,
         MoveResourceRecoveryTest.class,
         CopyCollectionRecoveryTest.class,

--- a/test/src/org/exist/storage/AllStorageTests.java
+++ b/test/src/org/exist/storage/AllStorageTests.java
@@ -34,6 +34,7 @@ import org.junit.runners.Suite;
         CopyResourceTest.class,
         CopyResourceRecoveryTest.class,
         MoveResourceRecoveryTest.class,
+        CopyCollectionTest.class,
         CopyCollectionRecoveryTest.class,
         MoveCollectionRecoveryTest.class,
         MoveOverwriteCollectionTest.class,

--- a/test/src/org/exist/storage/CopyCollectionTest.java
+++ b/test/src/org/exist/storage/CopyCollectionTest.java
@@ -1,0 +1,367 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2018 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.*;
+import org.exist.security.SecurityManager;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+import org.exist.storage.lock.Lock.LockMode;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.test.TestConstants;
+import org.exist.util.LockException;
+import org.exist.xmldb.XmldbURI;
+import org.hamcrest.Matcher;
+import org.junit.*;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.exist.TestUtils.ADMIN_DB_PWD;
+import static org.exist.TestUtils.ADMIN_DB_USER;
+import static org.exist.security.SecurityManager.DBA_GROUP;
+import static org.exist.test.TestConstants.TEST_COLLECTION_URI;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests to ensure that collection content and attributes
+ * are correctly copied under various circumstances.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
+public class CopyCollectionTest {
+
+    private static final String USER1_NAME = "user1";
+    private static final String USER1_PWD = USER1_NAME;
+    private static final String USER2_NAME = "user2";
+    private static final String USER2_PWD = USER2_NAME;
+
+    private static final XmldbURI USER1_COL1 = XmldbURI.create("u1c1");
+    private static final XmldbURI USER1_COL2 = XmldbURI.create("u1c2");
+    private static final XmldbURI USER1_NEW_COL = XmldbURI.create("u1cx");
+
+    private static final XmldbURI USER2_COL2 = XmldbURI.create("u2c2");
+    private static final XmldbURI USER2_NEW_COL = XmldbURI.create("u2cx");
+
+    private static final int USER1_COL1_MODE = 0555;  // r-xr-xr-x
+    private static final int USER1_COL2_MODE = 0744;  // rwxr--r--
+
+    private static final int USER2_COL2_MODE = 0744;  // rwxr--r--
+
+    @ClassRule
+    public static final ExistEmbeddedServer existWebServer = new ExistEmbeddedServer(true, true);
+
+    /**
+     * As the owner copy {@link #USER1_COL1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_COL}.
+     */
+    @Test
+    public void copyToNonExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException, TriggerException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        copyCol(user1, USER1_COL1, USER1_NEW_COL);
+        checkAttributes(USER1_NEW_COL, USER1_NAME, USER1_NAME, USER1_COL1_MODE, not(getCreated(USER1_COL1)));
+    }
+
+    /**
+     * As the owner copy {@link #USER1_COL1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER1_COL2}.
+     */
+    @Test
+    public void copyToExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException, TriggerException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        copyCol(user1, USER1_COL1, USER1_COL2);
+        checkAttributes(USER1_COL2, USER1_NAME, USER1_NAME, USER1_COL2_MODE, equalTo(getCreated(USER1_COL2)));
+    }
+
+    /**
+     * As a DBA copy {@link #USER1_COL1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_COL}.
+     */
+    @Test
+    public void copyToNonExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException, TriggerException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        copyCol(adminUser, USER1_COL1, USER1_NEW_COL);
+        checkAttributes(USER1_NEW_COL, ADMIN_DB_USER, DBA_GROUP, USER1_COL1_MODE, not(getCreated(USER1_COL1)));
+    }
+
+    /**
+     * As a DBA copy {@link #USER1_COL1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER1_COL2}.
+     */
+    @Test
+    public void copyToExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException, TriggerException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        copyCol(adminUser, USER1_COL1, USER1_COL2);
+        checkAttributes(USER1_COL2, USER1_NAME, USER1_NAME, USER1_COL2_MODE, equalTo(getCreated(USER1_COL2)));
+    }
+
+    /**
+     * As some other (non-owner) user copy {@link #USER1_COL1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER2_NEW_COL}.
+     */
+    @Test
+    public void copyToNonExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException, TriggerException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        copyCol(user2, USER1_COL1, USER2_NEW_COL);
+        checkAttributes(USER2_NEW_COL, USER2_NAME, USER2_NAME, USER1_COL1_MODE, not(getCreated(USER1_COL1)));
+    }
+
+    /**
+     * As some other (non-owner) user copy {@link #USER1_COL1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER2_COL2}.
+     */
+    @Test
+    public void copyToExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException, TriggerException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        copyCol(user2, USER1_COL1, USER2_COL2);
+        checkAttributes(USER2_COL2, USER2_NAME, USER2_NAME, USER2_COL2_MODE, equalTo(getCreated(USER2_COL2)));
+    }
+
+    private void copyCol(final Subject execAsUser, final XmldbURI srcColName, final XmldbURI destColName) throws EXistException, PermissionDeniedException, LockException, IOException, TriggerException {
+        final XmldbURI src = TEST_COLLECTION_URI.append(srcColName);
+        final XmldbURI dest = TEST_COLLECTION_URI.append(destColName);
+
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(execAsUser));
+                final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            Collection srcCol = null;
+            try {
+                srcCol = broker.openCollection(src, LockMode.READ_LOCK);
+
+                Collection destCol = null;
+                try {
+                    destCol = broker.openCollection(dest.removeLastSegment(), LockMode.WRITE_LOCK);
+
+                    broker.copyCollection(transaction, srcCol, destCol, dest.lastSegment());
+
+                } finally {
+                    if (destCol != null) {
+                        destCol.getLock().release(LockMode.WRITE_LOCK);
+                    }
+                }
+            } finally {
+                if (srcCol != null) {
+                    srcCol.getLock().release(LockMode.READ_LOCK);
+                }
+            }
+
+            transaction.commit();
+        }
+
+
+        // basic shallow check that copy of the collection is the same as the original
+        try (final DBBroker broker = pool.get(Optional.of(execAsUser))) {
+
+            Collection original = null;
+            Collection copy = null;
+            try {
+                original = broker.openCollection(src, LockMode.READ_LOCK);
+                copy = broker.openCollection(dest, LockMode.READ_LOCK);
+
+                assertEquals(original.getDocumentCount(broker), copy.getDocumentCount(broker));
+                assertEquals(original.getChildCollectionCount(broker), copy.getChildCollectionCount(broker));
+            } finally {
+                if (copy != null) {
+                    copy.getLock().release(LockMode.READ_LOCK);
+                }
+                if (original != null) {
+                    original.getLock().release(LockMode.READ_LOCK);
+                }
+            }
+
+        }
+    }
+
+    private long getCreated(final XmldbURI colName) throws EXistException, PermissionDeniedException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            Collection col = null;
+            try {
+                col = broker.openCollection(TEST_COLLECTION_URI.append(colName), LockMode.READ_LOCK);
+                return col.getMetadata().getCreated();
+            } finally {
+                if (col != null) {
+                    col.getLock().release(LockMode.READ_LOCK);
+                }
+            }
+        }
+    }
+
+    private void checkAttributes(final XmldbURI colName, final String expectedOwner, final String expectedGroup, final int expectedMode, final Matcher<Long> expectedCreated) throws EXistException, PermissionDeniedException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            Collection col = null;
+            try {
+                col = broker.openCollection(TEST_COLLECTION_URI.append(colName), LockMode.READ_LOCK);
+
+                final Permission permission = col.getPermissions();
+                assertEquals("Owner value was not expected", expectedOwner, permission.getOwner().getName());
+                assertEquals("Group value was not expected", expectedGroup, permission.getGroup().getName());
+                assertEquals("Mode value was not expected", expectedMode, permission.getMode());
+
+                assertThat("Created value is not correct", col.getMetadata().getCreated(), expectedCreated);
+            } finally {
+                if (col != null) {
+                    col.getLock().release(LockMode.READ_LOCK);
+                }
+            }
+        }
+    }
+
+    @BeforeClass
+    public static void prepareDb() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
+            chmod(broker, collection.getURI(), 511);
+            broker.saveCollection(transaction, collection);
+
+            createUser(broker, sm, USER1_NAME, USER1_PWD);
+            createUser(broker, sm, USER2_NAME, USER2_PWD);
+
+            transaction.commit();
+        }
+    }
+
+    @Before
+    public void setup() throws EXistException, PermissionDeniedException, LockException, SAXException, IOException, AuthenticationException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+
+        // create user1 resources
+        final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        try (final DBBroker broker = pool.get(Optional.of(user1));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            Collection collection = null;
+            try {
+                collection = broker.openCollection(TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
+
+                final Collection u1c1 = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI.append(USER1_COL1));
+                chmod(broker, TEST_COLLECTION_URI.append(USER1_COL1), USER1_COL1_MODE);
+
+                final Collection u1c2 = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI.append(USER1_COL2));
+                chmod(broker, TEST_COLLECTION_URI.append(USER1_COL2), USER1_COL2_MODE);
+
+                broker.saveCollection(transaction, collection);
+
+                transaction.commit();
+
+            } finally {
+                if (collection != null) {
+                    collection.getLock().release(LockMode.WRITE_LOCK);
+                }
+            }
+        }
+
+        // create user2 resources
+        final Subject user2 = pool.getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        try (final DBBroker broker = pool.get(Optional.of(user2));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            Collection collection = null;
+            try {
+                collection = broker.openCollection(TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
+
+                final Collection u2c2 = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI.append(USER2_COL2));
+                chmod(broker, TEST_COLLECTION_URI.append(USER2_COL2), USER2_COL2_MODE);
+
+                broker.saveCollection(transaction, collection);
+
+                transaction.commit();
+
+            } finally {
+                if (collection != null) {
+                    collection.getLock().release(LockMode.WRITE_LOCK);
+                }
+            }
+        }
+    }
+
+    @After
+    public void teardown() throws EXistException, LockException, TriggerException, PermissionDeniedException, IOException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            removeCollection(broker, transaction, TEST_COLLECTION_URI.append(USER1_COL1));
+            removeCollection(broker, transaction, TEST_COLLECTION_URI.append(USER1_COL2));
+            removeCollection(broker, transaction, TEST_COLLECTION_URI.append(USER1_NEW_COL));
+
+            removeCollection(broker, transaction, TEST_COLLECTION_URI.append(USER2_COL2));
+            removeCollection(broker, transaction, TEST_COLLECTION_URI.append(USER2_NEW_COL));
+
+            transaction.commit();
+        }
+    }
+
+    @AfterClass
+    public static void cleanupDb() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            removeUser(sm, USER2_NAME);
+            removeUser(sm, USER1_NAME);
+
+            removeCollection(broker, transaction, TEST_COLLECTION_URI);
+
+            transaction.commit();
+        }
+    }
+
+    private static void createUser(final DBBroker broker, final SecurityManager sm, final String username, final String password) throws PermissionDeniedException, EXistException {
+        Group userGroup = new GroupAider(username);
+        sm.addGroup(broker, userGroup);
+        final Account user = new UserAider(username);
+        user.setPassword(password);
+        user.setPrimaryGroup(userGroup);
+        sm.addAccount(user);
+
+        userGroup = sm.getGroup(username);
+        userGroup.addManager(sm.getAccount(username));
+        sm.updateGroup(userGroup);
+    }
+
+
+    private static void chmod(final DBBroker broker, final XmldbURI pathUri, final int mode) throws PermissionDeniedException {
+        PermissionFactory.updatePermissions(broker, pathUri, permission -> permission.setMode(mode));
+    }
+
+    private static void removeUser(final SecurityManager sm, final String username) throws PermissionDeniedException, EXistException {
+        sm.deleteAccount(username);
+        sm.deleteGroup(username);
+    }
+
+    private static void removeCollection(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws PermissionDeniedException, IOException, TriggerException {
+        Collection collection = null;
+        try {
+            collection = broker.openCollection(collectionUri, LockMode.WRITE_LOCK);
+            if (collection != null) {
+                broker.removeCollection(transaction, collection);
+            }
+        } finally {
+            if (collection != null) {
+                collection.getLock().release(LockMode.WRITE_LOCK);
+            }
+        }
+    }
+}

--- a/test/src/org/exist/storage/CopyResourceTest.java
+++ b/test/src/org/exist/storage/CopyResourceTest.java
@@ -1,0 +1,515 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2018 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.IndexInfo;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.security.*;
+import org.exist.security.SecurityManager;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+import org.exist.storage.lock.Lock.LockMode;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.test.TestConstants;
+import org.exist.util.LockException;
+import org.exist.xmldb.XmldbURI;
+import org.hamcrest.Matcher;
+import org.junit.*;
+import org.xml.sax.SAXException;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.exist.TestUtils.ADMIN_DB_USER;
+import static org.exist.TestUtils.ADMIN_DB_PWD;
+import static org.exist.security.SecurityManager.DBA_GROUP;
+import static org.exist.test.TestConstants.TEST_COLLECTION_URI;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.allOf;
+
+/**
+ * Tests to ensure that document content and attributes
+ * are correctly copied under various circumstances.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
+public class CopyResourceTest {
+
+    private static final String USER1_NAME = "user1";
+    private static final String USER1_PWD = USER1_NAME;
+    private static final String USER2_NAME = "user2";
+    private static final String USER2_PWD = USER2_NAME;
+
+    private static final XmldbURI USER1_DOC1 = XmldbURI.create("u1d1.xml");
+    private static final XmldbURI USER1_DOC2 = XmldbURI.create("u1d2.xml");
+    private static final XmldbURI USER1_NEW_DOC = XmldbURI.create("u1nx.xml");
+    private static final XmldbURI USER1_BIN_DOC1 = XmldbURI.create("u1d1.bin");
+    private static final XmldbURI USER1_BIN_DOC2 = XmldbURI.create("u1d2.bin");
+    private static final XmldbURI USER1_NEW_BIN_DOC = XmldbURI.create("u1nx.bin");
+
+    private static final XmldbURI USER2_DOC2 = XmldbURI.create("u2d2.xml");
+    private static final XmldbURI USER2_NEW_DOC = XmldbURI.create("u2nx.xml");
+    private static final XmldbURI USER2_BIN_DOC2 = XmldbURI.create("u2d2.bin");
+    private static final XmldbURI USER2_NEW_BIN_DOC = XmldbURI.create("u2nx.bin");
+
+    private static final int USER1_DOC1_MODE = 0444;  // r--r--r--
+    private static final int USER1_DOC2_MODE = 0644;  // rw-r--r--
+    private static final int USER1_BIN_DOC1_MODE = 0444;  // r--r--r--
+    private static final int USER1_BIN_DOC2_MODE = 0644;  // rw-r--r--
+
+    private static final int USER2_DOC2_MODE = 0644;  // rw-r--r--
+    private static final int USER2_BIN_DOC2_MODE = 0644;  // rw-r--r--
+
+    @ClassRule
+    public static final ExistEmbeddedServer existWebServer = new ExistEmbeddedServer(true, true);
+
+    /**
+     * As the owner copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_DOC}.
+     */
+    @Test
+    public void copyXmlToNonExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        copyDoc(user1, USER1_DOC1, USER1_NEW_DOC);
+        checkAttributes(USER1_NEW_DOC, USER1_NAME, USER1_NAME, USER1_DOC1_MODE, not(getCreated(USER1_DOC1)), not(getLastModified(USER1_DOC1)));
+    }
+
+    /**
+     * As the owner copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_BIN_DOC}.
+     */
+    @Test
+    public void copyBinaryToNonExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        copyDoc(user1, USER1_BIN_DOC1, USER1_NEW_BIN_DOC);
+        checkAttributes(USER1_NEW_BIN_DOC, USER1_NAME, USER1_NAME, USER1_BIN_DOC1_MODE, not(getCreated(USER1_BIN_DOC1)), not(getLastModified(USER1_BIN_DOC1)));
+    }
+
+    /**
+     * As the owner copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER1_DOC2}.
+     */
+    @Test
+    public void copyXmlToExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        final long originalDoc2LastModified = getLastModified(USER1_DOC2);
+        copyDoc(user1, USER1_DOC1, USER1_DOC2);
+        checkAttributes(USER1_DOC2, USER1_NAME, USER1_NAME, USER1_DOC2_MODE, equalTo(getCreated(USER1_DOC2)), allOf(not(getLastModified(USER1_DOC1)), not(originalDoc2LastModified)));
+    }
+
+    /**
+     * As the owner copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER1_BIN_DOC2}.
+     */
+    @Test
+    public void copyBinaryToExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        final long originalBinDoc2LastModified = getLastModified(USER1_BIN_DOC2);
+        copyDoc(user1, USER1_BIN_DOC1, USER1_BIN_DOC2);
+        checkAttributes(USER1_BIN_DOC2, USER1_NAME, USER1_NAME, USER1_BIN_DOC2_MODE, equalTo(getCreated(USER1_BIN_DOC2)), allOf(not(getLastModified(USER1_BIN_DOC1)), not(originalBinDoc2LastModified)));
+    }
+
+    /**
+     * As a DBA copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_DOC}.
+     */
+    @Test
+    public void copyXmlToNonExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        copyDoc(adminUser, USER1_DOC1, USER1_NEW_DOC);
+        checkAttributes(USER1_NEW_DOC, ADMIN_DB_USER, DBA_GROUP, USER1_DOC1_MODE, not(getCreated(USER1_DOC1)), not(getLastModified(USER1_DOC1)));
+    }
+
+    /**
+     * As a DBA copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_BIN_DOC}.
+     */
+    @Test
+    public void copyBinaryToNonExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        copyDoc(adminUser, USER1_BIN_DOC1, USER1_NEW_BIN_DOC);
+        checkAttributes(USER1_NEW_BIN_DOC, ADMIN_DB_USER, DBA_GROUP, USER1_BIN_DOC1_MODE, not(getCreated(USER1_BIN_DOC1)), not(getLastModified(USER1_BIN_DOC1)));
+    }
+
+    /**
+     * As a DBA copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER1_DOC2}.
+     */
+    @Test
+    public void copyXmlToExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        final long originalDoc2LastModified = getLastModified(USER1_DOC2);
+        copyDoc(adminUser, USER1_DOC1, USER1_DOC2);
+        checkAttributes(USER1_DOC2, USER1_NAME, USER1_NAME, USER1_DOC2_MODE, equalTo(getCreated(USER1_DOC2)), allOf(not(getLastModified(USER1_DOC1)), not(originalDoc2LastModified)));
+    }
+
+    /**
+     * As a DBA copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_BIN_DOC}.
+     */
+    @Test
+    public void copyBinaryToExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        final long originalBinDoc2LastModified = getLastModified(USER1_BIN_DOC2);
+        copyDoc(adminUser, USER1_BIN_DOC1, USER1_BIN_DOC2);
+        checkAttributes(USER1_BIN_DOC2, USER1_NAME, USER1_NAME, USER1_BIN_DOC2_MODE, equalTo(getCreated(USER1_BIN_DOC2)), allOf(not(getLastModified(USER1_BIN_DOC1)), not(originalBinDoc2LastModified)));
+    }
+
+    /**
+     * As some other (non-owner) user copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER2_NEW_DOC}.
+     */
+    @Test
+    public void copyXmlToNonExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        copyDoc(user2, USER1_DOC1, USER2_NEW_DOC);
+        checkAttributes(USER2_NEW_DOC, USER2_NAME, USER2_NAME, USER1_DOC1_MODE, not(getCreated(USER1_DOC1)), not(getLastModified(USER1_DOC1)));
+    }
+
+    /**
+     * As some other (non-owner) user copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER2_NEW_BIN_DOC}.
+     */
+    @Test
+    public void copyBinaryToNonExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        copyDoc(user2, USER1_BIN_DOC1, USER2_NEW_BIN_DOC);
+        checkAttributes(USER2_NEW_BIN_DOC, USER2_NAME, USER2_NAME, USER1_BIN_DOC1_MODE, not(getCreated(USER1_BIN_DOC1)), not(getLastModified(USER1_BIN_DOC1)));
+    }
+
+    /**
+     * As some other (non-owner) user copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER2_DOC2}.
+     */
+    @Test
+    public void copyXmlToExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final long originalDoc2LastModified = getLastModified(USER2_DOC2);
+        copyDoc(user2, USER1_DOC1, USER2_DOC2);
+        checkAttributes(USER2_DOC2, USER2_NAME, USER2_NAME, USER2_DOC2_MODE, equalTo(getCreated(USER2_DOC2)), allOf(not(getLastModified(USER1_DOC1)), not(originalDoc2LastModified)));
+    }
+
+    /**
+     * As some other (non-owner) user copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER2_BIN_DOC2}.
+     */
+    @Test
+    public void copyBinaryToExistentAsOther() throws AuthenticationException, EXistException, PermissionDeniedException, LockException, IOException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final long originalBinDoc2LastModified = getLastModified(USER2_BIN_DOC2);
+        copyDoc(user2, USER1_BIN_DOC1, USER2_BIN_DOC2);
+        checkAttributes(USER2_BIN_DOC2, USER2_NAME, USER2_NAME, USER2_BIN_DOC2_MODE, equalTo(getCreated(USER2_BIN_DOC2)), allOf(not(getLastModified(USER1_BIN_DOC1)), not(originalBinDoc2LastModified)));
+    }
+
+    private void copyDoc(final Subject execAsUser, final XmldbURI srcDocName, final XmldbURI destDocName) throws EXistException, PermissionDeniedException, LockException, IOException {
+        final XmldbURI src = TEST_COLLECTION_URI.append(srcDocName);
+        final XmldbURI dest = TEST_COLLECTION_URI.append(destDocName);
+
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(execAsUser));
+                final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            DocumentImpl srcDoc = null;
+            try {
+                srcDoc = broker.getXMLResource(src, LockMode.READ_LOCK);
+
+                Collection destCol = null;
+                try {
+                    destCol = broker.openCollection(dest.removeLastSegment(), LockMode.WRITE_LOCK);
+
+                    broker.copyResource(transaction, srcDoc, destCol, dest.lastSegment());
+
+                } finally {
+                    if (destCol != null) {
+                        destCol.getLock().release(LockMode.WRITE_LOCK);
+                    }
+                }
+            } finally {
+                if (srcDoc != null) {
+                    srcDoc.getUpdateLock().release(LockMode.READ_LOCK);
+                }
+            }
+
+            transaction.commit();
+        }
+
+
+        // check the copy of the document is the same as the original
+        try (final DBBroker broker = pool.get(Optional.of(execAsUser))) {
+
+            DocumentImpl original = null;
+            DocumentImpl copy = null;
+            try {
+                original = broker.getXMLResource(src, LockMode.READ_LOCK);
+                copy = broker.getXMLResource(dest, LockMode.READ_LOCK);
+
+                final Diff diff = DiffBuilder
+                        .compare(Input.fromDocument(original))
+                        .withTest(Input.fromDocument(copy))
+                        .build();
+
+                assertFalse(diff.toString(), diff.hasDifferences());
+
+            } finally {
+                if (copy != null) {
+                    copy.getUpdateLock().release(LockMode.READ_LOCK);
+                }
+                if (original != null) {
+                    original.getUpdateLock().release(LockMode.READ_LOCK);
+                }
+            }
+
+        }
+    }
+
+    private long getCreated(final XmldbURI docName) throws EXistException, PermissionDeniedException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            DocumentImpl doc = null;
+            try {
+                doc = broker.getXMLResource(TEST_COLLECTION_URI.append(docName), LockMode.READ_LOCK);
+                return doc.getMetadata().getCreated();
+            } finally {
+                if (doc != null) {
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
+                }
+            }
+        }
+    }
+
+    private long getLastModified(final XmldbURI docName) throws EXistException, PermissionDeniedException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            DocumentImpl doc = null;
+            try {
+                doc = broker.getXMLResource(TEST_COLLECTION_URI.append(docName), LockMode.READ_LOCK);
+                return doc.getMetadata().getLastModified();
+            } finally {
+                if (doc != null) {
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
+                }
+            }
+        }
+    }
+
+    private void checkAttributes(final XmldbURI docName, final String expectedOwner, final String expectedGroup, final int expectedMode, final Matcher<Long> expectedCreated, final Matcher<Long> expectedLastModified) throws EXistException, PermissionDeniedException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            DocumentImpl doc = null;
+            try {
+                doc = broker.getXMLResource(TEST_COLLECTION_URI.append(docName), LockMode.READ_LOCK);
+
+                final Permission permission = doc.getPermissions();
+                assertEquals("Owner value was not expected", expectedOwner, permission.getOwner().getName());
+                assertEquals("Group value was not expected", expectedGroup, permission.getGroup().getName());
+                assertEquals("Mode value was not expected", expectedMode, permission.getMode());
+
+                assertThat("Created value is not correct", doc.getMetadata().getCreated(), expectedCreated);
+                assertThat("LastModified value is not correct", doc.getMetadata().getLastModified(), expectedLastModified);
+            } finally {
+                if (doc != null) {
+                    doc.getUpdateLock().release(LockMode.READ_LOCK);
+                }
+            }
+        }
+    }
+
+    @BeforeClass
+    public static void prepareDb() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
+            chmod(broker, collection.getURI(), 511);
+            broker.saveCollection(transaction, collection);
+
+            createUser(broker, sm, USER1_NAME, USER1_PWD);
+            createUser(broker, sm, USER2_NAME, USER2_PWD);
+
+            transaction.commit();
+        }
+    }
+
+    @Before
+    public void setup() throws EXistException, PermissionDeniedException, LockException, SAXException, IOException, AuthenticationException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+
+        // create user1 resources
+        final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        try (final DBBroker broker = pool.get(Optional.of(user1));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            Collection collection = null;
+            try {
+                collection = broker.openCollection(TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
+
+                final String u1d1xml = "<empty1/>";
+                final IndexInfo u1d1ii = collection.validateXMLResource(transaction, broker, USER1_DOC1, u1d1xml);
+                collection.store(transaction, broker, u1d1ii, u1d1xml);
+                chmod(broker, TEST_COLLECTION_URI.append(USER1_DOC1), USER1_DOC1_MODE);
+
+                final String u1d2xml = "<empty2/>";
+                final IndexInfo u1d2ii = collection.validateXMLResource(transaction, broker, USER1_DOC2, u1d2xml);
+                collection.store(transaction, broker, u1d2ii, u1d2xml);
+                chmod(broker, TEST_COLLECTION_URI.append(USER1_DOC2), USER1_DOC2_MODE);
+
+                final String u1d1bin = "bin1";
+                collection.addBinaryResource(transaction, broker, USER1_BIN_DOC1, u1d1bin.getBytes(UTF_8), "text/plain");
+                chmod(broker, TEST_COLLECTION_URI.append(USER1_BIN_DOC1), USER1_BIN_DOC1_MODE);
+
+                final String u1d2bin = "bin2";
+                collection.addBinaryResource(transaction, broker, USER1_BIN_DOC2, u1d2bin.getBytes(UTF_8), "text/plain");
+                chmod(broker, TEST_COLLECTION_URI.append(USER1_BIN_DOC2), USER1_BIN_DOC2_MODE);
+
+                broker.saveCollection(transaction, collection);
+
+                transaction.commit();
+
+            } finally {
+                if (collection != null) {
+                    collection.getLock().release(LockMode.WRITE_LOCK);
+                }
+            }
+        }
+
+        // create user2 resources
+        final Subject user2 = pool.getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        try (final DBBroker broker = pool.get(Optional.of(user2));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            Collection collection = null;
+            try {
+                collection = broker.openCollection(TEST_COLLECTION_URI, LockMode.WRITE_LOCK);
+
+                final String u2d2xml = "<empty2/>";
+                final IndexInfo u2d2ii = collection.validateXMLResource(transaction, broker, USER2_DOC2, u2d2xml);
+                collection.store(transaction, broker, u2d2ii, u2d2xml);
+                chmod(broker, TEST_COLLECTION_URI.append(USER2_DOC2), USER2_DOC2_MODE);
+
+                final String u2d2bin = "bin2";
+                collection.addBinaryResource(transaction, broker, USER2_BIN_DOC2, u2d2bin.getBytes(UTF_8), "text/plain");
+                chmod(broker, TEST_COLLECTION_URI.append(USER2_BIN_DOC2), USER2_BIN_DOC2_MODE);
+
+                broker.saveCollection(transaction, collection);
+
+                transaction.commit();
+
+            } finally {
+                if (collection != null) {
+                    collection.getLock().release(LockMode.WRITE_LOCK);
+                }
+            }
+        }
+    }
+
+    @After
+    public void teardown() throws EXistException, LockException, TriggerException, PermissionDeniedException, IOException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC1));
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC2));
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER1_NEW_DOC));
+
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC1));
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC2));
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER1_NEW_BIN_DOC));
+
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER2_DOC2));
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER2_NEW_DOC));
+
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER2_BIN_DOC2));
+            removeDocument(broker, transaction, TEST_COLLECTION_URI.append(USER2_NEW_BIN_DOC));
+
+            transaction.commit();
+        }
+    }
+
+    @AfterClass
+    public static void cleanupDb() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            removeUser(sm, USER2_NAME);
+            removeUser(sm, USER1_NAME);
+
+            removeCollection(broker, transaction, TEST_COLLECTION_URI);
+
+            transaction.commit();
+        }
+    }
+
+    private static void createUser(final DBBroker broker, final SecurityManager sm, final String username, final String password) throws PermissionDeniedException, EXistException {
+        Group userGroup = new GroupAider(username);
+        sm.addGroup(broker, userGroup);
+        final Account user = new UserAider(username);
+        user.setPassword(password);
+        user.setPrimaryGroup(userGroup);
+        sm.addAccount(user);
+
+        userGroup = sm.getGroup(username);
+        userGroup.addManager(sm.getAccount(username));
+        sm.updateGroup(userGroup);
+    }
+
+
+    private static void chmod(final DBBroker broker, final XmldbURI pathUri, final int mode) throws PermissionDeniedException {
+        PermissionFactory.updatePermissions(broker, pathUri, permission -> permission.setMode(mode));
+    }
+
+    private static void removeUser(final SecurityManager sm, final String username) throws PermissionDeniedException, EXistException {
+        sm.deleteAccount(username);
+        sm.deleteGroup(username);
+    }
+
+    private static void removeDocument(final DBBroker broker, final Txn transaction, final XmldbURI documentUri) throws PermissionDeniedException, LockException, IOException, TriggerException {
+        Collection collection = null;
+        try {
+            collection = broker.openCollection(documentUri.removeLastSegment(), LockMode.WRITE_LOCK);
+
+            final DocumentImpl doc = collection.getDocument(broker, documentUri.lastSegment());
+            if (doc != null) {
+                collection.removeResource(transaction, broker, doc);
+            }
+
+            broker.saveCollection(transaction, collection);
+        } finally {
+            if (collection != null) {
+                collection.getLock().release(LockMode.WRITE_LOCK);
+            }
+        }
+    }
+
+    private static void removeCollection(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws PermissionDeniedException, IOException, TriggerException {
+        Collection collection = null;
+        try {
+            collection = broker.openCollection(collectionUri, LockMode.WRITE_LOCK);
+            if (collection != null) {
+                broker.removeCollection(transaction, collection);
+            }
+        } finally {
+            if (collection != null) {
+                collection.getLock().release(LockMode.WRITE_LOCK);
+            }
+        }
+    }
+}


### PR DESCRIPTION
It seems we still had some issues with permissions not being set in the correct POSIX like way.

Prior to this PR:
1. Documents:
    1. Documents copied by the DBA (when not overwriting an existing document), would end up with the DBA user and group as the owner.
    2. Documents copied (when not overwriting an existing document), did not also copy the mode from the source document.
    3. Documents copied over an existing document, would have the wrong creation time and mode.
2. Collections:
    1. Collections copied by  anyone (when not overwriting an existing Collection), would have the wrong mode.

This PR includes a small API change and so requires a major release line, e.g. 5.0.0.