### PR TITLE
(4xx) Update path to new location of yajsw classes

### DIFF
--- a/tools/yajsw/conf/wrapper.conf.in
+++ b/tools/yajsw/conf/wrapper.conf.in
@@ -86,7 +86,7 @@ wrapper.java.app.mainclass=org.exist.yajsw.Main
 # Java Classpath (include wrapper.jar)  Add class path elements as
 #  needed starting from 1
 # YAJSW: all libs required by YAJSW are in the manifest of the wrapper.jar -> only classpath of your application is required
-wrapper.java.classpath.1=@server.dir@/tools/yajsw/classes
+wrapper.java.classpath.1=@server.dir@/tools/yajsw/target/classes
 wrapper.java.classpath.2=start.jar
 
 # Java Library Path


### PR DESCRIPTION
requires #2500 

```
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|error finding main method in class: org.exist.yajsw.Main : org.exist.yajsw.Main
INFO|wrapper|Service eXist-db|19-02-19 20:55:20|too many restarts 
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|java.lang.ClassNotFoundException: org.exist.yajsw.Main
INFO|wrapper|Service eXist-db|19-02-19 20:55:20|too many restarts 
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|no java main method found -> aborting
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at org.rzo.yajsw.app.WrapperManagerImpl.init(WrapperManagerImpl.java:333)
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at org.rzo.yajsw.app.WrapperManagerProxy.getWrapperManager(WrapperManagerProxy.java:53)
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at org.rzo.yajsw.app.AbstractWrapperJVMMain$1.run(AbstractWrapperJVMMain.java:64)
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at java.security.AccessController.doPrivileged(Native Method)
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at org.rzo.yajsw.app.AbstractWrapperJVMMain.preExecute(AbstractWrapperJVMMain.java:56)
INFO|94578/5|Service eXist-db|19-02-19 20:55:20|        at org.rzo.yajsw.app.WrapperJVMMain.main(WrapperJVMMain.java:41)
```