### PR TITLE
Improve reporting of xar downloads from package repo during build process

### DIFF
--- a/build/scripts/setup.xml
+++ b/build/scripts/setup.xml
@@ -46,6 +46,7 @@
     Download xar files from the package website.
   -->
   <target name="setup" depends="prepare" description="Download standard xar packages.">
+    <echo message="Downloading xar packages: ${autodeploy}..."/>
     <foreach list="${autodeploy}" target="download" param="xar"></foreach>
   </target>
 
@@ -55,6 +56,10 @@
             <include name="${xar}-*.xar"/>
         </fileset>
     </pathconvert>
+    <condition property="xar-found-status" value="Existing copy of ${xar} found at ${xar-installed}. Download will be skipped." else="No copy of ${xar} found in ${autostart-dir}. Download will be attempted.">
+      <isset property="xar-installed"/>
+    </condition>
+    <echo message="${xar-found-status}"/>
     <antcall target="download-xar"/>
   </target>
 


### PR DESCRIPTION
### Description:

When building eXist via `./build.sh`, packages listed in `$EXIST_HOME/build.properties` (or `local.build.properties`) are downloaded and placed into the `autodeploy` directory. The download is skipped if a xar file matching the package abbreviation is found. 

Until this PR, the information reported from this step in the build process (which can be seen with `ant -f build/scripts/setup.xml`) was quite limited, particularly in the case that a download was skipped because a file matching the package name was found:

```text
download:

download-xar:
```

This lack of information makes it difficult to troubleshoot problems in the process. This PR adds the following information about xars:

1. A message indicating what packages are going to be downloaded
2. A message indicating whether the download will proceed (if a local copy was not found) or if it will be skipped (because a copy was found, and the location of the file)

Here is the new output showing the start, a download that proceeded, and a download that was skipped:

```text
setup:
     [echo] Downloading xar packages: dashboard,shared,eXide,monex,functx,markdown,fundocs,usermanager,packageservice,existdb-dashboard,tei-publisher,tei-publisher-lib,tei-publisher-docx...

download:
     [echo] No copy of dashboard found in autodeploy. Download will be attempted.

download-xar:
    [fetch] Getting: http://demo.exist-db.org/exist/apps/public-repo/pkg.zip?abbrev=dashboard&zip=yes&processor=5.0.0-SNAPSHOT
    [fetch] To: /var/folders/j8/k8hn66_942d9t877btw7_xn00000gn/T/FetchTask16941964063704900011tmp
    [fetch] ....................................................
    [fetch] Expanding: /var/folders/j8/k8hn66_942d9t877btw7_xn00000gn/T/FetchTask16941964063704900011tmp into /Users/joe/workspace/exist/autodeploy

download:
     [echo] Existing copy of shared found at /Users/joe/workspace/exist/autodeploy/shared-resources-0.7.0.xar. Download will be skipped.

download-xar:
```

### Reference:

HipChat conversation from July 12, 2018, in which this lack of logging confused me:

> But what I'm having trouble with is fetching this package during the eXist build, i.e., when including it in the build.properties file... When I run build.sh with an empty autodeploy directory, the build skips over tei-publisher. All other packages download successfully, in the order presented. It's as if the build.sh script just skips over tei-publisher.

The new logging isn't smart enough to tell me what was wrong, but it would've immediately provided the clue I needed to discover the problem:

> Existing copy of tei-publisher found at /Users/joe/workspace/exist/autodeploy/tei-publisher-docx-1.0.0.xar:/Users/joe/workspace/exist/autodeploy/tei-publisher-lib-2.3.0.xar. Download will be skipped.

### Type of tests:

None.