### PR TITLE
(5.0.0): implement fn:parse-ietf-date()

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -7,16 +7,16 @@
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *  
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
+ *
  *  $Id$
  */
 package org.exist.xquery;
@@ -29,7 +29,7 @@ import org.exist.dom.QName;
  * @author aretter
  */
 public class ErrorCodes {
-    
+
 	/* XPath 2.0 http://www.w3.org/TR/xpath20/#id-errors */
     public static final ErrorCode XPST0001 = new W3CErrorCode("XPST0001", "It is a static error if analysis of an expression relies on some component of the static context that has not been assigned a value.");
     public static final ErrorCode XPDY0002 = new W3CErrorCode("XPDY0002", "It is a dynamic error if evaluation of an expression relies on some part of the dynamic context that has not been assigned a value.");
@@ -166,6 +166,7 @@ public class ErrorCodes {
     public static final ErrorCode FORG0006 = new W3CErrorCode("FORG0006", "Invalid argument type.");
     public static final ErrorCode FORG0008 = new W3CErrorCode("FORG0008", "Both arguments to fn:dateTime have a specified timezone.");
     public static final ErrorCode FORG0009 = new W3CErrorCode("FORG0009", "Error in resolving a relative URI against a base URI in fn:resolve-uri.");
+    public static final ErrorCode FORG0010 = new W3CErrorCode("FORG0010", "Invalid date/time.");
     public static final ErrorCode FORX0001 = new W3CErrorCode("FORX0001", "Invalid regular expression. flags");
     public static final ErrorCode FORX0002 = new W3CErrorCode("FORX0002", "Invalid regular expression.");
     public static final ErrorCode FORX0003 = new W3CErrorCode("FORX0003", "Regular expression matches zero-length string.");
@@ -200,9 +201,9 @@ public class ErrorCodes {
 
     public static final ErrorCode FODF1310 = new W3CErrorCode("FODF1310", " Invalid decimal format picture string.");
 	public static final ErrorCode FTDY0020 = new W3CErrorCode("FTDY0020", "");
-	
+
 	public static final ErrorCode FODC0006 = new W3CErrorCode("FODC0006", "String passed to fn:parse-xml is not a well-formed XML document.");
-	
+
 	public static final ErrorCode FOAP0001 = new W3CErrorCode("FOAP0001", "Wrong number of arguments");
 
     /* XQuery 3.1 */
@@ -223,7 +224,7 @@ public class ErrorCodes {
     public static final ErrorCode FOQM0005 = new W3CErrorCode("FOQM0005", "Parameter for dynamically-loaded XQuery " +
             "module has incorrect type");
     public static final ErrorCode FOQM0006 = new W3CErrorCode("FOQM0006", "No suitable XQuery processor available.");
-    
+
     /* eXist specific XQuery and XPath errors
      *
      * Codes have the format [EX][XQ|XP][DY|SE|ST][nnnn]
@@ -240,9 +241,9 @@ public class ErrorCodes {
     public static final ErrorCode EXXQDY0002 = new EXistErrorCode("EXXQDY0002", "Error parsing XML.");
     public static final ErrorCode EXXQDY0003 = new EXistErrorCode("EXXQDY0003", "Only Supported for xquery version \"3.0\" and later.");
     public static final ErrorCode EXXQDY0004 = new EXistErrorCode("EXXQDY0004", "Only Supported for xquery version \"3.1\" and later.");
-    
+
     public static final ErrorCode ERROR = new EXistErrorCode("ERROR", "Error.");
-    
+
     public static class ErrorCode {
 
         private final QName errorQName;

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
@@ -7,16 +7,16 @@
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *  
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
+ *
  *  $Id$
  */
 package org.exist.xquery.functions.fn;
@@ -122,6 +122,7 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(FunAdjustTimezone.fnAdjustTimeToTimezone[1], FunAdjustTimezone.class),
         new FunctionDef(FunAdjustTimezone.fnAdjustDateTimeToTimezone[0], FunAdjustTimezone.class),
         new FunctionDef(FunAdjustTimezone.fnAdjustDateTimeToTimezone[1], FunAdjustTimezone.class),
+        new FunctionDef(FunParseIetfDate.FNS_PARSE_IETF_DATE, FunParseIetfDate.class),
         new FunctionDef(FnHasChildren.FNS_HAS_CHILDREN_0, FnHasChildren.class),
         new FunctionDef(FnHasChildren.FNS_HAS_CHILDREN_1, FnHasChildren.class),
         new FunctionDef(FunId.signature[0], FunId.class),
@@ -229,7 +230,7 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(FunHigherOrderFun.FN_FOLD_RIGHT, FunHigherOrderFun.class),
         new FunctionDef(FunHigherOrderFun.FN_APPLY, FunHigherOrderFun.class),
         new FunctionDef(FunEnvironment.signature[0], FunEnvironment.class),
-        new FunctionDef(FunEnvironment.signature[1], FunEnvironment.class),        
+        new FunctionDef(FunEnvironment.signature[1], FunEnvironment.class),
         new FunctionDef(ParsingFunctions.signatures[0], ParsingFunctions.class),
         new FunctionDef(ParsingFunctions.signatures[1], ParsingFunctions.class),
         new FunctionDef(JSON.signatures[0], JSON.class),

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunParseIetfDate.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunParseIetfDate.java
@@ -1,0 +1,395 @@
+package org.exist.xquery.functions.fn;
+
+import org.exist.dom.QName;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Arrays;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Parses a string containing the date and time in IETF format,
+ * returning the corresponding xs:dateTime value.
+ *
+ * @author Juri Leino (juri@existsolutions.com)
+ */
+public class FunParseIetfDate extends BasicFunction {
+
+    private static FunctionParameterSequenceType IETF_DATE =
+            new FunctionParameterSequenceType(
+                    "value", Type.STRING, Cardinality.ZERO_OR_ONE, "The IETF-dateTime string");
+
+    private static FunctionReturnSequenceType RETURN =
+            new FunctionReturnSequenceType(
+                    Type.DATE_TIME, Cardinality.ZERO_OR_ONE, "The parsed date");
+
+
+    public final static FunctionSignature FNS_PARSE_IETF_DATE = new FunctionSignature(
+            new QName("parse-ietf-date", Function.BUILTIN_FUNCTION_NS),
+            "Parses a string containing the date and time in IETF format,\n" +
+                    "returning the corresponding xs:dateTime value.",
+            new SequenceType[]{IETF_DATE},
+            RETURN
+    );
+
+    public FunParseIetfDate(XQueryContext context, FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
+        if (args[0].isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+        final String value = args[0].getStringValue();
+        final Parser p = new Parser(value.trim());
+
+        try {
+            return new DateTimeValue(p.parse());
+        } catch (final IllegalArgumentException i) {
+            throw new XPathException(ErrorCodes.FORG0010, "Invalid Date time " + value, i);
+        }
+    }
+
+    private class Parser {
+        private final char[] WS = {0x000A, 0x0009, 0x000D, 0x0020};
+        private final String WS_STR = new String(WS);
+
+        private final String[] dayNames = {
+                "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
+                "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+        };
+
+        private final String[] monthNames = {
+                "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+        };
+
+        private final String[] tzNames = {
+                "UT", "UTC", "GMT", "EST", "EDT", "CST", "CDT", "MST", "MDT", "PST", "PDT"
+        };
+
+        private final Map<String, Integer> TZ_MAP = initMap();
+        private final String value;
+        private final int vlen;
+        private int vidx;
+
+        private BigInteger year = null;
+        private int month = DatatypeConstants.FIELD_UNDEFINED;
+        private int day = DatatypeConstants.FIELD_UNDEFINED;
+
+        private int hour = DatatypeConstants.FIELD_UNDEFINED;
+        private int minute = DatatypeConstants.FIELD_UNDEFINED;
+        private int second = DatatypeConstants.FIELD_UNDEFINED;
+        private BigDecimal fractionalSecond = null;
+
+        private int timezone = DatatypeConstants.FIELD_UNDEFINED;
+
+        private Parser(String value) {
+            this.value = value;
+            this.vlen = value.length();
+        }
+
+        private Map<String, Integer> initMap() {
+            Map<String, Integer> result = new HashMap<>();
+            result.put("UT", 0);
+            result.put("UTC", 0);
+            result.put("GMT", 0);
+            result.put("EST", -5);
+            result.put("EDT", -4);
+            result.put("CST", -6);
+            result.put("CDT", -5);
+            result.put("MST", -7);
+            result.put("MDT", -6);
+            result.put("PST", -8);
+            result.put("PDT", -7);
+            return result;
+        }
+
+        /**
+         * <p>Parse a formatted <code>String</code> into an <code>XMLGregorianCalendar</code>.</p>
+         * <p>
+         * <p>If <code>String</code> is not formatted as a legal <code>IETF Date</code> value,
+         * an <code>IllegalArgumentException</code> is thrown.</p>
+         * <pre>
+         * input	::=	(dayname ","? S)? ((datespec S time) | asctime)
+         * datespec	::=	daynum dsep monthname dsep year
+         * dsep	::=	S | (S? "-" S?)
+         * daynum	::=	digit digit?
+         * year	::=	digit digit (digit digit)?
+         * digit	::=	[0-9]
+         * time	::=	hours ":" minutes (":" seconds)? (S? timezone)?
+         * hours	::=	digit digit?
+         * minutes	::=	digit digit
+         * seconds	::=	digit digit ("." digit+)?
+         * S ::= (x0A|x09|x0D|x20)+
+         * </pre>
+         *
+         * @throws IllegalArgumentException If <code>String</code> is not formatted as a legal <code>IETF Date</code> value.
+         */
+        public XMLGregorianCalendar parse() throws IllegalArgumentException {
+            dayName();
+            dateSpec();
+            if (vidx != vlen) {
+                throw new IllegalArgumentException(value);
+            }
+            return TimeUtils
+                    .getInstance()
+                    .getFactory()
+                    .newXMLGregorianCalendar(year, month, day, hour, minute, second, fractionalSecond, timezone);
+        }
+
+        private void dayName() {
+            if (StringUtils.startsWithAny(value, dayNames)) {
+                skipTo(WS_STR);
+                vidx++;
+            }
+        }
+
+        private void dateSpec() throws IllegalArgumentException {
+            if (isWS(peek())) {
+                skipWS();
+            }
+            if (StringUtils.startsWithAny(value.substring(vidx), monthNames)) {
+                asctime();
+            } else {
+                rfcDate();
+            }
+        }
+
+        private void rfcDate() throws IllegalArgumentException {
+            day();
+            dsep();
+            month();
+            dsep();
+            year();
+            skipWS();
+            time();
+        }
+
+        private void asctime() throws IllegalArgumentException {
+            month();
+            dsep();
+            day();
+            skipWS();
+            time();
+            skipWS();
+            year();
+        }
+
+        private void year() throws IllegalArgumentException {
+            final int vstart = vidx;
+
+            while (isDigit(peek())) {
+                vidx++;
+            }
+            final int digits = vidx - vstart;
+            String yearString;
+            if (digits == 2) {
+                yearString = "19" + value.substring(vstart, vidx);
+            } else if (digits == 4) {
+                yearString = value.substring(vstart, vidx);
+            } else {
+                throw new IllegalArgumentException(value);
+            }
+
+            year = new BigInteger(yearString);
+        }
+
+        private void month() throws IllegalArgumentException {
+            final int vstart = vidx;
+            vidx += 3;
+            if (vidx >= vlen) {
+                throw new IllegalArgumentException(value);
+            }
+            final String monthName = value.substring(vstart, vidx);
+            final int idx = Arrays.asList(monthNames).indexOf(monthName);
+            if (idx < 0) {
+                throw new IllegalArgumentException(value);
+            }
+            month = idx + 1;
+        }
+
+        private void day() throws IllegalArgumentException {
+            day = parseInt(1, 2);
+        }
+
+        private void time() throws IllegalArgumentException {
+            hours();
+            minutes();
+            seconds();
+            skipWS();
+            timezone();
+        }
+
+        private void hours() throws IllegalArgumentException {
+            hour = parseInt(2, 2);
+        }
+
+        private void minutes() throws IllegalArgumentException {
+            skip(':');
+            minute = parseInt(2, 2);
+            checkMinutes(minute);
+        }
+
+        private void seconds() throws IllegalArgumentException {
+            if (isWS(peek())) {
+                second = 0;
+                return;
+            }
+            skip(':');
+            second = parseInt(2, 2);
+            fractionalSecond = parseBigDecimal();
+        }
+
+        private void timezone() throws IllegalArgumentException {
+            if (!StringUtils.startsWithAny(value.substring(vidx), tzNames)) {
+                tzoffset();
+                return;
+            }
+            parseTimezoneName();
+        }
+
+        private void parseTimezoneName() {
+            final int vstart = vidx;
+            while (isUpperCaseLetter(peek())) {
+                vidx++;
+            }
+            final String tzName = value.substring(vstart, vidx);
+            if (!TZ_MAP.containsKey(tzName)) {
+                throw new IllegalArgumentException(value);
+            }
+            timezone = TZ_MAP.get(tzName) * 60;
+        }
+
+        private void tzoffset() throws IllegalArgumentException {
+            final char sign = peek();
+            if (!(sign == '+' || sign == '-')) {
+                throw new IllegalArgumentException(value);
+            }
+
+            vidx++;
+            final int h = parseInt(1, 2);
+
+            if (peek() == ':') {
+                skip(':');
+            }
+
+            int m = 0;
+            if (isDigit(peek())) {
+                m = parseInt(2, 2);
+            }
+            checkMinutes(m);
+
+            final int offset = h * 60 + m;
+            final int factor = (sign == '+' ? 1 : -1);
+            timezone = offset * factor;
+
+            // cut off whitespace and optional timezone in parenthesis
+            if (isWS(peek()) || peek() == '(') {
+                vidx = vlen;
+            }
+        }
+
+        private void dsep() throws IllegalArgumentException {
+            if (isWS(peek())) {
+                skipWS();
+            }
+            if (peek() != '-') {
+                return;
+            }
+            skip('-');
+            if (isWS(peek())) {
+                skipWS();
+            }
+        }
+
+        private void skipWS() throws IllegalArgumentException {
+            if (!isWS(peek())) {
+                throw new IllegalArgumentException(value);
+            }
+
+            while (isWS(peek())) {
+                vidx++;
+            }
+        }
+
+        private char peek() {
+            if (vidx == vlen) {
+                return (char) -1;
+            }
+            return value.charAt(vidx);
+        }
+
+        private char read() throws IllegalArgumentException {
+            if (vidx == vlen) {
+                throw new IllegalArgumentException(value);
+            }
+            return value.charAt(vidx++);
+        }
+
+        private void skipTo(String sequence) throws IllegalArgumentException {
+            while (sequence.indexOf(peek()) < 0) {
+                read();
+            }
+        }
+
+        private void skip(char ch) throws IllegalArgumentException {
+            if (read() != ch) throw new IllegalArgumentException(value);
+        }
+
+        private int parseInt(int minDigits, int maxDigits) throws IllegalArgumentException {
+            final int vstart = vidx;
+            while (isDigit(peek()) && (vidx - vstart) < maxDigits) {
+                vidx++;
+            }
+            if ((vidx - vstart) < minDigits) {
+                // we are expecting more digits
+                throw new IllegalArgumentException(value);
+            }
+
+            return Integer.parseInt(value.substring(vstart, vidx));
+        }
+
+        private BigDecimal parseBigDecimal() throws IllegalArgumentException {
+            final int vstart = vidx;
+
+            if (peek() == '.') {
+                vidx++;
+            } else {
+                return new BigDecimal("0");
+            }
+            while (isDigit(peek())) {
+                vidx++;
+            }
+            return new BigDecimal(value.substring(vstart, vidx));
+        }
+
+        private void checkMinutes(int m) {
+            if (m >= 60 || m < 0) {
+                throw new IllegalArgumentException(value);
+            }
+        }
+
+        private boolean isWS(char c) {
+            return (WS_STR.indexOf(c) >= 0);
+        }
+
+        private boolean isDigit(char ch) {
+            return '0' <= ch && ch <= '9';
+        }
+
+        private boolean isUpperCaseLetter(char ch) {
+            return 'A' <= ch && ch <= 'Z';
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunString.java
@@ -7,16 +7,16 @@
  * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *  
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
+ *
  *  $Id$
  */
 package org.exist.xquery.functions.fn;
@@ -58,7 +58,7 @@ public class FunString extends Function {
 			"If the value of $arg is the empty sequence, the zero-length string is returned. " +
 			"If the context item of $arg is undefined, an error is raised.",
 			new SequenceType[] {
-				 new FunctionParameterSequenceType("arg", Type.ITEM, Cardinality.ZERO_OR_ONE, "The sequence to get the vaule of as an xs:string")},
+				 new FunctionParameterSequenceType("arg", Type.ITEM, Cardinality.ZERO_OR_ONE, "The sequence to get the value of as an xs:string")},
 			new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the value of $arg as an xs:string")
 		)
 	};
@@ -70,7 +70,7 @@ public class FunString extends Function {
 	@Override
 	public Sequence eval(Sequence contextSequence, final Item contextItem) throws XPathException {
         if (context.getProfiler().isEnabled()) {
-            context.getProfiler().start(this);       
+            context.getProfiler().start(this);
             context.getProfiler().message(this, Profiler.DEPENDENCIES, "DEPENDENCIES", Dependency.getDependenciesName(this.getDependencies()));
             if (contextSequence != null) {
             	context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT SEQUENCE", contextSequence);
@@ -78,8 +78,8 @@ public class FunString extends Function {
             if (contextItem != null) {
             	context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT ITEM", contextItem.toSequence());
             }
-        }      
-        
+        }
+
 		if (contextItem != null) {
 			contextSequence = contextItem.toSequence();
 		}
@@ -98,13 +98,13 @@ public class FunString extends Function {
         else if (contextSequence.isEmpty()) {
         	return Sequence.EMPTY_SEQUENCE;
         }
-        
-        final Sequence result = contextSequence.convertTo(Type.STRING);        
+
+        final Sequence result = contextSequence.convertTo(Type.STRING);
 
         if (context.getProfiler().isEnabled()) {
         	context.getProfiler().end(this, "", result);
         }
-        
-        return result;           
+
+        return result;
 	}
 }

--- a/exist-core/src/test/xquery/xquery3/parseIetfDate.xqm
+++ b/exist-core/src/test/xquery/xquery3/parseIetfDate.xqm
@@ -1,0 +1,43 @@
+xquery version "3.1";
+
+module namespace parse-ietf-date-spec="http://exist-db.org/xquery/test/parse-ietf-date-spec";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args('Tue, 18 Jun 2019 13:10:56 GMT', '2019-06-18T13:10:56Z') %test:assertTrue
+    %test:args('Tue, 01 Jun 70 13:10:56 +5:00', '1970-06-01T13:10:56+05:00') %test:assertTrue
+    %test:args('Tue 25 Dec 81 18:12:34 EST', '1981-12-25T18:12:34-05:00') %test:assertTrue
+    %test:args('Tue 01-Jan-70 00:00:00 -1:30', '1970-01-01T00:00:00-01:30') %test:assertTrue
+    %test:args("Wed, 06 Jun 1994 07:29:35 GMT", "1994-06-06T07:29:35Z") %test:assertTrue
+    %test:args(" Wed, 6 Jun 94 07:29:35 GMT ", "1994-06-06T07:29:35Z") %test:assertTrue
+    %test:args("Wed Jun 06 11:54:45 EST 2013", "2013-06-06T11:54:45-05:00") %test:assertTrue
+    %test:args("Sunday, 06-Nov-94 08:49:37 GMT", "1994-11-06T08:49:37Z") %test:assertTrue
+    %test:args("&#10;Sun,&#10;&#09;06&#10;&#09;-&#10;&#09;Nov&#10;&#09;-&#10;&#09;94&#10;&#09;08:49:37&#10;&#09;GMT&#10;", "1994-11-06T08:49:37Z") %test:assertTrue
+    %test:args("Wed, 6 Jun 94 07:29:35 +0100 (CET)", "1994-06-06T07:29:35+01:00") %test:assertTrue
+function parse-ietf-date-spec:test-valid-date ($date, $expected) {
+    fn:parse-ietf-date($date) eq xs:dateTime($expected)
+};
+
+declare
+    %test:assertTrue
+function parse-ietf-date-spec:test-empty-date () {
+    empty(fn:parse-ietf-date(()))
+};
+
+
+declare
+    %test:args('') %test:assertError("FORG0010")
+    %test:args('asdfa') %test:assertError("FORG0010")
+
+    %test:args(0) %test:assertError("FORG0010")
+    %test:args(1) %test:assertError("FORG0010")
+
+    %test:args('-1') %test:assertError("FORG0010")
+    %test:args('Tue, 30 Feb 2019 13:10:56 GMT') %test:assertError("FORG0010")
+    %test:args('Tue Feb 28 2019 13:10:56 XYZ') %test:assertError("FORG0010")
+    %test:args('Tue Feb 28 -2019 13:10:56') %test:assertError("FORG0010")
+    %test:args('Tue Feb 28 2019 30:10') %test:assertError("FORG0010")
+function parse-ietf-date-spec:test-invalid-date ($date) {
+    fn:parse-ietf-date($date)
+};


### PR DESCRIPTION
### Description:

port of #2857 

Fully [spec](https://www.w3.org/XML/Group/qtspecs/specifications/xpath-functions-31/html/Overview.html#func-parse-ietf-date)
compliant implementation of `fn:parse-ietf-date()` in java.

- add error code FORG0010
- add function to fn namespace

### Reference:

### Type of tests:

- add testsuite
