### PR TITLE
Opening a collection using full XmldbURI (with scheme) fails.

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -650,7 +650,7 @@ public class NativeBroker extends DBBroker {
      * @throws TriggerException If a CollectionTrigger throws an exception
      */
     private Tuple2<Boolean, Collection> getOrCreateCollectionExplicit(final Txn transaction, final XmldbURI path, final Optional<Tuple2<Permission, Long>> creationAttributes) throws PermissionDeniedException, IOException, TriggerException {
-        final XmldbURI collectionUri = prepend(path.normalizeCollectionPath());
+        final XmldbURI collectionUri = prepend(path.toCollectionPathURI().normalizeCollectionPath());
         final XmldbURI parentCollectionUri = collectionUri.removeLastSegment();
 
         final CollectionCache collectionsCache = pool.getCollectionsCache();
@@ -874,7 +874,7 @@ public class NativeBroker extends DBBroker {
      */
     private @Nullable @EnsureLocked Collection openCollection(final XmldbURI path, final long address, final LockMode lockMode)
             throws PermissionDeniedException {
-        final XmldbURI collectionUri = prepend(path.normalizeCollectionPath());
+        final XmldbURI collectionUri = prepend(path.toCollectionPathURI().normalizeCollectionPath());
 
         final ManagedCollectionLock collectionLock;
         final Runnable unlockFn;    // we unlock on error, or if there is no Collection

--- a/exist-core/src/test/java/org/exist/collections/AllCollectionTests.java
+++ b/exist-core/src/test/java/org/exist/collections/AllCollectionTests.java
@@ -29,7 +29,8 @@ import org.junit.runners.Suite;
         CollectionOrderTest.class,
         CollectionRemovalTest.class,
         CollectionStoreTest.class,
-        CollectionURITest.class
+        CollectionURITest.class,
+        OpenCollectionTest.class
 })
 public class AllCollectionTests {
 }

--- a/exist-core/src/test/java/org/exist/collections/OpenCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/collections/OpenCollectionTest.java
@@ -1,0 +1,88 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.collections;
+
+import org.exist.EXistException;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.xmldb.XmldbURI;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+import static junit.framework.TestCase.assertNotNull;
+
+public class OpenCollectionTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, false);
+
+    private static XmldbURI TEST_COLLECTION = XmldbURI.ROOT_COLLECTION_URI.append("testCollection");
+
+    @BeforeClass
+    public static void init() throws EXistException, PermissionDeniedException, IOException, TriggerException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            broker.getOrCreateCollection(transaction, TEST_COLLECTION);
+            transaction.commit();
+
+            try (final Collection col = broker.openCollection(TEST_COLLECTION, Lock.LockMode.READ_LOCK)) {
+                assertNotNull(col);
+            }
+        }
+    }
+
+    /**
+     * Test opening a collection using a full XmldbURI including scheme.
+     */
+    @Test
+    public void loadFullXmldbURI() throws PermissionDeniedException, IOException, EXistException, URISyntaxException, DatabaseConfigurationException {
+        loadCollection(XmldbURI.xmldbUriFor("xmldb:exist:///db/testCollection"));
+    }
+
+    @Test
+    public void loadRelativeXmldbURI() throws PermissionDeniedException, IOException, EXistException, URISyntaxException, DatabaseConfigurationException {
+        loadCollection(XmldbURI.xmldbUriFor("testCollection"));
+    }
+
+    private void loadCollection(XmldbURI uri) throws DatabaseConfigurationException, IOException, EXistException, PermissionDeniedException {
+        // Restart database, otherwise collection would be read from cache
+        existEmbeddedServer.restart();
+
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            try (final Collection col = broker.openCollection(uri, Lock.LockMode.READ_LOCK)) {
+                assertNotNull(col);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Loading an existing collection fails on develop/5.0 when calling `DBBroker.openCollection` with a full XmldbURI (i.e. with scheme part). This manifests itself in issue #2691, where accessing the root of an app shows just a collection listing. The cause for this is that the collection is not found when searching for the controller. It is found later by the REST servlet though, because this uses an XmldbURI without scheme part.

The issue does not apply to 4.x.x. The uri is correctly processed there.

Closes #2691