### PR TITLE
Update the public-xar-repo-plugin

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -589,7 +589,7 @@
             <plugin>
                 <groupId>org.exist-db.maven.plugins</groupId>
                 <artifactId>public-xar-repo-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.1</version>
                 <executions>
                     <execution>
                         <id>fetch-xars</id>


### PR DESCRIPTION
The plugin now correctly handles versions like `5.0.0-RC1`