### PR TITLE
Start fine with recovery disabled (Fixes issue #2533)

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -1442,7 +1442,9 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
          *            made by some transaction T, it is necessary that the update record
          *            <T,X,v,w> appear on disk.
          */
-        journalManager.get().flush(true, true);
+        if(journalManager.isPresent()) {
+            journalManager.get().flush(true, true);
+        }
 
         // sync various DBX files
         broker.sync(syncEvent);

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/LogFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/LogFunction.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.source.StringSource;
-import org.exist.storage.serializers.Serializer;
 import org.exist.util.serializer.XQuerySerializer;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
@@ -57,7 +56,7 @@ public class LogFunction extends BasicFunction {
     public static final String FUNCTION_LOGAPP = "log-app";
     public static final String FUNCTION_LOG_SYSTEM_OUT = "log-system-out";
     public static final String FUNCTION_LOG_SYSTEM_ERR = "log-system-err";
-    public final static FunctionSignature signatures[] = {
+    public final static FunctionSignature[] signatures = {
             new FunctionSignature(
                     new QName(FUNCTION_LOG, UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Logs the message to the current logger.",
@@ -147,13 +146,21 @@ public class LogFunction extends BasicFunction {
         // Iterate over all input
         while (i.hasNext()) {
             final Item next = i.nextItem();
-            try (StringWriter writer = new StringWriter()) {
-                XQuerySerializer xqs = new XQuerySerializer(context.getBroker(), props, writer);
-                xqs.serialize(next.toSequence());
-                buf.append(writer.toString());
 
-            } catch (IOException | SAXException e) {
-                throw new XPathException(this, e.getMessage());
+            if(next instanceof StringValue){
+                // Use simple string value
+                buf.append(next.getStringValue());
+
+            } else {
+                // Serialize data
+                try (StringWriter writer = new StringWriter()) {
+                    XQuerySerializer xqs = new XQuerySerializer(context.getBroker(), props, writer);
+                    xqs.serialize(next.toSequence());
+                    buf.append(writer.toString());
+
+                } catch (IOException | SAXException e) {
+                    throw new XPathException(this, e.getMessage());
+                }
             }
 
         }

--- a/exist-core/src/test/java/org/exist/storage/BrokerPoolNoRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/BrokerPoolNoRecoveryTest.java
@@ -19,6 +19,8 @@
  */
 package org.exist.storage;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.exist.test.ExistEmbeddedServer;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,15 +34,16 @@ public class BrokerPoolNoRecoveryTest {
 
     @Rule
     public final ExistEmbeddedServer existEmbeddedServer =
-        new ExistEmbeddedServer( createConfigProperties(), true, false);
+            new ExistEmbeddedServer(createConfigProperties(), true, false);
 
     @Test
-    public void testIt(){
+    public void testSync_Recovery_Disabled() {
         // For this test it is sufficient to have startDb() called in ExistEmbeddedServer.
         // With disabled recovery, this used to fail with a java.util.NoSuchElementException: No value present
+        assertNotNull(existEmbeddedServer.getBrokerPool()); // for Codacy alone
     }
 
-    private static Properties createConfigProperties(){
+    private static Properties createConfigProperties() {
         Properties configProperties = new Properties();
         configProperties.put(BrokerPoolConstants.PROPERTY_RECOVERY_ENABLED, Boolean.FALSE);
         return configProperties;

--- a/exist-core/src/test/java/org/exist/storage/BrokerPoolNoRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/BrokerPoolNoRecoveryTest.java
@@ -1,0 +1,48 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.exist.test.ExistEmbeddedServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Properties;
+
+/**
+ * @author Otmar Humbel <ohumbel@gmail.com>
+ */
+public class BrokerPoolNoRecoveryTest {
+
+    @Rule
+    public final ExistEmbeddedServer existEmbeddedServer =
+        new ExistEmbeddedServer( createConfigProperties(), true, false);
+
+    @Test
+    public void testIt(){
+        // For this test it is sufficient to have startDb() called in ExistEmbeddedServer.
+        // With disabled recovery, this used to fail with a java.util.NoSuchElementException: No value present
+    }
+
+    private static Properties createConfigProperties(){
+        Properties configProperties = new Properties();
+        configProperties.put(BrokerPoolConstants.PROPERTY_RECOVERY_ENABLED, Boolean.FALSE);
+        return configProperties;
+    }
+}


### PR DESCRIPTION
### Description:
In `BrokerPool`, there are several accesses to the `Optional` `journalManager`. All except one are checking it for presence before calling `get()`. The fix adds the missing one which was causing the `java.util.NoSuchElementException: No value present` exception.

### Reference:
This fixes [Issue 2533](https://github.com/eXist-db/exist/issues/2533).

### Type of test:
`JUnit` test