### PR TITLE
(4.x.x) [bugfix] Only omit values for attributes which are considered boolean in HTML5Writer

### DIFF
--- a/src/org/exist/util/serializer/HTML5Writer.java
+++ b/src/org/exist/util/serializer/HTML5Writer.java
@@ -35,6 +35,88 @@ import java.io.Writer;
  */
 public class HTML5Writer extends XHTML5Writer {
 
+    /**
+     * Holds the names of the attributes that are considered boolean
+     * according to http://www.w3.org/TR/html51/single-page.html.
+     * 
+     * The value of these attributes are written if they equal the
+     * name of the attribute. For example: checked="checked" will be
+     * written as checked.
+     * 
+     * See https://github.com/eXist-db/exist/issues/777 for details. 
+     */
+    private final static ObjectHashSet<String> BOOLEAN_ATTRIBUTE_NAMES = new ObjectHashSet<String>(68);
+    static {
+        BOOLEAN_ATTRIBUTE_NAMES.add("allowFullscreen");
+        BOOLEAN_ATTRIBUTE_NAMES.add("async");
+        BOOLEAN_ATTRIBUTE_NAMES.add("autofocus");
+        BOOLEAN_ATTRIBUTE_NAMES.add("autoplay");
+        BOOLEAN_ATTRIBUTE_NAMES.add("badInput");
+        BOOLEAN_ATTRIBUTE_NAMES.add("checked");
+        BOOLEAN_ATTRIBUTE_NAMES.add("closed");
+        BOOLEAN_ATTRIBUTE_NAMES.add("commandChecked");
+        BOOLEAN_ATTRIBUTE_NAMES.add("commandDisabled");
+        BOOLEAN_ATTRIBUTE_NAMES.add("commandHidden");
+        BOOLEAN_ATTRIBUTE_NAMES.add("compact");
+        BOOLEAN_ATTRIBUTE_NAMES.add("complete");
+        BOOLEAN_ATTRIBUTE_NAMES.add("controls");
+        BOOLEAN_ATTRIBUTE_NAMES.add("cookieEnabled");
+        BOOLEAN_ATTRIBUTE_NAMES.add("customError");
+        BOOLEAN_ATTRIBUTE_NAMES.add("declare");
+        BOOLEAN_ATTRIBUTE_NAMES.add("default");
+        BOOLEAN_ATTRIBUTE_NAMES.add("defaultChecked");
+        BOOLEAN_ATTRIBUTE_NAMES.add("defaultMuted");
+        BOOLEAN_ATTRIBUTE_NAMES.add("defaultSelected");
+        BOOLEAN_ATTRIBUTE_NAMES.add("defer");
+        BOOLEAN_ATTRIBUTE_NAMES.add("disabled");
+        BOOLEAN_ATTRIBUTE_NAMES.add("draggable");
+        BOOLEAN_ATTRIBUTE_NAMES.add("enabled");
+        BOOLEAN_ATTRIBUTE_NAMES.add("ended");
+        BOOLEAN_ATTRIBUTE_NAMES.add("formNoValidate");
+        BOOLEAN_ATTRIBUTE_NAMES.add("hidden");
+        BOOLEAN_ATTRIBUTE_NAMES.add("indeterminate");
+        BOOLEAN_ATTRIBUTE_NAMES.add("isContentEditable");
+        BOOLEAN_ATTRIBUTE_NAMES.add("isMap");
+        BOOLEAN_ATTRIBUTE_NAMES.add("itemScope");
+        BOOLEAN_ATTRIBUTE_NAMES.add("javaEnabled");
+        BOOLEAN_ATTRIBUTE_NAMES.add("loop");
+        BOOLEAN_ATTRIBUTE_NAMES.add("multiple");
+        BOOLEAN_ATTRIBUTE_NAMES.add("muted");
+        BOOLEAN_ATTRIBUTE_NAMES.add("noHref");
+        BOOLEAN_ATTRIBUTE_NAMES.add("noResize");
+        BOOLEAN_ATTRIBUTE_NAMES.add("noShade");
+        BOOLEAN_ATTRIBUTE_NAMES.add("noValidate");
+        BOOLEAN_ATTRIBUTE_NAMES.add("noWrap");
+        BOOLEAN_ATTRIBUTE_NAMES.add("onLine");
+        BOOLEAN_ATTRIBUTE_NAMES.add("open");
+        BOOLEAN_ATTRIBUTE_NAMES.add("patternMismatch");
+        BOOLEAN_ATTRIBUTE_NAMES.add("pauseOnExit");
+        BOOLEAN_ATTRIBUTE_NAMES.add("paused");
+        BOOLEAN_ATTRIBUTE_NAMES.add("persisted");
+        BOOLEAN_ATTRIBUTE_NAMES.add("rangeOverflow");
+        BOOLEAN_ATTRIBUTE_NAMES.add("rangeUnderflow");
+        BOOLEAN_ATTRIBUTE_NAMES.add("readOnly");
+        BOOLEAN_ATTRIBUTE_NAMES.add("required");
+        BOOLEAN_ATTRIBUTE_NAMES.add("reversed");
+        BOOLEAN_ATTRIBUTE_NAMES.add("scoped");
+        BOOLEAN_ATTRIBUTE_NAMES.add("seamless");
+        BOOLEAN_ATTRIBUTE_NAMES.add("seeking");
+        BOOLEAN_ATTRIBUTE_NAMES.add("selected");
+        BOOLEAN_ATTRIBUTE_NAMES.add("sortable");
+        BOOLEAN_ATTRIBUTE_NAMES.add("spellcheck");
+        BOOLEAN_ATTRIBUTE_NAMES.add("stepMismatch");
+        BOOLEAN_ATTRIBUTE_NAMES.add("tooLong");
+        BOOLEAN_ATTRIBUTE_NAMES.add("tooShort");
+        BOOLEAN_ATTRIBUTE_NAMES.add("translate");
+        BOOLEAN_ATTRIBUTE_NAMES.add("trueSpeed");
+        BOOLEAN_ATTRIBUTE_NAMES.add("typeMismatch");
+        BOOLEAN_ATTRIBUTE_NAMES.add("typeMustMatch");
+        BOOLEAN_ATTRIBUTE_NAMES.add("valid");
+        BOOLEAN_ATTRIBUTE_NAMES.add("valueMissing");
+        BOOLEAN_ATTRIBUTE_NAMES.add("visible");
+        BOOLEAN_ATTRIBUTE_NAMES.add("willValidate");
+    }
+
     private final static ObjectHashSet<String> EMPTY_TAGS = new ObjectHashSet<String>(31);
     static {
         EMPTY_TAGS.add("area");
@@ -100,7 +182,7 @@ public class HTML5Writer extends XHTML5Writer {
             final Writer writer = getWriter();
             writer.write(' ');
             writer.write(qname);
-            if (!qname.equals(value)) {
+            if (!(BOOLEAN_ATTRIBUTE_NAMES.contains(qname) && qname.equals(value))) {
                 writer.write("=\"");
                 writeChars(value, true);
                 writer.write('"');
@@ -125,8 +207,9 @@ public class HTML5Writer extends XHTML5Writer {
                 writer.write(qname.getPrefix());
                 writer.write(':');
             }
-            if (!qname.getLocalPart().equals(value)) {
-                writer.write(qname.getLocalPart());
+            final String localPart = qname.getLocalPart();
+            writer.write(localPart);
+            if (!(BOOLEAN_ATTRIBUTE_NAMES.contains(localPart) && localPart.equals(value))) {
                 writer.write("=\"");
                 writeChars(value, true);
                 writer.write('"');

--- a/test/src/org/exist/util/serializer/HTML5WriterTest.java
+++ b/test/src/org/exist/util/serializer/HTML5WriterTest.java
@@ -1,0 +1,90 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2018 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.util.serializer;
+
+import java.io.StringWriter;
+
+import org.exist.dom.QName;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HTML5WriterTest {
+
+    private HTML5Writer writer;
+    private StringWriter targetWriter;
+    
+    @Before
+    public void setUp() throws Exception {
+        targetWriter = new StringWriter();
+        writer = new HTML5Writer(targetWriter);
+    }
+
+    @Test
+    public void testAttributeWithBooleanValue() throws Exception {
+        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<input checked>";
+        final QName elQName = new QName("input");
+        writer.startElement(elQName);
+        writer.attribute("checked", "checked");
+        writer.closeStartTag(true);
+
+        final String actual = targetWriter.toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAttributeWithNonBooleanValue() throws Exception {
+        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<input name=\"name\">";
+        final QName elQName = new QName("input");
+        writer.startElement(elQName);
+        writer.attribute("name", "name");
+        writer.closeStartTag(true);
+
+        final String actual = targetWriter.toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAttributeQNameWithBooleanValue() throws Exception {
+        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<input checked>";
+        final QName elQName = new QName("input");
+        final QName attrQName = new QName("checked");
+        writer.startElement(elQName);
+        writer.attribute(attrQName, attrQName.getLocalPart());
+        writer.closeStartTag(true);
+
+        final String actual = targetWriter.toString();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAttributeQNameWithNonBooleanValue() throws Exception {
+        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<input name=\"name\">";
+        final QName elQName = new QName("input");
+        final QName attrQName = new QName("name");
+        writer.startElement(elQName);
+        writer.attribute(attrQName, attrQName.getLocalPart());
+        writer.closeStartTag(true);
+
+        final String actual = targetWriter.toString();
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Back-port of https://github.com/eXist-db/exist/pull/1933