### PR TITLE
WIP: support lucene suggestions

### DIFF
--- a/extensions/indexes/lucene/pom.xml
+++ b/extensions/indexes/lucene/pom.xml
@@ -81,6 +81,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-suggest</artifactId>
+            <version>${lucene.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.evolvedbinary.j8fu</groupId>
             <artifactId>j8fu</artifactId>
         </dependency>

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractLuceneIndex.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractLuceneIndex.java
@@ -1,0 +1,316 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2019 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.indexing.lucene;
+
+import com.evolvedbinary.j8fu.function.Function2E;
+import com.evolvedbinary.j8fu.function.FunctionE;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.Version;
+import org.exist.backup.RawDataBackup;
+import org.exist.indexing.AbstractIndex;
+import org.exist.indexing.IndexWorker;
+import org.exist.indexing.RawBackupSupport;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.btree.DBException;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.FileUtils;
+import org.exist.xquery.XPathException;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Abstract base class for all lucene-based indexes.
+ *
+ * @author wolfgang
+ * @param <S> Class of the searcher manager to use. Implementations may need different searcher managers, depending
+ *           on e.g. if taxonomies are used or not.
+ */
+public abstract class AbstractLuceneIndex<S> extends AbstractIndex implements RawBackupSupport {
+
+    public final static Version LUCENE_VERSION_IN_USE = Version.LUCENE_4_10_4;
+
+    private static final Logger LOG = LogManager.getLogger(AbstractLuceneIndex.class);
+
+    public final static String ID = LuceneIndex.class.getName();
+
+    private static final String DIR_NAME = "lucene";
+
+    protected Directory directory;
+
+    protected Analyzer defaultAnalyzer;
+
+    protected double bufferSize = IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB;
+
+    protected IndexWriter cachedWriter = null;
+
+    protected ReferenceManager<S> searcherManager = null;
+    protected ReaderManager readerManager = null;
+
+    public String getDirName() {
+        return DIR_NAME;
+    }
+
+    @Override
+    public void configure(BrokerPool pool, Path dataDir, Element config) throws DatabaseConfigurationException {
+        super.configure(pool, dataDir, config);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Configuring Lucene index");
+
+        String bufferSizeParam = config.getAttribute("buffer");
+        if (bufferSizeParam != null)
+            try {
+                bufferSize = Double.parseDouble(bufferSizeParam);
+            } catch (NumberFormatException e) {
+                LOG.warn("Invalid buffer size setting for lucene index: " + bufferSizeParam, e);
+            }
+
+        if (LOG.isDebugEnabled())
+            LOG.debug("Using buffer size: " + bufferSize);
+
+        NodeList nl = config.getElementsByTagName("analyzer");
+        if (nl.getLength() > 0) {
+            Element node = (Element) nl.item(0);
+            defaultAnalyzer = AnalyzerConfig.configureAnalyzer(node);
+        }
+
+        if (defaultAnalyzer == null)
+            defaultAnalyzer = new StandardAnalyzer(LUCENE_VERSION_IN_USE);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Using default analyzer: " + defaultAnalyzer.getClass().getName());
+    }
+
+    /**
+     * Get an {@link IndexWorker} to be owned by the specified broker.
+     *
+     * @param broker The DBBroker that owns this worker
+     * @return a new index worker
+     */
+    @Override
+    public abstract IndexWorker getWorker(DBBroker broker);
+
+    /**
+     * Called during {@link #open()} to create the actual searcher manager.
+     *
+     * @param writer the writer created
+     * @return a searcher manager
+     * @throws DatabaseConfigurationException in case the searcher could not be created
+     */
+    public abstract ReferenceManager<S> createSearcherManager(IndexWriter writer) throws DatabaseConfigurationException;
+
+    /**
+     * Called before the writer is committed. Can be overwritten by subclasses to
+     * commit additional resources.
+     *
+     * @throws IOException in case writing fails
+     */
+    protected void beforeCommit() throws IOException {
+        // do nothing by default
+    }
+
+    /**
+     * Called after the writer is committed. Can be overwritten by subclasses to
+     * perform additional actions, e.g. update suggestions.
+     *
+     * @throws IOException in case writing fails
+     */
+    protected void afterCommit() throws IOException {
+        // do nothing by default
+    }
+
+    /**
+     * Called by {@link #close()} before the writer is closed. Can be overwritten
+     * by subclasses to properly close other resources first.
+     * @throws IOException
+     */
+    protected void beforeWriterClose() throws IOException {
+        // do nothing by default
+    }
+
+    @Override
+    public void open() throws DatabaseConfigurationException {
+        Path dir = getDataDir().resolve(getDirName());
+        if (LOG.isDebugEnabled())
+            LOG.debug("Opening Lucene index directory: " + dir.toAbsolutePath().toString());
+
+        IndexWriter writer = null;
+        try {
+            if (Files.exists(dir)) {
+                if (!Files.isDirectory(dir))
+                    throw new DatabaseConfigurationException("Lucene index location is not a directory: " +
+                            dir.toAbsolutePath().toString());
+            } else {
+                Files.createDirectories(dir);
+            }
+
+            directory = FSDirectory.open(dir.toFile());
+
+            final IndexWriterConfig idxWriterConfig = new IndexWriterConfig(LUCENE_VERSION_IN_USE, defaultAnalyzer);
+            idxWriterConfig.setRAMBufferSizeMB(bufferSize);
+            cachedWriter = new IndexWriter(directory, idxWriterConfig);
+
+            searcherManager = createSearcherManager(cachedWriter);
+            readerManager = new ReaderManager(cachedWriter, true);
+        } catch (IOException e) {
+            throw new DatabaseConfigurationException("Exception while reading lucene index directory: " +
+                    e.getMessage(), e);
+        } finally {
+            releaseWriter(writer);
+        }
+    }
+
+    @Override
+    public synchronized void close() throws DBException {
+        try {
+            if (searcherManager != null) {
+                searcherManager.close();
+                searcherManager = null;
+            }
+            if (readerManager != null) {
+                readerManager.close();
+                readerManager = null;
+            }
+            if (cachedWriter != null) {
+                commit();
+                beforeWriterClose();
+                cachedWriter.close();
+                cachedWriter = null;
+            }
+            directory.close();
+        } catch (IOException e) {
+            throw new DBException("Caught exception while closing lucene indexes: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public synchronized void sync() throws DBException {
+        //Nothing special to do
+        commit();
+    }
+
+    @Override
+    public void remove() throws DBException {
+        close();
+        Path dir = getDataDir().resolve(getDirName());
+        try {
+            Files.list(dir).forEach(FileUtils::deleteQuietly);
+        } catch (Exception e) {
+            // never abort at this point, so recovery can continue
+            LOG.warn(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean checkIndex(DBBroker broker) {
+        return false;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    public Analyzer getDefaultAnalyzer() {
+        return defaultAnalyzer;
+    }
+
+    protected boolean needsCommit = false;
+
+    public IndexWriter getWriter() throws IOException {
+        return getWriter(false);
+    }
+
+    public IndexWriter getWriter(boolean exclusive) throws IOException {
+        return cachedWriter;
+    }
+
+    public synchronized void releaseWriter(IndexWriter writer) {
+        if (writer == null)
+            return;
+        needsCommit = true;
+    }
+
+    protected void commit() {
+        if (!needsCommit) {
+            return;
+        }
+        try {
+            if(LOG.isDebugEnabled()) {
+                LOG.debug("Committing lucene index");
+            }
+            beforeCommit();
+            if (cachedWriter != null) {
+                cachedWriter.commit();
+            }
+            afterCommit();
+            needsCommit = false;
+        } catch(CorruptIndexException cie) {
+            LOG.error("Detected corrupt Lucence index on writer release and commit: " + cie.getMessage(), cie);
+        } catch(IOException ioe) {
+            LOG.error("Detected Lucence index issue on writer release and commit: " + ioe.getMessage(), ioe);
+        }
+    }
+
+    public <R> R withReader(FunctionE<IndexReader, R, IOException> fn) throws IOException {
+        if (readerManager == null) {
+            return null;
+        }
+        readerManager.maybeRefreshBlocking();
+        final DirectoryReader reader = readerManager.acquire();
+        try {
+            return fn.apply(reader);
+        } finally {
+            readerManager.release(reader);
+        }
+    }
+
+    public <R> R withSearcher(Function2E<S, R, IOException, XPathException> consumer) throws IOException, XPathException {
+        searcherManager.maybeRefreshBlocking();
+        final S searcher = searcherManager.acquire();
+        try {
+            return consumer.apply(searcher);
+        } finally {
+            searcherManager.release(searcher);
+        }
+    }
+
+    @Override
+    public void backupToArchive(final RawDataBackup backup) throws IOException {
+        for (final String name : directory.listAll()) {
+            final String path = getDirName() + "/" + name;
+
+            // do not use try-with-resources here, closing the OutputStream will close the entire backup
+//            try(final OutputStream os = backup.newEntry(path)) {
+            try {
+                final OutputStream os = backup.newEntry(path);
+                Files.copy(getDataDir().resolve(path), os);
+            } finally {
+                backup.closeEntry();
+            }
+        }
+    }
+}

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractLuceneIndex.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractLuceneIndex.java
@@ -254,7 +254,7 @@ public abstract class AbstractLuceneIndex<S> extends AbstractIndex implements Ra
         needsCommit = true;
     }
 
-    protected void commit() {
+    public void commit() {
         if (!needsCommit) {
             return;
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
@@ -52,6 +52,8 @@ public class LuceneConfig {
     private static final String ATTR_MODULE_PREFIX = "prefix";
     private static final String ATTR_MODULE_AT = "at";
 
+    protected LuceneIndex index;
+
     private Map<QName, LuceneIndexConfig> paths = new TreeMap<>();
     private List<LuceneIndexConfig> wildcardPaths = new ArrayList<>();
     private Map<String, LuceneIndexConfig> namedIndexes = new TreeMap<>();
@@ -73,7 +75,8 @@ public class LuceneConfig {
 
     protected FacetsConfig facetsConfig = new FacetsConfig();
 
-    public LuceneConfig(NodeList configNodes, Map<String, String> namespaces) throws DatabaseConfigurationException {
+    public LuceneConfig(LuceneIndex index, NodeList configNodes, Map<String, String> namespaces) throws DatabaseConfigurationException {
+        this.index = index;
         parseConfig(configNodes, namespaces);
     }
 
@@ -84,6 +87,7 @@ public class LuceneConfig {
      * @param other
      */
     public LuceneConfig(LuceneConfig other) {
+        this.index = other.index;
     	this.paths = other.paths;
     	this.wildcardPaths = other.wildcardPaths;
     	this.namedIndexes = other.namedIndexes;

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -34,6 +34,7 @@ import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.value.*;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -61,6 +62,7 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
     private final static String ATTR_STORE = "store";
     private final static String ATTR_ANALYZER = "analyzer";
     private final static String ATTR_IF = "if";
+    private final static String ELEMENT_SUGGEST = "suggest";
 
     protected String fieldName;
     protected int type = Type.STRING;
@@ -102,6 +104,17 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
         final String cond = configElement.getAttribute(ATTR_IF);
         if (StringUtils.isNotEmpty(cond)) {
             this.condition = Optional.of(cond);
+        }
+
+        Node child = configElement.getFirstChild();
+        while (child != null) {
+            if (child.getNodeType() == Node.ELEMENT_NODE) {
+                final String localName = child.getLocalName();
+                if (ELEMENT_SUGGEST.equals(localName)) {
+                    config.index.suggestService.configure(fieldName, (Element) child, analyzer);
+                }
+            }
+            child = child.getNextSibling();
         }
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -25,6 +25,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.*;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
+import org.exist.indexing.lucene.suggest.LuceneSuggest;
 import org.exist.numbering.NodeId;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.DBBroker;
@@ -62,7 +63,6 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
     private final static String ATTR_STORE = "store";
     private final static String ATTR_ANALYZER = "analyzer";
     private final static String ATTR_IF = "if";
-    private final static String ELEMENT_SUGGEST = "suggest";
 
     protected String fieldName;
     protected int type = Type.STRING;
@@ -110,7 +110,7 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
         while (child != null) {
             if (child.getNodeType() == Node.ELEMENT_NODE) {
                 final String localName = child.getLocalName();
-                if (ELEMENT_SUGGEST.equals(localName)) {
+                if (LuceneSuggest.ELEMENT_SUGGEST.equals(localName)) {
                     config.index.suggestService.configure(fieldName, (Element) child, analyzer);
                 }
             }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndex.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndex.java
@@ -1,6 +1,6 @@
 /*
  *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-2015 The eXist Project
+ *  Copyright (C) 2001-2019 The eXist Project
  *  http://exist-db.org
  *
  *  This program is free software; you can redistribute it and/or
@@ -19,172 +19,57 @@
  */
 package org.exist.indexing.lucene;
 
-import com.evolvedbinary.j8fu.function.Function2E;
-import com.evolvedbinary.j8fu.function.FunctionE;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
 import org.apache.lucene.facet.taxonomy.TaxonomyWriter;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
-import org.apache.lucene.index.*;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.ReferenceManager;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
-import org.apache.lucene.util.Version;
-import org.exist.backup.RawDataBackup;
-import org.exist.indexing.AbstractIndex;
 import org.exist.indexing.IndexWorker;
-import org.exist.indexing.RawBackupSupport;
-import org.exist.storage.BrokerPool;
+import org.exist.indexing.lucene.suggest.LuceneSuggest;
 import org.exist.storage.DBBroker;
-import org.exist.storage.btree.DBException;
 import org.exist.util.DatabaseConfigurationException;
-import org.exist.util.FileUtils;
-import org.exist.xquery.XPathException;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public class LuceneIndex extends AbstractIndex implements RawBackupSupport {
-    
-    public final static Version LUCENE_VERSION_IN_USE = Version.LUCENE_4_10_4;
-
-    private static final Logger LOG = LogManager.getLogger(LuceneIndexWorker.class);
+public class LuceneIndex extends AbstractLuceneIndex<SearcherTaxonomyManager.SearcherAndTaxonomy> {
 
     public final static String ID = LuceneIndex.class.getName();
 
 	private static final String DIR_NAME = "lucene";
 	private static final String TAXONOMY_DIR_NAME = "taxonomy";
 
-    protected Directory directory;
     protected Directory taxoDirectory;
 
-    protected Analyzer defaultAnalyzer;
-
-    protected double bufferSize = IndexWriterConfig.DEFAULT_RAM_BUFFER_SIZE_MB;
-
-    protected IndexWriter cachedWriter = null;
     protected DirectoryTaxonomyWriter cachedTaxonomyWriter = null;
 
-    protected SearcherTaxonomyManager searcherManager = null;
-    protected ReaderManager readerManager = null;
+    protected LuceneSuggest suggestService;
 
     public String getDirName() {
         return DIR_NAME;
     }
 
     @Override
-    public void configure(BrokerPool pool, Path dataDir, Element config) throws DatabaseConfigurationException {
-        super.configure(pool, dataDir, config);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Configuring Lucene index");
-
-        String bufferSizeParam = config.getAttribute("buffer");
-        if (bufferSizeParam != null)
-            try {
-                bufferSize = Double.parseDouble(bufferSizeParam);
-            } catch (NumberFormatException e) {
-                LOG.warn("Invalid buffer size setting for lucene index: " + bufferSizeParam, e);
-            }
-
-        if (LOG.isDebugEnabled())
-            LOG.debug("Using buffer size: " + bufferSize);
-        
-        NodeList nl = config.getElementsByTagName("analyzer");
-        if (nl.getLength() > 0) {
-            Element node = (Element) nl.item(0);
-            defaultAnalyzer = AnalyzerConfig.configureAnalyzer(node);
-        }
-
-        if (defaultAnalyzer == null)
-            defaultAnalyzer = new StandardAnalyzer(LUCENE_VERSION_IN_USE);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Using default analyzer: " + defaultAnalyzer.getClass().getName());
-    }
-
-    @Override
-    public void open() throws DatabaseConfigurationException {
+    public ReferenceManager<SearcherTaxonomyManager.SearcherAndTaxonomy> createSearcherManager(IndexWriter writer) throws DatabaseConfigurationException {
         Path dir = getDataDir().resolve(getDirName());
         Path taxoDir = dir.resolve(TAXONOMY_DIR_NAME);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Opening Lucene index directory: " + dir.toAbsolutePath().toString());
-
-        IndexWriter writer = null;
         try {
-            if (Files.exists(dir)) {
-                if (!Files.isDirectory(dir))
-                    throw new DatabaseConfigurationException("Lucene index location is not a directory: " +
-                        dir.toAbsolutePath().toString());
+            if (Files.exists(taxoDir)) {
+                if (!Files.isDirectory(taxoDir))
+                    throw new DatabaseConfigurationException("Lucene index location for taxonomy is not a directory: " +
+                            taxoDir.toAbsolutePath());
             } else {
                 Files.createDirectories(taxoDir);
             }
-
-            directory = FSDirectory.open(dir.toFile());
             taxoDirectory = FSDirectory.open(taxoDir.toFile());
-
-            final IndexWriterConfig idxWriterConfig = new IndexWriterConfig(LUCENE_VERSION_IN_USE, defaultAnalyzer);
-            idxWriterConfig.setRAMBufferSizeMB(bufferSize);
-            cachedWriter = new IndexWriter(directory, idxWriterConfig);
             cachedTaxonomyWriter = new DirectoryTaxonomyWriter(taxoDirectory);
-
-            searcherManager = new SearcherTaxonomyManager(cachedWriter, true, null, cachedTaxonomyWriter);
-            readerManager = new ReaderManager(cachedWriter, true);
+            suggestService = new LuceneSuggest(this, dir);
+            return new SearcherTaxonomyManager(writer, true, null, cachedTaxonomyWriter);
         } catch (IOException e) {
-            throw new DatabaseConfigurationException("Exception while reading lucene index directory: " +
-                e.getMessage(), e);
-        } finally {
-            releaseWriter(writer);
-        }
-    }
-
-    @Override
-    public synchronized void close() throws DBException {
-        try {
-            if (searcherManager != null) {
-                searcherManager.close();
-                searcherManager = null;
-            }
-            if (readerManager != null) {
-                readerManager.close();
-                readerManager = null;
-            }
-            if (cachedWriter != null) {
-            	commit();
-            	cachedTaxonomyWriter.close();
-                cachedWriter.close();
-                cachedTaxonomyWriter = null;
-                cachedWriter = null;
-            }
-
-            taxoDirectory.close();
-            directory.close();
-        } catch (IOException e) {
-            throw new DBException("Caught exception while closing lucene indexes: " + e.getMessage());
-        }
-    }
-
-    @Override
-    public synchronized void sync() throws DBException {
-        //Nothing special to do
-        commit();
-    }
-
-    @Override
-    public void remove() throws DBException {
-        close();
-        Path dir = getDataDir().resolve(getDirName());
-        try {
-            Files.list(dir).forEach(path -> {
-                FileUtils.deleteQuietly(path);
-            });
-        } catch (Exception e) {
-            // never abort at this point, so recovery can continue
-            LOG.warn(e.getMessage(), e);
+            throw new DatabaseConfigurationException("IO error while creating searcher manager: " + e.getMessage(), e);
         }
     }
 
@@ -193,88 +78,26 @@ public class LuceneIndex extends AbstractIndex implements RawBackupSupport {
         return new LuceneIndexWorker(this, broker);
     }
 
-    @Override
-    public boolean checkIndex(DBBroker broker) {
-        return false;  //To change body of implemented methods use File | Settings | File Templates.
-    }
-
-    protected Analyzer getDefaultAnalyzer() {
-        return defaultAnalyzer;
-    }
-    
-    protected boolean needsCommit = false;
-
-    public IndexWriter getWriter() throws IOException {
-        return getWriter(false);
-    }
-
-    public IndexWriter getWriter(boolean exclusive) throws IOException {
-        return cachedWriter;
-    }
-
     public TaxonomyWriter getTaxonomyWriter() {
         return cachedTaxonomyWriter;
     }
 
-    public synchronized void releaseWriter(IndexWriter writer) {
-        if (writer == null)
-            return;
-        needsCommit = true;
+    @Override
+    protected void beforeWriterClose() throws IOException {
+        cachedTaxonomyWriter.close();
+        cachedTaxonomyWriter = null;
+        suggestService.close();
     }
 
-    protected void commit() {
-    	if (!needsCommit) {
-            return;
-        }
-        try {
-            if(LOG.isDebugEnabled()) {
-                LOG.debug("Committing lucene index");
-            }
-        	if (cachedWriter != null) {
-                cachedTaxonomyWriter.commit();
-                cachedWriter.commit();
-            }
-            needsCommit = false;
-        } catch(CorruptIndexException cie) {
-            LOG.error("Detected corrupt Lucence index on writer release and commit: " + cie.getMessage(), cie);
-        } catch(IOException ioe) {
-            LOG.error("Detected Lucence index issue on writer release and commit: " + ioe.getMessage(), ioe);
+    @Override
+    protected void beforeCommit() throws IOException {
+        if (cachedTaxonomyWriter != null) {
+            cachedTaxonomyWriter.commit();
         }
     }
 
-    public <R> R withReader(FunctionE<IndexReader, R, IOException> fn) throws IOException {
-        readerManager.maybeRefreshBlocking();
-        final DirectoryReader reader = readerManager.acquire();
-        try {
-            return fn.apply(reader);
-        } finally {
-            readerManager.release(reader);
-        }
+    @Override
+    protected void afterCommit() throws IOException {
+        suggestService.rebuild();
     }
-
-    public <R> R withSearcher(Function2E<SearcherTaxonomyManager.SearcherAndTaxonomy, R, IOException, XPathException> consumer) throws IOException, XPathException {
-        searcherManager.maybeRefreshBlocking();
-        final SearcherTaxonomyManager.SearcherAndTaxonomy searcher = searcherManager.acquire();
-        try {
-            return consumer.apply(searcher);
-        } finally {
-            searcherManager.release(searcher);
-        }
-    }
-
-	@Override
-	public void backupToArchive(final RawDataBackup backup) throws IOException {
-		for (final String name : directory.listAll()) {
-			final String path = getDirName() + "/" + name;
-
-            // do not use try-with-resources here, closing the OutputStream will close the entire backup
-//            try(final OutputStream os = backup.newEntry(path)) {
-            try {
-                final OutputStream os = backup.newEntry(path);
-                Files.copy(getDataDir().resolve(path), os);
-            } finally {
-                backup.closeEntry();
-            }
-		}
-	}
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexConfig.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.AttrImpl;
+import org.exist.indexing.lucene.suggest.LuceneSuggest;
 import org.exist.storage.ElementValue;
 import org.exist.storage.NodePath;
 import org.exist.util.DatabaseConfigurationException;
@@ -204,6 +205,15 @@ public class LuceneIndexConfig {
                             matchAttrs.put(qname, new MatchAttrData(qname, value, boost, onSibling));
                             break;
                         }
+                        case LuceneSuggest.ELEMENT_SUGGEST:
+                            String contentField;
+                            if (name == null) {
+                                contentField = LuceneUtil.encodeQName(getQName(), parent.index.getBrokerPool().getSymbols());
+                            } else {
+                                contentField = name;
+                            }
+                            parent.index.suggestService.configure(contentField, (Element) child, getAnalyzer());
+                            break;
                     }
                 }
             }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -49,6 +49,7 @@ import org.exist.indexing.*;
 import org.exist.indexing.StreamListener.ReindexMode;
 import org.exist.indexing.lucene.PlainTextHighlighter.Offset;
 import org.exist.indexing.lucene.PlainTextIndexConfig.PlainTextField;
+import org.exist.indexing.lucene.suggest.LuceneSuggest;
 import org.exist.numbering.NodeId;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.*;
@@ -136,13 +137,17 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         return index.getIndexName();
     }
 
+    public LuceneSuggest getSuggesters() {
+        return index.suggestService;
+    }
+
     public QueryRewriter getQueryRewriter(XQueryContext context) {
         return null;
     }
 
     public Object configure(IndexController controller, NodeList configNodes, Map<String, String> namespaces) throws DatabaseConfigurationException {
         LOG.debug("Configuring lucene index...");
-        config = new LuceneConfig(configNodes, namespaces);
+        config = new LuceneConfig(index, configNodes, namespaces);
         return config;
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/analyzers/MetaAnalyzer.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/analyzers/MetaAnalyzer.java
@@ -50,7 +50,7 @@ public class MetaAnalyzer extends DelegatingAnalyzerWrapper {
     }
 
     @Override
-    protected Analyzer getWrappedAnalyzer(@Nullable String fieldName) {
+    public Analyzer getWrappedAnalyzer(@Nullable String fieldName) {
         if (fieldName == null) {
             return defaultAnalyzer;
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/AnalyzingInfixSuggesterWrapper.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/AnalyzingInfixSuggesterWrapper.java
@@ -20,13 +20,12 @@
 package org.exist.indexing.lucene.suggest;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.search.spell.Dictionary;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.suggest.Lookup;
 import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.exist.indexing.lucene.LuceneIndex;
-import org.exist.indexing.lucene.analyzers.MetaAnalyzer;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.FileUtils;
 import org.w3c.dom.Element;
@@ -63,12 +62,12 @@ public class AnalyzingInfixSuggesterWrapper extends Suggester {
 
     @Override
     List<Lookup.LookupResult> lookup(CharSequence key, boolean onlyMorePopular, int num) throws IOException {
-        return suggester.lookup(key, num, false, false);
+        return suggester.lookup(key, num, true, false);
     }
 
     @Override
-    public void build(Dictionary dictionary) throws IOException {
-        suggester.build(dictionary);
+    public void build(IndexReader reader, String field) throws IOException {
+        suggester.build(getDictionary(reader, field));
     }
 
     @Override

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/AnalyzingInfixSuggesterWrapper.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/AnalyzingInfixSuggesterWrapper.java
@@ -1,0 +1,75 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2019 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.indexing.lucene.suggest;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.spell.Dictionary;
+import org.apache.lucene.search.suggest.Lookup;
+import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.exist.indexing.lucene.LuceneIndex;
+import org.exist.util.DatabaseConfigurationException;
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public class AnalyzingInfixSuggesterWrapper extends Suggester {
+
+    private AnalyzingInfixSuggester suggester;
+
+    public AnalyzingInfixSuggesterWrapper(String id, String field, Element config, Path indexDir, Analyzer analyzer) throws DatabaseConfigurationException {
+        super(id, field, config, indexDir, analyzer);
+
+        final Path dir = indexDir.resolve("suggest_" + id);
+        try {
+            if (Files.exists(dir)) {
+                if (!Files.isDirectory(dir)) {
+                    throw new DatabaseConfigurationException("Lucene suggestions location is not a directory: " +
+                            dir.toAbsolutePath().toString());
+                }
+            } else {
+                Files.createDirectories(dir);
+            }
+            final Directory directory = FSDirectory.open(dir.toFile());
+            suggester = new AnalyzingInfixSuggester(LuceneIndex.LUCENE_VERSION_IN_USE, directory, analyzer);
+        } catch(IOException e) {
+            throw new DatabaseConfigurationException("Error initializing lucene suggestions with id " + id + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    List<Lookup.LookupResult> lookup(CharSequence key, boolean onlyMorePopular, int num) throws IOException {
+        return suggester.lookup(key, onlyMorePopular, num);
+    }
+
+    @Override
+    public void build(Dictionary dictionary) throws IOException {
+        suggester.build(dictionary);
+    }
+
+    @Override
+    public void close() throws IOException {
+        suggester.close();
+    }
+}

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FreetextSuggesterWrapper.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FreetextSuggesterWrapper.java
@@ -20,7 +20,7 @@
 package org.exist.indexing.lucene.suggest;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.search.spell.Dictionary;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.suggest.Lookup;
 import org.apache.lucene.search.suggest.analyzing.FreeTextSuggester;
 import org.exist.util.DatabaseConfigurationException;
@@ -63,8 +63,8 @@ public class FreetextSuggesterWrapper extends Suggester {
     }
 
     @Override
-    void build(Dictionary dictionary) throws IOException {
-        suggester.build(dictionary);
+    void build(IndexReader reader, String field) throws IOException {
+        suggester.build(getDictionary(reader, field));
         suggester.store(Files.newOutputStream(storage, StandardOpenOption.WRITE, StandardOpenOption.CREATE));
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FreetextSuggesterWrapper.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FreetextSuggesterWrapper.java
@@ -71,4 +71,9 @@ public class FreetextSuggesterWrapper extends Suggester {
     @Override
     void close() {
     }
+
+    @Override
+    void remove() throws IOException {
+        Files.deleteIfExists(storage);
+    }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FuzzySuggesterWrapper.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FuzzySuggesterWrapper.java
@@ -1,3 +1,22 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2019 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package org.exist.indexing.lucene.suggest;
 
 import org.apache.lucene.analysis.Analyzer;
@@ -40,7 +59,7 @@ public class FuzzySuggesterWrapper extends Suggester {
 
     @Override
     List<Lookup.LookupResult> lookup(CharSequence key, boolean onlyMorePopular, int num) throws IOException {
-        return suggester.lookup(key, onlyMorePopular, num);
+        return suggester.lookup(key, false, num);
     }
 
     @Override

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FuzzySuggesterWrapper.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FuzzySuggesterWrapper.java
@@ -20,7 +20,7 @@
 package org.exist.indexing.lucene.suggest;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.search.spell.Dictionary;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.suggest.Lookup;
 import org.apache.lucene.search.suggest.analyzing.FuzzySuggester;
 import org.exist.util.DatabaseConfigurationException;
@@ -63,8 +63,8 @@ public class FuzzySuggesterWrapper extends Suggester {
     }
 
     @Override
-    void build(Dictionary dictionary) throws IOException {
-        suggester.build(dictionary);
+    void build(IndexReader reader, String field) throws IOException {
+        suggester.build(getDictionary(reader, field));
         suggester.store(Files.newOutputStream(storage, StandardOpenOption.WRITE, StandardOpenOption.CREATE));
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FuzzySuggesterWrapper.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FuzzySuggesterWrapper.java
@@ -1,0 +1,55 @@
+package org.exist.indexing.lucene.suggest;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.spell.Dictionary;
+import org.apache.lucene.search.suggest.Lookup;
+import org.apache.lucene.search.suggest.analyzing.FuzzySuggester;
+import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.FileUtils;
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+public class FuzzySuggesterWrapper extends Suggester {
+
+    private final FuzzySuggester suggester;
+    private final Path storage;
+
+    public FuzzySuggesterWrapper(String id, String field, Element config, Path indexDir, Analyzer analyzer) throws DatabaseConfigurationException {
+        super(id, field, config, indexDir, analyzer);
+
+        suggester = new FuzzySuggester(analyzer);
+
+        storage = indexDir.resolve("suggest_" + id);
+        try {
+            if (Files.exists(storage)) {
+                if (Files.isDirectory(storage)) {
+                    FileUtils.delete(storage);
+                } else {
+                    suggester.load(Files.newInputStream(storage, StandardOpenOption.READ));
+                }
+            }
+        } catch (IOException e) {
+            throw new DatabaseConfigurationException("Error initializing fuzzy suggester: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    List<Lookup.LookupResult> lookup(CharSequence key, boolean onlyMorePopular, int num) throws IOException {
+        return suggester.lookup(key, onlyMorePopular, num);
+    }
+
+    @Override
+    void build(Dictionary dictionary) throws IOException {
+        suggester.build(dictionary);
+        suggester.store(Files.newOutputStream(storage, StandardOpenOption.WRITE, StandardOpenOption.CREATE));
+    }
+
+    @Override
+    void close() {
+    }
+}

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FuzzySuggesterWrapper.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/FuzzySuggesterWrapper.java
@@ -71,4 +71,9 @@ public class FuzzySuggesterWrapper extends Suggester {
     @Override
     void close() {
     }
+
+    @Override
+    void remove() throws IOException {
+        Files.deleteIfExists(storage);
+    }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/LuceneSuggest.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/LuceneSuggest.java
@@ -21,8 +21,6 @@ package org.exist.indexing.lucene.suggest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.search.spell.LuceneDictionary;
-import org.apache.lucene.search.suggest.DocumentDictionary;
 import org.apache.lucene.search.suggest.Lookup;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.analyzers.MetaAnalyzer;
@@ -114,9 +112,7 @@ public class LuceneSuggest {
     public void rebuild() throws IOException {
         for (Suggester entry : suggesters.values()) {
             parent.withReader((reader) -> {
-                // final DocumentDictionary dictionary = new DocumentDictionary(reader, entry.getField(), null);
-                final LuceneDictionary dictionary = new LuceneDictionary(reader, entry.getField());
-                entry.build(dictionary);
+                entry.build(reader, entry.getField());
                 return null;
             });
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/LuceneSuggest.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/LuceneSuggest.java
@@ -1,0 +1,114 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2019 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.indexing.lucene.suggest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.spell.LuceneDictionary;
+import org.apache.lucene.search.suggest.Lookup;
+import org.exist.indexing.lucene.LuceneIndex;
+import org.exist.util.DatabaseConfigurationException;
+import org.w3c.dom.Element;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class LuceneSuggest {
+
+    private final static String ATTR_ID = "id";
+    private final static String ATTR_TYPE = "type";
+
+    private enum Suggesters {
+        ANALYZING,
+        FUZZY
+    }
+
+    private Path indexDir;
+
+    private Map<String, Suggester> suggesters = new ConcurrentHashMap<>();
+    private LuceneIndex parent;
+
+    public LuceneSuggest(LuceneIndex index, Path indexDir) {
+        this.parent = index;
+        this.indexDir = indexDir;
+    }
+
+    @Nullable
+    public List<Lookup.LookupResult> lookup(String id, CharSequence key, boolean onlyMorePopular, int num) throws IOException {
+        final Suggester config = suggesters.get(id);
+        return config == null ? null : config.lookup(key, onlyMorePopular, num);
+    }
+
+    public void configure(String field, Element child, Analyzer analyzer) throws DatabaseConfigurationException {
+        final String id = child.getAttribute(ATTR_ID);
+        if (StringUtils.isEmpty(id)) {
+            throw new DatabaseConfigurationException("Child element <suggest> lacks required id attribute");
+        }
+
+        if (suggesters.containsKey(id)) {
+            return;
+        }
+
+        Suggesters type = Suggesters.ANALYZING;
+        final String typeAttr = child.getAttribute(ATTR_TYPE);
+        if (StringUtils.isNotEmpty(typeAttr)) {
+            try {
+                type = Suggesters.valueOf(typeAttr.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new DatabaseConfigurationException("Unknown suggester type specified: " + typeAttr);
+            }
+        }
+
+        Suggester suggester = new AnalyzingInfixSuggesterWrapper(id, field, child, indexDir, analyzer == null ? parent.getDefaultAnalyzer() : analyzer);
+//        switch (type) {
+//            case FUZZY:
+//                suggester = new FuzzySuggesterWrapper(id, field, child, indexDir, analyzer == null ? parent.getDefaultAnalyzer() : analyzer);
+//                break;
+//            default:
+//                suggester = new AnalyzingInfixSuggesterWrapper(id, field, child, indexDir, analyzer == null ? parent.getDefaultAnalyzer() : analyzer);
+//                break;
+//        }
+        suggesters.put(id, suggester);
+    }
+
+    public void rebuild() throws IOException {
+        for (Suggester entry : suggesters.values()) {
+            parent.withReader((reader) -> {
+                final LuceneDictionary dictionary = new LuceneDictionary(reader, entry.getField());
+                entry.build(dictionary);
+                return null;
+            });
+        }
+    }
+
+    public void close() {
+        for (Suggester entry : suggesters.values()) {
+            try {
+                entry.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/Suggester.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/Suggester.java
@@ -1,0 +1,49 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2019 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.indexing.lucene.suggest;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.spell.Dictionary;
+import org.apache.lucene.search.suggest.Lookup;
+import org.exist.util.DatabaseConfigurationException;
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+public abstract class Suggester {
+
+    private final String field;
+
+    public Suggester(String id, String field, Element config, Path indexDir, Analyzer analyzer) throws DatabaseConfigurationException {
+        this.field = field;
+    }
+
+    String getField() {
+        return field;
+    }
+
+    abstract List<Lookup.LookupResult> lookup(CharSequence key, boolean onlyMorePopular, int num) throws IOException;
+
+    abstract void build(Dictionary dictionary) throws IOException;
+
+    abstract void close() throws IOException;
+}

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/Suggester.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/Suggester.java
@@ -42,7 +42,7 @@ public abstract class Suggester {
     private final String id;
     private boolean entireContent = false;
 
-    public Suggester(String id, String field, Element config, Path indexDir, Analyzer analyzer) throws DatabaseConfigurationException {
+    public Suggester(String id, String field, Element config, Path indexDir, Analyzer analyzer) {
         this.id = id;
         this.field = field;
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/Suggester.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/Suggester.java
@@ -19,8 +19,12 @@
  */
 package org.exist.indexing.lucene.suggest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.spell.Dictionary;
+import org.apache.lucene.search.spell.LuceneDictionary;
+import org.apache.lucene.search.suggest.DocumentDictionary;
 import org.apache.lucene.search.suggest.Lookup;
 import org.exist.util.DatabaseConfigurationException;
 import org.w3c.dom.Element;
@@ -31,21 +35,37 @@ import java.util.List;
 
 public abstract class Suggester {
 
+    public final String USE_ATTR = "use";
+    public final String USE_STORED = "stored";
+
     private final String field;
     private final String id;
+    private boolean entireContent = false;
 
     public Suggester(String id, String field, Element config, Path indexDir, Analyzer analyzer) throws DatabaseConfigurationException {
         this.id = id;
         this.field = field;
+
+        final String useOpt = config.getAttribute(USE_ATTR);
+        if (StringUtils.isNotEmpty(useOpt)) {
+            entireContent = useOpt.equalsIgnoreCase(USE_STORED);
+        }
     }
 
     String getField() {
         return field;
     }
 
+    Dictionary getDictionary(IndexReader reader, String field) {
+        if (entireContent) {
+            return new DocumentDictionary(reader, field, null);
+        }
+        return new LuceneDictionary(reader, field);
+    }
+
     abstract List<Lookup.LookupResult> lookup(CharSequence key, boolean onlyMorePopular, int num) throws IOException;
 
-    abstract void build(Dictionary dictionary) throws IOException;
+    abstract void build(IndexReader reader, String field) throws IOException;
 
     abstract void close() throws IOException;
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/Suggester.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/suggest/Suggester.java
@@ -32,8 +32,10 @@ import java.util.List;
 public abstract class Suggester {
 
     private final String field;
+    private final String id;
 
     public Suggester(String id, String field, Element config, Path indexDir, Analyzer analyzer) throws DatabaseConfigurationException {
+        this.id = id;
         this.field = field;
     }
 
@@ -46,4 +48,6 @@ public abstract class Suggester {
     abstract void build(Dictionary dictionary) throws IOException;
 
     abstract void close() throws IOException;
+
+    abstract void remove() throws IOException;
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
@@ -68,7 +68,8 @@ public class LuceneModule extends AbstractInternalModule {
         new FunctionDef(Facets.signatures[2], Facets.class),
         new FunctionDef(Field.signatures[0], Field.class),
         new FunctionDef(Field.signatures[1], Field.class),
-        new FunctionDef(LuceneIndexKeys.signatures[0], LuceneIndexKeys.class)
+        new FunctionDef(LuceneIndexKeys.signatures[0], LuceneIndexKeys.class),
+        new FunctionDef(Suggest.signatures[0], Suggest.class)
     };
 
     public LuceneModule(Map<String, List<? extends Object>> parameters) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Suggest.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Suggest.java
@@ -1,0 +1,76 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-2019 The eXist Project
+ *  http://exist-db.org
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.modules.lucene;
+
+import org.apache.lucene.search.suggest.Lookup;
+import org.exist.dom.QName;
+import org.exist.indexing.lucene.LuceneIndex;
+import org.exist.indexing.lucene.LuceneIndexWorker;
+import org.exist.xquery.*;
+import org.exist.xquery.functions.map.MapType;
+import org.exist.xquery.value.*;
+
+import java.io.IOException;
+import java.util.List;
+
+public class Suggest extends BasicFunction {
+
+    public final static FunctionSignature[] signatures = {
+            new FunctionSignature(
+                    new QName("suggest", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+                    "Return a map of facet labels and counts for the result of a Lucene query.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("field", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "Name of the field"),
+                            new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "The string to pass to the suggester")
+                    },
+                    new FunctionReturnSequenceType(Type.MAP, Cardinality.EXACTLY_ONE,
+                            "A map with each suggestion as key and the score as value")
+            )
+    };
+
+    public Suggest(XQueryContext context, FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    @Override
+    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
+        final String field = args[0].getStringValue();
+        final String query = args[1].getStringValue();
+        final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+        try {
+            final List<Lookup.LookupResult> lookup = index.getSuggesters().lookup(field, query, true, 10);
+            if (lookup == null) {
+                // return empty sequence if no suggester is defined for the field
+                return Sequence.EMPTY_SEQUENCE;
+            }
+            final MapType map = new MapType(context);
+            lookup.forEach((lookupResult) -> {
+                final StringValue key = new StringValue(lookupResult.key.toString());
+                final IntegerValue score = new IntegerValue(lookupResult.value);
+                map.add(key, score);
+            });
+            return map;
+        } catch (IOException e) {
+            throw new XPathException(this, LuceneModule.EXXQDYFT0002, "exception caught reading suggestions: " + e.getMessage());
+        }
+    }
+}

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Suggest.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Suggest.java
@@ -42,7 +42,7 @@ public class Suggest extends BasicFunction {
                             new FunctionParameterSequenceType("query", Type.STRING, Cardinality.EXACTLY_ONE,
                                     "The string to pass to the suggester")
                     },
-                    new FunctionReturnSequenceType(Type.MAP, Cardinality.EXACTLY_ONE,
+                    new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_MORE,
                             "A map with each suggestion as key and the score as value")
             )
     };
@@ -62,13 +62,12 @@ public class Suggest extends BasicFunction {
                 // return empty sequence if no suggester is defined for the field
                 return Sequence.EMPTY_SEQUENCE;
             }
-            final MapType map = new MapType(context);
+            final ValueSequence result = new ValueSequence(lookup.size());
             lookup.forEach((lookupResult) -> {
                 final StringValue key = new StringValue(lookupResult.key.toString());
-                final IntegerValue score = new IntegerValue(lookupResult.value);
-                map.add(key, score);
+                result.add(key);
             });
-            return map;
+            return result;
         } catch (IOException e) {
             throw new XPathException(this, LuceneModule.EXXQDYFT0002, "exception caught reading suggestions: " + e.getMessage());
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Suggest.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Suggest.java
@@ -24,7 +24,6 @@ import org.exist.dom.QName;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
 import org.exist.xquery.*;
-import org.exist.xquery.functions.map.MapType;
 import org.exist.xquery.value.*;
 
 import java.io.IOException;
@@ -43,7 +42,7 @@ public class Suggest extends BasicFunction {
                                     "The string to pass to the suggester")
                     },
                     new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_MORE,
-                            "A map with each suggestion as key and the score as value")
+                            "Sequence of suggestion terms or empty sequence if none")
             )
     };
 

--- a/extensions/indexes/lucene/src/test/xquery/lucene/suggestions.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/suggestions.xql
@@ -40,9 +40,6 @@ declare variable $suggest:XCONF1 :=
                 <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer" id="standard"/>
                 <text qname="document">
                     <suggest id="document-content"/>
-                    <field name="content">
-                        <suggest id="document-text" type="freetext"/>
-                    </field>
                     <field name="title" expression="title">
                         <suggest id="document-title" type="fuzzy"/>
                     </field>

--- a/extensions/indexes/lucene/src/test/xquery/lucene/suggestions.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/suggestions.xql
@@ -1,0 +1,93 @@
+xquery version "3.1";
+
+module namespace suggest="http://exist-db.org/xquery/lucene/test/suggestions";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $suggest:DOCUMENTS :=
+    <documents>
+        <document id="D-37/2">
+            <title>Vogel, Vögel, Vogelhaus</title>
+            <abstract>Es zwitschern die Vögel im Wald</abstract>
+            <abstract>Über dem Walde weht ein Wind</abstract>
+            <category>nature</category>
+        </document>
+        <document id="Z-49/2">
+            <title>Streiten und Hoffen</title>
+            <abstract>Da nun einmal der Himmel zerrissen und die Götter sich streiten</abstract>
+            <category>philosophy</category>
+        </document>
+    </documents>;
+
+declare variable $suggest:XCONF1 :=
+    <collection xmlns="http://exist-db.org/collection-config/1.0">
+        <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <lucene>
+                <analyzer class="org.exist.indexing.lucene.analyzers.NoDiacriticsStandardAnalyzer" id="nodiacritics"/>
+                <analyzer class="org.apache.lucene.analysis.core.KeywordAnalyzer" id="keyword"/>
+                <analyzer class="org.apache.lucene.analysis.de.GermanAnalyzer" id="german"/>
+                <analyzer class="org.apache.lucene.analysis.en.EnglishAnalyzer" id="english"/>
+                <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer" id="standard"/>
+                <text qname="document">
+                    <suggest id="document-content"/>
+                    <field name="content" analyzer="standard">
+                        <suggest id="document-text" type="freetext"/>
+                    </field>
+                    <field name="title" expression="title" analyzer="german">
+                        <suggest id="document-title" type="fuzzy"/>
+                    </field>
+                    <field name="abstract" expression="abstract" analyzer="german">
+                        <suggest id="document-abstract"/>
+                    </field>
+                    <field name="ident" expression="@id/string()" analyzer="keyword">
+                        <suggest id="document-ident"/>
+                    </field>
+                    <facet dimension="cat" expression="category"/>
+                </text>
+            </lucene>
+        </index>
+    </collection>;
+
+declare
+    %test:setUp
+function suggest:setup() {
+    let $testCol := xmldb:create-collection("/db", "lucenetest")
+    let $confCol := xmldb:create-collection("/db/system/config/db", "lucenetest")
+    return (
+        xmldb:store($confCol, "collection.xconf", $suggest:XCONF1),
+        xmldb:store($testCol, "documents.xml", $suggest:DOCUMENTS)
+    )
+};
+
+declare
+    %test:tearDown
+function suggest:tearDown() {
+    xmldb:remove("/db/lucenetest"),
+    xmldb:remove("/db/system/config/db/lucenetest")
+};
+
+declare
+    %test:assertEquals("wald", "walde", "weht", "wind", "vögel")
+function suggest:no-field-standard-analyzer() {
+    ft:suggest("document-content", "w"),
+    ft:suggest("document-content", "vög")
+};
+
+declare
+    %test:assertEquals("wald", "weht", "wind", "vogel")
+function suggest:field-with-stemming() {
+    ft:suggest("document-abstract", "w"),
+    ft:suggest("document-abstract", "vög")
+};
+
+declare
+    %test:assertEquals("vogel", "vogelhaus")
+function suggest:field-fuzzy-suggester() {
+    ft:suggest("document-title", "vogle")
+};
+
+declare
+    %test:assertEquals("Z-49/2")
+function suggest:field-keyword-analyzer() {
+    ft:suggest("document-ident", "Z")
+};

--- a/extensions/indexes/lucene/src/test/xquery/lucene/suggestions.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/suggestions.xql
@@ -6,16 +6,26 @@ declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 declare variable $suggest:DOCUMENTS :=
     <documents>
-        <document id="D-37/2">
-            <title>Vogel, Vögel, Vogelhaus</title>
-            <abstract>Es zwitschern die Vögel im Wald</abstract>
-            <abstract>Über dem Walde weht ein Wind</abstract>
-            <category>nature</category>
+        <document id="B-01/1" xml:lang="en">
+            <title>Evolutionary Biology</title>
+            <abstract>Evolutionary biology is the subfield of biology that studies the evolutionary processes
+            that produced the diversity of life on Earth, starting from a single common ancestor. These processes
+            include natural selection, common descent, and speciation.</abstract>
+            <category>biology</category>
         </document>
-        <document id="Z-49/2">
-            <title>Streiten und Hoffen</title>
-            <abstract>Da nun einmal der Himmel zerrissen und die Götter sich streiten</abstract>
-            <category>philosophy</category>
+        <document id="B-01/2" xml:lang="it">
+            <title>Biologia Evoluzionistica</title>
+            <abstract>La biologia evolutiva è la disciplina scientifica della biologia che analizza l'origine e
+            la discendenza delle specie, così come i loro cambiamenti, la loro diffusione e diversità nel corso
+            del tempo. Uno studioso di biologia evolutiva è noto come biologo dell'evoluzione o, meno formalmente,
+            evoluzionista.</abstract>
+            <category>biology</category>
+        </document>
+        <document id="B-01/3" xml:lang="de">
+            <title>Biologie</title>
+            <abstract>Biologie (von altgriechisch βίος bíos, deutsch ‚Leben‘, und λόγος, lógos, hier: ‚Lehre‘;
+            Biologie wurde früher auch Lebenskunde genannt) ist die Wissenschaft der Lebewesen.</abstract>
+            <category>biology</category>
         </document>
     </documents>;
 
@@ -30,19 +40,27 @@ declare variable $suggest:XCONF1 :=
                 <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer" id="standard"/>
                 <text qname="document">
                     <suggest id="document-content"/>
-                    <field name="content" analyzer="standard">
+                    <field name="content">
                         <suggest id="document-text" type="freetext"/>
                     </field>
-                    <field name="title" expression="title" analyzer="german">
+                    <field name="title" expression="title">
                         <suggest id="document-title" type="fuzzy"/>
                     </field>
-                    <field name="abstract" expression="abstract" analyzer="german">
-                        <suggest id="document-abstract"/>
+                    <field name="title-en" expression="title" if="@xml:lang='en'">
+                        <suggest id="title-en" use="stored"/>
+                    </field>
+                    <field name="title-it" expression="title" if="@xml:lang='it'">
+                        <suggest id="title-it" use="stored"/>
+                    </field>
+                    <field name="abstract-en" expression="abstract" if="@xml:lang='en'">
+                        <suggest id="abstract-en"/>
+                    </field>
+                    <field name="abstract-it" expression="abstract" if="@xml:lang='it'">
+                        <suggest id="abstract-it"/>
                     </field>
                     <field name="ident" expression="@id/string()" analyzer="keyword">
                         <suggest id="document-ident"/>
                     </field>
-                    <facet dimension="cat" expression="category"/>
                 </text>
             </lucene>
         </index>
@@ -67,27 +85,49 @@ function suggest:tearDown() {
 };
 
 declare
-    %test:assertEquals("wald", "walde", "weht", "wind", "vögel")
+    %test:assertEquals("biologia", "biologie", "biologo", "biology")
 function suggest:no-field-standard-analyzer() {
-    ft:suggest("document-content", "w"),
-    ft:suggest("document-content", "vög")
+    ft:suggest("document-content", "bio")
 };
 
 declare
-    %test:assertEquals("wald", "weht", "wind", "vogel")
-function suggest:field-with-stemming() {
-    ft:suggest("document-abstract", "w"),
-    ft:suggest("document-abstract", "vög")
+    %test:assertEquals("Evolutionary Biology")
+function suggest:title-en() {
+    ft:suggest("title-en", "biol")
 };
 
 declare
-    %test:assertEquals("vogel", "vogelhaus")
+    %test:assertEquals("Biologia Evoluzionistica")
+function suggest:title-it() {
+    ft:suggest("title-it", "biol")
+};
+
+declare
+    %test:assertEquals("Biologia Evoluzionistica")
+function suggest:title-it-multi() {
+    ft:suggest("title-it", "biologia evo")
+};
+
+declare
+    %test:assertEquals("evolutiva", "evoluzionista")
+function suggest:abstract-it() {
+    ft:suggest("abstract-it", "evol")
+};
+
+declare
+    %test:assertEquals("evolutionary")
+function suggest:abstract-en() {
+    ft:suggest("abstract-en", "evol")
+};
+
+declare
+    %test:assertEquals("biologia", "biologie")
 function suggest:field-fuzzy-suggester() {
-    ft:suggest("document-title", "vogle")
+    ft:suggest("document-title", "biologei")
 };
 
 declare
-    %test:assertEquals("Z-49/2")
+    %test:assertEquals("B-01/1", "B-01/2", "B-01/3")
 function suggest:field-keyword-analyzer() {
-    ft:suggest("document-ident", "Z")
+    ft:suggest("document-ident", "B-01")
 };

--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndex.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndex.java
@@ -25,10 +25,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ReferenceManager;
+import org.apache.lucene.search.SearcherManager;
 import org.exist.indexing.IndexWorker;
+import org.exist.indexing.lucene.AbstractLuceneIndex;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.storage.DBBroker;
+import org.exist.util.DatabaseConfigurationException;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +44,7 @@ import java.util.Map;
  *
  * @author Wolfgang Meier
  */
-public class RangeIndex extends LuceneIndex {
+public class RangeIndex extends AbstractLuceneIndex<IndexSearcher> {
 
     protected static final Logger LOG = LogManager.getLogger(RangeIndex.class);
 
@@ -64,7 +71,7 @@ public class RangeIndex extends LuceneIndex {
         private static final Map<String, Operator> LOOKUP_MAP;
 
         static {
-            LOOKUP_MAP = new HashMap<String, Operator>();
+            LOOKUP_MAP = new HashMap<>();
             for (Operator operator : Operator.values()) {
                 LOOKUP_MAP.put(operator.name, operator);
             }
@@ -108,5 +115,14 @@ public class RangeIndex extends LuceneIndex {
 
     public Analyzer getDefaultAnalyzer() {
         return defaultAnalyzer;
+    }
+
+    @Override
+    public ReferenceManager<IndexSearcher> createSearcherManager(IndexWriter writer) throws DatabaseConfigurationException {
+        try {
+            return new SearcherManager(writer, true, null);
+        } catch (IOException e) {
+            throw new DatabaseConfigurationException("IO error while creating searcher manager: " + e.getMessage(), e);
+        }
     }
 }

--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexWorker.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexWorker.java
@@ -532,7 +532,7 @@ public class RangeIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 final short nodeType = qname.getNameType() == ElementValue.ATTRIBUTE ? Node.ATTRIBUTE_NODE : Node
                         .ELEMENT_NODE;
 
-                resultSet.addAll(doQuery(contextId, docs, contextSet, axis, searcher.searcher, nodeType, query, null));
+                resultSet.addAll(doQuery(contextId, docs, contextSet, axis, searcher, nodeType, query, null));
             }
             return resultSet;
         });
@@ -564,7 +564,7 @@ public class RangeIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 qu = clauses[0].getQuery();
             }
             final NodeSet resultSet = new NewArrayNodeSet();
-            resultSet.addAll(doQuery(contextId, docs, contextSet, axis, searcher.searcher, Node.ELEMENT_NODE, qu, null));
+            resultSet.addAll(doQuery(contextId, docs, contextSet, axis, searcher, Node.ELEMENT_NODE, qu, null));
             return resultSet;
         });
     }


### PR DESCRIPTION
Lucene provides a package to generate suggestion lists based on an index, which can be presented to users to help formulating a query. This PR integrates the feature into eXist's lucene-based indexing. It also refactors the index package to get a cleaner separation between the lucene full-text index and the range index.

While eXist always had a feature to read index terms via XQuery, this method often fails if the text was passed through an analyzer, e.g. to apply language-dependent stemming to the tokenized text. Lucene's own suggestion package does address this problem, taking analyzers into account properly.

**Work in progress,** do not merge.

See tests in `extensions/indexes/lucene/src/test/xquery/lucene/suggestions.xql`