### PR TITLE
Security fixes to mitigate Zip/Tar file exit attacks when decompressing archives.

### DIFF
--- a/extensions/modules/src/org/exist/xquery/modules/compression/AbstractExtractFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/AbstractExtractFunction.java
@@ -42,15 +42,7 @@ import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.functions.xmldb.XMLDBAbstractCollectionManipulator;
 import org.exist.xquery.modules.ModuleUtils;
-import org.exist.xquery.value.AnyURIValue;
-import org.exist.xquery.value.Base64BinaryValueType;
-import org.exist.xquery.value.BinaryValue;
-import org.exist.xquery.value.BinaryValueFromInputStream;
-import org.exist.xquery.value.BooleanValue;
-import org.exist.xquery.value.FunctionReference;
-import org.exist.xquery.value.NodeValue;
-import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.StringValue;
+import org.exist.xquery.value.*;
 
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -157,7 +149,7 @@ public abstract class AbstractExtractFunction extends BasicFunction
             Sequence entryDataFunctionResult;
             Sequence uncompressedData = Sequence.EMPTY_SEQUENCE;
 
-            if (entryDataFunction.getSignature().getArgumentCount() == 3) {
+            if (entryDataFunction.getSignature().getReturnType().getPrimaryType() != Type.EMPTY && entryDataFunction.getSignature().getArgumentCount() == 3) {
 
                 Sequence dataParams[] = new Sequence[3];
                 System.arraycopy(filterParams, 0, dataParams, 0, 2);

--- a/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2007-2009 The eXist Project
+ *  Copyright (C) 2007-2018 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -16,28 +16,25 @@
  *  You should have received a copy of the GNU Lesser General Public
  *  License along with this library; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- * $Id$
  */
 package org.exist.xquery.modules.compression;
 
 import java.util.List;
 import java.util.Map;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.exist.xquery.AbstractInternalModule;
-import org.exist.xquery.FunctionDef;
+import org.exist.dom.QName;
+import org.exist.xquery.*;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.FunctionReturnSequenceType;
+
+import static org.exist.xquery.FunctionDSL.functionDefs;
 
 /**
  * XQuery Extension module for compression and de-compression functions
  * 
  * @author Adam Retter <adam@exist-db.org>
  * @author ljo
- * @version 1.0
  */
 public class CompressionModule extends AbstractInternalModule {
-
-    private final static Logger logger = LogManager.getLogger(CompressionModule.class);
 
     public final static String NAMESPACE_URI = "http://exist-db.org/xquery/compression";
 
@@ -45,24 +42,40 @@ public class CompressionModule extends AbstractInternalModule {
     public final static String INCLUSION_DATE = "2007-07-10";
     public final static String RELEASED_IN_VERSION = "eXist-1.2";
 
-    private final static FunctionDef[] functions = {
-        new FunctionDef(ZipFunction.signatures[0], ZipFunction.class),
-        new FunctionDef(ZipFunction.signatures[1], ZipFunction.class),
-        new FunctionDef(ZipFunction.signatures[2], ZipFunction.class),
-        new FunctionDef(UnZipFunction.signatures[0], UnZipFunction.class),
-        new FunctionDef(UnZipFunction.signatures[1], UnZipFunction.class),
-		
-        new FunctionDef(GZipFunction.signatures[0], GZipFunction.class),
-        new FunctionDef(UnGZipFunction.signatures[0], UnGZipFunction.class),
+    private final static FunctionDef[] functions = functionDefs(
+            functionDefs(ZipFunction.class,
+                    ZipFunction.signatures[0],
+                    ZipFunction.signatures[1],
+                    ZipFunction.signatures[2]
+            ),
+            functionDefs(UnZipFunction.class,
+                    UnZipFunction.signatures[0],
+                    UnZipFunction.signatures[1]
+            ),
+            functionDefs(GZipFunction.class,
+                    GZipFunction.signatures[0]
+            ),
+            functionDefs(UnGZipFunction.class,
+                    UnGZipFunction.signatures[0]
+            ),
+            functionDefs(TarFunction.class,
+                    TarFunction.signatures[0],
+                    TarFunction.signatures[1],
+                    TarFunction.signatures[2]
+            ),
+            functionDefs(UnTarFunction.class,
+                    UnTarFunction.signatures[0],
+                    UnTarFunction.signatures[1]
+            ),
+            functionDefs(EntryFunctions.class,
+                    EntryFunctions.FS_NO_FILTER[0],
+                    EntryFunctions.FS_NO_FILTER[1],
+                    EntryFunctions.FS_FS_STORE_ENTRY4,
+                    EntryFunctions.FS_DB_STORE_ENTRY4
+            )
+    );
 
-        new FunctionDef(TarFunction.signatures[0], TarFunction.class),
-        new FunctionDef(TarFunction.signatures[1], TarFunction.class),
-        new FunctionDef(TarFunction.signatures[2], TarFunction.class),
-        new FunctionDef(UnTarFunction.signatures[0], UnTarFunction.class),
-        new FunctionDef(UnTarFunction.signatures[1], UnTarFunction.class)
-    };
-
-    public CompressionModule(Map<String, List<?>> parameters) {
+    public CompressionModule(final Map<String, List<?>> parameters) {
         super(functions, parameters);
     }
 
@@ -84,4 +97,19 @@ public class CompressionModule extends AbstractInternalModule {
         return RELEASED_IN_VERSION;
     }
 
+    static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
+        return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI), description, returnType, paramTypes);
+    }
+
+    static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI), description, returnType, variableParamTypes);
+    }
+
+    static class CompressionModuleErrorCode extends ErrorCodes.ErrorCode {
+        private CompressionModuleErrorCode(final String code, final String description) {
+            super(new QName(code, NAMESPACE_URI, PREFIX), description);
+        }
+    }
+
+    static final ErrorCodes.ErrorCode ARCHIVE_EXIT_ATTACK = new CompressionModuleErrorCode("archive-exit-attack", "The archive likely contains an exit attack, whereby a file extraction tries to escape the destination path.");
 }

