### PR TITLE
Fix lucene term range queries

### DIFF
--- a/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
+++ b/extensions/indexes/lucene/src/org/exist/indexing/lucene/LuceneUtil.java
@@ -146,6 +146,8 @@ public class LuceneUtil {
             extractTermsFromPrefix((PrefixQuery) query, terms, reader, includeFields);
         } else if (query instanceof PhraseQuery) {
             extractTermsFromPhrase((PhraseQuery) query, terms, includeFields);
+        } else if (query instanceof TermRangeQuery) {
+            extractTermsFromTermRange((TermRangeQuery) query, terms, reader, includeFields);
         } else {
             // fallback to Lucene's Query.extractTerms if none of the
             // above matches
@@ -201,6 +203,10 @@ public class LuceneUtil {
                 terms.put(t1.text(), query);
             }
         }
+    }
+
+    private static void extractTermsFromTermRange(final TermRangeQuery query, final Map<Object, Query> terms, final IndexReader reader, boolean includeFields) throws IOException {
+        TERM_EXTRACTOR.extractTerms(query, terms, reader, includeFields);
     }
 
     private static Query rewrite(final MultiTermQuery query, final IndexReader reader) throws IOException {

--- a/extensions/indexes/lucene/test/src/xquery/lucene/plain-ft-functions.xml
+++ b/extensions/indexes/lucene/test/src/xquery/lucene/plain-ft-functions.xml
@@ -146,4 +146,11 @@
         ]]></code>
         <expected>another foobar title</expected>
     </test>
+    <test output="text" >
+        <task>Test Index 7 - search term range (resulted in UnsupportedOperationException)</task>
+        <code><![CDATA[
+        count( ft:search("/db/binary/", "para:[even TO foobaar]")//@uri  )
+        ]]></code>
+        <expected>3</expected>
+    </test>
 </TestSet>

--- a/extensions/indexes/lucene/test/src/xquery/lucene/queries.xml
+++ b/extensions/indexes/lucene/test/src/xquery/lucene/queries.xml
@@ -74,7 +74,16 @@
         <remove-collection collection="/db/lucene"/>
         <remove-document collection="/db/system/config/db/lucene" name="collection.xconf"/>
     </tearDown>
-	<!-- Following axis tests -->
+	<test output="xml">
+		<task>Term range query</task>
+		<code>
+			declare namespace tei="http://www.tei-c.org/ns/1.0";
+
+			doc("/db/lucene/text1.xml")//p[ft:query(., 'eins TO zwei')]</code>
+		<expected>
+			<p>Eins zwei drei vier zwei fünf sechs.</p>
+		</expected>
+	</test>
 	<test output="xml">
 		<task>Case sensitivity</task>
 		<code> for $hit in doc("/db/lucene/text1.xml")//p[ft:query(., 'Eins')] return $hit </code>


### PR DESCRIPTION
Forward port of #2386

A lucene query like ft:search("/db/binary/", "para:[even TO foobaar]") would result in an UnsupportedOperationException. Fixed both: queries on standard and constructed indexes, added tests.