### PR TITLE
Addition to #2367: added [@attr != value] predicate

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/NodePathPattern.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/NodePathPattern.java
@@ -186,10 +186,6 @@ public class NodePathPattern {
             input = input.substring("fn:not".length()).trim();
             negate = true;
         }
-        else if (input.startsWith("not(")) {
-            input = input.substring("not".length()).trim();
-            negate = true;
-        }
 
         if (negate) {
             if (!input.startsWith("(") || !input.endsWith(")")) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/NodePathPattern.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/NodePathPattern.java
@@ -87,13 +87,13 @@ public class NodePathPattern {
         public boolean evaluate(NodePath2 nodePath, int elementIdx) {
             String val = nodePath.attribs(elementIdx).get(attrName);
             switch (pcode) {
-                case EQUALS:
-                case EQ:
+                case EQUALS: // =
+                case EQ: // eq
                     return Objects.equals(val, attrVal);
-                case NOT_EQUALS:
+                case NOT_EQUALS: // !=
                     // actual attr val should be present but different:
                     return val != null && !Objects.equals(val, attrVal);
-                case NE:
+                case NE: // ne
                     // actual attr val may be null (i.e. not present) or present but different:
                     return !Objects.equals(val, attrVal);
                 default:
@@ -157,7 +157,7 @@ public class NodePathPattern {
     private void addSegment(final Map<String, String> namespaces, final String segment) {
         String qname;
         int predBeg = segment.indexOf('[');
-        Predicate pred = null;
+        Predicate pred;
         if (predBeg >= 0) {
             qname = segment.substring(0, predBeg);
             pred = parsePredicate(segment.substring(predBeg));

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -325,6 +325,7 @@ public class LuceneIndexTest {
                 "            <analyzer class='org.apache.lucene.analysis.standard.StandardAnalyzer'/>\n" +
                 "            <text match=\"//title[@xml:lang='Sa-Ltn']\"/>\n" +
                 "            <text match=\"/TEI/text\"><ignore qname=\"text\"/></text>\n" +
+                "            <text field=\"non-Sa-Ltn\" match=\"//title[@xml:lang != 'Sa-Ltn']\"/>\n" +
                 "        </lucene> \n" +
                 "    </index>\n" +
                 "</collection>";
@@ -383,6 +384,40 @@ public class LuceneIndexTest {
             seq = xquery.execute(broker, "//.[ft:query(title, 'AFord')]", null);
             assertNotNull(seq);
             assertEquals(0, seq.getItemCount());
+
+            // Field query with negative attribute predicate: <text field="non-En" match="//title[@xml:lang != 'En']"/>
+
+            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'Buick')]", null);
+            assertNotNull(seq);
+            assertEquals(0, seq.getItemCount());
+
+            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'Cadillac')]", null);
+            assertNotNull(seq);
+            assertEquals(1, seq.getItemCount());
+
+            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'Dodge')]", null);
+            assertNotNull(seq);
+            assertEquals(1, seq.getItemCount());
+
+            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'Ford')]", null);
+            assertNotNull(seq);
+            assertEquals(1, seq.getItemCount());
+
+            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'ABuick')]", null);
+            assertNotNull(seq);
+            assertEquals(0, seq.getItemCount());
+
+            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'ACadillac')]", null);
+            assertNotNull(seq);
+            assertEquals(1, seq.getItemCount());
+
+            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'ADodge')]", null);
+            assertNotNull(seq);
+            assertEquals(1, seq.getItemCount());
+
+            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'AFord')]", null);
+            assertNotNull(seq);
+            assertEquals(1, seq.getItemCount());
         }
     }
 

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -325,7 +325,9 @@ public class LuceneIndexTest {
                 "            <analyzer class='org.apache.lucene.analysis.standard.StandardAnalyzer'/>\n" +
                 "            <text match=\"//title[@xml:lang='Sa-Ltn']\"/>\n" +
                 "            <text match=\"/TEI/text\"><ignore qname=\"text\"/></text>\n" +
-                "            <text field=\"non-Sa-Ltn\" match=\"//title[@xml:lang != 'Sa-Ltn']\"/>\n" +
+                "            <text field=\"not-equals-Sa-Ltn\" match=\"//title[@xml:lang != 'Sa-Ltn']\"/>\n" +
+                "            <text field=\"ne-Sa-Ltn\" match=\"//title[fn:not(@xml:lang='Sa-Ltn')]\"/>\n" +
+                "            <text field=\"eq-Sa-Ltn\" match=\"//title[@xml:lang eq 'Sa-Ltn']\"/>\n" +
                 "        </lucene> \n" +
                 "    </index>\n" +
                 "</collection>";
@@ -337,87 +339,54 @@ public class LuceneIndexTest {
 
 
             // unbeknownst to me, the test on the next line fails if the literal "buick" is replaced with "Buick":
-            final Occurrences[] o1 = checkIndex(docs, broker, new QName[]{new QName("title")}, "buick", 1);
-            final Occurrences[] o2 = checkIndex(docs, broker, new QName[]{new QName("title")}, "cadillac", 0);
-            final Occurrences[] o3 = checkIndex(docs, broker, new QName[]{new QName("title")}, "dodge", 0);
-            final Occurrences[] o4 = checkIndex(docs, broker, new QName[]{new QName("title")}, "ford", 0);
+            checkIndex(docs, broker, new QName[]{new QName("title")}, "buick", 1);
+            checkIndex(docs, broker, new QName[]{new QName("title")}, "cadillac", 0);
+            checkIndex(docs, broker, new QName[]{new QName("title")}, "dodge", 0);
+            checkIndex(docs, broker, new QName[]{new QName("title")}, "ford", 0);
 
-            final Occurrences[] p1 = checkIndex(docs, broker, new QName[]{new QName("title")}, "abuick", 1);
-            final Occurrences[] p2 = checkIndex(docs, broker, new QName[]{new QName("title")}, "acadillac", 0);
-            final Occurrences[] p3 = checkIndex(docs, broker, new QName[]{new QName("title")}, "adodge", 0);
-            final Occurrences[] p4 = checkIndex(docs, broker, new QName[]{new QName("title")}, "aford", 0);
+            checkIndex(docs, broker, new QName[]{new QName("title")}, "abuick", 1);
+            checkIndex(docs, broker, new QName[]{new QName("title")}, "acadillac", 0);
+            checkIndex(docs, broker, new QName[]{new QName("title")}, "adodge", 0);
+            checkIndex(docs, broker, new QName[]{new QName("title")}, "aford", 0);
+
             // nested <text> should be ignored and not indexed by match="/TEI/text"
-            final Occurrences[] p5 = checkIndex(docs, broker, new QName[]{new QName("text")}, "nested", 0);
+            checkIndex(docs, broker, new QName[]{new QName("text")}, "nested", 0);
 
             final XQuery xquery = pool.getXQueryService();
             assertNotNull(xquery);
-            Sequence seq;
 
-            seq = xquery.execute(broker, "//.[ft:query(title, 'Buick')]", null);
-            assertNotNull(seq);
-            assertEquals(1, seq.getItemCount());
+            String[]  searchTerms = {
+                    "Buick", "Cadillac", "Dodge", "Ford",
+                    "ABuick", "ACadillac", "ADodge", "AFord",
+            };
 
-            seq = xquery.execute(broker, "//.[ft:query(title, 'Cadillac')]", null);
-            assertNotNull(seq);
-            assertEquals(0, seq.getItemCount());
+            String[]  queryTemplates = {
+                    "//.[ft:query(title, '%s')]",
+            // Field query with != attribute predicate: <text field="non-En" match="//title[@xml:lang != 'En']"/>:
+                    "//.[ft:query-field('not-equals-Sa-Ltn', '%s')]",
+            // Field query with 'ne' attribute predicate: <text field="non-En" match="//title[@xml:lang ne 'En']"/>:
+                    "//.[ft:query-field('ne-Sa-Ltn', '%s')]",
+            // Field query with 'eq' attribute predicate: <text field="non-En" match="//title[@xml:lang ne 'En']"/>:
+                    "//.[ft:query-field('eq-Sa-Ltn', '%s')]",
+            };
 
-            seq = xquery.execute(broker, "//.[ft:query(title, 'Dodge')]", null);
-            assertNotNull(seq);
-            assertEquals(0, seq.getItemCount());
+            int[][] resultCounts = {
+                    {1, 0, 0, 0 },
+                    {0, 0, 1, 0 },
+                    {0, 1, 1, 1 },
+                    {1, 0, 0, 0 },
+            };
 
-            seq = xquery.execute(broker, "//.[ft:query(title, 'Ford')]", null);
-            assertNotNull(seq);
-            assertEquals(0, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query(title, 'ABuick')]", null);
-            assertNotNull(seq);
-            assertEquals(1, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query(title, 'ACadillac')]", null);
-            assertNotNull(seq);
-            assertEquals(0, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query(title, 'ADodge')]", null);
-            assertNotNull(seq);
-            assertEquals(0, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query(title, 'AFord')]", null);
-            assertNotNull(seq);
-            assertEquals(0, seq.getItemCount());
-
-            // Field query with negative attribute predicate: <text field="non-En" match="//title[@xml:lang != 'En']"/>
-
-            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'Buick')]", null);
-            assertNotNull(seq);
-            assertEquals(0, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'Cadillac')]", null);
-            assertNotNull(seq);
-            assertEquals(1, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'Dodge')]", null);
-            assertNotNull(seq);
-            assertEquals(1, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'Ford')]", null);
-            assertNotNull(seq);
-            assertEquals(1, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'ABuick')]", null);
-            assertNotNull(seq);
-            assertEquals(0, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'ACadillac')]", null);
-            assertNotNull(seq);
-            assertEquals(1, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'ADodge')]", null);
-            assertNotNull(seq);
-            assertEquals(1, seq.getItemCount());
-
-            seq = xquery.execute(broker, "//.[ft:query-field('non-Sa-Ltn', 'AFord')]", null);
-            assertNotNull(seq);
-            assertEquals(1, seq.getItemCount());
+            for (int qi = 0; qi < queryTemplates.length; ++qi) {
+                int[] resultCount = resultCounts[qi];
+                for (int ri=0; ri < searchTerms.length; ++ri) {
+                    String query = String.format(queryTemplates[qi], searchTerms[ri]);
+                    Sequence seq = xquery.execute(broker, query, null);
+                    assertNotNull(seq);
+                    int expected = resultCount[ri % resultCount.length];
+                    assertEquals(query, expected, seq.getItemCount());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Added [@attr != value] predicate in XPath spec for Lucene index spec.
Previously only [@attr = value] was supported
Tests added too.
( see original https://github.com/eXist-db/exist/pull/2367 )
