### PR TITLE
fixes an NPE resulting from expression using range index not being (4.x.x)

### DIFF
--- a/src/org/exist/xquery/OrderByClause.java
+++ b/src/org/exist/xquery/OrderByClause.java
@@ -99,6 +99,7 @@ public class OrderByClause extends AbstractFLWORClause {
     @Override
     public void resetState(boolean postOptimization) {
         super.resetState(postOptimization);
+        returnExpr.resetState(postOptimization);
         stack.clear();
     }
 }

--- a/test/src/xquery/xquery3/flwor.xql
+++ b/test/src/xquery/xquery3/flwor.xql
@@ -46,13 +46,13 @@ function flwor:cleanup() {
     xmldb:remove("/db/system/config/db/" || $flwor:COLLECTION_NAME)
 };
 
-declare function flwor:test($a) {
-    collection($flwor:COLLECTION_NAME)//place[placeName = "berlin"]/string()
+declare function flwor:test($name) {
+    collection($flwor:COLLECTION_NAME)//place[placeName = $name]/string()
 };
 
 
 declare
-    %test:assertEquals("Berlin")
+    %test:assertEquals("Berlin", "Berlin")
 function flwor:order-by-with-range() {
     for $i in 1 to 2
     order by $i

--- a/test/src/xquery/xquery3/flwor.xql
+++ b/test/src/xquery/xquery3/flwor.xql
@@ -47,7 +47,7 @@ function flwor:cleanup() {
 };
 
 declare function flwor:test($name) {
-    collection($flwor:COLLECTION_NAME)//place[placeName = $name]/string()
+    collection($flwor:COLLECTION)//place[placeName = $name]/string()
 };
 
 


### PR DESCRIPTION
properly initialized due to lack of call to resetState after analyzing OrderByClause

Description

This issue manifested itself in my project, suddenly throwing NPE when using rather innocent filter expression. Lengthy investigation pointed to a problem in OrderByClause resetState cleanup which was not in line with other classes extending AbstractFLWORClause. This fix does bring it in line with the rest and fixes my problem.

Reference:

No issue has been filed afaik

Type of tests:

Test has been attached in this PR.
