### PR TITLE
(4.x.x) Remove the 2GB log file limit for the Journal

### DIFF
--- a/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndex.java
+++ b/extensions/indexes/ngram/src/org/exist/indexing/ngram/NGramIndex.java
@@ -42,7 +42,7 @@ import java.nio.file.Path;
  */
 public class NGramIndex extends AbstractIndex implements RawBackupSupport {
 
-    public static final short FILE_FORMAT_VERSION_ID = 13;
+    public static final short FILE_FORMAT_VERSION_ID = 14;
 
     public final static String ID = NGramIndex.class.getName();
 

--- a/extensions/indexes/sort/src/org/exist/indexing/sort/SortIndex.java
+++ b/extensions/indexes/sort/src/org/exist/indexing/sort/SortIndex.java
@@ -34,7 +34,7 @@ public class SortIndex extends AbstractIndex implements RawBackupSupport {
 
     public static final String ID = SortIndex.class.getName();
     public static final String FILE_NAME = "sort.dbx";
-    public final static short FILE_FORMAT_VERSION_ID = 2;
+    public final static short FILE_FORMAT_VERSION_ID = 3;
     public static final byte SORT_INDEX_ID = 0x10;
     protected static final Logger LOG = LogManager.getLogger(SortIndex.class);
     protected BTreeStore btree;

--- a/src/org/exist/storage/NativeValueIndex.java
+++ b/src/org/exist/storage/NativeValueIndex.java
@@ -118,7 +118,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
     private final static Logger LOG = LogManager.getLogger(NativeValueIndex.class);
 
     public static final String FILE_NAME = "values.dbx";
-    public static final short FILE_FORMAT_VERSION_ID = 13;
+    public static final short FILE_FORMAT_VERSION_ID = 14;
     public static final String FILE_KEY_IN_CONFIG = "db-connection.values";
 
     private static final double DEFAULT_VALUE_CACHE_GROWTH = 1.25;

--- a/src/org/exist/storage/btree/BTree.java
+++ b/src/org/exist/storage/btree/BTree.java
@@ -754,7 +754,7 @@ public class BTree extends Paged implements Lockable {
     }
 
     protected boolean requiresRedo(final Loggable loggable, final Page page) {
-        return loggable.getLsn() > page.getPageHeader().getLsn();
+        return loggable.getLsn().compareTo(page.getPageHeader().getLsn()) > 0;
     }
 
     protected void redoCreateBTNode(final CreateBTNodeLoggable loggable) throws LogException {
@@ -766,7 +766,7 @@ public class BTree extends Paged implements Lockable {
                 page.read();
                 if ((page.getPageHeader().getStatus() == BRANCH ||
                         page.getPageHeader().getStatus() == LEAF) &&
-                        page.getPageHeader().getLsn() != Lsn.LSN_INVALID &&
+                        (!page.getPageHeader().getLsn().equals(Lsn.LSN_INVALID)) &&
                         !requiresRedo(loggable, page)) {
                     // node already found on disk: read it
                     node = new BTreeNode(page, false);
@@ -809,7 +809,7 @@ public class BTree extends Paged implements Lockable {
 
     protected void redoUpdateValue(final UpdateValueLoggable loggable) throws LogException {
         final BTreeNode node = getBTreeNode(loggable.pageNum);
-        if (node.page.getPageHeader().getLsn() != Page.NO_PAGE && requiresRedo(loggable, node.page)) {
+        if (!node.page.getPageHeader().getLsn().equals(Lsn.LSN_INVALID) && requiresRedo(loggable, node.page)) {
             if (loggable.idx > node.ptrs.length) {
                 LOG.warn(node.page.getPageInfo() +
                         "; loggable.idx = " + loggable.idx + "; node.ptrs.length = " + node.ptrs.length);
@@ -839,7 +839,7 @@ public class BTree extends Paged implements Lockable {
 
     protected void redoRemoveValue(final RemoveValueLoggable loggable) throws LogException {
         final BTreeNode node = getBTreeNode(loggable.pageNum);
-        if (node.page.getPageHeader().getLsn() != Page.NO_PAGE && requiresRedo(loggable, node.page)) {
+        if (!node.page.getPageHeader().getLsn().equals(Lsn.LSN_INVALID) && requiresRedo(loggable, node.page)) {
             node.removeKey(loggable.idx);
             node.removePointer(loggable.idx);
             node.recalculateDataLen();

--- a/src/org/exist/storage/btree/Paged.java
+++ b/src/org/exist/storage/btree/Paged.java
@@ -1014,7 +1014,7 @@ public abstract class Paged implements AutoCloseable {
         public static final int LENGTH_PAGE_STATUS = 1; //sizeof byte
         public static final int LENGTH_PAGE_DATA_LENGTH = 4; //sizeof int
         public static final int LENGTH_PAGE_NEXT_PAGE = 8; //sizeof long
-        public static final int LENGTH_PAGE_LSN = 8; //sizeof long
+        public static final int LENGTH_PAGE_LSN = Lsn.RAW_LENGTH;
 
         private int dataLen = 0;
         private boolean dirty = false;
@@ -1022,7 +1022,7 @@ public abstract class Paged implements AutoCloseable {
 
         private byte status = UNUSED;
 
-        private long lsn = Lsn.LSN_INVALID;
+        private Lsn lsn = Lsn.LSN_INVALID;
         
         public PageHeader() {
         }
@@ -1081,11 +1081,11 @@ public abstract class Paged implements AutoCloseable {
          * 
          * @return log sequence number of the last operation that modified this page.
          */
-        public final long getLsn() {
+        public final Lsn getLsn() {
             return lsn;
         }
 
-        public final void setLsn(final long lsn) {
+        public final void setLsn(final Lsn lsn) {
             this.lsn = lsn;
         }
 
@@ -1096,7 +1096,7 @@ public abstract class Paged implements AutoCloseable {
             offset += LENGTH_PAGE_DATA_LENGTH;
             nextPage = ByteConversion.byteToLong(data, offset);
             offset += LENGTH_PAGE_NEXT_PAGE;
-            lsn = ByteConversion.byteToLong(data, offset);
+            lsn = Lsn.read(data, offset);
             offset += LENGTH_PAGE_LSN;
         	return offset;
         }
@@ -1108,7 +1108,7 @@ public abstract class Paged implements AutoCloseable {
             offset += LENGTH_PAGE_DATA_LENGTH;
             ByteConversion.longToByte(nextPage, data, offset);
             offset += LENGTH_PAGE_NEXT_PAGE;
-            ByteConversion.longToByte(lsn, data, offset);
+            lsn.write(data, offset);
             offset += LENGTH_PAGE_LSN;
             dirty = false;
             return offset;

--- a/src/org/exist/storage/dom/DOMFile.java
+++ b/src/org/exist/storage/dom/DOMFile.java
@@ -164,7 +164,7 @@ public class DOMFile extends BTree implements Lockable {
         LogEntryTypes.addEntryType(LOG_UPDATE_LINK, UpdateLinkLoggable::new);
     }
 
-    public final static short FILE_FORMAT_VERSION_ID = 9;
+    public final static short FILE_FORMAT_VERSION_ID = 10;
 
     //Page types
     public final static byte LOB = 21;

--- a/src/org/exist/storage/dom/DOMFile.java
+++ b/src/org/exist/storage/dom/DOMFile.java
@@ -2178,13 +2178,13 @@ public class DOMFile extends BTree implements Lockable {
      */
 
     private boolean requiresRedo(final Loggable loggable, final DOMPage page) {
-        return loggable.getLsn() > page.getPageHeader().getLsn();
+        return loggable.getLsn().compareTo(page.getPageHeader().getLsn()) > 0;
     }
 
     protected void redoCreatePage(final CreatePageLoggable loggable) {
         final DOMPage newPage = getDOMPage(loggable.newPage);
         final DOMFilePageHeader newPageHeader = newPage.getPageHeader();
-        if (newPageHeader.getLsn() == Lsn.LSN_INVALID || requiresRedo(loggable, newPage)) {
+        if (newPageHeader.getLsn().equals(Lsn.LSN_INVALID) || requiresRedo(loggable, newPage)) {
             try {
                 dropFreePageList();
                 newPageHeader.setStatus(RECORD);
@@ -2240,7 +2240,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoAddValue(final AddValueLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             try {
                 ByteConversion.shortToByte(loggable.tid, page.data, page.len);
                 page.len += LENGTH_TID;
@@ -2272,7 +2272,7 @@ public class DOMFile extends BTree implements Lockable {
         final DOMFilePageHeader pageHeader = page.getPageHeader();
 
         // is there anything to undo?
-        if (pageHeader.getLsn() == Lsn.LSN_INVALID || pageHeader.getStatus() == UNUSED) {
+        if (pageHeader.getLsn().equals(Lsn.LSN_INVALID) || pageHeader.getStatus() == UNUSED) {
             LOG.warn("Nothing to undo, but received: AddValueLoggable(txnId=" + loggable.getTransactionId()
                     + ", lsn=" + loggable.getLsn() + ", pageNum=" + loggable.pageNum
                     + ", isOverflow=" + loggable.isOverflow + ")");
@@ -2304,7 +2304,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoUpdateValue(final UpdateValueLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader ph = page.getPageHeader();
-        if (ph.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!ph.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             final RecordPos rec = page.findRecord(ItemId.getId(loggable.tid));
             SanityCheck.THROW_ASSERT(rec != null, 
                 "tid " + ItemId.getId(loggable.tid) +
@@ -2344,7 +2344,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoRemoveValue(final RemoveValueLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             final RecordPos pos = page.findRecord(ItemId.getId(loggable.tid));
             SanityCheck.ASSERT(pos != null, 
                 "Record not found: " + ItemId.getId(loggable.tid) + ": " + 
@@ -2447,7 +2447,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoRemoveEmptyPage(final RemoveEmptyPageLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             removePage(page);
         }
     }
@@ -2489,7 +2489,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoRemovePage(final RemovePageLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             try {
                 pageHeader.setNextDataPage(Page.NO_PAGE);
                 pageHeader.setPrevDataPage(Page.NO_PAGE);
@@ -2533,7 +2533,7 @@ public class DOMFile extends BTree implements Lockable {
         try {
             final Page page = getPage(loggable.pageNum);
             final PageHeader pageHeader = page.getPageHeader();
-            if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+            if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
 
                 dropFreePageList();
                 pageHeader.setStatus(RECORD);
@@ -2568,7 +2568,7 @@ public class DOMFile extends BTree implements Lockable {
             final Page page = getPage(loggable.pageNum);
             page.read();
             final PageHeader pageHeader = page.getPageHeader();
-            if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+            if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
                 unlinkPages(page);
             }
         } catch (final IOException e) {
@@ -2599,7 +2599,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoInsertValue(final InsertValueLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             final int dlen = pageHeader.getDataLength();
             int offset = loggable.offset;
             // insert in the middle of the page?
@@ -2686,7 +2686,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoSplitPage(final SplitPageLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             final byte[] oldData = page.data;
             page.data = new byte[fileHeader.getWorkSize()];
             System.arraycopy(oldData, 0, page.data, 0, loggable.splitOffset);
@@ -2718,7 +2718,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoAddLink(final AddLinkLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             ByteConversion.shortToByte(ItemId.setIsLink(loggable.tid), page.data, page.len);
             page.len += LENGTH_TID;
             ByteConversion.longToByte(loggable.link, page.data, page.len);
@@ -2754,7 +2754,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoUpdateLink(final UpdateLinkLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             ByteConversion.longToByte(loggable.link, page.data, loggable.offset);
             pageHeader.setLsn(loggable.getLsn());
             page.setDirty(true);
@@ -2774,7 +2774,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoAddMovedValue(final AddMovedValueLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             try {
                 ByteConversion.shortToByte(ItemId.setIsRelocated(loggable.tid), page.data, page.len);
                 page.len += LENGTH_TID;
@@ -2842,7 +2842,7 @@ public class DOMFile extends BTree implements Lockable {
     protected void redoUpdateHeader(final UpdateHeaderLoggable loggable) {
         final DOMPage page = getDOMPage(loggable.pageNum);
         final DOMFilePageHeader pageHeader = page.getPageHeader();
-        if (pageHeader.getLsn() != Lsn.LSN_INVALID && requiresRedo(loggable, page)) {
+        if ((!pageHeader.getLsn().equals(Lsn.LSN_INVALID)) && requiresRedo(loggable, page)) {
             if (loggable.nextPage != Page.NO_PAGE) {
                 pageHeader.setNextDataPage(loggable.nextPage);
             }
@@ -3192,7 +3192,7 @@ public class DOMFile extends BTree implements Lockable {
         public boolean sync(final boolean syncJournal) {
             if (isDirty()) {
                 write();
-                if (isRecoveryEnabled() && syncJournal && logManager.get().lastWrittenLsn() < pageHeader.getLsn()) {
+                if (isRecoveryEnabled() && syncJournal && logManager.get().lastWrittenLsn().compareTo(pageHeader.getLsn()) < 0) {
                     logManager.get().flush(true, false);
                 }
                 return true;

--- a/src/org/exist/storage/index/CollectionStore.java
+++ b/src/org/exist/storage/index/CollectionStore.java
@@ -27,7 +27,7 @@ import java.util.Deque;
  */
 public class CollectionStore extends BFile {
 
-    public static final short FILE_FORMAT_VERSION_ID = 14;
+    public static final short FILE_FORMAT_VERSION_ID = 15;
 
     public static final String FILE_NAME = "collections.dbx";
     public static final String  FILE_KEY_IN_CONFIG = "db-connection.collections";

--- a/src/org/exist/storage/journal/AbstractLoggable.java
+++ b/src/org/exist/storage/journal/AbstractLoggable.java
@@ -29,7 +29,7 @@ public abstract class AbstractLoggable implements Loggable {
 
     protected final byte type;
     protected long transactionId;
-    protected long lsn;
+    protected Lsn lsn;
 
     public AbstractLoggable(final byte type, final long transactionId) {
         this.type = type;
@@ -51,12 +51,12 @@ public abstract class AbstractLoggable implements Loggable {
     }
 
     @Override
-    public void setLsn(long lsn) {
+    public void setLsn(final Lsn lsn) {
         this.lsn = lsn;
     }
 
     @Override
-    public long getLsn() {
+    public Lsn getLsn() {
         return lsn;
     }
 
@@ -76,6 +76,6 @@ public abstract class AbstractLoggable implements Loggable {
      */
     @Override
     public String dump() {
-        return '[' + Lsn.dump(getLsn()) + "] " + getClass().getName() + ' ';
+        return '[' + getLsn().toString() + "] " + getClass().getName() + ' ';
     }
 }

--- a/src/org/exist/storage/journal/Journal.java
+++ b/src/org/exist/storage/journal/Journal.java
@@ -111,7 +111,7 @@ public final class Journal {
      */
     public static final int JOURNAL_HEADER_LEN = 6;
     public static final byte[] JOURNAL_MAGIC_NUMBER = {0x0E, 0x0D, 0x0B, 0x01};
-    public static final short JOURNAL_VERSION = 4;
+    public static final short JOURNAL_VERSION = 5;
 
     public static final String RECOVERY_SYNC_ON_COMMIT_ATTRIBUTE = "sync-on-commit";
     public static final String RECOVERY_JOURNAL_DIR_ATTRIBUTE = "journal-dir";

--- a/src/org/exist/storage/journal/JournalManager.java
+++ b/src/org/exist/storage/journal/JournalManager.java
@@ -153,7 +153,7 @@ public class JournalManager implements BrokerPoolService {
     /**
      * @see Journal#lastWrittenLsn()
      */
-    public long lastWrittenLsn() {
+    public Lsn lastWrittenLsn() {
         return journal.lastWrittenLsn();
     }
 

--- a/src/org/exist/storage/journal/Loggable.java
+++ b/src/org/exist/storage/journal/Loggable.java
@@ -54,14 +54,14 @@ public interface Loggable {
      * 
      * @return the Log Sequence Number
      */
-    long getLsn();
+    Lsn getLsn();
     
     /**
      * Set the {@link Lsn} of the entry.
      * 
      * @param lsn the Log Sequence Number
      */
-    void setLsn(long lsn);
+    void setLsn(Lsn lsn);
     
     /**
      * Write this entry to the specified ByteBuffer.

--- a/src/org/exist/storage/journal/Lsn.java
+++ b/src/org/exist/storage/journal/Lsn.java
@@ -1,64 +1,149 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-04 The eXist Project
- *  http://exist-db.org
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2018 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exist.storage.journal;
+
+import org.exist.util.ByteConversion;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 /**
  * Log Sequence Number: identifies a log record within the journal file.
  * A LSN is represented by a Java long and consists of the file number
  * of the journal file and an offset into the file.
- * 
- * @author wolf
+ *
+ * An LSN is 10 bytes, the first 8 bytes are the offset, the last 2 bytes
+ * are the fileNumber. The LSN is in <i>big-endian</i> byte-order: the
+ * most significant byte is in the zeroth element.
+ *
+ * @author Adam Retter <adam@evolvedbinary.com>
  */
-public class Lsn {
+public class Lsn implements Comparable<Lsn> {
 
-	public static final long LSN_INVALID = -1;
-		
-    private static final long INT_MASK = 0xFFFFFFFFL;
-    
-    public static long create(int fileNumber, int offset) {
-        return offset & INT_MASK | ((fileNumber & INT_MASK) << 32);
+    /**
+     * Length of the LSN in bytes.
+     */
+    public static final int RAW_LENGTH = 10;
+    private static final int FILE_NUMBER_OFFSET = 0;
+    private static final int FILE_OFFSET_OFFSET = 2;
+
+    /**
+     * This mask is used to obtain the value of an int as if it were unsigned.
+     */
+    private static final long LONG_MASK = 0xffffffffL;
+
+    /**
+     * Singleton which represents an Invalid LSN
+     */
+	public static final Lsn LSN_INVALID = new Lsn((short)-1, -1l);
+
+    private final byte[] lsn;
+
+    public Lsn(final short fileNumber, final long offset) {
+        this.lsn = new byte[RAW_LENGTH];
+        ByteConversion.shortToByteH(fileNumber, lsn, FILE_NUMBER_OFFSET);
+        ByteConversion.longToByte(offset, lsn, FILE_OFFSET_OFFSET);
     }
-    
+
+    private Lsn(final byte data[], final int offset) {
+        this.lsn = new byte[RAW_LENGTH];
+        System.arraycopy(data, offset, lsn, 0, RAW_LENGTH);
+    }
+
+    private Lsn(final byte lsn[]) {
+        this.lsn = lsn;
+    }
+
+    public static Lsn read(final byte[] lsn, final int offset) {
+        return new Lsn(lsn, offset);
+    }
+
+    public static Lsn read(final ByteBuffer buffer) {
+        final byte[] lsn = new byte[RAW_LENGTH];
+        buffer.get(lsn);
+        return new Lsn(lsn);
+    }
+
+    public void write(final byte[] buffer, final int offset) {
+        System.arraycopy(lsn, 0, buffer, offset, RAW_LENGTH);
+    }
+
+    public void write(final ByteBuffer buffer) {
+        buffer.put(lsn);
+    }
+
     /**
      * Returns the file number encoded in the passed LSN.
-     * 
-     * @param lsn
+     *
      * @return file number
      */
-    public static long getFileNumber(long lsn) {
-        return (lsn >> 32) & INT_MASK;
+    public long getFileNumber() {
+        return ByteConversion.byteToShortH(lsn, FILE_NUMBER_OFFSET);
     }
-    
+
     /**
      * Returns the file offset encoded in the passed LSN.
-     * 
-     * @param lsn
+     *
      * @return file offset
      */
-    public static long getOffset(long lsn) {
-        return (lsn & INT_MASK);
+    public long getOffset() {
+        return ByteConversion.byteToLong(lsn, FILE_OFFSET_OFFSET);
     }
-	
-	public static String dump(long lsn) {
-		return getFileNumber(lsn) + ", " + getOffset(lsn);
-	}
+
+    @Override
+    public int compareTo(final Lsn other) {
+        final boolean thisInvalid = this == LSN_INVALID || LSN_INVALID.equals(this);
+        final boolean otherInvalid = other == LSN_INVALID || LSN_INVALID.equals(other);
+
+        if (thisInvalid && otherInvalid) {
+            return 0;
+        } else if(thisInvalid && !otherInvalid) {
+            return -1;
+        } else if (otherInvalid && !thisInvalid) {
+            return 1;
+        }
+
+        for (int i = 0; i < RAW_LENGTH; i++) {
+            int a = lsn[i];
+            int b = other.lsn[i];
+            if (a != b)
+                return ((a & LONG_MASK) < (b & LONG_MASK)) ? -1 : 1;
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final Lsn other = (Lsn) o;
+        return Arrays.equals(lsn, other.lsn);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(lsn);
+    }
+
+    @Override
+    public String toString() {
+        return getFileNumber() + ", " + getOffset();
+    }
 }

--- a/src/org/exist/storage/structural/NativeStructuralIndex.java
+++ b/src/org/exist/storage/structural/NativeStructuralIndex.java
@@ -47,7 +47,7 @@ public class NativeStructuralIndex extends AbstractIndex implements RawBackupSup
 
     public final static String ID = NativeStructuralIndex.class.getName();
     public static final String FILE_NAME = "structure.dbx";
-    public final static short FILE_FORMAT_VERSION_ID = 2;
+    public final static short FILE_FORMAT_VERSION_ID = 3;
 
     public static final byte STRUCTURAL_INDEX_ID = 1;
 

--- a/src/org/exist/storage/txn/Checkpoint.java
+++ b/src/org/exist/storage/txn/Checkpoint.java
@@ -27,13 +27,17 @@ import java.util.Date;
 import org.exist.storage.DBBroker;
 import org.exist.storage.journal.AbstractLoggable;
 import org.exist.storage.journal.LogEntryTypes;
+import org.exist.storage.journal.Lsn;
 
 /**
  * @author wolf
  */
 public class Checkpoint extends AbstractLoggable {
+
+    private static final int TIMESTAMP_LEN = 8;
+
 	private long timestamp;
-	private long storedLsn;
+	private Lsn storedLsn;
 	
 	private final DateFormat df = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM);
 	
@@ -48,23 +52,23 @@ public class Checkpoint extends AbstractLoggable {
     
     @Override
     public void write(final ByteBuffer out) {
-    	out.putLong(lsn);
+        lsn.write(out);
 		out.putLong(timestamp);
     }
 
     @Override
     public void read(final ByteBuffer in) {
-    	storedLsn = in.getLong();
+        storedLsn = Lsn.read(in);
 		timestamp = in.getLong();
     }
 
-    public long getStoredLsn() {
+    public Lsn getStoredLsn() {
     	return storedLsn;
     }
     
     @Override
     public int getLogSize() {
-        return 16;
+        return Lsn.RAW_LENGTH + TIMESTAMP_LEN;
     }
 
     public String getDateString() {

--- a/test/src/org/exist/storage/RemoveCollectionTest.java
+++ b/test/src/org/exist/storage/RemoveCollectionTest.java
@@ -40,6 +40,7 @@ import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.TestDataGenerator;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.xml.sax.InputSource;
 import static org.junit.Assert.*;
 import org.junit.Test;
@@ -235,5 +236,10 @@ public class RemoveCollectionTest {
     @After
     public void stopDb() {
         existEmbeddedServer.stopDb();
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        BrokerPool.FORCE_CORRUPTION = false;
     }
 }

--- a/test/src/org/exist/storage/journal/LsnTest.java
+++ b/test/src/org/exist/storage/journal/LsnTest.java
@@ -1,0 +1,70 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2018 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.storage.journal;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Adam Retter <adam@evolvedbinary.com>
+ */
+public class LsnTest {
+
+    @Test
+    public void compareTo() {
+        assertEquals(0, Lsn.LSN_INVALID.compareTo(Lsn.LSN_INVALID));
+        assertEquals(-1, Lsn.LSN_INVALID.compareTo(new Lsn((short)0, 0)));
+        assertEquals(1, new Lsn((short)0, 0).compareTo(Lsn.LSN_INVALID));
+
+        assertEquals(0, new Lsn((short)0, 0).compareTo(new Lsn((short)0, 0)));
+
+        assertEquals(0, new Lsn((short)1, 123).compareTo(new Lsn((short)1, 123)));
+        assertEquals(-1, new Lsn((short)1, 123).compareTo(new Lsn((short)1, 124)));
+        assertEquals(1, new Lsn((short)1, 124).compareTo(new Lsn((short)1, 122)));
+
+        assertEquals(-1, new Lsn((short)1, 123).compareTo(new Lsn((short)2, 123)));
+        assertEquals(1, new Lsn((short)2, 123).compareTo(new Lsn((short)1, 123)));
+
+        assertEquals(-1, new Lsn((short)1, Long.MAX_VALUE).compareTo(new Lsn((short)2, Long.MIN_VALUE)));
+        assertEquals(-1, new Lsn((short)1, Long.MAX_VALUE).compareTo(new Lsn((short)2, 0)));
+        assertEquals(-1, new Lsn((short)1, Long.MAX_VALUE).compareTo(new Lsn((short)2, 1)));
+        assertEquals(-1, new Lsn((short)1, Long.MAX_VALUE).compareTo(new Lsn((short)2, Long.MAX_VALUE)));
+
+        assertEquals(1, new Lsn((short)2, Long.MIN_VALUE).compareTo(new Lsn((short)1, Integer.MAX_VALUE)));
+        assertEquals(1, new Lsn((short)2, 0).compareTo(new Lsn((short)1, Integer.MAX_VALUE)));
+        assertEquals(1, new Lsn((short)2, 1).compareTo(new Lsn((short)1, Integer.MAX_VALUE)));
+        assertEquals(1, new Lsn((short)2, Long.MAX_VALUE).compareTo(new Lsn((short)1, Integer.MAX_VALUE)));
+    }
+
+    @Test
+    public void equalsTo() {
+        assertTrue(Lsn.LSN_INVALID.equals(Lsn.LSN_INVALID));
+        assertTrue(Lsn.LSN_INVALID.equals(new Lsn((short)-1, -1)));
+        assertTrue(new Lsn((short)-1, -1).equals(Lsn.LSN_INVALID));
+
+        assertFalse(new Lsn((short)0, 0).equals(Lsn.LSN_INVALID));
+        assertFalse(Lsn.LSN_INVALID.equals(new Lsn((short)0, 0)));
+    }
+
+}


### PR DESCRIPTION
Previously eXist-db would silently write bad entries to the Journal if the Journal file exceeded 2 GB. I recently added a check which would detect the situation and raise an error to avoid silent corruption.

I had two reports from different individuals, both saying they had encountered the error! It seems that it is relatively easy to store enough data into eXist-db in a single transaction to exceed the 2 GB limit. 

Previously the limit was caused by the use of 4 bytes for storing the file position of the Journal entry within the LSN (Log Sequence Number). I have now increased that to 8 bytes, which allows for Journal files as large as the JVM can support, i.e. 8,191 PB. It is unlikely that will ever be exceeded! ;-)

Unfortunately fixing this was not straightforward due to a number of assumptions made in some of eXist-db's older code.

**NOTE:** This patch increments the file version of all `.dbx` and `.log` files by one, as the storage format needed to change to accomodate the larger LSN. A full database backup and restore is required to use this branch.