### PR TITLE
Correct jmx option parsing

### DIFF
--- a/bin/functions.d/getopt-settings.sh
+++ b/bin/functions.d/getopt-settings.sh
@@ -45,19 +45,19 @@ is_jmx_switch() {
 	if substring "${JMX_OPTS}" "|$1|"; then
 		JMX_ENABLED=1;
 		return 0;
-	elif substring "|$1|" "$JMX_SHORT_EQUAL"; then
+	elif substring "|X$1|" "X$JMX_SHORT_EQUAL"; then
 		JMX_ENABLED=1;
 		JMX_PORT="${1#${JMX_SHORT_EQUAL}}" && is_integer "${JMX_PORT}";
 		return 0;
-	elif substring "|$1|" "${JMX_LONG_EQUAL}"; then
+	elif substring "|X$1|" "X${JMX_LONG_EQUAL}"; then
 		JMX_ENABLED=1;
 		JMX_PORT="${1#${JMX_LONG_EQUAL}}" && is_integer "${JMX_PORT}";
 		return 0;
-	elif substring "|$1|" "${JMX_SHORT}"; then
+	elif substring "|X$1|" "X${JMX_SHORT}"; then
 		JMX_ENABLED=1;
 		JMX_PORT="${1#${JMX_SHORT}}" && is_integer "${JMX_PORT}";
 		return 0;
-	elif substring "|$1|" "${JMX_LONG}"; then
+	elif substring "|X$1|" "X${JMX_LONG}"; then
 		JMX_ENABLED=1;
 		JMX_PORT="${1#${JMX_LONG}}" && is_integer "${JMX_PORT}";
 		return 0;


### PR DESCRIPTION
Enable jmx and try to parse port ONLY when option matches at beginning of argument.