### PR TITLE
Memory leak in higher-order functions

### DIFF
--- a/extensions/indexes/range/src/org/exist/xquery/modules/range/IndexKeys.java
+++ b/extensions/indexes/range/src/org/exist/xquery/modules/range/IndexKeys.java
@@ -54,30 +54,31 @@ public class IndexKeys extends BasicFunction {
         if (args.length == 4) {
             start = args[arg++].getStringValue();
         }
-        final FunctionReference ref = (FunctionReference) args[arg++].itemAt(0);
-        int max = -1;
-        if (!args[arg].isEmpty()) {
-            max = ((IntegerValue)args[arg].itemAt(0)).getInt();
-        }
+        try (final FunctionReference ref = (FunctionReference) args[arg++].itemAt(0)) {
+            int max = -1;
+            if (!args[arg].isEmpty()) {
+                max = ((IntegerValue) args[arg].itemAt(0)).getInt();
+            }
 
-        final Sequence result = new ValueSequence();
-        final RangeIndexWorker worker = (RangeIndexWorker) context.getBroker().getIndexController().getWorkerByIndexName("range-index");
-        Occurrences[] occur = worker.scanIndexByField(field, contextSequence == null ? context.getStaticallyKnownDocuments() : contextSequence.getDocumentSet(), start, max);
-        final int len = (max != -1 && occur.length > max ? max : occur.length);
-        final Sequence params[] = new Sequence[2];
-        ValueSequence data = new ValueSequence();
-        for (int j = 0; j < len; j++) {
-            params[0] = new StringValue(occur[j].getTerm().toString());
-            data.add(new IntegerValue(occur[j].getOccurrences(),
-                    Type.UNSIGNED_INT));
-            data.add(new IntegerValue(occur[j].getDocuments(),
-                    Type.UNSIGNED_INT));
-            data.add(new IntegerValue(j + 1, Type.UNSIGNED_INT));
-            params[1] = data;
+            final Sequence result = new ValueSequence();
+            final RangeIndexWorker worker = (RangeIndexWorker) context.getBroker().getIndexController().getWorkerByIndexName("range-index");
+            Occurrences[] occur = worker.scanIndexByField(field, contextSequence == null ? context.getStaticallyKnownDocuments() : contextSequence.getDocumentSet(), start, max);
+            final int len = (max != -1 && occur.length > max ? max : occur.length);
+            final Sequence params[] = new Sequence[2];
+            ValueSequence data = new ValueSequence();
+            for (int j = 0; j < len; j++) {
+                params[0] = new StringValue(occur[j].getTerm().toString());
+                data.add(new IntegerValue(occur[j].getOccurrences(),
+                        Type.UNSIGNED_INT));
+                data.add(new IntegerValue(occur[j].getDocuments(),
+                        Type.UNSIGNED_INT));
+                data.add(new IntegerValue(j + 1, Type.UNSIGNED_INT));
+                params[1] = data;
 
-            result.addAll(ref.evalFunction(Sequence.EMPTY_SEQUENCE, null, params));
-            data.clear();
+                result.addAll(ref.evalFunction(Sequence.EMPTY_SEQUENCE, null, params));
+                data.clear();
+            }
+            return result;
         }
-        return result;
     }
 }

--- a/extensions/modules/src/org/exist/xquery/modules/compression/AbstractExtractFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/AbstractExtractFunction.java
@@ -85,7 +85,7 @@ public abstract class AbstractExtractFunction extends BasicFunction
             throw new XPathException("entry-filter function must take at least 3 arguments.");
 
         filterParam = args[2];
-        
+
         //get the entry-data function and check its types
         if(!(args[3].itemAt(0) instanceof FunctionReference))
             throw new XPathException("No entry-data function provided.");
