### PR TITLE
Use ErrorCodes for XQuery Errors

### DIFF
--- a/extensions/indexes/ngram/src/org/exist/xquery/modules/ngram/NGramSearch.java
+++ b/extensions/indexes/ngram/src/org/exist/xquery/modules/ngram/NGramSearch.java
@@ -403,7 +403,7 @@ public class NGramSearch extends Function implements Optimizable {
                     token.append(query.substring(i, i + 2));
                     i++;
                 } else {
-                    throw new XPathException("err:FTDY0020: query string is terminated by an unescaped backslash");
+                    throw new XPathException(ErrorCodes.FTDY0020, "Query string is terminated by an unescaped backslash");
                 }
             } else {
                 if (currentChar == '.') {

--- a/src/org/exist/xquery/FunctionCall.java
+++ b/src/org/exist/xquery/FunctionCall.java
@@ -232,7 +232,7 @@ public class FunctionCall extends Function {
                 getSignature().getReturnType().checkType(result.getItemType());
             }
         } catch(final XPathException e) {
-            throw new XPathException(this, ErrorCodes.XPTY0004, "err:XPTY0004: return type of function '" + getSignature().getName() + "'. " + e.getMessage(), Sequence.EMPTY_SEQUENCE, e);
+            throw new XPathException(this, ErrorCodes.XPTY0004, "Return type of function '" + getSignature().getName() + "'. " + e.getMessage(), Sequence.EMPTY_SEQUENCE, e);
         }
 
 	

--- a/src/org/exist/xquery/VariableDeclaration.java
+++ b/src/org/exist/xquery/VariableDeclaration.java
@@ -83,13 +83,13 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
             if(myModule != null) {
 // WM: duplicate var declaration is now caught in the XQuery tree parser
 //                if (myModule.isVarDeclared(qn))
-//                    throw new XPathException(this, "err:XQST0049: It is a static error if more than one " +
+//                    throw new XPathException(this, ErrorCodes.XQST0049, "It is a static error if more than one " +
 //                            "variable declared or imported by a module has the same expanded QName. Variable: " + qn);
                 myModule.declareVariable(var);
             } else {
 // WM: duplicate var declaration is now caught in the XQuery tree parser
 //                if(context.isVarDeclared(qn)) {
-//                    throw new XPathException(this, "err:XQST0049: It is a static error if more than one " +
+//                    throw new XPathException(this, ErrorCodes.XQST0049, "It is a static error if more than one " +
 //                            "variable declared or imported by a module has the same expanded QName. Variable: " + qn);
 //                }
                 context.declareGlobalVariable(var);

--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -951,7 +951,7 @@ public class XQueryContext implements BinaryValueManager, Context
     {
         //Not sure for the 2nd clause : eXist forces the function NS as default.
         if( ( defaultFunctionNamespace != null ) && !defaultFunctionNamespace.equals( Function.BUILTIN_FUNCTION_NS ) && !defaultFunctionNamespace.equals( uri ) ) {
-            throw( new XPathException( "err:XQST0066: default function namespace is already set to: '" + defaultFunctionNamespace + "'" ) );
+            throw( new XPathException(ErrorCodes.XQST0066, "Default function namespace is already set to: '" + defaultFunctionNamespace + "'" ) );
         }
         defaultFunctionNamespace = uri;
     }
@@ -981,7 +981,7 @@ public class XQueryContext implements BinaryValueManager, Context
     {
         // eXist forces the empty element NS as default.
         if( !defaultElementNamespaceSchema.equals( AnyURIValue.EMPTY_URI ) ) {
-            throw( new XPathException( "err:XQST0066: default function namespace schema is already set to: '" + defaultElementNamespaceSchema.getStringValue() + "'" ) );
+            throw( new XPathException(ErrorCodes.XQST0066, "Default function namespace schema is already set to: '" + defaultElementNamespaceSchema.getStringValue() + "'" ) );
         }
         defaultElementNamespaceSchema = new AnyURIValue( uri );
     }
@@ -1012,7 +1012,7 @@ public class XQueryContext implements BinaryValueManager, Context
     {
         // eXist forces the empty element NS as default.
         if( !defaultElementNamespace.equals( AnyURIValue.EMPTY_URI ) ) {
-            throw( new XPathException( "err:XQST0066: default element namespace is already set to: '" + defaultElementNamespace.getStringValue() + "'" ) );
+            throw( new XPathException(ErrorCodes.XQST0066, "Default element namespace is already set to: '" + defaultElementNamespace.getStringValue() + "'" ) );
         }
         defaultElementNamespace = new AnyURIValue( uri );
 
@@ -1043,7 +1043,7 @@ public class XQueryContext implements BinaryValueManager, Context
             uriTest = new URI( uri );
         }
         catch( final URISyntaxException e ) {
-            throw( new XPathException( "err:XQST0038: Unknown collation : '" + uri + "'" ) );
+            throw( new XPathException(ErrorCodes.XQST0038, "Unknown collation : '" + uri + "'" ) );
         }
 
         if( uri.startsWith( Collations.EXIST_COLLATION_URI ) || uri.startsWith( "?" ) || uriTest.isAbsolute() ) {
@@ -2460,7 +2460,7 @@ public class XQueryContext implements BinaryValueManager, Context
         // is then undefined, and any attempt to use its value may result in
         // an error [err:XPST0001].
         if( ( baseURI == null ) || baseURI.equals( AnyURIValue.EMPTY_URI ) ) {
-            //throw new XPathException("err:XPST0001: base URI of the static context  has not been assigned a value.");
+            //throw new XPathException(ErrorCodes.XPST0001, "Base URI of the static context  has not been assigned a value.");
             // We catch and resolve this to the XmlDbURI.ROOT_COLLECTION_URI
             // at least in DocumentImpl so maybe we should do it here./ljo
         }

--- a/src/org/exist/xquery/functions/fn/FunReplace.java
+++ b/src/org/exist/xquery/functions/fn/FunReplace.java
@@ -200,10 +200,10 @@ public class FunReplace extends FunMatches {
             	if (replace.charAt(i) == '$') {
             		try {
             			if (!(replace.charAt(i - 1) == '\\' || Character.isDigit(replace.charAt(i + 1))))
-            				throw new XPathException(this, "err:FORX0004 The value of $replacement contains a '$' character that is not immediately followed by a digit 0-9 and not immediately preceded by a '\\'.");
+            				throw new XPathException(this, ErrorCodes.FORX0004, "The value of $replacement contains a '$' character that is not immediately followed by a digit 0-9 and not immediately preceded by a '\\'.");
             		//Handle index exceptions
             		} catch (Exception e){
-            			throw new XPathException(this, "err:FORX0004 The value of $replacement contains a '$' character that is not immediately followed by a digit 0-9 and not immediately preceded by a '\\'.");
+            			throw new XPathException(this, ErrorCodes.FORX0004, "The value of $replacement contains a '$' character that is not immediately followed by a digit 0-9 and not immediately preceded by a '\\'.");
             		}
             	}
             	*/

--- a/src/org/exist/xquery/parser/XQuery.g
+++ b/src/org/exist/xquery/parser/XQuery.g
@@ -1053,7 +1053,7 @@ pragma throws XPathException
 exception catch [RecognitionException e]
         {
             lexer.wsExplicit = false;
-            throw new XPathException("err:XPST0003: Parse error: " + e.getMessage() + " at line: " + e.getLine() + " column: " + e.getColumn());
+            throw new XPathException(ErrorCodes.XPST0003, "Parse error: " + e.getMessage() + " at line: " + e.getLine() + " column: " + e.getColumn());
         }
 	;
 
@@ -1671,7 +1671,7 @@ elementWithoutAttributes throws XPathException
         {
         	if (e.getMessage().contains("expecting XML end tag") || e.getMessage().contains("<")) {
             	lexer.wsExplicit = false;
-            	throw new XPathException(#q, "err:XPST0003: No closing end tag found for element constructor: " + name);
+            	throw new XPathException(#q, ErrorCodes.XPST0003, "No closing end tag found for element constructor: " + name);
             } else if (e.getMessage().contains("unexpected token")) {
 	        	throw new XPathException(e.getLine(), e.getColumn(), ErrorCodes.XPST0003, e.getMessage() +
 	        		" (while expecting closing tag for element constructor: " + name + ")");
@@ -1706,10 +1706,10 @@ elementWithAttributes throws XPathException
 			content:mixedElementContent END_TAG_START! cname=qn:qName! GT!
 			{
 				if (elementStack.isEmpty())
-					throw new XPathException(#qn, "err:XPST0003: Found closing tag without opening tag: " + cname);
+					throw new XPathException(#qn, ErrorCodes.XPST0003, "Found closing tag without opening tag: " + cname);
 				String prev= (String) elementStack.pop();
 				if (!prev.equals(cname))
-					throw new XPathException(#qn, "err:XPST0003: Found closing tag: " + cname + "; expected: " + prev);
+					throw new XPathException(#qn, ErrorCodes.XPST0003, "Found closing tag: " + cname + "; expected: " + prev);
 				#elementWithAttributes= #(#[ELEMENT, cname], #attrs);
 				if (!elementStack.isEmpty()) {
 					lexer.inElementContent= true;
@@ -1722,7 +1722,7 @@ elementWithAttributes throws XPathException
         {
         	if (e.getMessage().contains("expecting XML end tag") || e.getMessage().contains("<")) {
 	            lexer.wsExplicit = false;
-	            throw new XPathException(#q, "err:XPST0003: Static error: no closing end tag found for element constructor: " + name);
+	            throw new XPathException(#q, ErrorCodes.XPST0003, "Static error: no closing end tag found for element constructor: " + name);
 	        } else if (e.getMessage().contains("unexpected token")) {
 	        	throw new XPathException(e.getLine(), e.getColumn(), ErrorCodes.XPST0003, e.getMessage() +
 	        		" (while expecting closing tag for element constructor: " + name + ")");

--- a/src/org/exist/xquery/parser/XQueryParser.java
+++ b/src/org/exist/xquery/parser/XQueryParser.java
@@ -7905,7 +7905,7 @@ inputState.guessing--;
 			if (inputState.guessing==0) {
 				
 				lexer.wsExplicit = false;
-				throw new XPathException("err:XPST0003: Parse error: " + e.getMessage() + " at line: " + e.getLine() + " column: " + e.getColumn());
+				throw new XPathException(ErrorCodes.XPST0003, "Parse error: " + e.getMessage() + " at line: " + e.getLine() + " column: " + e.getColumn());
 				
 			} else {
 				throw e;
@@ -13736,10 +13736,10 @@ inputState.guessing--;
 					elementWithAttributes_AST = (org.exist.xquery.parser.XQueryAST)currentAST.root;
 					
 									if (elementStack.isEmpty())
-										throw new XPathException(qn_AST, "err:XPST0003: Found closing tag without opening tag: " + cname);
+										throw new XPathException(qn_AST, ErrorCodes.XPST0003, "Found closing tag without opening tag: " + cname);
 									String prev= (String) elementStack.pop();
 									if (!prev.equals(cname))
-										throw new XPathException(qn_AST, "err:XPST0003: Found closing tag: " + cname + "; expected: " + prev);
+										throw new XPathException(qn_AST, ErrorCodes.XPST0003, "Found closing tag: " + cname + "; expected: " + prev);
 									elementWithAttributes_AST= (org.exist.xquery.parser.XQueryAST)astFactory.make( (new ASTArray(2)).add((org.exist.xquery.parser.XQueryAST)astFactory.create(ELEMENT,cname)).add(attrs_AST));
 									if (!elementStack.isEmpty()) {
 										lexer.inElementContent= true;
@@ -13770,7 +13770,7 @@ inputState.guessing--;
 				
 					if (e.getMessage().contains("expecting XML end tag") || e.getMessage().contains("<")) {
 					            lexer.wsExplicit = false;
-					            throw new XPathException(q_AST, "err:XPST0003: Static error: no closing end tag found for element constructor: " + name);
+					            throw new XPathException(q_AST, ErrorCodes.XPST0003, "Static error: no closing end tag found for element constructor: " + name);
 					        } else if (e.getMessage().contains("unexpected token")) {
 					        	throw new XPathException(e.getLine(), e.getColumn(), ErrorCodes.XPST0003, e.getMessage() +
 					        		" (while expecting closing tag for element constructor: " + name + ")");
@@ -13882,7 +13882,7 @@ inputState.guessing--;
 				
 					if (e.getMessage().contains("expecting XML end tag") || e.getMessage().contains("<")) {
 					lexer.wsExplicit = false;
-					throw new XPathException(q_AST, "err:XPST0003: No closing end tag found for element constructor: " + name);
+					throw new XPathException(q_AST, ErrorCodes.XPST0003, "No closing end tag found for element constructor: " + name);
 				} else if (e.getMessage().contains("unexpected token")) {
 					        	throw new XPathException(e.getLine(), e.getColumn(), ErrorCodes.XPST0003, e.getMessage() +
 					        		" (while expecting closing tag for element constructor: " + name + ")");

--- a/src/org/exist/xquery/parser/XQueryTree.g
+++ b/src/org/exist/xquery/parser/XQueryTree.g
@@ -251,14 +251,14 @@ throws PermissionDeniedException, EXistException, XPathException
                 } else if (version.equals("1.0")) {
                     context.setXQueryVersion(10);
                 } else {
-                    throw new XPathException(v, "err:XQST0031: Wrong XQuery version: require 1.0, 3.0 or 3.1");
+                    throw new XPathException(v, ErrorCodes.XQST0031, "Wrong XQuery version: require 1.0, 3.0 or 3.1");
                 }
             }
             ( enc:STRING_LITERAL )?
             {
                 if (enc != null) {
                     if (!XMLChar.isValidIANAEncoding(enc.getText())) {
-                        throw new XPathException(enc, "err:XQST0087: Unknown or wrong encoding not adhering to required XML 1.0 EncName.");
+                        throw new XPathException(enc, ErrorCodes.XQST0087, "Unknown or wrong encoding not adhering to required XML 1.0 EncName.");
                     }
                     if (!enc.getText().equals("UTF-8")) {
                         //util.serializer.encodings.CharacterSet
@@ -321,7 +321,7 @@ throws PermissionDeniedException, EXistException, XPathException
 			prefix:NAMESPACE_DECL uri:STRING_LITERAL
 			{
 				if (declaredNamespaces.get(prefix.getText()) != null)
-					throw new XPathException(prefix, "err:XQST0033: Prolog contains " +
+					throw new XPathException(prefix, ErrorCodes.XQST0033, "Prolog contains " +
 						"multiple declarations for namespace prefix: " + prefix.getText());
 				context.declareNamespace(prefix.getText(), uri.getText());
 				staticContext.declareNamespace(prefix.getText(), uri.getText());
@@ -335,7 +335,7 @@ throws PermissionDeniedException, EXistException, XPathException
 				"preserve"
                 {
                 if (boundaryspace)
-					throw new XPathException("err:XQST0068: Boundary-space already declared.");
+					throw new XPathException(ErrorCodes.XQST0068, "Boundary-space already declared.");
                 boundaryspace = true;
                 context.setStripWhitespace(false);
                 }
@@ -343,7 +343,7 @@ throws PermissionDeniedException, EXistException, XPathException
 				"strip"
                 {
                 if (boundaryspace)
-					throw new XPathException("err:XQST0068: Boundary-space already declared.");
+					throw new XPathException(ErrorCodes.XQST0068, "Boundary-space already declared.");
                 boundaryspace = true;
                 context.setStripWhitespace(true);
                 }
@@ -364,7 +364,7 @@ throws PermissionDeniedException, EXistException, XPathException
             )
             {
                 if (orderempty)
-                    throw new XPathException("err:XQST0065: Ordering mode already declared.");
+                    throw new XPathException(ErrorCodes.XQST0065, "Ordering mode already declared.");
                 orderempty = true;
             }
 		)
@@ -399,19 +399,19 @@ throws PermissionDeniedException, EXistException, XPathException
             )
             {
                 if (copynamespaces)
-                    throw new XPathException("err:XQST0055: Copy-namespaces mode already declared.");
+                    throw new XPathException(ErrorCodes.XQST0055, "Copy-namespaces mode already declared.");
                 copynamespaces = true;
             }
 		)
             exception catch [RecognitionException se]
-        {throw new XPathException("err:XPST0003: XQuery syntax error.");}
+        {throw new XPathException(ErrorCodes.XPST0003, "XQuery syntax error.");}
 		|
 		#(
 			"base-uri" base:STRING_LITERAL
 			{
                 context.setBaseURI(new AnyURIValue(StringValue.expand(base.getText())), true);
                 if (baseuri)
-                    throw new XPathException(base, "err:XQST0032: Base URI is already declared.");
+                    throw new XPathException(base, ErrorCodes.XQST0032, "Base URI is already declared.");
                 baseuri = true;
             }
 		)
@@ -421,7 +421,7 @@ throws PermissionDeniedException, EXistException, XPathException
             {
                 // ignored
                 if (ordering)
-                    throw new XPathException("err:XQST0065: Ordering already declared.");
+                    throw new XPathException(ErrorCodes.XQST0065, "Ordering already declared.");
                 ordering = true;
             }
 		)
@@ -431,7 +431,7 @@ throws PermissionDeniedException, EXistException, XPathException
             {
                 // ignored
                 if (construction)
-                    throw new XPathException("err:XQST0069: Construction already declared.");
+                    throw new XPathException(ErrorCodes.XQST0069, "Construction already declared.");
                 construction = true;
             }
 		)
@@ -456,12 +456,12 @@ throws PermissionDeniedException, EXistException, XPathException
 			DEF_COLLATION_DECL defc:STRING_LITERAL
 			{
                 if (defaultcollation)
-                    throw new XPathException("err:XQST0038: Default collation already declared.");
+                    throw new XPathException(ErrorCodes.XQST0038, "Default collation already declared.");
                 defaultcollation = true;
                 try {
                     context.setDefaultCollation(defc.getText());
                 } catch (XPathException xp) {
-                    throw new XPathException(defc, "err:XQST0038: the value specified by a default collation declaration is not present in statically known collations.");
+                    throw new XPathException(defc, ErrorCodes.XQST0038, "the value specified by a default collation declaration is not present in statically known collations.");
                 }
             }
 		)
@@ -478,7 +478,7 @@ throws PermissionDeniedException, EXistException, XPathException
 				    throw new XPathException(qname.getLine(), qname.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + qname.getText());
 				}
 				if (declaredGlobalVars.contains(qn))
-					throw new XPathException(qname, "err:XQST0049: It is a " +
+					throw new XPathException(qname, ErrorCodes.XQST0049, "It is a " +
 						"static error if more than one variable declared or " +
 						"imported by a module has the same expanded QName. " +
 						"Variable: " + qn.toString());
@@ -621,7 +621,7 @@ throws PermissionDeniedException, EXistException, XPathException
 		{
 			if (modulePrefix != null) {
 				if (declaredNamespaces.get(modulePrefix) != null)
-					throw new XPathException(i, "err:XQST0033: Prolog contains " +
+					throw new XPathException(i, ErrorCodes.XQST0033, "Prolog contains " +
 						"multiple declarations for namespace prefix: " + modulePrefix);
 				declaredNamespaces.put(modulePrefix, moduleURI.getText());
 			}
@@ -665,11 +665,11 @@ throws PermissionDeniedException, EXistException, XPathException
 		( uriList [uriList] )?
 		{
             if ("".equals(targetURI.getText()) && nsPrefix != null) {
-                    throw new XPathException(s, "err:XQST0057: A schema without target namespace (zero-length string target namespace) may not bind a namespace prefix: " + nsPrefix);
+                    throw new XPathException(s, ErrorCodes.XQST0057, "A schema without target namespace (zero-length string target namespace) may not bind a namespace prefix: " + nsPrefix);
             }
             if (nsPrefix != null) {
                 if (declaredNamespaces.get(nsPrefix) != null)
-                    throw new XPathException(s, "err:XQST0033: Prolog contains " +
+                    throw new XPathException(s, ErrorCodes.XQST0033, "Prolog contains " +
                                              "multiple declarations for namespace prefix: " + nsPrefix);
                 declaredNamespaces.put(nsPrefix, targetURI.getText());
             }
@@ -682,7 +682,7 @@ throws PermissionDeniedException, EXistException, XPathException
                 throw xpe;
             }
             // We ought to do this for now until Dannes can say it works. /ljo
-            //throw new XPathException(s, "err:XQST0009: the eXist XQuery implementation does not support the Schema Import Feature quite yet.");
+            //throw new XPathException(s, ErrorCodes.XQST0009, "The eXist-db XQuery implementation does not support the Schema Import Feature quite yet.");
 		}
 	)
 	;
@@ -1204,7 +1204,7 @@ throws PermissionDeniedException, EXistException, XPathException
             // Added for handling empty mainModule /ljo
             // System.out.println("EMPTY EXPR");
             if (eof.getText() == null || "".equals(eof.getText()))
-                throw new XPathException(eof, "err:XPST0003: EOF or zero-length string found where a valid XPath expression was expected.");
+                throw new XPathException(eof, ErrorCodes.XPST0003, "EOF or zero-length string found where a valid XPath expression was expected.");
 
         }
     |
@@ -3136,7 +3136,7 @@ throws PermissionDeniedException, EXistException, XPathException
                 QName qname = QName.parse(staticContext, qna.getText());
                 if (Namespaces.XMLNS_NS.equals(qname.getNamespaceURI())
                     || ("".equals(qname.getNamespaceURI()) && qname.getLocalPart().equals(XMLConstants.XMLNS_ATTRIBUTE)))
-                    throw new XPathException("err:XQDY0044: the node-name property of the node constructed by a computed attribute constructor is in the namespace http://www.w3.org/2000/xmlns/ (corresponding to namespace prefix xmlns), or is in no namespace and has local name xmlns.");
+                    throw new XPathException(ErrorCodes.XQDY0044, "The node-name property of the node constructed by a computed attribute constructor is in the namespace http://www.w3.org/2000/xmlns/ (corresponding to namespace prefix xmlns), or is in no namespace and has local name xmlns.");
             } catch (final IllegalQNameException iqe) {
                 throw new XPathException(qna.getLine(), qna.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + qna.getText());
             }
@@ -3165,7 +3165,7 @@ throws PermissionDeniedException, EXistException, XPathException
                 contentExpr=ex:expr [elementContent]
                 {
                     if (ex.getText() != null && ex.getText().indexOf("?>") > Constants.STRING_NOT_FOUND)
-                throw new XPathException("err:XQDY0026: content expression of a computed processing instruction constructor contains the string '?>' which is not allowed.");
+                throw new XPathException(ErrorCodes.XQDY0026, "Content expression of a computed processing instruction constructor contains the string '?>' which is not allowed.");
                 }
             )?
         )

--- a/src/org/exist/xquery/parser/XQueryTreeParser.java
+++ b/src/org/exist/xquery/parser/XQueryTreeParser.java
@@ -293,7 +293,7 @@ public XQueryTreeParser() {
 			// Added for handling empty mainModule /ljo
 			// System.out.println("EMPTY EXPR");
 			if (eof.getText() == null || "".equals(eof.getText()))
-			throw new XPathException(eof, "err:XPST0003: EOF or zero-length string found where a valid XPath expression was expected.");
+			throw new XPathException(eof, ErrorCodes.XPST0003, "EOF or zero-length string found where a valid XPath expression was expected.");
 			
 			
 			break;
@@ -3684,7 +3684,7 @@ public XQueryTreeParser() {
 			} else if (version.equals("1.0")) {
 			context.setXQueryVersion(10);
 			} else {
-			throw new XPathException(v, "err:XQST0031: Wrong XQuery version: require 1.0, 3.0 or 3.1");
+			throw new XPathException(v, ErrorCodes.XQST0031, "Wrong XQuery version: require 1.0, 3.0 or 3.1");
 			}
 			
 			{
@@ -3710,7 +3710,7 @@ public XQueryTreeParser() {
 			
 			if (enc != null) {
 			if (!XMLChar.isValidIANAEncoding(enc.getText())) {
-			throw new XPathException(enc, "err:XQST0087: Unknown or wrong encoding not adhering to required XML 1.0 EncName.");
+			throw new XPathException(enc, ErrorCodes.XQST0087, "Unknown or wrong encoding not adhering to required XML 1.0 EncName.");
 			}
 			if (!enc.getText().equals("UTF-8")) {
 			//util.serializer.encodings.CharacterSet
@@ -4095,7 +4095,7 @@ public XQueryTreeParser() {
 				_t = _t.getNextSibling();
 				
 								if (declaredNamespaces.get(prefix.getText()) != null)
-									throw new XPathException(prefix, "err:XQST0033: Prolog contains " +
+									throw new XPathException(prefix, ErrorCodes.XQST0033, "Prolog contains " +
 										"multiple declarations for namespace prefix: " + prefix.getText());
 								context.declareNamespace(prefix.getText(), uri.getText());
 								staticContext.declareNamespace(prefix.getText(), uri.getText());
@@ -4121,7 +4121,7 @@ public XQueryTreeParser() {
 					_t = _t.getNextSibling();
 					
 					if (boundaryspace)
-										throw new XPathException("err:XQST0068: Boundary-space already declared.");
+										throw new XPathException(ErrorCodes.XQST0068, "Boundary-space already declared.");
 					boundaryspace = true;
 					context.setStripWhitespace(false);
 					
@@ -4134,7 +4134,7 @@ public XQueryTreeParser() {
 					_t = _t.getNextSibling();
 					
 					if (boundaryspace)
-										throw new XPathException("err:XQST0068: Boundary-space already declared.");
+										throw new XPathException(ErrorCodes.XQST0068, "Boundary-space already declared.");
 					boundaryspace = true;
 					context.setStripWhitespace(true);
 					
@@ -4187,7 +4187,7 @@ public XQueryTreeParser() {
 				}
 				
 				if (orderempty)
-				throw new XPathException("err:XQST0065: Ordering mode already declared.");
+				throw new XPathException(ErrorCodes.XQST0065, "Ordering mode already declared.");
 				orderempty = true;
 				
 				_t = __t18;
@@ -4265,14 +4265,14 @@ public XQueryTreeParser() {
 					}
 					
 					if (copynamespaces)
-					throw new XPathException("err:XQST0055: Copy-namespaces mode already declared.");
+					throw new XPathException(ErrorCodes.XQST0055, "Copy-namespaces mode already declared.");
 					copynamespaces = true;
 					
 					_t = __t20;
 					_t = _t.getNextSibling();
 				}
 				catch (RecognitionException se) {
-					throw new XPathException("err:XPST0003: XQuery syntax error.");
+					throw new XPathException(ErrorCodes.XPST0003, "XQuery syntax error.");
 				}
 				break;
 			}
@@ -4288,7 +4288,7 @@ public XQueryTreeParser() {
 				
 				context.setBaseURI(new AnyURIValue(StringValue.expand(base.getText())), true);
 				if (baseuri)
-				throw new XPathException(base, "err:XQST0032: Base URI is already declared.");
+				throw new XPathException(base, ErrorCodes.XQST0032, "Base URI is already declared.");
 				baseuri = true;
 				
 				_t = __t23;
@@ -4327,7 +4327,7 @@ public XQueryTreeParser() {
 				
 				// ignored
 				if (ordering)
-				throw new XPathException("err:XQST0065: Ordering already declared.");
+				throw new XPathException(ErrorCodes.XQST0065, "Ordering already declared.");
 				ordering = true;
 				
 				_t = __t24;
@@ -4366,7 +4366,7 @@ public XQueryTreeParser() {
 				
 				// ignored
 				if (construction)
-				throw new XPathException("err:XQST0069: Construction already declared.");
+				throw new XPathException(ErrorCodes.XQST0069, "Construction already declared.");
 				construction = true;
 				
 				_t = __t26;
@@ -4418,12 +4418,12 @@ public XQueryTreeParser() {
 				_t = _t.getNextSibling();
 				
 				if (defaultcollation)
-				throw new XPathException("err:XQST0038: Default collation already declared.");
+				throw new XPathException(ErrorCodes.XQST0038, "Default collation already declared.");
 				defaultcollation = true;
 				try {
 				context.setDefaultCollation(defc.getText());
 				} catch (XPathException xp) {
-				throw new XPathException(defc, "err:XQST0038: the value specified by a default collation declaration is not present in statically known collations.");
+				throw new XPathException(defc, ErrorCodes.XQST0038, "the value specified by a default collation declaration is not present in statically known collations.");
 				}
 				
 				_t = __t30;
@@ -4446,7 +4446,7 @@ public XQueryTreeParser() {
 								    throw new XPathException(qname.getLine(), qname.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + qname.getText());
 								}
 								if (declaredGlobalVars.contains(qn))
-									throw new XPathException(qname, "err:XQST0049: It is a " +
+									throw new XPathException(qname, ErrorCodes.XQST0049, "It is a " +
 										"static error if more than one variable declared or " +
 										"imported by a module has the same expanded QName. " +
 										"Variable: " + qn.toString());
@@ -6300,7 +6300,7 @@ public XQueryTreeParser() {
 			
 						if (modulePrefix != null) {
 							if (declaredNamespaces.get(modulePrefix) != null)
-								throw new XPathException(i, "err:XQST0033: Prolog contains " +
+								throw new XPathException(i, ErrorCodes.XQST0033, "Prolog contains " +
 									"multiple declarations for namespace prefix: " + modulePrefix);
 							declaredNamespaces.put(modulePrefix, moduleURI.getText());
 						}
@@ -6401,11 +6401,11 @@ public XQueryTreeParser() {
 			}
 			
 			if ("".equals(targetURI.getText()) && nsPrefix != null) {
-			throw new XPathException(s, "err:XQST0057: A schema without target namespace (zero-length string target namespace) may not bind a namespace prefix: " + nsPrefix);
+			throw new XPathException(s, ErrorCodes.XQST0057, "A schema without target namespace (zero-length string target namespace) may not bind a namespace prefix: " + nsPrefix);
 			}
 			if (nsPrefix != null) {
 			if (declaredNamespaces.get(nsPrefix) != null)
-			throw new XPathException(s, "err:XQST0033: Prolog contains " +
+			throw new XPathException(s, ErrorCodes.XQST0033, "Prolog contains " +
 			"multiple declarations for namespace prefix: " + nsPrefix);
 			declaredNamespaces.put(nsPrefix, targetURI.getText());
 			}
@@ -6418,7 +6418,7 @@ public XQueryTreeParser() {
 			throw xpe;
 			}
 			// We ought to do this for now until Dannes can say it works. /ljo
-			//throw new XPathException(s, "err:XQST0009: the eXist XQuery implementation does not support the Schema Import Feature quite yet.");
+			//throw new XPathException(s, ErrorCodes.XQST0009, "The eXist-db XQuery implementation does not support the Schema Import Feature quite yet.");
 					
 			_t = __t48;
 			_t = _t.getNextSibling();
@@ -10165,7 +10165,7 @@ public XQueryTreeParser() {
 			QName qname = QName.parse(staticContext, qna.getText());
 			if (Namespaces.XMLNS_NS.equals(qname.getNamespaceURI())
 			|| ("".equals(qname.getNamespaceURI()) && qname.getLocalPart().equals(XMLConstants.XMLNS_ATTRIBUTE)))
-			throw new XPathException("err:XQDY0044: the node-name property of the node constructed by a computed attribute constructor is in the namespace http://www.w3.org/2000/xmlns/ (corresponding to namespace prefix xmlns), or is in no namespace and has local name xmlns.");
+			throw new XPathException(ErrorCodes.XQDY0044, "The node-name property of the node constructed by a computed attribute constructor is in the namespace http://www.w3.org/2000/xmlns/ (corresponding to namespace prefix xmlns), or is in no namespace and has local name xmlns.");
 			} catch (final IllegalQNameException iqe) {
 			throw new XPathException(qna.getLine(), qna.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + qna.getText());
 			}
@@ -10438,7 +10438,7 @@ public XQueryTreeParser() {
 				_t = _retTree;
 				
 				if (ex.getText() != null && ex.getText().indexOf("?>") > Constants.STRING_NOT_FOUND)
-				throw new XPathException("err:XQDY0026: content expression of a computed processing instruction constructor contains the string '?>' which is not allowed.");
+				throw new XPathException(ErrorCodes.XQDY0026, "Content expression of a computed processing instruction constructor contains the string '?>' which is not allowed.");
 				
 				break;
 			}

--- a/src/org/exist/xquery/value/AbstractSequence.java
+++ b/src/org/exist/xquery/value/AbstractSequence.java
@@ -27,6 +27,7 @@ import org.exist.dom.persistent.NodeHandle;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.numbering.NodeId;
 import org.exist.xquery.Cardinality;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 
@@ -160,8 +161,8 @@ public abstract class AbstractSequence implements Sequence {
             if (OLD_EXIST_VERSION_COMPATIBILITY) {
                 return true;
             } else {
-                throw new XPathException(
-                        "err:FORG0006: effectiveBooleanValue: first item of '" +
+                throw new XPathException(ErrorCodes.FORG0006,
+                        "effectiveBooleanValue: first item of '" +
                                 (toString().length() < 20 ? toString() : toString().substring(0, 20) + "...") +
                                 "' is not a node, and sequence length > 1");
             }

--- a/src/org/exist/xquery/value/OrderedDurationValue.java
+++ b/src/org/exist/xquery/value/OrderedDurationValue.java
@@ -182,7 +182,7 @@ abstract class OrderedDurationValue extends DurationValue {
 			return date.createSameKind(gc);
 		*/
             default:
-                throw new XPathException("err:XPTY0004: cannot substract " +
+                throw new XPathException(ErrorCodes.XPTY0004, "Cannot substract " +
                         Type.getTypeName(other.getType()) + "('" + other.getStringValue() + "') from " +
                         Type.getTypeName(getType()) + "('" + getStringValue() + "')");
         }


### PR DESCRIPTION
Avoids the horrible and incorrect `exerr:ERROR` in a number of situations, by using the correct error codes.