### PR TITLE
Lucene: fix AlreadyClosedException

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -20,6 +20,7 @@
 
 package org.exist.indexing.lucene;
 
+import org.apache.lucene.facet.Facets;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
 import org.exist.dom.persistent.Match;
@@ -41,7 +42,7 @@ public class LuceneMatch extends Match {
     private float score = 0.0f;
     private final Query query;
 
-    private LuceneIndexWorker.ExtFacetsCollector facetsCollector;
+    private LuceneIndexWorker.LuceneFacets facets;
 
     private Map<String, FieldValue[]> fields = null;
 
@@ -49,17 +50,17 @@ public class LuceneMatch extends Match {
         this(contextId, nodeId, query, null);
     }
 
-    LuceneMatch(int contextId, NodeId nodeId, Query query, LuceneIndexWorker.ExtFacetsCollector facetsCollector) {
+    LuceneMatch(int contextId, NodeId nodeId, Query query, LuceneIndexWorker.LuceneFacets facets) {
         super(contextId, nodeId, null);
         this.query = query;
-        this.facetsCollector = facetsCollector;
+        this.facets = facets;
     }
 
     private LuceneMatch(LuceneMatch copy) {
         super(copy);
         this.score = copy.score;
         this.query = copy.query;
-        this.facetsCollector = copy.facetsCollector;
+        this.facets = copy.facets;
         this.fields = copy.fields;
     }
 
@@ -94,8 +95,8 @@ public class LuceneMatch extends Match {
         this.score = score;
     }
 
-    public LuceneIndexWorker.ExtFacetsCollector getFacetsCollector() {
-        return this.facetsCollector;
+    public Facets getFacets() {
+        return this.facets.getFacets();
     }
 
     protected void addField(String name, IndexableField[] values) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Facets.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Facets.java
@@ -26,7 +26,6 @@ import org.exist.dom.QName;
 import org.exist.dom.persistent.Match;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.indexing.lucene.LuceneIndex;
-import org.exist.indexing.lucene.LuceneIndexWorker;
 import org.exist.indexing.lucene.LuceneMatch;
 import org.exist.xquery.*;
 import org.exist.xquery.functions.map.MapType;
@@ -146,9 +145,8 @@ public class Facets extends BasicFunction {
         return map;
     }
 
-    private void addFacetsToMap(MapType map, String dimension, int count, String[] paths, LuceneMatch match) throws IOException, XPathException {
-        final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
-        final org.apache.lucene.facet.Facets facets = index.getFacets(match);
+    private void addFacetsToMap(MapType map, String dimension, int count, String[] paths, LuceneMatch match) throws IOException {
+        final org.apache.lucene.facet.Facets facets = match.getFacets();
         final FacetResult result;
         if (paths == null) {
             result = facets.getTopChildren(count, dimension);


### PR DESCRIPTION
Fix AlreadyClosedException when retrieving facets during a reindex. Previously we were postponing the actual facet computation until the user requested it via `ft:facets`. Internally lucene would potentially use an outdated reader for the computation though, which led to the exception.

Instead of postponing, compute facets immediately within the same lucene search context and thus using the same reader. Memory and performance-wise, the overhead is minimal.

Closes #2700 