### PR TITLE
enable oracleJDK11 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ matrix:
     - jdk: openjdk9
     - jdk: openjdk10
     - jdk: openjdk11
-#     - jdk: oraclejdk11
+    - jdk: oraclejdk11
+    
     - os: osx
       osx_image: xcode9.2
       env: JAVA_HOME=$(/usr/libexec/java_home)


### PR DESCRIPTION
11 is LTS we can now enable it on Travis, where we had to remove oracle 9 and 10.                                 