### PR TITLE
Ci adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ matrix:
     - jdk: openjdk8
     - jdk: openjdk9
     - jdk: openjdk10
-    - jdk: openjdk11
     - jdk: oraclejdk11
 
     - os: osx
-      osx_image: xcode9.2
+      osx_image: xcode9.3
       env: JAVA_HOME=$(/usr/libexec/java_home)
 
 script: ./build.sh -Dexist.autodeploy=off -Dtest.haltonerror=true -Dtest.haltonfailure=true clean clean-all all test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,10 @@ environment:
       JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       JAVA_HOME: C:\Program Files\Java\jdk11
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
       JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-      JAVA_HOME: /usr/lib/jvm/java-9-openjdk-amd64
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-      JAVA_HOME: /usr/lib/jvm/java-10-openjdk-amd64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
+      JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
 
 install:
   - cmd: set EXIST_HOME=%APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      JAVA_HOME: C:\Program Files\Java\jdk9
+      JAVA_HOME: C:\Program Files\Java\jdk11
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu


### PR DESCRIPTION
This PR adjusts our combined Travis and Appveyor Ci matrix: 
-   on Appveyor we only test java8 and java11 aka lts releases java9 and 10 are outdated
-   Travis is on ubuntu 16.04, i see little point in duplicating this on appveyor so i bumped appveyor linux builds to 18.04
-   macOS on travis now uses macOS 10.13 aka HighSierra
-   removed a duplicate ubuntu openjdk 11 build. openjdk is on appveyor, oraclejdk on travis. 

This makes test runs faster, while still broadening our system coverage.
