### PR TITLE
Fix a race condition in WeakLazyStripes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install: travis_wait mvn -T 2C -DskipTests=true -Dmaven.javadoc.skip=true -Ddock
 script: mvn -T 2C -Ddocker=$BUILD_DOCKER test -B
 
 after_failure:
-   - tar -cjf surefire-reports.tar.bz2 exist-core/target/surefire-reports exist-core/target/test-logs
+   - tar -cjf surefire-reports.tar.bz2 exist-core/target/surefire-reports exist-core/target/test-logs-*
    - curl -v -u $CHUNK_USER:$CHUNK_PW -sT surefire-reports.tar.bz2 chunk.io
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,15 +41,9 @@ after_test:
 
 on_failure:
   - cmd: 7z a exist-core-surefire-reports.zip %APPVEYOR_BUILD_FOLDER%\exist-core\target\surefire-reports\ && appveyor PushArtifact exist-core-surefire-reports.zip
-  - cmd: 7z a exist-core-test-logs.zip %APPVEYOR_BUILD_FOLDER%\exist-core\target\test-logs\ && appveyor PushArtifact exist-core-test-logs.zip
+  - cmd: 7z a exist-core-test-logs.zip %APPVEYOR_BUILD_FOLDER%\exist-core\target\test-logs-* && appveyor PushArtifact exist-core-test-logs.zip
   - sh: tar czvf exist-core-surefire-reports.tgz $APPVEYOR_BUILD_FOLDER/exist-core/target/surefire-reports/ && appveyor PushArtifact exist-core-surefire-reports.tgz
-  - sh: tar czvf exist-core-test-logs.tgz $APPVEYOR_BUILD_FOLDER/exist-core/target/test-logs/ && appveyor PushArtifact exist-core-test-logs.tgz
-
-artifacts:
-  - path: exist-core\target\surefire-reports
-    name: exist-core-surefire-reports
-  - path: exist-core\target\test-logs
-    name: exist-core-test-logs
+  - sh: tar czvf exist-core-test-logs.tgz $APPVEYOR_BUILD_FOLDER/exist-core/target/test-logs-* && appveyor PushArtifact exist-core-test-logs.tgz
 
 cache:
   - '%USERPROFILE%\.m2'

