### PR TITLE
Fix purging of old zip backups

### DIFF
--- a/exist-core/src/main/java/org/exist/util/FileUtils.java
+++ b/exist-core/src/main/java/org/exist/util/FileUtils.java
@@ -38,6 +38,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.function.Predicate;
 
 import static java.nio.file.StandardOpenOption.READ;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
@@ -479,4 +480,21 @@ public class FileUtils {
             }
         }
     }
+    
+    /**
+     * Provides a filter for entries in a directory.
+     *
+     * @param path the entry to be filtered.
+     * @param prefix the prefix used for filtering.
+     * @param prefix the suffix used for filtering.
+     * 
+     * @return The filter.
+     */
+	public static Predicate<Path> getPrefixSuffixFilter(final String prefix, final String suffix) {
+		return path -> {
+			String entryName = path.getFileName().toString();
+			
+			return entryName.startsWith(prefix) && entryName.endsWith(suffix);
+		};
+	}    
 }


### PR DESCRIPTION
Closes #2387

### What is the problem
A backup job as below is not limiting the number of backups in case when suffix is not equal with ".zip
```xml
<job type="system" class="org.exist.storage.BackupSystemTask" cron-trigger="0 0 3 ? * * *">
        <parameter name="dir" value="/home/claudius/exist-db/backup" />
        <parameter name="prefix" value="full-backup-" />
        <parameter name="collection" value="/db" />
        <parameter name="user" value="admin" />
        <parameter name="password" value="password" />
        <parameter name="zip-files-max" value="2" />
</job>
```
### What did you expect
I would expect only two backups to be maintained.

### Describe how to reproduce or add a test
Anyone can reproduce this issue, by using the above backup job in conf.xml.

### Context information
- eXist-db 4.4.0 / ab5716180
- java version "1.8.0_191"
- ubuntu 18
- 64 bit
- How is eXist-db installed? - JAR installer
