### PR TITLE
(4.x.x) XMLWriter is leaking instances of QName

### DIFF
--- a/exist-core/src/main/java/org/exist/util/serializer/XMLWriter.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/XMLWriter.java
@@ -247,12 +247,12 @@ public class XMLWriter {
         try {
             if (tagIsOpen) {
                 closeStartTag(true);
-                elementName.pop();
             } else {
                 writer.write("</");
                 writer.write(qname);
                 writer.write('>');
             }
+            elementName.pop();
         } catch(final IOException ioe) {
             throw new TransformerException(ioe.getMessage(), ioe);
         }
@@ -262,7 +262,6 @@ public class XMLWriter {
         try {
             if(tagIsOpen) {
                 closeStartTag(true);
-                elementName.pop();
             } else {
                 writer.write("</");
                 if(qname.getPrefix() != null && qname.getPrefix().length() > 0) {
@@ -272,6 +271,7 @@ public class XMLWriter {
                 writer.write(qname.getLocalPart());
                 writer.write('>');
             }
+            elementName.pop();
         } catch(final IOException ioe) {
             throw new TransformerException(ioe.getMessage(), ioe);
         }


### PR DESCRIPTION
Fix a memory leak introduced with 6e8d781fa3574896c51409cfbacbb9263a36b2a7. The leak becomes visible when serializing a larger amount of XML.