### PR TITLE
Add AppVeyor CI notification to Slack #integrations

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,3 +37,10 @@ on_failure:
 artifacts:
   - path: exist-core\target\junit-reports
     name: junit-reports
+
+notifications:
+  - provider: Slack
+    auth_token:
+      secure: ycaTfB/7lfRhyK4KL/DRHw8pHuU3+Y1vT3vk0WybnUFjR9HC+8TH5KlHqxYhKuFW
+    channel: '#integrations'
+    template: "<{{buildUrl}}|Build {{projectName}} {{buildVersion}} {{status}}> Commit <{{commitUrl}}|{{commitId}}> by {{commitAuthor}} on {{commitDate}}: _{{commitMessage}}_"


### PR DESCRIPTION
Our #integrations channel does a nice job with notifications from GitHub and Travis CI, but it doesn’t show Appveyor CI. Appveyor CI isn’t available as an “app” in Slack, but they do offer directions for manually configuring notifications: https://www.appveyor.com/docs/notifications/#slack - which involves adding some entries here.