### PR TITLE
(4.x.x) Use the correct name for the endorsed Saxon-HE.jar on Windows, too.

### DIFF
--- a/installer/jobs.xml
+++ b/installer/jobs.xml
@@ -5,7 +5,7 @@
         <os family="windows"/>
         <executefile name="java">
             <arg>-cp</arg>
-            <arg>$INSTALL_PATH\lib\endorsed\Saxon-HE-Saxon-HE-9.6.0-7.jar</arg>
+            <arg>$INSTALL_PATH\lib\endorsed\Saxon-HE-9.6.0-7.jar</arg>
             <arg>net.sf.saxon.Transform</arg>
             <arg>-s:$INSTALL_PATH\conf.xml</arg>
             <arg>-xsl:$INSTALL_PATH\bin\conf.xslt</arg>


### PR DESCRIPTION
### Description:
This PR fixes a typo in the `Saxon-HE.jar` name for `<os family="windows"/>` in  `installer/jobs.xml`

### Reference:
Fixes [Issue #2895](https://github.com/eXist-db/exist/issues/2895)

### Type of tests:
Now the unattended installation under Windows (using an `autoinstaller.xml` file) passes.
Verified on our site on different windows machines.