### PR TITLE
Align EXPath HTTP Client namespace prefix with spec convention (change "hc" to "http")

### DIFF
--- a/extensions/expath/src/main/java/org/expath/exist/HttpClientModule.java
+++ b/extensions/expath/src/main/java/org/expath/exist/HttpClientModule.java
@@ -36,7 +36,7 @@ public class HttpClientModule extends AbstractInternalModule {
 
     public final static String NAMESPACE_URI = HttpConstants.HTTP_CLIENT_NS_URI;
 
-    public final static String PREFIX = HttpConstants.HTTP_CLIENT_NS_PREFIX;
+    public final static String PREFIX = "http";
     public final static String INCLUSION_DATE = "2011-03-17";
     public final static String RELEASED_IN_VERSION = "1.5";
 


### PR DESCRIPTION
### Description:

The EXPath HTTP Client specification uses the namespace prefix `http`. eXist's implementation uses a different prefix, `hc`. 

While module namespace prefixes are mere convention, there is no good reason for eXist to use a different prefix than the spec does. As a result of this mismatch, eXist users are understandably confused when they search the function documentation for "http" and find no hits, as in this exchange from Slack last week: 

> I did notice that http-client function docs are missing from fundocs on exist-db.org. Is that known  or where they never in there?
>
> search for `hc`
>
> ah

... Or when they invoke the `http:send-request` function and encounter the error:

> Invalid qname `http:send-request`. No namespace defined for prefix `http`. QName is invalid: INVALID_PREFIX

This PR changes the module's statically-bound namespace prefix to `http`, aligning eXist's implementation of the EXPath HTTP Client module with the convention used in the specification. This change will allow eXist users to find the HTTP Client's function documentation by searching for "http" and to directly call `http:send-request` without explicitly importing the module and overriding a default, non-conventional prefix.

**Implication:** After merging this PR, no change is needed for code that *explicitly imports* the EXPath HTTP Client module. Only code that relies on the previous statically bound prefix `hc` would need to be adjusted. Recommended approach: Either (1) change `hc` to `http` or (2) explicitly importing the module using the `hc` prefix with `import module namespace hc="http://expath.org/ns/http-client"`.

### Reference:

- http://expath.org/spec/http-client
- https://github.com/expath/expath-http-client-java/issues/6

### Type of tests:

n/a