### PR TITLE
[feature] Enable JSR-356 websocket support in jetty

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -271,11 +271,16 @@
             <artifactId>jetty-jmx</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <!-- TODO Needed for Monex Console! :-/ Should not be in here! -->
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-servlet</artifactId>
+            <artifactId>websocket-server</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <!-- server-side dependency for javax.websocket (JSR-356) support -->
+        <dependency>
+          <groupId>org.eclipse.jetty.websocket</groupId>
+          <artifactId>javax-websocket-server-impl</artifactId>
+          <scope>runtime</scope>
         </dependency>
 
         <!-- needed for the AppAssembler booter approach -->

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -293,7 +293,13 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>websocket-servlet</artifactId>
+                <artifactId>websocket-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <!-- server-side dependency for javax.websocket (JSR-356) support -->
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>javax-websocket-server-impl</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
As discussed during last community call and in https://github.com/eXist-db/monex/pull/88, this PR enables websockets in the included Jetty. For JSR-356 compliant websockets on the server, two dependencies are required. Unfortunately they recursively pull in quite a few extra jars, including `websocket-client`, which seems unnecessary, but it's the documented approach.