### PR TITLE
Move from Ubuntu Trusty to Xenial on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: java
 
+dist: xenial
+
 matrix:
   include:
     - jdk: openjdk8
-    - jdk: oraclejdk8
     - jdk: openjdk9
     - jdk: openjdk10
     - jdk: openjdk11


### PR DESCRIPTION
I am not certain why, but after Travis-CI's move from Ubuntu Trusty on their container architecture to Ubuntu Trusty on their GCE architecture, the build fails. Using Travis-CI's Ubuntu Xenial on GCE seems to work fine.