--- a/exist-ant/src/test/resources/log4j2.xml
+++ b/exist-ant/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/exist-core-jcstress/pom.xml
+++ b/exist-core-jcstress/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.exist-db</groupId>
+        <artifactId>exist-parent</artifactId>
+        <version>5.1.0-SNAPSHOT</version>
+        <relativePath>../exist-parent</relativePath>
+    </parent>
+
+
+    <artifactId>exist-core-jcstress</artifactId>
+    <packaging>jar</packaging>
+
+    <name>eXist-db Core JCStress Tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jcstress</groupId>
+            <artifactId>jcstress-core</artifactId>
+            <version>0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.exist-db</groupId>
+            <artifactId>exist-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <uberjar.name>jcstress</uberjar.name>
+    </properties>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>main</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jcstress.Main</mainClass>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/TestList</resource>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/exist-core-jcstress/src/main/java/org/exist/util/WeakLazyStripesStressTest.java
+++ b/exist-core-jcstress/src/main/java/org/exist/util/WeakLazyStripesStressTest.java
@@ -1,0 +1,158 @@
+/**
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Project
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+ */
+package org.exist.util;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.Z_Result;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class WeakLazyStripesStressTest {
+
+    @JCStressTest
+    @Outcome(id = "false", expect = Expect.FORBIDDEN, desc = "Different Object for Same Key")
+    @Outcome(id = "true", expect = Expect.ACCEPTABLE, desc = "Same Object for Same Key")
+    @State
+    public static class SameObjectForSameKey {
+        WeakLazyStripes<String, Lock> lockMap = new WeakLazyStripes<>((key) -> new ReentrantLock());
+        Object ar1;
+        Object ar2;
+        Object ar3;
+        Object ar4;
+        Object ar5;
+        Object ar6;
+        Object ar7;
+        Object ar8;
+
+
+        @Actor
+        public void actor1() {
+            ar1 = lockMap.get("key1");
+        }
+
+        @Actor
+        public void actor2() {
+            ar2 = lockMap.get("key1");
+        }
+
+        @Actor
+        public void actor3() {
+            ar3 = lockMap.get("key1");
+        }
+
+        @Actor
+        public void actor4() {
+            ar4 = lockMap.get("key1");
+        }
+
+        @Actor
+        public void actor5() {
+            ar5 = lockMap.get("key1");
+        }
+
+        @Actor
+        public void actor6() {
+            ar6 = lockMap.get("key1");
+        }
+
+        @Actor
+        public void actor7() {
+            ar7 = lockMap.get("key1");
+        }
+
+        @Actor
+        public void actor8() {
+            ar8 = lockMap.get("key1");
+        }
+
+        @Arbiter
+        public void arbiter(Z_Result r) {
+            r.r1 = ar1 == ar2 && ar2 == ar3 && ar3 == ar4 && ar4 == ar5 && ar5 == ar6 && ar6 == ar7 && ar7 == ar8;
+        }
+    }
+
+    @JCStressTest
+    @Outcome(id = "false", expect = Expect.FORBIDDEN, desc = "Same Object for Different Keys")
+    @Outcome(id = "true", expect = Expect.ACCEPTABLE, desc = "Different Object for Different Keys")
+    @State
+    public static class DifferentObjectForDifferentKeys {
+        WeakLazyStripes<String, Lock> lockMap = new WeakLazyStripes<>((key) -> new ReentrantLock());
+        Object ar1;
+        Object ar2;
+        Object ar3;
+        Object ar4;
+        Object ar5;
+        Object ar6;
+        Object ar7;
+        Object ar8;
+
+
+        @Actor
+        public void actor1() {
+            ar1 = lockMap.get("key1");
+        }
+
+        @Actor
+        public void actor2() {
+            ar2 = lockMap.get("key2");
+        }
+
+        @Actor
+        public void actor3() {
+            ar3 = lockMap.get("key3");
+        }
+
+        @Actor
+        public void actor4() {
+            ar4 = lockMap.get("key4");
+        }
+
+        @Actor
+        public void actor5() {
+            ar5 = lockMap.get("key5");
+        }
+
+        @Actor
+        public void actor6() {
+            ar6 = lockMap.get("key6");
+        }
+
+        @Actor
+        public void actor7() {
+            ar7 = lockMap.get("key7");
+        }
+
+        @Actor
+        public void actor8() {
+            ar8 = lockMap.get("key8");
+        }
+
+        @Arbiter
+        public void arbiter(Z_Result r) {
+            r.r1 = ar1 != ar2 && ar2 != ar3 && ar3 != ar4 && ar4 != ar5 && ar5 != ar6 && ar6 != ar7 && ar7 != ar8;
+        }
+    }
+
+}

