### PR TITLE
(4.x.x) Dont use oracle JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - jdk: openjdk8
     - jdk: openjdk9
     - jdk: openjdk10
-    - jdk: oraclejdk11
+    - jdk: openjdk11
 
     - os: osx
       osx_image: xcode9.3


### PR DESCRIPTION
oracle JDK11 is still used... it should not

![image](https://user-images.githubusercontent.com/1700062/60111327-0b1a9900-976e-11e9-8975-dd0ac8554ac9.png)
