### PR TITLE
(5.0.0) Prevent ClassNotFound exception for document triggers

### DIFF
--- a/exist-core/src/main/java/org/exist/collections/CollectionConfiguration.java
+++ b/exist-core/src/main/java/org/exist/collections/CollectionConfiguration.java
@@ -145,7 +145,7 @@ public class CollectionConfiguration {
                     for (int j = 0; j < triggers.getLength(); j++) {
                         node = triggers.item(j);
                         if (node.getNodeType() == Node.ELEMENT_NODE && node.getLocalName().equals(TRIGGER_ELEMENT)) {
-                            configureTrigger((Element) node, srcCollectionURI, checkOnly);
+                            configureTrigger(broker.getBrokerPool().getClassLoader(), (Element) node, srcCollectionURI, checkOnly);
                         }
                     }
                 } else if (INDEX_ELEMENT.equals(node.getLocalName())) {
@@ -299,14 +299,14 @@ public class CollectionConfiguration {
         return indexSpec;
     }
 
-    private void configureTrigger(final Element triggerElement, final XmldbURI collectionConfigurationURI, final boolean testOnly) throws CollectionConfigurationException {
+    private void configureTrigger(ClassLoader cl, final Element triggerElement, final XmldbURI collectionConfigurationURI, final boolean testOnly) throws CollectionConfigurationException {
 
         //TODO : rely on schema-driven validation -pb
 
         final String classname = triggerElement.getAttributes().getNamedItem(CLASS_ATTRIBUTE).getNodeValue();
 
         try {
-            final Class clazz = Class.forName(classname);
+            final Class clazz = Class.forName(classname, true, cl);
             if (!Trigger.class.isAssignableFrom(clazz)) {
                 throwOrLog("Trigger's class '" + classname + "' is not assignable from '" + Trigger.class + "'", testOnly);
                 return;

--- a/exist-core/src/main/java/org/exist/collections/CollectionConfiguration.java
+++ b/exist-core/src/main/java/org/exist/collections/CollectionConfiguration.java
@@ -299,7 +299,7 @@ public class CollectionConfiguration {
         return indexSpec;
     }
 
-    private void configureTrigger(ClassLoader cl, final Element triggerElement, final XmldbURI collectionConfigurationURI, final boolean testOnly) throws CollectionConfigurationException {
+    private void configureTrigger(final ClassLoader cl, final Element triggerElement, final XmldbURI collectionConfigurationURI, final boolean testOnly) throws CollectionConfigurationException {
 
         //TODO : rely on schema-driven validation -pb
 


### PR DESCRIPTION
port of #2949 

### Description:

Make sure 'correct' classloader is used; in current v5 situation (document) Trigger classes that are in a JAR file in a XAR file can not be found. Using the classloader of the BrokerPool fixes this issue

```
2019-08-10 23:32:47,522 [qtp728236551-42] WARN  (CollectionConfiguration.java [configureTrigger]:336) - Trigger class not found: org.exist.jms.replication.publish.ReplicationTrigger 
java.lang.ClassNotFoundException: org.exist.jms.replication.publish.ReplicationTrigger
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382) ~[?:1.8.0_212]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[?:1.8.0_212]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_212]
	at java.lang.Class.forName0(Native Method) ~[?:1.8.0_212]
	at java.lang.Class.forName(Class.java:264) ~[?:1.8.0_212]
	at org.exist.collections.CollectionConfiguration.configureTrigger(CollectionConfiguration.java:309) ~[exist-core-5.0.0-RC9-SNAPSHOT.jar:5.0.0-RC9-SNAPSHOT]
```

### Reference:

[exist.log](https://slack-files.com/TG47XS7E2-FM8MAGFNU-29d292b843) 
[expath.log](https://slack-files.com/TG47XS7E2-FM87P4HE0-cf9226fb7d)
[xar](https://slack-files.com/TG47XS7E2-FLX8D6N10-6360eacc9c)

### Type of tests:

how to reproduce: 
- install messaging/replication XAR (snapshot)
- open eXide
- open /db/apps/messaging-replication/demo/replication/collection.xconf
- edit document, save + allow re-index

notes
- no automated tests yet
- after fix an other issue appears where the parameters of the trigger are not shared with the trigger code. not sure if this is related to THIS specific class loader change
