### PR TITLE
(5.0.0) Update Multilock to the released version

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -51,9 +51,9 @@
         </dependency -->
 
         <dependency>
-            <groupId>org.exist-db.thirdparty.uk.ac.ic.doc.slurp.multilock</groupId>
+            <groupId>com.evolvedbinary.multilock</groupId>
             <artifactId>multilock</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/2854