### PR TITLE
Fix two issues with Lucene facets

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -430,9 +430,14 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 String field = LuceneUtil.encodeQName(qname, index.getBrokerPool().getSymbols());
                 LuceneConfig config = getLuceneConfig(broker, docs);
                 Analyzer analyzer = getAnalyzer(config,null, qname);
-                QueryParserWrapper parser = getQueryParser(field, analyzer, docs);
-                options.configureParser(parser.getConfiguration());
-                Query query = queryStr == null ? new ConstantScoreQuery(new FieldValueFilter(field)) : parser.parse(queryStr);
+                Query query;
+                if (queryStr == null) {
+                    query = new ConstantScoreQuery(new FieldValueFilter(field));
+                } else {
+                    QueryParserWrapper parser = getQueryParser(field, analyzer, docs);
+                    options.configureParser(parser.getConfiguration());
+                    query = parser.parse(queryStr);
+                }
                 Optional<Map<String, List<String>>> facets = options.getFacets();
                 if (facets.isPresent() && config != null) {
                     query = drilldown(facets.get(), query, config);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -432,7 +432,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 Analyzer analyzer = getAnalyzer(config,null, qname);
                 QueryParserWrapper parser = getQueryParser(field, analyzer, docs);
                 options.configureParser(parser.getConfiguration());
-                Query query = queryStr == null ? new MatchAllDocsQuery() : parser.parse(queryStr);
+                Query query = queryStr == null ? new ConstantScoreQuery(new FieldValueFilter(field)) : parser.parse(queryStr);
                 Optional<Map<String, List<String>>> facets = options.getFacets();
                 if (facets.isPresent() && config != null) {
                     query = drilldown(facets.get(), query, config);
@@ -472,7 +472,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 String field = LuceneUtil.encodeQName(qname, index.getBrokerPool().getSymbols());
                 LuceneConfig config = getLuceneConfig(broker, docs);
                 analyzer = getAnalyzer(config, null, qname);
-                Query query = queryRoot == null ? new MatchAllDocsQuery() : queryTranslator.parse(field, queryRoot, analyzer, options);
+                Query query = queryRoot == null ? new ConstantScoreQuery(new FieldValueFilter(field)) : queryTranslator.parse(field, queryRoot, analyzer, options);
                 Optional<Map<String, List<String>>> facets = options.getFacets();
                 if (facets.isPresent() && config != null) {
                     query = drilldown(facets.get(), query, config);

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Facets.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Facets.java
@@ -21,6 +21,7 @@
 package org.exist.xquery.modules.lucene;
 
 import org.apache.lucene.facet.FacetResult;
+import org.apache.lucene.search.Query;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.Match;
 import org.exist.dom.persistent.NodeProxy;
@@ -32,6 +33,8 @@ import org.exist.xquery.functions.map.MapType;
 import org.exist.xquery.value.*;
 
 import java.io.IOException;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 public class Facets extends BasicFunction {
 
@@ -42,13 +45,13 @@ public class Facets extends BasicFunction {
                         "to the entire sequence returned by ft:query, so the same map will be returned for all nodes in the sequence. " +
                         "It is thus sufficient to specify one node from the sequence as first argument to this function.",
                 new SequenceType[] {
-                        new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
+                        new FunctionParameterSequenceType("node", Type.NODE, Cardinality.ZERO_OR_MORE,
                                 "A single node resulting from a call to ft:query for which facet information should be retrieved. " +
                                         "If the node has no facet information attached, an empty sequence will be returned."),
                         new FunctionParameterSequenceType("dimension", Type.STRING, Cardinality.EXACTLY_ONE,
                                 "The facet dimension. This should correspond to a dimension defined in the index configuration")
                 },
-                new FunctionReturnSequenceType(Type.MAP, Cardinality.ZERO_OR_ONE,
+                new FunctionReturnSequenceType(Type.MAP, Cardinality.EXACTLY_ONE,
                         "A map having the facet label as key and the facet count as value")
         ),
         new FunctionSignature(
@@ -57,7 +60,7 @@ public class Facets extends BasicFunction {
                     "to the entire sequence returned by ft:query, so the same map will be returned for all nodes in the sequence. " +
                     "It is thus sufficient to specify one node from the sequence as first argument to this function.",
             new SequenceType[] {
-                    new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
+                    new FunctionParameterSequenceType("node", Type.NODE, Cardinality.ZERO_OR_MORE,
                             "A single node resulting from a call to ft:query for which facet information should be retrieved. " +
                                     "If the node has no facet information attached, an empty sequence will be returned."),
                     new FunctionParameterSequenceType("dimension", Type.STRING, Cardinality.EXACTLY_ONE,
@@ -66,7 +69,7 @@ public class Facets extends BasicFunction {
                             "The number of facet labels to be returned. Facets with more occurrences in the result will be returned " +
                                     "first.")
             },
-            new FunctionReturnSequenceType(Type.MAP, Cardinality.ZERO_OR_ONE,
+            new FunctionReturnSequenceType(Type.MAP, Cardinality.EXACTLY_ONE,
                     "A map having the facet label as key and the facet count as value")
         ),
         new FunctionSignature(
@@ -75,7 +78,7 @@ public class Facets extends BasicFunction {
                     "to the entire sequence returned by ft:query, so the same map will be returned for all nodes in the sequence. " +
                     "It is thus sufficient to specify one node from the sequence as first argument to this function.",
             new SequenceType[] {
-                    new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
+                    new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ZERO_OR_MORE,
                             "A single node resulting from a call to ft:query for which facet information should be retrieved. " +
                                     "If the node has no facet information attached, an empty sequence will be returned."),
                     new FunctionParameterSequenceType("dimension", Type.STRING, Cardinality.EXACTLY_ONE,
@@ -87,7 +90,7 @@ public class Facets extends BasicFunction {
                             "For hierarchical facets, specify a sequence of paths leading to the position in the hierarchy you" +
                                     "would like to get facet counts for.")
             },
-                new FunctionReturnSequenceType(Type.MAP, Cardinality.ZERO_OR_ONE,
+                new FunctionReturnSequenceType(Type.MAP, Cardinality.EXACTLY_ONE,
                         "A map having the facet label as key and the facet count as value")
         )
     };
@@ -98,11 +101,6 @@ public class Facets extends BasicFunction {
 
     @Override
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-        final NodeValue nv = (NodeValue) args[0].itemAt(0);
-        if (nv.getImplementationType() == NodeValue.IN_MEMORY_NODE) {
-            return Sequence.EMPTY_SEQUENCE;
-        }
-
         final String dimension = args[1].getStringValue();
 
         int count = Integer.MAX_VALUE;
@@ -119,22 +117,39 @@ public class Facets extends BasicFunction {
             }
         }
 
-        final NodeProxy proxy = (NodeProxy) nv;
-        try {
-            Match match = proxy.getMatches();
-            while (match != null) {
-                if (match.getIndexId().equals(LuceneIndex.ID)) {
-                    return getFacetsMap(dimension, count, paths, (LuceneMatch) match);
+        // Find all lucene queries referenced from the input sequence and remember
+        // the first match for each. Every query will have its own facets attached,
+        // so we have to merge them below.
+        final Map<Query, LuceneMatch> luceneQueries = new IdentityHashMap<>();
+        for (final SequenceIterator i = args[0].unorderedIterator(); i.hasNext(); ) {
+            final NodeValue nv = (NodeValue) i.nextItem();
+            if (nv.getImplementationType() == NodeValue.PERSISTENT_NODE) {
+                final NodeProxy proxy = (NodeProxy) nv;
+
+                Match match = proxy.getMatches();
+                while (match != null) {
+                    if (match.getIndexId().equals(LuceneIndex.ID)) {
+                        final LuceneMatch luceneMatch = (LuceneMatch) match;
+                        luceneQueries.putIfAbsent(luceneMatch.getQuery(), luceneMatch);
+                    }
+                    match = match.getNextMatch();
                 }
-                match = match.getNextMatch();
             }
-        } catch (IOException e) {
-            throw new XPathException(this, LuceneModule.EXXQDYFT0002, e.getMessage());
         }
-        return Sequence.EMPTY_SEQUENCE;
+
+        // Iterate the found queries/matches and collect facets for each
+        final MapType map = new MapType(context);
+        for (LuceneMatch match : luceneQueries.values()) {
+            try {
+                addFacetsToMap(map, dimension, count, paths, match);
+            } catch (IOException e) {
+                throw new XPathException(this, LuceneModule.EXXQDYFT0002, e.getMessage());
+            }
+        }
+        return map;
     }
 
-    private Sequence getFacetsMap(String dimension, int count, String[] paths, LuceneMatch match) throws IOException, XPathException {
+    private void addFacetsToMap(MapType map, String dimension, int count, String[] paths, LuceneMatch match) throws IOException, XPathException {
         final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
         final org.apache.lucene.facet.Facets facets = index.getFacets(match);
         final FacetResult result;
@@ -144,16 +159,18 @@ public class Facets extends BasicFunction {
             result = facets.getTopChildren(count, dimension, paths);
         }
 
-        if (result == null) {
-            return new MapType(context);
-        } else {
-            final MapType map = new MapType(context);
+        if (result != null) {
             for (int i = 0; i < result.labelValues.length; i++) {
                 final String label = result.labelValues[i].label;
                 final Number value = result.labelValues[i].value;
-                map.add(new StringValue(label), new IntegerValue(value.longValue()));
+                final AtomicValue key = new StringValue(label);
+                if (map.contains(key)) {
+                    final IntegerValue existing = (IntegerValue)map.get(key);
+                    map.add(key, new IntegerValue(value.longValue() + existing.getLong()));
+                } else {
+                    map.add(new StringValue(label), new IntegerValue(value.longValue()));
+                }
             }
-            return map;
         }
     }
 }

--- a/extensions/indexes/lucene/src/test/java/xquery/lucene/LuceneTests.java
+++ b/extensions/indexes/lucene/src/test/java/xquery/lucene/LuceneTests.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(XSuite.class)
 @XSuite.XSuiteFiles({
-    "extensions/indexes/lucene/src/test/xquery/lucene/"
+    "extensions/indexes/lucene/src/test/xquery/lucene/facets.xql"
 })
 public class LuceneTests {
 }

--- a/extensions/indexes/lucene/src/test/java/xquery/lucene/LuceneTests.java
+++ b/extensions/indexes/lucene/src/test/java/xquery/lucene/LuceneTests.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(XSuite.class)
 @XSuite.XSuiteFiles({
-    "extensions/indexes/lucene/src/test/xquery/lucene/facets.xql"
+    "extensions/indexes/lucene/src/test/xquery/lucene"
 })
 public class LuceneTests {
 }


### PR DESCRIPTION
This fixes two issues related to Lucene facets:

1. calling `ft:query` with an empty query parameter (to match all indexed elements) would pass an `MatchAllDocsQuery` to Lucene. This is wrong though as it would include Lucene matches in other elements than the current context node. While the XPath result was correct, facet counts got messed up. The PR fixes this by taking the context node into account.
2. `ft:facet` expected a single node as input sequence to return facet counts for. This is inconvenient if  you want to retrieve facet counts for a sequence of nodes resulting from **multiple** lucene queries. `ft:facet` will now accept an entire sequence and merge the facet counts for each lucene query referenced from nodes in the sequence.