### PR TITLE
(4.x.x) Fix an issue where AbstractSequence#convertTo(int) was returning an empty sequence when it should not

### DIFF
--- a/src/org/exist/xquery/value/AbstractSequence.java
+++ b/src/org/exist/xquery/value/AbstractSequence.java
@@ -68,7 +68,7 @@ public abstract class AbstractSequence implements Sequence {
 
     @Override
     public AtomicValue convertTo(final int requiredType) throws XPathException {
-        if(isEmpty) {
+        if(isEmpty()) {
             return null;
         }
 


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/2002

Fixes the build of `develop-4.x.x`.