### PR TITLE
Fix a number of security issues around user groups

### DIFF
--- a/exist-ant/src/main/java/org/exist/ant/UserPasswordTask.java
+++ b/exist-ant/src/main/java/org/exist/ant/UserPasswordTask.java
@@ -24,6 +24,7 @@ package org.exist.ant;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
+import org.exist.security.internal.Password;
 import org.xmldb.api.base.XMLDBException;
 
 import org.exist.security.Account;
@@ -39,9 +40,7 @@ public class UserPasswordTask extends UserTask
     private String name;
     private String secret;
 
-    /* (non-Javadoc)
-     * @see org.apache.tools.ant.Task#execute()
-     */
+    @Override
     public void execute() throws BuildException
     {
         super.execute();
@@ -58,8 +57,8 @@ public class UserPasswordTask extends UserTask
                 log( "Setting password for user " + name, Project.MSG_INFO );
 
                 if( secret != null ) {
-                    usr.setPassword( secret );
-                    this.service.updateUser(usr);
+                    usr.setCredential(new Password(usr, secret));
+                    this.service.updateAccount(usr);
                 }
 
             } else {

--- a/exist-core/src/main/java/org/exist/security/AbstractAccount.java
+++ b/exist-core/src/main/java/org/exist/security/AbstractAccount.java
@@ -152,6 +152,11 @@ public abstract class AbstractAccount extends AbstractPrincipal implements Accou
 
                 group.assertCanModifyGroup(subject);
 
+
+                if (groups.size() <= 1) {
+                    throw new PermissionDeniedException("You cannot remove the primary group of an account.");
+                }
+
                 //remove from the group
                 groups.remove(group);
                 break;

--- a/exist-core/src/main/java/org/exist/security/AbstractRealm.java
+++ b/exist-core/src/main/java/org/exist/security/AbstractRealm.java
@@ -358,6 +358,12 @@ public abstract class AbstractRealm implements Realm, Configurable {
             }
         }
 
