### PR TITLE
Increase Travis timeout while silencing the logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ cache:
   directories:
   - $HOME/.m2
 
-install: mvn -T 2C -DskipTests=true -Dmaven.javadoc.skip=true -Ddocker=$BUILD_DOCKER install -B -V
+install: travis_wait mvn -T 2C -DskipTests=true -Dmaven.javadoc.skip=true -Ddocker=$BUILD_DOCKER install -B -V -q
 
 script: mvn -T 2C -Ddocker=$BUILD_DOCKER test -B
 

--- a/extensions/indexes/spatial/pom.xml
+++ b/extensions/indexes/spatial/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.4.1</version>
+            <version>2.5.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bump travis timeout for install phase to 20min, but reign in the noise. We can increase further but at some point we ll run into overall stalled build timeout limit of 50min. 