### PR TITLE
[feature] dashboard is dead; long live dashboard

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -30,7 +30,7 @@ keystore.validity = 100000
 # The EnsureLockAspect enforces the locking contracts by annotation
 enable.ensurelocking.aspect=false
 
-autodeploy=dashboard,shared,eXide,monex,functx,usermanager
+autodeploy=existdb-dashboard,packageservice,shared,eXide,monex,functx
 autodeploy.repo=http://demo.exist-db.org/exist/apps/public-repo
 use.autodeploy.feature=true
 

--- a/exist-versioning-release.md
+++ b/exist-versioning-release.md
@@ -236,7 +236,7 @@ Once development on a new stable version is complete, the following steps will p
     
     6. Create a XAR for the website: `$ git checkout eXist-3.1.0 && ant`.
     
-    7. Visit http://www.exist-db.org/exist/apps/dashboard/index.html, login and upload the new `build/homepage.xar` file via the Package Manager.
+    7. Visit http://www.exist-db.org/exist/apps/existdb-dashboard/index.html, login and upload the new `build/homepage.xar` file via the Package Manager.
 
 6. Login to the blog at http://exist-db.org/exist/apps/wiki/blogs/eXist/ and add a new news item which announces the release and holds the release notes. It should be named like http://exist-db.org/exist/apps/wiki/blogs/eXist/eXistdb310
 

--- a/installer/apps.properties
+++ b/installer/apps.properties
@@ -1,2 +1,2 @@
 apps.repo=http://demo.exist-db.org/exist/apps/public-repo
-apps=shared,dashboard,functx,usermanager,eXide,monex,doc,fundocs,markdown
+apps=shared,existdb-dashboard,packageservice,functx,eXide,monex,exist-documentation,fundocs,markdown

--- a/installer/install.xsl
+++ b/installer/install.xsl
@@ -38,7 +38,7 @@
         <pack name="{$package/@abbrev}" required="no" preselected="yes" parent="Apps">
             <xsl:attribute name="required">
                 <xsl:choose>
-                    <xsl:when test="$package/@abbrev = 'shared' or $package/@abbrev = 'dashboard'">yes</xsl:when>
+                    <xsl:when test="$package/@abbrev = 'shared' or $package/@abbrev = 'existdb-dashboard'">yes</xsl:when>
                     <xsl:otherwise>no</xsl:otherwise>
                 </xsl:choose>
             </xsl:attribute>

--- a/src/org/exist/launcher/Launcher.java
+++ b/src/org/exist/launcher/Launcher.java
@@ -73,7 +73,7 @@ public class Launcher extends Observable implements Observer {
     private MenuItem showServices;
     private MenuItem quitItem;
 
-    public final static String PACKAGE_DASHBOARD = "http://exist-db.org/apps/dashboard";
+    public final static String PACKAGE_DASHBOARD = "http://exist-db.org/apps/existdb-dashboard";
     public final static String PACKAGE_EXIDE = "http://exist-db.org/apps/eXide";
     public final static String PACKAGE_MONEX = "http://exist-db.org/apps/monex";
 
@@ -465,7 +465,7 @@ public class Launcher extends Observable implements Observer {
         serviceLock.lock();
         try {
             final int port = jetty.isPresent() ? jetty.get().getPrimaryPort() : 8080;
-            final URI url = new URI("http://localhost:" + port + "/exist/apps/dashboard/");
+            final URI url = new URI("http://localhost:" + port + "/exist/apps/existdb-dashboard/");
             desktop.browse(url);
         } catch (final URISyntaxException e) {
             if (isSystemTraySupported())

--- a/webapp/404.html
+++ b/webapp/404.html
@@ -34,7 +34,7 @@
             <h1>Page Not Found</h1>
             
             <p>The requested page could not be found, probably because the application is not
-                installed. Please use the <a href="apps/dashboard/">dashboard</a> to install
+                installed. Please use the <a href="apps/existdb-dashboard/">dashboard</a> to install
                 missing application packages.</p>
         </div>
     </body>

--- a/webapp/controller.xql
+++ b/webapp/controller.xql
@@ -14,7 +14,7 @@ import module namespace request="http://exist-db.org/xquery/request";
 import module namespace xdb = "http://exist-db.org/xquery/xmldb";
 
 declare function local:get-dashboard() {
-	let $path := collection(repo:get-root())//expath:package[@name = "http://exist-db.org/apps/dashboard"]
+	let $path := collection(repo:get-root())//expath:package[@name = "http://exist-db.org/apps/existdb-dashboard"]
     return
         if ($path) then
             substring-after(util:collection-name($path), repo:get-root())


### PR DESCRIPTION
### Description:

- This PR replaces the [old dashboard](https://github.com/eXist-db/dashboard) with the [new dashboard](https://github.com/eXist-db/existdb-dashboard) for the purpose of populating the autodeploy directory during a normal and installer builds.
- It also updates the webapp default redirect of requests for "/" to "/exist/apps/existdb-dashboard" and similarly updates the URL associated with dashboard in the menubar/taskbar and tool window.

Many developers have been using and testing the new dashboard and, as discussed in the January 7, 2018 community call, recommend that the new dashboard be included in the next 5.0.0-RC. (There are no current plans to backport this to the 4.x.x series.)

### Reference:

- [January 7, 2018 community call](https://docs.google.com/document/d/1-5iWMTIdnev3eaiRwAJPm7e2OmfbDroi9e6pVhJIq6A/edit?usp=sharing)
- Numerous [completed action items relating to Dashboard](https://docs.google.com/spreadsheets/d/10uqjXLrhWxvcZ9WlJzhT6IeD8gpy6a5abfmGVLw7LwM/edit?usp=sharing)

### Type of tests:

- I tested regular and installer builds and confirmed that with these PR changes, eXist starts correctly; the new dashboard loads; all panes in the app open without error; the new dashboard is the target of the redirect when requesting "/"; and the new dashboard is the target when selecting dashboard entries from menubar/taskbar and tool window.