### PR TITLE
Add coverage for new range index features to collection.xconf.xsd

### DIFF
--- a/schema/collection.xconf.xsd
+++ b/schema/collection.xconf.xsd
@@ -195,10 +195,10 @@
         <xs:sequence>
             <xs:element ref="inline" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element ref="ignore" minOccurs="0" maxOccurs="unbounded"/>
-	    <xs:element name="match-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
-	    <xs:element name="has-attribute" minOccurs="0" maxOccurs="unbounded" type="hasAttrBoostType"/>
-	    <xs:element name="match-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
-	    <xs:element name="has-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="hasAttrBoostType"/>
+       	    <xs:element name="match-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
+       	    <xs:element name="has-attribute" minOccurs="0" maxOccurs="unbounded" type="hasAttrBoostType"/>
+       	    <xs:element name="match-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
+       	    <xs:element name="has-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="hasAttrBoostType"/>
         </xs:sequence>
     </xs:group>
 
@@ -219,20 +219,20 @@
     </xs:complexType>
 
     <xs:complexType name="matchAttrBoostType">
-      <xs:annotation>
-        <xs:documentation>text element children match-attr or match-sibling-attr</xs:documentation>
-      </xs:annotation>
-      <xs:attributeGroup ref="qnameReq"/>
-      <xs:attributeGroup ref="valueReq"/>
-      <xs:attribute name="boost" use="required" type="xs:double"/>
+        <xs:annotation>
+            <xs:documentation>text element children match-attr or match-sibling-attr</xs:documentation>
+        </xs:annotation>
+        <xs:attributeGroup ref="qnameReq"/>
+        <xs:attributeGroup ref="valueReq"/>
+        <xs:attribute name="boost" use="required" type="xs:double"/>
     </xs:complexType>
 
     <xs:complexType name="hasAttrBoostType">
-      <xs:annotation>
-        <xs:documentation>text element children has-attr or has-sibling-attr</xs:documentation>
-      </xs:annotation>
-      <xs:attributeGroup ref="qnameReq"/>
-      <xs:attribute name="boost" use="required" type="xs:double"/>
+        <xs:annotation>
+            <xs:documentation>text element children has-attr or has-sibling-attr</xs:documentation>
+        </xs:annotation>
+        <xs:attributeGroup ref="qnameReq"/>
+        <xs:attribute name="boost" use="required" type="xs:double"/>
     </xs:complexType>
 
     <xs:complexType name="singleQnameAttrType">
@@ -326,27 +326,6 @@
     <xs:attributeGroup name="name">
         <xs:attribute name="name" type="xs:NCName" use="required" form="unqualified"/>
     </xs:attributeGroup>
-    <xs:attributeGroup name="valueReq">
-        <xs:attribute name="value" type="xs:string" use="required" form="unqualified"/>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="valueOpt">
-        <xs:attribute name="value" type="xs:string" use="optional" form="unqualified"/>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="qnameReq">
-        <xs:attribute name="qname" type="xs:string" use="required" form="unqualified"/>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="qnameOpt">
-        <xs:attribute name="qname" type="xs:string" use="optional" form="unqualified"/>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="matchOpt">
-        <xs:attribute name="match" type="xs:string" use="optional" form="unqualified"/>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="pathReq">
-        <xs:attribute name="path" type="xs:string" use="required" form="unqualified"/>
-    </xs:attributeGroup>
-    <xs:attributeGroup name="pathOpt">
-        <xs:attribute name="path" type="xs:string" use="optional" form="unqualified"/>
-    </xs:attributeGroup>
     <xs:attributeGroup name="nestedOpt">
         <xs:attribute name="nested" use="optional">
             <xs:simpleType>
@@ -364,6 +343,27 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="matchOpt">
+        <xs:attribute name="match" type="xs:string" use="optional" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="pathOpt">
+        <xs:attribute name="path" type="xs:string" use="optional" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="pathReq">
+        <xs:attribute name="path" type="xs:string" use="required" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="qnameOpt">
+        <xs:attribute name="qname" type="xs:string" use="optional" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="qnameReq">
+        <xs:attribute name="qname" type="xs:string" use="required" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="valueOpt">
+        <xs:attribute name="value" type="xs:string" use="optional" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="valueReq">
+        <xs:attribute name="value" type="xs:string" use="required" form="unqualified"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="whitespaceOpt">
         <xs:attribute name="whitespace" use="optional">

