### PR TITLE
Allow distinct Lucene Analyzers to be specified and then used during indexing vs. querying

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
@@ -177,14 +177,24 @@ public class LuceneConfig {
         return analyzers.getDefaultAnalyzer();
     }
 
+
     public Analyzer getAnalyzer(String field) {
         LuceneIndexConfig config = namedIndexes.get(field);
-        if (config != null) {
-            String id = config.getAnalyzerId();
-            if (id != null)
-                return analyzers.getAnalyzerById(config.getAnalyzerId());
+        String id = config != null ? config.getAnalyzerId() : null;
+        if (id == null)
+            return analyzers.getDefaultAnalyzer();
+
+        final String indexSuffix = ":index";
+        if (id.endsWith(indexSuffix)) {
+            // Substitute <analyzer-id>:index with <analyzer-id>:query
+            String qid = id.substring(0, id.length() - indexSuffix.length()) + ":query";
+            Analyzer queryAnalyzer = analyzers.getAnalyzerById(qid);
+            if (queryAnalyzer != null)
+                return queryAnalyzer;
+
+            LOG.warn(String.format("Failed to substitute %s with %s analyzer", id, qid));
         }
-        return analyzers.getDefaultAnalyzer();
+        return analyzers.getAnalyzerById(config.getAnalyzerId());
     }
 
     /**

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
@@ -197,6 +197,13 @@ public class LuceneConfig {
         return analyzers.getAnalyzerById(config.getAnalyzerId());
     }
 
+    /** Gets the Analyzer (defined in this LuceneConfig) with the specified id.
+     *  Returns null if no match was found.
+     */
+    public Analyzer getAnalyzerById(String analyzerId) {
+        return analyzers.getAnalyzerById(analyzerId);
+    }
+
     /**
      * Try to instantiate the configured Lucene query parser. Lucene's parsers
      * do not all have a common base class, so we need to wrap around the implementation

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -1068,7 +1068,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             if (opts.getQueryAnalyzerId() != null) {
                 analyzer = config.getAnalyzerById(opts.getQueryAnalyzerId());
                 if (analyzer == null) {
-                    String msg = String.format("getAnalyzerById(%s) returned null!", opts.getQueryAnalyzerId());
+                    String msg = String.format("getAnalyzerById('%s') returned null!", opts.getQueryAnalyzerId());
                     LOG.error(msg);
                 }
             }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -433,7 +433,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             for (QName qname : definedIndexes) {
                 String field = LuceneUtil.encodeQName(qname, index.getBrokerPool().getSymbols());
                 LuceneConfig config = getLuceneConfig(broker, docs);
-                Analyzer analyzer = getAnalyzer(config,null, qname);
+                Analyzer analyzer = getQueryAnalyzer(config,null, qname, options);
                 Query query;
                 if (queryStr == null) {
                     query = new ConstantScoreQuery(new FieldValueFilter(field));
@@ -483,7 +483,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             for (QName qname : definedIndexes) {
                 String field = LuceneUtil.encodeQName(qname, index.getBrokerPool().getSymbols());
                 LuceneConfig config = getLuceneConfig(broker, docs);
-                analyzer = getAnalyzer(config, null, qname);
+                analyzer = getQueryAnalyzer(config, null, qname, options);
                 Query query = queryRoot == null ? new ConstantScoreQuery(new FieldValueFilter(field)) : queryTranslator.parse(field, queryRoot, analyzer, options);
                 Optional<Map<String, List<String>>> facets = options.getFacets();
                 if (facets.isPresent() && config != null) {
@@ -505,7 +505,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             final NodeSet resultSet = new NewArrayNodeSet();
             final boolean returnAncestor = axis == NodeSet.ANCESTOR;
             final LuceneConfig config = getLuceneConfig(broker, docs);
-            analyzer = getAnalyzer(config, field, null);
+            analyzer = getQueryAnalyzer(config, field, null, options);
             final Query query = queryTranslator.parse(field, queryRoot, analyzer, options);
             if (query != null) {
                 searchAndProcess(contextId, null, docs, contextSet, resultSet,
@@ -578,7 +578,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             NodeSet resultSet = new NewArrayNodeSet();
             boolean returnAncestor = axis == NodeSet.ANCESTOR;
             LuceneConfig config = getLuceneConfig(context.getBroker(), docs);
-            Analyzer analyzer = getAnalyzer(config, field, null);
+            Analyzer analyzer = getQueryAnalyzer(config, field, null, options);
             LOG.debug("Using analyzer " + analyzer + " for " + queryString);
             QueryParserWrapper parser = getQueryParser(field, analyzer, docs);
             options.configureParser(parser.getConfiguration());
@@ -1062,10 +1062,17 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
      *
      * @return the analyzer or null
      */
-    @Nullable protected Analyzer getAnalyzer(LuceneConfig config, String field, QName qname) {
+    @Nullable protected Analyzer getQueryAnalyzer(LuceneConfig config, String field, QName qname, QueryOptions opts) {
         if (config != null) {
             Analyzer analyzer;
-            if (field == null) {
+            if (opts.getQueryAnalyzerId() != null) {
+                analyzer = config.getAnalyzerById(opts.getQueryAnalyzerId());
+                if (analyzer == null) {
+                    String msg = String.format("getAnalyzerById(%s) returned null!", opts.getQueryAnalyzerId());
+                    LOG.error(msg);
+                }
+            }
+            else if (field == null) {
                 analyzer = config.getAnalyzer(qname);
             } else {
                 analyzer = config.getAnalyzer(field);

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
@@ -49,12 +49,14 @@ public class QueryOptions {
     public static final String OPTION_LOWERCASE_EXPANDED_TERMS = "lowercase-expanded-terms";
     public static final String OPTION_FACETS = "facets";
     public static final String OPTION_FIELDS = "fields";
+    public static final String OPTION_QUERY_ANALYZER_ID = "query-analyzer-id";
 
     protected enum DefaultOperator {
         OR,
         AND
     }
 
+    protected String queryAnalyzerId = null;
     protected DefaultOperator defaultOperator = DefaultOperator.AND;
     protected boolean allowLeadingWildcard = false;
     protected Optional<Integer> phraseSlop = Optional.empty();
@@ -151,6 +153,8 @@ public class QueryOptions {
             case OPTION_LOWERCASE_EXPANDED_TERMS:
                 lowercaseExpandedTerms = value.equalsIgnoreCase("yes");
                 break;
+            case OPTION_QUERY_ANALYZER_ID:
+                queryAnalyzerId = value;
             default:
                 // unknown option, ignore
                 break;
@@ -182,5 +186,5 @@ public class QueryOptions {
         }
     }
 
-    public String  getQueryAnalyzerId() { return null; }
+    public String  getQueryAnalyzerId() { return queryAnalyzerId; }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
@@ -181,4 +181,6 @@ public class QueryOptions {
             parser.setLowercaseExpandedTerms(lowercaseExpandedTerms);
         }
     }
+
+    public String  getQueryAnalyzerId() { return null; }
 }

--- a/extensions/indexes/lucene/src/test/xquery/lucene/analyzers.xml
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/analyzers.xml
@@ -17,10 +17,7 @@
                         <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
                         <analyzer id="keyword" class="org.apache.lucene.analysis.core.KeywordAnalyzer"/>
                         <analyzer id="de" class="org.apache.lucene.analysis.de.GermanAnalyzer"/>
-                        <analyzer id="LA:index" class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
-                        <analyzer id="LA:query" class="org.apache.lucene.analysis.de.GermanAnalyzer"/>
                         <text field="line" qname="l"/>
-                        <text field="line-again" qname="l" analyzer="LA:index"/>
                         <text qname="l" analyzer="de"/>
                         <text field="lineno" qname="@n" analyzer="keyword"/>
                     </lucene>
@@ -75,14 +72,53 @@
         </expected>
     </test>
     <test output="xml">
-        <task>Query field "line" with standard analyzer, no match</task>
+        <task>&lt;query-analyzer-id&gt;de&lt;...</task>
+        <code>doc("/db/lucene/text.xml")//l[ft:query(., 'herzen',
+            &lt;options&gt;&lt;query-analyzer-id&gt;de&lt;/query-analyzer-id&gt;&lt;/options&gt;
+                                                    )]
+        </code>
+        <expected>
+            <l n="l1.12">Das will mir schier das Herz verbrennen.</l>
+        </expected>
+    </test>
+    <test output="xml">
+        <task>query-analyzer-id:de</task>
+        <code>doc("/db/lucene/text.xml")//l[ft:query(., 'herzen', map { "query-analyzer-id": "de" })]</code>
+        <expected>
+            <l n="l1.12">Das will mir schier das Herz verbrennen.</l>
+        </expected>
+    </test>
+    <test output="xml">
+        <task>&lt;query-analyzer-id&gt;keyword&lt;...</task>
+        <code>doc("/db/lucene/text.xml")//l[ft:query(., 'herzen',
+            &lt;options&gt;&lt;query-analyzer-id&gt;keyword&lt;/query-analyzer-id&gt;&lt;/options&gt;
+                                                    )]
+        </code>
+        <expected/>
+    </test>
+    <test output="xml">
+        <task>query-analyzer-id:keyword</task>
+        <code>doc("/db/lucene/text.xml")//l[ft:query(., 'herzen', map { "query-analyzer-id": "keyword" })]</code>
+        <expected/>
+    </test>
+    <test output="xml">
+        <task>Query field with standard analyzer, no match</task>
         <code>ft:query-field("line", "herzen")</code>
         <expected/>
     </test>
     <test output="xml">
-        <task>Index/Query field "line-again" with different analyzers (see PR#2991)</task>
-        <!--code>doc("/db/lucene/text.xml")//l[ft:query(., "line-again:herzen")]</code-->
-        <code>ft:query-field("line-again", "herzen")</code>
+        <task>Query field with query analyzer overridden (options as map)</task>
+        <code>ft:query-field("line", "herzen", map { "query-analyzer-id": "de" })</code>
+        <expected>
+            <l n="l1.12">Das will mir schier das Herz verbrennen.</l>
+        </expected>
+    </test>
+    <test output="xml">
+        <task>Query field with query analyzer overridden (options as xml)</task>
+        <code>ft:query-field("line", "herzen",
+            &lt;options&gt;&lt;query-analyzer-id&gt;de&lt;/query-analyzer-id&gt;&lt;/options&gt;
+                            )
+        </code>
         <expected>
             <l n="l1.12">Das will mir schier das Herz verbrennen.</l>
         </expected>

--- a/extensions/indexes/lucene/src/test/xquery/lucene/analyzers.xml
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/analyzers.xml
@@ -80,7 +80,7 @@
         <expected/>
     </test>
     <test output="xml">
-        <task>Index/Query field "line-again" with different analyzers (see PR#2990)</task>
+        <task>Index/Query field "line-again" with different analyzers (see PR#2991)</task>
         <code>ft:query-field("line-again", "herzen")</code>
         <expected>
             <l n="l1.12">Das will mir schier das Herz verbrennen.</l>

--- a/extensions/indexes/lucene/src/test/xquery/lucene/analyzers.xml
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/analyzers.xml
@@ -17,7 +17,10 @@
                         <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
                         <analyzer id="keyword" class="org.apache.lucene.analysis.core.KeywordAnalyzer"/>
                         <analyzer id="de" class="org.apache.lucene.analysis.de.GermanAnalyzer"/>
+                        <analyzer id="line-again:index" class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+                        <analyzer id="line-again:query" class="org.apache.lucene.analysis.de.GermanAnalyzer"/>
                         <text field="line" qname="l"/>
+                        <text field="line-again" qname="l" analyzer="line-again:index"/>
                         <text qname="l" analyzer="de"/>
                         <text field="lineno" qname="@n" analyzer="keyword"/>
                     </lucene>
@@ -72,9 +75,16 @@
         </expected>
     </test>
     <test output="xml">
-        <task>Query field with standard analyzer, no match</task>
+        <task>Query field "line" with standard analyzer, no match</task>
         <code>ft:query-field("line", "herzen")</code>
         <expected/>
+    </test>
+    <test output="xml">
+        <task>Index/Query field "line-again" with different analyzers (see PR#2990)</task>
+        <code>ft:query-field("line-again", "herzen")</code>
+        <expected>
+            <l n="l1.12">Das will mir schier das Herz verbrennen.</l>
+        </expected>
     </test>
     <test output="xml">
         <task>Query field with standard analyzer and without context</task>

--- a/extensions/indexes/lucene/src/test/xquery/lucene/analyzers.xml
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/analyzers.xml
@@ -17,10 +17,10 @@
                         <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
                         <analyzer id="keyword" class="org.apache.lucene.analysis.core.KeywordAnalyzer"/>
                         <analyzer id="de" class="org.apache.lucene.analysis.de.GermanAnalyzer"/>
-                        <analyzer id="line-again:index" class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
-                        <analyzer id="line-again:query" class="org.apache.lucene.analysis.de.GermanAnalyzer"/>
+                        <analyzer id="LA:index" class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+                        <analyzer id="LA:query" class="org.apache.lucene.analysis.de.GermanAnalyzer"/>
                         <text field="line" qname="l"/>
-                        <text field="line-again" qname="l" analyzer="line-again:index"/>
+                        <text field="line-again" qname="l" analyzer="LA:index"/>
                         <text qname="l" analyzer="de"/>
                         <text field="lineno" qname="@n" analyzer="keyword"/>
                     </lucene>
@@ -81,6 +81,7 @@
     </test>
     <test output="xml">
         <task>Index/Query field "line-again" with different analyzers (see PR#2991)</task>
+        <!--code>doc("/db/lucene/text.xml")//l[ft:query(., "line-again:herzen")]</code-->
         <code>ft:query-field("line-again", "herzen")</code>
         <expected>
             <l n="l1.12">Das will mir schier das Herz verbrennen.</l>


### PR DESCRIPTION
(based on https://github.com/eXist-db/exist/pull/2908)

In our usage of eXist, we're utilising a 'State of the art' LuceneAnalyzer for Sanskrit language developed by our colleagues from BDRC It has several modes of operation, but the one that we use - 'lenient mode' - requires one Analyzer to be used during the indexing phase, but then a different (or a differently configured) one to be used during querying.
Currently, eXist does not provide support for this use case, but this PR is aiming to achieve this feat.
