### PR TITLE
Update pkg-java from 1.4.1 to 1.4.2

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -339,7 +339,7 @@
             <dependency>
                 <groupId>org.expath.packaging</groupId>
                 <artifactId>pkg-java</artifactId>
-                <version>1.4.1</version>
+                <version>1.4.2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
* Fixes an issue with SemVer comparison of package versions when restoring backups
Closes https://github.com/eXist-db/exist/issues/3118