### PR TITLE
(4.x.x) Don't unsign the Bouncy Castle jar file

### DIFF
--- a/build/scripts/jarsigner.xml
+++ b/build/scripts/jarsigner.xml
@@ -133,6 +133,7 @@
             </fileset>
             <fileset dir="lib/core">
                 <include name="*.jar"/>
+                <exclude name="bcprov-*.jar"/>
             </fileset>
             <fileset dir="lib/extensions" erroronmissingdir="false">
                 <include name="*.jar"/>


### PR DESCRIPTION
Fixes an issue with signing/unsigning a build of eXist-db.
The BouncyCastle Jar contains additional signatures from the Legion of Bouncy Castle which should not be removed.