### PR TITLE
Fix bugs in CropFunction

### DIFF
--- a/extensions/modules/src/org/exist/xquery/modules/image/CropFunction.java
+++ b/extensions/modules/src/org/exist/xquery/modules/image/CropFunction.java
@@ -117,16 +117,26 @@ public class CropFunction extends BasicFunction {
         int y1 = 0;
         int x2 = MAXHEIGHT;
         int y2 = MAXWIDTH;
-
+        int width = 0;
+        int height = 0;
         if(!args[1].isEmpty()) {
             x1 = ((IntegerValue) args[1].itemAt(0)).getInt();
             if(args[1].hasMany()) {
                 y1 = ((IntegerValue) args[1].itemAt(1)).getInt();
                 x2 = ((IntegerValue) args[1].itemAt(2)).getInt();
                 y2 = ((IntegerValue) args[1].itemAt(3)).getInt();
+                width = x2 - x1;
+                height = y2 - y1;
             }
         }
-
+            if(width < 1 ) {
+                logger.error("cropping error: x2 value must be greater than x1");
+                return Sequence.EMPTY_SEQUENCE;
+            }
+           if(height < 1) {
+                logger.error("cropping error: y2 must be greater than y1");
+                return Sequence.EMPTY_SEQUENCE;
+           }
         //get the mime-type
         String mimeType = args[2].itemAt(0).getStringValue();
         String formatName = mimeType.substring(mimeType.indexOf("/")+1);
@@ -146,14 +156,14 @@ public class CropFunction extends BasicFunction {
             }
 			
             //crop the image
-            Image cropImage = Toolkit.getDefaultToolkit().createImage(new FilteredImageSource(image.getSource(), new CropImageFilter(x1, y1, x2, y2)));
+            Image cropImage = Toolkit.getDefaultToolkit().createImage(new FilteredImageSource(image.getSource(), new CropImageFilter(x1, y1, width, height)));
             if(cropImage instanceof BufferedImage) {
                 // just in case cropImage is allready an BufferedImage
                 bImage = (BufferedImage)cropImage;
 
             } else {
-                bImage = new BufferedImage(cropImage.getHeight(null),
-                cropImage.getWidth(null),BufferedImage.TYPE_INT_RGB);
+                bImage = new BufferedImage(cropImage.getWidth(null),
+                cropImage.getHeight(null),BufferedImage.TYPE_INT_RGB);
                 Graphics2D g = bImage.createGraphics(); // Paint the image onto the buffered image
                 g.drawImage(cropImage, 0, 0, null);
                 g.dispose();


### PR DESCRIPTION
CropFunction.java has two errors:

1. It is presented as a x1,y1,x2,y2 set of bounding boxes, but java.awt.image.CropImageFilter has this signature:
public CropImageFilter(int x,
               int y,
               int w,
               int h)
Constructs a CropImageFilter that extracts the absolute rectangular region of pixels from its source Image as specified by the x, y, w, and h parameters.
Parameters:
x - the x location of the top of the rectangle to be extracted
y - the y location of the top of the rectangle to be extracted
w - the width of the rectangle to be extracted
h - the height of the rectangle to be extracted
https://docs.oracle.com/javase/7/docs/api/java/awt/image/CropImageFilter.html

Thus, the last two parameters were misaligned. This commit converts the x2,y2 given through the xquery function into height and width values, and checks that these values are not < 1.

2. It generated the new cropped image with the width and height values inverted, so that any non-square cropping created a black band and was also misaligned. This commit fixes the dimensions of the new cropped image.

Thank you for your contribution to eXist-db! 

To help the community judge your pull request (PR), please include the following:

- A (short) description of the content of changes.
- A context reference to a [Github Issue](https://github.com/eXist-db/exist/issues), a message in the [eXist-open mailinglist](http://exist-open.markmail.org), or a [specification](https://www.w3.org/TR/xquery-31/).
- Tests. The [XQSuite - Annotation-based Test Framework for XQuery](http://exist-db.org/exist/apps/doc/xqsuite.xml) makes it very easy for you to create tests. These tests can be executed from the [eXide editor](http://exist-db.org/exist/apps/eXide/index.html) via XQuery > Run as Test.

Your PR will be tested using [Travis CI](https://travis-ci.org/eXist-db/exist) and [AppVeyor](https://ci.appveyor.com/project/AdamRetter/exist) against a number of operating systems and environments. The build status is visible in the PR. 

To detect errors in your PR before submitting it, please run eXist's full test suite on your own system via `build.sh test`.

------

### Description:

### Reference:

### Type of tests:
