### PR TITLE
(5.0.0) Fix an issue where AbstractSequence#convertTo(int) was returning an empty sequence when it should not

### DIFF
--- a/src/org/exist/xquery/value/AbstractSequence.java
+++ b/src/org/exist/xquery/value/AbstractSequence.java
@@ -68,7 +68,7 @@ public abstract class AbstractSequence implements Sequence {
 
     @Override
     public AtomicValue convertTo(final int requiredType) throws XPathException {
-        if(isEmpty) {
+        if(isEmpty()) {
             return null;
         }
 


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/2002
Fixed the build of `develop-5.0.0`.