--- a/exist-core/src/main/java/org/exist/util/WeakLazyStripes.java
+++ b/exist-core/src/main/java/org/exist/util/WeakLazyStripes.java
@@ -374,7 +374,7 @@ public class WeakLazyStripes<K, S> {
                         expired reference in #get(K) before calling #drainClearedReferences()
                      */
                     final WeakValueReference<K, S> check = stripes.get(stripeRef.key);
-                    if (check.get() == null) {
+                    if (check != null && check.get() == null) {
 
                         stripes.remove(stripeRef.key);
 

--- a/exist-core/src/main/java/org/exist/util/WeakLazyStripes.java
+++ b/exist-core/src/main/java/org/exist/util/WeakLazyStripes.java
@@ -358,7 +358,19 @@ public class WeakLazyStripes<K, S> {
 
                 final long writeStamp = stripesLock.writeLock();
                 try {
-                    stripes.remove(stripeRef.key);
+
+                    // TODO(AR) it may be more performant to call #drainClearedReferences() at the beginning of #get(K) as oposed to the end, then we could avoid the extra check here which calls stripes#get(K)
+
+                    /*
+                        NOTE: we have to check that we have not added a new reference to replace an
+                        expired reference in #get(K) before calling #drainClearedReferences()
+                     */
+                    final WeakValueReference<K, S> check = stripes.get(stripeRef.key);
+                    if (check.get() == null) {
+
+                        stripes.remove(stripeRef.key);
+
+                    }
                 } finally {
                     stripesLock.unlockWrite(writeStamp);
                 }

--- a/exist-core/src/main/java/org/exist/util/WeakLazyStripes.java
+++ b/exist-core/src/main/java/org/exist/util/WeakLazyStripes.java
@@ -244,6 +244,9 @@ public class WeakLazyStripes<K, S> {
                 if (wasGCd && !amortizeCleanup) {
                     expiredReferenceReadCount.incrementAndGet();
                 }
+            } else {
+                // invalid conversion to write lock... small optimisation for the fall-through to #getPessimistic(K, Holder) in #get(K)
+                stripeRef = null;
             }
         } else {
             if (stripesLock.validate(stamp)) {
@@ -287,6 +290,9 @@ public class WeakLazyStripes<K, S> {
                     if (wasGCd && !amortizeCleanup) {
                         expiredReferenceReadCount.incrementAndGet();
                     }
+                } else {
+                    // invalid conversion to write lock... small optimisation for the fall-through to #getExclusive(K, Holder) in #get(K)
+                    stripeRef = null;
                 }
 
                 return stripeRef;

--- a/exist-core/src/test/resources/log4j2.xml
+++ b/exist-core/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/debuggee/src/test/resources/log4j2.xml
+++ b/extensions/debuggee/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/expath/src/test/resources/log4j2.xml
+++ b/extensions/expath/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/exquery/restxq/src/test/resources/log4j2.xml
+++ b/extensions/exquery/restxq/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/indexes/lucene/src/test/resources/log4j2.xml
+++ b/extensions/indexes/lucene/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/indexes/ngram/src/test/resources/log4j2.xml
+++ b/extensions/indexes/ngram/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/indexes/range/src/test/resources/log4j2.xml
+++ b/extensions/indexes/range/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/indexes/sort/src/test/resources/log4j2.xml
+++ b/extensions/indexes/sort/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/indexes/spatial/src/test/resources/log4j2.xml
+++ b/extensions/indexes/spatial/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/modules/cache/src/test/resources/log4j2.xml
+++ b/extensions/modules/cache/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/modules/compression/src/test/resources/log4j2.xml
+++ b/extensions/modules/compression/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/modules/counter/src/test/resources/log4j2.xml
+++ b/extensions/modules/counter/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/modules/expathrepo/src/test/resources/log4j2.xml
+++ b/extensions/modules/expathrepo/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/modules/file/src/test/resources/log4j2.xml
+++ b/extensions/modules/file/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/modules/persistentlogin/src/test/resources/log4j2.xml
+++ b/extensions/modules/persistentlogin/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/security/activedirectory/src/test/resources/log4j2.xml
+++ b/extensions/security/activedirectory/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/extensions/xqdoc/src/test/resources/log4j2.xml
+++ b/extensions/xqdoc/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Properties>
-        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs</Property>
+        <Property name="logs">${log4j:configParentLocation}/../../target/test-logs-${date:yyyyMMddHHmmssSSS}-${date:yyyyMMddHHmmssSSS}</Property>
         <Property name="rollover.max.size">10MB</Property>
         <Property name="rollover.max">14</Property>
         <Property name="rollover.file.pattern">%d{yyyyMMddHHmmss}</Property>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>exist-parent</module>
         <module>exist-ant</module>
         <module>exist-core</module>
+        <module>exist-core-jcstress</module>
         <module>exist-core-jmh</module>
         <module>exist-distribution</module>
         <module>exist-installer</module>


### PR DESCRIPTION
Thanks very much to @paulmer for digging in and finding the cause:

Quoting @paulmer regarding `WeakLazyStripes`:
>The "get" method allocates a new lock if it finds that the weak reference matching the key has expired.  It then saves this new lock in the stripes hash (see getOptimistic, for example).  Then it proceeds to run drainClearedReferences().  If an expired reference with the same name as the lock just requested is on the refererenceQueue, drainClearedReferences will remove the reference to the newly created lock from the hash table.  A subsequent thread can then obtain a new lock for the same key even while the previous thread is still holding onto its lock.