### PR TITLE
Fix IntelliJ shared run target for Jetty Server

### DIFF
--- a/.idea/runConfigurations/Java_Admin_Client.xml
+++ b/.idea/runConfigurations/Java_Admin_Client.xml
@@ -5,7 +5,7 @@
     <option name="MAIN_CLASS_NAME" value="org.exist.start.Main" />
     <module name="exist-distribution" />
     <option name="PROGRAM_PARAMETERS" value="client" />
-    <option name="VM_PARAMETERS" value="-Dexist.configurationFile=$MODULE_DIR$/src/main/config/conf.xml -Dlog4j.configurationFile=$MODULE_DIR$/src/main/config/log4j2.xml -Dorg.exist.db-connection.files=$MODULE_DIR$/target/data -Dorg.exist.db-connection.recovery.journal-dir=$MODULE_DIR$/target/data -Dexist.ensurelocking.disabled=true -Dfile.encoding=UTF-8" />
+    <option name="VM_PARAMETERS" value="-Dexist.home=$MODULE_DIR$/target/exist-distribution-5.0.0-RC8-SNAPSHOT-dir -Dexist.configurationFile=$MODULE_DIR$/target/exist-distribution-5.0.0-RC8-SNAPSHOT-dir/etc/conf.xml -Dlog4j.configurationFile=$MODULE_DIR$/target/exist-distribution-5.0.0-RC8-SNAPSHOT-dir/etc/log4j2.xml -Dorg.exist.db-connection.files=$MODULE_DIR$/target/data -Dorg.exist.db-connection.recovery.journal-dir=$MODULE_DIR$/target/data -Dexist.ensurelocking.disabled=true -Dfile.encoding=UTF-8" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Jetty_Server.xml
+++ b/.idea/runConfigurations/Jetty_Server.xml
@@ -4,8 +4,8 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="org.exist.start.Main" />
     <module name="exist-distribution" />
-    <option name="PROGRAM_PARAMETERS" value="jetty $MODULE_DIR$/src/main/config/conf.xml" />
-    <option name="VM_PARAMETERS" value="-Dexist.configurationFile=$MODULE_DIR$/src/main/config/conf.xml -Dlog4j.configurationFile=$MODULE_DIR$/src/main/config/log4j2.xml -Dorg.exist.db-connection.files=$MODULE_DIR$/target/data -Dorg.exist.db-connection.recovery.journal-dir=$MODULE_DIR$/target/data -Dexist.jetty.config=$MODULE_DIR$/../exist-jetty-config/src/main/resources/org/exist/jetty/etc/standard.enabled-jetty-configs -Djetty.home=$MODULE_DIR$/../exist-jetty-config/src/main/resources/org/exist/jetty/etc -Dexist.ensurelocking.disabled=true -Dfile.encoding=UTF-8" />
+    <option name="PROGRAM_PARAMETERS" value="jetty $MODULE_DIR$/target/exist-distribution-5.0.0-RC8-SNAPSHOT-dir/etc/conf.xml" />
+    <option name="VM_PARAMETERS" value="-Dexist.home=$MODULE_DIR$/target/exist-distribution-5.0.0-RC8-SNAPSHOT-dir -Dexist.configurationFile=$MODULE_DIR$/target/exist-distribution-5.0.0-RC8-SNAPSHOT-dir/etc/conf.xml -Dlog4j.configurationFile=$MODULE_DIR$/target/exist-distribution-5.0.0-RC8-SNAPSHOT-dir/etc/log4j2.xml -Dorg.exist.db-connection.files=$MODULE_DIR$/target/data -Dorg.exist.db-connection.recovery.journal-dir=$MODULE_DIR$/target/data -Dexist.jetty.config=$MODULE_DIR$/target/exist-distribution-5.0.0-RC8-SNAPSHOT-dir/etc/jetty/standard.enabled-jetty-configs -Djetty.home=$MODULE_DIR$/target/exist-distribution-5.0.0-RC8-SNAPSHOT-dir -Dexist.ensurelocking.disabled=true -Dfile.encoding=UTF-8" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>


### PR DESCRIPTION
The "Jetty Server" run configuration in IntelliJ was previously not starting correctly in IntelliJ on the Mavenized version of eXist-db.