### PR TITLE
Installing service fails with OpenJDK

### DIFF
--- a/exist-core/src/main/java/org/exist/launcher/WindowsServiceManager.java
+++ b/exist-core/src/main/java/org/exist/launcher/WindowsServiceManager.java
@@ -109,7 +109,7 @@ class WindowsServiceManager implements ServiceManager {
                 "--LogPrefix=service",
                 "--PidFile=service.pid",
                 "--Startup=auto",
-                "--Jvm=auto",
+                "--Jvm=" + findJvm().orElse("auto"),
                 "--Classpath=\"" + existHome.resolve("lib").toAbsolutePath().toString().replace('\\', '/') + "/*\"",
                 "--JvmMs=" + minMemory,
                 "--StartMode=jvm",
@@ -257,6 +257,25 @@ class WindowsServiceManager implements ServiceManager {
         } catch (final IOException e) {
             throw new ServiceManagerException(e.getMessage(), e);
         }
+    }
+
+    /**
+     * Try to find jvm.dll, which should either reside in `bin/client` or `bin/server` below
+     * JAVA_HOME. Autodetection does not seem to work with OpenJDK-based Java distributions.
+     *
+     * @return Path to jvm.dll or empty Optional
+     */
+    private Optional<String> findJvm() {
+        final Path javaHome = Paths.get(System.getProperty("java.home")).toAbsolutePath();
+        Path jvm = javaHome.resolve("bin/client/jvm.dll");
+        if (Files.exists(jvm)) {
+            return Optional.of(jvm.toString());
+        }
+        jvm = javaHome.resolve("bin/server/jvm.dll");
+        if (Files.exists(jvm)) {
+            return Optional.of(jvm.toString());
+        }
+        return Optional.empty();
     }
 
     private WindowsServiceState getState() throws ServiceManagerException {

--- a/exist-core/src/main/java/org/exist/launcher/WindowsServiceManager.java
+++ b/exist-core/src/main/java/org/exist/launcher/WindowsServiceManager.java
@@ -267,11 +267,11 @@ class WindowsServiceManager implements ServiceManager {
      */
     private Optional<String> findJvm() {
         final Path javaHome = Paths.get(System.getProperty("java.home")).toAbsolutePath();
-        Path jvm = javaHome.resolve("bin/client/jvm.dll");
+        Path jvm = javaHome.resolve("bin").resolve("client").resolve("jvm.dll");
         if (Files.exists(jvm)) {
             return Optional.of(jvm.toString());
         }
-        jvm = javaHome.resolve("bin/server/jvm.dll");
+        jvm = javaHome.resolve("bin").resolve("server").resolve("jvm.dll");
         if (Files.exists(jvm)) {
             return Optional.of(jvm.toString());
         }


### PR DESCRIPTION
Auto-detection of `jvm.dll` needed by procrun does not work reliably across different JDK distributions (ok with Oracle, fails with Zulu and Amazon Corretto). We can easily determine the correct location from `JAVA_HOME` though.

Closes #2731

Tested on Windows 10 with Zulu 8 and 11, Amazon Corretto 11 and Oracle JDK 11.