### PR TITLE
Fix an issue with lock lifetime when changing permissions

### DIFF
--- a/src/org/exist/management/impl/LockTableMXBean.java
+++ b/src/org/exist/management/impl/LockTableMXBean.java
@@ -22,11 +22,11 @@ package org.exist.management.impl;
 
 import org.exist.storage.lock.Lock;
 import org.exist.storage.lock.LockTable;
+import org.exist.storage.lock.LockTable.LockCountTraces;
 import org.exist.storage.lock.LockTable.LockModeOwner;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * JMX MXBean interface for examining the LockTable
@@ -40,7 +40,7 @@ public interface LockTableMXBean extends PerInstanceMBean {
      *
      * @return information about acquired locks
      */
-    Map<String, Map<Lock.LockType, Map<Lock.LockMode, Map<String, Integer>>>> getAcquired();
+    Map<String, Map<Lock.LockType, Map<Lock.LockMode, Map<String, LockCountTraces>>>> getAcquired();
 
     /**
      * Get information about outstanding attempts to acquire locks
@@ -52,4 +52,16 @@ public interface LockTableMXBean extends PerInstanceMBean {
     void dumpToConsole();
 
     void dumpToLog();
+
+    void xmlDumpToConsole();
+
+    void xmlDumpToLog();
+
+    void fullDumpToConsole();
+
+    void fullDumpToLog();
+
+    void xmlFullDumpToConsole();
+
+    void xmlFullDumpToLog();
 }

--- a/src/org/exist/security/PermissionFactory.java
+++ b/src/org/exist/security/PermissionFactory.java
@@ -39,7 +39,6 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import com.evolvedbinary.j8fu.function.ConsumerE;
-import org.exist.util.LockException;
 import org.exist.util.SyntaxException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
@@ -134,8 +133,8 @@ public class PermissionFactory {
 
                         final DocumentImpl doc = lockedDoc.getDocument();
 
-                        // keep a write lock in the transaction
-                        transaction.acquireDocumentLock(() -> brokerPool.getLockManager().acquireDocumentWriteLock(doc.getURI()));
+//                        // keep a write lock in the transaction
+//                        transaction.acquireDocumentLock(() -> brokerPool.getLockManager().acquireDocumentWriteLock(doc.getURI()));
 
 
                         final Permission permissions = doc.getPermissions();
@@ -144,8 +143,8 @@ public class PermissionFactory {
                         broker.storeXMLResource(transaction, doc);
                     }
                 } else {
-                    // keep a write lock in the transaction
-                    transaction.acquireCollectionLock(() -> brokerPool.getLockManager().acquireCollectionWriteLock(collection.getURI()));
+//                    // keep a write lock in the transaction
+//                    transaction.acquireCollectionLock(() -> brokerPool.getLockManager().acquireCollectionWriteLock(collection.getURI()));
 
                     final Permission permissions = collection.getPermissionsNoLock();
                     permissionModifier.accept(permissions);
@@ -154,7 +153,7 @@ public class PermissionFactory {
                 }
                 broker.flush();
             }
-        } catch(final XPathException | PermissionDeniedException | IOException | LockException e) {
+        } catch(final XPathException | PermissionDeniedException | IOException e) {
             throw new PermissionDeniedException("Permission to modify permissions is denied for user '" + broker.getCurrentSubject().getName() + "' on '" + pathUri.toString() + "': " + e.getMessage(), e);
         }
     }

--- a/src/org/exist/storage/txn/Txn.java
+++ b/src/org/exist/storage/txn/Txn.java
@@ -81,15 +81,6 @@ public class Txn implements Transaction {
         return id;
     }
 
-    /**
-     * @deprecated Moving a Lock to a Txn is error prone and should not be done
-     *   instead use {@link #acquireLock(Lock, LockMode)} to take a second lock
-     */
-    @Deprecated
-    public void registerLock(final Lock lock, final LockMode lockMode) {
-        locksHeld.add(new LockInfo(new Tuple2<>(lock, lockMode), () -> lock.release(lockMode)));
-    }
-
     public void acquireLock(final Lock lock, final LockMode lockMode) throws LockException {
         lock.acquire(lockMode);
         locksHeld.add(new LockInfo(new Tuple2<>(lock, lockMode), () -> lock.release(lockMode)));


### PR DESCRIPTION
1. We previously kept the lock for longer than necessary when changing permissions.
2. The JMX output for lock table dump can now also include stack trace info and provide an XML formatted response.