### PR TITLE
Implement preserve for copy

### DIFF
--- a/conf.xml.tmpl
+++ b/conf.xml.tmpl
@@ -138,6 +138,7 @@
 
             If you need stable, incremental ids, set the option doc-ids to
             "incremental".
+
         - minDiskSpace:
             The amount of disk space (in megabytes) which should be available for
             the database to continue operations. If free disk space goes below
@@ -166,6 +167,26 @@
            further details can be seen in the "Rationale" section for the
            chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
            See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+
+        - preserve-on-copy
+            When copying Collections and Documents within the database, the
+            default (`false`), is not to preserve their attributes
+            (modification time, mode, user-id, group-id, and ACL).
+
+            NOTE: Not preserving attributes, is inline with both the GNU and
+            BSD `cp` commands, and therefore expected behaviour; The target
+            Collection or Document is created following the rules of the
+            target parent, and the effective user and their umask.
+
+            Setting preserve-on-copy="true" changes the default behaviour
+            so that the target Collection or Document of a copy, has the same
+            attributes as the source.
+
+            The preserve-on-copy setting can be overridden on a case-by-case
+            basis by setting the `preserve` flag to either `true` or `false`
+            when calling xmldb:copy(), or via any other API that supports copy.
+            Omitting the preserve flag when calling a copy operation, implies
+            the behaviour that is set in this configuration.
     
         =====================================================================
         
@@ -178,7 +199,7 @@
     -->
     <db-connection cacheSize="@cacheSize@M" checkMaxCacheSize="true" collectionCache="@collectionCacheSize@M" database="@database@"
         files="@dataDir@" pageSize="4096" nodesBuffer="1000" cacheShrinkThreshold="10000"
-        doc-ids="default" minDiskSpace="128M" posix-chown-restricted="true">
+        doc-ids="default" minDiskSpace="128M" posix-chown-restricted="true" preserve-on-copy="false">
 
         <!--
             Startup Triggers are executed before the database becomes generally available

--- a/src/org/exist/collections/Collection.java
+++ b/src/org/exist/collections/Collection.java
@@ -311,9 +311,8 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
      *
      * @param broker The database broker
      * @param child  The child Collection to add to this Collection
-     * @param isNew  Whether the Child Collection is a newly created Collection
      */
