### PR TITLE
(4.x.x) Fix failing xml:id tests by using proper checks for xs:NCName

### DIFF
--- a/src/org/exist/Indexer.java
+++ b/src/org/exist/Indexer.java
@@ -70,6 +70,7 @@ public class Indexer extends Observable implements ContentHandler, LexicalHandle
 
     private static final int CACHE_CHILD_COUNT_MAX = 0x10000;
 
+    public static final String ATTR_CDATA_TYPE = "CDATA";
     public static final String ATTR_ID_TYPE = "ID";
     public static final String ATTR_IDREF_TYPE = "IDREF";
     public static final String ATTR_IDREFS_TYPE = "IDREFS";

--- a/src/org/exist/dom/QName.java
+++ b/src/org/exist/dom/QName.java
@@ -24,6 +24,7 @@ package org.exist.dom;
 import org.exist.interpreter.Context;
 import org.exist.storage.ElementValue;
 import org.exist.util.XMLChar;
+import org.exist.util.XMLNames;
 import org.exist.xquery.Constants;
 
 import javax.xml.XMLConstants;
@@ -375,11 +376,11 @@ public class QName implements Comparable<QName> {
 
         if(!(allowWildcards && this == QName.WildcardQName.getInstance())) {
 
-            if ((!(this instanceof WildcardLocalPartQName && allowWildcards)) && !XMLChar.isValidNCName(localPart)) {
+            if ((!(this instanceof WildcardLocalPartQName && allowWildcards)) && !XMLNames.isNCName(localPart)) {
                 result ^= INVALID_LOCAL_PART.val;
             }
 
-            if (prefix != null && !XMLChar.isValidNCName(prefix)) {
+            if (prefix != null && !XMLNames.isNCName(prefix)) {
                 result ^= INVALID_PREFIX.val;
             }
         }
@@ -391,12 +392,12 @@ public class QName implements Comparable<QName> {
         final int colon = name.indexOf(COLON);
 
         if (colon == Constants.STRING_NOT_FOUND) {
-            return XMLChar.isValidNCName(name) ? VALID.val : INVALID_LOCAL_PART.val;
+            return XMLNames.isNCName(name) ? VALID.val : INVALID_LOCAL_PART.val;
         } else if (colon == 0 || colon == name.length() - 1) {
             return ILLEGAL_FORMAT.val;
-        } else if (!XMLChar.isValidNCName(name.substring(0, colon))) {
+        } else if (!XMLNames.isNCName(name.substring(0, colon))) {
             return INVALID_PREFIX.val;
-        } else if (!XMLChar.isValidNCName(name.substring(colon + 1))) {
+        } else if (!XMLNames.isNCName(name.substring(colon + 1))) {
             return INVALID_LOCAL_PART.val;
         }
 

--- a/src/org/exist/dom/memtree/MemTreeBuilder.java
+++ b/src/org/exist/dom/memtree/MemTreeBuilder.java
@@ -190,10 +190,8 @@ public class MemTreeBuilder {
 
 
     private int getAttribType(final QName qname, final String type) {
-        if(qname.equals(Namespaces.XML_ID_QNAME)) {
+        if(qname.equals(Namespaces.XML_ID_QNAME) || type.equals(Indexer.ATTR_ID_TYPE)) {
             // an xml:id attribute.
-            return AttrImpl.ATTR_CDATA_TYPE;
-        } else if(type.equals(Indexer.ATTR_ID_TYPE)) {
             return AttrImpl.ATTR_ID_TYPE;
         } else if(type.equals(Indexer.ATTR_IDREF_TYPE)) {
             return AttrImpl.ATTR_IDREF_TYPE;
@@ -259,7 +257,7 @@ public class MemTreeBuilder {
         //} else {
         //lastNode = doc.addAttribute(lastNode, qname, value);
         //}
-        final int nodeNr = doc.addAttribute(lastNode, qname, value, AttrImpl.ATTR_CDATA_TYPE);
+        final int nodeNr = doc.addAttribute(lastNode, qname, value, getAttribType(qname, Indexer.ATTR_CDATA_TYPE));
 
         //TODO :
         //1) call linkNode(nodeNr); ?

--- a/src/org/exist/util/XMLNames.java
+++ b/src/org/exist/util/XMLNames.java
@@ -1,0 +1,141 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2018 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.util;
+
+/**
+ * Implements correct checks for XML names and NCNames.
+ *
+ * @author Wolfgang
+ */
+public class XMLNames {
+
+    /**
+     * Determines if a character is an XML name start character.
+     * See https://www.w3.org/TR/REC-xml/#NT-Name.
+     */
+    public static boolean isXMLNameStartCharacter(final int codePoint) {
+        return codePoint == ':'
+                || codePoint >= 'A' && codePoint <= 'Z'
+                || codePoint == '_'
+                || codePoint >= 'a' && codePoint <= 'z'
+                || codePoint >= 0xC0 && codePoint <= 0xD6
+                || codePoint >= 0xD8 && codePoint <= 0xF6
+                || codePoint >= 0xF8 && codePoint <= 0x2FF
+                || codePoint >= 0x370 && codePoint <= 0x37D
+                || codePoint >= 0x37F && codePoint <= 0x1FFF
+                || codePoint >= 0x200C && codePoint <= 0x200D
+                || codePoint >= 0x2070 && codePoint <= 0x218F
+                || codePoint >= 0x2C00 && codePoint <= 0x2FEF
+                || codePoint >= 0x3001 && codePoint <= 0xD7FF
+                || codePoint >= 0xF900 && codePoint <= 0xFDCF
+                || codePoint >= 0xFDF0 && codePoint <= 0xFFFD
+                || codePoint >= 0x10000 && codePoint <= 0xEFFFF;
+
+    }
+
+    /**
+     * Determines if a character is an XML name character.
+     * See https://www.w3.org/TR/REC-xml/#NT-Name.
+     */
+    public static boolean isXMLNameChar(final int codePoint) {
+        return isXMLNameStartCharacter(codePoint)
+                || codePoint == '-'
+                || codePoint == '.'
+                || codePoint >= '0' && codePoint <= '9'
+                || codePoint == 0xB7
+                || codePoint >= 0x0300 && codePoint <= 0x036F
+                || codePoint >= 0x203F && codePoint <= 0x2040;
+    }
+
+
+    /**
+     * Deterimines if a character is an NCName start character.
+     *
+     * See https://www.w3.org/TR/REC-xml-names/#NT-NCName
+     */
+    public static boolean isNCNameStartChar(final int codePoint) {
+        return codePoint != ':' && isXMLNameStartCharacter(codePoint);
+    }
+
+    /**
+     * Deterimines if a character is an NCName (Non-Colonised Name) character.
+     *
+     * See https://www.w3.org/TR/REC-xml-names/#NT-NCName
+     */
+    public static boolean isNCNameChar(final int codePoint) {
+        return codePoint != ':' && isXMLNameChar(codePoint);
+    }
+
+    /**
+     * Check if the provided string is a valid xs:NCName.
+     *
+     * See https://www.w3.org/TR/REC-xml-names/#NT-NCName
+     */
+    public static  boolean isNCName(final CharSequence s) {
+        if (s == null || s.length() == 0) {
+            return false;
+        }
+        int firstCodePoint = Character.codePointAt(s, 0);
+        if(!isNCNameStartChar(firstCodePoint)) {
+            return false;
+        }
+        for(int i = Character.charCount(firstCodePoint); i < s.length(); ) {
+            final int codePoint = Character.codePointAt(s, i);
+            if(!isNCNameChar(codePoint)) {
+                return false;
+            }
+            i += Character.charCount(codePoint);
+        }
+        return true;
+    }
+
+    public static boolean isName(final CharSequence s) {
+        if (s == null || s.length() == 0) {
+            return false;
+        }
+        int firstCodePoint = Character.codePointAt(s, 0);
+        if(!isXMLNameStartCharacter(firstCodePoint)) {
+            return false;
+        }
+        for(int i = Character.charCount(firstCodePoint); i < s.length(); ) {
+            final int codePoint = Character.codePointAt(s, i);
+            if(!isXMLNameChar(codePoint)) {
+                return false;
+            }
+            i += Character.charCount(codePoint);
+        }
+        return true;
+    }
+
+    public static boolean isNmToken(final CharSequence s) {
+        if (s == null || s.length() == 0) {
+            return false;
+        }
+        for(int i = 0; i < s.length(); ) {
+            final int codePoint = Character.codePointAt(s, i);
+            if(!isXMLNameChar(codePoint)) {
+                return false;
+            }
+            i += Character.charCount(codePoint);
+        }
+        return true;
+    }
+}

--- a/src/org/exist/xquery/DynamicAttributeConstructor.java
+++ b/src/org/exist/xquery/DynamicAttributeConstructor.java
@@ -26,14 +26,9 @@ import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.NodeImpl;
-import org.exist.util.XMLChar;
+import org.exist.util.XMLNames;
 import org.exist.xquery.util.ExpressionDumper;
-import org.exist.xquery.value.Item;
-import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceIterator;
-import org.exist.xquery.value.StringValue;
-import org.exist.xquery.value.Type;
-import org.exist.xquery.value.QNameValue;
+import org.exist.xquery.value.*;
 import org.w3c.dom.DOMException;
 
 /**
@@ -122,7 +117,7 @@ public class DynamicAttributeConstructor extends NodeConstructor {
 				}
 
             //Not in the specs but... makes sense
-            if(!XMLChar.isValidName(qn.getLocalPart()))
+            if(!XMLNames.isName(qn.getLocalPart()))
             	{throw new XPathException(this, ErrorCodes.XPTY0004, "'" + qn.getLocalPart() + "' is not a valid attribute name");}
             
             if ("xmlns".equals(qn.getLocalPart()) && qn.getNamespaceURI().isEmpty())

--- a/src/org/exist/xquery/DynamicPIConstructor.java
+++ b/src/org/exist/xquery/DynamicPIConstructor.java
@@ -24,7 +24,7 @@ package org.exist.xquery;
 
 import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.MemTreeBuilder;
-import org.exist.util.XMLChar;
+import org.exist.util.XMLNames;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
@@ -100,7 +100,7 @@ public class DynamicPIConstructor extends NodeConstructor {
                         " or a " + Type.getTypeName(Type.NCNAME) +
                         " or a " + Type.getTypeName(Type.UNTYPED_ATOMIC) +
                         ". Got: " + Type.getTypeName(nameItem.getType()));}
-            if(!XMLChar.isValidNCName(nameSeq.getStringValue()))
+            if(!XMLNames.isNCName(nameSeq.getStringValue()))
                 {throw new XPathException(this, ErrorCodes.XQDY0041,
                     nameSeq.getStringValue() + "' is not a valid processing instruction name", nameSeq);}
             if (nameSeq.getStringValue().equalsIgnoreCase("XML"))

--- a/src/org/exist/xquery/ElementConstructor.java
+++ b/src/org/exist/xquery/ElementConstructor.java
@@ -27,7 +27,7 @@ import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.NodeImpl;
-import org.exist.util.XMLChar;
+import org.exist.util.XMLNames;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.QNameValue;
@@ -298,7 +298,7 @@ public class ElementConstructor extends NodeConstructor {
              }
 
             //Not in the specs but... makes sense
-            if(!XMLChar.isValidName(qn.getLocalPart())) {
+            if(!XMLNames.isName(qn.getLocalPart())) {
                 throw new XPathException(this, ErrorCodes.XPTY0004, "'" + qnitem.getStringValue() + "' is not a valid element name");
             }
 

--- a/src/org/exist/xquery/NamespaceConstructor.java
+++ b/src/org/exist/xquery/NamespaceConstructor.java
@@ -25,12 +25,10 @@ package org.exist.xquery;
 import org.exist.Namespaces;
 import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.MemTreeBuilder;
-import org.exist.util.XMLChar;
+import org.exist.util.XMLNames;
 import org.exist.xquery.util.*;
 import org.exist.xquery.util.Error;
 import org.exist.xquery.value.*;
-
-import java.util.Iterator;
 
 
 /**
@@ -101,7 +99,7 @@ public class NamespaceConstructor extends NodeConstructor {
         String prefix = "";
         if (!prefixSeq.isEmpty()) {
             prefix = prefixSeq.getStringValue();
-            if (!(prefix.length() == 0 || XMLChar.isValidNCName(prefix))) {
+            if (!(prefix.length() == 0 || XMLNames.isNCName(prefix))) {
                 throw new XPathException(this, ErrorCodes.XQDY0074, "Prefix cannot be cast to xs:NCName");
             }
         }

--- a/src/org/exist/xquery/functions/fn/FunId.java
+++ b/src/org/exist/xquery/functions/fn/FunId.java
@@ -27,7 +27,7 @@ import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentImpl;
 import org.exist.dom.memtree.NodeImpl;
 import org.exist.dom.persistent.*;
-import org.exist.util.XMLChar;
+import org.exist.util.XMLNames;
 import org.exist.xquery.*;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.value.*;
@@ -155,7 +155,7 @@ public class FunId extends Function {
     				final StringTokenizer tok = new StringTokenizer(nextId, " ");
     				while(tok.hasMoreTokens()) {
     					nextId = tok.nextToken();
-    					if(XMLChar.isValidNCName(nextId)) {
+    					if(XMLNames.isNCName(nextId)) {
                             if (processInMem)
                                 {getId(result, contextSequence, nextId);}
                             else
@@ -163,7 +163,7 @@ public class FunId extends Function {
                         }
     				}
     			} else {
-    				if(XMLChar.isValidNCName(nextId)) {
+    				if(XMLNames.isNCName(nextId)) {
                         if (processInMem)
                             {getId(result, contextSequence, nextId);}
                         else
@@ -195,7 +195,7 @@ public class FunId extends Function {
         final Set<DocumentImpl> visitedDocs = new TreeSet<>();
         for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
             final NodeImpl v = (NodeImpl) i.nextItem();
-            final DocumentImpl doc = v.getOwnerDocument();
+            final DocumentImpl doc = v.getNodeType() == Node.DOCUMENT_NODE ? (DocumentImpl)v : v.getOwnerDocument();
 
             if (doc != null && !visitedDocs.contains(doc)) {
                 final NodeImpl elem = doc.selectById(id);

--- a/src/org/exist/xquery/functions/fn/FunIdRef.java
+++ b/src/org/exist/xquery/functions/fn/FunIdRef.java
@@ -31,7 +31,7 @@ import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.persistent.NodeSet;
 import org.exist.dom.QName;
-import org.exist.util.XMLChar;
+import org.exist.util.XMLNames;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.Dependency;
@@ -166,7 +166,7 @@ public class FunIdRef extends Function {
             for(final SequenceIterator i = idrefval.iterate(); i.hasNext(); ) {
     			nextId = i.nextItem().getStringValue();
                 if (nextId.length() == 0) {continue;}
-                if(XMLChar.isValidNCName(nextId)) {
+                if(XMLNames.isNCName(nextId)) {
                     if (processInMem)
                         {getIdRef(result, contextSequence, nextId);}
                     else

--- a/src/org/exist/xquery/functions/fn/FunQName.java
+++ b/src/org/exist/xquery/functions/fn/FunQName.java
@@ -23,7 +23,7 @@ package org.exist.xquery.functions.fn;
 
 import org.exist.Namespaces;
 import org.exist.dom.QName;
-import org.exist.util.XMLChar;
+import org.exist.util.XMLNames;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.Dependency;
@@ -142,7 +142,7 @@ public class FunQName extends BasicFunction {
             //context.declareInScopeNamespace(prefix, namespace);
         }
 
-        if(!XMLChar.isValidName(qname.getLocalPart()))
+        if(!XMLNames.isName(qname.getLocalPart()))
             {throw new XPathException(this, ErrorCodes.FOCA0002, "'" + qname.getLocalPart() + "' is not a valid local name.");}
 
         final Sequence result = new QNameValue(context, qname);

--- a/src/org/exist/xquery/value/StringValue.java
+++ b/src/org/exist/xquery/value/StringValue.java
@@ -26,6 +26,7 @@ import org.exist.dom.QName;
 import org.exist.util.Collations;
 import org.exist.util.UTF8;
 import org.exist.util.XMLChar;
+import org.exist.util.XMLNames;
 import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.ErrorCodes;
@@ -373,11 +374,12 @@ public class StringValue extends AtomicValue {
             case Type.ID:
             case Type.IDREF:
             case Type.ENTITY:
-                if (!XMLChar.isValidNCName(value)) {
+                if (!XMLNames.isNCName(value)) {
                     throw new XPathException("Type error: string " + value + " is not a valid " + Type.getTypeName(type));
                 }
+                return;
             case Type.NMTOKEN:
-                if (!XMLChar.isValidNmtoken(value)) {
+                if (!XMLNames.isNmToken(value)) {
                     throw new XPathException("Type error: string " + value + " is not a valid xs:NMTOKEN");
                 }
         }

--- a/test/src/xquery/xmlid.xql
+++ b/test/src/xquery/xmlid.xql
@@ -28,7 +28,7 @@ function xid:cleanup() {
 declare
     %test:assertEquals("<item xml:id='nym_Ͷαναξιμοῦς'/>")
 function xid:stored-xml() {
-    xmldb:store($xid:COLLECTION_NAME, "test.xml", $xid:XML),
+    xmldb:store($xid:COLLECTION_NAME, "test.xml", $xid:XML)[2],
     doc($xid:COLLECTION_NAME || "/test.xml")/id("nym_Ͷαναξιμοῦς"),
     (: not a valid ncname and thus ignored, c.f. https://www.w3.org/TR/xpath-functions-31/#func-id :)
     doc($xid:COLLECTION_NAME || "/test.xml")/id("123")


### PR DESCRIPTION
Fixes the failing tests on xml:id related functions demonstrated by #2142.

* `fn:id` lookups on in-memory documents basically never worked
* tests for NCName were wrong and are replaced by an implementation more closely following the character ranges defined in the specs (https://www.w3.org/TR/REC-xml/#NT-Name)

*Do **not** merge before all issues in #2142 have been addressed!*