### PR TITLE
LauncherWrapper not exiting after first start

### DIFF
--- a/exist-core/src/main/java/org/exist/launcher/ConfigurationDialog.java
+++ b/exist-core/src/main/java/org/exist/launcher/ConfigurationDialog.java
@@ -107,6 +107,9 @@ public class ConfigurationDialog extends JDialog {
         }
         setVisible(true);
         requestFocus();
+        // make sure the process dies when the dialog is closed
+        // we cannot set this before the dialog is open though
+        setDefaultCloseOperation(EXIT_ON_CLOSE);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/launcher/ConfigurationDialog.java
+++ b/exist-core/src/main/java/org/exist/launcher/ConfigurationDialog.java
@@ -107,9 +107,6 @@ public class ConfigurationDialog extends JDialog {
         }
         setVisible(true);
         requestFocus();
-        // make sure the process dies when the dialog is closed
-        // we cannot set this before the dialog is open though
-        setDefaultCloseOperation(EXIT_ON_CLOSE);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/launcher/LauncherWrapper.java
+++ b/exist-core/src/main/java/org/exist/launcher/LauncherWrapper.java
@@ -55,6 +55,8 @@ public class LauncherWrapper {
             System.out.println("First launch: opening configuration dialog");
             ConfigurationDialog configDialog = new ConfigurationDialog(restart -> {
                 wrapper.launch();
+                // make sure the process dies when the dialog is closed
+                System.exit(0);
             });
             configDialog.open(true);
             configDialog.requestFocus();


### PR DESCRIPTION
Fixes issue #1248. During first start, the launcher shows a configuration dialog and restarts after it is closed. The wrapper process kept running though.

Checked on OSX and Windows 10.