### PR TITLE
Adds VirtualTempPath on set content methods

### DIFF
--- a/exist-core/src/main/java/org/exist/util/io/ByteArrayContent.java
+++ b/exist-core/src/main/java/org/exist/util/io/ByteArrayContent.java
@@ -1,0 +1,59 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.util.io;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Patrick Reinhart <patrick@reini.net>
+ */
+public final class ByteArrayContent implements ContentFile {
+    private static final byte[] EMPTY_BUFFER = new byte[0];
+
+    private byte[] data;
+
+    public static ByteArrayContent of(byte[] data) {
+        return new ByteArrayContent(data);
+    }
+
+    public static ByteArrayContent of(String data) {
+        return new ByteArrayContent(data.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private ByteArrayContent(byte[] data) {
+        this.data = data;
+    }
+
+    @Override
+    public void close() {
+        data = null;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return data == null ? EMPTY_BUFFER : data;
+    }
+
+    @Override
+    public long size() {
+        return data == null ? 0 : data.length;
+    }
+}

--- a/exist-core/src/main/java/org/exist/util/io/ContentFile.java
+++ b/exist-core/src/main/java/org/exist/util/io/ContentFile.java
@@ -1,0 +1,43 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.util.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @author Patrick Reinhart <patrick@reini.net>
+ */
+public interface ContentFile extends AutoCloseable {
+
+    @Override
+    void close();
+
+    byte[] getBytes();
+
+    long size();
+
+    default InputStream newInputStream() throws IOException {
+       return new ByteArrayInputStream(getBytes());
+    }
+
+}

--- a/exist-core/src/main/java/org/exist/util/io/VirtualTempPath.java
+++ b/exist-core/src/main/java/org/exist/util/io/VirtualTempPath.java
@@ -38,9 +38,11 @@ import org.exist.util.FileUtils;
  * @author Patrick Reinhart <patrick@reini.net>
  */
 @ThreadSafe
-public final class VirtualTempPath implements AutoCloseable {
-    private static final Log LOG = LogFactory.getLog(VirtualTempPath.class);
+public final class VirtualTempPath implements ContentFile {
+    public static final int DEFAULT_IN_MEMORY_SIZE = 4 * 1024 * 1024; // 4 MB
+
     private static final byte[] EMPTY_BUFFER = new byte[0];
+    private static final Log LOG = LogFactory.getLog(VirtualTempPath.class);
 
     private final int inMemorySize;
     private final StampedLock lock;

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteCollection.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteCollection.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2001-2015 The eXist Project
+ * Copyright (C) 2001-2019 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
@@ -40,11 +40,21 @@ import org.xmldb.api.base.*;
 import org.xmldb.api.modules.BinaryResource;
 import org.xmldb.api.modules.XMLResource;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteResourceSet.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteResourceSet.java
@@ -1,6 +1,6 @@
 /*
  * eXist Open Source Native XML Database
- * Copyright (C) 2001-2015 The eXist Project
+ * Copyright (C) 2001-2019 The eXist Project
  * http://exist-db.org
  *
  * This program is free software; you can redistribute it and/or
@@ -23,14 +23,18 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 import javax.xml.transform.OutputKeys;
 
 import com.evolvedbinary.j8fu.function.FunctionE;
+import com.evolvedbinary.j8fu.lazy.LazyVal;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
@@ -40,6 +44,7 @@ import org.apache.xmlrpc.client.XmlRpcClient;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.util.Leasable;
 import org.exist.util.io.TemporaryFileManager;
+import org.exist.util.io.VirtualTempPath;
 import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceIterator;
@@ -56,6 +61,7 @@ public class RemoteResourceSet implements ResourceSet, AutoCloseable {
     private final List resources;
     private final Properties outputProperties;
     private boolean closed;
+    private LazyVal<Integer> inMemoryBufferSize;
 
     private static Logger LOG = LogManager.getLogger(RemoteResourceSet.class.getName());
 
@@ -69,6 +75,13 @@ public class RemoteResourceSet implements ResourceSet, AutoCloseable {
         this.outputProperties = properties;
     }
 
+    private final int getInMemorySize(Properties properties) {
+        if (inMemoryBufferSize == null) {
+            inMemoryBufferSize = new LazyVal<>(() -> Integer.parseInt(properties.getProperty("in-memory-buffer-size", Integer.toString(VirtualTempPath.DEFAULT_IN_MEMORY_SIZE))));
+        }
+        return inMemoryBufferSize.get().intValue();
+    }
+    
     @Override
     public void addResource(final Resource resource) {
         resources.add(resource);
@@ -116,9 +129,8 @@ public class RemoteResourceSet implements ResourceSet, AutoCloseable {
         params.add(outputProperties);
 
         try {
-
-            final Path tmpfile = TemporaryFileManager.getInstance().getTemporaryFile();
-            try (final OutputStream os = Files.newOutputStream(tmpfile)) {
+            VirtualTempPath tempFile = new VirtualTempPath(getInMemorySize(outputProperties), TemporaryFileManager.getInstance());
+            try (final OutputStream os = tempFile.newOutputStream()) {
 
                 Map<?, ?> table = (Map<?, ?>) xmlRpcClient.execute("retrieveAllFirstChunk", params);
 
@@ -163,7 +175,7 @@ public class RemoteResourceSet implements ResourceSet, AutoCloseable {
                 }
 
                 final RemoteXMLResource res = new RemoteXMLResource(leasableXmlRpcClient.lease(), collection, handle, 0, XmldbURI.EMPTY_URI, Optional.empty());
-                res.setContent(tmpfile);
+                res.setContent(tempFile);
                 res.setProperties(outputProperties);
                 return res;
             } catch (final XmlRpcException xre) {
@@ -183,8 +195,6 @@ public class RemoteResourceSet implements ResourceSet, AutoCloseable {
             } catch (final IOException | DataFormatException ioe) {
                 throw new XMLDBException(ErrorCodes.VENDOR_ERROR, ioe.getMessage(), ioe);
             }
-        } catch (final IOException ioe) {
-            throw new XMLDBException(ErrorCodes.VENDOR_ERROR, ioe.getMessage(), ioe);
         } catch (final XmlRpcException xre) {
             throw new XMLDBException(ErrorCodes.INVALID_RESOURCE, xre.getMessage(), xre);
         }

--- a/exist-core/src/test/java/org/exist/util/io/ByteArrayContentTest.java
+++ b/exist-core/src/test/java/org/exist/util/io/ByteArrayContentTest.java
@@ -1,0 +1,70 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.util.io;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link ByteArrayContent} implementation.
+ *
+ * @author Patrick Reinhart <patrick@reini.net>
+ */
+public class ByteArrayContentTest {
+    private ByteArrayContent content;
+
+    @Before
+    public void setUp() {
+        content = ByteArrayContent.of("test data");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testOfNullString() {
+        ByteArrayContent.of((String) null);
+    }
+
+    @Test
+    public void testOfNullBytes() {
+        content = ByteArrayContent.of((byte[]) null);
+        assertEquals(0, content.size());
+        assertArrayEquals(new byte[0], content.getBytes());
+    }
+
+    @Test
+    public void testClose() {
+        content.close();
+        assertEquals(0, content.size());
+        assertArrayEquals(new byte[0], content.getBytes());
+    }
+
+    @Test
+    public void testGetBytes() {
+        assertArrayEquals("test data".getBytes(), content.getBytes());
+    }
+
+    @Test
+    public void testSize() {
+        assertEquals(9, content.size());
+    }
+}


### PR DESCRIPTION
### Description:
Adds `VirtualTempPath` usage to also update methods within `RemoteXMLResource` and others like `RemoteResourceSet` in order to use less file file I/O for small data values. This will increase the the performance mainly on Windows systems and generally reduce the disk I/O.

### Reference:
The implementation is a follow up on the already implemented issue #2592