### PR TITLE
(4.x.x) Switch to script drive before calling subsequent commands

### DIFF
--- a/tools/yajsw/bin/installService.bat
+++ b/tools/yajsw/bin/installService.bat
@@ -1,4 +1,4 @@
-cd %~dp0
+cd /D %~dp0
 call setenv.bat
 %wrapper_bat% -i %conf_file%
 

--- a/tools/yajsw/bin/queryService.bat
+++ b/tools/yajsw/bin/queryService.bat
@@ -1,4 +1,4 @@
-cd %~dp0
+cd /D %~dp0
 call setenv.bat
 %wrapper_bat% -q %conf_file%
 

--- a/tools/yajsw/bin/runConsole.bat
+++ b/tools/yajsw/bin/runConsole.bat
@@ -1,4 +1,4 @@
-cd %~dp0
+cd /D %~dp0
 call setenv.bat
 %wrapper_bat% -c %conf_file%
 

--- a/tools/yajsw/bin/startService.bat
+++ b/tools/yajsw/bin/startService.bat
@@ -1,4 +1,4 @@
-cd %~dp0
+cd /D %~dp0
 call setenv.bat
 %wrapper_bat% -t %conf_file%
 

--- a/tools/yajsw/bin/stopService.bat
+++ b/tools/yajsw/bin/stopService.bat
@@ -1,4 +1,4 @@
-cd %~dp0
+cd /D %~dp0
 call setenv.bat
 %wrapper_bat% -p %conf_file%
 

--- a/tools/yajsw/bin/uninstallService.bat
+++ b/tools/yajsw/bin/uninstallService.bat
@@ -1,3 +1,3 @@
-cd %~dp0
+cd /D %~dp0
 call setenv.bat
 %wrapper_bat% -r %conf_file%


### PR DESCRIPTION
### Description:
Switches to the same drive as the script location in case of calling a script from an other drive. This fixes the command file not found error due to try to invoke subsequent calls on the wrong drive.