-    void addCollection(DBBroker broker, Collection child, boolean isNew)
+    void addCollection(DBBroker broker, Collection child)
             throws PermissionDeniedException, LockException;
 
     /**
@@ -827,6 +826,32 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, BinaryDocument blob, InputStream is,
             String mimeType, long size, Date created, Date modified) throws EXistException, PermissionDeniedException,
             LockException, TriggerException, IOException;
+
+    /**
+     * Store a binary document into the Collection (streaming)
+     *
+     * Locks the collection while the resource is being saved. Triggers will be called after the collection
+     * has been unlocked while keeping a lock on the resource to prevent modification.
+     *
+     * Callers should not lock the collection before calling this method as this may lead to deadlocks.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param blob        the binary resource to store the data into
+     * @param is          The content for the document
+     * @param mimeType    The Internet Media Type of the document
+     * @param size        The size in bytes of the document
+     * @param created     The created timestamp of the document
+     * @param modified    The modified timestamp of the document
+     * @param preserve    In the case of a copy, cause the copy process to preserve the following attributes of each
+     *                    source in the copy: modification time, file mode, user ID, and group ID, as allowed by
+     *                    permissions. Access Control Lists (ACLs) will also be preserved.
+     *
+     * @return The stored Binary Document object
+     */
+    BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, BinaryDocument blob, InputStream is,
+            String mimeType, long size, Date created, Date modified, DBBroker.PreserveType preserve)
+            throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException;
 
     /**
      * Gets an Observable object for this Collection

--- a/src/org/exist/security/PermissionFactory.java
+++ b/src/org/exist/security/PermissionFactory.java
@@ -481,6 +481,23 @@ public class PermissionFactory {
     }
 
     /**
+     * Changes the ACL of a permissioned object in the database
+     * inline with the rules for chmod of POSIX.1-2017 (Issue 7, 2018 edition).
+     *
+     * @param permission the permissions of the object in the database.
+     * @param permissionModifier a function which will modify the ACL.
+     *
+     * @throws PermissionDeniedException if the calling process has insufficient permissions.
+     */
+    public static void chacl(final Permission permission, final ConsumerE<ACLPermission, PermissionDeniedException> permissionModifier) throws PermissionDeniedException {
+        if(permission instanceof SimpleACLPermission) {
+            chacl((SimpleACLPermission)permission, permissionModifier);
+        } else {
+            throw new PermissionDeniedException("ACL like permissions have not been enabled");
+        }
+    }
+
+    /**
      * Changes the ACL of permissions in the database
      * inline with the rules for chmod of POSIX.1-2017 (Issue 7, 2018 edition).
      *

--- a/src/org/exist/util/Configuration.java
+++ b/src/org/exist/util/Configuration.java
@@ -1001,6 +1001,20 @@ public class Configuration implements ErrorHandler
         }
         config.put(DBBroker.POSIX_CHOWN_RESTRICTED_PROPERTY, posixChownRestricted);
 
+        final String preserveOnCopyStr = getConfigAttributeValue(con,  DBBroker.PRESERVE_ON_COPY_ATTRIBUTE);
+        final DBBroker.PreserveType preserveOnCopy;
+        if(preserveOnCopyStr == null) {
+            preserveOnCopy = DBBroker.PreserveType.NO_PRESERVE;  // default
+        } else {
+            if(Boolean.valueOf(preserveOnCopyStr)) {
+                // configuration explicitly specifies that attributes should be preserved on copy
+                preserveOnCopy = DBBroker.PreserveType.PRESERVE;
+            } else {
+                preserveOnCopy = DBBroker.PreserveType.NO_PRESERVE;
+            }
+        }
+        config.put(DBBroker.PRESERVE_ON_COPY_PROPERTY, preserveOnCopy);
+
         final NodeList securityConf             = con.getElementsByTagName( BrokerPool.CONFIGURATION_SECURITY_ELEMENT_NAME );
         String   securityManagerClassName = BrokerPool.DEFAULT_SECURITY_CLASS;
 

--- a/src/org/exist/xmldb/EXistCollectionManagementService.java
+++ b/src/org/exist/xmldb/EXistCollectionManagementService.java
@@ -65,9 +65,33 @@ public interface EXistCollectionManagementService extends CollectionManagementSe
 
     void moveResource(XmldbURI resourcePath, XmldbURI destinationPath, XmldbURI newName) throws XMLDBException;
 
+    /**
+     * @deprecated Use {@link #copyResource(XmldbURI, XmldbURI, XmldbURI, String)}
+     */
+    @Deprecated
     void copyResource(XmldbURI resourcePath, XmldbURI destinationPath, XmldbURI newName) throws XMLDBException;
 
+    /**
+     * @param resourcePath The source document
+     * @param destinationPath The destination collection
+     * @param newName The new name of the copied source in the destination collection
+     * @param preserveType one of either "DEFAULT", "NO_PRESERVE", "PRESERVE"
+     */
+    void copyResource(XmldbURI resourcePath, XmldbURI destinationPath, XmldbURI newName, String preserveType) throws XMLDBException;
+
+    /**
+     * @deprecated Use {@link #copy(XmldbURI, XmldbURI, XmldbURI, String)}
+     */
+    @Deprecated
     void copy(XmldbURI collection, XmldbURI destination, XmldbURI newName) throws XMLDBException;
+
+    /**
+     * @param collection The source collection
+     * @param destination The destination collection
+     * @param newName The new name of the copied source in the destination collection
+     * @param preserveType one of either "DEFAULT", "NO_PRESERVE", "PRESERVE"
+     */
+    void copy(XmldbURI collection, XmldbURI destination, XmldbURI newName, String preserveType) throws XMLDBException;
 
     Collection createCollection(XmldbURI collName, Date created) throws XMLDBException;
 

