### PR TITLE
(4.x.x) XQSuite tests relying on the query trace log were failing

### DIFF
--- a/src/org/exist/xquery/Profiler.java
+++ b/src/org/exist/xquery/Profiler.java
@@ -27,6 +27,7 @@ import java.util.Deque;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Database;
+import org.exist.source.Source;
 import org.exist.storage.DBBroker;
 import org.exist.xquery.value.Sequence;
 
@@ -182,10 +183,15 @@ public class Profiler {
 
     public final void traceFunctionEnd(Function function, long elapsed) {
         if (stats.isEnabled()) {
-            final String source = String.format("%s [%d:%d]", function.getContext().getSource().getKey(),
-                    function
-                    .getLine(), function.getColumn());
-            stats.recordFunctionCall(function.getSignature().getName(), source, elapsed);
+            final Source source = function.getContext().getSource();
+            final String sourceMsg;
+            if (source == null) {
+                sourceMsg = String.format("[unknown source] [%d:%d]", function.getLine(), function.getColumn());
+            } else {
+                sourceMsg = String.format("%s [%d:%d]", function.getContext().getSource().getKey(),
+                        function.getLine(), function.getColumn());
+            }
+            stats.recordFunctionCall(function.getSignature().getName(), sourceMsg, elapsed);
         }
         if (isLogEnabled()) {
             log.trace(String.format("EXIT  %-25s %10d ms", function.getSignature().getName(), elapsed));

--- a/src/org/exist/xquery/XQueryContext.java
+++ b/src/org/exist/xquery/XQueryContext.java
@@ -387,10 +387,14 @@ public class XQueryContext implements BinaryValueManager, Context {
     }
 
     public XQueryContext(final Database db) {
+        this(db, new Profiler(db));
+    }
+
+    public XQueryContext(final Database db, Profiler profiler) {
         this();
         this.db = db;
         loadDefaults(db.getConfiguration());
-        this.profiler = new Profiler(db);
+        this.profiler = profiler;
     }
 
     public XQueryContext(final XQueryContext copyFrom) {

--- a/src/org/exist/xquery/functions/fn/LoadXQueryModule.java
+++ b/src/org/exist/xquery/functions/fn/LoadXQueryModule.java
@@ -136,7 +136,7 @@ public class LoadXQueryModule extends BasicFunction {
         }
 
         // create temporary context so main context is not polluted
-        final XQueryContext tempContext = new XQueryContext(context.getBroker().getBrokerPool());
+        final XQueryContext tempContext = new XQueryContext(context.getBroker().getBrokerPool(), context.getProfiler());
         tempContext.setModuleLoadPath(context.getModuleLoadPath());
         setExternalVars(externalVars, tempContext::declareGlobalVariable);
 

--- a/src/org/exist/xquery/functions/inspect/ModuleFunctions.java
+++ b/src/org/exist/xquery/functions/inspect/ModuleFunctions.java
@@ -63,7 +63,7 @@ public class ModuleFunctions extends BasicFunction {
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
         final ValueSequence list = new ValueSequence();
         if (getArgumentCount() == 1) {
-            final XQueryContext tempContext = new XQueryContext(context.getBroker().getBrokerPool());
+            final XQueryContext tempContext = new XQueryContext(context.getBroker().getBrokerPool(), context.getProfiler());
             tempContext.setModuleLoadPath(context.getModuleLoadPath());
 
             Module module = null;


### PR DESCRIPTION
This PR fixes most of the failing tests concerning query optimization as revealed by #2142. Reason for the failure was that we were instantiating a different `Profiler` instance for the dynamically imported module, so stats were not available to the main query running XQSuite.

*Do **not** merge before all issues in #2142 have been addressed!*