### PR TITLE
Complement #3075: optimization was missed due to wrong static type

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -902,7 +902,7 @@ public class LocationStep extends Step {
         // process an in-memory node set
         if (!contextSequence.isPersistentSet()) {
             final MemoryNodeSet nodes = contextSequence.toMemNodeSet();
-            if (hasPositionalPredicate && position > -1) {
+            if (position > -1) {
                 applyPredicate = false;
             }
 
@@ -960,7 +960,7 @@ public class LocationStep extends Step {
                     registerUpdateListener();
                 }
 
-                if (hasPositionalPredicate) {
+                if (position > -1) {
                     try {
                         applyPredicate = false;
                         if (axis == Constants.PRECEDING_AXIS) {
@@ -996,7 +996,7 @@ public class LocationStep extends Step {
      */
     private int computeLimit() throws XPathException {
         int position = -1;
-        if (hasPositionalPredicate) {
+        if (this.checkPositionalFilters(this.inPredicate)) {
             final Predicate pred = predicates.get(0);
             final Sequence seq = pred.preprocess();
 

--- a/exist-core/src/main/java/org/exist/xquery/Step.java
+++ b/exist-core/src/main/java/org/exist/xquery/Step.java
@@ -47,8 +47,6 @@ public abstract class Step extends AbstractExpression {
 
     protected int staticReturnType = Type.ITEM;
 
-    protected boolean hasPositionalPredicate = false;
-
     public Step( XQueryContext context, int axis ) {
         super(context);
         this.axis = axis;
@@ -100,8 +98,6 @@ public abstract class Step extends AbstractExpression {
             for (final Predicate pred : predicates) {
                 pred.analyze(newContext);
             }
-
-            this.checkPositionalFilters(inPredicate);
         }
         // if we are on the self axis, remember the static return type given in the context
         if (this.axis == Constants.SELF_AXIS)
@@ -112,7 +108,7 @@ public abstract class Step extends AbstractExpression {
      * Static check if the location steps first filter is a positional predicate.
      * If yes, set a flag on the {@link LocationStep}
      */
-    private void checkPositionalFilters(final boolean inPredicate) {
+    protected boolean checkPositionalFilters(final boolean inPredicate) {
         if (!inPredicate && this.hasPredicates()) {
             final List<Predicate> preds = this.getPredicates();
             final Predicate predicate = preds.get(0);
@@ -121,9 +117,10 @@ public abstract class Step extends AbstractExpression {
             // and there are no dependencies on the context item
             if (Type.subTypeOf(predExpr.returnsType(), Type.NUMBER) &&
                     !Dependency.dependsOn(predExpr, Dependency.CONTEXT_POSITION)) {
-                this.hasPositionalPredicate = true;
+                return true;
             }
         }
+        return false;
     }
 
     public abstract Sequence eval( Sequence contextSequence, Item contextItem ) throws XPathException;

--- a/exist-core/src/test/xquery/optimizer/positional.xql
+++ b/exist-core/src/test/xquery/optimizer/positional.xql
@@ -110,6 +110,16 @@ function ot:optimize-simple-following-node() {
 };
 
 declare
+    %test:stats
+    %test:assertXPath("$result//stats:optimization[@type = 'PositionalPredicate']")
+function ot:optimize-simple-following-in-for() {
+    let $w := doc($ot:DOC)//w[@xml:id='25000']
+    for $i in 1 to 3
+    return
+        $w/following::node()[$i]
+};
+
+declare
     %test:assertEquals("25001")
 function ot:simple-following-text() {
     let $w := doc($ot:DOC)//w[@xml:id='25000']


### PR DESCRIPTION
Static type checking for positional filter optimizations is difficult and has no added benefit, so switch back to dynamic checks. Added a test which shows the query failing before. See discussion at the bottom of #3075 for details. This PR is required for #3075 to have the desired effect.