@@ -109,7 +109,10 @@ public abstract class AbstractExtractFunction extends BasicFunction
             return processCompressedData(compressedData, encoding);
         } catch(final UnsupportedCharsetException | XMLDBException e) {
             throw new XPathException(this, e.getMessage(), e);
-		}
+		} finally {
+            entryDataFunction.close();
+            entryFilterFunction.close();
+        }
     }
 
     /**

--- a/extensions/modules/src/org/exist/xquery/modules/persistentlogin/PersistentLoginFunctions.java
+++ b/extensions/modules/src/org/exist/xquery/modules/persistentlogin/PersistentLoginFunctions.java
@@ -84,7 +84,13 @@ public class PersistentLoginFunctions extends UserSwitchingBasicFunction {
             } else {
                 callback = null;
             }
-            return register(user, pass, timeToLive, callback);
+            try {
+                return register(user, pass, timeToLive, callback);
+            } finally {
+                if (callback != null) {
+                    callback.close();
+                }
+            }
         } else if (isCalledAs("login")) {
             final String token = args[0].getStringValue();
             final FunctionReference callback;
@@ -93,7 +99,13 @@ public class PersistentLoginFunctions extends UserSwitchingBasicFunction {
             } else {
                 callback = null;
             }
-            return authenticate(token, callback);
+            try {
+                return authenticate(token, callback);
+            } finally {
+                if (callback != null) {
+                    callback.close();
+                }
+            }
         } else {
             PersistentLogin.getInstance().invalidate(args[0].getStringValue());
             return Sequence.EMPTY_SEQUENCE;

--- a/src/org/exist/xquery/ArrowOperator.java
+++ b/src/org/exist/xquery/ArrowOperator.java
@@ -109,18 +109,20 @@ public class ArrowOperator extends AbstractExpression {
             }
             fref = (FunctionReference)item0;
         }
-        final List<Expression> fparams = new ArrayList<>(parameters.size() + 1);
-        fparams.add(new ContextParam(context, contextSequence));
-        fparams.addAll(parameters);
+        try {
+            final List<Expression> fparams = new ArrayList<>(parameters.size() + 1);
+            fparams.add(new ContextParam(context, contextSequence));
+            fparams.addAll(parameters);
 
-        fref.setArguments(fparams);
-        // need to create a new AnalyzeContextInfo to avoid memory leak
-        // cachedContextInfo will stay in memory
-        fref.analyze(new AnalyzeContextInfo(cachedContextInfo));
-        // Evaluate the function
-        final Sequence result = fref.eval(contextSequence);
-        fref.resetState(false);
-        return result;
+            fref.setArguments(fparams);
+            // need to create a new AnalyzeContextInfo to avoid memory leak
+            // cachedContextInfo will stay in memory
+            fref.analyze(new AnalyzeContextInfo(cachedContextInfo));
+            // Evaluate the function
+            return fref.eval(contextSequence);
+        } finally {
+            fref.close();
+        }
     }
 
     @Override

--- a/src/org/exist/xquery/DynamicFunctionCall.java
+++ b/src/org/exist/xquery/DynamicFunctionCall.java
@@ -73,14 +73,14 @@ public class DynamicFunctionCall extends AbstractExpression {
 	        ref.analyze(new AnalyzeContextInfo(cachedContextInfo));
 	        // Evaluate the function
             try {
-                final Sequence result = ref.eval(contextSequence);
-                ref.resetState(false);
-                return result;
+                return ref.eval(contextSequence);
             } catch (XPathException e) {
                 if (e.getLine() <= 0) {
                     e.setLocation(getLine(), getColumn(), getSource());
                 }
                 throw e;
+            } finally {
+                ref.close();
             }
         }
     }

--- a/src/org/exist/xquery/InlineFunction.java
+++ b/src/org/exist/xquery/InlineFunction.java
@@ -96,10 +96,6 @@ public class InlineFunction extends AbstractExpression {
     @Override
     public void resetState(boolean postOptimization) {
         super.resetState(postOptimization);
-        // clear closure variables set on inline function
-		if (!postOptimization) {
-			calls.forEach(call -> call.getFunction().setClosureVariables(null));
-		}
         calls.clear();
         function.resetState(postOptimization);
     }

--- a/src/org/exist/xquery/UserDefinedFunction.java
+++ b/src/org/exist/xquery/UserDefinedFunction.java
@@ -278,6 +278,10 @@ public class UserDefinedFunction extends Function implements Cloneable {
     
     public void setClosureVariables(List<ClosureVariable> vars) {
     	this.closureVariables = vars;
+    	if (vars != null) {
+    		// register the closure with the context so it gets cleared after execution
+    		context.pushClosure(this);
+		}
     }
 
     public List<ClosureVariable> getClosureVariables() {

--- a/src/org/exist/xquery/functions/fn/FunSort.java
+++ b/src/org/exist/xquery/functions/fn/FunSort.java
@@ -92,28 +92,27 @@ public class FunSort extends BasicFunction {
     Sequence seq = args[0];
 
     Collator collator = collator(args, 1);
-
-    FunctionReference ref = function(args, 2);
-
     ArrayList<Sequence> keys = new ArrayList<>(seq.getItemCount());
 
-    final Sequence refArgs[] = new Sequence[1];
+    try (FunctionReference ref = function(args, 2)) {
 
-    Item item;
-    Sequence value;
+      final Sequence refArgs[] = new Sequence[1];
 
-    for (final SequenceIterator i = seq.iterate(); i.hasNext();) {
-      item = i.nextItem();
-      if (ref != null) {
-        refArgs[0] = item.toSequence();
-        value = ref.evalFunction(contextSequence, null, refArgs);
-      } else {
-        value = item.toSequence();
+      Item item;
+      Sequence value;
+
+      for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
+        item = i.nextItem();
+        if (ref != null) {
+          refArgs[0] = item.toSequence();
+          value = ref.evalFunction(contextSequence, null, refArgs);
+        } else {
+          value = item.toSequence();
+        }
+
+        keys.add(Atomize.atomize(value));
       }
-
-      keys.add(Atomize.atomize(value));
     }
-
     return sort(seq, keys, collator);
   }
 

--- a/src/org/exist/xquery/functions/map/MapFunction.java
+++ b/src/org/exist/xquery/functions/map/MapFunction.java
@@ -264,13 +264,14 @@ public class MapFunction extends BasicFunction {
 
     private Sequence forEach(final Sequence[] args) throws XPathException {
         final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
-        final FunctionReference ref = (FunctionReference) args[1].itemAt(0);
-        ref.analyze(cachedContextInfo);
-        final ValueSequence result = new ValueSequence();
-        for (final Map.Entry<AtomicValue, Sequence> entry : map) {
-            final Sequence s = ref.evalFunction(null, null, new Sequence[] { entry.getKey(), entry.getValue() });
-            result.addAll(s);
+        try (final FunctionReference ref = (FunctionReference) args[1].itemAt(0)) {
+            ref.analyze(cachedContextInfo);
+            final ValueSequence result = new ValueSequence();
+            for (final Map.Entry<AtomicValue, Sequence> entry : map) {
+                final Sequence s = ref.evalFunction(null, null, new Sequence[]{entry.getKey(), entry.getValue()});
+                result.addAll(s);
+            }
+            return result;
         }
-        return result;
     }
 }

--- a/src/org/exist/xquery/functions/util/CallFunction.java
+++ b/src/org/exist/xquery/functions/util/CallFunction.java
@@ -82,16 +82,17 @@ public class CallFunction extends Function {
         final Item item0 = arg0.itemAt(0);
         if(item0.getType() != Type.FUNCTION_REFERENCE)
             {throw new XPathException(this, "Type error: expected function, got " + Type.getTypeName(item0.getType()));}
-        final FunctionReference ref = (FunctionReference)item0;
-        
-        // pass the remaining parameters to the function call
-        final List<Expression> params = new ArrayList<Expression>(getArgumentCount() - 1);
-        for(int i = 1; i < getArgumentCount(); i++) {
-            params.add(getArgument(i));
+        try (final FunctionReference ref = (FunctionReference)item0) {
+
+            // pass the remaining parameters to the function call
+            final List<Expression> params = new ArrayList<Expression>(getArgumentCount() - 1);
+            for (int i = 1; i < getArgumentCount(); i++) {
+                params.add(getArgument(i));
+            }
+            ref.setArguments(params);
+            ref.analyze(new AnalyzeContextInfo(this, 0));
+            // Evaluate the function
+            return ref.eval(contextSequence);
         }
-        ref.setArguments(params);
-        ref.analyze(new AnalyzeContextInfo(this, 0));
-        // Evaluate the function
-        return ref.eval(contextSequence);
     }
 }

--- a/src/org/exist/xquery/value/FunctionReference.java
+++ b/src/org/exist/xquery/value/FunctionReference.java
@@ -34,7 +34,7 @@ import java.util.List;
  *
  * @author wolf
  */
-public class FunctionReference extends AtomicValue {
+public class FunctionReference extends AtomicValue implements AutoCloseable {
 
     private final static Logger LOG = LogManager.getLogger(FunctionReference.class);
 
@@ -95,6 +95,11 @@ public class FunctionReference extends AtomicValue {
 
     public void setContext(XQueryContext context) {
         functionCall.setContext(context);
+    }
+
+    @Override
+    public void close() {
+        resetState(false);
     }
 
     public void resetState(boolean postOptimization) {


### PR DESCRIPTION
Most functions which take a function item as argument are leaking memory. This includes nearly all functions on arrays and maps, but also `for-each` and similar. The memory leak will at least result in higher memory consumption but frequently leads to a complete system breakdown on production servers facing higher traffic.

The PR does two things to fix the issue:

1. `FunctionReference` now implements `Closable` so the caller can make sure temporary objects are cleared after the function item was used. Existing code will continue to work, but all core functions have been changed accordingly.
2. above change leads to issues with closures in inline functions. Those should not be cleared until the very end of query execution. I have thus decoupled the lifecycle of closures, which makes sure we really clear all of them.