### PR TITLE
Small improvements to XML:DB Remote Collection

### DIFF
--- a/src/org/exist/xmldb/RemoteCollection.java
+++ b/src/org/exist/xmldb/RemoteCollection.java
@@ -596,7 +596,16 @@ public class RemoteCollection extends AbstractRemote implements EXistCollection 
                 }
             }
 
-            final byte[] chunk = new byte[MAX_UPLOAD_CHUNK];
+            final byte[] chunk;
+            if (res instanceof ExtendedResource) {
+                if(res instanceof AbstractRemoteResource) {
+                    chunk = new byte[(int)Math.min(((AbstractRemoteResource)res).getContentLength(), MAX_UPLOAD_CHUNK)];
+                } else {
+                    chunk = new byte[(int)Math.min(((ExtendedResource)res).getStreamLength(), MAX_UPLOAD_CHUNK)];
+                }
+            } else {
+                chunk = new byte[MAX_UPLOAD_CHUNK];
+            }
             try {
                 int len;
                 String fileName = null;


### PR DESCRIPTION
1. Don't allocate an entire chunk of memory if we know we won't use it all.
2. Don't compress chunks which are so small, the compression overhead would result in a larger chunk overall.