### PR TITLE
Align function signatures with XQuery 3.1 F&O

### DIFF
--- a/src/org/exist/xquery/functions/array/ArrayFunction.java
+++ b/src/org/exist/xquery/functions/array/ArrayFunction.java
@@ -70,7 +70,7 @@ public class ArrayFunction extends BasicFunction {
                         new FunctionParameterSequenceType("array", Type.ARRAY, Cardinality.EXACTLY_ONE, "The array"),
                         new FunctionParameterSequenceType("index", Type.INTEGER, Cardinality.EXACTLY_ONE, "The index")
                     },
-                    new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_MORE, "The value at $index")
+                    new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "The value at $index")
             ),
             new FunctionSignature(
                     new QName(Fn.APPEND.fname, ArrayModule.NAMESPACE_URI, ArrayModule.PREFIX),
@@ -80,7 +80,7 @@ public class ArrayFunction extends BasicFunction {
                             new FunctionParameterSequenceType("array", Type.ARRAY, Cardinality.EXACTLY_ONE, "The array"),
                             new FunctionParameterSequenceType("appendage", Type.ITEM, Cardinality.ZERO_OR_MORE, "The items to append")
                     },
-                    new FunctionReturnSequenceType(Type.ARRAY, Cardinality.ZERO_OR_MORE, "A copy of $array with the new member attached")
+                    new FunctionReturnSequenceType(Type.ARRAY, Cardinality.EXACTLY_ONE, "A copy of $array with the new member attached")
             ),
             new FunctionSignature(
                     new QName(Fn.HEAD.fname, ArrayModule.NAMESPACE_URI, ArrayModule.PREFIX),
@@ -119,12 +119,12 @@ public class ArrayFunction extends BasicFunction {
             ),
             new FunctionSignature(
                     new QName(Fn.REMOVE.fname, ArrayModule.NAMESPACE_URI, ArrayModule.PREFIX),
-                    "Returns an array containing all members from $array except the member whose position is $position.",
+                    "Returns an array containing all the members of the supplied array, except for the members at specified positions.",
                     new SequenceType[] {
                             new FunctionParameterSequenceType("array", Type.ARRAY, Cardinality.EXACTLY_ONE, "The array"),
-                            new FunctionParameterSequenceType("position", Type.INTEGER, Cardinality.EXACTLY_ONE, "Position of the member to remove")
+                            new FunctionParameterSequenceType("positions", Type.INTEGER, Cardinality.ZERO_OR_MORE, "Positions of the members to remove")
                     },
-                    new FunctionReturnSequenceType(Type.ARRAY, Cardinality.EXACTLY_ONE, "A new array containing all members except the one at $position")
+                    new FunctionReturnSequenceType(Type.ARRAY, Cardinality.EXACTLY_ONE, "A new array containing all members from $array except the members whose position (counting from 1) is present in the sequence $positions")
             ),
             new FunctionSignature(
                     new QName(Fn.INSERT_BEFORE.fname, ArrayModule.NAMESPACE_URI, ArrayModule.PREFIX),

--- a/src/org/exist/xquery/functions/fn/FnFormatDates.java
+++ b/src/org/exist/xquery/functions/fn/FnFormatDates.java
@@ -67,7 +67,7 @@ public class FnFormatDates extends BasicFunction {
 
 	private static FunctionReturnSequenceType RETURN = 
 		new FunctionReturnSequenceType(
-			Type.STRING, Cardinality.EXACTLY_ONE, "The formatted date");
+			Type.STRING, Cardinality.ZERO_OR_ONE, "The formatted date");
 
 
     public final static FunctionSignature FNS_FORMAT_DATETIME_2 = new FunctionSignature(

--- a/src/org/exist/xquery/functions/fn/FnFormatNumbers.java
+++ b/src/org/exist/xquery/functions/fn/FnFormatNumbers.java
@@ -53,7 +53,7 @@ public class FnFormatNumbers extends BasicFunction {
     private static final String PICTURE_DESCRIPTION = "The formatting of a number is controlled by a picture string. The picture string is a sequence of ·characters·, in which the characters assigned to the variables decimal-separator-sign, grouping-sign, decimal-digit-family, optional-digit-sign and pattern-separator-sign are classified as active characters, and all other characters (including the percent-sign and per-mille-sign) are classified as passive characters.";
     private static final SequenceType DECIMAL_FORMAT = new FunctionParameterSequenceType("decimal-format-name", Type.STRING, Cardinality.EXACTLY_ONE, "The decimal-format name must be a QName, which is expanded as described in [2.4 Qualified Names]. It is an error if the stylesheet does not contain a declaration of the decimal-format with the specified expanded-name.");
     private static final String DECIMAL_FORMAT_DESCRIPTION = "";
-    private static final FunctionReturnSequenceType FUNCTION_RETURN_TYPE = new FunctionReturnSequenceType(Type.STRING, Cardinality.ONE, "the formatted string");
+    private static final FunctionReturnSequenceType FUNCTION_RETURN_TYPE = new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the formatted string");
 
     public static final FunctionSignature signatures[] = {
             new FunctionSignature(

--- a/src/org/exist/xquery/functions/fn/FunAbs.java
+++ b/src/org/exist/xquery/functions/fn/FunAbs.java
@@ -51,7 +51,7 @@ public class FunAbs extends Function {
                 new FunctionParameterSequenceType("number", Type.NUMBER, 
                     Cardinality.ZERO_OR_ONE, "The number")
             },
-            new FunctionReturnSequenceType(Type.NUMBER, Cardinality.EXACTLY_ONE,
+            new FunctionReturnSequenceType(Type.NUMBER, Cardinality.ZERO_OR_ONE,
                 "The absolute value of the argument")
         );
 

--- a/src/org/exist/xquery/functions/fn/FunCeiling.java
+++ b/src/org/exist/xquery/functions/fn/FunCeiling.java
@@ -49,7 +49,7 @@ public class FunCeiling extends Function {
                 new FunctionParameterSequenceType("number", Type.NUMBER,
                     Cardinality.ZERO_OR_ONE, "The number")
             },
-            new FunctionReturnSequenceType(Type.NUMBER, Cardinality.ONE,
+            new FunctionReturnSequenceType(Type.NUMBER, Cardinality.ZERO_OR_ONE,
                 "The non-fractional number not less than $number")
         );
 

--- a/src/org/exist/xquery/functions/fn/FunConcat.java
+++ b/src/org/exist/xquery/functions/fn/FunConcat.java
@@ -69,7 +69,7 @@ public class FunConcat extends Function {
                 new FunctionParameterSequenceType("atomizable-values",
                     Type.ATOMIC, Cardinality.ZERO_OR_ONE, "The atomizable values")
             },
-            new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE,
+            new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE,
                 "The concatenated values"),
             true
         );

--- a/src/org/exist/xquery/functions/fn/FunCurrentDateTime.java
+++ b/src/org/exist/xquery/functions/fn/FunCurrentDateTime.java
@@ -52,6 +52,7 @@ public class FunCurrentDateTime extends Function {
             "during the evaluation of a query or transformation in which " +
             "fn:current-dateTime() is executed.",
             null,
+            //should be xs:dateTimeStamp, need to add support for DATE_TIME_STAMP
             new FunctionReturnSequenceType(Type.DATE_TIME,
                 Cardinality.EXACTLY_ONE, "the date-time current " +
                     "within query execution time span"));

--- a/src/org/exist/xquery/functions/fn/FunEndsWith.java
+++ b/src/org/exist/xquery/functions/fn/FunEndsWith.java
@@ -54,7 +54,7 @@ public class FunEndsWith extends CollatingFunction {
                 new FunctionParameterSequenceType("suffix", Type.STRING,
                     Cardinality.ZERO_OR_ONE, "The suffix")
             },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE,
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "true() if $suffix is suffix of $source-string, false() otherwise")
         ),
         new FunctionSignature (
@@ -72,7 +72,7 @@ public class FunEndsWith extends CollatingFunction {
                 new FunctionParameterSequenceType("collation-uri", Type.STRING,
                     Cardinality.EXACTLY_ONE, "The collation URI")
                 },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ZERO_OR_ONE,
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "true() if $suffix is suffix of $source-string, false() otherwise"))
     };
 