--- a/schema/collection.xconf.xsd
+++ b/schema/collection.xconf.xsd
@@ -87,7 +87,7 @@
         </xs:annotation>
         <xs:attributeGroup ref="pathOpt"/>
         <xs:attributeGroup ref="qnameOpt"/>
-        <xs:attribute name="type" use="required" type="xs:QName"/>
+        <xs:attributeGroup ref="typeReq"/>
     </xs:complexType>
 
     <xs:element name="range" type="newRangeIndexType"/>
@@ -101,9 +101,7 @@
     <xs:element name="create" type="rangeIndexCreateType"/>
     
     <xs:complexType name="rangeIndexCreateType">
-        <xs:sequence>
-            <xs:group ref="fieldDefinitions" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
+        <xs:group ref="fieldDefinitions" minOccurs="0" maxOccurs="unbounded"/>
         <xs:attributeGroup ref="qnameOpt"/>
         <xs:attributeGroup ref="nestedOpt"/>
         <xs:attributeGroup ref="whitespaceOpt"/>
@@ -117,7 +115,7 @@
     </xs:group>
     
     <xs:complexType name="newRangeIndexFieldType">
-        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attributeGroup ref="nameReq"/>
         <xs:attributeGroup ref="qnameOpt"/>
         <xs:attributeGroup ref="matchOpt"/>
         <xs:attribute name="case" use="optional">
@@ -138,7 +136,7 @@
         </xs:attribute>
         <xs:attributeGroup ref="nestedOpt"/>
         <xs:attributeGroup ref="whitespaceOpt"/>
-        <xs:attribute name="type" type="xs:QName" use="required"/>
+        <xs:attributeGroup ref="typeReq"/>
     </xs:complexType>
     
     <xs:element name="lucene" type="luceneType"/>
@@ -183,18 +181,15 @@
         <xs:sequence minOccurs="0">
             <xs:element name="value" minOccurs="1" maxOccurs="unbounded" type="xs:string"/>
         </xs:sequence>
-        <xs:attributeGroup ref="name"/>
+        <xs:attributeGroup ref="nameReq"/>
         <xs:attribute name="type" type="xs:string" use="optional" default="java.lang.String"/>
         <xs:attributeGroup ref="valueOpt"/>
     </xs:complexType>
 
-    <xs:element name="inline" type="singleQnameAttrType"/>
-    <xs:element name="ignore" type="singleQnameAttrType"/>
-
     <xs:group name="textInstruction">
         <xs:sequence>
-            <xs:element ref="inline" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="ignore" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="inline" minOccurs="0" maxOccurs="unbounded" type="singleQnameAttrType"/>
+            <xs:element name="ignore" minOccurs="0" maxOccurs="unbounded" type="singleQnameAttrType"/>
        	    <xs:element name="match-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
        	    <xs:element name="has-attribute" minOccurs="0" maxOccurs="unbounded" type="hasAttrBoostType"/>
        	    <xs:element name="match-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
@@ -212,9 +207,9 @@
             <xs:group ref="textInstruction"/>
         </xs:sequence>
         <xs:attributeGroup ref="qnameOpt"/>
-        <xs:attribute name="match" use="optional" type="xs:string"/>
+        <xs:attributeGroup ref="matchOpt"/>
         <xs:attribute name="analyzer" use="optional" type="xs:IDREF"/>
-        <xs:attribute name="boost" use="optional" type="xs:double"/>
+        <xs:attributeGroup ref="boostOpt"/>
         <xs:attribute name="field" use="optional" type="xs:string"/>
     </xs:complexType>
 
@@ -224,7 +219,7 @@
         </xs:annotation>
         <xs:attributeGroup ref="qnameReq"/>
         <xs:attributeGroup ref="valueReq"/>
