### PR TITLE
Add options for securing the XML Parser

### DIFF
--- a/conf.xml.tmpl
+++ b/conf.xml.tmpl
@@ -608,6 +608,18 @@
     <!--
         Default settings for parsing structured documents:
 
+        - xml (optional)
+
+            - features
+                Any default SAX2 feature flags to set on the parser
+
+                    - feature
+                        - name
+                            the name of the feature flag
+                        - value
+                            the value of the feature flag
+
+
         - html-to-xml (optional)
 
             - class
@@ -644,6 +656,22 @@
                             the value of the feature flag
     -->
     <parser>
+
+        <xml>
+
+            <features>
+
+                <!-- NOTE: the following feature flags should likely be set in production to ensure a secure environment -->
+
+                <!--
+                <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
+                <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
+                <feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
+                -->
+
+            </features>
+
+        </xml>
 
         <!-- html-to-xml class="org.ccil.cowan.tagsoup.Parser"/ -->
 

--- a/src/org/exist/util/Configuration.java
+++ b/src/org/exist/util/Configuration.java
@@ -537,6 +537,28 @@ public class Configuration implements ErrorHandler
     }
 
     private void configureParser(final Element parser) {
+        configureXmlParser(parser);
+        configureHtmlToXmlParser(parser);
+    }
+
+    private void configureXmlParser(final Element parser) {
+        final NodeList nlXml = parser.getElementsByTagName(XMLReaderPool.XmlParser.XML_PARSER_ELEMENT);
+        if(nlXml.getLength() > 0) {
+            final Element xml = (Element)nlXml.item(0);
+
+            final NodeList nlFeatures = xml.getElementsByTagName(XMLReaderPool.XmlParser.XML_PARSER_FEATURES_ELEMENT);
+            if(nlFeatures.getLength() > 0) {
+                final Properties pFeatures = ParametersExtractor.parseFeatures(nlFeatures.item(0));
+                if(pFeatures != null) {
+                    final Map<String, Boolean> features = new HashMap<>();
+                    pFeatures.forEach((k,v) -> features.put(k.toString(), Boolean.valueOf(v.toString())));
+                    config.put(XMLReaderPool.XmlParser.XML_PARSER_FEATURES_PROPERTY, features);
+                }
+            }
+        }
+    }
+
+    private void configureHtmlToXmlParser(final Element parser) {
         final NodeList nlHtmlToXml = parser.getElementsByTagName(HtmlToXmlParser.HTML_TO_XML_PARSER_ELEMENT);
         if(nlHtmlToXml.getLength() > 0) {
             final Element htmlToXml = (Element)nlHtmlToXml.item(0);

--- a/test/src/org/exist/util/XMLReaderSecurityTest.java
+++ b/test/src/org/exist/util/XMLReaderSecurityTest.java
@@ -124,7 +124,7 @@ public class XMLReaderSecurityTest {
 
             try (final Collection testCollection = broker.openCollection(TEST_COLLECTION, Lock.LockMode.WRITE_LOCK)) {
 
-                debugReader("expandExternalEntities", broker, testCollection);
+                //debugReader("expandExternalEntities", broker, testCollection);
 
                 final String docContent = EXPANSION_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._2.toUri().toString());
                 final IndexInfo indexInfo = testCollection.validateXMLResource(transaction, broker, docName, docContent);
@@ -173,7 +173,7 @@ public class XMLReaderSecurityTest {
 
             try (final Collection testCollection = broker.openCollection(TEST_COLLECTION, Lock.LockMode.WRITE_LOCK);){
 
-                debugReader("cannotExpandExternalEntitiesWhenDisabled", broker, testCollection);
+                //debugReader("cannotExpandExternalEntitiesWhenDisabled", broker, testCollection);
 
                 final String docContent = EXPANSION_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._2.toUri().toString());
                 final IndexInfo indexInfo = testCollection.validateXMLResource(transaction, broker, docName, docContent);
@@ -235,18 +235,18 @@ public class XMLReaderSecurityTest {
         return String.valueOf(chars);
     }
 
-    private void debugReader(final String label, final DBBroker broker, final Collection collection) {
-        try {
-            final Method method = MutableCollection.class.getDeclaredMethod("getReader", DBBroker.class, boolean.class, CollectionConfiguration.class);
-            method.setAccessible(true);
-
-            final XMLReader reader = (XMLReader)method.invoke(LockedCollection.unwrapLocked(collection), broker, false, collection.getConfiguration(broker));
-
-            System.out.println(label + ": READER: " + reader.getClass().getName());
-            System.out.println(label + ": " + FEATURE_EXTERNAL_GENERAL_ENTITIES + "=" + reader.getFeature(FEATURE_EXTERNAL_GENERAL_ENTITIES));
-
-        } catch (final Throwable e) {
-            e.printStackTrace();
-        }
-    }
+//    private void debugReader(final String label, final DBBroker broker, final Collection collection) {
+//        try {
+//            final Method method = MutableCollection.class.getDeclaredMethod("getReader", DBBroker.class, boolean.class, CollectionConfiguration.class);
+//            method.setAccessible(true);
+//
+//            final XMLReader reader = (XMLReader)method.invoke(LockedCollection.unwrapLocked(collection), broker, false, collection.getConfiguration(broker));
+//
+//            System.out.println(label + ": READER: " + reader.getClass().getName());
+//            System.out.println(label + ": " + FEATURE_EXTERNAL_GENERAL_ENTITIES + "=" + reader.getFeature(FEATURE_EXTERNAL_GENERAL_ENTITIES));
+//
+//        } catch (final Throwable e) {
+//            e.printStackTrace();
+//        }
+//    }
 }

--- a/test/src/org/exist/util/XMLReaderSecurityTest.java
+++ b/test/src/org/exist/util/XMLReaderSecurityTest.java
@@ -18,7 +18,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -28,7 +27,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;

--- a/test/src/org/exist/util/XMLReaderSecurityTest.java
+++ b/test/src/org/exist/util/XMLReaderSecurityTest.java
@@ -64,9 +64,9 @@ public class XMLReaderSecurityTest {
                     "<!ENTITY xxe SYSTEM \"" + EXTERNAL_FILE_PLACEHOLDER + "\" >]>\n" +
                     "<foo>&xxe;</foo>";
 
-    private final static String EXPECTED_EXPANSION_DISABLED_DOC = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo/>\n";
+    private final static String EXPECTED_EXPANSION_DISABLED_DOC = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo/>";
 
-    private final static String EXPECTED_EXPANDED_DOC = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo>" + EXTERNAL_FILE_PLACEHOLDER + "</foo>\n";
+    private final static String EXPECTED_EXPANDED_DOC = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo>" + EXTERNAL_FILE_PLACEHOLDER + "</foo>";
 
     @ClassRule
     public final static ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
@@ -147,7 +147,9 @@ public class XMLReaderSecurityTest {
 
                     assertNotNull(testDoc);
                     final String expected = EXPECTED_EXPANDED_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._1);
-                    assertEquals(expected, serialize(testDoc.getDocument()));
+                    final String actual = serialize(testDoc.getDocument());
+
+                    assertEquals(expected, actual);
                 }
             }
 
@@ -195,7 +197,11 @@ public class XMLReaderSecurityTest {
                     testCollection.close();
 
                     assertNotNull(testDoc);
-                    assertEquals(EXPECTED_EXPANSION_DISABLED_DOC, serialize(testDoc.getDocument()));
+
+                    final String expected = EXPECTED_EXPANSION_DISABLED_DOC;
+                    final String actual = serialize(testDoc.getDocument());
+
+                    assertEquals(expected, actual);
                 }
             }
 
@@ -205,7 +211,7 @@ public class XMLReaderSecurityTest {
 
     private String serialize(final Document doc) throws TransformerException, IOException {
         final Transformer transformer = TransformerFactory.newInstance().newTransformer();
-        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.INDENT, "no");
         transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
 
         try(final StringWriter writer = new StringWriter()) {
@@ -215,7 +221,6 @@ public class XMLReaderSecurityTest {
             return writer.toString();
         }
     }
-
 
     /**
      * @return A tuple whose first item is the secret, and the second which is the path to a temporary file containing the secret

--- a/test/src/org/exist/util/XMLReaderSecurityTest.java
+++ b/test/src/org/exist/util/XMLReaderSecurityTest.java
@@ -1,0 +1,230 @@
+package org.exist.util;
+
+import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.IndexInfo;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xmldb.XmldbURI;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests around security exploits of the {@link org.xml.sax.XMLReader}
+ */
+public class XMLReaderSecurityTest {
+
+    private final static int START_CHAR_RANGE = '@';
+    private final static int END_CHAR_RANGE = '~';
+
+    private final static int SECRET_LENGTH = 100;
+
+    private final static XmldbURI TEST_COLLECTION = XmldbURI.ROOT_COLLECTION_URI.append("test");
+
+    private final static String EXTERNAL_FILE_PLACEHOLDER = "file:///topsecret";
+
+    private final static String EXPANSION_DOC =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                    "<!DOCTYPE foo [\n" +
+                    "<!ELEMENT foo ANY >\n" +
+                    "<!ENTITY xxe SYSTEM \"" + EXTERNAL_FILE_PLACEHOLDER + "\" >]>\n" +
+                    "<foo>&xxe;</foo>";
+
+    private final static String EXPECTED_EXPANSION_DISABLED_DOC = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo/>\n";
+
+    private final static String EXPECTED_EXPANDED_DOC = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><foo>" + EXTERNAL_FILE_PLACEHOLDER + "</foo>\n";
+
+    @ClassRule
+    public final static ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer();
+
+    @BeforeClass
+    public static void setupTestData() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+
+            createCollection(broker, transaction, TEST_COLLECTION);
+
+            transaction.commit();
+        }
+    }
+
+    private static Collection createCollection(final DBBroker broker, final Txn transaction, final XmldbURI uri) throws PermissionDeniedException, IOException, TriggerException {
+        final Collection collection = broker.getOrCreateCollection(transaction, uri);
+        broker.saveCollection(transaction, collection);
+        return collection;
+    }
+
+    @AfterClass
+    public static void removeTestData() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+            final Collection testCollection = broker.getCollection(TEST_COLLECTION);
+            if (testCollection != null) {
+                if (!broker.removeCollection(transaction, testCollection)) {
+                    transaction.abort();
+                    fail("Unable to remove test collection");
+                }
+            }
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void expandExternalEntities() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException, TransformerException {
+        final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+        final Map<String, Boolean> parserConfig = new HashMap<>();
+        parserConfig.put("http://xml.org/sax/features/external-general-entities", true);
+        brokerPool.getConfiguration().setProperty(XMLReaderPool.XmlParser.XML_PARSER_FEATURES_PROPERTY, parserConfig);
+
+        // create a temporary file on disk that contains secret info
+        final Tuple2<String, Path> secret = createTempSecretFile();
+
+        final XmldbURI docName = XmldbURI.create("expand-secret.xml");
+
+        // attempt to store a document with an external entity which would be expanded to the content of the secret file
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+                final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+
+            try (final Collection testCollection = broker.openCollection(TEST_COLLECTION, Lock.LockMode.WRITE_LOCK)) {
+
+                final String docContent = EXPANSION_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._2.toUri().toString());
+                final IndexInfo indexInfo = testCollection.validateXMLResource(transaction, broker, docName, docContent);
+                testCollection.store(transaction, broker, indexInfo, docContent);
+            }
+
+            transaction.commit();
+        }
+
+        // read back the document, to confirm that it does not contain the secret
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+                final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+
+            try (final Collection testCollection = broker.openCollection(TEST_COLLECTION, Lock.LockMode.READ_LOCK)) {
+
+                try (final LockedDocument testDoc = testCollection.getDocumentWithLock(broker, docName, Lock.LockMode.READ_LOCK);){
+
+                    // release the collection lock early inline with asymmetrical locking
+                    testCollection.close();
+
+                    assertNotNull(testDoc);
+                    final String expected = EXPECTED_EXPANDED_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._1);
+                    assertEquals(expected, serialize(testDoc.getDocument()));
+                }
+            }
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void cannotExpandExternalEntitiesWhenDisabled() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException, TransformerException {
+        final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+        final Map<String, Boolean> parserConfig = new HashMap<>();
+        parserConfig.put("http://xml.org/sax/features/external-general-entities", false);
+        brokerPool.getConfiguration().setProperty(XMLReaderPool.XmlParser.XML_PARSER_FEATURES_PROPERTY, parserConfig);
+
+        // create a temporary file on disk that contains secret info
+        final Tuple2<String, Path> secret = createTempSecretFile();
+
+        final XmldbURI docName = XmldbURI.create("expand-secret.xml");
+
+        // attempt to store a document with an external entity which would be expanded to the content of the secret file
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+
+            try (final Collection testCollection = broker.openCollection(TEST_COLLECTION, Lock.LockMode.WRITE_LOCK);){
+
+                final String docContent = EXPANSION_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._2.toUri().toString());
+                final IndexInfo indexInfo = testCollection.validateXMLResource(transaction, broker, docName, docContent);
+                testCollection.store(transaction, broker, indexInfo, docContent);
+            }
+
+            transaction.commit();
+        }
+
+        // read back the document, to confirm that it does not contain the secret
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+
+            try (final Collection testCollection = broker.openCollection(TEST_COLLECTION, Lock.LockMode.READ_LOCK)) {
+
+                try (final LockedDocument testDoc = testCollection.getDocumentWithLock(broker, docName, Lock.LockMode.READ_LOCK)) {
+
+                    // release the collection lock early inline with asymmetrical locking
+                    testCollection.close();
+
+                    assertNotNull(testDoc);
+                    assertEquals(EXPECTED_EXPANSION_DISABLED_DOC, serialize(testDoc.getDocument()));
+                }
+            }
+
+            transaction.commit();
+        }
+    }
+
+    private String serialize(final Document doc) throws TransformerException, IOException {
+        final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+
+        try(final StringWriter writer = new StringWriter()) {
+            final StreamResult result = new StreamResult(writer);
+            final DOMSource source = new DOMSource(doc);
+            transformer.transform(source, result);
+            return writer.toString();
+        }
+    }
+
+
+    /**
+     * @return A tuple whose first item is the secret, and the second which is the path to a temporary file containing the secret
+     */
+    private Tuple2<String, Path> createTempSecretFile() throws IOException {
+        final Path file = Files.createTempFile("exist.XMLReaderSecurityTest", "topsecret");
+        final String randomSecret = generateRandomString(SECRET_LENGTH);
+        return new Tuple2<>(randomSecret, Files.write(file, randomSecret.getBytes(UTF_8)));
+    }
+
+    private String generateRandomString(final int length) {
+        final char[] chars = new char[length];
+        for (int i = 0; i < length; i++) {
+            final char c = (char) ThreadLocalRandom.current().nextInt(START_CHAR_RANGE, END_CHAR_RANGE + 1);
+            chars[i] = c;
+        }
+        return String.valueOf(chars);
+    }
+}


### PR DESCRIPTION
Adds the facility for configuring the XML parser from `conf.xml`. This allows the user to specify various options. It is suggested to use the commented options in `conf.xml` to secure the parser.
