### PR TITLE
(4.x.x) Consistency check should check the entire document

### DIFF
--- a/src/org/exist/backup/ConsistencyCheck.java
+++ b/src/org/exist/backup/ConsistencyCheck.java
@@ -21,6 +21,7 @@
  */
 package org.exist.backup;
 
+import org.exist.dom.persistent.*;
 import org.exist.security.Account;
 import org.exist.security.Group;
 import org.exist.security.Permission;
@@ -28,10 +29,6 @@ import org.exist.storage.StorageAddress;
 import org.w3c.dom.Node;
 
 import org.exist.collections.Collection;
-import org.exist.dom.persistent.BinaryDocument;
-import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.ElementImpl;
-import org.exist.dom.persistent.IStoredNode;
 import org.exist.management.Agent;
 import org.exist.management.AgentFactory;
 import org.exist.numbering.NodeId;
@@ -323,8 +320,8 @@ public class ConsistencyCheck
                     public Object start() {
                         EmbeddedXMLStreamReader reader = null;
                         try {
-                            final ElementImpl             root            = (ElementImpl)doc.getDocumentElement();
-                            reader = (EmbeddedXMLStreamReader)broker.getXMLStreamReader( root, true );
+                            final Node              root            = doc.getFirstChild();
+                            reader = (EmbeddedXMLStreamReader)broker.getXMLStreamReader((NodeHandle)root, true );
                             NodeId                  nodeId;
                             boolean                 attribsAllowed  = false;
                             int                     expectedAttribs = 0;


### PR DESCRIPTION
A very simple two line fix, that ensures the consistency check considers all nodes in the document and not just the document element.