### PR TITLE
Separate the eXist config/data and code at startup

### DIFF
--- a/bin/backup.bat
+++ b/bin/backup.bat
@@ -19,8 +19,6 @@ if not "%JAVA_HOME%" == "" (
     goto gotJavaHome
 )
 
-rem @WINDOWS_INSTALLER_1@
-
 echo WARNING: JAVA_HOME not found in your environment.
 echo.
 echo Please, set the JAVA_HOME variable in your enviroment to match the
@@ -28,29 +26,31 @@ echo location of the Java Virtual Machine you want to use in case of run fail.
 echo.
 
 :gotJavaHome
-if not "%EXIST_HOME%" == "" goto gotExistHome
 
-rem try to guess (will be overridden by the installer)
-set EXIST_HOME=.
-
-rem @WINDOWS_INSTALLER_2@
-
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-
-set EXIST_HOME=..
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-
-echo EXIST_HOME not found. Please set your
-echo EXIST_HOME environment variable to the
-echo home directory of eXist.
+if not "%EXIST_APP_HOME%" == "" goto gotExistAppHome
+set EXIST_APP_HOME="%~dp0\.."
+if exist "%EXIST_APP_HOME%\start.jar" goto gotExistAppHome
+echo EXIST_APP_HOME not found. Please set your
+echo EXIST_APP_HOME environment variable to the
+echo installation directory of eXist-db.
 goto :eof
+:gotExistAppHome
 
-:gotExistHome
-set MX=768
-rem @WINDOWS_INSTALLER_3@
+if not "%JAVA_OPTIONS%" == "" goto doneJavaOptions
+set MX=2048
+set JAVA_OPTIONS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+:doneJavaOptions
 
-set JAVA_OPTS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+if "%EXIST_HOME%" == "" goto doneExistHome
+set OPTIONS="-Dexist.home=%EXIST_HOME%"
+:doneExistHome
 
-%JAVA_RUN% "%JAVA_OPTS%"  -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" backup %CMD_LINE_ARGS%
+:: copy the command line args preserving equals chars etc. for thinks like -ouri=http://something
+for /f "tokens=*" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
+set BATCH.D="%~dp0\batch.d"
+call %BATCH.D%\get_opts.bat %CMD_LINE_ARGS%
+call %BATCH.D%\check_jmx_status.bat
+
+%JAVA_RUN% "%JAVA_OPTIONS%" "%OPTIONS%" -jar "%EXIST_APP_HOME%\start.jar" backup %JAVA_ARGS%
 :eof
 

--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # backup.sh - Backup tool start script
-#
-# $Id$
 # -----------------------------------------------------------------------------
-
-## @UNIX_INSTALLER_1@ 
 
 #
 # In addition to the other parameter options for the interactive client 
@@ -29,7 +25,7 @@ source "${SCRIPTPATH}"/functions.d/getopt-settings.sh
 
 get_opts "$@";
 
-check_exist_home "$0";
+check_exist_app_home "$0";
 
 set_exist_options;
 
@@ -46,10 +42,10 @@ set_locale_lang;
 
 if [ "${QUIET_ENABLED}" -gt 0 ]; then
     # Be quiet, no messages on stdout
-    "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} ${DEBUG_OPTS} -jar "$EXIST_HOME/start.jar" backup "${JAVA_OPTS[@]}" > /dev/null || exit 1 # forward non-zero exit status
+    "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} ${DEBUG_OPTS} -jar "$EXIST_APP_HOME/start.jar" backup "${JAVA_ARGS[@]}" > /dev/null || exit 1 # forward non-zero exit status
 else
     echo "Using locale: ${LANG}";
-    "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} ${DEBUG_OPTS} -jar "$EXIST_HOME/start.jar" backup "${JAVA_OPTS[@]}" || exit 1 # forward non-zero exit status
+    "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} ${DEBUG_OPTS} -jar "$EXIST_APP_HOME/start.jar" backup "${JAVA_ARGS[@]}" || exit 1 # forward non-zero exit status
 
 fi
 

--- a/bin/client.bat
+++ b/bin/client.bat
@@ -6,6 +6,10 @@ rem pass -j or --jmx to enable JMX agent.  The port for it can be specified
 rem with optional port number e.g. -j1099 or --jmx=1099.
 rem
 
+:: This will enable Java debugging via JDWP on port 4000 in Server mode
+rem set DEBUG_OPTIONS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=4000"
+rem set DEBUG_OPTIONS="%DEBUG_OPTS% -Dexist.start.debug=true"
+
 set JMX_ENABLED=0
 set JMX_PORT=1099
 set JAVA_ARGS=
@@ -21,8 +25,6 @@ if not "%JAVA_HOME%" == "" (
     goto gotJavaHome
 )
 
-rem @WINDOWS_INSTALLER_1@
-
 echo WARNING: JAVA_HOME not found in your environment.
 echo.
 echo Please, set the JAVA_HOME variable in your enviroment to match the
@@ -30,33 +32,30 @@ echo location of the Java Virtual Machine you want to use in case of run fail.
 echo.
 
 :gotJavaHome
-rem @WINDOWS_INSTALLER_2@
 
