### PR TITLE
add tests to arrowop spec for #1960

### DIFF
--- a/test/src/xquery/xquery3/arrowop.xql
+++ b/test/src/xquery/xquery3/arrowop.xql
@@ -149,3 +149,75 @@ declare
 function ao:function-declared-later() {
     ao:A("hello")
 };
+
+(:~ 
+    the tests below (`ao:wrap-*`) were added because of
+    https://github.com/exist-db/exist/issues/1960
+~:)
+declare
+	%private
+function ao:wrap ($item as item()) as item() { 
+    <wrap>{$item}</wrap>
+};
+
+declare
+	%private
+function ao:wrap-explicit-type-conversion ($item as item()) as item() { 
+    <wrap>{xs:string($item)}</wrap>
+};
+
+declare
+	%private 
+function ao:first-element-text ($s as node()*) as text() {
+    $s[1]/text()
+};
+
+declare
+    %test:assertEquals("1")
+function ao:wrap-atomic-sequence () {
+    (1, 2, 3)
+        => for-each(ao:wrap#1)
+        => ao:first-element-text()
+};
+
+declare
+    %test:assertEquals("1")
+function ao:wrap-atomic-sequence-with-explicit-type-conversion () {
+    (1, 2, 3)
+        => for-each(ao:wrap-with-explicit-type-conversion#1) 
+        => ao:first-element-text()
+};
+
+declare
+	%private 
+function ao:get-i-elements ($i as item()) { $i//i };
+
+(:~ 
+    must be 3 not 9
+    closes https://github.com/exist-db/exist/issues/1960
+ ~:)
+declare
+    %test:pending
+    %test:assertEquals(3)
+function ao:wrap-element-sequence () {
+    let $xml := <root><i/><i/><i/></root>
+    return $xml/node()
+        => for-each(ao:wrap#1)
+        => for-each(ao:get-i-elements#1)
+        => count()
+};
+
+(:~ 
+    must not fail with duplicate attribute exception err:XQDY0025
+    closes https://github.com/exist-db/exist/issues/1960
+ ~:)
+declare
+    %test:pending
+    %test:assertEquals('1')
+function ao:wrap-attribute-from-sequence () {
+    (<item n="1"/>, <item n="2"/>, <item n="3"/>) 
+        => for-each(function ($item as item()) as element(a) { <a>{$item/@n}</a> })
+        => (function($sequence) {
+                $sequence[1]/@n/string()
+            })()
+}


### PR DESCRIPTION
### Description:

adds 4 tests to the arrowop test suite

-  ao:wrap-atomic-sequence
- ao:wrap-atomic-sequence-with-explicit-type-conversion
- ao:wrap-element-sequence (pending)
- ao:wrap-attribute-from-sequence (pending)

### Reference:

They were added to test #1960 

### Type of tests:

xqsuite