### PR TITLE
[bugfix] index-of should return xs:integer*

### DIFF
--- a/src/org/exist/xquery/functions/fn/FunIndexOf.java
+++ b/src/org/exist/xquery/functions/fn/FunIndexOf.java
@@ -50,7 +50,7 @@ import org.exist.xquery.value.ValueSequence;
  */
 public class FunIndexOf extends BasicFunction {
 
-	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the sequence of positive integers giving the positions within the sequence");
+	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_MORE, "the sequence of positive integers giving the positions within the sequence");
 
 	protected static final FunctionParameterSequenceType COLLATION_PARAM = new FunctionParameterSequenceType("collation-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collation URI");
 


### PR DESCRIPTION
### Description:

According to https://www.w3.org/TR/xpath-functions-31/#func-index-of, `fn:index-of` should return `xs:integer*` (`ZERO_OR_MORE`), but eXist had return `xs:integer?` (`ZERO_OR_ONE`). 

### Reference:

- XQuery F&O 1.0: https://www.w3.org/TR/xquery-operators/#func-index-of
- XQuery F&O 3.1 https://www.w3.org/TR/xpath-functions-31/#func-index-of
- Function mismatches in eXist: https://github.com/eXist-db/exist/issues/1714 and https://gist.github.com/joewiz/78b1827971a3c1c5dec8fc2d13dec8b2#file-signature-mismatches_results-xml-L351-L369
- exist-open thread: https://exist-open.markmail.org/thread/6h77llsoi76hyxgy

### Type of tests:

Forthcoming. As discussed with @wolfgangmm and @adamretter, the QT3 test suite will be integrated very soon.