--- a/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
@@ -50,7 +50,8 @@ public class CompressionModule extends AbstractInternalModule {
             ),
             functionDefs(UnZipFunction.class,
                     UnZipFunction.FS_UNZIP[0],
-                    UnZipFunction.FS_UNZIP[1]
+                    UnZipFunction.FS_UNZIP[1],
+                    UnZipFunction.FS_UNZIP[2]
             ),
             functionDefs(GZipFunction.class,
                     GZipFunction.signatures[0]
@@ -65,12 +66,15 @@ public class CompressionModule extends AbstractInternalModule {
             ),
             functionDefs(UnTarFunction.class,
                     UnTarFunction.FS_UNTAR[0],
-                    UnTarFunction.FS_UNTAR[1]
+                    UnTarFunction.FS_UNTAR[1],
+                    UnTarFunction.FS_UNTAR[2]
             ),
             functionDefs(EntryFunctions.class,
                     EntryFunctions.FS_NO_FILTER[0],
                     EntryFunctions.FS_NO_FILTER[1],
+                    EntryFunctions.FS_FS_STORE_ENTRY3,
                     EntryFunctions.FS_FS_STORE_ENTRY4,
+                    EntryFunctions.FS_DB_STORE_ENTRY3,
                     EntryFunctions.FS_DB_STORE_ENTRY4
             )
     );