-        <xs:attribute name="boost" use="required" type="xs:double"/>
+        <xs:attributeGroup ref="boostReq"/>
     </xs:complexType>
 
     <xs:complexType name="hasAttrBoostType">
@@ -232,7 +227,7 @@
             <xs:documentation>text element children has-attr or has-sibling-attr</xs:documentation>
         </xs:annotation>
         <xs:attributeGroup ref="qnameReq"/>
-        <xs:attribute name="boost" use="required" type="xs:double"/>
+        <xs:attributeGroup ref="boostReq"/>
     </xs:complexType>
 
     <xs:complexType name="singleQnameAttrType">
@@ -285,7 +280,7 @@
     <xs:element name="parameter" type="parameterType"/>
 
     <xs:complexType name="parameterType">
-        <xs:attributeGroup ref="name"/>
+        <xs:attributeGroup ref="nameReq"/>
         <xs:attributeGroup ref="valueReq"/>
     </xs:complexType>
 
@@ -306,24 +301,24 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="yesNoType">
-        <xs:restriction base="xs:token">
-            <xs:enumeration value="yes"/>
-            <xs:enumeration value="no"/>
-            <xs:enumeration value="true"/>
-            <xs:enumeration value="false"/>
-        </xs:restriction>
-    </xs:simpleType>
-    
     <!-- we are hiding attributes in attributeGroup to manage their
         namespaces as described here: http://docstore.mik.ua/orelly/xml/schema/ch10_04.htm -->
     <xs:attributeGroup name="class">
         <xs:attribute name="class" type="xs:string" use="required" form="unqualified"/>
     </xs:attributeGroup>
 
-    <!-- ideally we would have just one of each attribute - but due do the form restrictions in XML Schema
+    <!-- ideally we would have just one of each attribute - but due to the form restrictions in XML Schema
     we need both -->
-    <xs:attributeGroup name="name">
+    <xs:attributeGroup name="boostOpt">
+        <xs:attribute name="boost" type="xs:double" use="optional" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="boostReq">
+        <xs:attribute name="boost" type="xs:double" use="required" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="matchOpt">
+        <xs:attribute name="match" type="xs:string" use="optional" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="nameReq">
         <xs:attribute name="name" type="xs:NCName" use="required" form="unqualified"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="nestedOpt">
@@ -344,9 +339,6 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:attributeGroup>
-    <xs:attributeGroup name="matchOpt">
-        <xs:attribute name="match" type="xs:string" use="optional" form="unqualified"/>
-    </xs:attributeGroup>
     <xs:attributeGroup name="pathOpt">
         <xs:attribute name="path" type="xs:string" use="optional" form="unqualified"/>
     </xs:attributeGroup>
@@ -358,6 +350,12 @@
     </xs:attributeGroup>
     <xs:attributeGroup name="qnameReq">
         <xs:attribute name="qname" type="xs:string" use="required" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="typeOpt">
+        <xs:attribute name="type" type="xs:QName" use="optional" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="typeReq">
+        <xs:attribute name="type" type="xs:QName" use="required" form="unqualified"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="valueOpt">
         <xs:attribute name="value" type="xs:string" use="optional" form="unqualified"/>

--- a/schema/collection.xconf.xsd
+++ b/schema/collection.xconf.xsd
@@ -103,37 +103,102 @@
     <xs:complexType name="rangeIndexCreateType">
         <xs:group ref="fieldDefinitions" minOccurs="0" maxOccurs="unbounded"/>
         <xs:attributeGroup ref="qnameOpt"/>
+        <xs:attributeGroup ref="typeOpt"/>
         <xs:attributeGroup ref="nestedOpt"/>
         <xs:attributeGroup ref="whitespaceOpt"/>
+        <xs:attributeGroup ref="caseOpt"/>
         <xs:attribute name="collation" use="optional" type="xs:string"/>
     </xs:complexType>
     
     <xs:group name="fieldDefinitions">
         <xs:sequence>
+            <xs:element name="condition" type="newRangeIndexConditionType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="field" type="newRangeIndexFieldType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:group>
     
