### PR TITLE
Fixes unattended installation with data directory & admin password

### DIFF
--- a/exist-installer/src/main/izpack/jobs.xml
+++ b/exist-installer/src/main/izpack/jobs.xml
@@ -17,7 +17,7 @@
             <arg>-s:$INSTALL_PATH\etc\conf.xml</arg>
             <arg>-xsl:$tmpdir\conf.xslt</arg>
             <arg>-o:$INSTALL_PATH\etc\conf.xml</arg>
-            <arg>dataDir=${dataDir}</arg>
+            <arg>dataDir=$dataDir</arg>
         </executefile>
     </job>
 
@@ -30,7 +30,7 @@
             <arg>-s:$INSTALL_PATH/etc/conf.xml</arg>
             <arg>-xsl:$tmpdir/conf.xslt</arg>
             <arg>-o:$INSTALL_PATH/etc/conf.xml</arg>
-            <arg>dataDir=${dataDir}</arg>
+            <arg>dataDir=$dataDir</arg>
         </executefile>
     </job>
 
@@ -42,7 +42,7 @@
     <job name="Setting admin password..." condition="!dataDirExists">
         <os family="windows"/>
         <executefile name="$INSTALL_PATH/bin/client.bat">
-            <env>JAVA_OPTS="-Dexist.autodeploy=off"</env>
+            <env>JAVA_OPTS=-Dexist.autodeploy=off</env>
             <arg>-s</arg>
             <arg>-l</arg>
             <arg>--user</arg>
@@ -55,7 +55,7 @@
     <job name="Setting admin password..." condition="!dataDirExists">
         <os family="unix"/>
         <executefile name="$INSTALL_PATH/bin/client.sh">
-            <env>JAVA_OPTS="-Dexist.autodeploy=off"</env>
+            <env>JAVA_OPTS=-Dexist.autodeploy=off</env>
             <arg>-s</arg>
             <arg>-l</arg>
             <arg>--user</arg>

--- a/exist-installer/src/main/izpack/userInput.xml
+++ b/exist-installer/src/main/izpack/userInput.xml
@@ -16,7 +16,7 @@
             type="title"/ -->
         <field size="1.33" bold="false" txt="Set Admin Password" align="left"
             type="title"/>
-        <field align="left" variable="adminPasswd" type="password">
+        <field align="left" variable="adminPasswd" type="password" omitFromAuto="false">
             <description txt="Please enter a password for user 'admin', the database administrator:"
                 align="left"/>
             <spec>


### PR DESCRIPTION
### Description:
This PR fixes two issues:
1. The data directory specified (within Dialog/unattended) is not set correctly
2. The admin password specified using unattended installation has been ignored

### Type of tests:
Manual installation test using the GUI dialog, specifying a different data directory and admin password.

Unattended installation using the following command: 
`-jar exist-installer/target/exist-installer-5.0.0-RC8-SNAPSHOT.jar -options exist.props`
where the content of `exist-props` was:
```
INSTALL_PATH=/opt/exist-test
dataDir=/opt/exist-data
adminPasswd=installTest
```