### PR TITLE
Fixes getBytes() method returning wrong data if switched to file

### DIFF
--- a/exist-core/src/main/java/org/exist/util/io/VirtualTempPath.java
+++ b/exist-core/src/main/java/org/exist/util/io/VirtualTempPath.java
@@ -142,12 +142,13 @@ public final class VirtualTempPath implements AutoCloseable {
     public byte[] getBytes() {
         long stamp = lock.readLock();
         try {
+            if (contentFile != null) {
+                return Files.readAllBytes(contentFile);
+            }
             if (content != null) {
                 byte[] buffer = new byte[(int) content.size()];
                 content.read(buffer, 0L, 0, buffer.length);
                 return buffer;
-            } else if (contentFile != null) {
-                return Files.readAllBytes(contentFile);
             }
         } catch (IOException e) {
             LOG.error("Unable to get content", e);

--- a/exist-core/src/test/java/org/exist/util/io/VirtualTempPathTest.java
+++ b/exist-core/src/test/java/org/exist/util/io/VirtualTempPathTest.java
@@ -89,6 +89,7 @@ public class VirtualTempPathTest {
         assertEquals(MemoryContentsInputStream.class, in.getClass());
 
         assertArrayEquals(buf, readAllBytes(in));
+        assertArrayEquals(buf, virtualTempPath.getBytes());
     }
 
     @Test
@@ -100,6 +101,7 @@ public class VirtualTempPathTest {
         assertNotEquals(MemoryContentsInputStream.class, in.getClass());
 
         assertArrayEquals(buf, readAllBytes(in));
+        assertArrayEquals(buf, virtualTempPath.getBytes());
     }
 
     @Test


### PR DESCRIPTION
### Description:
Fixes the bug that `getBytes()` return a empty array if the `VirtualTempPath` has switched to a real file instead of using the in-memory model

### Type of tests:
Extended the `VirtualTempPathTest` to also check the correct behaviour of the `getBytes()` method for in-memory and real file case.