### PR TITLE
Remove XQuery draft Map constructor

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -1338,7 +1338,13 @@ mapConstructor throws XPathException
 
 mapAssignment throws XPathException
 	:
-	exprSingle COLON^ ( EQ! )? exprSingle
+    (exprSingle COLON! EQ!) => exprSingle COLON^ eq:EQ^ exprSingle
+    {
+        throw new XPathException(#eq.getLine(), #eq.getColumn(), ErrorCodes.XPST0003,
+               "The ':=' notation is no longer accepted in map expressions: use ':' instead.");
+    }
+    |
+	exprSingle COLON^ exprSingle
 	;
 
 arrayConstructor throws XPathException

--- a/exist-core/src/test/xquery/optimizer/optimizer.xql
+++ b/exist-core/src/test/xquery/optimizer/optimizer.xql
@@ -366,7 +366,7 @@ declare
     %test:assertXPath("$result//stats:index[@type = 'range'][@optimization = 2]")
 function ot:optimize-map($name as xs:string) {
     let $map := map {
-        "key" := collection($ot:COLLECTION)//address[name = $name]/city/text()
+        "key": collection($ot:COLLECTION)//address[name = $name]/city/text()
     }
     return
         $map("key")

--- a/exist-core/src/test/xquery/xquery3/inline.xml
+++ b/exist-core/src/test/xquery/xquery3/inline.xml
@@ -15,7 +15,7 @@
     <!-- 
     <test output="text" id="inline-function-001">
         <task>Try to call a %public function</task>
-        <code><![CDATA[xquery version "3.0";
+        <code><![CDATA[xquery version "3.1";
 
 declare function local:external-func($data) {
         let $case := function ($result-generator) {
@@ -29,14 +29,14 @@ declare function local:external-func($data) {
 
 local:external-func(
 map {
-	'string' := 'some string'
+	"string": "some string"
 })]]></code>
         <expected>error</expected>
     </test>
     -->
     <test output="text" id="inline-function-002">
         <task></task>
-        <code><![CDATA[xquery version "3.0";
+        <code><![CDATA[xquery version "3.1";
 
 declare function local:external-func($data) {
         let $case := function ($result-generator) {
@@ -44,13 +44,13 @@ declare function local:external-func($data) {
         }
 
         return $case(function ($data) {
-                $data('string')
+                $data("string")
         })
 };
 
 local:external-func(
 map {
-	'string' := 'some string'
+	"string": "some string"
 })]]></code>
         <expected>some string</expected>
     </test>

--- a/exist-core/src/test/xquery/xquery3/recursion_calls.xml
+++ b/exist-core/src/test/xquery/xquery3/recursion_calls.xml
@@ -53,10 +53,10 @@ declare function local:join($value){
 };
 
 let $map := map {
-    "args" := [
+    "args": [
         "'a'",
         map {
-            "args":=["'x'","'y'"]
+            "args": ["'x'","'y'"]
         },
         "'b'"]
 }

--- a/extensions/modules/cache/src/test/xquery/modules/cache/cache.xqm
+++ b/extensions/modules/cache/src/test/xquery/modules/cache/cache.xqm
@@ -9,9 +9,9 @@ declare namespace test="http://exist-db.org/xquery/xqsuite";
 declare variable $c:cache-name := "test" ;
 declare variable $c:simple-options := map {};
 declare variable $c:maximumSize := 5;
-declare variable $c:maximumSize-options := map { "maximumSize" := $c:maximumSize };
+declare variable $c:maximumSize-options := map { "maximumSize": $c:maximumSize };
 declare variable $c:expireAfterAccess := 1000;
-declare variable $c:expireAfterAccess-options := map { "expireAfterAccess" := $c:expireAfterAccess };
+declare variable $c:expireAfterAccess-options := map { "expireAfterAccess": $c:expireAfterAccess };
 
 declare function c:_create-simple() {
     cache:create($c:cache-name, $c:simple-options)


### PR DESCRIPTION
### Description:

Fixes: #2887 

Constructing a map with `map { 'a': 1 }` works.
Using the draft syntax with `map { 'a':= 1}` will fail with
```
error found while executing expression: org.exist.xquery.XPathException: err:XPST0003 unexpected token: null [at line 1, column 10]
```
### Reference:

https://www.w3.org/TR/xquery-31/#prod-xquery31-MapConstructor

### Type of tests:

Added test to `exist-core/src/test/xquery/maps/maps.xql`