-if not "%EXIST_HOME%" == "" goto gotExistHome
-
-rem try to guess (will be set by the installer)
-set EXIST_HOME=.
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-
-set EXIST_HOME=..
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-
-echo EXIST_HOME not found. Please set your
-echo EXIST_HOME environment variable to the
-echo home directory of eXist.
+if not "%EXIST_APP_HOME%" == "" goto gotExistAppHome
+set EXIST_APP_HOME="%~dp0\.."
+if exist "%EXIST_APP_HOME%\start.jar" goto gotExistAppHome
+echo EXIST_APP_HOME not found. Please set your
+echo EXIST_APP_HOME environment variable to the
+echo installation directory of eXist-db.
 goto :eof
+:gotExistAppHome
 
-:gotExistHome
+if not "%JAVA_OPTIONS%" == "" goto doneJavaOptions
 set MX=2048
-rem @WINDOWS_INSTALLER_3@
+set JAVA_OPTIONS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+:doneJavaOptions
 
-set JAVA_OPTS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+if "%EXIST_HOME%" == "" goto doneExistHome
+set OPTIONS="-Dexist.home=%EXIST_HOME%"
+:doneExistHome
 
 :: copy the command line args preserving equals chars etc. for things like -ouri=http://something
 for /f "tokens=*" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
-set BATCH.D=%EXIST_HOME%\bin\batch.d
+set BATCH.D="%~dp0\batch.d"
 call %BATCH.D%\get_opts.bat %CMD_LINE_ARGS%
 call %BATCH.D%\check_jmx_status.bat
 
-%JAVA_RUN% "%JAVA_OPTS%" -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" client %JAVA_ARGS%
+%JAVA_RUN% "%JAVA_OPTIONS%" "%OPTIONS%" "%DEBUG_OPTIONS%" -jar "%EXIST_APP_HOME%\start.jar" client %JAVA_ARGS%
 :eof

--- a/bin/client.sh
+++ b/bin/client.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # client.sh - Start Script for eXist interactive client
-#
-# $Id$
 # -----------------------------------------------------------------------------
 
 # This will enable Java debugging via JDWP on port 4000 in Server mode
-#DEBUG_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=4000"
-
-
-## @UNIX_INSTALLER_1@ 
+# DEBUG_OPTIONS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=4000"
+# DEBUG_OPTIONS="$DEBUG_OPTS -Dexist.start.debug=true"
 
 #
 # In addition to the other parameter options for the interactive client 
@@ -33,7 +29,7 @@ source "${SCRIPTPATH}"/functions.d/getopt-settings.sh
 
 get_opts "$@";
 
-check_exist_home "$0";
+check_exist_app_home "$0";
 
 set_exist_options;
 
@@ -53,10 +49,10 @@ set_library_path;
 
 if [ "${QUIET_ENABLED}" -gt 0 ]; then
     # Be quiet, no messages on stdout
-    "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} ${DEBUG_OPTS} -jar "$EXIST_HOME/start.jar" client "${JAVA_OPTS[@]}" > /dev/null || exit 1 # forward non-zero exit status
+    "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} ${DEBUG_OPTS} -jar "$EXIST_APP_HOME/start.jar" client "${JAVA_ARGS[@]}" > /dev/null || exit 1 # forward non-zero exit status
 else
     echo "Using locale: ${LANG}";
-    "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} ${DEBUG_OPTS} -jar "$EXIST_HOME/start.jar" client "${JAVA_OPTS[@]}" || exit 1 # forward non-zero exit status
+    "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} ${DEBUG_OPTS} -jar "$EXIST_APP_HOME/start.jar" client "${JAVA_ARGS[@]}" || exit 1 # forward non-zero exit status
 
 fi
 restore_library_path;

--- a/bin/functions.d/eXist-settings.sh
+++ b/bin/functions.d/eXist-settings.sh
@@ -4,7 +4,7 @@
 # Common eXist-db script functions and settings
 ##
 
