### PR TITLE
Improve the performance of the LockTable

### DIFF
--- a/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
@@ -64,7 +64,7 @@ public class LockTableBenchmark {
                 lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                 lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                 eventsState.btreeReads++;
-                lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                lockTableState.lockTable.released(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
             }
 
             boolean didCollectionIntentionRead = false;
@@ -77,7 +77,7 @@ public class LockTableBenchmark {
                     lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     eventsState.btreeReads++;
-                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.released(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                 }
 
                 lockTableState.lockTable.attempt(groupId, "/db/apps", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
@@ -89,7 +89,7 @@ public class LockTableBenchmark {
                     lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     eventsState.btreeReads++;
-                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.released(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                 }
 
                 lockTableState.lockTable.attempt(groupId, "/db/apps/docs", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
@@ -101,7 +101,7 @@ public class LockTableBenchmark {
                     lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     eventsState.btreeReads++;
-                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.released(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                 }
 
                 lockTableState.lockTable.attempt(groupId, "/db/apps/docs/data", Lock.LockType.COLLECTION, Lock.LockMode.INTENTION_READ);
@@ -113,7 +113,7 @@ public class LockTableBenchmark {
                     lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     eventsState.btreeReads++;
-                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.released(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                 }
 
                 didCollectionIntentionRead = true;
@@ -131,7 +131,7 @@ public class LockTableBenchmark {
                     lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     eventsState.btreeReads++;
-                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.released(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                 }
 
                 lockTableState.lockTable.attempt(groupId, dataSubCollection, Lock.LockType.COLLECTION, Lock.LockMode.READ_LOCK);
@@ -150,7 +150,7 @@ public class LockTableBenchmark {
                     lockTableState.lockTable.attempt(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                     eventsState.btreeReads++;
-                    lockTableState.lockTable.acquired(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
+                    lockTableState.lockTable.released(groupId, "BTREE", Lock.LockType.BTREE, Lock.LockMode.READ_LOCK);
                 }
 
                 if (eventsState.documentsIndex > DOCUMENTS) {

--- a/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
@@ -36,7 +36,7 @@ public class LockTableBenchmark {
 
     @State(Scope.Benchmark)
     public static class LockTableState {
-        private final LockTable lockTable = new LockTable("jmh-LockTableBenchmark", new ThreadGroup("jmh-locktable"));
+        private final LockTable lockTable = new LockTable();
     }
 
     @State(Scope.Thread)

--- a/exist-core/src/main/java/org/exist/collections/MutableCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/MutableCollection.java
@@ -961,7 +961,7 @@ public class MutableCollection implements Collection {
     }
 
     @Override
-public void removeXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name)
+    public void removeXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name)
             throws PermissionDeniedException, TriggerException, LockException, IOException {
         final BrokerPool db = broker.getBrokerPool();
 
@@ -972,7 +972,7 @@ public void removeXMLResource(final Txn transaction, final DBBroker broker, fina
             }
 
             final XmldbURI docUri = XmldbURI.create(name.getRawCollectionPath());
-            try(final ManagedDocumentLock docUpdateLock = lockManager.acquireDocumentWriteLock(docUri)) {
+            try(final ManagedDocumentLock docUpdateLock = lockManager.acquireDocumentWriteLock(path.append(docUri))) {
 
                 final DocumentImpl doc = documents.get(docUri);
 

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -454,7 +454,7 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
     }
 
     private void _initialize() throws EXistException, DatabaseConfigurationException {
-        this.lockManager = new LockManager(instanceName, instanceThreadGroup, concurrencyLevel);
+        this.lockManager = new LockManager(concurrencyLevel);
 
         //Flag to indicate that we are initializing
         status.process(Event.INITIALIZE);

--- a/exist-core/src/main/java/org/exist/storage/lock/Lock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/Lock.java
@@ -28,12 +28,22 @@ public interface Lock extends Debuggable {
      * The modes of a {@link Lock}
      */
     enum LockMode {
-        NO_LOCK,
-        READ_LOCK,
-        WRITE_LOCK,
+        NO_LOCK((byte)0x0),
+        READ_LOCK((byte)0x1),
+        WRITE_LOCK((byte)0x2),
 
-        INTENTION_READ,
-        INTENTION_WRITE
+        INTENTION_READ((byte)0x3),
+        INTENTION_WRITE((byte)0x4);
+
+        private final byte val;
+
+        LockMode(final byte val) {
+            this.val = val;
+        }
+
+        public byte getVal() {
+            return val;
+        }
     }
 
     /**
@@ -44,15 +54,25 @@ public interface Lock extends Debuggable {
         /**
          * Should not be used outside of {@link EnsureLocked}!
          */
-        @Deprecated UNKNOWN,
+        @Deprecated UNKNOWN((byte) 0x5),
 
-        @Deprecated LEGACY_COLLECTION,
-        @Deprecated LEGACY_DOCUMENT,
+        @Deprecated LEGACY_COLLECTION((byte) 0x4),
+        @Deprecated LEGACY_DOCUMENT((byte) 0x3),
 
-        COLLECTION,
-        DOCUMENT,
+        COLLECTION((byte) 0x2),
+        DOCUMENT((byte) 0x1),
 
-        BTREE
+        BTREE((byte) 0x0);
+
+        private final byte val;
+
+        LockType(final byte val) {
+            this.val = val;
+        }
+
+        public byte getVal() {
+            return val;
+        }
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/lock/LockEventLogListener.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockEventLogListener.java
@@ -43,9 +43,14 @@ public class LockEventLogListener implements LockTable.LockEventListener {
     }
 
     @Override
-    public void accept(final LockTable.LockAction lockAction) {
+    public void accept(final LockTable.LockEventType lockEventType, final long timestamp, final long groupId,
+            final LockTable.Entry entry) {
         if(log.isEnabled(level)) {
-            log.log(level, lockAction);
+            // read count first to ensure memory visibility from volatile!
+            final int localCount = entry.count;
+
+            log.log(level, LockTable.formatString(lockEventType, groupId, entry.id, entry.lockType, entry.lockMode,
+                    entry.owner, localCount, timestamp, entry.stackTraces == null ? null : entry.stackTraces.get(0)));
         }
     }
 }

--- a/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
@@ -96,8 +96,8 @@ public class LockManager {
     private final WeakLazyStripes<String, ReentrantLock> btreeLocks;
 
 
-    public LockManager(final String brokerPoolId, final ThreadGroup threadGroup, final int concurrencyLevel) {
-        this.lockTable = new LockTable(brokerPoolId, threadGroup);
+    public LockManager(final int concurrencyLevel) {
+        this.lockTable = new LockTable();
         this.collectionLocks = new WeakLazyStripes<>(concurrencyLevel, LockManager::createCollectionLock);
         this.documentLocks = new WeakLazyStripes<>(concurrencyLevel, LockManager::createDocumentLock);
         this.btreeLocks = new WeakLazyStripes<>(concurrencyLevel, LockManager::createBtreeLock);

--- a/exist-core/src/main/java/org/exist/storage/lock/LockTable.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockTable.java
@@ -466,8 +466,6 @@ public class LockTable {
         final long stamp = listenersLock.writeLock();
         try {
             // reduce listeners by 1
-            //final int newSize = listeners.length - 1;
-            //final LockEventListener[] newListeners = new LockEventListener[newSize];
             for (int i = listeners.length - 1; i > -1; i--) {
                 // intentionally compare by identity!
                 if (listeners[i] == lockEventListener) {

--- a/exist-core/src/main/java/org/exist/util/RingBuffer.java
+++ b/exist-core/src/main/java/org/exist/util/RingBuffer.java
@@ -1,0 +1,76 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.util;
+
+import net.jcip.annotations.NotThreadSafe;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+/**
+ * Simple Ring Buffer implementation.
+ *
+ * @author Adam Retter adam.retter@googlemail.com
+ */
+@NotThreadSafe
+public class RingBuffer<T> {
+    private final int capacity;
+    private final T[] elements;
+
+    private int writePos;
+    private int available;
+
+    @SuppressWarnings("unchecked")
+    public RingBuffer(final int capacity, final Supplier<T> constructor) {
+        this.capacity = capacity;
+        this.elements = (T[])new Object[capacity];
+        for (int i = 0; i < capacity; i++) {
+            elements[i] = constructor.get();
+        }
+
+        this.available = capacity;
+        this.writePos = capacity;
+    }
+
+    public @Nullable T takeEntry() {
+        if(available == 0){
+            return null;
+        }
+        int nextSlot = writePos - available;
+        if(nextSlot < 0){
+            nextSlot += capacity;
+        }
+        final T nextObj = elements[nextSlot];
+        available--;
+        return nextObj;
+    }
+
+    public void returnEntry(final T element) {
+        if(available < capacity){
+            if(writePos >= capacity){
+                writePos = 0;
+            }
+            elements[writePos] = element;
+            writePos++;
+            available++;
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/storage/StartupLockingTest.java
+++ b/exist-core/src/test/java/org/exist/storage/StartupLockingTest.java
@@ -30,10 +30,7 @@ import org.exist.storage.lock.LockTable;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.xmldb.XmldbURI;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.IOException;
 import java.util.Map;
@@ -62,29 +59,22 @@ public class StartupLockingTest {
 
     private static LockTable lockTable;
 
-    @ClassRule
-    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+    @Rule
+    public final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
-    @BeforeClass
-    public static void addListener() {
+    @Before
+    public void addListener() {
         lockTable = existEmbeddedServer.getBrokerPool().getLockManager().getLockTable();
         lockTable.registerListener(lockCountListener);
         while(!lockCountListener.isRegistered()) {}
-//        lockTable.registerListener(lockEventJsonListener);
-//        while(!lockEventJsonListener.isRegistered()) {}
-//        lockTable.registerListener(lockEventXmlListener);
-//        while(!lockEventXmlListener.isRegistered()) {}
     }
 
-    @AfterClass
-    public static void removeListener() {
-        lockTable.deregisterListener(lockCountListener);
-//        lockTable.deregisterListener(lockEventJsonListener);
-//        lockTable.deregisterListener(lockEventXmlListener);
-
-        while(lockCountListener.isRegistered()) {}
-//        while(lockEventJsonListener.isRegistered()) {}
-//        while(lockEventXmlListener.isRegistered()) {}
+    @After
+    public void removeListener() {
+        if (lockCountListener.isRegistered()) {
+            lockTable.deregisterListener(lockCountListener);
+            while (lockCountListener.isRegistered()) {}
+        }
     }
 
     /**

--- a/exist-core/src/test/java/org/exist/storage/StartupLockingTest.java
+++ b/exist-core/src/test/java/org/exist/storage/StartupLockingTest.java
@@ -22,14 +22,10 @@ package org.exist.storage;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import net.jcip.annotations.ThreadSafe;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
-import org.exist.storage.lock.LockEventJsonListener;
-import org.exist.storage.lock.LockEventXmlListener;
 import org.exist.storage.lock.LockTable;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
@@ -40,7 +36,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -192,10 +187,15 @@ public class StartupLockingTest {
         }
 
         @Override
-        public void accept(final LockTable.LockAction lockAction) {
+        public void accept(final LockTable.LockEventType lockEventType, final long timestamp, final long groupId,
+                final LockTable.Entry entry) {
+
+            // read count first to ensure memory visibility from volatile!
+            final int localCount = entry.getCount();
+
             synchronized (lockReadWriteCount) {
                 final long change;
-                switch(lockAction.action) {
+                switch(lockEventType) {
                     case Acquired:
                         change = 1;
                         break;
@@ -208,12 +208,12 @@ public class StartupLockingTest {
                         change = 0;
                 }
 
-                Tuple2<Long, Long> value = lockReadWriteCount.get(lockAction.id);
+                Tuple2<Long, Long> value = lockReadWriteCount.get(entry.getId());
                 if(value == null) {
                     value = new Tuple2<>(0l, 0l);
                 }
 
-                switch(lockAction.mode) {
+                switch(entry.getLockMode()) {
                     case READ_LOCK:
                         value = new Tuple2<>(value._1 + change, value._2);
                         break;
@@ -228,9 +228,9 @@ public class StartupLockingTest {
                 }
 
                 if(value._1 == 0 && value._2 == 0) {
-                    lockReadWriteCount.remove(lockAction.id);
+                    lockReadWriteCount.remove(entry.getId());
                 } else {
-                    lockReadWriteCount.put(lockAction.id, value);
+                    lockReadWriteCount.put(entry.getId(), value);
                 }
             }
         }

--- a/exist-core/src/test/java/org/exist/storage/lock/CollectionLocksTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/CollectionLocksTest.java
@@ -46,9 +46,6 @@ public class CollectionLocksTest {
     private static final int CONCURRENCY_LEVEL = Runtime.getRuntime().availableProcessors() * 3;
     private static final int TEST_DEADLOCK_TIMEOUT = 4000; // 4 seconds
 
-    private final String instanceId = "test.collection-locks-test";
-    private final ThreadGroup threadGroup = new ThreadGroup("collection-locks-test");
-
     /**
      * In the noDeadlock tests this is the maximum amount of time to wait for the second thread to acquire its lock
      *
@@ -113,7 +110,7 @@ public class CollectionLocksTest {
         final int numberOfThreads = CONCURRENCY_LEVEL;
         final XmldbURI collectionUri = XmldbURI.create("/db/x/y/z");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
         final CountDownLatch continueLatch = new CountDownLatch(numberOfThreads);
 
         // thread definition
@@ -184,7 +181,7 @@ public class CollectionLocksTest {
         final int numberOfThreads = CONCURRENCY_LEVEL;
         final XmldbURI collectionUri = XmldbURI.create("/db/x/y/z");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
         final CountDownLatch thread2StartLatch = new CountDownLatch(1);
         final AtomicReference firstWriteHolder = new AtomicReference();
         final AtomicReference lastWriteHolder = new AtomicReference();
@@ -440,7 +437,7 @@ public class CollectionLocksTest {
     }
 
     private void noDeadlock_writeWrite(final XmldbURI col1Uri, final XmldbURI col2Uri) throws InterruptedException {
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
         final Tuple2<Callable<Void>, Callable<Void>> t1t2 = createInterleaved(
                 () -> lockManager.acquireCollectionWriteLock(col1Uri, false),   //t1,1
                 () -> lockManager.acquireCollectionWriteLock(col2Uri, false),   //t2,1
@@ -451,7 +448,7 @@ public class CollectionLocksTest {
     }
 
     private void noDeadlock_writeRead(final XmldbURI col1Uri, final XmldbURI col2Uri) throws InterruptedException {
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
         final Tuple2<Callable<Void>, Callable<Void>> t1t2 = createInterleaved(
                 () -> lockManager.acquireCollectionWriteLock(col1Uri, false),     //t1,1
                 () -> lockManager.acquireCollectionReadLock(col2Uri),                       //t2,1
@@ -462,7 +459,7 @@ public class CollectionLocksTest {
     }
 
     private void noDeadlock_readRead(final XmldbURI col1Uri, final XmldbURI col2Uri) throws InterruptedException {
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
         final Tuple2<Callable<Void>, Callable<Void>> t1t2 = createInterleaved(
                 () -> lockManager.acquireCollectionReadLock(col1Uri),   //t1,1
                 () -> lockManager.acquireCollectionReadLock(col2Uri),   //t2,1
@@ -539,7 +536,7 @@ public class CollectionLocksTest {
         final XmldbURI col1Uri = XmldbURI.create("/db/x/y");
         final XmldbURI col2Uri = XmldbURI.create("/db/x/y/z");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
 
         stress_noDeadlock(
                 () -> lockManager.acquireCollectionWriteLock(col1Uri, false),   //t1,1
@@ -557,7 +554,7 @@ public class CollectionLocksTest {
         final XmldbURI col1Uri = XmldbURI.create("/db/a");
         final XmldbURI col2Uri = XmldbURI.create("/db/b");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
 
         stress_noDeadlock(
                 () -> lockManager.acquireCollectionWriteLock(col1Uri, false),   //t1,1
@@ -575,7 +572,7 @@ public class CollectionLocksTest {
         final XmldbURI col1Uri = XmldbURI.create("/db/x/y");
         final XmldbURI col2Uri = XmldbURI.create("/db/x/y/z");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
 
         stress_noDeadlock(
                 () -> lockManager.acquireCollectionWriteLock(col1Uri, false),     //t1,1
@@ -593,7 +590,7 @@ public class CollectionLocksTest {
         final XmldbURI col1Uri = XmldbURI.create("/db/a");
         final XmldbURI col2Uri = XmldbURI.create("/db/b");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
 
         stress_noDeadlock(
                 () -> lockManager.acquireCollectionWriteLock(col1Uri, false),   //t1,1
@@ -611,7 +608,7 @@ public class CollectionLocksTest {
         final XmldbURI col1Uri = XmldbURI.create("/db/x/y");
         final XmldbURI col2Uri = XmldbURI.create("/db/x/y/z");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
 
         stress_noDeadlock(
                 () -> lockManager.acquireCollectionReadLock(col1Uri),   //t1,1
@@ -629,7 +626,7 @@ public class CollectionLocksTest {
         final XmldbURI col1Uri = XmldbURI.create("/db/a");
         final XmldbURI col2Uri = XmldbURI.create("/db/b");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
 
         stress_noDeadlock(
                 () -> lockManager.acquireCollectionReadLock(col1Uri),   //t1,1

--- a/exist-core/src/test/java/org/exist/storage/lock/DocumentLocksTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/DocumentLocksTest.java
@@ -42,9 +42,6 @@ public class DocumentLocksTest {
 
     private static final int CONCURRENCY_LEVEL = Runtime.getRuntime().availableProcessors() * 3;
 
-    private final String instanceId = "test.document-locks-test";
-    private final ThreadGroup threadGroup = new ThreadGroup("document-locks-test");
-
     /**
      * This test makes sure that there can be multiple reader locks
      * held by different threads on the same Document at the same time
@@ -57,7 +54,7 @@ public class DocumentLocksTest {
         final int numberOfThreads = CONCURRENCY_LEVEL;
         final XmldbURI docUri = XmldbURI.create("/db/x/y/z/1.xml");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
         final CountDownLatch continueLatch = new CountDownLatch(numberOfThreads);
 
         // thread definition
@@ -101,7 +98,7 @@ public class DocumentLocksTest {
         final int numberOfThreads = CONCURRENCY_LEVEL;
         final XmldbURI docUri = XmldbURI.create("/db/x/y/z/1.xml");
 
-        final LockManager lockManager = new LockManager(instanceId, threadGroup, CONCURRENCY_LEVEL);
+        final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
         final CountDownLatch thread2StartLatch = new CountDownLatch(1);
         final AtomicReference firstWriteHolder = new AtomicReference();
         final AtomicReference lastWriteHolder = new AtomicReference();


### PR DESCRIPTION
Hopefully this resolves the performance issue of eXist-db 5.0.0 compared to 4.x.x.

For production, users also have the option of disabling the lock table by using the system property `-Dexist.locktable.disable=true`.