### PR TITLE
Add missing Semver.xq to autodeploy

### DIFF
--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -318,7 +318,7 @@ public class Deployment {
             try {
                 final Optional<ElementImpl> cleanup = findElement(repoXML, CLEANUP_ELEMENT);
                 if(cleanup.isPresent()) {
-                    runQuery(broker, null, packageDir, cleanup.get().getStringValue(), false);
+                    runQuery(broker, null, packageDir, cleanup.get().getStringValue(), false, pkgName);
                 }
 
                 final Optional<ElementImpl> target = findElement(repoXML, TARGET_COLL_ELEMENT);
@@ -359,7 +359,7 @@ public class Deployment {
             final Optional<String> setupPath = setup.map(ElementImpl::getStringValue).filter(s -> !s.isEmpty());
 
             if (setupPath.isPresent()) {
-                runQuery(broker, null, packageDir, setupPath.get(), true);
+                runQuery(broker, null, packageDir, setupPath.get(), true, pkgName);
                 return Optional.empty();
             } else {
                 // otherwise copy all child directories to the target collection
@@ -428,7 +428,7 @@ public class Deployment {
                 final Optional<String> preSetupPath = preSetup.map(ElementImpl::getStringValue).filter(s -> !s.isEmpty());
 
                 if(preSetupPath.isPresent()) {
-                    runQuery(broker, targetCollection, packageDir, preSetupPath.get(), true);
+                    runQuery(broker, targetCollection, packageDir, preSetupPath.get(), true, pkgName);
                 }
 
                 // any required users and group should have been created by the pre-setup query.
@@ -448,7 +448,7 @@ public class Deployment {
                 final Optional<String> postSetupPath = postSetup.map(ElementImpl::getStringValue).filter(s -> !s.isEmpty());
 
                 if(postSetupPath.isPresent()) {
-                    runQuery(broker, targetCollection, packageDir, postSetupPath.get(), false);
+                    runQuery(broker, targetCollection, packageDir, postSetupPath.get(), false, pkgName);
                 }
 
                 storeRepoXML(broker, transaction, repoXML, targetCollection, requestedPerms);
@@ -644,11 +644,12 @@ public class Deployment {
         }
     }
 
-    private Sequence runQuery(final DBBroker broker, final XmldbURI targetCollection, final Path tempDir, final String fileName, final boolean preInstall)
+    private Sequence runQuery(final DBBroker broker, final XmldbURI targetCollection, final Path tempDir,
+            final String fileName, final boolean preInstall, final String pkgName)
             throws PackageException, IOException, XPathException {
         final Path xquery = tempDir.resolve(fileName);
         if (!Files.isReadable(xquery)) {
-            LOG.warn("The XQuery resource specified in the <setup> element was not found");
+            LOG.warn("The XQuery resource specified in the <setup> element was not found for EXPath Package: '" + pkgName + "'");
             return Sequence.EMPTY_SEQUENCE;
         }
         final XQuery xqs = broker.getBrokerPool().getXQueryService();

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -612,28 +612,28 @@
                                     <abbrev>dashboard</abbrev>
                                 </package>
                                 <package>
-                                    <abbrev>packageservice</abbrev>
-                                </package>
-                                <package>
-                                    <abbrev>shared</abbrev>
-                                </package>
-                                <package>
                                     <abbrev>eXide</abbrev>
-                                </package>
-                                <package>
-                                    <abbrev>monex</abbrev>
-                                </package>
-                                <package>
-                                    <abbrev>functx</abbrev>
                                 </package>
                                 <package>
                                     <abbrev>exist-documentation</abbrev>
                                 </package>
                                 <package>
+                                    <abbrev>functx</abbrev>
+                                </package>
+                                <package>
                                     <abbrev>fundocs</abbrev>
                                 </package>
                                 <package>
+                                    <abbrev>monex</abbrev>
+                                </package>
+                                <package>
                                     <abbrev>markdown</abbrev>
+                                </package>
+                                <package>
+                                    <abbrev>packageservice</abbrev>
+                                </package>
+                                <package>
+                                    <abbrev>shared</abbrev>
                                 </package>
                             </packages>
                         </configuration>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -633,6 +633,9 @@
                                     <abbrev>packageservice</abbrev>
                                 </package>
                                 <package>
+                                    <abbrev>semver-xq</abbrev>
+                                </package>
+                                <package>
                                     <abbrev>shared</abbrev>
                                 </package>
                             </packages>

--- a/exist-distribution/src/main/config/log4j2.xml
+++ b/exist-distribution/src/main/config/log4j2.xml
@@ -244,10 +244,10 @@
         </Logger>
 
         <!-- expath pkg repo -->
-        <Logger name="org.expath.pkg" additivity="false" level="trace">
+        <Logger name="org.expath.pkg" additivity="false" level="info">
             <AppenderRef ref="expath.repo"/>
         </Logger>
-        <Logger name="org.exist.repo" additivity="false" level="trace">
+        <Logger name="org.exist.repo" additivity="false" level="info">
             <AppenderRef ref="expath.repo"/>
         </Logger>
         <Logger name="org.exist.launcher" additivity="false" level="warn">


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/2973

At auto-deploy time, package dependency ordering is not needed. The packages are just deployed as a bunch of files into the db regardless of any missing dependencies. The dependency resolution then occurs at runtime.