--- a/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
@@ -49,8 +49,8 @@ public class CompressionModule extends AbstractInternalModule {
                     ZipFunction.signatures[2]
             ),
             functionDefs(UnZipFunction.class,
-                    UnZipFunction.signatures[0],
-                    UnZipFunction.signatures[1]
+                    UnZipFunction.FS_UNZIP[0],
+                    UnZipFunction.FS_UNZIP[1]
             ),
             functionDefs(GZipFunction.class,
                     GZipFunction.signatures[0]
@@ -64,8 +64,8 @@ public class CompressionModule extends AbstractInternalModule {
                     TarFunction.signatures[2]
             ),
             functionDefs(UnTarFunction.class,
-                    UnTarFunction.signatures[0],
-                    UnTarFunction.signatures[1]
+                    UnTarFunction.FS_UNTAR[0],
+                    UnTarFunction.FS_UNTAR[1]
             ),
             functionDefs(EntryFunctions.class,
                     EntryFunctions.FS_NO_FILTER[0],

--- a/extensions/modules/src/org/exist/xquery/modules/compression/EntryFunctions.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/EntryFunctions.java
@@ -1,0 +1,330 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2018 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.xquery.modules.compression;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.TransactionException;
+import org.exist.storage.txn.Txn;
+import org.exist.util.LockException;
+import org.exist.util.MimeTable;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Optional;
+
+import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.modules.compression.CompressionModule.functionSignature;
+import static org.exist.xquery.modules.compression.CompressionModule.functionSignatures;
+
+/**
+ * Various Entry helper functions for filtering etc.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class EntryFunctions extends BasicFunction {
+    private final static Logger LOG = LogManager.getLogger(EntryFunctions.class);
+
+    private static final FunctionParameterSequenceType FS_PARAM_PATH = param("path", Type.STRING, "The path of the entry");
+    private static final FunctionParameterSequenceType FS_PARAM_DATA_TYPE = param("data-type", Type.STRING, "The type of the entry, either 'directory' or 'resource'.");
+    private static final FunctionParameterSequenceType FS_PARAM_PARAM = optManyParam("param", Type.ITEM, "One or more parameters.");
+    private static final FunctionParameterSequenceType FS_PARAM_DATA = optParam("data", Type.ITEM, "The data of the entry in the archive");
+    private static final FunctionParameterSequenceType FS_PARAM_FS_DEST_PATH = optParam("destination", Type.STRING, "A path to a directory on the filesystem where the entry should be extracted. If the path does not exist it will be created.");
+    private static final FunctionParameterSequenceType FS_PARAM_DB_DEST_COLLECTION = optParam("destination", Type.STRING, "A path to a Collection in the database where the entry should be extracted. If the Collection does not exist it will be created.");
+
+    private static final String FS_NO_FILTER_NAME = "no-filter";
+    static final FunctionSignature[] FS_NO_FILTER = functionSignatures(
+            FS_NO_FILTER_NAME,
+            "Does not filter any entries.",
+            returns(Type.BOOLEAN, "Always true, so that no entries are filtered. Parameters are ignored."),
+            arities(
+                arity(
+                    FS_PARAM_PATH,
+                    FS_PARAM_DATA_TYPE
+                ),
+                arity(
+                    FS_PARAM_PATH,
+                    FS_PARAM_DATA_TYPE,
+                    FS_PARAM_PARAM
+                )
+            )
+    );
+
+    private static final String FS_FS_STORE_ENTRY_NAME4 = "fs-store-entry4";
+    static final FunctionSignature FS_FS_STORE_ENTRY4 = functionSignature(
+            FS_FS_STORE_ENTRY_NAME4,
+            "Stores an entry to the filesystem. This method is only available to the DBA role. Attempts to guard against exit attacks; If an exit attack is detected then the error `compression:archive-exit-attack is raised`.",
+            returns(Type.FUNCTION_REFERENCE, "A function suitable for passing as the $entry-data#4"),
+            FS_PARAM_FS_DEST_PATH
+    );
+
+    private static final String FS_DB_STORE_ENTRY_NAME4 = "db-store-entry4";
+    static final FunctionSignature FS_DB_STORE_ENTRY4 = functionSignature(
+            FS_DB_STORE_ENTRY_NAME4,
+            "Stores an entry to the database. Attempts to guard against exit attacks; If an exit attack is detected then the error `compression:archive-exit-attack is raised`.",
+            returns(Type.FUNCTION_REFERENCE, "A function suitable for passing as the $entry-data#4"),
+            FS_PARAM_DB_DEST_COLLECTION
+    );
+
+    public EntryFunctions(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        switch (getName().getLocalPart()) {
+
+            case FS_NO_FILTER_NAME:
+                return BooleanValue.TRUE;
+
+            case FS_FS_STORE_ENTRY_NAME4:
+                checkIsDBA();
+                return fsStoreEntry4(args);
+
+            case FS_DB_STORE_ENTRY_NAME4:
+                return dbStoreEntry4(args);
+
+            default:
+                throw new XPathException(this, "No function: " + getName() + "#" + getSignature().getArgumentCount());
+        }
+    }
+
+    private void checkIsDBA() throws XPathException {
+        if(!context.getSubject().hasDbaRole()) {
+            final XPathException xpe = new XPathException(this, "Permission denied, calling user '" + context.getSubject().getName() + "' must be a DBA to call this function.");
+            LOG.error("Invalid user", xpe);
+            throw xpe;
+        }
+    }
+
+    // returns a function reference like: ($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*) as empty-sequence()
+    private FunctionReference fsStoreEntry4(final Sequence[] args) throws XPathException {
+        final Path fsDest = getFile(args[0].itemAt(0).toString());
+        return new FunctionReference(new FunctionCall(context, new StoreFsFunction4(context, fsDest)));
+    }
+
+    // returns a function reference like: ($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*) as empty-sequence()
+    private FunctionReference dbStoreEntry4(final Sequence[] args) throws XPathException {
+        final XmldbURI destCollection = XmldbURI.create(args[0].itemAt(0).toString());
+        return new FunctionReference(new FunctionCall(context, new StoreDbFunction4(context, destCollection)));
+    }
+
+    private static class StoreFsFunction4 extends StoreFsFunction {
+        public StoreFsFunction4(final XQueryContext context, final Path fsDest) {
+            super(context, fsDest, FS_FS_STORE_ENTRY_NAME4 + "-store", FS_PARAM_PATH, FS_PARAM_DATA_TYPE, FS_PARAM_DATA, FS_PARAM_PARAM);
+        }
+    }
+
+    private static class StoreDbFunction4 extends StoreDbFunction {
+        public StoreDbFunction4(final XQueryContext context, final XmldbURI destCollection) {
+            super(context, destCollection, FS_DB_STORE_ENTRY_NAME4 + "-store", FS_PARAM_PATH, FS_PARAM_DATA_TYPE, FS_PARAM_DATA, FS_PARAM_PARAM);
+        }
+    }
+
+    private static abstract class StoreFsFunction extends StoreFunction {
+        private final Path fsDest;
+
+        public StoreFsFunction(final XQueryContext context, final Path fsDest, final String functionName, final FunctionParameterSequenceType... paramTypes) {
+            super(context, functionName, "Stores an entry to the filesystem.", paramTypes);
+            this.fsDest = fsDest;
+        }
+
+        @Override
+        protected void eval(final String path, final DataType dataType, final Optional<Item> data) throws XPathException {
+            final Path destPath = fsDest.resolve(path).normalize();
+
+            if (!destPath.startsWith(fsDest)) {
+                throw new XPathException(this, CompressionModule.ARCHIVE_EXIT_ATTACK, "Detected archive exit attack!");
+            }
+
+            switch (dataType) {
+
+                case resource:
+                    mkdirs(destPath.getParent());
+                    if(data.isPresent()) {
+                        // store the resource
+                        try (final OutputStream os = Files.newOutputStream(destPath, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                            ((BinaryValue)data.get()).streamBinaryTo(os);
+                        } catch (final IOException e) {
+                            throw new XPathException(this, "Cannot serialize file. A problem occurred while serializing the binary data: " + e.getMessage(), e);
+                        }
+                    }
+                    break;
+
+                case directory:
+                    mkdirs(destPath);
+                    break;
+            }
+        }
+
+        /**
+         * Create the directory path if it does not exist.
+         *
+         * @param dir the directory path to create.
+         */
+        private void mkdirs(final Path dir) throws XPathException {
+            try {
+                if (!Files.exists(dir)) {
+                    Files.createDirectories(dir);
+                }
+            } catch (final IOException e) {
+                throw new XPathException(this, "Cannot create directory(s): " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private static abstract class StoreDbFunction extends StoreFunction {
+        private final XmldbURI destCollection;
+
+        public StoreDbFunction(final XQueryContext context, final XmldbURI destCollection, final String functionName, final FunctionParameterSequenceType... paramTypes) {
+            super(context, functionName, "Stores an entry to the filesystem.", paramTypes);
+            this.destCollection = destCollection;
+        }
+
+        @Override
+        protected void eval(final String path, final DataType dataType, final Optional<Item> data) throws XPathException {
+            final XmldbURI destPath = destCollection.resolveCollectionPath(XmldbURI.create(path));
+
+            if (!destPath.startsWith(destCollection)) {
+                throw new XPathException(this, CompressionModule.ARCHIVE_EXIT_ATTACK, "Detected archive exit attack!");
+            }
+
+            switch (dataType) {
+
+                case resource:
+                    mkcols(destPath.removeLastSegment());
+                    if (data.isPresent()) {
+                        // store the resource
+                        Collection collection = null;
+                        try (final Txn transaction = context.getBroker().getBrokerPool().getTransactionManager().beginTransaction()) {
+                            collection = context.getBroker().openCollection(destPath.removeLastSegment(), Lock.LockMode.WRITE_LOCK);
+                            final BinaryValue binaryValue = (BinaryValue)data.get();
+                            final String mediaType = MimeTable.getInstance().getContentTypeFor(destPath.lastSegment()).getName();
+                            try (final InputStream is = binaryValue.getInputStream()) {
+                                collection.addBinaryResource(transaction, context.getBroker(), destPath.lastSegment(), is, mediaType, -1);
+                            }
+                            transaction.commit();
+                        } catch (final IOException | PermissionDeniedException | EXistException | LockException | TriggerException e) {
+                            throw new XPathException(this, "Cannot serialize file. A problem occurred while serializing the binary data: " + e.getMessage(), e);
+                        } finally {
+                            if (collection != null) {
+                                collection.getLock().release(Lock.LockMode.WRITE_LOCK);
+                            }
+                        }
+                    }
+                    break;
+
+                case directory:
+                    mkcols(destPath);
+                    break;
+            }
+        }
+
+        /**
+         * Create the Collection path if it does not exist.
+         *
+         * @param collection The collection path to create.
+         */
+        private void mkcols(final XmldbURI collection) throws XPathException {
+            try (final Txn transaction = context.getBroker().getBrokerPool().getTransactionManager().beginTransaction()) {
+                context.getBroker().getOrCreateCollection(transaction, collection);
+                transaction.commit();
+            } catch (final IOException | PermissionDeniedException | TriggerException | TransactionException e) {
+                throw new XPathException(this, "Cannot create Collection(s): " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private static abstract class StoreFunction extends UserDefinedFunction {
+        public StoreFunction(final XQueryContext context, final String functionName, final String description, final FunctionParameterSequenceType... paramTypes) {
+            super(context, functionSignature(functionName, description, returnsNothing(), paramTypes));
+        }
+
+        @Override
+        public void accept(final ExpressionVisitor visitor) {
+            if (visited) {
+                return;
+            }
+            visited = true;
+        }
+
+        @Override
+        public final Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+            final Sequence arg1 = getCurrentArguments()[0];
+            final String path = arg1.itemAt(0).getStringValue();
+
+            final Sequence arg2 = getCurrentArguments()[1];
+            final String dataType = arg2.itemAt(0).getStringValue();
+
+            final Sequence dataSeq = getCurrentArguments()[2];
+            final Optional<Item> data;
+            if(!dataSeq.isEmpty()) {
+                data = Optional.of(dataSeq.itemAt(0));
+            } else {
+                data = Optional.empty();
+            }
+
+            eval(path, DataType.valueOf(dataType), data);
+
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        protected abstract void eval(final String path, final DataType dataType, final Optional<Item> data) throws XPathException;
+    }
+
+    private enum DataType {
+        resource,
+        directory
+    }
+
+    /**
+     *  Convert path (URL, file path) to a File object.
+     *
+     * @param path Path written as OS specific path or as URL
+     * @return File object
+     * @throws XPathException Thrown when the URL cannot be used.
+     */
+    public static Path getFile(final String path) throws XPathException {
+        if(path.startsWith("file:")){
+            try {
+                return Paths.get(new URI(path));
+            } catch (Exception ex) { // catch all (URISyntaxException)
+                throw new XPathException(path + " is not a valid URI: '"+ ex.getMessage() +"'");
+            }
+        } else {
+            return Paths.get(path);
+        }
+    }
+}

--- a/extensions/modules/src/org/exist/xquery/modules/compression/UnTarFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/UnTarFunction.java
@@ -60,14 +60,19 @@ public class UnTarFunction extends AbstractExtractFunction {
                 		"user:untar-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. " +
                 		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, " +
                 		"for example a list of extracted files. If the return type is true() it indicates the entry " +
-                		"should be processed and passed to the entry-data function, else the resource is skipped."),
+                		"should be processed and passed to the entry-data function, else the resource is skipped. " +
+                        "If you wish to extract all resources you can use the provided compression:no-filter#3 function."
+                ),
                 new FunctionParameterSequenceType("entry-filter-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for filtering function."),
                 new FunctionParameterSequenceType("entry-data", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
                 		"A user defined function for storing an extracted resource from the tar file. The function takes 4 parameters e.g. " +
                 		"user:untar-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). " +
                 		"Or a user defined function wich returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. " +
                 		"user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. " +
-                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters"),
+                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters" +
+                        "Functions for storing the entries to a folder on the filesystem or a collection in the database " +
+                        "provided by compression:fs-store-entry4($dest) and compression:db-store-entry4($dest)."
+                ),
                 new FunctionParameterSequenceType("entry-data-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for storing function."),
             },
             new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
@@ -84,14 +89,19 @@ public class UnTarFunction extends AbstractExtractFunction {
                 		"user:untar-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. " +
                 		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, " +
                 		"for example a list of extracted files. If the return type is true() it indicates the entry " +
-                		"should be processed and passed to the entry-data function, else the resource is skipped."),
+                		"should be processed and passed to the entry-data function, else the resource is skipped. " +
+                        "If you wish to extract all resources you can use the provided compression:no-filter#3 function."
+                ),
                 new FunctionParameterSequenceType("entry-filter-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for filtering function."),
                 new FunctionParameterSequenceType("entry-data", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
                 		"A user defined function for storing an extracted resource from the tar file. The function takes 4 parameters e.g. " +
                 		"user:untar-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). " +
                 		"Or a user defined function wich returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. " +
                 		"user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. " +
-                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters"),
+                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters" +
+                        "Functions for storing the entries to a folder on the filesystem or a collection in the database " +
+                        "provided by compression:fs-store-entry4($dest) and compression:db-store-entry4($dest)."
+                ),
                 new FunctionParameterSequenceType("entry-data-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for storing function."),
 				new FunctionParameterSequenceType("encoding", Type.STRING, Cardinality.EXACTLY_ONE, "The encoding to be used during uncompressing eg: UTF8 or Cp437 from https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html"),
             },

--- a/extensions/modules/src/org/exist/xquery/modules/compression/UnTarFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/UnTarFunction.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-09 The eXist Project
+ *  Copyright (C) 2001-2018 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -16,8 +16,6 @@
  *  You should have received a copy of the GNU Lesser General Public
  *  License along with this library; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- * $Id$
  */
 package org.exist.xquery.modules.compression;
 
@@ -27,18 +25,18 @@ import java.nio.charset.Charset;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 
-import org.exist.dom.QName;
-import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.BinaryValue;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 import org.xmldb.api.base.XMLDBException;
+
+import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.modules.compression.CompressionModule.functionSignatures;
 
 /**
  * Extracts files and folders from a Tar file
@@ -48,75 +46,58 @@ import org.xmldb.api.base.XMLDBException;
  */
 public class UnTarFunction extends AbstractExtractFunction {
 
-   public final static FunctionSignature signatures[] = {
-        new FunctionSignature(
-            new QName("untar", CompressionModule.NAMESPACE_URI, CompressionModule.PREFIX),
-            "UnTar all the resources/folders from the provided data by calling user defined functions " +
-            "to determine what and how to store the resources/folders",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("tar-data", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The tar file data"),
-                new FunctionParameterSequenceType("entry-filter", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
-                		"A user defined function for filtering resources from the tar file. The function takes 3 parameters e.g. " +
-                		"user:untar-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. " +
-                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, " +
-                		"for example a list of extracted files. If the return type is true() it indicates the entry " +
-                		"should be processed and passed to the entry-data function, else the resource is skipped. " +
-                        "If you wish to extract all resources you can use the provided compression:no-filter#3 function."
-                ),
-                new FunctionParameterSequenceType("entry-filter-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for filtering function."),
-                new FunctionParameterSequenceType("entry-data", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
-                		"A user defined function for storing an extracted resource from the tar file. The function takes 4 parameters e.g. " +
-                		"user:untar-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). " +
-                		"Or a user defined function wich returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. " +
-                		"user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. " +
-                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters" +
-                        "Functions for storing the entries to a folder on the filesystem or a collection in the database " +
-                        "provided by compression:fs-store-entry4($dest) and compression:db-store-entry4($dest)."
-                ),
-                new FunctionParameterSequenceType("entry-data-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for storing function."),
-            },
-            new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
-        ),
-		
-        new FunctionSignature(
-            new QName("untar", CompressionModule.NAMESPACE_URI, CompressionModule.PREFIX),
-            "UnTar all the resources/folders from the provided data by calling user defined functions " +
-            "to determine what and how to store the resources/folders",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("tar-data", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The tar file data"),
-                new FunctionParameterSequenceType("entry-filter", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
-                		"A user defined function for filtering resources from the tar file. The function takes 3 parameters e.g. " +
-                		"user:untar-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. " +
-                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, " +
-                		"for example a list of extracted files. If the return type is true() it indicates the entry " +
-                		"should be processed and passed to the entry-data function, else the resource is skipped. " +
-                        "If you wish to extract all resources you can use the provided compression:no-filter#3 function."
-                ),
-                new FunctionParameterSequenceType("entry-filter-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for filtering function."),
-                new FunctionParameterSequenceType("entry-data", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
-                		"A user defined function for storing an extracted resource from the tar file. The function takes 4 parameters e.g. " +
-                		"user:untar-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). " +
-                		"Or a user defined function wich returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. " +
-                		"user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. " +
-                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters" +
-                        "Functions for storing the entries to a folder on the filesystem or a collection in the database " +
-                        "provided by compression:fs-store-entry4($dest) and compression:db-store-entry4($dest)."
-                ),
-                new FunctionParameterSequenceType("entry-data-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for storing function."),
-				new FunctionParameterSequenceType("encoding", Type.STRING, Cardinality.EXACTLY_ONE, "The encoding to be used during uncompressing eg: UTF8 or Cp437 from https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html"),
-            },
-            new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
-        )
-    };
+    private static final FunctionParameterSequenceType FS_PARAM_TAR_DATA = param("tar-data", Type.BASE64_BINARY, "The tar file data");
+    private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER = param("entry-filter", Type.FUNCTION_REFERENCE,
+            "A user defined function for filtering resources from the tar file. The function takes 3 parameters e.g. "
+            + "user:untar-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. "
+            + "$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, "
+            + "for example a list of extracted files. If the return type is true() it indicates the entry "
+            + "should be processed and passed to the entry-data function, else the resource is skipped. "
+            + "If you wish to extract all resources you can use the provided compression:no-filter#3 function."
+    );
+    private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER_PARAM = optManyParam("entry-filter-param", Type.ANY_TYPE, "A sequence with an additional parameters for filtering function.");
+    private static final FunctionParameterSequenceType FS_PARAM_ENTRY_DATA = param("entry-data", Type.FUNCTION_REFERENCE,
+            "A user defined function for storing an extracted resource from the tar file. The function takes 4 parameters e.g. "
+            + "user:untar-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). "
+            + "Or a user defined function wich returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. "
+            + "user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. "
+            + "$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters"
+            + "Functions for storing the entries to a folder on the filesystem or a collection in the database "
+            + "provided by compression:fs-store-entry4($dest) and compression:db-store-entry4($dest)."
+    );
+    private static final FunctionParameterSequenceType FS_PARAM_ENTRY_DATA_PARAM = optManyParam("entry-data-param", Type.ANY_TYPE, "A sequence with an additional parameters for storing function.");
 
-    public UnTarFunction(XQueryContext context, FunctionSignature signature)
-    {
+
+    private static final String FS_UNTAR_NAME = "untar";
+    static final FunctionSignature[] FS_UNTAR = functionSignatures(
+            FS_UNTAR_NAME,
+            "UnTar all the resources/folders from the provided data by calling user defined functions to determine what and how to store the resources/folders",
+            returnsOptMany(Type.ITEM),
+            arities(
+                arity(
+                    FS_PARAM_TAR_DATA,
+                    FS_PARAM_ENTRY_FILTER,
+                    FS_PARAM_ENTRY_FILTER_PARAM,
+                    FS_PARAM_ENTRY_DATA,
+                    FS_PARAM_ENTRY_DATA_PARAM
+                ),
+                arity(
+                    FS_PARAM_TAR_DATA,
+                    FS_PARAM_ENTRY_FILTER,
+                    FS_PARAM_ENTRY_FILTER_PARAM,
+                    FS_PARAM_ENTRY_DATA,
+                    FS_PARAM_ENTRY_DATA_PARAM,
+                    param("encoding", Type.STRING, "The encoding to be used during uncompressing eg: UTF8 or Cp437 from https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html")
+                )
+            )
+    );
+
+    public UnTarFunction(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 	
     @Override
-    protected Sequence processCompressedData(final BinaryValue compressedData, final Charset encoding) throws XPathException, XMLDBException
-    {
+    protected Sequence processCompressedData(final BinaryValue compressedData, final Charset encoding) throws XPathException, XMLDBException {
         try(final TarArchiveInputStream tis = new TarArchiveInputStream(compressedData.getInputStream(), encoding.name())) {
 
             TarArchiveEntry entry = null;

--- a/extensions/modules/src/org/exist/xquery/modules/compression/UnTarFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/UnTarFunction.java
@@ -48,6 +48,13 @@ public class UnTarFunction extends AbstractExtractFunction {
 
     private static final FunctionParameterSequenceType FS_PARAM_TAR_DATA = param("tar-data", Type.BASE64_BINARY, "The tar file data");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER = param("entry-filter", Type.FUNCTION_REFERENCE,
+            "A user defined function for filtering resources from the tar file. The function takes 2 parameters e.g. "
+            + "user:untar-entry-filter($path as xs:string, $data-type as xs:string) as xs:boolean. "
+            + "$data-type may be 'resource' or 'folder'. If the return type is true() it indicates the entry "
+            + "should be processed and passed to the entry-data function, else the resource is skipped. "
+            + "If you wish to extract all resources you can use the provided compression:no-filter#2 function."
+    );
+    private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER_WITH_PARAMS = param("entry-filter", Type.FUNCTION_REFERENCE,
             "A user defined function for filtering resources from the tar file. The function takes 3 parameters e.g. "
             + "user:untar-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. "
             + "$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, "
@@ -57,9 +64,17 @@ public class UnTarFunction extends AbstractExtractFunction {
     );
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER_PARAM = optManyParam("entry-filter-param", Type.ANY_TYPE, "A sequence with an additional parameters for filtering function.");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_DATA = param("entry-data", Type.FUNCTION_REFERENCE,
+            "A user defined function for storing an extracted resource from the tar file. The function takes 3 parameters e.g. "
+            + "user:untar-entry-data($path as xs:string, $data-type as xs:string, $data as item()?). "
+            + "Or a user defined function which returns a db path for storing an extracted resource from the tar file. "
+            + "The function takes 3 parameters e.g. user:entry-path($path as xs:string, $data-type as xs:string, "
+            + "$param as item()*) as xs:anyURI. $data-type may be 'resource' or 'folder'. "
+            + "Functions for storing the entries to a folder on the filesystem or a collection in the database "
+            + "provided by compression:fs-store-entry3($dest) and compression:db-store-entry3($dest).");
+    private static final FunctionParameterSequenceType FS_PARAM_ENTRY_DATA_WITH_PARAMS = param("entry-data", Type.FUNCTION_REFERENCE,
             "A user defined function for storing an extracted resource from the tar file. The function takes 4 parameters e.g. "
             + "user:untar-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). "
-            + "Or a user defined function wich returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. "
+            + "Or a user defined function which returns a db path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. "
             + "user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. "
             + "$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters"
             + "Functions for storing the entries to a folder on the filesystem or a collection in the database "
@@ -77,15 +92,20 @@ public class UnTarFunction extends AbstractExtractFunction {
                 arity(
                     FS_PARAM_TAR_DATA,
                     FS_PARAM_ENTRY_FILTER,
+                    FS_PARAM_ENTRY_DATA
+                ),
+                arity(
+                    FS_PARAM_TAR_DATA,
+                    FS_PARAM_ENTRY_FILTER_WITH_PARAMS,
                     FS_PARAM_ENTRY_FILTER_PARAM,
-                    FS_PARAM_ENTRY_DATA,
+                    FS_PARAM_ENTRY_DATA_WITH_PARAMS,
                     FS_PARAM_ENTRY_DATA_PARAM
                 ),
                 arity(
                     FS_PARAM_TAR_DATA,
-                    FS_PARAM_ENTRY_FILTER,
+                    FS_PARAM_ENTRY_FILTER_WITH_PARAMS,
                     FS_PARAM_ENTRY_FILTER_PARAM,
-                    FS_PARAM_ENTRY_DATA,
+                    FS_PARAM_ENTRY_DATA_WITH_PARAMS,
                     FS_PARAM_ENTRY_DATA_PARAM,
                     param("encoding", Type.STRING, "The encoding to be used during uncompressing eg: UTF8 or Cp437 from https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html")
                 )

--- a/extensions/modules/src/org/exist/xquery/modules/compression/UnZipFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/UnZipFunction.java
@@ -46,17 +46,31 @@ public class UnZipFunction extends AbstractExtractFunction {
 
     private static final FunctionParameterSequenceType FS_PARAM_ZIP_DATA = param("zip-data", Type.BASE64_BINARY,"The zip file data");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER = param("entry-filter", Type.FUNCTION_REFERENCE,
+            "A user defined function for filtering resources from the zip file. The function takes 2 parameters e.g. "
+            + "user:unzip-entry-filter($path as xs:string, $data-type as xs:string) as xs:boolean. "
+            + "$data-type may be 'resource' or 'folder'. If the return type is true() it indicates the entry "
+            + "should be processed and passed to the $entry-data function, else the resource is skipped. "
+            + "If you wish to extract all resources you can use the provided compression:no-filter#2 function.");
+    private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER_WITH_PARAMS = param("entry-filter", Type.FUNCTION_REFERENCE,
             "A user defined function for filtering resources from the zip file. The function takes 3 parameters e.g. "
             + "user:unzip-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. "
             + "$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, "
             + "for example a list of extracted files. If the return type is true() it indicates the entry "
-            + "should be processed and passed to the entry-data function, else the resource is skipped. "
+            + "should be processed and passed to the $entry-data function, else the resource is skipped. "
             + "If you wish to extract all resources you can use the provided compression:no-filter#3 function.");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_FILTER_PARAM = optManyParam("entry-filter-param", Type.ANY_TYPE, "A sequence with an additional parameters for filtering function.");
     private static final FunctionParameterSequenceType FS_PARAM_ENTRY_DATA = param("entry-data", Type.FUNCTION_REFERENCE,
+            "A user defined function for storing an extracted resource from the zip file. The function takes 3 parameters e.g. "
+            + "user:unzip-entry-data($path as xs:string, $data-type as xs:string, $data as item()?). "
+            + "Or a user defined function which returns a db path for storing an extracted resource from the zip file. "
+            + "The function takes 3 parameters e.g. user:entry-path($path as xs:string, $data-type as xs:string, "
+            + "$param as item()*) as xs:anyURI. $data-type may be 'resource' or 'folder'. "
+            + "Functions for storing the entries to a folder on the filesystem or a collection in the database "
+            + "provided by compression:fs-store-entry3($dest) and compression:db-store-entry3($dest).");
+    private static final FunctionParameterSequenceType FS_PARAM_ENTRY_DATA_WITH_PARAMS = param("entry-data", Type.FUNCTION_REFERENCE,
             "A user defined function for storing an extracted resource from the zip file. The function takes 4 parameters e.g. "
             + "user:unzip-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). "
-            + "Or a user defined function which returns path for storing an extracted resource from the zip file. The function takes 3 parameters e.g. "
+            + "Or a user defined function which returns a db path for storing an extracted resource from the zip file. The function takes 3 parameters e.g. "
             + "user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. "
             + "$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters. "
             + "Functions for storing the entries to a folder on the filesystem or a collection in the database "
@@ -73,15 +87,20 @@ public class UnZipFunction extends AbstractExtractFunction {
                 arity(
                     FS_PARAM_ZIP_DATA,
                     FS_PARAM_ENTRY_FILTER,
+                    FS_PARAM_ENTRY_DATA
+                ),
+                arity(
+                    FS_PARAM_ZIP_DATA,
+                    FS_PARAM_ENTRY_FILTER_WITH_PARAMS,
                     FS_PARAM_ENTRY_FILTER_PARAM,
-                    FS_PARAM_ENTRY_DATA,
+                    FS_PARAM_ENTRY_DATA_WITH_PARAMS,
                     FS_PARAM_ENTRY_DATA_PARAM
                 ),
                 arity(
                     FS_PARAM_ZIP_DATA,
-                    FS_PARAM_ENTRY_FILTER,
+                    FS_PARAM_ENTRY_FILTER_WITH_PARAMS,
                     FS_PARAM_ENTRY_FILTER_PARAM,
-                    FS_PARAM_ENTRY_DATA,
+                    FS_PARAM_ENTRY_DATA_WITH_PARAMS,
                     FS_PARAM_ENTRY_DATA_PARAM,
                     param("encoding", Type.STRING, "The encoding to be used during uncompressing eg: UTF8 or Cp437 from https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html")
                 )

--- a/extensions/modules/src/org/exist/xquery/modules/compression/UnZipFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/UnZipFunction.java
@@ -64,7 +64,7 @@ public class UnZipFunction extends AbstractExtractFunction {
                 new FunctionParameterSequenceType("entry-data", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
                 		"A user defined function for storing an extracted resource from the zip file. The function takes 4 parameters e.g. " +
                 		"user:unzip-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). " +
-                		"Or a user defined function which returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. " +
+                		"Or a user defined function which returns path for storing an extracted resource from the zip file. The function takes 3 parameters e.g. " +
                 		"user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. " +
                 		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters. " +
                         "Functions for storing the entries to a folder on the filesystem or a collection in the database " +
@@ -93,7 +93,7 @@ public class UnZipFunction extends AbstractExtractFunction {
                 new FunctionParameterSequenceType("entry-data", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
                 		"A user defined function for storing an extracted resource from the zip file. The function takes 4 parameters e.g. " +
                 		"user:unzip-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). " +
-                		"Or a user defined function which returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. " +
+                		"Or a user defined function which returns path for storing an extracted resource from the zip file. The function takes 3 parameters e.g. " +
                 		"user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. " +
                 		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters." +
                         "Functions for storing the entries to a folder on the filesystem or a collection in the database " +

--- a/extensions/modules/src/org/exist/xquery/modules/compression/UnZipFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/UnZipFunction.java
@@ -58,14 +58,18 @@ public class UnZipFunction extends AbstractExtractFunction {
                 		"user:unzip-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. " +
                 		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, " +
                 		"for example a list of extracted files. If the return type is true() it indicates the entry " +
-                		"should be processed and passed to the entry-data function, else the resource is skipped."),
+                		"should be processed and passed to the entry-data function, else the resource is skipped. " +
+                        "If you wish to extract all resources you can use the provided compression:no-filter#3 function."),
                 new FunctionParameterSequenceType("entry-filter-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for filtering function."),
                 new FunctionParameterSequenceType("entry-data", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
                 		"A user defined function for storing an extracted resource from the zip file. The function takes 4 parameters e.g. " +
                 		"user:unzip-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). " +
                 		"Or a user defined function which returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. " +
                 		"user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. " +
-                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters."),
+                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters. " +
+                        "Functions for storing the entries to a folder on the filesystem or a collection in the database " +
+                        "provided by compression:fs-store-entry4($dest) and compression:db-store-entry4($dest)."
+                ),
                 new FunctionParameterSequenceType("entry-data-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for storing function."),
             },
             new SequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE)
@@ -82,14 +86,19 @@ public class UnZipFunction extends AbstractExtractFunction {
                 		"user:unzip-entry-filter($path as xs:string, $data-type as xs:string, $param as item()*) as xs:boolean. " +
                 		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters, " +
                 		"for example a list of extracted files. If the return type is true() it indicates the entry " +
-                		"should be processed and passed to the entry-data function, else the resource is skipped."),
+                		"should be processed and passed to the entry-data function, else the resource is skipped. " +
+                        "If you wish to extract all resources you can use the provided compression:no-filter#3 function."
+                ),
                 new FunctionParameterSequenceType("entry-filter-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for filtering function."),
                 new FunctionParameterSequenceType("entry-data", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
                 		"A user defined function for storing an extracted resource from the zip file. The function takes 4 parameters e.g. " +
                 		"user:unzip-entry-data($path as xs:string, $data-type as xs:string, $data as item()?, $param as item()*). " +
                 		"Or a user defined function which returns path for storing an extracted resource from the tar file. The function takes 3 parameters e.g. " +
                 		"user:entry-path($path as xs:string, $data-type as xs:string, $param as item()*) as xs:anyURI. " +
-                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters."),
+                		"$data-type may be 'resource' or 'folder'. $param is a sequence with any additional parameters." +
+                        "Functions for storing the entries to a folder on the filesystem or a collection in the database " +
+                        "provided by compression:fs-store-entry4($dest) and compression:db-store-entry4($dest)."
+                ),
                 new FunctionParameterSequenceType("entry-data-param", Type.ANY_TYPE, Cardinality.ZERO_OR_MORE, "A sequence with an additional parameters for storing function."),
 				new FunctionParameterSequenceType("encoding", Type.STRING, Cardinality.EXACTLY_ONE, "The encoding to be used during uncompressing eg: UTF8 or Cp437 from https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html"),
             },

--- a/extensions/modules/src/org/exist/xquery/modules/file/DirectoryCreate.java
+++ b/extensions/modules/src/org/exist/xquery/modules/file/DirectoryCreate.java
@@ -22,6 +22,7 @@
 package org.exist.xquery.modules.file;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
@@ -103,9 +104,12 @@ public class DirectoryCreate extends BasicFunction {
                 Files.createDirectories(file);
                 created = BooleanValue.TRUE;
             }
-            return created;
-        } catch(final IOException ioe) {
-            throw new XPathException(this, ioe);
+        } catch (final FileAlreadyExistsException e) {
+            created = BooleanValue.FALSE;
+        } catch(final IOException e) {
+            throw new XPathException(this, e);
         }
+
+        return created;
     }
 }

--- a/src/org/exist/backup/ZipArchiveBackupDescriptor.java
+++ b/src/org/exist/backup/ZipArchiveBackupDescriptor.java
@@ -85,6 +85,10 @@ public class ZipArchiveBackupDescriptor extends AbstractBackupDescriptor {
         if (descriptor == null) {
             throw new FileNotFoundException("Archive " + fileArchive.toAbsolutePath().toString() + " is not a valid eXist backup archive");
         }
+
+        if ((!base.startsWith("db/")) || (!Paths.get(base).normalize().startsWith(Paths.get("db/")))) {
+            throw new IOException("Detected archive exit attack! zipFile=" + fileArchive.toAbsolutePath().normalize().toString());
+        }
     }
 
 

--- a/src/org/exist/repo/RepoBackup.java
+++ b/src/org/exist/repo/RepoBackup.java
@@ -86,19 +86,23 @@ public class RepoBackup {
      * @param outdir Output directory
      */
     public static void unzip(final Path zipfile, final Path outdir) throws IOException {
-        try(final ZipInputStream zin = new ZipInputStream(Files.newInputStream(zipfile))) {
+        try (final ZipInputStream zin = new ZipInputStream(Files.newInputStream(zipfile))) {
             ZipEntry entry;
-            String name, dir;
-            while ((entry = zin.getNextEntry()) != null)
-            {
-                name = entry.getName();
-                if(entry.isDirectory() ) {
+            while ((entry = zin.getNextEntry()) != null) {
+                final String name = entry.getName();
+                final Path out = outdir.resolve(name);
+
+                if (!out.startsWith(outdir)) {
+                    throw new IOException("Detected archive exit attack! zipFile=" + zipfile.toAbsolutePath().normalize().toString() + ", entry=" + name + ", outdir=" + outdir.toAbsolutePath().normalize().toString());
+                }
+
+                if (entry.isDirectory() ) {
                     Files.createDirectories(outdir.resolve(name));
                     continue;
                 }
 
-                dir = dirpart(name);
-                if(dir != null) {
+                final String dir = dirpart(name);
+                if (dir != null) {
                     Files.createDirectories(outdir.resolve(name));
                 }
 

--- a/src/org/exist/util/Compressor.java
+++ b/src/org/exist/util/Compressor.java
@@ -81,8 +81,7 @@ public class Compressor {
     throws IOException {
         try (final FastByteArrayInputStream bais = new FastByteArrayInputStream(whatToUncompress);
              final ZipInputStream gzis = new ZipInputStream(bais)) {
-            final ZipEntry zipentry = gzis.getNextEntry();
-            Integer.parseInt(zipentry.getName());
+            gzis.getNextEntry();    // move to the first entry in the zip stream!
             final byte[] buf = new byte[512];
             int bread;
             while ((bread = gzis.read(buf)) != -1)


### PR DESCRIPTION
Firstly I would like to thank the "**[Snyk Security Research Team](http://snyk.io)**" for reporting this issue to us. They provided both the insight to the problem and details of a suggested fix.

This PR also adds some additional functions to the Compression Module:

1. `compression:no-filter#2` and `compression:no-filter#3`. These functions can be used when the user does not want to filter anything from the archive they are uncompressing.

2. `compression:fs-store-entry3#1`, `compression:fs-store-entry4#1`, `compression:fs-store-entry3#1`, and `compression:db-store-entry4#1`. These functions can be used when the user wants to write the entries in the archive to either the filesystem or the database. Both of these functions offer in-built protection against the archive exit attack.

3. `compression:unzip#3` and `compression:untar3`, which are simplified versions of the existing unzip and untar functions for the most common use-cases.

**NOTE** users should be very careful when writing their own `$entry-data` functions for `compression:unzip` or `compression:untar` if they are writing the file entries to persistent storage using the name of the entry from the archive; Consideration should be given to employing further exit attack protections of their own.