### PR TITLE
fail-fast on DMG creation if missing `/sbin/mkfs.hfsplus`

### DIFF
--- a/exist-distribution/src/main/scripts/create-dmg-unix.sh
+++ b/exist-distribution/src/main/scripts/create-dmg-unix.sh
@@ -10,6 +10,15 @@
 set -e
 set -x
 
+if [ ! -e /sbin/mkfs.hfsplus ]
+then
+	>&2 echo "ERROR: Skipping DMG creation because /sbin/mkfs.hfsplus is missing!"
+	>&2 echo "       To install it, you might run:"
+	>&2 echo "       * CentOS & co.: sudo yum install hfsutils hfsplus-tools"
+	>&2 echo "       * Debian, Ubuntu & co.: sudo apt-get install hfsprogs hfsplus"
+	exit 1
+fi
+
 # cleanup any previous DMG before creating a new DMG
 if [[ -f "${6}" ]]; then
     echo "Removing previous DMG"


### PR DESCRIPTION
Checks whether the required tool is available, and if not, supplies the user with info for how to possibly install it.

As in the Java world, one is used to just clone a repo and then run `mvn install` and all works,
many might be lost when some *nix specific script fails, and would give up compiling entirely,
or loose some time looking for the solution online.