### PR TITLE
(5.0.0) Remove OSS parent

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -666,6 +666,14 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>org.exist.xquery.parser:org.exist.xquery.xqdoc.parser</excludePackageNames>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dlog4j.configurationFile=${project.build.testOutputDirectory}/log4j2.xml</argLine>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -673,6 +673,8 @@
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <tagNameFormat>eXist-@{project.version}</tagNameFormat>
+                        <useReleaseProfile>true</useReleaseProfile>
+                        <releaseProfiles>exist-release</releaseProfiles>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -769,19 +771,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -890,5 +879,29 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+
+    <profiles>
+        <profile>
+            <id>exist-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 
 </project>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -3,13 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-        <relativePath/>
-    </parent>
-
     <groupId>org.exist-db</groupId>
     <artifactId>exist-parent</artifactId>
     <version>5.0.0-RC8-SNAPSHOT</version>
@@ -89,6 +82,9 @@
         <milton.version>1.8.1.3</milton.version>
         <saxon.version>9.9.1-2</saxon.version>
         <xmlunit.version>2.6.2</xmlunit.version>
+
+        <!-- needed just for the license-maven-plugin in this module! -->
+        <project.parent.relativePath>.</project.parent.relativePath>
     </properties>
 
     <dependencyManagement>
@@ -587,7 +583,6 @@
                             <additionalJOption>-Xmaxwarns</additionalJOption>
                             <additionalJOption>65536</additionalJOption>
                         </additionalJOptions>
-                        <excludePackageNames>org.exist.xquery.parser:org.exist.xquery.xqdoc.parser</excludePackageNames>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -675,6 +670,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
+                    <configuration>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <tagNameFormat>eXist-@{project.version}</tagNameFormat>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -773,11 +772,20 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <tagNameFormat>eXist-@{project.version}</tagNameFormat>
-                </configuration>
             </plugin>
         </plugins>
 
@@ -818,23 +826,25 @@
 
     <repositories>
         <repository>
-            <id>exist-db</id>
-            <url>http://repo.evolvedbinary.com/repository/exist-db/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>exist-db-snapshots</id>
+            <name>Evolved Binary - eXist-db Snapshots</name>
             <url>http://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
             <snapshots>
                 <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>exist-db</id>
+            <name>Evolved Binary - eXist-db Releases</name>
+            <url>http://repo.evolvedbinary.com/repository/exist-db/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
     </repositories>
@@ -846,6 +856,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>exist-db</id>
+            <name>Evolved Binary - eXist-db Releases</name>
             <url>http://repo.evolvedbinary.com/repository/exist-db/</url>
             <releases>
                 <enabled>true</enabled>
@@ -856,6 +867,7 @@
         </pluginRepository>
         <pluginRepository>
             <id>exist-db-snapshots</id>
+            <name>Evolved Binary - eXist-db Snapshots</name>
             <url>http://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
@@ -869,8 +881,14 @@
     <distributionManagement>
         <snapshotRepository>
             <id>exist-db-snapshots</id>
+            <name>Evolved Binary - eXist-db Snapshots</name>
             <url>http://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
         </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
     </distributionManagement>
 
 </project>


### PR DESCRIPTION
The OSS Parent pom.xml is deprecated and should no longer be used.