### PR TITLE
(4.x.x) Add DEFLATE compression (RFC 1950 / 1951) to compression module

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,7 @@
 #
 # $Id$
 project.name = eXist-db
-project.version = 4.3.1
+project.version = 4.4.0-SNAPSHOT
 
 # db settings
 config.dataDir = webapp/WEB-INF/data

--- a/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
@@ -59,6 +59,14 @@ public class CompressionModule extends AbstractInternalModule {
             functionDefs(UnGZipFunction.class,
                     UnGZipFunction.signatures[0]
             ),
+            functionDefs(DeflateFunction.class,
+		    DeflateFunction.signatures[0],
+                    DeflateFunction.signatures[1]
+            ),
+            functionDefs(InflateFunction.class,
+                    InflateFunction.signatures[0],
+                    InflateFunction.signatures[1]
+            ),
             functionDefs(TarFunction.class,
                     TarFunction.signatures[0],
                     TarFunction.signatures[1],

--- a/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/CompressionModule.java
@@ -60,7 +60,7 @@ public class CompressionModule extends AbstractInternalModule {
                     UnGZipFunction.signatures[0]
             ),
             functionDefs(DeflateFunction.class,
-		    DeflateFunction.signatures[0],
+                    DeflateFunction.signatures[0],
                     DeflateFunction.signatures[1]
             ),
             functionDefs(InflateFunction.class,

--- a/extensions/modules/src/org/exist/xquery/modules/compression/DeflateFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/DeflateFunction.java
@@ -21,14 +21,12 @@
  */
 package org.exist.xquery.modules.compression;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
-
 import org.exist.dom.QName;
+import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
@@ -98,15 +96,15 @@ public class DeflateFunction extends BasicFunction
 	Deflater defl = new Deflater(java.util.zip.Deflater.DEFAULT_COMPRESSION, rawflag);
 
         // deflate the data
-        try(final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try(final FastByteArrayOutputStream baos = new FastByteArrayOutputStream();
 	    DeflaterOutputStream dos = new DeflaterOutputStream(baos, defl)) {
-	    //DeflaterOutputStream dos = new DeflaterOutputStream(baos, new Deflater(java.util.zip.Deflater.DEFAULT_COMPRESSION, true))) {
+
             bin.streamBinaryTo(dos);
             
             dos.flush();
             dos.finish();
             
-            return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), new ByteArrayInputStream(baos.toByteArray()));
+            return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), baos.toFastByteInputStream());
         } catch(IOException ioe) {
             throw new XPathException(this, ioe.getMessage(), ioe);
         }

