### PR TITLE
(5.0.0) Fixes another issue with zero byte binary resources in the XML:DB Remote API

### DIFF
--- a/src/org/exist/xmldb/RemoteCollection.java
+++ b/src/org/exist/xmldb/RemoteCollection.java
@@ -647,10 +647,12 @@ public class RemoteCollection extends AbstractRemote implements EXistCollection 
                             fileName = (String) xmlRpcClientLease.get().execute("uploadCompressed", params);
                         }
                     }
-                } else {
+                }
+
+                if (fileName == null) {
                     // Zero length stream? Let's get a fileName!
                     final List<Object> params = new ArrayList<>();
-                    params.add(chunk);
+                    params.add(new byte[0]);
                     params.add(0);
                     fileName = (String) xmlRpcClientLease.get().execute("upload", params);
                 }


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/2038