### PR TITLE
[feature] Switch to the new dashboard

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -30,7 +30,7 @@ keystore.validity = 100000
 # The EnsureLockAspect enforces the locking contracts by annotation
 enable.ensurelocking.aspect=false
 
-autodeploy=dashboard,shared,eXide,monex,functx,usermanager
+autodeploy=dashboard,packageservice,shared,eXide,monex,functx
 autodeploy.repo=http://demo.exist-db.org/exist/apps/public-repo
 use.autodeploy.feature=true
 

--- a/installer/apps.properties
+++ b/installer/apps.properties
@@ -1,2 +1,2 @@
 apps.repo=http://demo.exist-db.org/exist/apps/public-repo
-apps=shared,dashboard,functx,usermanager,eXide,monex,doc,fundocs,markdown
+apps=shared,dashboard,packageservice,functx,eXide,monex,doc,fundocs,markdown


### PR DESCRIPTION
### Description:

- This PR replaces the [old dashboard](https://github.com/eXist-db/dashboard) with the [new dashboard](https://github.com/eXist-db/existdb-dashboard) for the purpose of populating the autodeploy directory during a normal and installer builds.
- This PR assumes the URL for accessing the dashboard app has not changed, as required by https://github.com/eXist-db/existdb-dashboard/issues/13 and fixed by https://github.com/eXist-db/existdb-dashboard/pull/14 (still awaiting merge at the moment).

Many developers have been using and testing the new dashboard and, as discussed in the January 7, 2018 community call, recommend that the new dashboard be included in the next 5.0.0-RC. (There are no current plans to backport this to the 4.x.x series.)

### Reference:

- [January 7, 2018 community call](https://docs.google.com/document/d/1-5iWMTIdnev3eaiRwAJPm7e2OmfbDroi9e6pVhJIq6A/edit?usp=sharing)
- Numerous [completed action items relating to Dashboard](https://docs.google.com/spreadsheets/d/10uqjXLrhWxvcZ9WlJzhT6IeD8gpy6a5abfmGVLw7LwM/edit?usp=sharing)

### Type of tests:

- I tested regular and installer builds and confirmed that with this PR and https://github.com/eXist-db/existdb-dashboard/pull/14, eXist starts correctly; the new dashboard loads; all panes in the app open without error; the new dashboard is the target of the redirect when requesting "/"; and the new dashboard is the target when selecting dashboard entries from menubar/taskbar and tool window.
- I also tested that the new dashboard runs fine in browsers with HTML imports disabled, by consulting https://www.polymer-project.org/blog/2018-10-02-webcomponents-v0-deprecations. 