### PR TITLE
Add classes supporting a SAXSource for included database documents

### DIFF
--- a/exist-core/src/main/java/org/exist/xslt/EXistDbInputSource.java
+++ b/exist-core/src/main/java/org/exist/xslt/EXistDbInputSource.java
@@ -1,0 +1,63 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xslt;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.storage.DBBroker;
+import org.xml.sax.InputSource;
+
+/**
+ * {@link org.xml.sax.InputSource} identifying a document within the eXist database.
+ *
+ * @author <a href="mailto:Paul.L.Merchant.Jr@dartmouth.edu">Paul Merchant, Jr.</a>
+ */
+
+public class EXistDbInputSource extends InputSource {
+    protected DBBroker broker;
+    protected DocumentImpl doc;
+    
+    public EXistDbInputSource(DBBroker broker, DocumentImpl doc) {
+        super();
+        
+        this.broker = broker;
+        this.doc = doc;
+    }
+    
+    public DBBroker getBroker() {
+        return this.broker;
+    }
+    
+    public DocumentImpl getDocument() {
+        return this.doc;
+    }
+    
+    @Override
+    public void setByteStream(InputStream stream) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCharacterStream(Reader stream) {
+        throw new UnsupportedOperationException();
+    }    
+}

--- a/exist-core/src/main/java/org/exist/xslt/EXistDbInputSource.java
+++ b/exist-core/src/main/java/org/exist/xslt/EXistDbInputSource.java
@@ -33,8 +33,8 @@ import org.xml.sax.InputSource;
  */
 
 public class EXistDbInputSource extends InputSource {
-    protected DBBroker broker;
-    protected DocumentImpl doc;
+    private final DBBroker broker;
+    private final DocumentImpl doc;
     
     public EXistDbInputSource(DBBroker broker, DocumentImpl doc) {
         super();

--- a/exist-core/src/main/java/org/exist/xslt/EXistDbSource.java
+++ b/exist-core/src/main/java/org/exist/xslt/EXistDbSource.java
@@ -39,9 +39,8 @@ public class EXistDbSource extends SAXSource {
     private final static Logger LOG = LogManager.getLogger(EXistDbSource.class);
 
     private InputSource source;
-    private String systemId;
     
-    public EXistDbSource(DBBroker broker, DocumentImpl doc) {
+    public EXistDbSource(final DBBroker broker, final DocumentImpl doc) {
         this.source = new EXistDbInputSource(broker, doc);
     }
 
@@ -52,7 +51,7 @@ public class EXistDbSource extends SAXSource {
     
     @Override
     public String getSystemId() {
-        return this.systemId;
+        return (this.source == null) ? null : this.source.getSystemId();
     }
     
     @Override
@@ -64,7 +63,7 @@ public class EXistDbSource extends SAXSource {
     }
     
     @Override
-    public void setInputSource(InputSource inputSource) {
+    public void setInputSource(final InputSource inputSource) {
         if (!(inputSource instanceof EXistDbInputSource)) {
             throw new UnsupportedOperationException("EXistDbSource only accepts EXistDbInputSource");
         }
@@ -73,13 +72,16 @@ public class EXistDbSource extends SAXSource {
     }
     
     @Override
-    public void setSystemId(String systemId) {
-        this.systemId = systemId;
+    public void setSystemId(final String systemId) {
+	if (this.source == null) {
+	    // This should not be possible
+	    throw new IllegalStateException("EXistDbSource cannot initialize InputSource from a systemId");
+	}
         this.source.setSystemId(systemId);
     }
     
     @Override
-    public void setXMLReader(XMLReader reader) {
+    public void setXMLReader(final XMLReader reader) {
 	throw new UnsupportedOperationException("Setting external reader is not supported");
     }
 }

--- a/exist-core/src/main/java/org/exist/xslt/EXistDbSource.java
+++ b/exist-core/src/main/java/org/exist/xslt/EXistDbSource.java
@@ -1,0 +1,85 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xslt;
+
+import javax.xml.transform.sax.SAXSource;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.storage.DBBroker;
+
+/**
+ * {@link javax.xml.transform.sax.SAXSource} Supplying an XML document from the eXist database.
+ *
+ * @author <a href="mailto:Paul.L.Merchant.Jr@dartmouth.edu">Paul Merchant, Jr.</a>
+ */
+
+
+public class EXistDbSource extends SAXSource {
+    private final static Logger LOG = LogManager.getLogger(EXistDbSource.class);
+
+    private InputSource source;
+    private String systemId;
+    
+    public EXistDbSource(DBBroker broker, DocumentImpl doc) {
+        this.source = new EXistDbInputSource(broker, doc);
+    }
+
+    @Override
+    public InputSource getInputSource() { 
+        return this.source;
+    }
+    
+    @Override
+    public String getSystemId() {
+        return this.systemId;
+    }
+    
+    @Override
+    public XMLReader getXMLReader() {
+	/* FIXME:  Should the reader be configured to read our InputSource before returning?
+         * Apparently Saxon configures it later with our InputSource, leaving this an open question.
+	 */
+        return new EXistDbXMLReader();
+    }
+    
+    @Override
+    public void setInputSource(InputSource inputSource) {
+        if (!(inputSource instanceof EXistDbInputSource)) {
+            throw new UnsupportedOperationException("EXistDbSource only accepts EXistDbInputSource");
+        }
+        
+        this.source = inputSource;
+    }
+    
+    @Override
+    public void setSystemId(String systemId) {
+        this.systemId = systemId;
+        this.source.setSystemId(systemId);
+    }
+    
+    @Override
+    public void setXMLReader(XMLReader reader) {
+	throw new UnsupportedOperationException("Setting external reader is not supported");
+    }
+}

--- a/exist-core/src/main/java/org/exist/xslt/EXistDbXMLReader.java
+++ b/exist-core/src/main/java/org/exist/xslt/EXistDbXMLReader.java
@@ -1,0 +1,175 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2019 The eXist Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xslt;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.exist.storage.serializers.Serializer;
+
+import org.xml.sax.ContentHandler;
+import org.xml.sax.DTDHandler;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+
+/**
+ * {@link org.xml.sax.XMLReader} that uses an {@link org.exist.storage.serializers.Serializer}
+ * to send a database document to a content handler.
+ *
+ * @author <a href="mailto:Paul.L.Merchant.Jr@dartmouth.edu">Paul Merchant, Jr.</a>
+ */
+public class EXistDbXMLReader implements XMLReader, Locator {
+    private final static Logger LOG = LogManager.getLogger(EXistDbSource.class);
+
+    private ContentHandler contentHandler;
+    private ErrorHandler    errHandler;
+    
+    private InputSource     source;
+    
+    public EXistDbXMLReader() {
+    }
+    
+    @Override
+    public ContentHandler getContentHandler() {
+        return this.contentHandler;
+    }
+    
+    @Override
+    public DTDHandler getDTDHandler() {
+        return null;
+    }
+    
+    @Override
+    public EntityResolver getEntityResolver() {
+        return null;
+    }
+    
+    @Override
+    public ErrorHandler getErrorHandler() {
+        return this.errHandler;
+    }
+    
+    @Override
+    public boolean getFeature(String name) {
+        return false;
+    }
+    
+    @Override
+    public Object getProperty(String name) {
+        return null;
+    }
+    
+    @Override
+    public void parse(InputSource input) {
+        if (!(input instanceof EXistDbInputSource)) {
+            throw new UnsupportedOperationException("EXistDbXMLReader only accepts EXistDbInputSource");
+        }
+
+        EXistDbInputSource source = (EXistDbInputSource) input;
+        try {
+            final Serializer serializer = source.getBroker().newSerializer();
+            this.source = input;  
+            this.contentHandler.setDocumentLocator(this);
+            serializer.reset();
+            serializer.setSAXHandlers(this.contentHandler, null);
+            serializer.toSAX(source.getDocument());
+    
+            this.contentHandler.endDocument();
+        }
+        catch (SAXParseException e) {
+            LOG.error("SaxParseException: {}", e);
+            try {
+                this.errHandler.error(e);
+            } catch (Exception e2) {
+                LOG.error("Exception handling exception: {}", e2);
+            }
+        } catch (Exception e) {
+            LOG.error("Exception: {}", e);
+            try {
+		/* FIXME:  Do we need to forward the exception to the errHandler, or has this
+                 * been done for us? - PLM
+		 */
+                this.errHandler.error(new SAXParseException("Unable to parse document", null, e));
+            } catch (Exception e2) {
+                LOG.error("Exception handling exception: {}", e2);
+            }
+
+        } finally {
+            this.source = null;
+        }
+    }
+    
+    @Override
+    public void parse(String systemId) {
+        throw new UnsupportedOperationException();
+    }
+    
+    @Override
+    public void setContentHandler(ContentHandler handler) {
+        this.contentHandler = handler;
+    }
+    
+    @Override
+    public void setDTDHandler(DTDHandler handler) {
+    }
+    
+    @Override
+    public void setEntityResolver(EntityResolver resolver) {
+    }
+    
+    @Override
+    public void setErrorHandler(ErrorHandler handler) {
+        this.errHandler = handler;
+    }
+    
+    @Override
+    public void setFeature(String name, boolean value) {
+    }
+    
+    @Override
+    public void setProperty(String name, Object value) {
+    }
+   
+    @Override
+    public int getColumnNumber() {
+	// FIXME:  Can we do better than -1?
+        return -1;
+    }
+    
+    @Override
+    public int getLineNumber() {
+	// FIXME:  Can we do better than -1?
+        return -1;
+    }
+    
+    @Override
+    public String getSystemId() {
+        return this.source == null ? null : this.source.getSystemId(); 
+    }
+
+    @Override
+    public String getPublicId() {
+        return this.source == null ? null : this.source.getPublicId(); 
+    }
+}

--- a/exist-core/src/main/java/org/exist/xslt/EXistDbXMLReader.java
+++ b/exist-core/src/main/java/org/exist/xslt/EXistDbXMLReader.java
@@ -43,9 +43,9 @@ public class EXistDbXMLReader implements XMLReader, Locator {
     private final static Logger LOG = LogManager.getLogger(EXistDbSource.class);
 
     private ContentHandler contentHandler;
-    private ErrorHandler    errHandler;
+    private ErrorHandler   errHandler;
     
-    private InputSource     source;
+    private InputSource    source;
     
     public EXistDbXMLReader() {
     }
@@ -71,17 +71,17 @@ public class EXistDbXMLReader implements XMLReader, Locator {
     }
     
     @Override
-    public boolean getFeature(String name) {
+    public boolean getFeature(final String name) {
         return false;
     }
     
     @Override
-    public Object getProperty(String name) {
+    public Object getProperty(final String name) {
         return null;
     }
     
     @Override
-    public void parse(InputSource input) {
+    public void parse(final InputSource input) {
         if (!(input instanceof EXistDbInputSource)) {
             throw new UnsupportedOperationException("EXistDbXMLReader only accepts EXistDbInputSource");
         }
@@ -121,34 +121,34 @@ public class EXistDbXMLReader implements XMLReader, Locator {
     }
     
     @Override
-    public void parse(String systemId) {
+    public void parse(final String systemId) {
         throw new UnsupportedOperationException();
     }
     
     @Override
-    public void setContentHandler(ContentHandler handler) {
+    public void setContentHandler(final ContentHandler handler) {
         this.contentHandler = handler;
     }
     
     @Override
-    public void setDTDHandler(DTDHandler handler) {
+    public void setDTDHandler(final DTDHandler handler) {
     }
     
     @Override
-    public void setEntityResolver(EntityResolver resolver) {
+    public void setEntityResolver(final EntityResolver resolver) {
     }
     
     @Override
-    public void setErrorHandler(ErrorHandler handler) {
+    public void setErrorHandler(final ErrorHandler handler) {
         this.errHandler = handler;
     }
     
     @Override
-    public void setFeature(String name, boolean value) {
+    public void setFeature(final String name, final boolean value) {
     }
     
     @Override
-    public void setProperty(String name, Object value) {
+    public void setProperty(final String name, final Object value) {
     }
    
     @Override

--- a/exist-core/src/main/java/org/exist/xslt/EXistURIResolver.java
+++ b/exist-core/src/main/java/org/exist/xslt/EXistURIResolver.java
@@ -208,7 +208,7 @@ public class EXistURIResolver implements URIResolver {
         }
 
       } else {
-        source = new DOMSource(doc);
+        source = new EXistDbSource(broker, doc);
         source.setSystemId(uri.toASCIIString());
         return source;
       }

--- a/exist-core/src/main/java/org/exist/xslt/StylesheetResolverAndCompiler.java
+++ b/exist-core/src/main/java/org/exist/xslt/StylesheetResolverAndCompiler.java
@@ -140,7 +140,7 @@ public class StylesheetResolverAndCompiler implements Stylesheet {
     //factory.setURIResolver(new EXistURIResolver(broker, stylesheet.getCollection().getURI().toString()));
 
     final TemplatesHandler handler = factory(broker.getBrokerPool(), errorListener).newTemplatesHandler();
-
+    handler.setSystemId(stylesheet.getBaseURI());
     handler.startDocument();
 
     final Serializer serializer = broker.newSerializer();


### PR DESCRIPTION
### Description:

This PR includes classes that handle internal documents referenced in the course of transformations under the transform::transform function using a Serializer under a SAXSource subclass instead of a subclass of DOMSource.  It's a response to the relatively slow performance of the DOMSource previously returned by EXistURIResolver as [reported here](https://github.com/eXist-db/exist/issues/3044), and is intended to treat documents included via xsl:doc() and xsl:include() the same way that the initial XML and XSL parameters to transform::transform are treated.  The performance for included files under these modifications is similar to the performance reading the same files when passed as initial parameters.

The modifications pass the existing transformation tests in my build environment.

------

### Reference:
#3044