--- a/extensions/modules/src/org/exist/xquery/modules/compression/DeflateFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/DeflateFunction.java
@@ -1,0 +1,114 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2018 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * $Id$
+ */
+package org.exist.xquery.modules.compression;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+
+import org.apache.commons.io.output.ByteArrayOutputStream;
+
+import org.exist.dom.QName;
+import org.exist.xquery.BasicFunction;
+import org.exist.xquery.Cardinality;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.Base64BinaryValueType;
+import org.exist.xquery.value.BinaryValue;
+import org.exist.xquery.value.BinaryValueFromInputStream;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.BooleanValue;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.SequenceType;
+import org.exist.xquery.value.Type;
+
+
+/**
+ * Deflate compression
+ * 
+ * @author Olaf Schreck <olaf@existsolutions.com>
+ * @version 1.0
+ */
+public class DeflateFunction extends BasicFunction
+{
+    private final static QName DEFLATE_FUNCTION_NAME = new QName("deflate", CompressionModule.NAMESPACE_URI, CompressionModule.PREFIX);
+
+    public final static FunctionSignature signatures[] = {
+        new FunctionSignature(
+	    DEFLATE_FUNCTION_NAME,
+            "Deflate data (RFC 1950)",
+            new SequenceType[] {
+                new FunctionParameterSequenceType("data", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The data to Deflate")
+            },
+            new SequenceType(
+            Type.BASE64_BINARY, Cardinality.ZERO_OR_ONE)
+	),
+        new FunctionSignature(
+	    DEFLATE_FUNCTION_NAME,
+            "Deflate data (RFC 1951)",
+            new SequenceType[] {
+                new FunctionParameterSequenceType("data", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The data to Deflate"),
+                new FunctionParameterSequenceType("raw", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "If true, create raw deflate data that is not wrapped inside zlib header and checksum.")
+            },
+            new SequenceType(
+            Type.BASE64_BINARY, Cardinality.ZERO_OR_ONE)
+        )
+    };
+
+
+    public DeflateFunction(XQueryContext context, FunctionSignature signature)
+    {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException
+    {
+        // is there some data to Deflate?
+        if(args[0].isEmpty())
+            return Sequence.EMPTY_SEQUENCE;
+
+        BinaryValue bin = (BinaryValue) args[0].itemAt(0);
+
+	boolean rawflag = false;
+        if(args.length > 1 && !args[1].isEmpty())
+	    rawflag = args[1].itemAt(0).convertTo(Type.BOOLEAN).effectiveBooleanValue();
+
+	Deflater defl = new Deflater(java.util.zip.Deflater.DEFAULT_COMPRESSION, rawflag);
+
+        // deflate the data
+        try(final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+	    DeflaterOutputStream dos = new DeflaterOutputStream(baos, defl)) {
+	    //DeflaterOutputStream dos = new DeflaterOutputStream(baos, new Deflater(java.util.zip.Deflater.DEFAULT_COMPRESSION, true))) {
+            bin.streamBinaryTo(dos);
+            
+            dos.flush();
+            dos.finish();
+            
+            return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), new ByteArrayInputStream(baos.toByteArray()));
+        } catch(IOException ioe) {
+            throw new XPathException(this, ioe.getMessage(), ioe);
+        }
+    }
+}

--- a/extensions/modules/src/org/exist/xquery/modules/compression/InflateFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/InflateFunction.java
@@ -1,0 +1,110 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2018 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * $Id$
+ */
+
+package org.exist.xquery.modules.compression;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+
+import org.apache.commons.io.output.ByteArrayOutputStream;
+
+import org.exist.dom.QName;
+import org.exist.xquery.BasicFunction;
+import org.exist.xquery.Cardinality;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.Base64BinaryValueType;
+import org.exist.xquery.value.BinaryValue;
+import org.exist.xquery.value.BinaryValueFromInputStream;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.SequenceType;
+import org.exist.xquery.value.Type;
+
+
+/**
+ * Inflate uncompression
+ * 
+ * @author Olaf Schreck <olaf@existsolutions.com>
+ * @version 1.0
+ */
+public class InflateFunction extends BasicFunction
+{
+
+    public final static FunctionSignature signatures[] = {
+        new FunctionSignature(
+            new QName("inflate", CompressionModule.NAMESPACE_URI, CompressionModule.PREFIX),
+            "Inflate's data",
+            new SequenceType[] {
+                new FunctionParameterSequenceType("inflate-data", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The inflate data to uncompress.")
+            },
+            new SequenceType(Type.BASE64_BINARY, Cardinality.ZERO_OR_ONE)
+        ),
+        new FunctionSignature(
+            new QName("inflate", CompressionModule.NAMESPACE_URI, CompressionModule.PREFIX),
+            "Inflate's data",
+            new SequenceType[] {
+                new FunctionParameterSequenceType("inflate-data", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The inflate data to uncompress."),
+                new FunctionParameterSequenceType("raw", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "If true, expect raw deflate data that is not wrapped inside zlib header and checksum.")
+            },
+            new SequenceType(Type.BASE64_BINARY, Cardinality.ZERO_OR_ONE)
+        )
+    };
+
+    public InflateFunction(XQueryContext context, FunctionSignature signature)
+    {
+            super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException
+    {
+        // is there some data to inflate?
+        if(args[0].isEmpty())
+            return Sequence.EMPTY_SEQUENCE;
+
+        final BinaryValue bin = (BinaryValue) args[0].itemAt(0);
+
+	boolean rawflag = false;
+        if(args.length > 1 && !args[1].isEmpty())
+	    rawflag = args[1].itemAt(0).convertTo(Type.BOOLEAN).effectiveBooleanValue();
+
+	Inflater infl = new Inflater(rawflag);
+
+        // uncompress the data
+        try(final InflaterInputStream iis = new InflaterInputStream(bin.getInputStream(), infl);
+                final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            int read = -1;
+            final byte[] b = new byte[4096];
+            while ((read = iis.read(b)) != -1) {
+                baos.write(b, 0, read);
+            }
+
+            return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), new ByteArrayInputStream(baos.toByteArray()));
+        } catch(final IOException ioe) {
+            throw new XPathException(this, ioe.getMessage(), ioe);
+        }
+    }
+}

--- a/extensions/modules/src/org/exist/xquery/modules/compression/example-deflate.xql
+++ b/extensions/modules/src/org/exist/xquery/modules/compression/example-deflate.xql
@@ -1,0 +1,42 @@
+xquery version "3.1";
+
+declare namespace compression = "http://exist-db.org/xquery/compression";
+declare namespace util = "http://exist-db.org/xquery/util";
+
+(:~
+:
+: Simple example showing how to use compression:deflate() / inflate()
+:
+: @author Olaf Schreck <olaf@existsolutions.com>
+:)
+
+let $testinput  := "Hello World!"
+
+(: RFC1950 deflate [compressed data wrapped in zlib header/footer] :)
+let $ex_defl    := compression:deflate(util:string-to-binary($testinput))
+let $ex_infl    := compression:inflate($ex_defl)
+let $output     := util:base64-decode($ex_infl)
+let $result     := if ($output = $testinput) then "OK" else "FAIL"
+
+(: RFC1951 deflate [raw compression without zlib header/footer] :)
+(: for raw deflate/inflate, set 2nd arg to true() :)
+let $ex_rawdefl := compression:deflate(util:string-to-binary($testinput), true())
+let $ex_rawinfl := compression:inflate($ex_rawdefl, true())
+let $rawoutput  := util:base64-decode($ex_rawinfl)
+let $rawresult  := if ($rawoutput = $testinput) then "OK" else "FAIL"
+
+return
+    <result>
+        <rfc1950>
+            <ex_defl>{$ex_defl}</ex_defl>
+            <ex_infl>{$ex_infl}</ex_infl>
+            <output>{$output}</output>
+            <result>{$result}</result>
+        </rfc1950>
+        <rfc1951>
+            <ex_rawdefl>{$ex_rawdefl}</ex_rawdefl>
+            <ex_rawinfl>{$ex_rawinfl}</ex_rawinfl>
+            <rawoutput>{$rawoutput}</rawoutput>
+            <rawresult>{$rawresult}</rawresult>
+        </rfc1951>
+    </result>


### PR DESCRIPTION
------
### Description:

This adds DEFLATE compression (RFC 1950 / 1951) to the existdb compression module.

### Reference:

RFC 1951 DEFLATE is required for the existdb SAMLv2 implementation in XQuery.
Ref: Section 3.4.4.1 "DEFLATE Encoding" in SAMLv2 standard documentation https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf

While there, implement RFC 1950 as well.

### Type of tests:

I'm not familiar with the testing framework. This PR includes an example XQuery "example-deflate.xql" that demonstrates usage and tests compression/uncompression against its own behavior. I can add interoperability tests against Perl's DEFLATE implementation, not sure how.

### Misc

License follows the existing existdb license.