-get_exist_home() {
+get_exist_app_home() {
 	case "$1" in
 		/*)
 			p="$1"
@@ -20,14 +20,14 @@ resolve_dir() {
     (builtin cd `dirname "${1/#~/$HOME}"`'/'`basename "${1/#~/$HOME}"` 2>/dev/null; if [ $? -eq 0 ]; then pwd; fi)
 }
 
-check_exist_home() {
-    if [ -z "${EXIST_HOME}" ]; then
-	EXIST_HOME_1=$(get_exist_home "$1");
-	EXIST_HOME=`resolve_dir "$EXIST_HOME_1/.."`;
+check_exist_app_home() {
+    if [ -z "${EXIST_APP_HOME}" ]; then
+	EXIST_APP_HOME=$(get_exist_app_home "$1");
+	EXIST_APP_HOME=`resolve_dir "$EXIST_APP_HOME/.."`;
     fi
 
-    if [ ! -f "${EXIST_HOME}/start.jar" ]; then
-	echo "Unable to find start.jar. Please set EXIST_HOME to point to your installation directory." > /dev/stderr;
+    if [ ! -f "${EXIST_APP_HOME}/start.jar" ]; then
+	echo "Unable to find start.jar. Please set EXIST_APP_HOME to point to your installation directory." > /dev/stderr;
 	exit 1;
     fi
 }
@@ -64,7 +64,7 @@ set_library_path() {
 	OLD_LIBRARY_PATH="${LD_LIBRARY_PATH}";
     fi
 # add lib/core to LD_LIBRARY_PATH for readline support
-    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${EXIST_HOME}/lib/core";
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${EXIST_APP_HOME}/lib/core";
     export LD_LIBRARY_PATH;
 }
 
@@ -83,7 +83,7 @@ set_client_java_options() {
     OS=`uname`
     if [ "${OS}" == "Darwin" ]; then
 	CLIENT_NAME="Client"
-        JAVA_OPTIONS="${CLIENT_JAVA_OPTIONS} -Xdock:icon=${EXIST_HOME}/icon.png -Xdock:name=${CLIENT_NAME}";
+        JAVA_OPTIONS="${CLIENT_JAVA_OPTIONS} -Xdock:icon=${EXIST_APP_HOME}/icon.png -Xdock:name=${CLIENT_NAME}";
     else
         JAVA_OPTIONS="${CLIENT_JAVA_OPTIONS}";
     fi
@@ -119,11 +119,17 @@ check_java_home() {
 }
 
 set_exist_options() {
-    OPTIONS="-Dexist.home=$EXIST_HOME"
+    if [ -n "$EXIST_HOME" ]; then
+        OPTIONS="-Dexist.home=$EXIST_HOME"
+    fi
 }
 
-set_jetty_home() {
-if [ -n "$JETTY_HOME" ]; then
-	OPTIONS="-Djetty.home=$JETTY_HOME $OPTIONS"
-fi
+set_jetty_dirs() {
+    if [ -n "$JETTY_HOME" ]; then
+	    OPTIONS="$OPTIONS -Djetty.home=$JETTY_HOME"
+    fi
+
+    if [ -n "$JETTY_BASE" ]; then
+	    OPTIONS="$OPTIONS -Djetty.base=$JETTY_BASE"
+    fi
 }

--- a/bin/functions.d/getopt-settings.sh
+++ b/bin/functions.d/getopt-settings.sh
@@ -23,8 +23,8 @@ JMX_LONG_EQUAL="--jmx="
 QUIET_OPTS="|-q|--quiet|"
 QUIET_ENABLED=0
 
-NR_JAVA_OPTS=0
-declare -a JAVA_OPTS
+NR_JAVA_ARGS=0
+declare -a JAVA_ARGS
 declare -a CLIENT_PROPS
 
 substring() {
@@ -101,13 +101,13 @@ get_opts() {
 			found_pidfile_opt=1
 		else
 			check_quiet_switch "$OPT";
-			JAVA_OPTS[${NR_JAVA_OPTS}]="$OPT";
-			let "NR_JAVA_OPTS += 1";
+			JAVA_ARGS[${NR_JAVA_ARGS}]="$OPT";
+			let "NR_JAVA_ARGS += 1";
 		fi
 	done
 
 	if [ "${QUIET_ENABLED}" -eq 0 ]; then
-		echo "${JAVA_OPTS[@]}";
+		echo "${JAVA_ARGS[@]}";
 	fi
 }
 
@@ -121,5 +121,5 @@ get_client_props() {
 				CLIENT_PROPS["${key}"]="${value}"
 				;;
 		esac
-	done < ${EXIST_HOME}/client.properties
+	done < ${EXIST_APP_HOME}/client.properties
 }

--- a/bin/run.bat
+++ b/bin/run.bat
@@ -25,8 +25,6 @@ if not "%JAVA_HOME%" == "" (
     goto gotJavaHome
 )
 
-rem @WINDOWS_INSTALLER_1@
-
 echo WARNING: JAVA_HOME not found in your environment.
 echo.
 echo Please, set the JAVA_HOME variable in your enviroment to match the
@@ -34,27 +32,25 @@ echo location of the Java Virtual Machine you want to use in case of run fail.
 echo.
 
 :gotJavaHome
-rem @WINDOWS_INSTALLER_2@
 
-if not "%EXIST_HOME%" == "" goto gotExistHome
-
-rem try to guess
-set EXIST_HOME=.
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-set EXIST_HOME=..
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-
-echo EXIST_HOME not found. Please set your
-echo EXIST_HOME environment variable to the
-echo home directory of eXist.
+if not "%EXIST_APP_HOME%" == "" goto gotExistAppHome
+set EXIST_APP_HOME="%~dp0\.."
+if exist "%EXIST_APP_HOME%\start.jar" goto gotExistAppHome
+echo EXIST_APP_HOME not found. Please set your
+echo EXIST_APP_HOME environment variable to the
+echo installation directory of eXist-db.
 goto :eof
+:gotExistAppHome
 
-:gotExistHome
+if not "%JAVA_OPTIONS%" == "" goto doneJavaOptions
 set MX=2048
-rem @WINDOWS_INSTALLER_3@
+set JAVA_OPTIONS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+:doneJavaOptions
 
-set JAVA_OPTS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+if "%EXIST_HOME%" == "" goto doneExistHome
+set OPTIONS="-Dexist.home=%EXIST_HOME%"
+:doneExistHome
 
 :gotJavaOpts
-%JAVA_RUN% "%JAVA_OPTS%"  -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" %CMD_LINE_ARGS%
+%JAVA_RUN% "%JAVA_OPTIONS%" "%OPTIONS%" -jar "%EXIST_APP_HOME%\start.jar" %CMD_LINE_ARGS%
 :eof

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-#unset LANG
-
-# $Id$
 
 # Usage with profiler:
 usage="run.sh [-a architecture-and-cpu] [-y yjp-home-path] class-to-run\n run.sh -a linux-x86-32 -y /home/ljo/bin/yjp-8.0.13 org.exist.xquery.XPathQueryTest\n\nYou need yjp-8 now to profile since we are using java5+"
@@ -37,14 +34,17 @@ source "${SCRIPTPATH}"/functions.d/eXist-settings.sh
 source "${SCRIPTPATH}"/functions.d/jmx-settings.sh
 source "${SCRIPTPATH}"/functions.d/getopt-settings.sh
 
+if [ -z "$EXIST_APP_HOME" ]; then
+    EXIST_APP_HOME=`dirname "$0"`
+    EXIST_APP_HOME=`dirname "$EXIST_APP_HOME"`
+fi
+
 if [ -z "$EXIST_HOME" ]; then
-    EXIST_HOME_1=`dirname "$0"`
-    EXIST_HOME=`dirname "$EXIST_HOME_1"`
+    EXIST_HOME="$EXIST_APP_HOME"
 fi
 
 if [ ! -f "$EXIST_HOME/conf.xml" ]; then
-    EXIST_HOME_1="$EXIST_HOME/.."
-    EXIST_HOME=$EXIST_HOME_1
+    EXIST_HOME="$EXIST_HOME/.."
 fi
 
 if [ -z "$EXIST_BASE" ]; then
@@ -66,11 +66,11 @@ PROFILER_OPTS=-agentlib:yjpagent
 if [ "x${yjp_home}" != "x" ]; then
 "${JAVA_RUN}" $JAVA_OPTIONS \
 	-Dexist.home=$EXIST_HOME $PROFILER_OPTS \
-	-jar ${EXIST_HOME}/start.jar "$@"
+	-jar ${EXIST_App_HOME}/start.jar "$@"
 else
 "${JAVA_RUN}" $JAVA_OPTIONS \
 	-Dexist.home=$EXIST_HOME \
-	-jar ${EXIST_HOME}/start.jar "$@"
+	-jar ${EXIST_APP_HOME}/start.jar "$@"
 fi
 
 restore_locale_lang;

--- a/bin/server.bat
+++ b/bin/server.bat
@@ -21,8 +21,6 @@ if not "%JAVA_HOME%" == "" (
     goto gotJavaHome
 )
 
-rem @WINDOWS_INSTALLER_1@
-
 echo WARNING: JAVA_HOME not found in your environment.
 echo.
 echo Please, set the JAVA_HOME variable in your environment to match the
@@ -30,33 +28,30 @@ echo location of the Java Virtual Machine you want to use in case of run fail.
 echo.
 
 :gotJavaHome
-rem @WINDOWS_INSTALLER_2@
 
-if not "%EXIST_HOME%" == "" goto gotExistHome
-
-rem try to guess (will be set by the installer)
-set EXIST_HOME=.
-
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-set EXIST_HOME=..
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-
-echo EXIST_HOME not found. Please set your
-echo EXIST_HOME environment variable to the
-echo home directory of eXist.
+if not "%EXIST_APP_HOME%" == "" goto gotExistAppHome
+set EXIST_APP_HOME="%~dp0\.."
+if exist "%EXIST_APP_HOME%\start.jar" goto gotExistAppHome
+echo EXIST_APP_HOME not found. Please set your
+echo EXIST_APP_HOME environment variable to the
+echo installation directory of eXist-db.
 goto :eof
+:gotExistAppHome
 
-:gotExistHome
+if not "%JAVA_OPTIONS%" == "" goto doneJavaOptions
 set MX=2048
-rem @WINDOWS_INSTALLER_3@
+set JAVA_OPTIONS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+:doneJavaOptions
 
-set JAVA_OPTS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+if "%EXIST_HOME%" == "" goto doneExistHome
+set OPTIONS="-Dexist.home=%EXIST_HOME%"
+:doneExistHome
 
 :: copy the command line args preserving equals chars etc. for thinks like -ouri=http://something
 for /f "tokens=*" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
-set BATCH.D="%EXIST_HOME%\bin\batch.d"
+set BATCH.D="%~dp0\batch.d"
 call %BATCH.D%\get_opts.bat %CMD_LINE_ARGS%
 call %BATCH.D%\check_jmx_status.bat
 
-%JAVA_RUN% "%JAVA_OPTS%" -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" standalone %JAVA_ARGS%
+%JAVA_RUN% "%JAVA_OPTIONS%" "%OPTIONS%" -jar "%EXIST_APP_HOME%\start.jar" standalone %JAVA_ARGS%
 :eof

--- a/bin/server.sh
+++ b/bin/server.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # startup.sh - Start Script for Jetty + eXist
-#
-# $Id$
 # -----------------------------------------------------------------------------
-
-## @UNIX_INSTALLER_1@
 
 #
 # In addition to the other parameter options for the standalone server
@@ -29,7 +25,7 @@ source "${SCRIPTPATH}"/functions.d/getopt-settings.sh
 
 get_opts "$@";
 
-check_exist_home "$0";
+check_exist_app_home "$0";
 
 set_exist_options;
 
@@ -52,6 +48,6 @@ if [ $PIDFILE ]; then
     echo $$ > $PIDFILE
 fi
 
-${JAVA_RUN} $JAVA_OPTIONS $OPTIONS -jar "$EXIST_HOME/start.jar" standalone "${JAVA_OPTS[@]}"
+${JAVA_RUN} $JAVA_OPTIONS $OPTIONS -jar "$EXIST_APP_HOME/start.jar" standalone "${JAVA_ARGS[@]}"
 
 restore_locale_lang;

--- a/bin/shutdown.bat
+++ b/bin/shutdown.bat
@@ -19,8 +19,6 @@ if not "%JAVA_HOME%" == "" (
     goto gotJavaHome
 )
 
-rem @WINDOWS_INSTALLER_1@
-
 echo WARNING: JAVA_HOME not found in your environment.
 echo.
 echo Please, set the JAVA_HOME variable in your enviroment to match the
@@ -28,22 +26,30 @@ echo location of the Java Virtual Machine you want to use in case of run fail.
 echo.
 
 :gotJavaHome
-rem @WINDOWS_INSTALLER_2@
 
-if not "%EXIST_HOME%" == "" goto gotExistHome
-
-rem try to guess (will be set by the installer)
-set EXIST_HOME=.
-
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-set EXIST_HOME=..
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-
-echo EXIST_HOME not found. Please set your
-echo EXIST_HOME environment variable to the
-echo home directory of eXist.
+if not "%EXIST_APP_HOME%" == "" goto gotExistAppHome
+set EXIST_APP_HOME="%~dp0\.."
+if exist "%EXIST_APP_HOME%\start.jar" goto gotExistAppHome
+echo EXIST_APP_HOME not found. Please set your
+echo EXIST_APP_HOME environment variable to the
+echo installation directory of eXist-db.
 goto :eof
+:gotExistAppHome
 
-:gotExistHome
-%JAVA_RUN% -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" shutdown %CMD_LINE_ARGS%
+if not "%JAVA_OPTIONS%" == "" goto doneJavaOptions
+set MX=2048
+set JAVA_OPTIONS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+:doneJavaOptions
+
+if "%EXIST_HOME%" == "" goto doneExistHome
+set OPTIONS="-Dexist.home=%EXIST_HOME%"
+:doneExistHome
+
+:: copy the command line args preserving equals chars etc. for things like -ouri=http://something
+for /f "tokens=*" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
+set BATCH.D="%~dp0\batch.d"
+call %BATCH.D%\get_opts.bat %CMD_LINE_ARGS%
+call %BATCH.D%\check_jmx_status.bat
+
+%JAVA_RUN% "%JAVA_OPTIONS%" "%OPTIONS%" -jar "%EXIST_APP_HOME%\start.jar" shutdown %JAVA_ARGS%
 :eof

--- a/bin/shutdown.sh
+++ b/bin/shutdown.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # shutdown.sh - Stop Jetty + eXist
-#
-# $Id$
 # -----------------------------------------------------------------------------
-
-## @UNIX_INSTALLER_1@ 
 
 case "$0" in
 	/*)
@@ -21,7 +17,7 @@ source "${SCRIPTPATH}"/functions.d/eXist-settings.sh
 source "${SCRIPTPATH}"/functions.d/jmx-settings.sh
 source "${SCRIPTPATH}"/functions.d/getopt-settings.sh
 
-check_exist_home "$0";
+check_exist_app_home "$0";
 
 set_exist_options;
 check_java_home;
@@ -29,7 +25,7 @@ check_java_home;
 # set java options
 set_java_options;
 
-echo "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} -jar "$EXIST_HOME/start.jar" \
+echo "${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} -jar "$EXIST_APP_HOME/start.jar" \
 	shutdown "$@"
-"${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} -jar "$EXIST_HOME/start.jar" \
+"${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} -jar "$EXIST_APP_HOME/start.jar" \
 	shutdown "$@"

--- a/bin/startup.bat
+++ b/bin/startup.bat
@@ -6,6 +6,10 @@ rem pass -j or --jmx to enable JMX agent.  The port for it can be specified
 rem with optional port number e.g. -j1099 or --jmx=1099.
 rem
 
+:: This will enable Java debugging via JDWP on port 4000 in Server mode
+rem set DEBUG_OPTIONS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=4000"
+rem set DEBUG_OPTIONS="%DEBUG_OPTS% -Dexist.start.debug=true"
+
 set JMX_ENABLED=0
 set JMX_PORT=1099
 set JAVA_ARGS=
@@ -21,8 +25,6 @@ if not "%JAVA_HOME%" == "" (
     goto gotJavaHome
 )
 
-rem @WINDOWS_INSTALLER_1@
-
 echo WARNING: JAVA_HOME not found in your environment.
 echo.
 echo Please, set the JAVA_HOME variable in your enviroment to match the
@@ -30,35 +32,31 @@ echo location of the Java Virtual Machine you want to use in case of run fail.
 echo.
 
 :gotJavaHome
-rem @WINDOWS_INSTALLER_2@
 
-if not "%EXIST_HOME%" == "" goto gotExistHome
-
-rem try to guess
-set EXIST_HOME=.
-
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-set EXIST_HOME=..
-if exist "%EXIST_HOME%\start.jar" goto gotExistHome
-
-echo EXIST_HOME not found. Please set your
-echo EXIST_HOME environment variable to the
-echo home directory of eXist.
+if not "%EXIST_APP_HOME%" == "" goto gotExistAppHome
+set EXIST_APP_HOME="%~dp0\.."
+if exist "%EXIST_APP_HOME%\start.jar" goto gotExistAppHome
+echo EXIST_APP_HOME not found. Please set your
+echo EXIST_APP_HOME environment variable to the
+echo installation directory of eXist-db.
 goto :eof
+:gotExistAppHome
 
-:gotExistHome
-
+if not "%JAVA_OPTIONS%" == "" goto doneJavaOptions
 set MX=2048
-rem @WINDOWS_INSTALLER_3@
+set JAVA_OPTIONS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+:doneJavaOptions
 
-set JAVA_OPTS="-Xms128m -Xmx%MX%m -Dfile.encoding=UTF-8"
+if "%EXIST_HOME%" == "" goto doneExistHome
+set OPTIONS="-Dexist.home=%EXIST_HOME%"
+:doneExistHome
 
 :: copy the command line args preserving equals chars etc. for things like --ouri=http://something
 for /f "tokens=*" %%x IN ("%*") DO SET "CMD_LINE_ARGS=%%x"
-set BATCH.D="%EXIST_HOME%\bin\batch.d"
+set BATCH.D="%~dp0\batch.d"
 call %BATCH.D%\get_opts.bat %CMD_LINE_ARGS%
 call %BATCH.D%\check_jmx_status.bat
 
-%JAVA_RUN% "%JAVA_OPTS%"  -Dexist.home="%EXIST_HOME%" -jar "%EXIST_HOME%\start.jar" jetty %JAVA_ARGS%
+%JAVA_RUN% "%JAVA_OPTIONS%" "%OPTIONS%" "%DEBUG_OPTIONS" -jar "%EXIST_APP_HOME%\start.jar" jetty %JAVA_ARGS%
 :eof
 

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # startup.sh - Start Script for Jetty + eXist
-#
-# $Id$
 # -----------------------------------------------------------------------------
-
-## @UNIX_INSTALLER_1@
-
 #
 # In addition to the other parameter options for the jetty container
 # pass -j or --jmx to enable JMX agent. The port for it can be specified
@@ -15,9 +10,8 @@
 usage="startup.sh [-j[jmx-port]|--jmx[=jmx-port]]\n"
 
 # This will enable Java debugging via JDWP on port 4000 in Server mode
-# DEBUG_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=4000"
-
-#DEBUG_OPTS="-Dexist.start.debug=true"
+# DEBUG_OPTIONS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=4000"
+# DEBUG_OPTIONS="$DEBUG_OPTS -Dexist.start.debug=true"
 
 case "$0" in
 	/*)
@@ -35,10 +29,10 @@ source "${SCRIPTPATH}"/functions.d/getopt-settings.sh
 
 get_opts "$@";
 
-check_exist_home "$0";
+check_exist_app_home "$0";
 
 set_exist_options;
-set_jetty_home;
+set_jetty_dirs;
 
 check_java_home;
 
@@ -60,7 +54,7 @@ if [ $PIDFILE ]; then
 fi
 
 ${JAVA_RUN} ${JAVA_OPTIONS} ${OPTIONS} \
-	${DEBUG_OPTS} -jar "$EXIST_HOME/start.jar" \
-	jetty ${JAVA_OPTS[@]}
+	${DEBUG_OPTIONS} -jar "$EXIST_APP_HOME/start.jar" \
+	jetty ${JAVA_ARGS[@]}
 
 restore_locale_lang;

--- a/installer/scripts/setup.bat
+++ b/installer/scripts/setup.bat
@@ -2,11 +2,14 @@
 
 ::will be set by the installer
 set JAVA_HOME="$JAVA_HOME"
+set EXIST_APP_HOME="$INSTALL_PATH"
 set EXIST_HOME="$INSTALL_PATH"
 
-::remove any quotes from JAVA_HOME and EXIST_HOME env var, will be re-added below
+::remove any quotes from JAVA_HOME, EXIST_APP_HOME, and EXIST_HOME env vars, will be re-added below
 for /f "delims=" %%G IN (%JAVA_HOME%) DO SET JAVA_HOME=%%G
+for /f "delims=" %%G IN (%EXIST_APP_HOME%) DO SET EXIST_APP_HOME=%%G
 for /f "delims=" %%G IN (%EXIST_HOME%) DO SET EXIST_HOME=%%G
+
 
 :gotJavaHome
 set JAVA_CMD="%JAVA_HOME%\bin\java"
@@ -17,11 +20,12 @@ set JAVA_OPTS="-Xms64m -Xmx768m"
 mkdir "%EXIST_HOME%\tools\jetty\tmp"
 
 echo "JAVA_HOME: [%JAVA_HOME%]"
+echo "EXIST_APP_HOME: [%EXIST_APP_HOME%]"
 echo "EXIST_HOME: [%EXIST_HOME%]"
 echo "EXIST_OPTS: [%JAVA_OPTS%]"
 echo:
 echo:
 
-%JAVA_CMD% "%JAVA_OPTS%" -Dexist.home="%EXIST_HOME%" -Duse.autodeploy.feature=false -jar "%EXIST_HOME%\start.jar" org.exist.installer.Setup %1 %2 %3 %4 %5 %6 %7 %8 %9
+%JAVA_CMD% "%JAVA_OPTS%" -Dexist.home="%EXIST_HOME%" -Duse.autodeploy.feature=false -jar "%EXIST_APP_HOME%\start.jar" org.exist.installer.Setup %1 %2 %3 %4 %5 %6 %7 %8 %9
 
 :eof

--- a/installer/scripts/setup.sh
+++ b/installer/scripts/setup.sh
@@ -2,11 +2,10 @@
 # -----------------------------------------------------------------------------
 #
 # Shell script to start up the eXist command line client.
-#
-# $Id$
 # -----------------------------------------------------------------------------
 
 # will be set by the installer
+EXIST_APP_HOME="%{INSTALL_PATH}"
 EXIST_HOME="%{INSTALL_PATH}"
 
 if [ ! -d "$JAVA_HOME" ]; then
@@ -17,8 +16,8 @@ JAVA_CMD="$JAVA_HOME/bin/java"
 
 OPTIONS=
 
-if [ ! -f "$EXIST_HOME/start.jar" ]; then
-	echo "Unable to find start.jar. EXIST_HOME = $EXIST_HOME"
+if [ ! -f "$EXIST_APP_HOME/start.jar" ]; then
+	echo "Unable to find start.jar. EXIST_APP_HOME = $EXIST_APP_HOME"
 	exit 1
 fi
 
@@ -30,4 +29,4 @@ if [ -z "$JAVA_OPTIONS" ]; then
 fi
 
 "$JAVA_CMD" $JAVA_OPTIONS $OPTIONS \
-    -jar "$EXIST_HOME/start.jar" org.exist.installer.Setup $*
+    -jar "$EXIST_APP_HOME/start.jar" org.exist.installer.Setup $*

--- a/tools/yajsw/bin/installDaemon.sh
+++ b/tools/yajsw/bin/installDaemon.sh
@@ -51,13 +51,20 @@ if [ -z "${JAVA_HOME}" ]; then
   echo -e "Found JAVA_HOME=${JAVA_HOME}\n"
 fi
 
+# Set EXIST_APP_HOME (if not set in env)
+if [ -z "${EXIST_APP_HOME}" ]; then
+  echo -e "\nNo EXIST_APP_HOME environment variable found!"
+  echo "Attempting to derive EXIST_APP_HOME (if this fails you must manually set it)..."
+  exist_tools_dir=$(dirname "${wrapper_home}")
+  EXIST_APP_HOME=$(dirname "${exist_tools_dir}")
+  echo -e "Derived EXIST_APP_HOME=${EXIST_APP_HOME}\n"
+fi
+
 # Set EXIST_HOME (if not set in env)
 if [ -z "${EXIST_HOME}" ]; then
   echo -e "\nNo EXIST_HOME environment variable found!"
-  echo "Attempting to derive EXIST_HOME (if this fails you must manually set it)..."
-  exist_tools_dir=$(dirname "${wrapper_home}")
-  EXIST_HOME=$(dirname "${exist_tools_dir}")
-  echo -e "Derived EXIST_HOME=${EXIST_HOME}\n"
+  echo "Setting EXIST_HOME to EXIST_APP_HOME..."
+  EXIST_HOME="${EXIST_APP_HOME}"
 fi
 
 function review_systemd_config {
@@ -101,7 +108,7 @@ function systemd_user {
     if [ -z "${RUN_AS_USER}" ]; then
         echo -e "\nNo RUN_AS_USER environment variable found!"
         if [ -z "${WRAPPER_UNATTENDED}" ]; then
-            read -p "Which user should eXist run as for the systemd service (${USER})? " eval_response;
+            read -p "Which user should eXist-db run as for the systemd service (${USER})? " eval_response;
             case $eval_response in
                 "")
                     RUN_AS_USER="${USER}"
@@ -123,10 +130,11 @@ function use_systemd {
 
     systemd_user;
 
-    echo -e "\nPlease note that the environment variables JAVA_HOME, EXIST_HOME, and RUN_AS_USER are used for the systemd service setup."
+    echo -e "\nPlease note that the environment variables JAVA_HOME, EXIST_APP_HOME, EXIST_HOME, and RUN_AS_USER are used for the systemd service setup."
     echo -e "Please review them below and if they are not set correctly, please exit and set them in your environment before rerunning this script.\n\n"
 
     echo "JAVA_HOME=${JAVA_HOME}"
+    echo "EXIST_APP_HOME=${EXIST_APP_HOME}"
     echo "EXIST_HOME=${EXIST_HOME}"
     echo -e "RUN_AS_USER=${RUN_AS_USER}\n"
     if [ -z "${WRAPPER_UNATTENDED}" ]; then

--- a/tools/yajsw/templates/systemd.vm
+++ b/tools/yajsw/templates/systemd.vm
@@ -6,8 +6,8 @@ After=syslog.target
 [Service]
 Type=forking
 User=${RUN_AS_USER}
-ExecStart=${JAVA_HOME}/bin/java -Dwrapper.pidfile=$w_wrapper_pid_file -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir=${EXIST_HOME}/tools/yajsw/tmp -jar ${EXIST_HOME}/tools/yajsw/wrapper.jar -tx ${EXIST_HOME}/tools/yajsw/conf/wrapper.conf
-ExecStop=${JAVA_HOME}/bin/java -Dwrapper.pidfile=$w_wrapper_pid_file -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir=${EXIST_HOME}/tools/yajsw/tmp -jar ${EXIST_HOME}/tools/yajsw/wrapper.jar -px ${EXIST_HOME}/tools/yajsw/conf/wrapper.conf
+ExecStart=${JAVA_HOME}/bin/java -Dwrapper.pidfile=$w_wrapper_pid_file -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir=${EXIST_HOME}/tools/yajsw/tmp -jar ${EXIST_APP_HOME}/tools/yajsw/wrapper.jar -tx ${EXIST_HOME}/tools/yajsw/conf/wrapper.conf
+ExecStop=${JAVA_HOME}/bin/java -Dwrapper.pidfile=$w_wrapper_pid_file -Dwrapper.service=true -Dwrapper.visible=false -Djna_tmpdir=${EXIST_HOME}/tools/yajsw/tmp -jar ${EXIST_APP_HOME}/tools/yajsw/wrapper.jar -px ${EXIST_HOME}/tools/yajsw/conf/wrapper.conf
 Restart=on-abort
 StandardOutput=null
 


### PR DESCRIPTION
This PR adds a number of things which make it easier to have one copy of the eXist-db binaries, but run multiple instances with different configs.

The scripts in `$EXIST_HOME/bin` are now aware of two environment variables:
1. `EXIST_APP_HOME` - this is where the eXist-db binaries are installed
2. `EXIST_HOME` - this is where your eXist-db `conf.xml` file and other config files live (e.g. Log4j, Jetty, etc), and also your `webapp/WEB-INF/data` directory.

As before, if neither are set, we will attempt to derive them automatically.

**NOTE**: `conf.xml` is always considered to located at  `$EXIST_HOME/conf.xml`.

**NOTE**: In a normal (single instance) install `EXIST_APP_HOME` and `EXIST_HOME` will be the same!

In addition, for splitting jetty binaries and config, the following environment variables can be used.
1. `JETTY_HOME` - this locates the Jetty binaries and base config.
2. `JETTY_BASE` - this locates an overriding Jetty config

See https://www.eclipse.org/jetty/documentation/9.4.x/startup-base-and-home.html

There are also a number of Java system properties that can be set when calling the startup scripts, these should be set by using the environment variable `JAVA_OPTIONS`. System properties have a higher precedence than the environment variables.

1. `jetty.home` - overrides the environment variable `JETTY_HOME`.
2. `jetty.base` - overrides the environment variable `JETTY_BASE`.
3. `log4j.configurationFile` - overrides the location of `log4j2.xml`. This is normally `$EXIST_HOME/log4j2.xml`.
4. `org.exist.db-connection.files` - overrides the data folder for the database storage files. This is normally `$EXIST_HOME/webapp/WEB-INF/data`.
5. `org.exist.db-connection.recovery.journal-dir` - overrides the journal folder for the database journal files. This is normally `$EXIST_HOME/webapp/WEB-INF/data`.

Other settings from `conf.xml` are also overridable by setting the appropriate system properties.

**NOTE**: If you set `JAVA_OPTIONS` you SHOULD likely always set `-Dfile.encoding=UTF-8`.

## Examples
In each example, eXist-db has been installed to `/opt/exist`, and per-instance configs are located in sub-folders of `/usr/share/exist`, e.g. `/usr/share/exist/my-special-instance`:

1. To start eXist-db configured for the `my-special-instance` instance you would run:
```bash
$ JETTY_HOME=/opt/exist/tools/jetty \
    EXIST_HOME=/usr/share/exist/my-special-instance \
    /opt/exist/bin/startup.sh
```

2. If you want to start eXist-db again configured for `my-special-instance` but you need a custom Jetty config for `my-special-instance`, you would run:
```bash
$ JETTY_HOME=/opt/exist/tools/jetty \
    EXIST_HOME=/usr/share/exist/my-special-instance \
    JETTY_BASE="$EXIST_HOME/tools/jetty" \
    /opt/exist/bin/startup.sh
```

3. The same as (2) but using system properties:
```bash
$ EXIST_HOME=/usr/share/exist/my-special-instance \
    JAVA_OPTIONS="-Djetty.home=/opt/exist/tools/jetty -Djetty.base=$EXIST_HOME/tools/jetty -Dfile.encoding=UTF-8" \
    /opt/exist/bin/startup.sh
```