### PR TITLE
Fix ArrayOutOfBoundsException with fn:id

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
@@ -680,6 +680,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
         if(size == 1) {
             return null;
         }
+        expand();
         final ElementImpl root = (ElementImpl) getDocumentElement();
         if(hasIdAttribute(root.getNodeNumber(), id)) {
             return root;
@@ -699,6 +700,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
         if(size == 1) {
             return null;
         }
+        expand();
         final ElementImpl root = (ElementImpl) getDocumentElement();
         AttrImpl attr = getIdrefAttribute(root.getNodeNumber(), id);
         if(attr != null) {
@@ -1238,6 +1240,7 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
         attrNodeId = newDoc.attrNodeId;
         attrParent = newDoc.attrParent;
         attrValue = newDoc.attrValue;
+        attrType = newDoc.attrType;
         nextAttr = newDoc.nextAttr;
         namespaceParent = newDoc.namespaceParent;
         namespaceCode = newDoc.namespaceCode;

--- a/exist-core/src/test/xquery/xmlid.xql
+++ b/exist-core/src/test/xquery/xmlid.xql
@@ -4,6 +4,7 @@ xquery version "3.1";
 module namespace xid="http://exist-db.org/xquery/test/xmlid";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace tei="http://www.tei-c.org/ns/1.0";
 
 declare variable $xid:COLLECTION_NAME := "test-xmlid";
 
@@ -13,10 +14,20 @@ declare variable $xid:XML :=
         <item xml:id="123"/>
     </test>]``;
 
+declare variable $xid:XML2 :=
+    ``[<seg xmlns:tei="http://www.tei-c.org/ns/1.0">
+           <w xmlns="http://www.tei-c.org/ns/1.0" lemma="hippocratis" pos="fw-la" rendition="#hi" xml:id="A01622-005-a-05590">Hippocratis</w>
+           <w xmlns="http://www.tei-c.org/ns/1.0" lemma="&amp;" pos="cc" xml:id="A01622-005-a-05600">&amp;</w>
+           <w xmlns="http://www.tei-c.org/ns/1.0" lemma="galeni" pos="fw-la" rendition="#hi" xml:id="A01622-005-a-05610">Galeni</w>
+           <w xmlns="http://www.tei-c.org/ns/1.0" lemma="praeceptis" pos="fw-la" xml:id="A01622-005-a-05620">praeceptis</w>
+           <pc xmlns="http://www.tei-c.org/ns/1.0" xml:id="A01622-005-a-05630">,</pc>
+       </seg>]``;
+
 declare
 %test:setUp
 function xid:setup() {
-    xmldb:create-collection("/db", $xid:COLLECTION_NAME)
+    xmldb:create-collection("/db", $xid:COLLECTION_NAME),
+    xmldb:store($xid:COLLECTION_NAME, "tei.xml", $xid:XML2)
 };
 
 declare
@@ -72,4 +83,12 @@ function xid:constructed-attribute() {
     return (
         $test/id("nym_Ͷαναξιμοῦς")
     )
+};
+
+declare
+    %test:assertEquals(1)
+function xid:enclosed-expression() {
+    let $xml := <test>{doc($xid:COLLECTION_NAME || "/tei.xml")//tei:w}</test>
+    return
+    	count($xml/id("A01622-005-a-05590"))
 };


### PR DESCRIPTION
Exception thrown when querying doc containing xml:id attribute in enclosed expression. Closes #2636