### PR TITLE
(4.x.x) Fix Java10 signing problem

### DIFF
--- a/build/scripts/jarsigner.xml
+++ b/build/scripts/jarsigner.xml
@@ -62,6 +62,9 @@
             <fileset dir="lib/extensions">
                 <include name="*.jar"/>
             </fileset>
+            <fileset dir="tools/jetty/lib">
+                <include name="javax.annotation-api-*.jar"/>
+            </fileset>        
         </signjar>
     </target>
     
@@ -134,6 +137,9 @@
             <fileset dir="lib/extensions" erroronmissingdir="false">
                 <include name="*.jar"/>
             </fileset>
+            <fileset dir="tools/jetty/lib">
+                <include name="javax.annotation-api-*.jar"/>
+            </fileset>  
         </unsignjar>
     </target>
     
@@ -181,7 +187,7 @@
             </fileset>
             <fileset dir="lib/core">
                 <include name="*.jar"/>
-            </fileset>
+            </fileset> 
         </pack>
     </target> 
     


### PR DESCRIPTION
Fix java10 *java.lang.SecurityException: class "javax.annotation.Nullable"'s signer information does not match signer information of other classes in the same package"*

```
HTTP ERROR 500

Problem accessing /exist/apps/dashboard/index.html. Reason:

    Server Error
Caused by:

javax.servlet.ServletException: org.eclipse.jetty.servlet.ServletHolder$1: java.lang.SecurityException: class "javax.annotation.Nullable"'s signer information does not match signer information of other classes in the same package
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:724)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:531)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:132)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:760)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:678)
	at java.base/java.lang.Thread.run(Thread.java:844)
Caused by: org.eclipse.jetty.servlet.ServletHolder$1: java.lang.SecurityException: class "javax.annotation.Nullable"'s signer information does not match signer information of other classes in the same package
	at org.eclipse.jetty.servlet.ServletHolder.makeUnavailable(ServletHolder.java:629)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:681)
	at org.eclipse.jetty.servlet.ServletHolder.getServlet(ServletHolder.java:519)
	at org.eclipse.jetty.servlet.ServletHolder.prepare(ServletHolder.java:803)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:530)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:146)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:524)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:257)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1595)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1253)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1564)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1155)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:219)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:674)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:531)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)
	... 3 more
Caused by: java.lang.SecurityException: class "javax.annotation.Nullable"'s signer information does not match signer information of other classes in the same package
	at java.base/java.lang.ClassLoader.checkCerts(ClassLoader.java:1143)
	at java.base/java.lang.ClassLoader.preDefineClass(ClassLoader.java:898)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1007)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:545)
	at java.base/java.net.URLClassLoader.access$100(URLClassLoader.java:83)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:453)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:447)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:446)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:566)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:499)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:374)
	at java.base/sun.reflect.generics.factory.CoreReflectionFactory.makeNamedType(CoreReflectionFactory.java:114)
	at java.base/sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:125)
	at java.base/sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49)
	at java.base/sun.reflect.annotation.AnnotationParser.parseSig(AnnotationParser.java:439)
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotation2(AnnotationParser.java:241)
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:120)
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:72)
	at java.base/java.lang.reflect.Executable.declaredAnnotations(Executable.java:605)
	at java.base/java.lang.reflect.Executable.declaredAnnotations(Executable.java:603)
	at java.base/java.lang.reflect.Executable.getAnnotation(Executable.java:573)
	at java.base/java.lang.reflect.Method.getAnnotation(Method.java:693)
	at org.eclipse.jetty.annotations.ResourceAnnotationHandler.handleMethod(ResourceAnnotationHandler.java:226)
	at org.eclipse.jetty.annotations.ResourceAnnotationHandler.doHandle(ResourceAnnotationHandler.java:73)
	at org.eclipse.jetty.annotations.AnnotationIntrospector$AbstractIntrospectableAnnotationHandler.handle(AnnotationIntrospector.java:72)
	at org.eclipse.jetty.annotations.AnnotationIntrospector.introspect(AnnotationIntrospector.java:97)
	at org.eclipse.jetty.annotations.AnnotationDecorator.introspect(AnnotationDecorator.java:61)
	at org.eclipse.jetty.annotations.AnnotationDecorator.decorate(AnnotationDecorator.java:67)
	at org.eclipse.jetty.util.DecoratedObjectFactory.decorate(DecoratedObjectFactory.java:79)
	at org.eclipse.jetty.servlet.ServletContextHandler$Context.createServlet(ServletContextHandler.java:1373)
	at org.eclipse.jetty.servlet.ServletHolder.newInstance(ServletHolder.java:1297)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:647)
	... 29 more
Caused by:

org.eclipse.jetty.servlet.ServletHolder$1: java.lang.SecurityException: class "javax.annotation.Nullable"'s signer information does not match signer information of other classes in the same package
	at org.eclipse.jetty.servlet.ServletHolder.makeUnavailable(ServletHolder.java:629)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:681)
	at org.eclipse.jetty.servlet.ServletHolder.getServlet(ServletHolder.java:519)
	at org.eclipse.jetty.servlet.ServletHolder.prepare(ServletHolder.java:803)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:530)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:146)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:524)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:257)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1595)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1253)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1564)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1155)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:219)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:674)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:531)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:760)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:678)
	at java.base/java.lang.Thread.run(Thread.java:844)
Caused by: java.lang.SecurityException: class "javax.annotation.Nullable"'s signer information does not match signer information of other classes in the same package
	at java.base/java.lang.ClassLoader.checkCerts(ClassLoader.java:1143)
	at java.base/java.lang.ClassLoader.preDefineClass(ClassLoader.java:898)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1007)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:545)
	at java.base/java.net.URLClassLoader.access$100(URLClassLoader.java:83)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:453)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:447)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:446)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:566)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:499)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:374)
	at java.base/sun.reflect.generics.factory.CoreReflectionFactory.makeNamedType(CoreReflectionFactory.java:114)
	at java.base/sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:125)
	at java.base/sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49)
	at java.base/sun.reflect.annotation.AnnotationParser.parseSig(AnnotationParser.java:439)
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotation2(AnnotationParser.java:241)
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:120)
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:72)
	at java.base/java.lang.reflect.Executable.declaredAnnotations(Executable.java:605)
	at java.base/java.lang.reflect.Executable.declaredAnnotations(Executable.java:603)
	at java.base/java.lang.reflect.Executable.getAnnotation(Executable.java:573)
	at java.base/java.lang.reflect.Method.getAnnotation(Method.java:693)
	at org.eclipse.jetty.annotations.ResourceAnnotationHandler.handleMethod(ResourceAnnotationHandler.java:226)
	at org.eclipse.jetty.annotations.ResourceAnnotationHandler.doHandle(ResourceAnnotationHandler.java:73)
	at org.eclipse.jetty.annotations.AnnotationIntrospector$AbstractIntrospectableAnnotationHandler.handle(AnnotationIntrospector.java:72)
	at org.eclipse.jetty.annotations.AnnotationIntrospector.introspect(AnnotationIntrospector.java:97)
	at org.eclipse.jetty.annotations.AnnotationDecorator.introspect(AnnotationDecorator.java:61)
	at org.eclipse.jetty.annotations.AnnotationDecorator.decorate(AnnotationDecorator.java:67)
	at org.eclipse.jetty.util.DecoratedObjectFactory.decorate(DecoratedObjectFactory.java:79)
	at org.eclipse.jetty.servlet.ServletContextHandler$Context.createServlet(ServletContextHandler.java:1373)
	at org.eclipse.jetty.servlet.ServletHolder.newInstance(ServletHolder.java:1297)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:647)
	... 29 more
Caused by:

java.lang.SecurityException: class "javax.annotation.Nullable"'s signer information does not match signer information of other classes in the same package
	at java.base/java.lang.ClassLoader.checkCerts(ClassLoader.java:1143)
	at java.base/java.lang.ClassLoader.preDefineClass(ClassLoader.java:898)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1007)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:545)
	at java.base/java.net.URLClassLoader.access$100(URLClassLoader.java:83)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:453)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:447)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:446)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:566)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:499)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:374)
	at java.base/sun.reflect.generics.factory.CoreReflectionFactory.makeNamedType(CoreReflectionFactory.java:114)
	at java.base/sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:125)
	at java.base/sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49)
	at java.base/sun.reflect.annotation.AnnotationParser.parseSig(AnnotationParser.java:439)
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotation2(AnnotationParser.java:241)
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:120)
	at java.base/sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:72)
	at java.base/java.lang.reflect.Executable.declaredAnnotations(Executable.java:605)
	at java.base/java.lang.reflect.Executable.declaredAnnotations(Executable.java:603)
	at java.base/java.lang.reflect.Executable.getAnnotation(Executable.java:573)
	at java.base/java.lang.reflect.Method.getAnnotation(Method.java:693)
	at org.eclipse.jetty.annotations.ResourceAnnotationHandler.handleMethod(ResourceAnnotationHandler.java:226)
	at org.eclipse.jetty.annotations.ResourceAnnotationHandler.doHandle(ResourceAnnotationHandler.java:73)
	at org.eclipse.jetty.annotations.AnnotationIntrospector$AbstractIntrospectableAnnotationHandler.handle(AnnotationIntrospector.java:72)
	at org.eclipse.jetty.annotations.AnnotationIntrospector.introspect(AnnotationIntrospector.java:97)
	at org.eclipse.jetty.annotations.AnnotationDecorator.introspect(AnnotationDecorator.java:61)
	at org.eclipse.jetty.annotations.AnnotationDecorator.decorate(AnnotationDecorator.java:67)
	at org.eclipse.jetty.util.DecoratedObjectFactory.decorate(DecoratedObjectFactory.java:79)
	at org.eclipse.jetty.servlet.ServletContextHandler$Context.createServlet(ServletContextHandler.java:1373)
	at org.eclipse.jetty.servlet.ServletHolder.newInstance(ServletHolder.java:1297)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:647)
	at org.eclipse.jetty.servlet.ServletHolder.getServlet(ServletHolder.java:519)
	at org.eclipse.jetty.servlet.ServletHolder.prepare(ServletHolder.java:803)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:530)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:146)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:524)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:257)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1595)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1253)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1564)
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1155)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:219)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:674)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:531)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)
	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:760)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:678)
	at java.base/java.lang.Thread.run(Thread.java:844)
```