### PR TITLE
(5.0.0) Feature/lucene search leading wildcard

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -669,7 +669,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
      * @param queryText
      * @return search report
      */
-    public NodeImpl search(final XQueryContext context, final List<String> toBeMatchedURIs, String queryText, String[] fieldsToGet) throws XPathException, IOException {
+    public NodeImpl search(final XQueryContext context, final List<String> toBeMatchedURIs, String queryText, String[] fieldsToGet, Properties options) throws XPathException, IOException {
 
         return index.withSearcher(searcher -> {
             // Get analyzer : to be retrieved from configuration
@@ -677,7 +677,11 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
 
             // Setup query Version, default field, analyzer
             final QueryParserWrapper parser = getQueryParser("", searchAnalyzer, null);
-            final Query query = parser.parse(queryText);
+            try {
+                setOptions(options, parser.getConfiguration());
+            } catch (ParseException e) {
+                throw new XPathException("Lucene query syntax error: " + e.getMessage());
+            }       final Query query = parser.parse(queryText);
 
             // extract all used fields from query
             final String[] fields;

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -681,7 +681,8 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 setOptions(options, parser.getConfiguration());
             } catch (ParseException e) {
                 throw new XPathException("Lucene query syntax error: " + e.getMessage());
-            }       final Query query = parser.parse(queryText);
+            }
+            final Query query = parser.parse(queryText);
 
             // extract all used fields from query
             final String[] fields;

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -221,7 +221,7 @@ public class Query extends Function implements Optimizable {
         Item key = getKey(contextSequence, null);
         List<QName> qnames = new ArrayList<>(1);
         qnames.add(contextQName);
-        Properties options = parseOptions(contextSequence, null);
+        Properties options = parseOptions(this, contextSequence, null, 3);
         try {
             if (Type.subTypeOf(key.getType(), Type.ELEMENT))
                 preselectResult = index.query(context, getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null,
@@ -265,7 +265,7 @@ public class Query extends Function implements Optimizable {
                     qnames = new ArrayList<>(1);
                     qnames.add(contextQName);
                 }
-                Properties options = parseOptions(contextSequence, contextItem);
+                Properties options = parseOptions(this, contextSequence, contextItem, 3);
                 try {
                     if (Type.subTypeOf(key.getType(), Type.ELEMENT))
                         result = index.query(context, getExpressionId(), docs, inNodes, qnames,
@@ -311,15 +311,15 @@ public class Query extends Function implements Optimizable {
         return Type.NODE;
     }
 
-    protected Properties parseOptions(Sequence contextSequence, Item contextItem) throws XPathException {
-        if (getArgumentCount() < 3)
+    protected static Properties parseOptions(Function funct, Sequence contextSequence, Item contextItem, int position) throws XPathException {
+        if (funct.getArgumentCount() < position)
             return null;
         Properties options = new Properties();
-        Sequence optSeq = getArgument(2).eval(contextSequence, contextItem);
+        Sequence optSeq = funct.getArgument(position-1).eval(contextSequence, contextItem);
         NodeValue optRoot = (NodeValue) optSeq.itemAt(0);
         try {
             final int thisLevel = optRoot.getNodeId().getTreeLevel();
-            final XMLStreamReader reader = context.getXMLStreamReader(optRoot);
+            final XMLStreamReader reader = funct.getContext().getXMLStreamReader(optRoot);
             reader.next();
             reader.next();
             while (reader.hasNext()) {
@@ -337,7 +337,7 @@ public class Query extends Function implements Optimizable {
             }
             return options;
         } catch (XMLStreamException | IOException e) {
-            throw new XPathException(this, "Error while parsing options to ft:query: " + e.getMessage(), e);
+            throw new XPathException(funct, "Error while parsing options to ft:query: " + e.getMessage(), e);
         }
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
@@ -114,7 +114,7 @@ public class QueryField extends Query implements Optimizable {
         String field = getArgument(0).eval(contextSequence).getStringValue();
         DocumentSet docs = contextSequence.getDocumentSet();
         Item query = getKey(contextSequence, null);
-        Properties options = parseOptions(contextSequence, null);
+        Properties options = parseOptions(this, contextSequence, null, 3);
         try {
             if (Type.subTypeOf(query.getType(), Type.ELEMENT))
                 preselectResult = index.queryField(context, getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null,
@@ -156,7 +156,7 @@ public class QueryField extends Query implements Optimizable {
         	
         	LuceneIndexWorker index = (LuceneIndexWorker)
         		context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
-        	Properties options = parseOptions(contextSequence, contextItem);
+        	Properties options = parseOptions(this, contextSequence, contextItem, 3);
         	try {
         		if (Type.subTypeOf(query.getType(), Type.ELEMENT))
         			result = index.queryField(context, getExpressionId(), docs, contextSet, field,

--- a/extensions/indexes/lucene/src/test/xquery/lucene/binary.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/binary.xql
@@ -66,3 +66,11 @@ function luct:check-visibility-collection-pass() {
         ft:search("/db/lucenetest/sub/", "title:admin")/search/@uri/string()
     )
 };
+
+declare
+    %test:assertEquals("Lorem")
+function luct:check-leading-wildcard() {
+    system:as-user("admin", "",
+        ft:search("/db/lucenetest/", "title:*rem", (), <options><leading-wildcard>yes</leading-wildcard></options>)/search/@uri/string()
+    )
+};

--- a/extensions/indexes/lucene/src/test/xquery/lucene/binary.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/binary.xql
@@ -68,7 +68,7 @@ function luct:check-visibility-collection-pass() {
 };
 
 declare
-    %test:assertEquals("Lorem")
+    %test:assertEquals("/db/lucenetest/test.txt")
 function luct:check-leading-wildcard() {
     system:as-user("admin", "",
         ft:search("/db/lucenetest/", "title:*rem", (), <options><leading-wildcard>yes</leading-wildcard></options>)/search/@uri/string()


### PR DESCRIPTION
5.0.0 backport for #2279

### Description:
ft:search currently doesn't allow specifying options, which in particular makes leading-wildcard queries impossible on computed index fields

### Reference:
no issue has been registered so far afaik

### Type of tests:
Relevant test has been attached with this PR