### PR TITLE
Secure the XMLReader processing

### DIFF
--- a/extensions/debuggee/src/org/exist/debugger/dbgp/ResponseImpl.java
+++ b/extensions/debuggee/src/org/exist/debugger/dbgp/ResponseImpl.java
@@ -32,6 +32,7 @@ import org.apache.mina.core.session.IoSession;
 import org.exist.debugger.DebuggerImpl;
 import org.exist.debugger.Response;
 import org.exist.dom.memtree.SAXAdapter;
+import org.exist.util.ExistSAXParserFactory;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -53,7 +54,7 @@ public class ResponseImpl implements Response {
 	public ResponseImpl(IoSession session, InputStream inputStream) {
 		this.session = session;
 		
-		SAXParserFactory factory = SAXParserFactory.newInstance();
+		SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
 		factory.setNamespaceAware(true);
 		InputSource src = new InputSource(inputStream);
 		SAXParser parser;

--- a/extensions/indexes/spatial/test/src/org/exist/indexing/spatial/GMLIndexTest.java
+++ b/extensions/indexes/spatial/test/src/org/exist/indexing/spatial/GMLIndexTest.java
@@ -46,6 +46,7 @@ import org.exist.dom.memtree.SAXAdapter;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.xmldb.IndexQueryService;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
@@ -203,7 +204,7 @@ public class GMLIndexTest extends TestCase {
             AbstractGMLJDBCIndexWorker indexWorker = (AbstractGMLJDBCIndexWorker) broker.getIndexController().getWorkerByIndexId(AbstractGMLJDBCIndex.ID);
             //Unplugged
             if (indexWorker != null) {
-                SAXParserFactory factory = SAXParserFactory.newInstance();
+                SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
                 factory.setNamespaceAware(true);
                 InputSource src = new InputSource(new StringReader(IN_MEMORY_GML));
                 SAXParser parser = factory.newSAXParser();

--- a/src/org/exist/backup/BackupDescriptor.java
+++ b/src/org/exist/backup/BackupDescriptor.java
@@ -21,6 +21,7 @@
  */
 package org.exist.backup;
 
+import org.exist.util.XMLReaderPool;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
@@ -31,8 +32,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.Properties;
-
-import javax.xml.parsers.ParserConfigurationException;
 
 
 public interface BackupDescriptor
@@ -86,7 +85,8 @@ public interface BackupDescriptor
     boolean before( long timestamp );
 
 
-    void parse( ContentHandler handler ) throws IOException, SAXException, ParserConfigurationException;
+    void parse(XMLReaderPool parserPool, ContentHandler handler)
+            throws IOException, SAXException;
 
     Path getRepoBackup() throws IOException;
 }

--- a/src/org/exist/backup/Restore.java
+++ b/src/org/exist/backup/Restore.java
@@ -37,6 +37,7 @@ import org.exist.backup.restore.listener.RestoreListener;
 import org.exist.security.Account;
 import org.exist.security.SecurityManager;
 import org.exist.util.EXistInputSource;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.FileUtils;
 import org.exist.xmldb.UserManagementService;
 import org.exist.xmldb.XmldbURI;
@@ -67,7 +68,7 @@ public class Restore {
         //get the backup descriptors, can be more than one if it was an incremental backup
         final Deque<BackupDescriptor> descriptors = getBackupDescriptors(f);
         
-        final SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+        final SAXParserFactory saxFactory = ExistSAXParserFactory.getSAXParserFactory();
         saxFactory.setNamespaceAware(true);
         saxFactory.setValidating(false);
         final SAXParser sax = saxFactory.newSAXParser();

--- a/src/org/exist/backup/SystemExport.java
+++ b/src/org/exist/backup/SystemExport.java
@@ -462,7 +462,7 @@ public class SystemExport {
                 final CheckDeletedHandler check = new CheckDeletedHandler(current, serializer);
 
                 try {
-                    prevBackup.parse(check);
+                    prevBackup.parse(broker.getBrokerPool().getParserPool(), check);
                 } catch (final Exception e) {
                     LOG.error("Caught exception while trying to parse previous backup descriptor: " + prevBackup.getSymbolicPath(), e);
                 }

--- a/src/org/exist/backup/restore/RestoreHandler.java
+++ b/src/org/exist/backup/restore/RestoreHandler.java
@@ -41,6 +41,7 @@ import org.exist.security.SecurityManager;
 import org.exist.security.Subject;
 import org.exist.storage.BrokerPool;
 import org.exist.util.EXistInputSource;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.xmldb.EXistCollection;
 import org.exist.xmldb.EXistCollectionManagementService;
 import org.exist.xmldb.EXistResource;
@@ -71,7 +72,7 @@ import org.xmldb.api.modules.CollectionManagementService;
 public class RestoreHandler extends DefaultHandler {
     
     private final static Logger LOG = LogManager.getLogger(RestoreHandler.class);
-    private final static SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+    private final static SAXParserFactory saxFactory = ExistSAXParserFactory.getSAXParserFactory();
     static {
         saxFactory.setNamespaceAware(true);
         saxFactory.setValidating(false);

--- a/src/org/exist/config/Configurator.java
+++ b/src/org/exist/config/Configurator.java
@@ -65,6 +65,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.LockException;
 import org.exist.util.MimeType;
 import com.evolvedbinary.j8fu.function.ConsumerE;
@@ -78,6 +79,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
 import static java.lang.invoke.MethodType.methodType;
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
 /**
  * This class handle all configuration needs: extracting and saving,
@@ -751,11 +753,16 @@ public class Configurator {
 
     public static Configuration parse(final InputStream is) throws ConfigurationException {
         try {
-            final SAXParserFactory factory = SAXParserFactory.newInstance();
+            final SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
             factory.setNamespaceAware(true);
             final InputSource src = new InputSource(is);
             final SAXParser parser = factory.newSAXParser();
             final XMLReader reader = parser.getXMLReader();
+
+            reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            reader.setFeature(FEATURE_SECURE_PROCESSING, true);
+
             final SAXAdapter adapter = new SAXAdapter();
             reader.setContentHandler(adapter);
             reader.parse(src);

--- a/src/org/exist/http/Descriptor.java
+++ b/src/org/exist/http/Descriptor.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.memtree.SAXAdapter;
 import org.exist.util.ConfigurationHelper;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.SingleInstanceConfiguration;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -48,6 +49,8 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
+
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
 /**
  * Webapplication Descriptor
@@ -114,12 +117,17 @@ public class Descriptor implements ErrorHandler {
             // initialize xml parser
             // we use eXist's in-memory DOM implementation to work
             // around a bug in Xerces
-            final SAXParserFactory factory = SAXParserFactory.newInstance();
+            final SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
             factory.setNamespaceAware(true);
 
             final InputSource src = new InputSource(is);
             final SAXParser parser = factory.newSAXParser();
             final XMLReader reader = parser.getXMLReader();
+
+            reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            reader.setFeature(FEATURE_SECURE_PROCESSING, true);
+
             final SAXAdapter adapter = new SAXAdapter();
             reader.setContentHandler(adapter);
             reader.parse(src);

--- a/src/org/exist/util/Configuration.java
+++ b/src/org/exist/util/Configuration.java
@@ -82,6 +82,8 @@ import org.exist.Namespaces;
 import org.exist.scheduler.JobType;
 import org.exist.xquery.Module;
 
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
+
 
 public class Configuration implements ErrorHandler
 {
@@ -178,14 +180,19 @@ public class Configuration implements ErrorHandler
             // initialize xml parser
             // we use eXist's in-memory DOM implementation to work
             // around a bug in Xerces
-            final SAXParserFactory factory = SAXParserFactory.newInstance();
-            factory.setNamespaceAware( true );
+            final SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
+            factory.setNamespaceAware(true);
 
 //            factory.setFeature("http://apache.org/xml/features/validation/schema", true);
 //            factory.setFeature("http://apache.org/xml/features/validation/dynamic", true);
             final InputSource src = new InputSource(is);
             final SAXParser parser = factory.newSAXParser();
             final XMLReader reader = parser.getXMLReader();
+
+            reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            reader.setFeature(FEATURE_SECURE_PROCESSING, true);
+
             final SAXAdapter adapter = new SAXAdapter();
             reader.setContentHandler(adapter);
             reader.parse(src);

--- a/src/org/exist/util/ExistSAXParserFactory.java
+++ b/src/org/exist/util/ExistSAXParserFactory.java
@@ -21,6 +21,7 @@
  */
 package org.exist.util;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import javax.xml.parsers.SAXParserFactory;
 
@@ -28,30 +29,29 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- *  Helper class for creating an instance of javax.xml.parsers.SAXParserFactory
- * 
+ * Helper class for creating an instance of javax.xml.parsers.SAXParserFactory
+ *
  * @author dizzzz@exist-db.org
  */
 public class ExistSAXParserFactory {
 
     private final static Logger LOG = LogManager.getLogger(ExistSAXParserFactory.class);
 
-    public final static String ORG_EXIST_SAXPARSERFACTORY="org.exist.SAXParserFactory";
+    public final static String ORG_EXIST_SAXPARSERFACTORY = "org.exist.SAXParserFactory";
 
     /**
-     *  Get SAXParserFactory instance specified by factory class name.
+     * Get SAXParserFactory instance specified by factory class name.
      *
      * @param className Full class name of factory
-     *
      * @return A Sax parser factory or NULL when not available.
      */
-    public static SAXParserFactory getSAXParserFactory(String className) {
+    public static SAXParserFactory getSAXParserFactory(final String className) {
 
         Class<?> clazz = null;
         try {
             clazz = Class.forName(className);
 
-        } catch (final Exception ex) { // ClassNotFoundException
+        } catch (final ClassNotFoundException ex) {
             // quick escape
             LOG.debug(className + ": " + ex.getMessage(), ex);
             return null;
@@ -61,7 +61,7 @@ public class ExistSAXParserFactory {
         Method method = null;
         try {
             method = clazz.getMethod("newInstance", (Class[]) null);
-        } catch (final Exception ex) { // SecurityException and NoSuchMethodException
+        } catch (final SecurityException | NoSuchMethodException ex) {
             // quick escape
             LOG.debug("Method " + className + ".newInstance not found.", ex);
             return null;
@@ -72,7 +72,7 @@ public class ExistSAXParserFactory {
         try {
             result = method.invoke(null, (Object[]) null);
 
-        } catch (final Exception ex) { //IllegalAccessException and InvocationTargetException
+        } catch (final IllegalAccessException | InvocationTargetException ex) {
             // quick escape
             LOG.debug("Could not invoke method " + className + ".newInstance.", ex);
             return null;
@@ -84,11 +84,10 @@ public class ExistSAXParserFactory {
         }
 
         return (SAXParserFactory) result;
-
     }
 
     /**
-     *  Get instance of a SAXParserFactory. Return factory specified by
+     * Get instance of a SAXParserFactory. Return factory specified by
      * system property org.exist.SAXParserFactory (if available) otherwise
      * return system default.
      *
@@ -109,7 +108,7 @@ public class ExistSAXParserFactory {
         // If no factory could be retrieved, create system default property.
         if (factory == null) {
             factory = SAXParserFactory.newInstance();
-            LOG.debug(String.format("Using default SAXParserFactory '%s'", factory.getClass().getCanonicalName()));
+            LOG.info(String.format("Using default SAXParserFactory '%s'", factory.getClass().getCanonicalName()));
         }
 
         return factory;

--- a/src/org/exist/util/MimeTable.java
+++ b/src/org/exist/util/MimeTable.java
@@ -45,6 +45,8 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
+
 /**
  * Global table of mime types. This singleton class maintains a list
  * of mime types known to the system. It is used to look up the
@@ -273,12 +275,17 @@ public class MimeTable {
      * @throws IOException 
      */
     private void loadMimeTypes(InputStream stream) throws ParserConfigurationException, SAXException, IOException {
-        final SAXParserFactory factory = SAXParserFactory.newInstance();
+        final SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
         factory.setNamespaceAware(true);
         factory.setValidating(false);
 		final InputSource src = new InputSource(stream);
         final SAXParser parser = factory.newSAXParser();
         final XMLReader reader = parser.getXMLReader();
+
+        reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        reader.setFeature(FEATURE_SECURE_PROCESSING, true);
+
         reader.setContentHandler(new MimeTableHandler());
         reader.parse(src);
     }

--- a/src/org/exist/validation/Validator.java
+++ b/src/org/exist/validation/Validator.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.Logger;
 import org.exist.Namespaces;
 import org.exist.storage.BrokerPool;
 import org.exist.util.Configuration;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.XMLReaderObjectFactory;
 import org.exist.validation.resolver.AnyUriResolver;
 import org.exist.validation.resolver.SearchResourceResolver;
@@ -45,6 +46,8 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
+
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
 /**
  *  Validate XML documents with their grammars (DTD's and Schemas).
@@ -260,7 +263,7 @@ public class Validator {
             ErrorHandler errorHandler) throws ParserConfigurationException, SAXException {
 
         // setup sax factory ; be sure just one instance!
-        final SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+        final SAXParserFactory saxFactory = ExistSAXParserFactory.getSAXParserFactory();
 
         // Enable validation stuff
         saxFactory.setValidating(true);
@@ -269,6 +272,8 @@ public class Validator {
         // Create xml reader
         final SAXParser saxParser = saxFactory.newSAXParser();
         final XMLReader xmlReader = saxParser.getXMLReader();
+
+        xmlReader.setFeature(FEATURE_SECURE_PROCESSING, true);
 
         // Setup xmlreader
         xmlReader.setProperty(XMLReaderObjectFactory.APACHE_PROPERTIES_INTERNAL_GRAMMARPOOL, grammarPool);

--- a/src/org/exist/xmldb/RemoteXMLResource.java
+++ b/src/org/exist/xmldb/RemoteXMLResource.java
@@ -26,6 +26,7 @@ import org.apache.xmlrpc.XmlRpcException;
 import org.apache.xmlrpc.client.XmlRpcClient;
 import org.exist.Namespaces;
 import org.exist.dom.persistent.DocumentTypeImpl;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.Leasable;
 import org.exist.util.MimeType;
 import org.exist.util.io.TemporaryFileManager;
@@ -64,6 +65,8 @@ import java.util.List;
 import java.util.Properties;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
+
 import java.util.Optional;
 
 public class RemoteXMLResource
@@ -225,11 +228,12 @@ public class RemoteXMLResource
 
             XMLReader reader = xmlReader;
             if (reader == null) {
-                final SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+                final SAXParserFactory saxFactory = ExistSAXParserFactory.getSAXParserFactory();
                 saxFactory.setNamespaceAware(true);
                 saxFactory.setValidating(false);
                 final SAXParser sax = saxFactory.newSAXParser();
                 reader = sax.getXMLReader();
+                reader.setFeature(FEATURE_SECURE_PROCESSING, true);
             }
 
             reader.setContentHandler(handler);

--- a/src/org/exist/xquery/functions/validation/Jaxp.java
+++ b/src/org/exist/xquery/functions/validation/Jaxp.java
@@ -45,6 +45,7 @@ import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.storage.BrokerPool;
 import org.exist.util.Configuration;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.XMLReaderObjectFactory;
 import org.exist.util.io.TemporaryFileManager;
 import org.exist.validation.GrammarPool;
@@ -71,6 +72,8 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
+
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
 /**
  *   xQuery function for validation of XML instance documents
@@ -310,7 +313,7 @@ public class Jaxp extends BasicFunction {
     private XMLReader getXMLReader() throws ParserConfigurationException, SAXException {
 
         // setup sax factory ; be sure just one instance!
-        final SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+        final SAXParserFactory saxFactory = ExistSAXParserFactory.getSAXParserFactory();
 
         // Enable validation stuff
         saxFactory.setValidating(true);
@@ -319,6 +322,8 @@ public class Jaxp extends BasicFunction {
         // Create xml reader
         final SAXParser saxParser = saxFactory.newSAXParser();
         final XMLReader xmlReader = saxParser.getXMLReader();
+
+        xmlReader.setFeature(FEATURE_SECURE_PROCESSING, true);
 
         setXmlReaderFeature(xmlReader, Namespaces.SAX_VALIDATION, true);
         setXmlReaderFeature(xmlReader, Namespaces.SAX_VALIDATION_DYNAMIC, false);

--- a/test/src/org/exist/config/ConfigurableTest.java
+++ b/test/src/org/exist/config/ConfigurableTest.java
@@ -30,6 +30,7 @@ import javax.xml.parsers.SAXParserFactory;
 
 import com.googlecode.junittoolbox.ParallelRunner;
 import org.exist.dom.memtree.SAXAdapter;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.io.FastByteArrayInputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -107,7 +108,7 @@ public class ConfigurableTest {
         // initialize xml parser
         // we use eXist's in-memory DOM implementation to work
         // around a bug in Xerces
-        SAXParserFactory factory = SAXParserFactory.newInstance();
+        SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
         factory.setNamespaceAware(true);
         InputSource src = new InputSource(is);
         SAXParser parser = factory.newSAXParser();

--- a/test/src/org/exist/dom/memtree/DOMTest.java
+++ b/test/src/org/exist/dom/memtree/DOMTest.java
@@ -16,6 +16,7 @@ import javax.xml.transform.TransformerException;
 
 import com.googlecode.junittoolbox.ParallelRunner;
 import org.exist.dom.QName;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.serializer.DOMSerializer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +46,7 @@ public class DOMTest {
     @Test
     public void documentBuilder() throws ParserConfigurationException, SAXException, IOException, TransformerException {
         DocumentBuilderReceiver receiver = new DocumentBuilderReceiver();
-        SAXParserFactory factory = SAXParserFactory.newInstance();
+        SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
         factory.setNamespaceAware(true);
         XMLReader reader = factory.newSAXParser().getXMLReader();
         reader.setContentHandler(receiver);

--- a/test/src/org/exist/dom/memtree/DocumentImplTest.java
+++ b/test/src/org/exist/dom/memtree/DocumentImplTest.java
@@ -25,6 +25,7 @@ import net.sf.saxon.dom.AttrOverNodeInfo;
 import net.sf.saxon.dom.DocumentBuilderImpl;
 import org.apache.xerces.dom.AttrNSImpl;
 import org.exist.Namespaces;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.io.FastByteArrayInputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -168,7 +169,7 @@ public class DocumentImplTest {
     }
 
     private DocumentImpl parseExist(final InputStream is) throws ParserConfigurationException, SAXException, IOException {
-        final SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+        final SAXParserFactory saxParserFactory = ExistSAXParserFactory.getSAXParserFactory();
         final SAXParser saxParser  = saxParserFactory.newSAXParser();
         final XMLReader reader = saxParser.getXMLReader();
         final InputSource src = new InputSource(is);

--- a/test/src/org/exist/dom/memtree/MemtreeBuilderTest.java
+++ b/test/src/org/exist/dom/memtree/MemtreeBuilderTest.java
@@ -22,6 +22,7 @@ package org.exist.dom.memtree;
 
 import com.googlecode.junittoolbox.ParallelParameterized;
 import org.exist.Namespaces;
+import org.exist.util.ExistSAXParserFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -80,7 +81,7 @@ public class MemtreeBuilderTest {
     }
 
     private DocumentImpl parse(final String xml) throws ParserConfigurationException, SAXException, IOException {
-        final SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+        final SAXParserFactory saxParserFactory = ExistSAXParserFactory.getSAXParserFactory();
         saxParserFactory.setNamespaceAware(namespaceAware);
 
         final SAXAdapter saxAdapter = new SAXAdapter();

--- a/test/src/org/exist/http/RESTServiceTest.java
+++ b/test/src/org/exist/http/RESTServiceTest.java
@@ -37,6 +37,7 @@ import org.exist.Namespaces;
 import org.exist.dom.memtree.SAXAdapter;
 import org.exist.test.ExistWebServer;
 import org.exist.util.Base64Encoder;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.xmldb.XmldbURI;
 import org.junit.runner.RunWith;
 import org.xml.sax.InputSource;
@@ -866,7 +867,7 @@ try {
     }
 
     private int parseResponse(final String data) throws IOException, SAXException, ParserConfigurationException {
-        final SAXParserFactory factory = SAXParserFactory.newInstance();
+        final SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
         factory.setNamespaceAware(true);
         final InputSource src = new InputSource(new StringReader(data));
         final SAXParser parser = factory.newSAXParser();

--- a/test/src/org/exist/test/runner/XMLTestRunner.java
+++ b/test/src/org/exist/test/runner/XMLTestRunner.java
@@ -28,6 +28,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.source.ClassLoaderSource;
 import org.exist.source.Source;
 import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 import org.junit.runner.Description;
@@ -46,6 +47,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
+
 /**
  * A JUnit test runner which can run the XML formatter XQuery tests
  * of eXist-db using $EXIST_HOME/src/org/exist/xquery/lib/test.xq.
@@ -54,7 +57,7 @@ import java.util.*;
  */
 public class XMLTestRunner extends AbstractTestRunner {
 
-    private static final SAXParserFactory SAX_PARSER_FACTORY = SAXParserFactory.newInstance();
+    private static final SAXParserFactory SAX_PARSER_FACTORY = ExistSAXParserFactory.getSAXParserFactory();
     static {
         SAX_PARSER_FACTORY.setNamespaceAware(true);
     }
@@ -166,6 +169,10 @@ public class XMLTestRunner extends AbstractTestRunner {
         final InputSource src = new InputSource(path.toUri().toASCIIString());
         final SAXParser parser = SAX_PARSER_FACTORY.newSAXParser();
         final XMLReader xr = parser.getXMLReader();
+
+        xr.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        xr.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        xr.setFeature(FEATURE_SECURE_PROCESSING, true);
 
         // we have to use eXist-db's SAXAdapter, otherwise un-referenced namespaces as used by xpath assertions may be stripped by Xerces.
         final SAXAdapter adapter = new SAXAdapter();

--- a/test/src/org/exist/w3c/tests/TestCase.java
+++ b/test/src/org/exist/w3c/tests/TestCase.java
@@ -51,6 +51,7 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.FileUtils;
 import org.exist.xmldb.LocalCollection;
 import org.exist.xmldb.LocalXMLResource;
@@ -331,7 +332,7 @@ public abstract class TestCase {
     public NodeImpl loadVarFromURI(XQueryContext context, String uri) throws IOException {
         SAXAdapter adapter = new SAXAdapter(context);
 
-        SAXParserFactory factory = SAXParserFactory.newInstance();
+        SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
         factory.setNamespaceAware(true);
         
         XMLReader xr;
@@ -379,7 +380,7 @@ public abstract class TestCase {
     public NodeImpl loadVarFromString(XQueryContext context, String source) throws IOException {
         SAXAdapter adapter = new SAXAdapter(context);
 
-        SAXParserFactory factory = SAXParserFactory.newInstance();
+        SAXParserFactory factory = ExistSAXParserFactory.getSAXParserFactory();
         factory.setNamespaceAware(true);
         
         XMLReader xr;

--- a/test/src/org/exist/xmldb/ResourceTest.java
+++ b/test/src/org/exist/xmldb/ResourceTest.java
@@ -41,6 +41,7 @@ import org.exist.TestUtils;
 import org.exist.dom.QName;
 import org.exist.security.Account;
 import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.util.serializer.AttrList;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.XMLFilenameFilter;
@@ -194,7 +195,7 @@ public class ResourceTest {
                         + "<para>Paragraph2</para>"
                         + "</test>";
         ContentHandler handler = doc.setContentAsSAX();
-        SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+        SAXParserFactory saxFactory = ExistSAXParserFactory.getSAXParserFactory();
         saxFactory.setNamespaceAware(true);
         saxFactory.setValidating(false);
         SAXParser sax = saxFactory.newSAXParser();

--- a/test/src/org/exist/xquery/functions/fn/CollectionTest.java
+++ b/test/src/org/exist/xquery/functions/fn/CollectionTest.java
@@ -28,6 +28,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -63,7 +64,7 @@ public class CollectionTest {
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true);
 
-    private static SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+    private static SAXParserFactory saxParserFactory = ExistSAXParserFactory.getSAXParserFactory();
     static {
         saxParserFactory.setNamespaceAware(true);
     }

--- a/test/src/org/exist/xquery/functions/fn/DocTest.java
+++ b/test/src/org/exist/xquery/functions/fn/DocTest.java
@@ -30,6 +30,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.test.ExistXmldbEmbeddedServer;
+import org.exist.util.ExistSAXParserFactory;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.XQueryContext;
@@ -78,7 +79,7 @@ public class DocTest {
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true);
 
-    private static SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+    private static SAXParserFactory saxParserFactory = ExistSAXParserFactory.getSAXParserFactory();
     static {
         saxParserFactory.setNamespaceAware(true);
     }


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/2180

* Ensures that either `XMLReaderPool` is used (which can be securely configured from `$EXIST_HOME/conf.xml`) or that the XMLReader created has secure features set.