### PR TITLE
Fix user leak in XQuery User Switching functions

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/UserSwitchingBasicFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/UserSwitchingBasicFunction.java
@@ -33,10 +33,10 @@ import org.exist.security.Subject;
 public abstract class UserSwitchingBasicFunction extends BasicFunction {
 
     /**
-     * Flag which indicates that we have pushed a subject and so we must later
-     * pop the subject when the expression is reset, see {@link UserSwitchingBasicFunction#resetState(boolean)}
+     * Flag which indicates how many subjects we have pushed, and so we must later
+     * pop the same number of subjects when the expression is reset, see {@link UserSwitchingBasicFunction#resetState(boolean)}
      */
-    private boolean pushedSubject = false;
+    private int pushedSubjects = 0;
 
     public UserSwitchingBasicFunction(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
@@ -49,7 +49,7 @@ public abstract class UserSwitchingBasicFunction extends BasicFunction {
      */
     protected void switchUser(final Subject user) {
         context.getBroker().pushSubject(user);
-        pushedSubject = true;
+        pushedSubjects++;
     }
 
     /**
@@ -59,12 +59,9 @@ public abstract class UserSwitchingBasicFunction extends BasicFunction {
     @Override
     public void resetState(final boolean postOptimization) {
         //if we pushed a subject, we must pop it
-        if(this.pushedSubject) {
-            try {
-                context.getBroker().popSubject();
-            } finally {
-                this.pushedSubject = false;
-            }
+        while (pushedSubjects > 0) {
+            context.getBroker().popSubject();
+            pushedSubjects--;
         }
 
         super.resetState(postOptimization);


### PR DESCRIPTION
If a user switching function was re-used via a function item, it was possible to leak users.
Closes https://github.com/eXist-db/exist/issues/2922