### PR TITLE
(4.x.x) Fix an issue with XQSuite serialization of expected CData

### DIFF
--- a/exist-core/src/main/resources/org/exist/xquery/lib/test.xq
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/test.xq
@@ -62,7 +62,7 @@ declare function t:declare-variable($var as element(variable)) as item()? {
         if (empty($children)) then
             string-join($var/node(), '')
         else
-            util:serialize($children, ())
+            fn:serialize($children)
 };
 
 declare function t:init-prolog($test as element(test)) {
@@ -144,10 +144,17 @@ declare function t:run-test($test as element(test), $count as xs:integer,
             $output
         else if ($test/@serialize) then
             try {
-                let $options := $test/@serialize/string()
+
+                let $ser-params := map:merge(
+                    let $options := fn:tokenize($test/@serialize/string(), " ")
+                    for $option in $options
+                    let $kv := fn:tokenize($option, "=")
+                    return
+                        map:entry($kv[1], $kv[2])
+                )
                 return
                     map {
-                        "result": normalize-space(string-join($output("result") ! util:serialize(., $options)))
+                        "result": normalize-space(string-join($output("result") ! fn:serialize(., $ser-params)))
                     }
             } catch * {
                 map {

--- a/exist-core/src/main/resources/org/exist/xquery/lib/test.xq
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/test.xq
@@ -203,7 +203,7 @@ declare function t:run-test($test as element(test), $count as xs:integer,
                         if(not(empty($expanded("error")))) then
                             if(not(empty($test-error-function))) then $test-error-function($test/task, $expanded("error")) else ()
                         else
-                            if(not(empty($test-failure-function))) then $test-failure-function($test/task, map { "value": $test/expected/*, "xpath": $test/xpath/*, "error": $test/error/* }, $expanded) else ()
+                            if(not(empty($test-failure-function))) then $test-failure-function($test/task, map { "value": $test/expected/node(), "xpath": $test/xpath/node(), "error": $test/error/node() }, $expanded) else ()
                     return
                         ($test/task, $test/expected, $test/xpath, <result>{$expanded("result"), if(not(empty($expanded("error")))) then $expanded("error")("description") else ()}</result>)
                 else

--- a/exist-core/src/test/xquery/json.xml
+++ b/exist-core/src/test/xquery/json.xml
@@ -21,7 +21,7 @@
             </root>
         ]]></code>
         <expected><![CDATA[
-            { "object" : { "prop1" : "PROP1", "prop2" : "PROP2" } }
+            {"object":{"prop1":"PROP1","prop2":"PROP2"}}
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -35,7 +35,7 @@
             </root>
         ]]></code>
         <expected><![CDATA[
-            { "object" : { "attr1" : "a1", "attr2" : "a2", "prop1" : "PROP1", "prop2" : "PROP2" } }
+            {"object":{"attr1":"a1","attr2":"a2","prop1":"PROP1","prop2":"PROP2"}}
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -48,7 +48,9 @@
                 </object>
             </root>
         ]]></code>
-        <expected><![CDATA[{ "object" : { "attr1" : "a1", "attr2" : "a2", "prop" : ["PROP1", "PROP2"] } }]]></expected>
+        <expected><![CDATA[
+            {"object":{"attr1":"a1","attr2":"a2","prop":["PROP1","PROP2"]}}
+        ]]></expected>
     </test>
     <test output="text" serialize="method=json">
         <task>Empty element: serialize as null</task>
@@ -60,7 +62,7 @@
             </root>
         ]]></code>
         <expected><![CDATA[
-            { "object" : { "attr1" : "a1", "attr2" : "a2", "prop" : null } }
+            {"object":{"attr1":"a1","attr2":"a2","prop":null}}
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -71,7 +73,7 @@
             </root>
         ]]></code>
         <expected><![CDATA[
-            { "object" : { "attr1" : "a1", "attr2" : "a2", "#text" : "text" } }
+            {"object":{"attr1":"a1","attr2":"a2","#text":"text"}}
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -87,7 +89,7 @@
             </root>
         ]]></code>
         <expected><![CDATA[
-            { "object" : { "address" : { "street" : "a street", "city" : "a city" } } }
+            {"object":{"address":{"street":"a street","city":"a city"}}}
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -106,9 +108,7 @@
                 </object>
             </root>
         ]]></code>
-        <expected><![CDATA[
-            { "object" : { "address" : [{ "street" : "a street", "city" : "a city" }, { "street" : "another street", "city" : "another city" }] } }
-        ]]></expected>
+        <expected><![CDATA[{"object":{"address":[{"street":"a street","city":"a city"},{"street":"another street","city":"another city"}]}}]]></expected>
     </test>
     <test output="text" serialize="method=json">
         <task>Enforce array for single child</task>
@@ -120,7 +120,7 @@
             </root>
         ]]></code>
         <expected><![CDATA[
-            { "object" : { "prop" : ["PROP1"] } }
+            {"object":{"prop":["PROP1"]}}
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -134,7 +134,7 @@
             </root>
         ]]></code>
         <expected><![CDATA[
-            { "object" : { "prop" : ["PROP1", "PROP2"] } }
+            {"object":{"prop":["PROP1","PROP2"]}}
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -148,7 +148,7 @@
             </root>
         ]]></code>
         <expected><![CDATA[
-            { "object" : ["PROP1", "PROP2"] }
+            {"object":["PROP1","PROP2"]}
         ]]></expected>
     </test>
     <!-- The following should not be allowed as it generates invalid json -->
@@ -176,7 +176,7 @@
             </root>
         ]]></code>
         <expected><![CDATA[
-            { "object" : [["PROP1"]] }
+            {"object":[["PROP1"]]}
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -188,7 +188,7 @@
             </json:value>
         ]]></code>
         <expected><![CDATA[
-            [["PROP1", "PROP2"]]
+            [["PROP1","PROP2"]]
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -206,7 +206,7 @@
             </json:object>
         ]]></code>
         <expected><![CDATA[
-            [{ "first" : "Max", "last" : "Müller" }, { "first" : "Heinz", "last" : "Müller" }]
+            [{"first":"Max","last":"Müller"},{"first":"Heinz","last":"Müller"}]
         ]]></expected>
     </test>
     <test output="text" serialize="method=json">
@@ -218,7 +218,7 @@
             </json:value>
         ]]></code>
         <expected><![CDATA[
-            [{ "prop1" : "PROP1" }, { "prop2" : "PROP2" }]
+            [{"prop1":"PROP1"},{"prop2":"PROP2"}]
         ]]></expected>
     </test>
  </TestSet>


### PR DESCRIPTION
Fixes an bug with serialization of `expected` values in XQSuite when CData sections are present in the `<expected>` element of tests expressed in XML.

This was backported from https://github.com/eXist-db/exist/pull/2603