### PR TITLE
Don't quieten Maven output on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ cache:
   directories:
   - $HOME/.m2
 
-install: mvn -T 2C -DskipTests=true -Dmaven.javadoc.skip=true -Ddocker=$BUILD_DOCKER install -B -V -q
+install: mvn -T 2C -DskipTests=true -Dmaven.javadoc.skip=true -Ddocker=$BUILD_DOCKER install -B -V
 
 script: mvn -T 2C -Ddocker=$BUILD_DOCKER test -B
 


### PR DESCRIPTION
If there is a particularly slow build, either due to resource constraints at Travis, or slow connectivity for downloading dependencies, then the install phase could take more than 10 minutes. Previously the install phase was quietened (with `-q`), unfortunately Travis will kill any job which doesn't produce output for more than 10 minutes.