+        // if the primary group has changed, then make sure to update it!
+        if (account.getPrimaryGroup() != null
+                && (!account.getPrimaryGroup().equals(updatingAccount.getPrimaryGroup()))) {
+            updatingAccount.setPrimaryGroup(getGroup(account.getPrimaryGroup()));
+        }
+
         final String passwd = account.getPassword();
         if (passwd != null) {
             // if password is empty, ignore it to keep the old one

--- a/exist-core/src/main/java/org/exist/security/AbstractRealm.java
+++ b/exist-core/src/main/java/org/exist/security/AbstractRealm.java
@@ -164,6 +164,15 @@ public abstract class AbstractRealm implements Realm, Configurable {
                         final Account account;
                         try {
                             account = new AccountImpl(r, conf);
+
+                            // ensure that the account has at least a primary group
+                            if (account.getGroups().length == 0) {
+                                try {
+                                    account.setPrimaryGroup(getGroup(SecurityManager.UNKNOWN_GROUP));
+                                } catch (final PermissionDeniedException e) {
+                                    throw new ConfigurationException("Account has no group, unable to default to " + SecurityManager.UNKNOWN_GROUP + ": " + e.getMessage(), e);
+                                }
+                            }
                         } catch (Throwable e) {
                             LOG.error("Account object can't be built from '" + doc.getFileURI() + "'", e);
                             return;
@@ -175,6 +184,15 @@ public abstract class AbstractRealm implements Realm, Configurable {
                         //set collection
                         if(account.getId() > 0) {
                             ((AbstractPrincipal)account).setCollection(broker, collectionAccounts);
+
+                            // ensure that the account has at least a primary group
+                            if (account.getGroups().length == 0) {
+                                try {
+                                    account.setPrimaryGroup(getGroup(SecurityManager.UNKNOWN_GROUP));
+                                } catch (final PermissionDeniedException e) {
+                                    throw new ConfigurationException("Account has no group, unable to default to " + SecurityManager.UNKNOWN_GROUP + ": " + e.getMessage(), e);
+                                }
+                            }
                         }
                     }
                 });

--- a/exist-core/src/main/java/org/exist/security/PermissionFactory.java
+++ b/exist-core/src/main/java/org/exist/security/PermissionFactory.java
@@ -240,7 +240,7 @@ public class PermissionFactory {
                 if (!permission.isCurrentSubjectOwner()) {
                     throw new PermissionDeniedException("You cannot change the group ID of a file you do not own when posix-chown-restricted is in effect.");
                 }
-                // and, group equals either the effective group ID of the process or one of the processâs supplementary group IDs.
+                // and, group equals either the effective group ID of the process or one of the processes supplementary group IDs.
                 final int desiredGroupId = broker.getBrokerPool().getSecurityManager().getGroup(group.get()).getId();
                 if (!permission.isCurrentSubjectInGroup(desiredGroupId)) {
                     throw new PermissionDeniedException("You cannot change the group ID of a file to a group of which you are not a member when posix-chown-restricted is in effect.");

--- a/exist-core/src/main/java/org/exist/security/SecurityManager.java
+++ b/exist-core/src/main/java/org/exist/security/SecurityManager.java
@@ -51,6 +51,8 @@ public interface SecurityManager extends Configurable {
    String DBA_USER = "admin";
    String GUEST_GROUP = "guest";
    String GUEST_USER = "guest";
+   String UNKNOWN_GROUP = "nogroup";
+   String UNKNOWN_USER = "nobody";
 
    void attach(DBBroker broker, Txn transaction) throws EXistException;
    

--- a/exist-core/src/main/java/org/exist/security/internal/RealmImpl.java
+++ b/exist-core/src/main/java/org/exist/security/internal/RealmImpl.java
@@ -175,6 +175,13 @@ public class RealmImpl extends AbstractRealm {
                 throw new IllegalArgumentException("No such account exists!");
             }
 
+            if (SecurityManager.SYSTEM.equals(account.getName())
+                || SecurityManager.DBA_USER.equals(account.getName())
+                || SecurityManager.GUEST_USER.equals(account.getName())
+                || SecurityManager.UNKNOWN_USER.equals(account.getName())) {
+                throw new PermissionDeniedException("The '" + account.getName() + "' account is required by the system for correct operation, and you cannot delete it! You may be able to disable it instead.");
+            }
+
             try(final DBBroker broker = getDatabase().getBroker()) {
                 final Account user = broker.getCurrentSubject();
 
@@ -211,6 +218,12 @@ public class RealmImpl extends AbstractRealm {
             final AbstractPrincipal remove_group = (AbstractPrincipal)principalDb.get(group.getName());
             if (remove_group == null) {
                 throw new IllegalArgumentException("Group does '" + group.getName() + "' not exist!");
+            }
+
+            if (SecurityManager.DBA_GROUP.equals(group.getName())
+                    || SecurityManager.GUEST_GROUP.equals(group.getName())
+                    || SecurityManager.UNKNOWN_GROUP.equals(group.getName())) {
+                throw new PermissionDeniedException("The '" + group.getName() + "' group is required by the system for correct operation, you cannot delete it!");
             }
 
             final DBBroker broker = getDatabase().getActiveBroker();

--- a/exist-core/src/main/java/org/exist/security/internal/RealmImpl.java
+++ b/exist-core/src/main/java/org/exist/security/internal/RealmImpl.java
@@ -44,7 +44,6 @@ import org.exist.util.UUIDGenerator;
 import org.exist.security.internal.aider.UserAider;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.xmldb.XmldbURI;
 
@@ -112,9 +111,13 @@ public class RealmImpl extends AbstractRealm {
         registerGroup(GROUP_GUEST);
 
         //unknown account and group
-        GROUP_UNKNOWN = new GroupImpl(broker, this, UNKNOWN_GROUP_ID, "");
-    	ACCOUNT_UNKNOWN = new AccountImpl(broker, this, UNKNOWN_ACCOUNT_ID, "", null, GROUP_UNKNOWN);
-        
+        GROUP_UNKNOWN = new GroupImpl(broker, this, UNKNOWN_GROUP_ID, SecurityManager.UNKNOWN_GROUP);
+        sm.registerGroup(GROUP_UNKNOWN);
+        registerGroup(GROUP_UNKNOWN);
+    	ACCOUNT_UNKNOWN = new AccountImpl(broker, this, UNKNOWN_ACCOUNT_ID, SecurityManager.UNKNOWN_USER, null, GROUP_UNKNOWN);
+        sm.registerAccount(ACCOUNT_UNKNOWN);
+        registerAccount(ACCOUNT_UNKNOWN);
+
         //XXX: GROUP_DBA._addManager(ACCOUNT_ADMIN);
     	//XXX: GROUP_GUEST._addManager(ACCOUNT_ADMIN);
     }

--- a/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
+++ b/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
@@ -833,7 +833,6 @@ public class SecurityManagerImpl implements SecurityManager, BrokerPoolService {
                 } else if(name != null) {
                 	if (realm.hasAccount(name)) {
                 		final Integer oldId = saving.get(document.getURI());
-                		
             			final Integer newId = conf.getPropertyInteger("id");
             			
             			//XXX: resolve conflicts on ids!!! 
@@ -849,6 +848,13 @@ public class SecurityManagerImpl implements SecurityManager, BrokerPoolService {
             			}
                 	} else {
                 		final Account account = new AccountImpl( realm, conf );
+                		if (account.getGroups().length == 0) {
+                		    try {
+                                account.setPrimaryGroup(realm.getGroup(SecurityManager.UNKNOWN_GROUP));
+                            } catch (final PermissionDeniedException e) {
+                		        throw new ConfigurationException("Account has no group, unable to default to " + SecurityManager.UNKNOWN_GROUP + ": " + e.getMessage(), e);
+                            }
+                        }
                         registerAccount(account);
                 		realm.registerAccount(account);
                 	}

--- a/exist-core/src/main/java/org/exist/security/internal/aider/UserAider.java
+++ b/exist-core/src/main/java/org/exist/security/internal/aider/UserAider.java
@@ -134,7 +134,10 @@ public class UserAider implements Account {
     }
 
     @Override
-    public void remGroup(final String role) {
+    public void remGroup(final String role) throws PermissionDeniedException {
+        if (groups.containsKey(role) && groups.size() <= 1) {
+            throw new PermissionDeniedException("You cannot remove the primary group of an account.");
+        }
         groups.remove(role);
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/FindGroupFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/FindGroupFunction.java
@@ -65,7 +65,7 @@ public class FindGroupFunction extends BasicFunction {
         new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_MORE, "The list of matching group names")
     );
     
-    public final static FunctionSignature FNS_FIND_GROUPS_WHERE_GROUPNAME_CONTANINS = new FunctionSignature(
+    public final static FunctionSignature FNS_FIND_GROUPS_WHERE_GROUPNAME_CONTAINS = new FunctionSignature(
         qnFindGroupsWhereGroupnameContains,
         "Finds groups whoose group name contains the string fragment",
         new SequenceType[] {

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/GroupManagementFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/GroupManagementFunction.java
@@ -76,7 +76,7 @@ public class GroupManagementFunction extends BasicFunction {
 
     public final static FunctionSignature FNS_REMOVE_GROUP = new FunctionSignature(
         qnRemoveGroup,
-        "Remove a User Group. Any resources owned by the group will be moved to the 'guest' group.",
+        "Remove a User Group.",
         new SequenceType[]{
             new FunctionParameterSequenceType("group-name", Type.STRING, Cardinality.EXACTLY_ONE, "The group-id to delete")
         },

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/SecurityManagerModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/SecurityManagerModule.java
@@ -88,7 +88,7 @@ public class SecurityManagerModule extends AbstractInternalModule {
 
         new FunctionDef(FindGroupFunction.FNS_LIST_GROUPS, FindGroupFunction.class),
         new FunctionDef(FindGroupFunction.FNS_FIND_GROUPS_BY_GROUPNAME, FindGroupFunction.class),
-        new FunctionDef(FindGroupFunction.FNS_FIND_GROUPS_WHERE_GROUPNAME_CONTANINS, FindGroupFunction.class),
+        new FunctionDef(FindGroupFunction.FNS_FIND_GROUPS_WHERE_GROUPNAME_CONTAINS, FindGroupFunction.class),
         new FunctionDef(FindGroupFunction.FNS_GET_USER_GROUPS, FindGroupFunction.class),
         new FunctionDef(FindGroupFunction.FNS_GET_USER_PRIMARY_GROUP, FindGroupFunction.class),
         new FunctionDef(FindGroupFunction.FNS_GROUP_EXISTS, FindGroupFunction.class),

--- a/exist-core/src/test/java/org/exist/backup/XMLDBRestoreTest.java
+++ b/exist-core/src/test/java/org/exist/backup/XMLDBRestoreTest.java
@@ -22,12 +22,11 @@ package org.exist.backup;
 import org.apache.commons.codec.binary.Base64;
 import org.bouncycastle.crypto.digests.RIPEMD160Digest;
 import org.exist.TestUtils;
+import org.exist.security.Account;
 import org.exist.security.MessageDigester;
+import org.exist.security.SecurityManager;
 import org.exist.test.ExistWebServer;
-import org.exist.xmldb.AbstractRestoreServiceTaskListener;
-import org.exist.xmldb.EXistRestoreService;
-import org.exist.xmldb.RestoreServiceTaskListener;
-import org.exist.xmldb.XmldbURI;
+import org.exist.xmldb.*;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,7 +47,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class XMLDBRestoreTest {
@@ -79,7 +78,6 @@ public class XMLDBRestoreTest {
         return baseUri.replace(PORT_PLACEHOLDER, Integer.toString(existWebServer.getPort()));
     }
 
-
     @Test
     public void restoreIsBestEffortAttempt() throws IOException, XMLDBException {
         final Path contentsFile = createBackupWithInvalidContent();
@@ -104,6 +102,27 @@ public class XMLDBRestoreTest {
         assertEquals(3, listener.restored.size());
         assertEquals(0, listener.warnings.size());
         assertEquals(0, listener.errors.size());
+    }
+
+    @Test
+    public void restoreUserWithoutGroupIsPlacedInNoGroup() throws IOException, XMLDBException {
+        final String username = UUID.randomUUID().toString() + "-user";
+        final Path contentsFile = createBackupWithUserWithoutPrimaryGroup(username);
+        final TestRestoreListener listener = new TestRestoreListener();
+        final XmldbURI rootUri = XmldbURI.create(getBaseUri()).append(XmldbURI.ROOT_COLLECTION_URI);
+
+        restoreBackup(rootUri, contentsFile, null, listener);
+
+        assertEquals(2, listener.restored.size());
+        assertEquals(0, listener.warnings.size());
+        assertEquals(0, listener.errors.size());
+
+        final Collection collection = DatabaseManager.getCollection(rootUri.toString(), TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final EXistUserManagementService userManagementService = (EXistUserManagementService) collection.getService("UserManagementService", "1.0");
+        final Account account = userManagementService.getAccount(username);
+        assertNotNull(account);
+        assertEquals(SecurityManager.UNKNOWN_GROUP, account.getPrimaryGroup());
+        assertArrayEquals(new String[] { SecurityManager.UNKNOWN_GROUP }, account.getGroups());
     }
 
     private static void restoreBackup(final XmldbURI uri, final Path backup, @Nullable final String backupPassword, final RestoreServiceTaskListener listener) throws XMLDBException {
@@ -167,6 +186,34 @@ public class XMLDBRestoreTest {
         final Path contentsFile = Files.write(accountsCol.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), contents.getBytes(UTF_8));
         Files.write(accountsCol.resolve("admin.xml"), admin.getBytes(UTF_8));
         Files.write(accountsCol.resolve("guest.xml"), guest.getBytes(UTF_8));
+
+        return contentsFile;
+    }
+
+    private static Path createBackupWithUserWithoutPrimaryGroup(final String username) throws IOException {
+        final Path backupDir = tempFolder.newFolder().toPath();
+        final Path accountsCol = Files.createDirectories(backupDir.resolve("db").resolve("system").resolve("security").resolve("exist").resolve("accounts"));
+
+        final String contents =
+                "<collection xmlns=\"http://exist.sourceforge.net/NS/exist\" name=\"/db/system/security/exist/accounts\" owner=\"SYSTEM\" group=\"dba\" mode=\"770\" created=\"2019-05-15T15:58:39.385+04:00\" deduplicate-blobs=\"false\" version=\"2\">\n" +
+                        "    <acl entries=\"0\" version=\"1\"/>\n" +
+                        "    <resource type=\"XMLResource\" name=\"" + username + ".xml\" owner=\"SYSTEM\" group=\"dba\" mode=\"770\" created=\"2019-05-15T15:58:48.638+04:00\" modified=\"2019-05-15T15:58:48.638+04:00\" filename=\"" + username + ".xml\" mimetype=\"application/xml\">\n" +
+                        "        <acl entries=\"0\" version=\"1\"/>\n" +
+                        "    </resource>\n" +
+                        "</collection>";
+
+        // account with no primary group!
+        final String invalidUserDoc =
+                "<account xmlns=\"http://exist-db.org/Configuration\" id=\"999\">" +
+                    "<password>{RIPEMD160}EF2iMoMqNA2UXU9JARBuAQmMu2M=</password>\n" +
+                    "<expired>false</expired>" +
+                    "<enabled>true</enabled>" +
+                    "<umask>022</umask>" +
+                    "<name>" + username + "</name>" +
+                "</account>";
+
+        final Path contentsFile = Files.write(accountsCol.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR), contents.getBytes(UTF_8));
+        Files.write(accountsCol.resolve(username + ".xml"),  invalidUserDoc.getBytes(UTF_8));
 
         return contentsFile;
     }

--- a/exist-core/src/test/java/org/exist/security/AbstractAccountTest.java
+++ b/exist-core/src/test/java/org/exist/security/AbstractAccountTest.java
@@ -6,6 +6,8 @@ import org.easymock.EasyMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.verify;
 import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+
 import org.exist.Database;
 import org.exist.config.ConfigurationException;
 import org.exist.storage.BrokerPool;
@@ -45,11 +47,11 @@ public class AbstractAccountTest {
 
         verify(mockRealm, mockDatabase, mockBroker, mockGroup, partialMockAccount);
 
-        //TODO calls on assert from AbstractAccountXQuerty
+        //TODO calls on assert from AbstractAccountXQuery
     }
 
     @Test
-    public void remGroup_calls_assertCanModifyGroupForEachGroup() throws PermissionDeniedException, NoSuchMethodException, ConfigurationException {
+    public void remGroup_calls_assertCanModifyGroupForEachGroup() throws PermissionDeniedException, ConfigurationException {
         DBBroker mockBroker = EasyMock.createMock(DBBroker.class);
         AbstractRealm mockRealm = EasyMock.createMock(AbstractRealm.class);
         Database mockDatabase = EasyMock.createMock(Database.class);
@@ -72,7 +74,11 @@ public class AbstractAccountTest {
         replay(mockRealm, mockDatabase, mockBroker, mockGroup);
 
         //test
-        partialMockAccount.remGroup(groupName);
+        try {
+            partialMockAccount.remGroup(groupName);
+        } catch (final PermissionDeniedException e) {
+            assertEquals("You cannot remove the primary group of an account.", e.getMessage());
+        }
 
         verify(mockRealm, mockDatabase, mockBroker, mockGroup);
 

--- a/exist-core/src/test/java/org/exist/security/AbstractSecurityManagerRoundtripTest.java
+++ b/exist-core/src/test/java/org/exist/security/AbstractSecurityManagerRoundtripTest.java
@@ -71,9 +71,18 @@ public abstract class AbstractSecurityManagerRoundtripTest {
 
         } finally {
             //cleanup
-            try { ums.removeGroup(group1); } catch(Exception e) {}
-            try { ums.removeGroup(group2); } catch(Exception e) {}
-            try { ums.removeAccount(user); } catch(Exception e) {}
+            final Account u1 = ums.getAccount(userName);
+            if (u1 != null) {
+                ums.removeAccount(u1);
+            }
+            final Group g1 = ums.getGroup(group1Name);
+            if (g1 != null) {
+                ums.removeGroup(g1);
+            }
+            final Group g2 = ums.getGroup(group2Name);
+            if (g2 != null) {
+                ums.removeGroup(g2);
+            }
         }
     }
 
@@ -124,9 +133,18 @@ public abstract class AbstractSecurityManagerRoundtripTest {
 
         } finally {
             //cleanup
-            try { ums.removeGroup(group1); } catch(Exception e) {}
-            try { ums.removeGroup(group2); } catch(Exception e) {}
-            try { ums.removeAccount(user); } catch(Exception e) {}
+            final Account u1 = ums.getAccount(userName);
+            if (u1 != null) {
+                ums.removeAccount(u1);
+            }
+            final Group g1 = ums.getGroup(group1Name);
+            if (g1 != null) {
+                ums.removeGroup(g1);
+            }
+            final Group g2 = ums.getGroup(group2Name);
+            if (g2 != null) {
+                ums.removeGroup(g2);
+            }
         }
     }
 
@@ -175,9 +193,18 @@ public abstract class AbstractSecurityManagerRoundtripTest {
 
         } finally {
             //cleanup
-            try { ums.removeGroup(group1); } catch(Exception e) {}
-            try { ums.removeGroup(group2); } catch(Exception e) {}
-            try { ums.removeAccount(user); } catch(Exception e) {}
+            final Account u1 = ums.getAccount(userName);
+            if (u1 != null) {
+                ums.removeAccount(u1);
+            }
+            final Group g1 = ums.getGroup(group1Name);
+            if (g1 != null) {
+                ums.removeGroup(g1);
+            }
+            final Group g2 = ums.getGroup(group2Name);
+            if (g2 != null) {
+                ums.removeGroup(g2);
+            }
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/AccountManagementFunctionRemoveAccountTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/AccountManagementFunctionRemoveAccountTest.java
@@ -1,0 +1,87 @@
+package org.exist.xquery.functions.securitymanager;
+
+import com.evolvedbinary.j8fu.function.Runnable3E;
+import org.exist.EXistException;
+import org.exist.TestUtils;
+import org.exist.security.AuthenticationException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.SecurityManager;
+import org.exist.security.Subject;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.value.Sequence;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Optional;
+
+public class AccountManagementFunctionRemoveAccountTest {
+
+    @Rule
+    public final ExistEmbeddedServer existWebServer = new ExistEmbeddedServer(true, true);
+
+    @Test(expected = PermissionDeniedException.class)
+    public void cannotDeleteSystemAccount() throws XPathException, PermissionDeniedException, EXistException, AuthenticationException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject admin = pool.getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        extractPermissionDenied(() -> {
+            xqueryRemoveAccount(SecurityManager.SYSTEM, Optional.of(admin));
+        });
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void cannotDeleteDbaAccount() throws XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            xqueryRemoveAccount(SecurityManager.DBA_USER);
+        });
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void cannotDeleteGuestAccount() throws XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            xqueryRemoveAccount(SecurityManager.GUEST_USER);
+        });
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void cannotDeleteUnknownAccount() throws XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            xqueryRemoveAccount(SecurityManager.UNKNOWN_USER);
+        });
+    }
+
+    private Sequence xqueryRemoveAccount(final String username) throws XPathException, PermissionDeniedException, EXistException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Optional<Subject> asUser = Optional.of(pool.getSecurityManager().getSystemSubject());
+        return xqueryRemoveAccount(username, asUser);
+    }
+
+    private Sequence xqueryRemoveAccount(final String username, final Optional<Subject> asUser) throws EXistException, PermissionDeniedException, XPathException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+
+        final String query =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                        "sm:remove-account('" + username + "')";
+
+        try (final DBBroker broker = pool.get(asUser)) {
+            final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+            return result;
+        }
+    }
+
+    private static void extractPermissionDenied(final Runnable3E<XPathException, PermissionDeniedException, EXistException> runnable) throws XPathException, PermissionDeniedException, EXistException {
+        try {
+            runnable.run();
+        } catch (final XPathException e) {
+            if (e.getCause() != null && e.getCause() instanceof PermissionDeniedException) {
+                throw (PermissionDeniedException)e.getCause();
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GroupManagementFunctionRemoveGroupTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GroupManagementFunctionRemoveGroupTest.java
@@ -1,0 +1,260 @@
+package org.exist.xquery.functions.securitymanager;
+
+import org.exist.EXistException;
+import org.exist.security.*;
+import org.exist.security.SecurityManager;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.junit.*;
+
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class GroupManagementFunctionRemoveGroupTest {
+
+    private static final String USER1_NAME = "user1";
+    private static final String USER1_PWD = USER1_NAME;
+    private static final String USER2_NAME = "user2";
+    private static final String USER2_PWD = USER2_NAME;
+
+    private static final String OTHER_GROUP1_NAME = "otherGroup";
+    private static final String OTHER_GROUP2_NAME = "otherGroup2";
+
+    @Rule
+    public final ExistEmbeddedServer existWebServer = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void deleteUsersSupplementalGroups() throws PermissionDeniedException, EXistException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+
+        // create user with personal group as primary group
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Account user1 = createUser(broker, sm, USER1_NAME, USER1_PWD);
+
+            final Group otherGroup1 = createGroup(broker, sm, OTHER_GROUP1_NAME);
+            addUserToGroup(sm, user1, otherGroup1);
+
+            final Group otherGroup2 = createGroup(broker, sm, OTHER_GROUP2_NAME);
+            addUserToGroup(sm, user1, otherGroup2);
+
+            transaction.commit();
+        }
+
+        // check that the user is as we expect
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Account user1 = sm.getAccount(USER1_NAME);
+            assertEquals(USER1_NAME, user1.getPrimaryGroup());
+            final String[] user1Groups = user1.getGroups();
+            assertArrayEquals(new String[] { USER1_NAME, OTHER_GROUP1_NAME, OTHER_GROUP2_NAME }, user1Groups);
+            for (final String user1Group : user1Groups) {
+                assertNotNull(sm.getGroup(user1Group));
+            }
+            transaction.commit();
+        }
+
+        // attempt to remove the supplemental groups of the user
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            assertTrue(sm.deleteGroup(OTHER_GROUP1_NAME));
+            assertTrue(sm.deleteGroup(OTHER_GROUP2_NAME));
+
+            transaction.commit();
+        }
+
+        // check that the user no longer has the supplemental groups
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Account user1 = sm.getAccount(USER1_NAME);
+            final String user1PrimaryGroup = user1.getPrimaryGroup();
+            assertEquals(USER1_NAME, user1PrimaryGroup);
+            final String[] user1Groups = user1.getGroups();
+            assertArrayEquals(new String[] { USER1_NAME, OTHER_GROUP1_NAME, OTHER_GROUP2_NAME }, user1Groups);
+            for (final String user1Group : user1Groups) {
+                if (user1PrimaryGroup.equals(user1Group)) {
+                    assertNotNull(sm.getGroup(user1Group));
+                } else {
+                    // cannot retrieve groups which have been deleted!
+                    assertNull(sm.getGroup(user1Group));
+                }
+            }
+
+            transaction.commit();
+        }
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void deleteUsersPersonalPrimaryGroup() throws PermissionDeniedException, EXistException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+
+        // create user with personal group as primary group
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            createUser(broker, sm, USER1_NAME, USER1_PWD);
+            transaction.commit();
+        }
+
+        // check that the user is as we expect
+        String user1PrimaryGroup = null;
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Account user1 = sm.getAccount(USER1_NAME);
+            user1PrimaryGroup = user1.getPrimaryGroup();
+            assertEquals(USER1_NAME, user1PrimaryGroup);
+            assertArrayEquals(new String[] { USER1_NAME }, user1.getGroups());
+
+            transaction.commit();
+        }
+
+        // attempt to remove the primary group of the user
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            sm.deleteGroup(user1PrimaryGroup);
+            fail("Should have received: PermissionDeniedException: Account 'user1' still has 'user1' as their primary group!");
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void deleteUsersSharingPersonalPrimaryGroup() throws PermissionDeniedException, EXistException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+
+        // create two users which share a primary group
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Group otherGroup1 = createGroup(broker, sm, OTHER_GROUP1_NAME);
+
+            Account user1 = createUser(broker, sm, USER1_NAME, USER1_PWD);
+            addUserToGroup(sm, user1, otherGroup1);
+            setPrimaryGroup(sm, user1, otherGroup1);
+
+            final Account user2 = createUser(broker, sm, USER2_NAME, USER2_PWD);
+            addUserToGroup(sm, user2, otherGroup1);
+            setPrimaryGroup(sm, user2, otherGroup1);
+
+            transaction.commit();
+        }
+
+        // check that the users are as we expect
+        String primaryGroup = null;
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Account user1 = sm.getAccount(USER1_NAME);
+            primaryGroup = user1.getPrimaryGroup();
+            assertEquals(OTHER_GROUP1_NAME, primaryGroup);
+            final String[] user1Groups = user1.getGroups();
+            assertArrayEquals(new String[] { OTHER_GROUP1_NAME, USER1_NAME}, user1Groups);
+            for (final String user1Group : user1Groups) {
+                assertNotNull(sm.getGroup(user1Group));
+            }
+
+            final Account user2 = sm.getAccount(USER2_NAME);
+            assertEquals(OTHER_GROUP1_NAME, user2.getPrimaryGroup());
+            final String[] user2Groups = user2.getGroups();
+            assertArrayEquals(new String[] { OTHER_GROUP1_NAME, USER2_NAME}, user2Groups);
+            for (final String user2Group : user2Groups) {
+                assertNotNull(sm.getGroup(user2Group));
+            }
+
+            transaction.commit();
+        }
+
+        // attempt to remove the primary group of the first user
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            try {
+                sm.deleteGroup(primaryGroup);
+                fail("Should have received: PermissionDeniedException: Account 'user1' still has 'otherGroup1' as their primary group!");
+            } catch (final PermissionDeniedException e) {
+                // expected
+            }
+
+            transaction.commit();
+        }
+
+        // delete the first user
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            removeUser(sm, USER1_NAME);
+            transaction.commit();
+        }
+
+        // attempt to remove the primary group of the second user
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            try {
+                sm.deleteGroup(primaryGroup);
+                fail("Should have received: PermissionDeniedException: Account 'user2' still has 'otherGroup1' as their primary group!");
+            } catch (final PermissionDeniedException e) {
+                // expected
+            }
+
+            transaction.commit();
+        }
+
+        // delete the second user
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            removeUser(sm, USER2_NAME);
+            transaction.commit();
+        }
+
+        // no users have the group as primary group, so now should be able to delete the group
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            sm.deleteGroup(primaryGroup);
+
+            transaction.commit();
+        }
+    }
+
+    private static Account createUser(final DBBroker broker, final SecurityManager sm, final String username, final String password) throws PermissionDeniedException, EXistException {
+        Group userGroup = new GroupAider(username);
+        sm.addGroup(broker, userGroup);
+        final Account user = new UserAider(username);
+        user.setPassword(password);
+        user.setPrimaryGroup(userGroup);
+        sm.addAccount(user);
+
+        userGroup = sm.getGroup(username);
+        userGroup.addManager(sm.getAccount(username));
+        sm.updateGroup(userGroup);
+
+        return user;
+    }
+
+    private static Group createGroup(final DBBroker broker, final SecurityManager sm, final String groupName) throws PermissionDeniedException, EXistException {
+        final Group otherGroup = new GroupAider(groupName);
+        return sm.addGroup(broker, otherGroup);
+    }
+
+    private static void addUserToGroup(final SecurityManager sm, final Account user, final Group group) throws PermissionDeniedException, EXistException {
+        user.addGroup(group.getName());
+        sm.updateAccount(user);
+    }
+
+    private static void setPrimaryGroup(final SecurityManager sm, final Account user, final Group group) throws PermissionDeniedException, EXistException {
+        user.setPrimaryGroup(group);
+        sm.updateAccount(user);
+    }
+
+    private static void removeUser(final SecurityManager sm, final String username) throws PermissionDeniedException, EXistException {
+        sm.deleteAccount(username);
+        removeGroup(sm, username);
+    }
+
+    private static void removeGroup(final SecurityManager sm, final String groupname) throws PermissionDeniedException, EXistException {
+        sm.deleteGroup(groupname);
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GroupMembershipFunctionRemoveGroupMemberTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/GroupMembershipFunctionRemoveGroupMemberTest.java
@@ -1,0 +1,163 @@
+package org.exist.xquery.functions.securitymanager;
+
+import com.evolvedbinary.j8fu.function.Runnable3E;
+import org.exist.EXistException;
+import org.exist.TestUtils;
+import org.exist.security.*;
+import org.exist.security.SecurityManager;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.value.Sequence;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class GroupMembershipFunctionRemoveGroupMemberTest {
+
+    private static final String USER1_NAME = "user1";
+    private static final String USER1_PWD = USER1_NAME;
+
+    private static final String OTHER_GROUP1_NAME = "otherGroup";
+    private static final String OTHER_GROUP2_NAME = "otherGroup2";
+
+    @Rule
+    public final ExistEmbeddedServer existWebServer = new ExistEmbeddedServer(true, true);
+
+    @Test(expected = PermissionDeniedException.class)
+    public void cannotRemoveAllGroupsFromUserAsOwner() throws XPathException, PermissionDeniedException, EXistException, AuthenticationException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject owner = pool.getSecurityManager().authenticate(USER1_NAME, USER1_NAME);
+        extractPermissionDenied(() -> {
+            xqueryRemoveUserFromGroup(USER1_NAME, OTHER_GROUP2_NAME, Optional.of(owner));
+            xqueryRemoveUserFromGroup(USER1_NAME, OTHER_GROUP1_NAME, Optional.of(owner));
+            xqueryRemoveUserFromGroup(USER1_NAME, USER1_NAME, Optional.of(owner));
+        });
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void cannotRemoveAllGroupsFromUserAsDBA() throws XPathException, PermissionDeniedException, EXistException, AuthenticationException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Subject admin = pool.getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        extractPermissionDenied(() -> {
+            xqueryRemoveUserFromGroup(USER1_NAME, OTHER_GROUP2_NAME, Optional.of(admin));
+            xqueryRemoveUserFromGroup(USER1_NAME, OTHER_GROUP1_NAME, Optional.of(admin));
+            xqueryRemoveUserFromGroup(USER1_NAME, USER1_NAME, Optional.of(admin));
+        });
+    }
+
+    @Before
+    public void setup() throws EXistException, PermissionDeniedException, XPathException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final SecurityManager sm = pool.getSecurityManager();
+
+        // create user with personal group as primary group
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Account user1 = createUser(broker, sm, USER1_NAME, USER1_PWD);
+
+            final Group otherGroup1 = createGroup(broker, sm, OTHER_GROUP1_NAME);
+            addUserToGroup(sm, user1, otherGroup1);
+            addUserAsGroupManager(USER1_NAME, OTHER_GROUP1_NAME);
+
+            final Group otherGroup2 = createGroup(broker, sm, OTHER_GROUP2_NAME);
+            addUserToGroup(sm, user1, otherGroup2);
+            addUserAsGroupManager(USER1_NAME, OTHER_GROUP2_NAME);
+
+            transaction.commit();
+        }
+
+        // check that the user is as we expect
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            final Account user1 = sm.getAccount(USER1_NAME);
+            assertEquals(USER1_NAME, user1.getPrimaryGroup());
+            final String[] user1Groups = user1.getGroups();
+            assertArrayEquals(new String[] { USER1_NAME, OTHER_GROUP1_NAME, OTHER_GROUP2_NAME }, user1Groups);
+            for (final String user1Group : user1Groups) {
+                assertNotNull(sm.getGroup(user1Group));
+            }
+            transaction.commit();
+        }
+    }
+
+    private Sequence xqueryRemoveUserFromGroup(final String username, final String groupname) throws XPathException, PermissionDeniedException, EXistException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+        final Optional<Subject> asUser = Optional.of(pool.getSecurityManager().getSystemSubject());
+        return xqueryRemoveUserFromGroup(username, groupname, asUser);
+    }
+
+    private Sequence xqueryRemoveUserFromGroup(final String username, final String groupname, final Optional<Subject> asUser) throws EXistException, PermissionDeniedException, XPathException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+
+        final String query =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                        "sm:remove-group-member('" + groupname + "', '" + username + "')";
+
+        try (final DBBroker broker = pool.get(asUser)) {
+            final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+            return result;
+        }
+    }
+
+    private Sequence addUserAsGroupManager(final String username, final String groupname) throws EXistException, PermissionDeniedException, XPathException {
+        final BrokerPool pool = existWebServer.getBrokerPool();
+
+        final String query =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                        "sm:add-group-manager('" + groupname + "', '" + username + "')";
+
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
+            final Sequence result = xquery.execute(broker, query, null);
+            return result;
+        }
+    }
+
+    private static Account createUser(final DBBroker broker, final SecurityManager sm, final String username, final String password) throws PermissionDeniedException, EXistException {
+        Group userGroup = new GroupAider(username);
+        sm.addGroup(broker, userGroup);
+        final Account user = new UserAider(username);
+        user.setPassword(password);
+        user.setPrimaryGroup(userGroup);
+        sm.addAccount(user);
+
+        userGroup = sm.getGroup(username);
+        userGroup.addManager(sm.getAccount(username));
+        sm.updateGroup(userGroup);
+
+        return user;
+    }
+
+    private static Group createGroup(final DBBroker broker, final SecurityManager sm, final String groupName) throws PermissionDeniedException, EXistException {
+        final Group otherGroup = new GroupAider(groupName);
+        return sm.addGroup(broker, otherGroup);
+    }
+
+    private static void addUserToGroup(final SecurityManager sm, final Account user, final Group group) throws PermissionDeniedException, EXistException {
+        user.addGroup(group.getName());
+        sm.updateAccount(user);
+    }
+
+    private static void extractPermissionDenied(final Runnable3E<XPathException, PermissionDeniedException, EXistException> runnable) throws XPathException, PermissionDeniedException, EXistException {
+        try {
+            runnable.run();
+        } catch (final XPathException e) {
+            if (e.getCause() != null && e.getCause() instanceof PermissionDeniedException) {
+                throw (PermissionDeniedException)e.getCause();
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
@@ -21,6 +21,7 @@
 package org.exist.xquery.functions.securitymanager;
 
 import com.evolvedbinary.j8fu.function.Runnable4E;
+import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.collections.Collection;
@@ -51,6 +52,7 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.util.Optional;
 
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -68,6 +70,8 @@ public class PermissionsFunctionChownTest {
     private static final String USER1_PWD = USER1_NAME;
     private static final String USER2_NAME = "user2";
     private static final String USER2_PWD = USER2_NAME;
+    private static final String USERRM_NAME = "userrm";
+    private static final String USERRM_PWD = USERRM_NAME;
 
     private static final XmldbURI USER1_COL1 = XmldbURI.create("u1c1");
     private static final XmldbURI USER1_COL2 = XmldbURI.create("u1c2");
@@ -337,7 +341,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has cleared the setUid and setGid bits.
      */
     @Test
-    public void changeDocumentOwnerToSelfAsNonDbaOwner_clearsSetUidAndSetGid_restricted() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
+    public void changeDocumentOwnerToSelfAsNonDBAOwner_clearsSetUidAndSetGid_restricted() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
@@ -357,7 +361,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has cleared the setUid and setGid bits.
      */
     @Test
-    public void changeDocumentOwnerToSelfAsNonDbaOwner_clearsSetUidAndSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
+    public void changeDocumentOwnerToSelfAsNonDBAOwner_clearsSetUidAndSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
@@ -377,7 +381,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has cleared the setUid and setGid bits.
      */
     @Test
-    public void changeCollectionOwnerToSelfAsNonDbaOwner_clearsSetUidAndSetGid_restricted() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
+    public void changeCollectionOwnerToSelfAsNonDBAOwner_clearsSetUidAndSetGid_restricted() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
@@ -397,7 +401,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has cleared the setUid and setGid bits.
      */
     @Test
-    public void changeCollectionOwnerToSelfAsNonDbaOwner_clearsSetUidAndSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
+    public void changeCollectionOwnerToSelfAsNonDBAOwner_clearsSetUidAndSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
@@ -417,7 +421,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has preserved the setUid and setGid bits.
      */
     @Test
-    public void changeDocumentOwnerToSelfAsDba_preservesSetUidAndSetGid_restricted() throws EXistException, PermissionDeniedException, XPathException {
+    public void changeDocumentOwnerToSelfAsDBA_preservesSetUidAndSetGid_restricted() throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().getSystemSubject();
 
@@ -437,7 +441,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has preserved the setUid and setGid bits.
      */
     @Test
-    public void changeDocumentOwnerToSelfAsDba_preservesSetUidAndSetGid() throws EXistException, PermissionDeniedException, XPathException {
+    public void changeDocumentOwnerToSelfAsDBA_preservesSetUidAndSetGid() throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().getSystemSubject();
 
@@ -457,7 +461,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has preserved the setUid and setGid bits.
      */
     @Test
-    public void changeCollectionOwnerToSelfAsDba_preservesSetUidAndSetGid_restricted() throws EXistException, PermissionDeniedException, XPathException {
+    public void changeCollectionOwnerToSelfAsDBA_preservesSetUidAndSetGid_restricted() throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().getSystemSubject();
 
@@ -477,7 +481,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has preserved the setUid and setGid bits.
      */
     @Test
-    public void changeCollectionOwnerToSelfAsDba_preservesSetUidAndSetGid() throws EXistException, PermissionDeniedException, XPathException {
+    public void changeCollectionOwnerToSelfAsDBA_preservesSetUidAndSetGid() throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().getSystemSubject();
 
@@ -837,7 +841,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has cleared the setUid and setGid bits.
      */
     @Test
-    public void changeDocumentGroupToSelfAsNonDbaOwner_clearsSetUidAndSetGid_restricted() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
+    public void changeDocumentGroupToSelfAsNonDBAOwner_clearsSetUidAndSetGid_restricted() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
@@ -857,7 +861,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has cleared the setUid and setGid bits.
      */
     @Test
-    public void changeDocumentGroupToSelfAsNonDbaOwner_clearsSetUidAndSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
+    public void changeDocumentGroupToSelfAsNonDBAOwner_clearsSetUidAndSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
@@ -877,7 +881,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has cleared the setUid and setGid bits.
      */
     @Test
-    public void changeCollectionGroupToSelfAsNonDbaOwner_clearsSetUidAndSetGid_restricted() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
+    public void changeCollectionGroupToSelfAsNonDBAOwner_clearsSetUidAndSetGid_restricted() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
@@ -897,7 +901,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has cleared the setUid and setGid bits.
      */
     @Test
-    public void changeCollectionGroupToSelfAsNonDbaOwner_clearsSetUidAndSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
+    public void changeCollectionGroupToSelfAsNonDBAOwner_clearsSetUidAndSetGid() throws AuthenticationException, EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
 
@@ -917,7 +921,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has preserved the setUid and setGid bits.
      */
     @Test
-    public void changeDocumentGroupToSelfAsDba_preservesSetUidAndSetGid_restricted() throws EXistException, PermissionDeniedException, XPathException {
+    public void changeDocumentGroupToSelfAsDBA_preservesSetUidAndSetGid_restricted() throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().getSystemSubject();
 
@@ -937,7 +941,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has preserved the setUid and setGid bits.
      */
     @Test
-    public void changeDocumentGroupToSelfAsDba_preservesSetUidAndSetGid() throws EXistException, PermissionDeniedException, XPathException {
+    public void changeDocumentGroupToSelfAsDBA_preservesSetUidAndSetGid() throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().getSystemSubject();
 
@@ -957,7 +961,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has preserved the setUid and setGid bits.
      */
     @Test
-    public void changeCollectionGroupToSelfAsDba_preservesSetUidAndSetGid_restricted() throws EXistException, PermissionDeniedException, XPathException {
+    public void changeCollectionGroupToSelfAsDBA_preservesSetUidAndSetGid_restricted() throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().getSystemSubject();
 
@@ -977,7 +981,7 @@ public class PermissionsFunctionChownTest {
      * Finally make sure that chown has preserved the setUid and setGid bits.
      */
     @Test
-    public void changeCollectionGroupToSelfAsDba_preservesSetUidAndSetGid() throws EXistException, PermissionDeniedException, XPathException {
+    public void changeCollectionGroupToSelfAsDBA_preservesSetUidAndSetGid() throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         final Subject user1 = pool.getSecurityManager().getSystemSubject();
 
@@ -991,29 +995,571 @@ public class PermissionsFunctionChownTest {
         assertCollectionSetUidSetGid(user1, TestConstants.TEST_COLLECTION_URI.append(USER1_COL2), IS_SET);
     }
 
+    @Test
+    public void changeCollectionOwnerToNonExistentAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-user", USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionOwnerToNonExistentAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-user", USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionOwnerToRemovedUserAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionOwnerToRemovedUserAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionOwnerToNonExistentAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-user", USER1_NAME);
+    }
+
+    /**
+     * With {@code posix-chown-restricted="true"},
+     * as the collection owner user change the owner of {@link #USER1_COL1} from "user1" to "no-such-user".
+     */
+    public void changeCollectionOwnerToNonExistentAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-user", USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionOwnerToRemovedUserAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+    }
+
+    /**
+     * With {@code posix-chown-restricted="true"},
+     * as the collection owner user change the owner of {@link #USER1_COL1} from "user1" to "userrm".
+     */
+    @Test(expected=PermissionDeniedException.class)
+    public void changeCollectionOwnerToRemovedUserAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+            changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeCollectionOwnerToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-user", USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeCollectionOwnerToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-user", USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeCollectionOwnerToRemovedUserAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeCollectionOwnerToRemovedUserAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    @Test
+    public void changeCollectionGroupToNonExistentAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeGroup(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-group", USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionGroupToNonExistentAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeGroup(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-group", USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionGroupToRemovedGroupAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeGroup(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionGroupToRemovedGroupAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeGroup(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionGroupToNonExistentAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeGroup(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-group", USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionGroupToNonExistentAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeGroup(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-group", USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionGroupToRemovedGroupAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeGroup(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeCollectionGroupToRemovedGroupAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeGroup(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeCollectionGroupToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-group", USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeCollectionGroupToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), "no-such-group", USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeCollectionGroupToRemovedGroupAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeCollectionGroupToRemovedGroupAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    @Test
+    public void changeDocumentOwnerToNonExistentAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-user", USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentOwnerToNonExistentAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-user", USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentOwnerToRemovedUserAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentOwnerToRemovedUserAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentOwnerToNonExistentAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-user", USER1_NAME);
+    }
+
+    /**
+     * With {@code posix-chown-restricted="true"},
+     * as the document owner user change the owner of {@link #USER1_DOC1} from "user1" to "no-such-user".
+     */
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentOwnerToNonExistentAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+            changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-user", USER1_NAME);
+        });
+    }
+
+    @Test
+    public void changeDocumentOwnerToRemovedUserAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+    }
+
+    /**
+     * With {@code posix-chown-restricted="true"},
+     * as the document owner user change the owner of {@link #USER1_DOC1} from "user1" to "no-such-user".
+     */
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentOwnerToRemovedUserAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+            changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentOwnerToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-user", USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentOwnerToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-user", USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentOwnerToRemovedUserAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentOwnerToRemovedUserAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    @Test
+    public void changeDocumentGroupToNonExistentAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeGroup(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-group", USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentGroupToNonExistentAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeGroup(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-group", USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentGroupToRemovedGroupAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeGroup(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentGroupToRemovedGroupAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeGroup(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentGroupToNonExistentAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeGroup(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-group", USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentGroupToNonExistentAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeGroup(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-group", USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentGroupToRemovedGroupAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeGroup(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test
+    public void changeDocumentGroupToRemovedGroupAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeGroup(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentGroupToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-group", USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentGroupToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), "no-such-group", USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentGroupToRemovedGroupAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeGroup(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void changeDocumentGroupToRemovedGroupAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeGroup(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), USERRM_NAME, USER1_NAME);
+        });
+    }
+
+    //TODO need tests for changing owner like "user:group" and checking both resultant group and owner
+
+    @Test
+    public void ChangeCollectionOwnerAndGroupToNonExistentAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    @Test
+    public void ChangeCollectionOwnerAndGroupToNonExistentAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    @Test
+    public void ChangeCollectionOwnerAndGroupToRemovedAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    @Test
+    public void ChangeCollectionOwnerAndGroupToRemovedAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    @Test
+    public void ChangeCollectionOwnerAndGroupToNonExistentAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    /**
+     * With {@code posix-chown-restricted="true"},
+     * as the collection owner user change the owner of {@link #USER1_COL1} from "user1" to "no-such-user".
+     */
+    public void ChangeCollectionOwnerAndGroupToNonExistentAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    @Test
+    public void ChangeCollectionOwnerAndGroupToRemovedAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    /**
+     * With {@code posix-chown-restricted="true"},
+     * as the collection owner user change the owner of {@link #USER1_COL1} from "user1" to "userrm".
+     */
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeCollectionOwnerAndGroupToRemovedAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+            changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeCollectionOwnerAndGroupToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeCollectionOwnerAndGroupToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeCollectionOwnerAndGroupToRemovedAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeCollectionOwnerAndGroupToRemovedAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_COL1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test
+    public void ChangeDocumentOwnerAndGroupToNonExistentAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    @Test
+    public void ChangeDocumentOwnerAndGroupToNonExistentAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    @Test
+    public void ChangeDocumentOwnerAndGroupToRemovedAsDBA() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    @Test
+    public void ChangeDocumentOwnerAndGroupToRemovedAsDBA_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject adminUser = existWebServer.getBrokerPool().getSecurityManager().authenticate(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        changeOwner(adminUser, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    @Test
+    public void ChangeDocumentOwnerAndGroupToNonExistentAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    /**
+     * With {@code posix-chown-restricted="true"},
+     * as the document owner user change the owner of {@link #USER1_DOC1} from "user1" to "no-such-user".
+     */
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeDocumentOwnerAndGroupToNonExistentAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+            changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test
+    public void ChangeDocumentOwnerAndGroupToRemovedAsNonDBAOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+        changeOwner(user1, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+    }
+
+    /**
+     * With {@code posix-chown-restricted="true"},
+     * as the document owner user change the owner of {@link #USER1_DOC1} from "user1" to "no-such-user".
+     */
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeDocumentOwnerAndGroupToRemovedAsNonDBAOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user1 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER1_NAME, USER1_PWD);
+            changeOwner(user1, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeDocumentOwnerAndGroupToNonExistentAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeDocumentOwnerAndGroupToNonExistentAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple("no-such-user", "no-such-group"), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeDocumentOwnerAndGroupToRemovedAsNonOwner() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, NOT_RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
+    @Test(expected=PermissionDeniedException.class)
+    public void ChangeDocumentOwnerAndGroupToRemovedAsNonOwner_restricted() throws AuthenticationException, XPathException, PermissionDeniedException, EXistException {
+        extractPermissionDenied(() -> {
+            final Subject user2 = existWebServer.getBrokerPool().getSecurityManager().authenticate(USER2_NAME, USER2_PWD);
+            changeOwner(user2, RESTRICTED, TestConstants.TEST_COLLECTION_URI.append(USER1_DOC1), Tuple(USERRM_NAME, USERRM_NAME), Tuple(USER1_NAME, USER1_NAME));
+        });
+    }
+
     private void changeOwner(final Subject execAsUser, final boolean restricted, final XmldbURI uri, final String newOwner) throws EXistException, PermissionDeniedException, XPathException {
+        changeOwner(execAsUser, restricted, uri, newOwner, newOwner);
+    }
+
+    private void changeOwner(final Subject execAsUser, final boolean restricted, final XmldbURI uri, final Tuple2<String, String> newOwnerGroup, final Tuple2<String, String> expectedOwnerGroup) throws EXistException, PermissionDeniedException, XPathException {
+        changeOwner(execAsUser, restricted, uri, newOwnerGroup.<String>fold(og -> og._1 + ":" + og._2), expectedOwnerGroup.<String>fold(og -> og._1 + ":" + og._2));
+    }
+
+    private void changeOwner(final Subject execAsUser, final boolean restricted, final XmldbURI uri, final String newOwnerGroup, final String expectedOwnerGroup) throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
 
         final boolean prevRestricted = setPosixChownRestricted(restricted);
 
         final String query =
                 "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
-                "sm:chown(xs:anyURI('" + uri.getRawCollectionPath() + "'), '" + newOwner + "'),\n" +
-                "sm:get-permissions(xs:anyURI('" + uri.getRawCollectionPath() + "'))/sm:permission/string(@owner)";
+                "sm:chown(xs:anyURI('" + uri.getRawCollectionPath() + "'), '" + newOwnerGroup + "'),\n" +
+                "sm:get-permissions(xs:anyURI('" + uri.getRawCollectionPath() + "'))/sm:permission/(string(@owner), string(@group))";
 
         try (final DBBroker broker = pool.get(Optional.of(execAsUser))) {
 
             final XQuery xquery = existWebServer.getBrokerPool().getXQueryService();
             final Sequence result = xquery.execute(broker, query, null);
 
-            assertEquals(1, result.getItemCount());
-            assertEquals(newOwner, result.itemAt(0).getStringValue());
+            assertEquals(2, result.getItemCount());
+
+            final String expectedOwnerGroupParts[] = expectedOwnerGroup.split(":");
+            assertEquals(expectedOwnerGroupParts[0], result.itemAt(0).getStringValue());
+            if (expectedOwnerGroupParts.length == 2) {
+                assertEquals(expectedOwnerGroupParts[1], result.itemAt(1).getStringValue());
+            }
+
         } finally {
             setPosixChownRestricted(prevRestricted);
         }
     }
 
     private void changeGroup(final Subject execAsUser, final boolean restricted, final XmldbURI uri, final String newGroup) throws EXistException, PermissionDeniedException, XPathException {
+        changeGroup(execAsUser, restricted, uri, newGroup, newGroup);
+    }
+
+    private void changeGroup(final Subject execAsUser, final boolean restricted, final XmldbURI uri, final String newGroup, final String expectedGroup) throws EXistException, PermissionDeniedException, XPathException {
         final BrokerPool pool = existWebServer.getBrokerPool();
 
         final boolean prevRestricted = setPosixChownRestricted(restricted);
@@ -1029,7 +1575,7 @@ public class PermissionsFunctionChownTest {
             final Sequence result = xquery.execute(broker, query, null);
 
             assertEquals(1, result.getItemCount());
-            assertEquals(newGroup, result.itemAt(0).getStringValue());
+            assertEquals(expectedGroup, result.itemAt(0).getStringValue());
         } finally {
             setPosixChownRestricted(prevRestricted);
         }
@@ -1079,6 +1625,7 @@ public class PermissionsFunctionChownTest {
 
             createUser(broker, sm, USER1_NAME, USER1_PWD);
             createUser(broker, sm, USER2_NAME, USER2_PWD);
+            createUser(broker, sm, USERRM_NAME, USERRM_PWD);
 
             final Group otherGroup = new GroupAider(OTHER_GROUP_NAME);
             sm.addGroup(broker, otherGroup);
@@ -1090,6 +1637,11 @@ public class PermissionsFunctionChownTest {
             sm.updateAccount(user2);
 
             transaction.commit();
+        }
+
+        try (final DBBroker broker = pool.get(Optional.of(sm.getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+            removeUser(sm, USERRM_NAME);
         }
     }
 
@@ -1147,6 +1699,11 @@ public class PermissionsFunctionChownTest {
 
             removeUser(sm, USER2_NAME);
             removeUser(sm, USER1_NAME);
+            removeGroup(sm, OTHER_GROUP_NAME);
+
+            if (sm.hasAccount(USERRM_NAME)) {
+                removeUser(sm, USERRM_NAME);
+            }
 
             removeCollection(broker, transaction, TestConstants.TEST_COLLECTION_URI);
 
@@ -1194,7 +1751,11 @@ public class PermissionsFunctionChownTest {
 
     private static void removeUser(final SecurityManager sm, final String username) throws PermissionDeniedException, EXistException {
         sm.deleteAccount(username);
-        sm.deleteGroup(username);
+        removeGroup(sm, username);
+    }
+
+    private static void removeGroup(final SecurityManager sm, final String groupname) throws PermissionDeniedException, EXistException {
+        sm.deleteGroup(groupname);
     }
 
     /**


### PR DESCRIPTION
Previously there were several problems whereby accounts could end up without a group. Various parts of the system assumed that a group always had at least 1 group (i.e. a primary group). This has now been fixed, and accounts will always have at least 1 group, even if that is `nogroup`.

These previous problems could lead to NPEs and system instability.