### PR TITLE
(4.x.x) Remove openjdk 9 and 10 from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ dist: xenial
 matrix:
   include:
     - jdk: openjdk8
-    - jdk: openjdk9
-    - jdk: openjdk10
-    - jdk: oraclejdk11
+    - jdk: openjdk11
 
     - os: osx
       osx_image: xcode9.3


### PR DESCRIPTION
Openjdk 9 and 10 are EOL, we will not make fixes specific for these versions.

Proposal: get rid of them