### PR TITLE
remove non lts oracle java versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ matrix:
     - jdk: openjdk8
     - jdk: oraclejdk8
     - jdk: openjdk9
-    - jdk: oraclejdk9
     - jdk: openjdk10
-    - jdk: oraclejdk10
     - jdk: openjdk11
+#     - jdk: oraclejdk11
     - os: osx
       osx_image: xcode9.2
       env: JAVA_HOME=$(/usr/libexec/java_home)


### PR DESCRIPTION
oracle java11 not yet supported by travis it seems 
close #2227 
backport of  #2229