### PR TITLE
test(docker): port bats tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,12 @@ cache:
   directories:
   - $HOME/.m2
 
+# Simplest way to ensure latest version is used
+before_install: npm i -g bats
+
 install: travis_wait mvn -T 2C -DskipTests=true -Dmaven.javadoc.skip=true -Ddocker=$BUILD_DOCKER install -B -V -q
 
-script: mvn -T 2C -Ddocker=$BUILD_DOCKER test -B
+script: mvn -T 2C -Ddocker=$BUILD_DOCKER test integration-test -B
 
 after_failure:
    - tar -cjf surefire-reports.tar.bz2 exist-core/target/surefire-reports exist-core/target/test-logs

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -183,6 +183,17 @@
                                 <dockerFile>${project.build.outputDirectory}/Dockerfile</dockerFile>
                                 <contextDir>${assemble.dir}</contextDir>
                             </build>
+                            <run>
+                                <containerNamePattern>exist</containerNamePattern>
+                                <ports>
+                                    <port>8080:8080</port>
+                                </ports>
+                                <wait>
+                                    <time>35000</time>
+                                    <log> Server has started</log>
+                                    <healthy>true</healthy>
+                                </wait>
+                            </run>
                         </image>
                     </images>
                 </configuration>
@@ -195,6 +206,20 @@
                         </goals>
                     </execution>
                     <execution>
+                        <id>start IT image</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop IT image</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <id>push image to registry</id>
                         <phase>deploy</phase>
                         <goals>
