### PR TITLE
(4.x.x) Remove dependency on full Xcode installation

### DIFF
--- a/build/scripts/macosx.xml
+++ b/build/scripts/macosx.xml
@@ -313,7 +313,9 @@
               overwrite="true"/>
 
         <!-- Indicate that we want a custom icon -->
-        <exec executable="/Applications/Xcode.app/Contents/Developer/Tools/SetFile" os="Mac OS X">
+        <!-- The SetFile tool is included the Xcode Command Line Tools; a full installation 
+            of Xcode is not necessary. See https://developer.apple.com/library/archive/technotes/tn2339/_index.html -->
+        <exec executable="/usr/bin/SetFile" os="Mac OS X">
             <arg value="-a"/>
             <arg value="C"/>
             <arg value="${app.dest}"/>


### PR DESCRIPTION
### Description:

The macOS build file had a dependency on the full Xcode app for one of its command line tools, SetFile. This tool is available as part of the Xcode Command Line Tools, which can be installed without the full Xcode suite, using `xcode-select --install` — to receive the necessary command line tools at a fraction of the disk space needed. This PR allows systems without a full Xcode installation to build the 4.x.x macOS app (`./build.sh app`).

### Reference:

https://developer.apple.com/library/archive/technotes/tn2339/_index.html

### Type of tests:

Confirmed with local build on system without full Xcode installation, i.e., with only Xcode Command Line Tools installed.