### PR TITLE
JMH Benchmark

### DIFF
--- a/.idea/libraries/jmh.xml
+++ b/.idea/libraries/jmh.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+  <library name="jmh">
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/exist-core-jmh/lib" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+    <jarDirectory url="file://$PROJECT_DIR$/exist-core-jmh/lib" recursive="false" />
+  </library>
+</component>

--- a/build.properties
+++ b/build.properties
@@ -36,6 +36,7 @@ use.autodeploy.feature=true
 
 # folders
 module.exist-core = exist-core
+module.exist-core-jmh = exist-core-jmh
 module.exist-start = exist-start
 module.exist-testkit = exist-testkit
 src = src/main/java

--- a/build/scripts/build-impl.xml
+++ b/build/scripts/build-impl.xml
@@ -45,6 +45,7 @@
     <!-- <import file="../../build.xml"/> -->
     <import file="git-support.xml"/>
     <import file="./junit.xml"/>
+    <import file="./jmh.xml"/>
     <import file="./antlr3.xml"/>
 
     <!-- setup conditional properties -->

--- a/build/scripts/jmh.xml
+++ b/build/scripts/jmh.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- ======================================================================= -->
+<!-- eXist-db build file : Run JMH Benchmarks                                -->
+<!-- ======================================================================= -->
+
+<project basedir="../.." default="test" name="JMH Benhmarks">
+
+    <description>JMH Benchmarks for eXist-db</description>
+
+    <!-- import common targets -->
+    <import file="../../build.xml"/>
+
+    <property name="exist-core-jmh.dir" location="${module.exist-core-jmh}"/>
+
+    <property name="exist-core-jmh.lib" location="${exist-core-jmh.dir}/lib"/>
+    <property name="exist-core-jmh.src" location="${exist-core-jmh.dir}/src/main/java"/>
+    <property name="exist-core-jmh.target" location="${exist-core-jmh.dir}/target"/>
+    <property name="exist-core-jmh.target.classes" location="${exist-core-jmh.target}/classes"/>
+
+
+    <target name="jmh-get-deps" description="Download dependencies with Ivy" xmlns:ivy="antlib:org.apache.ivy.ant">
+        <echo>Retrieving JMH jar files</echo>
+        <mkdir dir="${exist-core-jmh.lib}"/>
+
+        <taskdef resource="org/apache/ivy/ant/antlib.xml" uri="antlib:org.apache.ivy.ant" classpathref="classpath.core"/>
+        <ivy:resolve file="${exist-core-jmh.dir}/ivy.xml"/>
+        <ivy:retrieve sync="true" pattern="${exist-core-jmh.lib}/[artifact].[ext]"/>
+        <ivy:cachepath pathid="jmh-deps.classpath" conf="default" />
+    </target>
+
+    <!-- Only remove jars from lib if ivy.xml file is present -->
+    <target name="jmh-rm-deps" description="Remove dependencies downloaded with Ivy">
+        <echo>Removing JMH jar files</echo>
+        <delete dir="${exist-core-jmh.lib}" verbose="true"/>
+    </target>
+
+    <target name="exist-core-jmh-compile" depends="compile,jmh-get-deps" description="Generate the self-contained JMH JAR">
+        <mkdir dir="${exist-core-jmh.target.classes}"/>
+
+        <javac includeantruntime="false" srcdir="${exist-core-jmh.src}" destdir="${exist-core-jmh.target.classes}"
+               encoding="UTF-8" source="${build.compiler.source}" target="${build.compiler.target}">
+            <classpath>
+                <path refid="jmh-deps.classpath"/>
+                <path refid="classpath.core"/>
+                <path path="${module.exist-core}/${build.classes}"/>
+            </classpath>
+        </javac>
+
+    </target>
+
+    <!--
+        The workflow is as follows:
+          - Compile the benchmarks with JMH and JMH Annotation processor in classpath.
+              * Annotation processors will run and generate synthetic code.
+              * Annotation processors will create the list of discovered benchmarks.
+          - Pack the classes, generated code, benchmark lists in a JAR
+              * Bring the dependencies along in the JAR; Annotation processor is not
+                required in final JAR
+              * (You might be able to run JMH without the self-contained JAR,
+                take note of the META-INF/* files in that case)
+              * Filter out META-INF/services/ to disable JMH processors for the future
+    -->
+    <target name="exist-core-jmh-jar" depends="jar,exist-core-jmh-compile" description="Generate the self-contained JMH JAR">
+
+        <jar jarfile="${exist-core-jmh.target}/exist-core-jmh-benchmarks.jar" basedir="${exist-core-jmh.target.classes}">
+            <manifest>
+                <attribute name="Main-Class" value="org.openjdk.jmh.Main"/>
+            </manifest>
+            <zipfileset src="${exist-core-jmh.lib}/jmh-core.jar" excludes="**/META-INF/services/**" />
+            <zipfileset src="${exist-core-jmh.lib}/jopt-simple.jar" />
+            <zipfileset src="${exist-core-jmh.lib}/commons-math3.jar" />
+
+            <zipfileset src="exist.jar" excludes="**/META-INF/**" />
+            <zipfileset src="${lib.core}/log4j-api-2.11.0.jar" excludes="**/META-INF/**" />
+            <zipfileset src="${lib.core}/j8fu-1.21.jar" excludes="**/META-INF/**" />
+            <zipfileset src="${lib.core}/jctools-core-2.1.2.jar" excludes="**/META-INF/**" />
+        </jar>
+    </target>
+
+    <target name="clean-exist-core-jmh" depends="jmh-rm-deps">
+        <delete dir="${exist-core-jmh.target}" verbose="true"/>
+    </target>
+
+</project>

--- a/eXist-db.iml
+++ b/eXist-db.iml
@@ -102,6 +102,7 @@
       <sourceFolder url="file://$MODULE_DIR$/exist-testkit/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/exist-testkit/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/exist-testkit/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/exist-core-jmh/src/main/java" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/autodeploy" />
       <excludeFolder url="file://$MODULE_DIR$/backup" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
@@ -140,5 +141,6 @@
     <orderEntry type="library" name="lib" level="project" />
     <orderEntry type="library" name="lib-memcached" level="project" />
     <orderEntry type="library" name="lib-cqlparser" level="project" />
+    <orderEntry type="library" name="jmh" level="project" />
   </component>
 </module>

--- a/exist-core-jmh/ivy.xml
+++ b/exist-core-jmh/ivy.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ eXist Open Source Native XML Database
+  ~ Copyright (C) 2001-2019 The eXist Project
+  ~ http://exist-db.org
+  ~
+  ~ This program is free software; you can redistribute it and/or
+  ~ modify it under the terms of the GNU Lesser General Public License
+  ~ as published by the Free Software Foundation; either version 2
+  ~ of the License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this library; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+  -->
+<ivy-module version="2.0">
+
+    <info organisation="org.exist" module="exist-core-jmh"/>
+
+    <dependencies>
+
+        <dependency org="org.openjdk.jmh" name="jmh-core" rev="1.21" conf="*->*,!sources,!javadoc"/>
+        <dependency org="org.openjdk.jmh" name="jmh-generator-annprocess" rev="1.21" conf="*->*,!sources,!javadoc"/>
+
+    </dependencies>
+
+</ivy-module>

--- a/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
@@ -20,12 +20,164 @@
 package org.exist.storage.lock;
 
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
 
 public class LockTableBenchmark {
 
+    private static final int DATA_SUB_COLLECTIONS = 13;
+    private static final int DOCUMENTS = 20;
+
+    private static final int EVENTS_BTREE_READ_LOCK = 593062;
+    private static final int EVENTS_COLLECTION_INTENTION_READ_LOCK = 86619;
+    private static final int EVENTS_COLLECTION_READ_LOCK = 19630;
+    private static final int EVENTS_DOCUMENT_READ_LOCK = 60370;
+
+
+    @State(Scope.Benchmark)
+    public static class LockTableState {
+        private final LockTable lockTable = new LockTable("jmh-LockTableBenchmark", new ThreadGroup("jmh-locktable"));
+    }
+
+    @State(Scope.Thread)
+    public static class EventsState {
+        private int btreeReads = 0;
+        private int collectionIntentionReads = 0;
+        private int collectionReads = 0;
+        private int documentReads = 0;
+
+        private int dataSubCollectionIndex = 0;
+        private int documentsIndex = 0;
+    }
+
     @Benchmark
-    public void testMethod() {
-        // This is a demo/sample template for building your JMH benchmarks. Edit as needed.
-        // Put your benchmark code here.
+    public void testEvent(final LockTableState lockTableState, final EventsState eventsState) {
+        while (!(eventsState.collectionIntentionReads >= EVENTS_COLLECTION_INTENTION_READ_LOCK
+                && eventsState.collectionReads >= EVENTS_COLLECTION_READ_LOCK
+                && eventsState.documentReads >= EVENTS_DOCUMENT_READ_LOCK
+                && eventsState.btreeReads >= EVENTS_BTREE_READ_LOCK
+        )) {
+
+            final long groupId = System.nanoTime();
+
+            if (eventsState.btreeReads < EVENTS_BTREE_READ_LOCK) {
+                lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                eventsState.btreeReads++;
+                lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+            }
+
+            boolean didCollectionIntentionRead = false;
+            if (eventsState.collectionIntentionReads < EVENTS_COLLECTION_INTENTION_READ_LOCK) {
+                lockTableState.lockTable.attempt(groupId, "/db", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                lockTableState.lockTable.acquired(groupId, "/db", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                eventsState.collectionIntentionReads++;
+
+                if (eventsState.btreeReads < EVENTS_BTREE_READ_LOCK) {
+                    lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    eventsState.btreeReads++;
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                }
+
+                lockTableState.lockTable.attempt(groupId, "/db/apps", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                lockTableState.lockTable.acquired(groupId, "/db/apps", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                lockTableState.lockTable.released(groupId, "/db", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                eventsState.collectionIntentionReads++;
+
+                if (eventsState.btreeReads < EVENTS_BTREE_READ_LOCK) {
+                    lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    eventsState.btreeReads++;
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                }
+
+                lockTableState.lockTable.attempt(groupId, "/db/apps/docs", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                lockTableState.lockTable.acquired(groupId, "/db/apps/docs", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                lockTableState.lockTable.released(groupId, "/db/apps", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                eventsState.collectionIntentionReads++;
+
+                if (eventsState.btreeReads < EVENTS_BTREE_READ_LOCK) {
+                    lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    eventsState.btreeReads++;
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                }
+
+                lockTableState.lockTable.attempt(groupId, "/db/apps/docs/data", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                lockTableState.lockTable.acquired(groupId, "/db/apps/docs/data", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                lockTableState.lockTable.released(groupId, "/db/apps/docs", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+                eventsState.collectionIntentionReads++;
+
+                if (eventsState.btreeReads < EVENTS_BTREE_READ_LOCK) {
+                    lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    eventsState.btreeReads++;
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                }
+
+                didCollectionIntentionRead = true;
+            }
+
+            if (eventsState.dataSubCollectionIndex > DATA_SUB_COLLECTIONS) {
+                eventsState.dataSubCollectionIndex = 0;
+            }
+            final String dataSubCollection = "/db/apps/docs/data/" + eventsState.dataSubCollectionIndex++;
+
+            boolean didCollectionRead = false;
+            if (eventsState.collectionReads < EVENTS_COLLECTION_READ_LOCK) {
+
+                if (eventsState.btreeReads < EVENTS_BTREE_READ_LOCK) {
+                    lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    eventsState.btreeReads++;
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                }
+
+                lockTableState.lockTable.attempt(groupId, dataSubCollection, Lock.LockType.COLLECTION, Lock.LockMode.READ_LOCK);
+                lockTableState.lockTable.acquired(groupId, dataSubCollection, Lock.LockType.COLLECTION, Lock.LockMode.READ_LOCK);
+                eventsState.collectionReads++;
+
+                didCollectionRead = true;
+            }
+
+            if (didCollectionIntentionRead) {
+                lockTableState.lockTable.released(groupId, "/db/apps/docs/data", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
+            }
+
+            if (eventsState.documentReads < EVENTS_DOCUMENT_READ_LOCK) {
+                if (eventsState.btreeReads < EVENTS_BTREE_READ_LOCK) {
+                    lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    eventsState.btreeReads++;
+                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                }
+
+                if (eventsState.documentsIndex > DOCUMENTS) {
+                    eventsState.documentsIndex = 0;
+                }
+                final String document = dataSubCollection + '/' + eventsState.documentsIndex++;
+                lockTableState.lockTable.attempt(groupId, document, Lock.LockType.DOCUMENT, Lock.LockMode.READ_LOCK);
+                lockTableState.lockTable.acquired(groupId, document, Lock.LockType.DOCUMENT, Lock.LockMode.READ_LOCK);
+                eventsState.documentReads++;
+
+                lockTableState.lockTable.released(groupId, document, Lock.LockType.DOCUMENT, Lock.LockMode.READ_LOCK);
+            }
+
+            if (didCollectionRead) {
+                lockTableState.lockTable.released(groupId, dataSubCollection, Lock.LockType.COLLECTION, Lock.LockMode.READ_LOCK);
+            }
+        }
+    }
+
+    public static void main(final String args[]) {
+        // NOTE: just for running with the java debugger
+        LockTableBenchmark lockTableBenchmark = new LockTableBenchmark();
+        LockTableState lockTableState = new LockTableState();
+        EventsState eventsState = new EventsState();
+
+        lockTableBenchmark.testEvent(lockTableState, eventsState);
+
+        lockTableState.lockTable.shutdown();
     }
 }

--- a/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
@@ -1,0 +1,31 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage.lock;
+
+import org.openjdk.jmh.annotations.Benchmark;
+
+public class LockTableBenchmark {
+
+    @Benchmark
+    public void testMethod() {
+        // This is a demo/sample template for building your JMH benchmarks. Edit as needed.
+        // Put your benchmark code here.
+    }
+}


### PR DESCRIPTION
This PR adds the ability to run JMH Benchmarks against eXist-db.

It also adds one JMH Benchmark for the `LockTable`.

I was previously using JMeter, which allowed me in combination with a profiler to identify where the bottleneck in eXist-db 5.0.0 is when compared to eXist-db 4.x.x. This revealed the fact that the `LockTable` was being overwhelmed, as it had 20 producers (20 brokers) and only one consumer to process the lock events... which could not keep up!

However, whilst JMeter is interesting, it shows far too much variance in results for it to be of use tuning small parts of the code base. JMH is a Microbenchmark which is designed for tightly measuring small functions, it also takes care of variation through *warmup* and allows one to run concurrent benchmarks with *N* threads.

To run the concurrent LockTable Benchmark with 8 threads:
```
$ cd $EXIST_HOME
$ ./build.sh exist-core-jmh-jar
$ java -jar /Users/aretter/code/exist-git/exist-core-jmh/target/exist-core-jmh-benchmarks.jar -t 8
```

If you wish to clean and try again, you can run `./build.sh clean-exist-core-jmh`.

I am by no means a JMH expert... so this just represents just a starting point!
