### PR TITLE
Basic support for available documents of Dynamic Context

### DIFF
--- a/test/src/org/exist/dom/memtree/DocumentImplTest.java
+++ b/test/src/org/exist/dom/memtree/DocumentImplTest.java
@@ -172,7 +172,7 @@ public class DocumentImplTest {
         final SAXParser saxParser  = saxParserFactory.newSAXParser();
         final XMLReader reader = saxParser.getXMLReader();
         final InputSource src = new InputSource(is);
-        final SAXAdapter adapter = new SAXAdapter(null);
+        final SAXAdapter adapter = new SAXAdapter();
         reader.setContentHandler(adapter);
 
         reader.setProperty(Namespaces.SAX_LEXICAL_HANDLER, adapter);

--- a/test/src/org/exist/xquery/functions/fn/DocTest.java
+++ b/test/src/org/exist/xquery/functions/fn/DocTest.java
@@ -21,9 +21,23 @@
  */
 package org.exist.xquery.functions.fn;
 
+import com.evolvedbinary.j8fu.Either;
+import org.exist.EXistException;
+import org.exist.Namespaces;
+import org.exist.dom.memtree.DocumentImpl;
+import org.exist.dom.memtree.SAXAdapter;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
 import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.xquery.CompiledXQuery;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.AnyURIValue;
+import org.exist.xquery.value.Sequence;
 import org.junit.*;
 
+import static com.evolvedbinary.j8fu.Either.Left;
 import static org.junit.Assert.*;
 
 import org.exist.xmldb.EXistResource;
@@ -31,22 +45,43 @@ import org.exist.xmldb.LocalXMLResource;
 import org.exist.xquery.XPathException;
 import org.w3c.dom.Node;
 
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.modules.CollectionManagementService;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.Source;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  *
  * @author Joe Wicentowski
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
+ * @author Adam Retter
  */
 public class DocTest {
 
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true);
 
+    private static SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+    static {
+        saxParserFactory.setNamespaceAware(true);
+    }
     private Collection test = null;
 
     @Before
@@ -104,5 +139,135 @@ public class DocTest {
         assertNotNull(res);
         n = res.getContentAsDOM();
         assertEquals("x", n.getLocalName());
+    }
+
+    @Test
+    public void doc_dynamicallyAvailableDocument_absoluteUri() throws XPathException, EXistException, PermissionDeniedException {
+        final BrokerPool pool = BrokerPool.getInstance();
+
+        final String doc = "<timestamp>" + System.currentTimeMillis() + "</timestamp>";
+        final String docUri = "http://from-dynamic-context/doc1";
+        final String query = "fn:doc('" + docUri + "')";
+
+        try (final DBBroker broker = pool.getBroker()) {
+            final XQueryContext context = new XQueryContext(pool);
+            context.addDynamicallyAvailableDocument(docUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
+
+            final XQuery xqueryService = pool.getXQueryService();
+            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final Sequence result = xqueryService.execute(broker, compiled, null);
+
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.getItemCount());
+            assertTrue(result.itemAt(0) instanceof Node);
+
+            final Source expectedSource = Input.fromString(doc).build();
+            final Source actualSource = Input.fromNode((Node)result.itemAt(0)).build();
+            final Diff diff = DiffBuilder.compare(actualSource)
+                    .withTest(expectedSource)
+                    .checkForIdentical()
+                    .checkForSimilar()
+                    .build();
+
+            assertFalse(diff.toString(), diff.hasDifferences());
+        }
+    }
+
+    @Test
+    public void doc_dynamicallyAvailableDocument_relativeUri() throws XPathException, EXistException, PermissionDeniedException, URISyntaxException {
+        final BrokerPool pool = BrokerPool.getInstance();
+
+        final String doc = "<timestamp>" + System.currentTimeMillis() + "</timestamp>";
+        final String baseUri = "http://from-dynamic-context/";
+        final String docRelativeUri = "doc1";
+        final String query = "fn:doc('" + docRelativeUri + "')";
+
+        try (final DBBroker broker = pool.getBroker()) {
+            final XQueryContext context = new XQueryContext(pool);
+            context.setBaseURI(new AnyURIValue(new URI(baseUri)));
+            context.addDynamicallyAvailableDocument(baseUri + docRelativeUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
+
+            final XQuery xqueryService = pool.getXQueryService();
+            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final Sequence result = xqueryService.execute(broker, compiled, null);
+
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.getItemCount());
+            assertTrue(result.itemAt(0) instanceof Node);
+
+            final Source expectedSource = Input.fromString(doc).build();
+            final Source actualSource = Input.fromNode((Node)result.itemAt(0)).build();
+            final Diff diff = DiffBuilder.compare(actualSource)
+                    .withTest(expectedSource)
+                    .checkForIdentical()
+                    .checkForSimilar()
+                    .build();
+
+            assertFalse(diff.toString(), diff.hasDifferences());
+        }
+    }
+
+    @Test
+    public void docAvailable_dynamicallyAvailableDocument_absoluteUri() throws XPathException, EXistException, PermissionDeniedException {
+        final BrokerPool pool = BrokerPool.getInstance();
+
+        final String doc = "<timestamp>" + System.currentTimeMillis() + "</timestamp>";
+        final String docUri = "http://from-dynamic-context/doc1";
+        final String query = "fn:doc-available('" + docUri + "')";
+
+        try (final DBBroker broker = pool.getBroker()) {
+            final XQueryContext context = new XQueryContext(pool);
+            context.addDynamicallyAvailableDocument(docUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
+
+            final XQuery xqueryService = pool.getXQueryService();
+            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final Sequence result = xqueryService.execute(broker, compiled, null);
+
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.getItemCount());
+            assertTrue(result.itemAt(0).toJavaObject(Boolean.class).booleanValue());
+        }
+    }
+
+    @Test
+    public void docAvailable_dynamicallyAvailableDocument_relativeUri() throws XPathException, EXistException, PermissionDeniedException, URISyntaxException {
+        final BrokerPool pool = BrokerPool.getInstance();
+
+        final String doc = "<timestamp>" + System.currentTimeMillis() + "</timestamp>";
+        final String baseUri = "http://from-dynamic-context/";
+        final String docRelativeUri = "doc1";
+        final String query = "fn:doc-available('" + docRelativeUri + "')";
+
+        try (final DBBroker broker = pool.getBroker()) {
+            final XQueryContext context = new XQueryContext(pool);
+            context.setBaseURI(new AnyURIValue(new URI(baseUri)));
+            context.addDynamicallyAvailableDocument(baseUri + docRelativeUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
+
+            final XQuery xqueryService = pool.getXQueryService();
+            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final Sequence result = xqueryService.execute(broker, compiled, null);
+
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.getItemCount());
+            assertTrue(result.itemAt(0).toJavaObject(Boolean.class).booleanValue());
+        }
+    }
+
+    private Either<DocumentImpl, org.exist.dom.persistent.DocumentImpl> asInMemoryDocument(final String doc) throws XPathException {
+        try {
+            final SAXAdapter saxAdapter = new SAXAdapter();
+            final SAXParser saxParser = saxParserFactory.newSAXParser();
+            final XMLReader xmlReader = saxParser.getXMLReader();
+
+            xmlReader.setContentHandler(saxAdapter);
+            xmlReader.setProperty(Namespaces.SAX_LEXICAL_HANDLER, saxAdapter);
+
+            try (final Reader reader = new StringReader(doc)) {
+                xmlReader.parse(new InputSource(reader));
+            }
+            return Left(saxAdapter.getDocument());
+        } catch (final ParserConfigurationException | SAXException | IOException e) {
+            throw new XPathException("Unable to parse document", e);
+        }
     }
 }


### PR DESCRIPTION
Implements basic support for https://www.w3.org/TR/xpath-31/#dt-available-docs

We need this to be able to execute the XQTS correctly.