### PR TITLE
Fix xmldb:copy-resource/xmldb:copy-collection

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBCopy.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBCopy.java
@@ -47,7 +47,6 @@ import static org.exist.xquery.functions.xmldb.XMLDBModule.functionSignatures;
 public class XMLDBCopy extends XMLDBAbstractCollectionManipulator {
     private static final Logger logger = LogManager.getLogger(XMLDBCopy.class);
 
-    private static final String FS_COPY_NAME = "copy";
     private static final String FS_COPY_COLLECTION_NAME = "copy-collection";
     private static final String FS_COPY_RESOURCE_NAME = "copy-resource";
     private static final FunctionParameterSequenceType FS_PARAM_SOURCE_COLLECTION_URI = param("source-collection-uri", Type.STRING, "The source URI");
@@ -102,11 +101,9 @@ public class XMLDBCopy extends XMLDBAbstractCollectionManipulator {
     public Sequence evalWithCollection(final Collection collection, final Sequence[] args,
             final Sequence contextSequence) throws XPathException {
 
-        final XmldbURI destination = new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI();
-
-        if (isCalledAs(FS_COPY_RESOURCE_NAME) || (isCalledAs(FS_COPY_NAME) && getArgumentCount() == 3)) {
-
-            final XmldbURI doc = new AnyURIValue(args[2].itemAt(0).getStringValue()).toXmldbURI();
+        if (isCalledAs(FS_COPY_RESOURCE_NAME)) {
+            final XmldbURI destination = new AnyURIValue(args[2].itemAt(0).getStringValue()).toXmldbURI();
+            final XmldbURI doc = new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI();
             try {
                 final Resource resource = collection.getResource(doc.toString());
                 if (resource == null) {
@@ -151,6 +148,7 @@ public class XMLDBCopy extends XMLDBAbstractCollectionManipulator {
             }
 
         } else {
+            final XmldbURI destination = new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI();
             try {
                 final EXistCollectionManagementService service = (EXistCollectionManagementService) collection.getService("CollectionManagementService", "1.0");
 
@@ -169,7 +167,8 @@ public class XMLDBCopy extends XMLDBAbstractCollectionManipulator {
                 service.copy(XmldbURI.xmldbUriFor(collection.getName()), destination, null, preserve.name());
 
                 if (isCalledAs(FS_COPY_COLLECTION_NAME)) {
-                    return new StringValue(destination.append(collection.getName()).getRawCollectionPath());
+                    final XmldbURI targetName = XmldbURI.xmldbUriFor(collection.getName()).lastSegment();
+                    return new StringValue(destination.append(targetName).getRawCollectionPath());
                 } else {
                     return Sequence.EMPTY_SEQUENCE;
                 }

--- a/exist-core/src/test/xquery/xmldb/copy-tests.xql
+++ b/exist-core/src/test/xquery/xmldb/copy-tests.xql
@@ -1,0 +1,96 @@
+xquery version "3.0";
+
+module namespace t="http://exist-db.org/testsuite/copy";
+
+import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
+declare variable $t:collection-name := "copy-test";
+declare variable $t:collection := "/db/" || $t:collection-name;
+declare variable $t:target-collection-name := "copy-target";
+declare variable $t:target-collection := "/db/" || $t:target-collection-name;
+
+declare
+    %test:setUp
+function t:setup() {
+    xmldb:create-collection("/db", $t:collection-name),
+    xmldb:create-collection("/db", $t:target-collection-name),
+    xmldb:store($t:collection, "test.xml", <test/>),
+    sm:chmod(xs:anyURI($t:collection || "/test.xml"), "rw-r-----")
+};
+
+declare
+    %test:tearDown
+function t:cleanup() {
+    xmldb:remove($t:collection),
+    xmldb:remove($t:target-collection)
+};
+
+declare
+    %test:assertEquals("/db/copy-test/copy.xml", "<test/>")
+function t:copy-resource-same-collection() {
+    let $copy := xmldb:copy-resource($t:collection, "test.xml", $t:collection, "copy.xml")
+    return (
+        $copy,
+        doc($copy)
+    )
+};
+
+declare
+    %test:assertEquals("/db/copy-target/copy.xml", "<test/>")
+function t:copy-resource-different-collection() {
+    let $copy := xmldb:copy-resource($t:collection, "test.xml", $t:target-collection, "copy.xml")
+    return (
+        $copy,
+        doc($copy)
+    )
+};
+
+declare
+    %test:assertTrue
+function t:copy-resource-preserve-last-modified() {
+    let $lastModified := xmldb:last-modified($t:collection, "test.xml")
+    let $copy := xmldb:copy-resource($t:collection, "test.xml", $t:target-collection, "preserve.xml", true())
+    return (
+        $lastModified = xmldb:last-modified($t:target-collection, "preserve.xml")
+    )
+};
+
+declare
+    %test:assertTrue
+function t:copy-resource-preserve-permissions() {
+    let $perms := sm:get-permissions(xs:anyURI($t:collection || "/test.xml"))/sm:permission
+    let $copy := xmldb:copy-resource($t:collection, "test.xml", $t:target-collection, "preserve.xml", true())
+    return (
+        deep-equal($perms, sm:get-permissions(xs:anyURI($t:target-collection || "/preserve.xml"))/sm:permission)
+    )
+};
+
+declare
+    %test:assertEquals("/db/copy-target/copy-test", "test")
+function t:copy-collection() {
+    let $copy := xmldb:copy-collection($t:collection, $t:target-collection)
+    return (
+        $copy,
+        doc($t:target-collection || "/" || $t:collection-name || "/test.xml")/*/local-name(.),
+        xmldb:remove($t:target-collection || "/" || $t:collection-name)
+    )
+};
+
+declare
+    %test:assertEquals("/db/copy-target/copy-test", "test", "true")
+function t:copy-collection-preserve() {
+    let $perms := sm:get-permissions(xs:anyURI($t:collection))/sm:permission
+    let $copy := xmldb:copy-collection($t:collection, $t:target-collection, true())
+    return (
+        $copy,
+        doc($t:target-collection || "/" || $t:collection-name || "/test.xml")/*/local-name(.),
+        deep-equal($perms, sm:get-permissions(xs:anyURI($t:target-collection || "/" || $t:collection-name))/sm:permission),
+        xmldb:remove($t:target-collection || "/" || $t:collection-name)
+    )
+};
+
+declare
+    %test:assertError
+function t:copy-collection-on-itself() {
+    xmldb:copy-collection($t:collection, $t:collection)
+};

--- a/exist-core/src/test/xquery/xmldb/permission-tests.xql
+++ b/exist-core/src/test/xquery/xmldb/permission-tests.xql
@@ -108,7 +108,7 @@ declare
     %test:user("guest", "guest")
     %test:assertError("Permission denied|not found")
 function t:copyCollection() {
-    xmldb:copy($t:collection || "/inaccessible", $t:collection || "/copy")
+    xmldb:copy-collection($t:collection || "/inaccessible", $t:collection || "/copy")
 };
 
 declare 


### PR DESCRIPTION
Broken after removing deprecated functions. Add tests.