### PR TITLE
Improve classpath modules resolution

### DIFF
--- a/src/org/exist/source/SourceFactory.java
+++ b/src/org/exist/source/SourceFactory.java
@@ -159,14 +159,14 @@ public class SourceFactory {
         // 1) try resolving location as child
         final Path childLocation = rootPath.resolve(location);
         try {
-            return new ClassLoaderSource(ClassLoaderSource.PROTOCOL + childLocation.toString());
+            return new ClassLoaderSource(ClassLoaderSource.PROTOCOL + childLocation.toString().replace('\\', '/'));
         } catch (final IOException e) {
             // no-op, we will try again below
         }
 
         // 2) try resolving location as sibling
         final Path siblingLocation = rootPath.resolveSibling(location);
-        return new ClassLoaderSource(ClassLoaderSource.PROTOCOL + siblingLocation.toString());
+        return new ClassLoaderSource(ClassLoaderSource.PROTOCOL + siblingLocation.toString().replace('\\', '/'));
     }
 
     /**

--- a/test/src/org/exist/source/SourceFactoryTest.java
+++ b/test/src/org/exist/source/SourceFactoryTest.java
@@ -134,6 +134,53 @@ public class SourceFactoryTest {
     }
 
     @Test
+    public void getSourceFromResource_contextFolderUrl_locationRelative() throws IOException, PermissionDeniedException {
+        final String contextPath = "resource:org/exist/source";
+        final String location = "library.xqm";
+
+        final Source source = SourceFactory.getSource(null, contextPath, location, false);
+
+        assertTrue(source instanceof ClassLoaderSource);
+        assertEquals(getClass().getResource("library.xqm"), source.getKey());
+    }
+
+    @Test
+    public void getSourceFromResource_contextFolderUrl_locationAbsoluteUrl() throws IOException, PermissionDeniedException {
+        final String contextPath = "resource:org/exist/source";
+        final String location = "resource:org/exist/source/library.xqm";
+
+        final Source source = SourceFactory.getSource(null, contextPath, location, false);
+
+        assertTrue(source instanceof ClassLoaderSource);
+        assertEquals(getClass().getResource("library.xqm"), source.getKey());
+    }
+
+    @Test
+    public void getSourceFromResource_contextFolderUrl_locationRelativeUrl() throws IOException, PermissionDeniedException {
+        final String contextPath = "resource:org/exist/source";
+        final String location = "library.xqm";
+
+        final Source source = SourceFactory.getSource(null, contextPath, location, false);
+
+        assertTrue(source instanceof ClassLoaderSource);
+        assertEquals(getClass().getResource("library.xqm"), source.getKey());
+    }
+
+    @Test
+    public void getSourceFromResource_contextFolderUrl_locationRelativeUrl_basedOnSource() throws IOException, PermissionDeniedException {
+        final String contextPath = "resource:org/exist/source";
+        final String location = "library.xqm";
+
+        final Source mainSource = SourceFactory.getSource(null, "", contextPath, false);
+        assertTrue(mainSource instanceof ClassLoaderSource);
+
+        final Source relativeSource = SourceFactory.getSource(null, ((ClassLoaderSource)mainSource).getSource(), location, false);
+
+        assertTrue(relativeSource instanceof ClassLoaderSource);
+        assertEquals(getClass().getResource(location), relativeSource.getKey());
+    }
+
+    @Test
     public void getSourceFromXmldb_noContext() throws IOException, PermissionDeniedException {
         final String contextPath = null;
         final String location = "xmldb:exist:///db/library.xqm";


### PR DESCRIPTION
Related to https://github.com/eXist-db/documentation/pull/291

Fixes a bug whereby XQuery Modules executed from the classpath cannot import modules from the same relative classpath location.