### PR TITLE
Update test suite info in PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,14 @@
-Thank you for your contribution to the eXist-db codebase! We will review your changes and pull them in when the project agrees with them and if the project benefits from it, content and quality wise.
+Thank you for your contribution to eXist-db! 
 
-To be able to judge the Pull Request (PR) please be sure the following is present
+To help the community judge your pull request (PR), please include the following:
 
 - A (short) description of the content of changes.
-- A context reference to e.g. a [Github Issue](https://github.com/eXist-db/exist/issues), a message in the  [eXist-open mailinglist](http://exist-open.markmail.org) or a [specification](https://www.w3.org/TR/xquery-3/).
+- A context reference to a [Github Issue](https://github.com/eXist-db/exist/issues), a message in the [eXist-open mailinglist](http://exist-open.markmail.org), or a [specification](https://www.w3.org/TR/xquery-31/).
+- Tests. The [XQSuite - Annotation-based Test Framework for XQuery](http://exist-db.org/exist/apps/doc/xqsuite.xml) makes it very easy for you to create tests. These tests can be executed from the [eXide editor](http://exist-db.org/exist/apps/eXide/index.html) via XQuery > Run as Test.
 
-Additionally please add a few tests to the PR. The [XQSuite - Annotation-based Test Framework for XQuery](http://exist-db.org/exist/apps/doc/xqsuite.xml) makes it very easy for you to create tests. These tests can be executed from the [eXide editor](http://exist-db.org/exist/apps/eXide/index.html) (XQuery - Run as Test)
+Your PR will be tested using [Travis CI](https://travis-ci.org/eXist-db/exist) and [AppVeyor](https://ci.appveyor.com/project/AdamRetter/exist) against a number of operating systems and environments. The build status is visible in the PR. 
 
-> When the PR is filed, the complete PR will be tested using [travis-ci](https://travis-ci.org/eXist-db/exist), the build status is visible in the PR. Note that only a limited number of tests are executed (smoketest).
-
-Please run the *full* junit testsuite before filing the PR! This can be done with `build.sh test` which generates a HTML report.
+To detect errors in your PR before submitting it, please run eXist's full test suite on your own system via `build.sh test`.
 
 ------
 


### PR DESCRIPTION
### Description:

- add AppVeyor
- running full test suite is no longer mandatory, now that the full test is run on the CI servers (assuming we merge https://github.com/eXist-db/exist/pull/1887)
- trim instructions

### Reference:

- https://github.com/eXist-db/exist/pull/1887

### Type of tests:

n/a