--- a/src/org/exist/xquery/functions/fn/FunEnvironment.java
+++ b/src/org/exist/xquery/functions/fn/FunEnvironment.java
@@ -58,7 +58,7 @@ public class FunEnvironment extends BasicFunction {
                 new FunctionParameterSequenceType("name", Type.STRING,
                     Cardinality.EXACTLY_ONE, "Name of environment variable.")
             },
-            new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO, "Corrensponding value of the environment variable, "
+            new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "Corrensponding value of the environment variable, "
             + "if there is no environment variable with a matching name, the function returns the empty sequence. User must be DBA.")
         )
     };

--- a/src/org/exist/xquery/functions/fn/FunError.java
+++ b/src/org/exist/xquery/functions/fn/FunError.java
@@ -62,7 +62,7 @@ public class FunError extends BasicFunction {
             "$qname and the default message, 'An error has been raised by the query'.",
             new SequenceType[] {
                 new FunctionParameterSequenceType("qname", Type.QNAME,
-                    Cardinality.EXACTLY_ONE, "The qname")
+                    Cardinality.ZERO_OR_ONE, "The qname")
             },
             new SequenceType(Type.EMPTY, Cardinality.ZERO)
         ),

--- a/src/org/exist/xquery/functions/fn/FunFloor.java
+++ b/src/org/exist/xquery/functions/fn/FunFloor.java
@@ -42,12 +42,12 @@ public class FunFloor extends Function {
 	public final static FunctionSignature signature =
 		new FunctionSignature(
 			new QName("floor", Function.BUILTIN_FUNCTION_NS),
-			"Returns the largets number not greater than the value of $number. " + 
+			"Returns the largest number not greater than the value of $number. " + 
 			"If $number is the empty sequence, returns the empty sequence.",
 			new SequenceType[] {
-                new FunctionParameterSequenceType("number", Type.NUMBER, Cardinality.ZERO_OR_MORE, "The number")
+                new FunctionParameterSequenceType("number", Type.NUMBER, Cardinality.ZERO_OR_ONE, "The number")
             },
-			new FunctionReturnSequenceType(Type.NUMBER, Cardinality.ONE, "the largets number without fraction part not greater than the value of $number"));
+			new FunctionReturnSequenceType(Type.NUMBER, Cardinality.ZERO_OR_ONE, "the largest number without fraction part not greater than the value of $number"));
 
 	public FunFloor(XQueryContext context) {
 		super(context, signature);

--- a/src/org/exist/xquery/functions/fn/FunGetDurationComponent.java
+++ b/src/org/exist/xquery/functions/fn/FunGetDurationComponent.java
@@ -56,6 +56,7 @@ public class FunGetDurationComponent extends BasicFunction {
 	protected static final Logger logger = LogManager.getLogger(FunGetDurationComponent.class);
     public final static FunctionParameterSequenceType DAYTIME_DURA_01_PARAM = new FunctionParameterSequenceType("duration", Type.DAY_TIME_DURATION, Cardinality.ZERO_OR_ONE, "The duration as xs:dayTimeDuration");
     public final static FunctionParameterSequenceType YEARMONTH_DURA_01_PARAM = new FunctionParameterSequenceType("duration", Type.YEAR_MONTH_DURATION, Cardinality.ZERO_OR_ONE, "The duration as xs:yearMonthDuration");
+    public final static FunctionParameterSequenceType DURA_01_PARAM = new FunctionParameterSequenceType("duration", Type.DURATION, Cardinality.ZERO_OR_ONE, "The duration as xs:duration");
 
 	public final static FunctionSignature fnDaysFromDuration =
 		new FunctionSignature(
@@ -63,7 +64,7 @@ public class FunGetDurationComponent extends BasicFunction {
 			"Returns an xs:integer representing the days component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {
-                DAYTIME_DURA_01_PARAM
+                DURA_01_PARAM
             },
 			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the days component of $duration"));
 	
@@ -73,7 +74,7 @@ public class FunGetDurationComponent extends BasicFunction {
 			"Returns an xs:integer representing the hours component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {
-                DAYTIME_DURA_01_PARAM
+                DURA_01_PARAM
             },
 			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the hours component of $duration"));
 	
@@ -83,7 +84,7 @@ public class FunGetDurationComponent extends BasicFunction {
 			"Returns an xs:integer representing the minutes component in the canonical " +
 			"lexical representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {
-                DAYTIME_DURA_01_PARAM
+                DURA_01_PARAM
             },
 			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the minutes component of $duration"));
 
@@ -93,7 +94,7 @@ public class FunGetDurationComponent extends BasicFunction {
 			"Returns an xs:decimal representing the seconds component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative",
 			new SequenceType[] {
-                DAYTIME_DURA_01_PARAM
+                DURA_01_PARAM
             },
 			new FunctionReturnSequenceType(Type.DECIMAL, Cardinality.ZERO_OR_ONE, "the seconds component of $duration"));
 
@@ -102,7 +103,7 @@ public class FunGetDurationComponent extends BasicFunction {
 			"Returns an xs:integer representing the months component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {
-                YEARMONTH_DURA_01_PARAM
+                DURA_01_PARAM
             },
 			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the months component of $duration"));
 
@@ -111,7 +112,7 @@ public class FunGetDurationComponent extends BasicFunction {
 			"Returns an xs:integer representing the years component in the canonical lexical " +
 			"representation of the value of $duration. The result may be negative.",
 			new SequenceType[] {
-                YEARMONTH_DURA_01_PARAM
+                DURA_01_PARAM
             },
 			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the years component of $duration"));
 

--- a/src/org/exist/xquery/functions/fn/FunLast.java
+++ b/src/org/exist/xquery/functions/fn/FunLast.java
@@ -49,7 +49,7 @@ public class FunLast extends Function {
 			"Returns the context size from the dynamic context. " + 
 			"If the context item is undefined, an error is raised.",
 			null,
-			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the context size from the dynamic context"));
+			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE, "the context size from the dynamic context"));
 
 	public FunLast(XQueryContext context) {
 		super(context, signature);

--- a/src/org/exist/xquery/functions/fn/FunMatches.java
+++ b/src/org/exist/xquery/functions/fn/FunMatches.java
@@ -90,7 +90,7 @@ public class FunMatches extends Function implements Optimizable, IndexUseReporte
 		"The text:matches-regex() variants of the fn:matches() functions are identical except that they avoid the translation of the specified regular expression from XPath2 to Java syntax. " +
 		"That is, the regular expression is evaluated as is, and must be valid according to Java regular expression syntax, rather than the more restrictive XPath2 syntax.";
 
-	protected static final FunctionParameterSequenceType INPUT_ARG = new FunctionParameterSequenceType("input", Type.STRING, Cardinality.ZERO_OR_MORE, "The input string");
+	protected static final FunctionParameterSequenceType INPUT_ARG = new FunctionParameterSequenceType("input", Type.STRING, Cardinality.ZERO_OR_ONE, "The input string");
 	protected static final FunctionParameterSequenceType PATTERN_ARG = new FunctionParameterSequenceType("pattern", Type.STRING, Cardinality.EXACTLY_ONE, "The pattern");
 	protected static final FunctionParameterSequenceType FLAGS_ARG = new FunctionParameterSequenceType("flags", Type.STRING, Cardinality.EXACTLY_ONE, "The flags");
 

--- a/src/org/exist/xquery/functions/fn/FunName.java
+++ b/src/org/exist/xquery/functions/fn/FunName.java
@@ -74,7 +74,7 @@ public class FunName extends Function {
                     new QName("name", Function.BUILTIN_FUNCTION_NS),
                     FUNCTION_DESCRIPTION_0_PARAM + FUNCTION_DESCRIPTION_COMMON,
                     new SequenceType[0],
-                    new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the name")
+                    new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the name")
             ),
             new FunctionSignature(
                     new QName("name", Function.BUILTIN_FUNCTION_NS),
@@ -82,7 +82,7 @@ public class FunName extends Function {
                     new SequenceType[] {
                             new FunctionParameterSequenceType("arg", Type.NODE, Cardinality.ZERO_OR_ONE, "The input node")
                     },
-                    new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the name")
+                    new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the name")
             )
     };
 

--- a/src/org/exist/xquery/functions/fn/FunPosition.java
+++ b/src/org/exist/xquery/functions/fn/FunPosition.java
@@ -48,7 +48,7 @@ public class FunPosition extends Function {
 			"Returns the context position from the dynamic context. " +
 			"If the context item is undefined, raises an error.",
 			null,
-			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the context position"));
+			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE, "the context position"));
 	
     public FunPosition(XQueryContext context) {
         super(context, signature);

--- a/src/org/exist/xquery/functions/fn/FunReplace.java
+++ b/src/org/exist/xquery/functions/fn/FunReplace.java
@@ -86,7 +86,7 @@ public class FunReplace extends FunMatches {
 	protected static final FunctionParameterSequenceType PATTERN_ARG = new FunctionParameterSequenceType("pattern", Type.STRING, Cardinality.EXACTLY_ONE, "The pattern to match");
 	protected static final FunctionParameterSequenceType REPLACEMENT_ARG = new FunctionParameterSequenceType("replacement", Type.STRING, Cardinality.EXACTLY_ONE, "The string to replace the pattern with");
 	protected static final FunctionParameterSequenceType FLAGS_ARG = new FunctionParameterSequenceType("flags", Type.STRING, Cardinality.EXACTLY_ONE, "The flags");
-	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the altered string");
+	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the altered string");
 			
 	public final static FunctionSignature signatures[] = {
 		new FunctionSignature(

--- a/src/org/exist/xquery/functions/fn/FunResolveQName.java
+++ b/src/org/exist/xquery/functions/fn/FunResolveQName.java
@@ -71,7 +71,7 @@ public class FunResolveQName extends BasicFunction {
     				new FunctionParameterSequenceType("qname", Type.STRING, Cardinality.ZERO_OR_ONE, "The QName name"), 
     				new FunctionParameterSequenceType("element", Type.ELEMENT, Cardinality.EXACTLY_ONE, "The element") 
     			}, 
-    			new FunctionReturnSequenceType(Type.QNAME, Cardinality.EXACTLY_ONE, "the QName of $element with lexical form $qname")
+    			new FunctionReturnSequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE, "the QName of $element with lexical form $qname")
     	);
 
     public FunResolveQName(XQueryContext context) {

--- a/src/org/exist/xquery/functions/fn/FunRound.java
+++ b/src/org/exist/xquery/functions/fn/FunRound.java
@@ -62,7 +62,7 @@ public class FunRound extends Function {
 				"[XML Schema Part 2: Datatypes Second Edition] does not " +
 				"distinguish between the values positive zero and negative zero.",
 				new SequenceType[] { new FunctionParameterSequenceType("arg", Type.NUMBER, Cardinality.ZERO_OR_ONE, "The input number") },
-				new FunctionReturnSequenceType(Type.NUMBER, Cardinality.EXACTLY_ONE, "the rounded value")
+				new FunctionReturnSequenceType(Type.NUMBER, Cardinality.ZERO_OR_ONE, "the rounded value")
 			);
 			
 	public FunRound(XQueryContext context) {

--- a/src/org/exist/xquery/functions/fn/FunRoundHalfToEven.java
+++ b/src/org/exist/xquery/functions/fn/FunRoundHalfToEven.java
@@ -78,8 +78,8 @@ public class FunRoundHalfToEven extends Function {
 		"value of the mantissa computed with exponent = 0.";
 	
 	protected static final FunctionParameterSequenceType ARG_PARAM = new FunctionParameterSequenceType("arg", Type.NUMBER, Cardinality.ZERO_OR_ONE, "The input number");
-	protected static final FunctionParameterSequenceType PRECISION_PARAM = new FunctionParameterSequenceType("precision", Type.NUMBER, Cardinality.ZERO_OR_ONE, "The precision factor");
-	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.NUMBER, Cardinality.EXACTLY_ONE, "the rounded value");
+	protected static final FunctionParameterSequenceType PRECISION_PARAM = new FunctionParameterSequenceType("precision", Type.INTEGER, Cardinality.EXACTLY_ONE, "The precision factor");
+	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.NUMBER, Cardinality.ZERO_OR_ONE, "the rounded value");
 
 	public final static FunctionSignature signatures[] = {
 			new FunctionSignature(

--- a/src/org/exist/xquery/functions/fn/FunStartsWith.java
+++ b/src/org/exist/xquery/functions/fn/FunStartsWith.java
@@ -63,7 +63,7 @@ public class FunStartsWith extends CollatingFunction {
 	protected static final FunctionParameterSequenceType ARG1_PARAM = new FunctionParameterSequenceType("source", Type.STRING, Cardinality.ZERO_OR_ONE, "The source string");
 	protected static final FunctionParameterSequenceType ARG2_PARAM = new FunctionParameterSequenceType("prefix", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to determine if is a prefix of $source");
 	protected static final FunctionParameterSequenceType COLLATION_PARAM = new FunctionParameterSequenceType("collation-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collation URI");
-	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ZERO_OR_ONE, "true if $prefix is a prefix of the string $source");
+	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if $prefix is a prefix of the string $source");
 	
     public final static FunctionSignature signatures[] = {
 	new FunctionSignature (

--- a/src/org/exist/xquery/functions/fn/FunStrLength.java
+++ b/src/org/exist/xquery/functions/fn/FunStrLength.java
@@ -50,7 +50,7 @@ public class FunStrLength extends Function {
 				"Returns an xs:integer equal to the length in characters of the value of the context item.\n" +
 				"If the context item is undefined an error is raised. ",
 				new SequenceType[0],
-				new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the length in characters")
+				new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE, "the length in characters")
 		),
 		new FunctionSignature(
 			new QName("string-length", Function.BUILTIN_FUNCTION_NS),
@@ -60,7 +60,7 @@ public class FunStrLength extends Function {
 			new SequenceType[] {
 				 new FunctionParameterSequenceType("arg", Type.STRING, Cardinality.ZERO_OR_ONE, "The input string")
 			},
-			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ZERO_OR_ONE, "the length in characters")
+			new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE, "the length in characters")
 		)
 	};
 			

--- a/src/org/exist/xquery/functions/fn/FunStringJoin.java
+++ b/src/org/exist/xquery/functions/fn/FunStringJoin.java
@@ -55,7 +55,7 @@ public class FunStringJoin extends BasicFunction {
             "The effect of calling the single-argument version of this function is the same as calling the " +
             "two-argument version with $separator set to a zero-length string.",
             new SequenceType[] {
-                new FunctionParameterSequenceType("arg", Type.STRING, Cardinality.ZERO_OR_MORE,
+                new FunctionParameterSequenceType("arg", Type.ATOMIC, Cardinality.ZERO_OR_MORE,
                         "The sequence to be joined to form the string. If it is empty, " +
                                 "a zero-length string is returned.")
             },
@@ -66,7 +66,7 @@ public class FunStringJoin extends BasicFunction {
             "$arg sequence using $separator as a separator. If the value of the separator is the zero-length " +
             "string, then the members of the sequence are concatenated without a separator.",
             new SequenceType[] {
-                new FunctionParameterSequenceType("arg", Type.STRING, Cardinality.ZERO_OR_MORE,
+                new FunctionParameterSequenceType("arg", Type.ATOMIC, Cardinality.ZERO_OR_MORE,
                     "The sequence to be joined to form the string. If it is empty, " +
                     "a zero-length string is returned."),
                 new FunctionParameterSequenceType("separator", Type.STRING, Cardinality.EXACTLY_ONE, "The separator to be placed in the string between the items of $arg")

--- a/src/org/exist/xquery/functions/fn/FunSubstring.java
+++ b/src/org/exist/xquery/functions/fn/FunSubstring.java
@@ -61,7 +61,7 @@ public class FunSubstring extends Function {
 					 new FunctionParameterSequenceType("source", Type.STRING, Cardinality.ZERO_OR_ONE, "The source string"),
 					 new FunctionParameterSequenceType("starting-at", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The starting position")
 				},
-				new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the substring")
+				new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the substring")
 			),
 			new FunctionSignature(
 				new QName("substring", Function.BUILTIN_FUNCTION_NS),
@@ -74,7 +74,7 @@ public class FunSubstring extends Function {
 					 new FunctionParameterSequenceType("starting-at", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The starting position"),
 					 new FunctionParameterSequenceType("length", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The number of characters in the substring")
 				},
-				new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the substring")
+				new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the substring")
 			)
 	};
 				

--- a/src/org/exist/xquery/functions/fn/FunSubstringAfter.java
+++ b/src/org/exist/xquery/functions/fn/FunSubstringAfter.java
@@ -63,7 +63,7 @@ public class FunSubstringAfter extends CollatingFunction {
 				 SOURCE_ARG,
 				 SEARCH_ARG
 			},
-			new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the substring after $search")),
+			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the substring after $search")),
 		new FunctionSignature(
 				new QName("substring-after", Function.BUILTIN_FUNCTION_NS),
 				"Returns the substring of the value of $source that follows the first occurrence " +
@@ -78,7 +78,7 @@ public class FunSubstringAfter extends CollatingFunction {
 					 SEARCH_ARG,
 					 COLLATION_ARG
 				},
-				new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the substring after $search"))
+				new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the substring after $search"))
 	};
 					
 	public FunSubstringAfter(XQueryContext context, FunctionSignature signature) {

--- a/src/org/exist/xquery/functions/fn/FunSubstringBefore.java
+++ b/src/org/exist/xquery/functions/fn/FunSubstringBefore.java
@@ -63,7 +63,7 @@ public class FunSubstringBefore extends CollatingFunction {
 				 SOURCE_ARG,
 				 SEARCH_ARG
 				},
-				new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the substring before $search")),
+				new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the substring before $search")),
 		new FunctionSignature(
 				new QName("substring-before", Function.BUILTIN_FUNCTION_NS),
 			"Returns the substring of the value of $source that precedes the first occurrence " +
@@ -78,7 +78,7 @@ public class FunSubstringBefore extends CollatingFunction {
 					 SEARCH_ARG,
 					 COLLATOR_ARG
 				},
-				new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the substring before $search"))
+				new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the substring before $search"))
 	};
 
 	public FunSubstringBefore(XQueryContext context, FunctionSignature signature) {

--- a/src/org/exist/xquery/functions/fn/FunSum.java
+++ b/src/org/exist/xquery/functions/fn/FunSum.java
@@ -66,7 +66,7 @@ public class FunSum extends Function {
 				 new FunctionParameterSequenceType("arg", Type.ATOMIC, Cardinality.ZERO_OR_MORE, "The sequence of numbers to be summed up"),
 				 new FunctionParameterSequenceType("default", Type.ATOMIC, Cardinality.ZERO_OR_ONE, "The default value if $arg computes to the empty sequence")
 				 },
-					new FunctionReturnSequenceType(Type.ATOMIC, Cardinality.EXACTLY_ONE, "the sum of all numbers in $arg")
+					new FunctionReturnSequenceType(Type.ATOMIC, Cardinality.ZERO_OR_ONE, "the sum of all numbers in $arg")
 		)
 	};
 				

--- a/src/org/exist/xquery/functions/fn/FunUnparsedText.java
+++ b/src/org/exist/xquery/functions/fn/FunUnparsedText.java
@@ -65,7 +65,7 @@ public class FunUnparsedText extends BasicFunction {
     static final FunctionSignature [] FS_UNPARSED_TEXT_AVAILABLE = functionSignatures(
         new QName("unparsed-text-available", Function.BUILTIN_FUNCTION_NS),
         "determines whether a call on the fn:unparsed-text function with identical arguments would return a string",
-        returnsOpt(Type.STRING),
+        returns(Type.BOOLEAN),
         arities(
                 arity(PARAM_HREF),
                 arity(PARAM_HREF, PARAM_ENCODING)

--- a/src/org/exist/xquery/functions/fn/ParsingFunctions.java
+++ b/src/org/exist/xquery/functions/fn/ParsingFunctions.java
@@ -55,8 +55,8 @@ public class ParsingFunctions extends BasicFunction {
 
 	protected static final FunctionReturnSequenceType RESULT_TYPE_FOR_PARSE_XML = new FunctionReturnSequenceType(Type.DOCUMENT,
 			Cardinality.ZERO_OR_ONE, "the parsed document");
-	protected static final FunctionReturnSequenceType RESULT_TYPE_FOR_PARSE_XML_FRAGMENT = new FunctionReturnSequenceType(Type.ELEMENT,
-			Cardinality.ZERO_OR_MORE, "the parsed document fragment");	
+	protected static final FunctionReturnSequenceType RESULT_TYPE_FOR_PARSE_XML_FRAGMENT = new FunctionReturnSequenceType(Type.DOCUMENT,
+			Cardinality.ZERO_OR_ONE, "the parsed document fragment");	
 
 	protected static final FunctionParameterSequenceType TO_BE_PARSED_PARAMETER = new FunctionParameterSequenceType(
 			"arg", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be parsed");

--- a/src/org/exist/xquery/functions/map/MapFunction.java
+++ b/src/org/exist/xquery/functions/map/MapFunction.java
@@ -97,7 +97,7 @@ public class MapFunction extends BasicFunction {
         "Constructs a new map by removing an entry from an existing map.",
         new SequenceType[] {
             new FunctionParameterSequenceType(MapModule.PREFIX, Type.MAP, Cardinality.EXACTLY_ONE, "The map"),
-            new FunctionParameterSequenceType("key", Type.STRING, Cardinality.EXACTLY_ONE, "The key to remove")
+            new FunctionParameterSequenceType("key", Type.ATOMIC, Cardinality.ZERO_OR_MORE, "The key to remove")
         },
         new SequenceType(Type.MAP, Cardinality.EXACTLY_ONE)
     );

--- a/src/org/exist/xquery/functions/math/OneParamFunctions.java
+++ b/src/org/exist/xquery/functions/math/OneParamFunctions.java
@@ -61,78 +61,78 @@ public class OneParamFunctions extends BasicFunction {
     public final static FunctionSignature FNS_ACOS = new FunctionSignature(
         new QName(ACOS, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the arc cosine of the argument, the result being in the range zero to +π radians.",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the result")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "the result")
     );
                         
     public final static FunctionSignature FNS_ASIN = new FunctionSignature(
         new QName(ASIN, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the arc sine of the argument, the result being in the range -π/2 to +π/2 radians.",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "result")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "result")
     );
     
     public final static FunctionSignature FNS_ATAN = new FunctionSignature(
         new QName(ATAN, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the arc tangent of the argument, the result being in the range -π/2 to +π/2 radians.",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the result")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "the result")
     );
     
     public final static FunctionSignature FNS_COS = new FunctionSignature(
         new QName(COS, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the cosine of the argument, expressed in radians.",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the cosine")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "the cosine")
     );
     
     public final static FunctionSignature FNS_EXP = new FunctionSignature(
         new QName(EXP, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Calculates e (the Euler Constant) raised to the power of $arg",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "e (the Euler Constant) raised to the power of a value or expression")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "e (the Euler Constant) raised to the power of a value or expression")
     );
                 
     public final static FunctionSignature FNS_EXP10 = new FunctionSignature( // NEW
         new QName(EXP10, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Calculates 10 raised to the power of $arg",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "e (the Euler Constant) raised to the power of a value or expression")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "e (the Euler Constant) raised to the power of a value or expression")
     );
         
     public final static FunctionSignature FNS_LOG = new FunctionSignature(
         new QName(LOG, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the natural logarithm of the argument.",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the log")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "the log")
     );
         
     public final static FunctionSignature FNS_LOG10 = new FunctionSignature( // NEW
         new QName(LOG10, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the base-ten logarithm of the argument.",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the log")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "the log")
     );
         
     public final static FunctionSignature FNS_SIN = new FunctionSignature(
         new QName(SIN, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the sine of the argument, expressed in radians.",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the sine")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "the sine")
     );
         
     public final static FunctionSignature FNS_SQRT = new FunctionSignature(
         new QName(SQRT, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the non-negative square root of the argument.",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The input number") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the square root of $x")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The input number") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "the square root of $x")
     );
     
     public final static FunctionSignature FNS_TAN = new FunctionSignature(
         new QName(TAN, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the tangent of the argument, expressed in radians.",
-        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The radians") },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the tangent")
+        new SequenceType[] { new FunctionParameterSequenceType("arg", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The radians") },
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "the tangent")
     );
     
     /**

--- a/src/org/exist/xquery/functions/math/TwoParamFunctions.java
+++ b/src/org/exist/xquery/functions/math/TwoParamFunctions.java
@@ -68,10 +68,10 @@ public class TwoParamFunctions extends BasicFunction {
         new QName(POW, MathModule.NAMESPACE_URI, MathModule.PREFIX),
         "Returns the result of raising the first argument to the power of the second.",
         new SequenceType[] {
-            new FunctionParameterSequenceType("value", Type.DOUBLE, Cardinality.EXACTLY_ONE, "The value"),
+            new FunctionParameterSequenceType("value", Type.DOUBLE, Cardinality.ZERO_OR_ONE, "The value"),
             new FunctionParameterSequenceType("power", Type.NUMBER, Cardinality.EXACTLY_ONE, "The power to raise the value to")
         },
-        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.EXACTLY_ONE, "the result")
+        new FunctionReturnSequenceType(Type.DOUBLE, Cardinality.ZERO_OR_ONE, "the result")
     );
     
     /**

--- a/src/org/exist/xquery/value/Type.java
+++ b/src/org/exist/xquery/value/Type.java
@@ -242,6 +242,8 @@ public class Type {
         defineBuiltInType(HEX_BINARY, "xs:hexBinary");
         defineBuiltInType(NOTATION, "xs:NOTATION");
 
+        //TODO add handling for xs:dateTimeStamp
+        //defineBuiltInType(DATE_TIME_STAMP, "xs:dateTimeStamp");
         defineBuiltInType(DATE_TIME, "xs:dateTime");
         defineBuiltInType(DATE, "xs:date");
         defineBuiltInType(TIME, "xs:time");


### PR DESCRIPTION
### Description:

Aligns the function signatures (data type and cardinality) of all functions in [XQuery and XPath Functions and Operators 3.1](https://www.w3.org/TR/xpath-functions-31/#func-format-number) currently implemented in eXist. 

There are 22 remaining mismatches, which fall into 4 categories:

1. `fn:collection`: A comment indicates that the eXist implementation of this function is known to be non-spec compliant, so I did not change it.
2. `fn:current-dateTime`: Returns `xs:dateTime` instead of the required `xs:dateTimeStamp`, which eXist has not implemented, so I left a comment. See https://github.com/eXist-db/exist/issues/1715
3. `fn:error`: Return `empty-sequence` with the cardinality of `zero`, instead of the required "none", which eXist has not implemented. The spec explains:
    > The type "none" is a special type defined in [XQuery 1.0 and XPath 2.0 Formal Semantics](https://www.w3.org/TR/xpath-functions-31/#xquery-semantics) and is not available to the user. It indicates that the function never returns and ensures that it has the correct static type.

    There is no issue tracking this yet.
4. Functions with complex types, which eXist's `FunctionReturnSequenceType` cannot express. For example, the return for `fn:analyze-string` should be `element(fn:analyze-string-result)`, but eXist expresses only `element()`. Similarly, the return for `fn:for-each-pair` should be `function(item(), item()) as item()*`, but eXist expresses only `function(*)`. There is no issue explicitly tracking this yet.

The 22 mismatches not addressed in this PR are enumerated below - the greatest number being from the 4th category above. This report was generated by the query at https://gist.github.com/joewiz/78b1827971a3c1c5dec8fc2d13dec8b2.

```xml
<signature-mismatches>
    <testcase name="array_filter_2">
        <name>array:filter#2</name>
        <arg>array(*)</arg>
        <arg>
            <expected>function(item()*) as xs:boolean</expected>
            <actual>function(*)</actual>
        </arg>
        <return>array(*)</return>
    </testcase>
    <testcase name="array_fold-left_3">
        <name>array:fold-left#3</name>
        <arg>array(*)</arg>
        <arg>item()*</arg>
        <arg>
            <expected>function(item()*, item()*) as item()*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>item()*</return>
    </testcase>
    <testcase name="array_fold-right_3">
        <name>array:fold-right#3</name>
        <arg>array(*)</arg>
        <arg>item()*</arg>
        <arg>
            <expected>function(item()*, item()*) as item()*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>item()*</return>
    </testcase>
    <testcase name="array_for-each-pair_3">
        <name>array:for-each-pair#3</name>
        <arg>array(*)</arg>
        <arg>array(*)</arg>
        <arg>
            <expected>function(item()*, item()*) as item()*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>array(*)</return>
    </testcase>
    <testcase name="array_for-each_2">
        <name>array:for-each#2</name>
        <arg>array(*)</arg>
        <arg>
            <expected>function(item()*) as item()*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>array(*)</return>
    </testcase>
    <testcase name="fn_analyze-string_2">
        <name>analyze-string#2</name>
        <arg>xs:string?</arg>
        <arg>xs:string</arg>
        <return>
            <expected>element(fn:analyze-string-result)</expected>
            <actual>element()</actual>
        </return>
    </testcase>
    <testcase name="fn_analyze-string_3">
        <name>analyze-string#3</name>
        <arg>xs:string?</arg>
        <arg>xs:string</arg>
        <arg>xs:string</arg>
        <return>
            <expected>element(fn:analyze-string-result)</expected>
            <actual>element()</actual>
        </return>
    </testcase>
    <testcase name="fn_collection_0">
        <name>collection#0</name>
        <return>
            <expected>item()*</expected>
            <actual>node()*</actual>
        </return>
    </testcase>
    <testcase name="fn_collection_1">
        <name>collection#1</name>
        <arg>
            <expected>xs:string?</expected>
            <actual>xs:string*</actual>
        </arg>
        <return>
            <expected>item()*</expected>
            <actual>node()*</actual>
        </return>
    </testcase>
    <testcase name="fn_current-dateTime_0">
        <name>current-dateTime#0</name>
        <return>
            <expected>xs:dateTimeStamp</expected>
            <actual>xs:dateTime</actual>
        </return>
    </testcase>
    <testcase name="fn_error_0">
        <name>error#0</name>
        <return>
            <expected>none</expected>
            <actual>empty-sequence()empty-sequence()</actual>
        </return>
    </testcase>
    <testcase name="fn_error_1">
        <name>error#1</name>
        <arg>xs:QName?</arg>
        <return>
            <expected>none</expected>
            <actual>empty-sequence()empty-sequence()</actual>
        </return>
    </testcase>
    <testcase name="fn_error_2">
        <name>error#2</name>
        <arg>xs:QName?</arg>
        <arg>xs:string</arg>
        <return>
            <expected>none</expected>
            <actual>empty-sequence()empty-sequence()</actual>
        </return>
    </testcase>
    <testcase name="fn_error_3">
        <name>error#3</name>
        <arg>xs:QName?</arg>
        <arg>xs:string</arg>
        <arg>item()*</arg>
        <return>
            <expected>none</expected>
            <actual>empty-sequence()empty-sequence()</actual>
        </return>
    </testcase>
    <testcase name="fn_filter_2">
        <name>filter#2</name>
        <arg>item()*</arg>
        <arg>
            <expected>function(item()) as xs:boolean</expected>
            <actual>function(*)</actual>
        </arg>
        <return>item()*</return>
    </testcase>
    <testcase name="fn_fold-left_3">
        <name>fold-left#3</name>
        <arg>item()*</arg>
        <arg>item()*</arg>
        <arg>
            <expected>function(item()*, item()) as item()*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>item()*</return>
    </testcase>
    <testcase name="fn_fold-right_3">
        <name>fold-right#3</name>
        <arg>item()*</arg>
        <arg>item()*</arg>
        <arg>
            <expected>function(item(), item()*) as item()*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>item()*</return>
    </testcase>
    <testcase name="fn_for-each-pair_3">
        <name>for-each-pair#3</name>
        <arg>item()*</arg>
        <arg>item()*</arg>
        <arg>
            <expected>function(item(), item()) as item()*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>item()*</return>
    </testcase>
    <testcase name="fn_for-each_2">
        <name>for-each#2</name>
        <arg>item()*</arg>
        <arg>
            <expected>function(item()) as item()*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>item()*</return>
    </testcase>
    <testcase name="fn_parse-xml_1">
        <name>parse-xml#1</name>
        <arg>xs:string?</arg>
        <return>
            <expected>document-node(element(*))?</expected>
            <actual>document-node()?</actual>
        </return>
    </testcase>
    <testcase name="fn_sort_3">
        <name>sort#3</name>
        <arg>item()*</arg>
        <arg>xs:string?</arg>
        <arg>
            <expected>function(item()) as xs:anyAtomicType*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>item()*</return>
    </testcase>
    <testcase name="map_for-each_2">
        <name>map:for-each#2</name>
        <arg>map(*)</arg>
        <arg>
            <expected>function(xs:anyAtomicType, item()*) as item()*</expected>
            <actual>function(*)</actual>
        </arg>
        <return>item()*</return>
    </testcase>
</signature-mismatches>
```

### Reference:

Picks up on observations made in https://github.com/eXist-db/exist/issues/1714 and partial work toward this goal started in https://github.com/eXist-db/exist/pull/1474, https://github.com/eXist-db/exist/pull/1593, https://github.com/eXist-db/exist/pull/1712, and https://github.com/eXist-db/exist/pull/1916.

### Type of tests:

No new tests. Passes the full test suite.