### PR TITLE
(4.x.x) Fix deadlock

### DIFF
--- a/exist-core/src/main/java/org/exist/collections/Collection.java
+++ b/exist-core/src/main/java/org/exist/collections/Collection.java
@@ -244,7 +244,7 @@ public interface Collection extends Resource, Comparable<Collection>, Cacheable 
      *
      * @return estimated amount of memory in bytes
      */
-    int getMemorySize();
+    int getMemorySizeNoLock();
 
     /**
      * Get the parent Collection.

--- a/exist-core/src/main/java/org/exist/collections/CollectionCache.java
+++ b/exist-core/src/main/java/org/exist/collections/CollectionCache.java
@@ -152,7 +152,7 @@ public class CollectionCache extends LRUCache<Collection> implements BrokerPoolS
         for (final LongIterator i = names.values().iterator(); i.hasNext(); ) {
             final Collection collection = get(i.nextLong());
             if (collection != null) {
-                size += collection.getMemorySize();
+                size += collection.getMemorySizeNoLock();
             }
         }
         return size;

--- a/exist-core/src/main/java/org/exist/collections/MutableCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/MutableCollection.java
@@ -614,21 +614,6 @@ public class MutableCollection implements Collection {
     }
 
     @Override
-    public int getMemorySize() {
-        try {
-            getLock().acquire(LockMode.READ_LOCK);
-            try {
-                return SHALLOW_SIZE + documents.size() * DOCUMENT_SIZE;
-            } finally {
-                getLock().release(LockMode.READ_LOCK);
-            }
-        } catch(final LockException e) {
-            LOG.error(e);
-            return -1;
-        }
-    }
-
-    @Override
     public int getMemorySizeNoLock() {
         return SHALLOW_SIZE + (documents.size() * DOCUMENT_SIZE);
     }

--- a/exist-core/src/main/java/org/exist/collections/MutableCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/MutableCollection.java
@@ -629,6 +629,11 @@ public class MutableCollection implements Collection {
     }
 
     @Override
+    public int getMemorySizeNoLock() {
+        return SHALLOW_SIZE + (documents.size() * DOCUMENT_SIZE);
+    }
+
+    @Override
     public int getChildCollectionCount(final DBBroker broker) throws PermissionDeniedException {
         if(!getPermissionsNoLock().validate(broker.getCurrentSubject(), Permission.READ)) {
             throw new PermissionDeniedException("Permission denied to read collection: " + path);


### PR DESCRIPTION
Manual port of 3da94f80ce2cb33684d354a98b6f16fa07bd59ae, which should address a deadlock recently reported on the list for 4.6.0: http://exist-open.markmail.org/thread/37alxcifbxknig6q. The issue seems blocking enough that it deserves a backport.