--- a/src/org/exist/xmldb/RemoteCollectionManagementService.java
+++ b/src/org/exist/xmldb/RemoteCollectionManagementService.java
@@ -234,7 +234,7 @@ public class RemoteCollectionManagementService extends AbstractRemote implements
     public void copy(final String collectionPath, final String destinationPath,
                      final String newName) throws XMLDBException {
         try {
-            copy(XmldbURI.xmldbUriFor(collectionPath), XmldbURI.xmldbUriFor(destinationPath), XmldbURI.xmldbUriFor(newName));
+            copy(XmldbURI.xmldbUriFor(collectionPath), XmldbURI.xmldbUriFor(destinationPath), XmldbURI.xmldbUriFor(newName), "DEFAULT");
         } catch (final URISyntaxException e) {
             throw new XMLDBException(ErrorCodes.INVALID_URI, e);
         }
@@ -242,6 +242,11 @@ public class RemoteCollectionManagementService extends AbstractRemote implements
 
     @Override
     public void copy(final XmldbURI src, final XmldbURI dest, final XmldbURI name) throws XMLDBException {
+        copy(src, dest, name, "DEFAULT");
+    }
+
+    @Override
+    public void copy(final XmldbURI src, final XmldbURI dest, final XmldbURI name, final String preserveType) throws XMLDBException {
         final XmldbURI srcPath = resolve(src);
         final XmldbURI destPath = dest == null ? srcPath.removeLastSegment() : resolve(dest);
         final XmldbURI newName;
@@ -255,6 +260,7 @@ public class RemoteCollectionManagementService extends AbstractRemote implements
         params.add(srcPath.toString());
         params.add(destPath.toString());
         params.add(newName.toString());
+        params.add(preserveType);
         try {
             client.execute("copyCollection", params);
         } catch (final XmlRpcException xre) {
@@ -270,9 +276,9 @@ public class RemoteCollectionManagementService extends AbstractRemote implements
     @Deprecated
     @Override
     public void copyResource(final String resourcePath, final String destinationPath,
-                             final String newName) throws XMLDBException {
+            final String newName) throws XMLDBException {
         try {
-            copyResource(XmldbURI.xmldbUriFor(resourcePath), XmldbURI.xmldbUriFor(destinationPath), XmldbURI.xmldbUriFor(newName));
+            copyResource(XmldbURI.xmldbUriFor(resourcePath), XmldbURI.xmldbUriFor(destinationPath), XmldbURI.xmldbUriFor(newName), "DEFAULT");
         } catch (final URISyntaxException e) {
             throw new XMLDBException(ErrorCodes.INVALID_URI, e);
         }
@@ -280,6 +286,12 @@ public class RemoteCollectionManagementService extends AbstractRemote implements
 
     @Override
     public void copyResource(final XmldbURI src, final XmldbURI dest, final XmldbURI name)
+            throws XMLDBException {
+        copyResource(src, dest, name, "DEFAULT");
+    }
+
+    @Override
+    public void copyResource(final XmldbURI src, final XmldbURI dest, final XmldbURI name, final String preserveType)
             throws XMLDBException {
         final XmldbURI srcPath = resolve(src);
         final XmldbURI destPath = dest == null ? srcPath.removeLastSegment() : resolve(dest);
@@ -293,6 +305,7 @@ public class RemoteCollectionManagementService extends AbstractRemote implements
         params.add(srcPath.toString());
         params.add(destPath.toString());
         params.add(newName.toString());
+        params.add(preserveType);
         try {
             client.execute("copyResource", params);
         } catch (final XmlRpcException xre) {

--- a/src/org/exist/xmlrpc/RpcAPI.java
+++ b/src/org/exist/xmlrpc/RpcAPI.java
@@ -923,7 +923,13 @@ public interface RpcAPI {
     boolean copyCollection(String collectionPath, String destinationPath, String newName)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
+    boolean copyCollection(String collectionPath, String destinationPath, String newName, final String preserveType)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
     boolean copyResource(String docPath, String destinationPath, String newName)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean copyResource(String docPath, String destinationPath, String newName, final String preserveType)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
     boolean reindexCollection(String name)

--- a/src/org/exist/xquery/functions/securitymanager/PermissionsFunction.java
+++ b/src/org/exist/xquery/functions/securitymanager/PermissionsFunction.java
@@ -302,6 +302,8 @@ public class PermissionsFunction extends BasicFunction {
         }
     }
 
+    // TODO(AR) need to do something in PermissionFactory for modifying ACL's
+
     private Sequence functionAddACE(final XmldbURI pathUri, final ACE_TARGET target, final String name, final ACE_ACCESS_TYPE access_type, final String mode) throws PermissionDeniedException {
         PermissionFactory.chacl(context.getBroker(), pathUri,
                 aclPermission -> aclPermission.addACE(access_type, target, name, mode)

--- a/src/org/exist/xquery/functions/xmldb/XMLDBModule.java
+++ b/src/org/exist/xquery/functions/xmldb/XMLDBModule.java
@@ -24,8 +24,14 @@ package org.exist.xquery.functions.xmldb;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import org.exist.dom.QName;
 import org.exist.xquery.AbstractInternalModule;
+import org.exist.xquery.FunctionDSL;
 import org.exist.xquery.FunctionDef;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.FunctionReturnSequenceType;
 
 /**
  * Module function definitions for xmldb module.
@@ -59,8 +65,10 @@ public class XMLDBModule extends AbstractInternalModule {
             new FunctionDef(XMLDBLoadFromPattern.signatures[2], XMLDBLoadFromPattern.class),
             new FunctionDef(XMLDBLoadFromPattern.signatures[3], XMLDBLoadFromPattern.class),
             new FunctionDef(XMLDBXUpdate.signature, XMLDBXUpdate.class),
-            new FunctionDef(XMLDBCopy.signatures[0], XMLDBCopy.class),
-            new FunctionDef(XMLDBCopy.signatures[1], XMLDBCopy.class),
+            new FunctionDef(XMLDBCopy.FS_COPY_COLLECTION[0], XMLDBCopy.class),
+            new FunctionDef(XMLDBCopy.FS_COPY_COLLECTION[1], XMLDBCopy.class),
+            new FunctionDef(XMLDBCopy.FS_COPY_RESOURCE[0], XMLDBCopy.class),
+            new FunctionDef(XMLDBCopy.FS_COPY_RESOURCE[1], XMLDBCopy.class),
             new FunctionDef(XMLDBMove.signatures[0], XMLDBMove.class),
             new FunctionDef(XMLDBMove.signatures[1], XMLDBMove.class),
             new FunctionDef(XMLDBRename.signatures[0], XMLDBRename.class),
@@ -171,4 +179,11 @@ public class XMLDBModule extends AbstractInternalModule {
         return RELEASED_IN_VERSION;
     }
 
+    static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
+        return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI), description, returnType, paramTypes);
+    }
+
+    static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI), description, returnType, variableParamTypes);
+    }
 }

--- a/test/src/org/exist/storage/CopyResourceTest.java
+++ b/test/src/org/exist/storage/CopyResourceTest.java
@@ -48,6 +48,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.TestUtils.ADMIN_DB_USER;
 import static org.exist.TestUtils.ADMIN_DB_PWD;
 import static org.exist.security.SecurityManager.DBA_GROUP;
+import static org.exist.storage.DBBroker.PreserveType.*;
 import static org.exist.test.TestConstants.TEST_COLLECTION_URI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -98,7 +99,7 @@ public class CopyResourceTest {
     @Test
     public void copyXmlToNonExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
-        copyDoc(user1, USER1_DOC1, USER1_NEW_DOC);
+        copyDoc(user1, NO_PRESERVE, USER1_DOC1, USER1_NEW_DOC);
         checkAttributes(USER1_NEW_DOC, USER1_NAME, USER1_NAME, USER1_DOC1_MODE, not(getCreated(USER1_DOC1)), not(getLastModified(USER1_DOC1)));
     }
 
@@ -108,7 +109,7 @@ public class CopyResourceTest {
     @Test
     public void copyBinaryToNonExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
-        copyDoc(user1, USER1_BIN_DOC1, USER1_NEW_BIN_DOC);
+        copyDoc(user1, NO_PRESERVE, USER1_BIN_DOC1, USER1_NEW_BIN_DOC);
         checkAttributes(USER1_NEW_BIN_DOC, USER1_NAME, USER1_NAME, USER1_BIN_DOC1_MODE, not(getCreated(USER1_BIN_DOC1)), not(getLastModified(USER1_BIN_DOC1)));
     }
 
@@ -119,7 +120,7 @@ public class CopyResourceTest {
     public void copyXmlToExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
         final long originalDoc2LastModified = getLastModified(USER1_DOC2);
-        copyDoc(user1, USER1_DOC1, USER1_DOC2);
+        copyDoc(user1, NO_PRESERVE, USER1_DOC1, USER1_DOC2);
         checkAttributes(USER1_DOC2, USER1_NAME, USER1_NAME, USER1_DOC2_MODE, equalTo(getCreated(USER1_DOC2)), allOf(not(getLastModified(USER1_DOC1)), not(originalDoc2LastModified)));
     }
 
@@ -130,7 +131,7 @@ public class CopyResourceTest {
     public void copyBinaryToExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
         final long originalBinDoc2LastModified = getLastModified(USER1_BIN_DOC2);
-        copyDoc(user1, USER1_BIN_DOC1, USER1_BIN_DOC2);
+        copyDoc(user1, NO_PRESERVE, USER1_BIN_DOC1, USER1_BIN_DOC2);
         checkAttributes(USER1_BIN_DOC2, USER1_NAME, USER1_NAME, USER1_BIN_DOC2_MODE, equalTo(getCreated(USER1_BIN_DOC2)), allOf(not(getLastModified(USER1_BIN_DOC1)), not(originalBinDoc2LastModified)));
     }
 
@@ -140,7 +141,7 @@ public class CopyResourceTest {
     @Test
     public void copyXmlToNonExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
-        copyDoc(adminUser, USER1_DOC1, USER1_NEW_DOC);
+        copyDoc(adminUser, NO_PRESERVE, USER1_DOC1, USER1_NEW_DOC);
         checkAttributes(USER1_NEW_DOC, ADMIN_DB_USER, DBA_GROUP, USER1_DOC1_MODE, not(getCreated(USER1_DOC1)), not(getLastModified(USER1_DOC1)));
     }
 
@@ -150,7 +151,7 @@ public class CopyResourceTest {
     @Test
     public void copyBinaryToNonExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
-        copyDoc(adminUser, USER1_BIN_DOC1, USER1_NEW_BIN_DOC);
+        copyDoc(adminUser, NO_PRESERVE, USER1_BIN_DOC1, USER1_NEW_BIN_DOC);
         checkAttributes(USER1_NEW_BIN_DOC, ADMIN_DB_USER, DBA_GROUP, USER1_BIN_DOC1_MODE, not(getCreated(USER1_BIN_DOC1)), not(getLastModified(USER1_BIN_DOC1)));
     }
 
@@ -161,7 +162,7 @@ public class CopyResourceTest {
     public void copyXmlToExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
         final long originalDoc2LastModified = getLastModified(USER1_DOC2);
-        copyDoc(adminUser, USER1_DOC1, USER1_DOC2);
+        copyDoc(adminUser, NO_PRESERVE, USER1_DOC1, USER1_DOC2);
         checkAttributes(USER1_DOC2, USER1_NAME, USER1_NAME, USER1_DOC2_MODE, equalTo(getCreated(USER1_DOC2)), allOf(not(getLastModified(USER1_DOC1)), not(originalDoc2LastModified)));
     }
 
@@ -172,7 +173,7 @@ public class CopyResourceTest {
     public void copyBinaryToExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
         final long originalBinDoc2LastModified = getLastModified(USER1_BIN_DOC2);
-        copyDoc(adminUser, USER1_BIN_DOC1, USER1_BIN_DOC2);
+        copyDoc(adminUser, NO_PRESERVE, USER1_BIN_DOC1, USER1_BIN_DOC2);
         checkAttributes(USER1_BIN_DOC2, USER1_NAME, USER1_NAME, USER1_BIN_DOC2_MODE, equalTo(getCreated(USER1_BIN_DOC2)), allOf(not(getLastModified(USER1_BIN_DOC1)), not(originalBinDoc2LastModified)));
     }
 
@@ -182,7 +183,7 @@ public class CopyResourceTest {
     @Test
     public void copyXmlToNonExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
-        copyDoc(user2, USER1_DOC1, USER2_NEW_DOC);
+        copyDoc(user2, NO_PRESERVE, USER1_DOC1, USER2_NEW_DOC);
         checkAttributes(USER2_NEW_DOC, USER2_NAME, USER2_NAME, USER1_DOC1_MODE, not(getCreated(USER1_DOC1)), not(getLastModified(USER1_DOC1)));
     }
 
@@ -192,7 +193,7 @@ public class CopyResourceTest {
     @Test
     public void copyBinaryToNonExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
-        copyDoc(user2, USER1_BIN_DOC1, USER2_NEW_BIN_DOC);
+        copyDoc(user2, NO_PRESERVE, USER1_BIN_DOC1, USER2_NEW_BIN_DOC);
         checkAttributes(USER2_NEW_BIN_DOC, USER2_NAME, USER2_NAME, USER1_BIN_DOC1_MODE, not(getCreated(USER1_BIN_DOC1)), not(getLastModified(USER1_BIN_DOC1)));
     }
 
@@ -203,7 +204,7 @@ public class CopyResourceTest {
     public void copyXmlToExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
         final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
         final long originalDoc2LastModified = getLastModified(USER2_DOC2);
-        copyDoc(user2, USER1_DOC1, USER2_DOC2);
+        copyDoc(user2, NO_PRESERVE, USER1_DOC1, USER2_DOC2);
         checkAttributes(USER2_DOC2, USER2_NAME, USER2_NAME, USER2_DOC2_MODE, equalTo(getCreated(USER2_DOC2)), allOf(not(getLastModified(USER1_DOC1)), not(originalDoc2LastModified)));
     }
 
@@ -214,11 +215,155 @@ public class CopyResourceTest {
     public void copyBinaryToExistentAsOther() throws AuthenticationException, EXistException, PermissionDeniedException, LockException, IOException {
         final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
         final long originalBinDoc2LastModified = getLastModified(USER2_BIN_DOC2);
-        copyDoc(user2, USER1_BIN_DOC1, USER2_BIN_DOC2);
+        copyDoc(user2, NO_PRESERVE, USER1_BIN_DOC1, USER2_BIN_DOC2);
         checkAttributes(USER2_BIN_DOC2, USER2_NAME, USER2_NAME, USER2_BIN_DOC2_MODE, equalTo(getCreated(USER2_BIN_DOC2)), allOf(not(getLastModified(USER1_BIN_DOC1)), not(originalBinDoc2LastModified)));
     }
 
-    private void copyDoc(final Subject execAsUser, final XmldbURI srcDocName, final XmldbURI destDocName) throws EXistException, PermissionDeniedException, LockException, IOException {
+    /**
+     * Whilst preserving attributes,
+     * as the owner copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_DOC}.
+     */
+    @Test
+    public void copyPreserveXmlToNonExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        final long doc1LastModified = getLastModified(USER1_DOC1);
+        copyDoc(user1, PRESERVE, USER1_DOC1, USER1_NEW_DOC);
+        checkAttributes(USER1_NEW_DOC, USER1_NAME, USER1_NAME, USER1_DOC1_MODE, equalTo(doc1LastModified), equalTo(doc1LastModified));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as the owner copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_BIN_DOC}.
+     */
+    @Test
+    public void copyPreserveBinaryToNonExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        final long binDoc1LastModified = getLastModified(USER1_BIN_DOC1);
+        copyDoc(user1, PRESERVE, USER1_BIN_DOC1, USER1_NEW_BIN_DOC);
+        checkAttributes(USER1_NEW_BIN_DOC, USER1_NAME, USER1_NAME, USER1_BIN_DOC1_MODE, equalTo(binDoc1LastModified), equalTo(binDoc1LastModified));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as the owner copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER1_DOC2}.
+     */
+    @Test
+    public void copyPreserveXmlToExistentAsSelf() throws AuthenticationException, EXistException, PermissionDeniedException, LockException, IOException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        final long originalDoc2Created = getCreated(USER1_DOC2);
+        copyDoc(user1, PRESERVE, USER1_DOC1, USER1_DOC2);
+        checkAttributes(USER1_DOC2, USER1_NAME, USER1_NAME, USER1_DOC1_MODE, equalTo(originalDoc2Created), equalTo(getLastModified(USER1_DOC1)));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as the owner copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER1_BIN_DOC2}.
+     */
+    @Test
+    public void copyPreserveBinaryToExistentAsSelf() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        final long originalBinDoc2Created = getCreated(USER1_BIN_DOC2);
+        copyDoc(user1, PRESERVE, USER1_BIN_DOC1, USER1_BIN_DOC2);
+        checkAttributes(USER1_BIN_DOC2, USER1_NAME, USER1_NAME, USER1_BIN_DOC1_MODE, equalTo(originalBinDoc2Created), equalTo(getLastModified(USER1_BIN_DOC1)));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as a DBA copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_DOC}.
+     */
+    @Test
+    public void copyPreserveXmlToNonExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        final long doc1LastModified = getLastModified(USER1_DOC1);
+        copyDoc(adminUser, PRESERVE, USER1_DOC1, USER1_NEW_DOC);
+        checkAttributes(USER1_NEW_DOC, USER1_NAME, USER1_NAME, USER1_DOC1_MODE, equalTo(doc1LastModified), equalTo(doc1LastModified));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as a DBA copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_BIN_DOC}.
+     */
+    @Test
+    public void copyPreserveBinaryToNonExistentAsDBA() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        final long binDoc1LastModified = getLastModified(USER1_BIN_DOC1);
+        copyDoc(adminUser, PRESERVE, USER1_BIN_DOC1, USER1_NEW_BIN_DOC);
+        checkAttributes(USER1_NEW_BIN_DOC, USER1_NAME, USER1_NAME, USER1_BIN_DOC1_MODE, equalTo(binDoc1LastModified), equalTo(binDoc1LastModified));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as a DBA copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER1_DOC2}.
+     */
+    @Test
+    public void copyPreserveXmlToExistentAsDBA() throws AuthenticationException, EXistException, PermissionDeniedException, LockException, IOException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        final long originalDoc2Created = getCreated(USER1_DOC2);
+        copyDoc(adminUser, PRESERVE, USER1_DOC1, USER1_DOC2);
+        checkAttributes(USER1_DOC2, USER1_NAME, USER1_NAME, USER1_DOC1_MODE, equalTo(originalDoc2Created), equalTo(getLastModified(USER1_DOC1)));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as a DBA copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER1_BIN_DOC2}.
+     */
+    @Test
+    public void copyPreserveBinaryToExistentAsDBA() throws AuthenticationException, EXistException, PermissionDeniedException, LockException, IOException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(ADMIN_DB_USER, ADMIN_DB_PWD);
+        final long originalBinDoc2Created = getCreated(USER1_BIN_DOC2);
+        copyDoc(adminUser, PRESERVE, USER1_BIN_DOC1, USER1_BIN_DOC2);
+        checkAttributes(USER1_BIN_DOC2, USER1_NAME, USER1_NAME, USER1_BIN_DOC1_MODE, equalTo(originalBinDoc2Created), equalTo(getLastModified(USER1_BIN_DOC1)));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as some other (non-owner) user copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER2_NEW_DOC}.
+     */
+    @Test
+    public void copyPreserveXmlToNonExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final long doc1LastModified = getLastModified(USER1_DOC1);
+        copyDoc(user2, PRESERVE, USER1_DOC1, USER2_NEW_DOC);
+        checkAttributes(USER2_NEW_DOC, USER2_NAME, USER2_NAME, USER1_DOC1_MODE, equalTo(doc1LastModified), equalTo(doc1LastModified));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * some other (non-owner) user copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} to non-existent {@link #USER1_NEW_BIN_DOC}.
+     */
+    @Test
+    public void copyPreserveBinaryToNonExistentAsOther() throws AuthenticationException, LockException, PermissionDeniedException, EXistException, IOException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final long binDoc1LastModified = getLastModified(USER1_BIN_DOC1);
+        copyDoc(user2, PRESERVE, USER1_BIN_DOC1, USER2_NEW_BIN_DOC);
+        checkAttributes(USER2_NEW_BIN_DOC, USER2_NAME, USER2_NAME, USER1_BIN_DOC1_MODE, equalTo(binDoc1LastModified), equalTo(binDoc1LastModified));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as some other (non-owner) user copy {@link #USER1_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER2_DOC2}.
+     */
+    @Test
+    public void copyPreserveXmlToExistentAsOther() throws AuthenticationException, EXistException, PermissionDeniedException, LockException, IOException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final long originalDoc2Created = getCreated(USER2_DOC2);
+        copyDoc(user2, PRESERVE, USER1_DOC1, USER2_DOC2);
+        checkAttributes(USER2_DOC2, USER2_NAME, USER2_NAME, USER1_DOC1_MODE, equalTo(originalDoc2Created), equalTo(getLastModified(USER1_DOC1)));
+    }
+
+    /**
+     * Whilst preserving attributes,
+     * as some other (non-owner) user copy {@link #USER1_BIN_DOC1} from {@link TestConstants#TEST_COLLECTION_URI} already existing {@link #USER2_BIN_DOC2}.
+     */
+    @Test
+    public void copyPreserveBinaryToExistentAsOther() throws AuthenticationException, EXistException, PermissionDeniedException, LockException, IOException {
+        final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+        final long originalBinDoc2Created = getCreated(USER2_BIN_DOC2);
+        copyDoc(user2, PRESERVE, USER1_BIN_DOC1, USER2_BIN_DOC2);
+        checkAttributes(USER2_BIN_DOC2, USER2_NAME, USER2_NAME, USER1_BIN_DOC1_MODE, equalTo(originalBinDoc2Created), equalTo(getLastModified(USER1_BIN_DOC1)));
+    }
+
+    private void copyDoc(final Subject execAsUser, final DBBroker.PreserveType preserve, final XmldbURI srcDocName, final XmldbURI destDocName) throws EXistException, PermissionDeniedException, LockException, IOException {
         final XmldbURI src = TEST_COLLECTION_URI.append(srcDocName);
         final XmldbURI dest = TEST_COLLECTION_URI.append(destDocName);
 
@@ -234,7 +379,7 @@ public class CopyResourceTest {
                 try {
                     destCol = broker.openCollection(dest.removeLastSegment(), LockMode.WRITE_LOCK);
 
-                    broker.copyResource(transaction, srcDoc, destCol, dest.lastSegment());
+                    broker.copyResource(transaction, srcDoc, destCol, dest.lastSegment(), preserve);
 
                 } finally {
                     if (destCol != null) {
@@ -470,7 +615,6 @@ public class CopyResourceTest {
         userGroup.addManager(sm.getAccount(username));
         sm.updateGroup(userGroup);
     }
-
 
     private static void chmod(final DBBroker broker, final XmldbURI pathUri, final int mode) throws PermissionDeniedException {
         PermissionFactory.chmod(broker, pathUri, Optional.of(mode), Optional.empty());


### PR DESCRIPTION
Requires #1888 and #1893 first.

This provided a feature for preserving attributes when copying a file. The rules of which attributes are preserved and when, is very similar to passing the `--preserve` flag to the GNU or BSD `cp` commands.

Our Collections and Documents have a "Created Time" of which there is no direct equivalent in POSIX.1-2017 (Issue 7, 2018 edition). As such I have based the behaviour on the `btime` (or "birth time") attribute which is present in MacOS X HFS+ and APFS.