### PR TITLE
(develop) Prevent NPE in unparsed-text-available for GitHub URL

### DIFF
--- a/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
+++ b/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
@@ -147,10 +147,11 @@ public class FunUnparsedText extends BasicFunction {
             final Charset charset = getCharset(encoding, source);
             final StringWriter output = new StringWriter();
             try (final InputStream is = source.getInputStream()) {
+                // InputStream can have value NULL for data retrieved from URL
                 IOUtils.copy(is, output, charset);
             }
             return output.toString();
-        } catch (final IOException e) {
+        } catch (final IOException | NullPointerException e) {
             throw new XPathException(this, ErrorCodes.FOUT1170, e.getMessage());
         }
     }

--- a/src/test/xquery/unparsed-text.xql
+++ b/src/test/xquery/unparsed-text.xql
@@ -157,6 +157,13 @@ function upt:unparsed-text-available-from-url-encoding() {
     unparsed-text-available("https://raw.githubusercontent.com/eXist-db/exist/develop/src/test/xquery/README", "UTF-8")
 };
 
+declare
+    %test:assumeInternetAccess("https://raw.githubusercontent.com")
+    %test:assertFalse
+function upt:unparsed-text-available-from-url-encoding-no-content() {
+    unparsed-text-available("https://raw.githubusercontent.com/eXist-db/exist/develop/src/test/xquery/READMEaaaa", "UTF-8")
+};
+
 declare 
     %test:assertTrue
 function upt:unparsed-text-available-from-db() {


### PR DESCRIPTION
Prevent unhandled NPE in unparsed-text-available() for GitHub URL

```xquery
unparsed-text-available("https://raw.githubusercontent.com/eXist-db/exist/develop/src/test/xquery/READMEaaaa")
```

