### PR TITLE
(5.0.0) Bump appbundler-maven-plugin from 1.0.1 to 1.0.4

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -865,7 +865,7 @@
             <plugin>
                 <groupId>com.evolvedbinary.appbundler</groupId>
                 <artifactId>appbundler-maven-plugin</artifactId>
-                <version>1.0.1</version>
+                <version>1.0.4</version>
                 <executions>
                     <execution>
                         <id>exist-db-mac-app</id>


### PR DESCRIPTION
Port of #2790.

Bump appbundler-maven-plugin from 1.0.1 to 1.0.4

Bumps [appbundler-maven-plugin](https://github.com/evolvedbinary/appbundler-maven-plugin) from 1.0.1 to 1.0.4.
- [Release notes](https://github.com/evolvedbinary/appbundler-maven-plugin/releases)
- [Commits](https://github.com/evolvedbinary/appbundler-maven-plugin/compare/appbundler-maven-plugin-1.0.1...appbundler-maven-plugin-1.0.4)