### PR TITLE
Fixed #2387, BackupSystemTask is not limiting the backups as folders.

### DIFF
--- a/src/org/exist/storage/BackupSystemTask.java
+++ b/src/org/exist/storage/BackupSystemTask.java
@@ -16,9 +16,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.function.Predicate;
 
 /**
  * BackupSystemTask creates an XML backup of the current database into a directory
@@ -140,14 +137,8 @@ public class BackupSystemTask implements SystemTask {
 
     public void purgeZipFiles() throws IOException {
         if (LOG.isDebugEnabled()) {LOG.debug("starting purgeZipFiles()");}
-        
-		Predicate<Path> filter = path -> {
-			String entryName = path.getFileName().toString();
-
-			return entryName.startsWith(prefix) && entryName.endsWith(suffix);
-		};
 		
-		List<Path> entriesPaths = FileUtils.list(directory, filter);
+		List<Path> entriesPaths = FileUtils.list(directory, FileUtils.getPrefixSuffixFilter(prefix, suffix));
 		int entriesNumber = entriesPaths.size();
 		int numberOfEntriesToBeDeleted = entriesNumber - zipFilesMax + 1;
 
@@ -174,7 +165,7 @@ public class BackupSystemTask implements SystemTask {
 	            FileUtils.deleteQuietly(path);
 			});	
 		}
-    } 
+    }  
 
     @Override
     public boolean afterCheckpoint() {

--- a/src/org/exist/storage/BackupSystemTask.java
+++ b/src/org/exist/storage/BackupSystemTask.java
@@ -18,6 +18,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.function.Predicate;
 
 /**
  * BackupSystemTask creates an XML backup of the current database into a directory
@@ -116,6 +117,15 @@ public class BackupSystemTask implements SystemTask {
 
     @Override
     public void execute(final DBBroker broker) throws EXistException {
+        // see if old zip files need to be purged
+        if (zipFilesMax > 0) {
+            try {
+                purgeZipFiles();
+            } catch(final IOException ioe) {
+                throw new EXistException("Unable to purge zip files", ioe);
+            }
+        } 
+        
         final String dateTime = creationDateFormat.format(Calendar.getInstance().getTime());
         final Path dest = directory.resolve(prefix + dateTime + suffix);
 
@@ -126,50 +136,45 @@ public class BackupSystemTask implements SystemTask {
             LOG.error(e.getMessage(), e);
             throw new EXistException(e.getMessage(), e);
         }
-
-        // see if old zip files need to be purged
-        if (".zip".equals(suffix) && zipFilesMax > 0) {
-            try {
-                purgeZipFiles();
-            } catch(final IOException ioe) {
-                throw new EXistException("Unable to purge zip files", ioe);
-            }
-        }
     }
 
     public void purgeZipFiles() throws IOException {
         if (LOG.isDebugEnabled()) {LOG.debug("starting purgeZipFiles()");}
+        
+		Predicate<Path> filter = path -> {
+			String entryName = path.getFileName().toString();
 
-        // get all files in target directory
-        final List<Path> files = FileUtils.list(directory);
+			return entryName.startsWith(prefix) && entryName.endsWith(suffix);
+		};
+		
+		List<Path> entriesPaths = FileUtils.list(directory, filter);
+		int entriesNumber = entriesPaths.size();
+		int numberOfEntriesToBeDeleted = entriesNumber - zipFilesMax + 1;
 
-        if (!files.isEmpty()) {
-            final Map<String, Path> sorted = new TreeMap<>();
-            for (final Path file : files) {
-                //check for prefix and suffix match
-                if (file.getFileName().startsWith(prefix) && FileUtils.fileName(file).endsWith(suffix)) {
-                    sorted.put(Long.toString(Files.getLastModifiedTime(file).toMillis()), file);
-                }
-            }
+		Comparator<Path> timestampComparator = new Comparator<Path>() {
+			public int compare(Path path1, Path path2) {
+				int result = 0;
 
+				try {
+					result = Files.getLastModifiedTime(path1).compareTo(Files.getLastModifiedTime(path2));
+				} catch (IOException e) {
+					LOG.error("Cannot compare files by timestamp: " + path1 + ", " + path2, e);
+				}
 
-            if (sorted.size() > zipFilesMax) {
-                final Set<String> keys = sorted.keySet();
-                final Iterator<String> ki = keys.iterator();
-                int i = sorted.size() - zipFilesMax;
-                while (ki.hasNext()) {
-                    final Path f = sorted.get(ki.next());
-                    if (i > 0) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Purging backup : " + FileUtils.fileName(f));
-                        }
-                        FileUtils.deleteQuietly(f);
-                    }
-                    i--;
-                }
-            }
-        }
-    }
+				return result;
+			}
+		};
+
+		if (numberOfEntriesToBeDeleted > 0) {
+			entriesPaths.stream().sorted(timestampComparator).limit(numberOfEntriesToBeDeleted).forEach(path -> {
+	            if (LOG.isDebugEnabled()) {
+	                LOG.debug("Purging backup : " + FileUtils.fileName(path));
+	            }
+	            
+	            FileUtils.deleteQuietly(path);
+			});	
+		}
+    } 
 
     @Override
     public boolean afterCheckpoint() {

--- a/src/org/exist/util/FileUtils.java
+++ b/src/org/exist/util/FileUtils.java
@@ -38,6 +38,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.function.Predicate;
 
 import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
@@ -479,4 +480,21 @@ public class FileUtils {
             }
         }
     }
+    
+    /**
+     * Provides a filter for entries in a directory.
+     *
+     * @param path the entry to be filtered.
+     * @param prefix the prefix used for filtering.
+     * @param prefix the suffix used for filtering.
+     * 
+     * @return The filter.
+     */
+	public static Predicate<Path> getPrefixSuffixFilter(final String prefix, final String suffix) {
+		return path -> {
+			String entryName = path.getFileName().toString();
+			
+			return entryName.startsWith(prefix) && entryName.endsWith(suffix);
+		};
+	}
 }


### PR DESCRIPTION
Fix for issue #2387.

If core team agrees, I would extract
```java
Predicate<Path> filter = path -> {
	String entryName = path.getFileName().toString();
	return entryName.startsWith(prefix) && entryName.endsWith(suffix);
};
```
and
```java
Comparator<Path> timestampComparator = new Comparator<Path>() {
	public int compare(Path path1, Path path2) {
		int result = 0;
		try {
			result = Files.getLastModifiedTime(path1).compareTo(Files.getLastModifiedTime(path2));
		} catch (IOException e) {
			LOG.error("Cannot compare files by timestamp: " + path1 + ", " + path2, e);
		}
		return result;
	}
};
```
into org.exist.util.FileUtils.
