### PR TITLE
Read webdav.properties from the etc directory when available.

### DIFF
--- a/extensions/webdav/src/main/java/org/exist/webdav/ExistResourceFactory.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/ExistResourceFactory.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
@@ -72,13 +71,14 @@ public class ExistResourceFactory implements ResourceFactory {
 
         // load specific options
         try {
+
             // Find right file
             final Optional<Path> eXistHome = brokerPool.getConfiguration().getExistHome();
-            final Path config = FileUtils.resolve(eXistHome, "webdav.properties");
+            final Path config = FileUtils.resolve(eXistHome, "etc").resolve("webdav.properties");
 
             // Read from file if existent
             if (Files.isReadable(config)) {
-                LOG.info(String.format("Read WebDAV configuration from %s", config.toAbsolutePath().toString()));
+                LOG.info("Read WebDAV configuration from {}", config.toAbsolutePath().toString());
                 try (final InputStream is = Files.newInputStream(config)) {
                     webDavOptions.load(is);
                 }


### PR DESCRIPTION
From the logs with fix: (fixes #3008)

```
2019-09-09 20:20:03,888 [main] INFO  (JettyStart.java [run]:285) - ----------------------------------------------------- 
2019-09-09 20:20:03,888 [main] INFO  (JettyStart.java [run]:286) - Server has started, listening on: 
2019-09-09 20:20:03,888 [main] INFO  (JettyStart.java [run]:288) -      http://10.0.10.11:8080/ 
2019-09-09 20:20:03,889 [main] INFO  (JettyStart.java [run]:288) -      https://10.0.10.11:8443/ 
2019-09-09 20:20:03,889 [main] INFO  (JettyStart.java [run]:291) - Configured contexts: 
2019-09-09 20:20:03,889 [main] INFO  (JettyStart.java [run]:297) -      /exist 
2019-09-09 20:20:03,890 [main] INFO  (JettyStart.java [run]:312) - '/exist/iprange' 
2019-09-09 20:20:03,890 [main] INFO  (JettyStart.java [run]:297) -      / 
2019-09-09 20:20:03,890 [main] INFO  (JettyStart.java [run]:312) - '/iprange' 
2019-09-09 20:20:03,890 [main] INFO  (JettyStart.java [run]:318) - ----------------------------------------------------- 
2019-09-09 20:21:04,661 [qtp2041742635-43] WARN  (Descriptor.java [<init>]:116) - Giving up unable to read descriptor.xml file from classloader in package org.exist.http 
2019-09-09 20:21:04,672 [qtp2041742635-43] INFO  (MiltonWebDAVServlet.java [init]:49) - Initializing webdav servlet 
2019-09-09 20:21:04,675 [qtp2041742635-43] INFO  (MiltonWebDAVServlet.java [init]:69) - Detected Milton WebDAV Server library version: 1.8.1.3 

2019-09-09 20:21:08,554 [qtp2041742635-43] INFO  (ExistResourceFactory.java [<init>]:83) - Read WebDAV configuration from /Users/xxxx/Development/github/exist/exist-distribution/target/exist-distribution-5.1.0-SNAPSHOT-dir/etc/webdav.properties 
```

