### PR TITLE
(4.x.x) Update to Tika version 1.20

### DIFF
--- a/extensions/contentextraction/ivy.xml
+++ b/extensions/contentextraction/ivy.xml
@@ -8,16 +8,18 @@
 
     <dependencies>
 
-        <dependency org="org.apache.tika" name="tika-parsers" rev="1.16" conf="*->*,!sources,!javadoc"/>
+        <dependency org="org.apache.tika" name="tika-parsers" rev="1.20" conf="*->*,!sources,!javadoc"/>
 
         <!-- identified as provided by eXist-db -->
         <exclude module="asm"/>
         <exclude module="aspectjrt"/>
+        <exclude module="bcprov-jdk15on"/>
         <exclude module="commons-codec"/>
         <exclude module="commons-compress"/>
         <exclude module="commons-httpclient"/>
         <exclude module="commons-io"/>
         <exclude module="commons-lang"/>
+        <exclude module="commons-lang3"/>
         <exclude module="commons-logging"/>
         <exclude module="commons-logging-api"/>
         <exclude module="ehcache-core"/>

--- a/extensions/modules/xslfo/ivy.xml
+++ b/extensions/modules/xslfo/ivy.xml
@@ -25,6 +25,9 @@
 
         <dependency org="org.apache.xmlgraphics" name="fop" rev="2.3" conf="*->*,!sources,!javadoc"/>
 
+        <!-- override the version of fontbox used with fop to use the newer one required by eXist-db contentextraction module -->
+        <dependency org="org.apache.pdfbox" name="fontbox" rev="2.0.13" conf="*->*,!sources,!javadoc"/>
+
         <!-- provided by eXist-db -->
         <exclude module="xercesImpl"/>
         <exclude module="xml-apis"/>


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/2558

**NOTE** if we plan to do a 4.6.2 release, we should wait until after that release, before merging this PR! 