### PR TITLE
Descendant nodes wrongly indexed, fix PR #2367

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -2626,7 +2626,7 @@ public class NativeBroker extends DBBroker {
             final IStoredNode<?> node = (IStoredNode<?>) nodes.item(i);
             try(final INodeIterator iterator = getNodeIterator(node)) {
                 iterator.next();
-                copyNodes(transaction, iterator, node, new NodePath(), newDoc, false, listener);
+                copyNodes(transaction, iterator, node, new NodePath2(), newDoc, false, listener);
             }
         }
         flush();
@@ -2989,7 +2989,7 @@ public class NativeBroker extends DBBroker {
                 final IStoredNode<?> node = (IStoredNode<?>) nodes.item(i);
                 try(final INodeIterator iterator = getNodeIterator(node)) {
                     iterator.next();
-                    copyNodes(transaction, iterator, node, new NodePath(), tempDoc, true, listener);
+                    copyNodes(transaction, iterator, node, new NodePath2(), tempDoc, true, listener);
                 }
             }
             flush();

--- a/exist-core/src/main/java/org/exist/storage/NodePath.java
+++ b/exist-core/src/main/java/org/exist/storage/NodePath.java
@@ -84,6 +84,10 @@ public class NodePath implements Comparable<NodePath> {
         this.includeDescendants = includeDescendants;
     }
 
+    public boolean includeDescendants() {
+        return includeDescendants;
+    }
+
     public void append(final NodePath other) {
         final QName[] newComponents = new QName[length() + other.length()];
         System.arraycopy(components, 0, newComponents, 0, pos);

--- a/exist-core/src/test/java/org/exist/storage/ShutdownTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ShutdownTest.java
@@ -36,7 +36,7 @@ public class ShutdownTest {
         "<collection xmlns=\"http://exist-db.org/collection-config/1.0\">" +
             "	<index>" +
             "       <lucene>" +
-            "           <text match=\"/*\"/>" +
+            "           <text match=\"//SPEECH/*\"/>" +
             "       </lucene>" +
             "	</index>" +
             "</collection>";
@@ -83,7 +83,7 @@ public class ShutdownTest {
                 assertNotNull(xquery);
                 final Sequence result = xquery.execute(broker, "//SPEECH[ft:query(LINE, 'love')]", Sequence.EMPTY_SEQUENCE);
                 assertNotNull(result);
-                assertEquals(result.getItemCount(), 160);
+                assertEquals(160, result.getItemCount());
 
                 transact.commit(transaction);
             }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/NodePathPattern.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/NodePathPattern.java
@@ -84,6 +84,7 @@ public class NodePathPattern {
 
     public NodePathPattern(Map<String, String> namespaces, String matchPattern) {
         qnPath = new NodePath();
+        qnPath.setIncludeDescendants(false);
         parseXPathExpression(namespaces, matchPattern);
     }
 
@@ -192,7 +193,7 @@ public class NodePathPattern {
         QName components_i = null;
         for (int j = from_pos; j < other_len; j++) {
             if (i == len) {
-                return true;
+                return qnPath.includeDescendants();
             }
             if (components_i == null)
                 components_i = qnPath.getComponent(i);

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -307,6 +307,11 @@ public class LuceneIndexTest {
                 "      <title type='t' xml:lang=\"En\"    > <tag> ADodge    </tag>  </title> \n" + // this should not get indexed -- attribute value does not match
                 "      <title type='t'                    > <tag> AFord     </tag>  </title> \n" + // this should not get indexed -- attribute is entirely missing
                 "   </teiHeader>\n" +
+                "   <text>\n" +
+                "       <group>\n" +
+                "           <text>Nested</text>\n" +
+                "       </group>\n" +
+                "   </text>\n" +
                 "</TEI>";
 
         final String COLLECTION_CONFIG10 =
@@ -316,6 +321,7 @@ public class LuceneIndexTest {
                 "        <lucene diacritics='no'>\n" +
                 "            <analyzer class='org.apache.lucene.analysis.standard.StandardAnalyzer'/>\n" +
                 "            <text match=\"//title[@xml:lang='Sa-Ltn']\"/>\n" +
+                "            <text match=\"/TEI/text\"><ignore qname=\"text\"/></text>\n" +
                 "        </lucene> \n" +
                 "    </index>\n" +
                 "</collection>";
@@ -336,6 +342,8 @@ public class LuceneIndexTest {
             final Occurrences[] p2 = checkIndex(docs, broker, new QName[]{new QName("title")}, "acadillac", 0);
             final Occurrences[] p3 = checkIndex(docs, broker, new QName[]{new QName("title")}, "adodge", 0);
             final Occurrences[] p4 = checkIndex(docs, broker, new QName[]{new QName("title")}, "aford", 0);
+            // nested <text> should be ignored and not indexed by match="/TEI/text"
+            final Occurrences[] p5 = checkIndex(docs, broker, new QName[]{new QName("text")}, "nested", 0);
 
             final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);


### PR DESCRIPTION
Fixes an issue introduced by PR #2367: a lucene index configured with a match attribute should only be created for nodes matching the path, not all its descendant nodes.