@@ -203,7 +228,25 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <!-- Run our integration tests for docker images -->
+                        <id>run bats test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>bash</executable>
+                            <commandlineArgs>${project.basedir}/src/test/bats-run.sh</commandlineArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/exist-docker/src/test/bats-run.sh
+++ b/exist-docker/src/test/bats-run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env
+
+set -xe
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+cd "$parent_path"
+
+bats -t ./bats/*.bats

--- a/exist-docker/src/test/bats/01-connect-spec.bats
+++ b/exist-docker/src/test/bats/01-connect-spec.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+# Basic start-up and connection tests
+@test "jvm responds from client" {
+  run docker exec exist java -version
+  [ "$status" -eq 0 ]
+}
+
+@test "eXist can be reached via http" {
+  result=$(curl -Is http://127.0.0.1:8080/ | grep -o 'Jetty')
+  [ "$result" == 'Jetty' ]
+}
+
+@test "eXist reports healthy to docker" {
+  result=$(docker ps | grep -o 'healthy')
+  [ "$result" == 'healthy' ]
+}
+
+@test "eXist logs show clean start" {
+  result=$(docker logs exist | grep -o 'Server has started')
+  [ "$result" == 'Server has started' ]
+}
+
+@test "logs are error free" {
+  result=$(docker logs exist | grep -ow -c 'ERROR' || true)
+  [ "$result" -eq 0 ]
+}

--- a/exist-docker/src/test/bats/02-config-spec.bats
+++ b/exist-docker/src/test/bats/02-config-spec.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+# Tests for modifying eXist's configuration files
+@test "copy configuration file from container to disk" {
+  run docker cp exist:exist/etc/conf.xml ./conf.xml && [[ -e ./conf.xml ]] && ls -l ./conf.xml
+  [ "$status" -eq 0 ]
+}
+
+@test "modify the copied config file" {
+  run sed -i.bak 's/wait-before-shutdown="120000"/wait-before-shutdown="60000"/' ./conf.xml
+  [ "$status" -eq 0 ]
+}
+
+@test "create modified image" {
+  run docker create --name ex-mod -p 9090:8080 existdb/exist-ci-build:latest
+  [ "$status" -eq 0 ]
+  run docker cp ./conf.xml ex-mod:exist/config/conf.xml
+  [ "$status" -eq 0 ]
+  run docker start ex-mod
+  [ "$status" -eq 0 ]
+}
+
+@test "modification is applied in container" {
+  # Make sure container is running
+  result=$(docker ps | grep -o 'ex-mod')
+  [ "$result" == 'ex-mod' ]
+  sleep 30
+  result=$(docker logs ex-mod | grep -o "60,000 ms during shutdown")
+  [ "$result" == '60,000 ms during shutdown' ]
+}
+
+@test "teardown modified image" {
+  run docker stop ex-mod
+  [ "$status" -eq 0 ]
+  [ "$output" == "ex-mod" ]
+  run docker rm ex-mod
+  [ "$status" -eq 0 ]
+  [ "$output" == "ex-mod" ]
+  run rm ./conf.xml
+  [ "$status" -eq 0 ]
+  run rm ./conf.xml.bak
+  [ "$status" -eq 0 ]
+}
+
+@test "log queries to system are visible to docker" {
+  run docker exec exist java org.exist.start.Main client -q -u admin -P '' -x 'util:log-system-out("HELLO SYSTEM-OUT")'
+  [ "$status" -eq 0 ]
+  result=$(docker logs exist | grep -o "HELLO SYSTEM-OUT" | head -1)
+  [ "$result" == "HELLO SYSTEM-OUT" ]
+}
+
+@test "regular log queries are visible to docker" {
+  run docker exec exist java org.exist.start.Main client -q -u admin -P '' -x 'util:log("INFO", "HELLO logged INFO")'
+  [ "$status" -eq 0 ]
+  result=$(docker logs exist | grep -o "HELLO logged INFO" | head -1)
+  [ "$result" == "HELLO logged INFO" ]
+}

--- a/exist-docker/src/test/bats/03-xquery-spec.bats
+++ b/exist-docker/src/test/bats/03-xquery-spec.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+# Tests that execute xquery via start.jar
+@test "Change admin password" {
+  run docker exec exist java org.exist.start.Main client -q -u admin -P '' -x 'sm:passwd("admin", "nimda")'
+  [ "$status" -eq 0 ]
+}
+
+# Tests that use rest endpoint, this might be disabled by default soon
+@test "confirm new password" {
+  result=$(curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @bats/dba-xq.xml http://127.0.0.1:8080/exist/rest/db | grep 'true' | head -1)
+  [ "$result" == 'true' ]
+}
+
+@test "GET version via rest" {
+  run curl -s -u 'admin:nimda' "http://127.0.0.1:8080/exist/rest/db?_query=system:get-version()&_wrap=no"
+  [ "$status" -eq 0 ]
+  echo '# ' $output >&3
+}
+
+@test "POST list repo query" {
+  result=$(curl -s -H 'Content-Type: text/xml' -u 'admin:nimda' --data-binary @bats/repo-list.xml http://127.0.0.1:8080/exist/rest/db | grep -o 'http://' | head -1)
+  [ "$result" == 'http://' ]
+}
+
+# see #2976
+@test "PUT xq should succeed and trigger auto-register" {
+  run curl -i -X PUT -H "Content-Type: application/xquery" -d $'xquery version "3.0";\nmodule namespace host = "http://host/service";\nimport module namespace rest = "http://exquery.org/ns/restxq";\ndeclare\n %rest:POST\n	%rest:path("/forgot")\n %rest:query-param("email", "{$email}")\n	%rest:consumes("application/x-www-form-urlencoded")\n %rest:produces("text/html")\nfunction host:function1($email) {\n let $doc := \n<Customer>\n <Metadata>\n <Created>{current-dateTime()}</Created>\n </Metadata>\n <Contact>\n <Email>{$email}</Email>\n </Contact>\n </Customer>\n return\n let $new-file-path := xmldb:store("/db/forgot", concat($email, ".xml"), $doc)\n return\n <html xmlns="http://www.w3.org/1999/xhtml">\n <body>SUCCESS</body>\n </html>\n};' http://admin:nimda@127.0.0.1:8080/exist/rest/db/forgot.xqm
+  [ "$status" -eq 0 ]
+  result=$(docker exec exist java org.exist.start.Main client -q -u admin -P 'nimda' -x 'rest:resource-functions()' | grep -o 'http://host/service')
+  [ "$result" == 'http://host/service' ]
+}
+
+@test "teardown revert changes" {
+  run docker exec exist java org.exist.start.Main client -q -u admin -P 'nimda' -x 'sm:passwd("admin", "")'
+  [ "$status" -eq 0 ]
+}

--- a/exist-docker/src/test/bats/dba-xq.xml
+++ b/exist-docker/src/test/bats/dba-xq.xml
@@ -1,0 +1,6 @@
+<query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
+<text><![CDATA[
+xquery version '3.1';
+sm:is-dba("admin")
+]]></text>
+</query>

--- a/exist-docker/src/test/bats/repo-list.xml
+++ b/exist-docker/src/test/bats/repo-list.xml
@@ -1,0 +1,6 @@
+<query xmlns='http://exist.sourceforge.net/NS/exist' start='1' max='99' wrap='no'>
+<text><![CDATA[
+xquery version '3.1';
+string-join(repo:list(), '&#10;')
+]]></text>
+</query>


### PR DESCRIPTION
### Description: 
integration tests for docker
ports the bats tests and executes them via maven-exec plugin

CI failures need more work. Although the lucen errors seem completely unrelated 🤷‍♂ 
also we need to make sure that we're still deploying a fresh container, instead of the ci container used for running the tests.

to execute just the tests in this PR:
```
mvn -pl exist-docker integration-test
```


### Reference:
close #2719

for skipped test: 
see #2976 

see #2726

### Type of tests:
shell