### PR TITLE
Dynamically loaded module vars not analyzed

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ExternalModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExternalModule.java
@@ -63,6 +63,11 @@ public interface ExternalModule extends Module {
 
     public void declareVariable(QName qname, VariableDeclaration decl) throws XPathException;
 
+    /**
+     * Analyze declared variables. Needs to be called when the module was imported dynamically.
+     *
+     * @throws XPathException
+     */
     public void analyzeGlobalVars() throws XPathException;
 
     public Collection<VariableDeclaration> getVariableDeclarations();

--- a/exist-core/src/main/java/org/exist/xquery/ExternalModuleImpl.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExternalModuleImpl.java
@@ -242,8 +242,7 @@ public class ExternalModuleImpl implements ExternalModule {
 
     public void analyzeGlobalVars() throws XPathException {
         for (final VariableDeclaration decl : mGlobalVariables.values()) {
-            decl.resetState(false);
-            decl.analyze(new AnalyzeContextInfo());
+            decl.analyzeExpression(new AnalyzeContextInfo());
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
+++ b/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
@@ -96,10 +96,21 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
             }
             analyzeDone = true;
         }
+        analyzeExpression(contextInfo);
+        var.setIsInitialized(true);
+    }
+
+    /**
+     * Analyze just the expression. For dynamically imported modules this needs to be done one time
+     * after import.
+     *
+     * @param contextInfo
+     * @throws XPathException
+     */
+    public void analyzeExpression(AnalyzeContextInfo contextInfo) throws XPathException {
         if (expression.isPresent()) {
             expression.get().analyze(contextInfo);
         }
-        var.setIsInitialized(true);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/LoadXQueryModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/LoadXQueryModule.java
@@ -177,6 +177,12 @@ public class LoadXQueryModule extends BasicFunction {
         final Module module = loadedModule;
         module.setContextItem(contextItem);
         setExternalVars(externalVars, module::declareVariable);
+        if (!module.isInternalModule()) {
+            // ensure variable declarations in the imported module are analyzed.
+            // unlike when using a normal import statement, this is not done automatically
+            ((ExternalModule)module).analyzeGlobalVars();
+        }
+
         final MapType result = new MapType(context);
 
         final ValueSequence functionSeq = new ValueSequence();

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/ModuleFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/ModuleFunctions.java
@@ -95,6 +95,11 @@ public class ModuleFunctions extends BasicFunction {
             if (module == null) {
                 return Sequence.EMPTY_SEQUENCE;
             }
+            if (!module.isInternalModule()) {
+                // ensure variable declarations in the imported module are analyzed.
+                // unlike when using a normal import statement, this is not done automatically
+                ((ExternalModule)module).analyzeGlobalVars();
+            }
             LoadXQueryModule.addFunctionRefsFromModule(this, tempContext, list, module);
         } else {
             addFunctionRefsFromContext(list);

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/PrologFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/PrologFunctions.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 import org.exist.dom.QName;
 import org.exist.xquery.*;
 import org.exist.xquery.Module;
+import org.exist.xquery.functions.fn.LoadXQueryModule;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceType;
@@ -48,7 +49,7 @@ public class PrologFunctions extends BasicFunction {
 				new FunctionParameterSequenceType("location", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The location of the module")
 			},
 			new SequenceType(Type.ITEM, Cardinality.EMPTY),
-			"Prefer fn:load-xquery-module"),
+			LoadXQueryModule.LOAD_XQUERY_MODULE_2),
 		new FunctionSignature(
 			new QName("declare-namespace", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
 			"Dynamically declares a namespace/prefix mapping for the current context.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/PrologFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/PrologFunctions.java
@@ -47,7 +47,8 @@ public class PrologFunctions extends BasicFunction {
 				new FunctionParameterSequenceType("prefix", Type.STRING, Cardinality.EXACTLY_ONE, "The prefix to be assigned to the namespace"),
 				new FunctionParameterSequenceType("location", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The location of the module")
 			},
-			new SequenceType(Type.ITEM, Cardinality.EMPTY)),
+			new SequenceType(Type.ITEM, Cardinality.EMPTY),
+			"Prefer fn:load-xquery-module"),
 		new FunctionSignature(
 			new QName("declare-namespace", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
 			"Dynamically declares a namespace/prefix mapping for the current context.",
@@ -115,9 +116,11 @@ public class PrologFunctions extends BasicFunction {
 
 		context.getRootContext().resolveForwardReferences();
 
-		if( !module.isInternalModule() ) {
-        	((ExternalModule)module).getRootExpression().analyze( new AnalyzeContextInfo() );
-        }
+		if (!module.isInternalModule()) {
+			// ensure variable declarations in the imported module are analyzed.
+			// unlike when using a normal import statement, this is not done automatically
+			((ExternalModule)module).analyzeGlobalVars();
+		}
 		
 //		context.getRootContext().analyzeAndOptimizeIfModulesChanged((PathExpr) context.getRootExpression());
 	}

--- a/exist-core/src/test/xquery/xquery3/closure-in-maps.xql
+++ b/exist-core/src/test/xquery/xquery3/closure-in-maps.xql
@@ -1,5 +1,5 @@
 (:~
- : See https://github.com/eXist-db/exist/issues/1550
+ : @see https://github.com/eXist-db/exist/issues/1550
  :)
 xquery version "3.1";
 
@@ -15,9 +15,9 @@ declare variable $ct:model := function($param) {
     }
     return
         map {
-        'test1' : $func,
-        'test2' : $func(),
-        'test3' : function() {
+        'test1': $func,
+        'test2': $func(),
+        'test3': function() {
             $param
         }
         }

--- a/exist-core/src/test/xquery/xquery3/closure-in-maps.xql
+++ b/exist-core/src/test/xquery/xquery3/closure-in-maps.xql
@@ -1,0 +1,45 @@
+(:~
+ : See https://github.com/eXist-db/exist/issues/1550
+ :)
+xquery version "3.1";
+
+module namespace ct="http://exist-db.org/xquery/closures/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $ct:test := "123";
+
+declare variable $ct:model := function($param) {
+    let $func := function() {
+        $param
+    }
+    return
+        map {
+        'test1' : $func,
+        'test2' : $func(),
+        'test3' : function() {
+            $param
+        }
+        }
+};
+
+declare %test:assertEquals('Hello World') function ct:test1-function-reference() as xs:string {
+    try {
+        $ct:model('Hello World')?test1()
+    }
+    catch * {$err:code || ' ' || $err:description}
+};
+
+declare %test:assertEquals('Hello World') function ct:test2-function-call() as xs:string {
+    try {
+        $ct:model('Hello World')?test2
+    }
+    catch * {$err:code || ' ' || $err:description}
+};
+
+declare %test:assertEquals('Hello World') function ct:test3-inline-function() as xs:string {
+    try {
+        $ct:model('Hello World')?test3()
+    }
+    catch * {$err:code || ' ' || $err:description}
+};

--- a/exist-core/src/test/xquery/xquery3/dynamically-declared-vars.xql
+++ b/exist-core/src/test/xquery/xquery3/dynamically-declared-vars.xql
@@ -1,0 +1,38 @@
+xquery version "3.1";
+
+module namespace devar="http://exist-db.org/xquery/test/declared-variables";
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $devar:static := 'I am static.';
+declare variable $devar:dynamic := replace($devar:static, 'static', 'dynamic');
+declare variable $devar:function := (function ($a) {
+    replace($a, 'static', 'the return of a function expression')
+})($devar:static);
+
+declare variable $devar:arrow := $devar:static
+=> replace('static', 'the return of an arrow expression')
+;
+
+declare
+%test:assertEquals('I am static.')
+function devar:read-static () {
+    $devar:static
+};
+
+declare
+%test:assertEquals('I am dynamic.')
+function devar:read-dynamic () {
+    $devar:dynamic
+};
+
+declare
+%test:assertEquals('I am the return of a function expression.')
+function devar:read-function () {
+    $devar:function
+};
+
+declare
+%test:assertEquals('I am the return of a arrow expression.')
+function devar:read-arrow () {
+    $devar:arrow
+};

--- a/exist-core/src/test/xquery/xquery3/dynamically-declared-vars.xql
+++ b/exist-core/src/test/xquery/xquery3/dynamically-declared-vars.xql
@@ -32,7 +32,7 @@ function devar:read-function () {
 };
 
 declare
-%test:assertEquals('I am the return of a arrow expression.')
+%test:assertEquals('I am the return of an arrow expression.')
 function devar:read-arrow () {
     $devar:arrow
 };


### PR DESCRIPTION
### Description:

Trying to reproduce #1550 it turned out that globally declared variables are not properly analyzed when a module is loaded dynamically, e.g. via `load-xquery-module`. A statically loaded module would be analyzed during compilation. For dynamically loaded modules we thus need to call analyze one time on all declared variables. Not doing so causes a NPE on expressions used within the variable declaration, which depend on the analysis context. #2437 demonstrates the XQuery issue itself, while #1550 reports a wrong failure in XQSuite due to the same bug.

### Reference:

Closes #1550, #2437