-    <xs:complexType name="newRangeIndexFieldType">
-        <xs:attributeGroup ref="nameReq"/>
-        <xs:attributeGroup ref="qnameOpt"/>
-        <xs:attributeGroup ref="matchOpt"/>
-        <xs:attribute name="case" use="optional">
+    <xs:complexType name="newRangeIndexConditionType">
+        <xs:attribute name="attribute" type="xs:NCName" use="required"/>
+        <xs:attribute name="operator" use="optional" default="eq">
             <xs:simpleType>
                 <xs:restriction base="xs:token">
-                    <xs:enumeration value="yes">
+                    <xs:enumeration value="eq">
                         <xs:annotation>
-                            <xs:documentation>Case sensitive</xs:documentation>
+                            <xs:documentation>Equals</xs:documentation>
                         </xs:annotation>
                     </xs:enumeration>
-                    <xs:enumeration value="no">
+                    <xs:enumeration value="ne">
                         <xs:annotation>
-                            <xs:documentation>Case insensitive</xs:documentation>
+                            <xs:documentation>Not equals</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="lt">
+                        <xs:annotation>
+                            <xs:documentation>Less than</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="gt">
+                        <xs:annotation>
+                            <xs:documentation>Greater than</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="le">
+                        <xs:annotation>
+                            <xs:documentation>Less than or equals</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="ge">
+                        <xs:annotation>
+                            <xs:documentation>Greater than or equals</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="starts-with">
+                        <xs:annotation>
+                            <xs:documentation>Starts with</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="ends-with">
+                        <xs:annotation>
+                            <xs:documentation>Ends with</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="contains">
+                        <xs:annotation>
+                            <xs:documentation>Contains</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="matches">
+                        <xs:annotation>
+                            <xs:documentation>Matches (supports Java regular expressions)</xs:documentation>
                         </xs:annotation>
                     </xs:enumeration>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
+        <xs:attribute name="value" type="xs:string" use="required"/>
+        <xs:attributeGroup ref="caseOpt"/>
+        <xs:attribute name="numeric" use="optional" default="no">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="yes">
+                        <xs:annotation>
+                            <xs:documentation>Use numeric comparison for equality and ordinal comparisons</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="no">
+                        <xs:annotation>
+                            <xs:documentation>Use string comparison</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    
+    <xs:complexType name="newRangeIndexFieldType">
+        <xs:attributeGroup ref="nameReq"/>
+        <xs:attributeGroup ref="matchOpt"/>
+        <xs:attributeGroup ref="caseOpt"/>
         <xs:attributeGroup ref="nestedOpt"/>
         <xs:attributeGroup ref="whitespaceOpt"/>
         <xs:attributeGroup ref="typeReq"/>
@@ -314,6 +379,24 @@
     </xs:attributeGroup>
     <xs:attributeGroup name="boostReq">
         <xs:attribute name="boost" type="xs:double" use="required" form="unqualified"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="caseOpt">
+        <xs:attribute name="case" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="yes">
+                        <xs:annotation>
+                            <xs:documentation>Case sensitive</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="no">
+                        <xs:annotation>
+                            <xs:documentation>Case insensitive</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:attributeGroup>
     <xs:attributeGroup name="matchOpt">
         <xs:attribute name="match" type="xs:string" use="optional" form="unqualified"/>


### PR DESCRIPTION
### Description:

The collection xconf schema file lacked coverage for:

- the new conditional combined index feature’s `<condition>` element, which may contain `@attribute`, `@operator`, `@value`, `@case`, and `@numeric`
- `@type` and `@case` attributes for the new range index's `<create> element

This PR adds those and includes some cleanup of the xsd file to conform to the documentation.

### Reference:

- https://exist-db.org/exist/apps/doc/newrangeindex
- https://stackoverflow.com/questions/54105990/failure-of-conditional-combination-index-in-exist-db-range-index

### Type of tests:

- No automated tests included, but I manually tested against the xconf file contained in `extensions/indexes/range/test/src/xquery/conditions.xql` and my most complex xconf files.