### PR TITLE
Lucene index fixes

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
@@ -36,6 +36,8 @@ import org.w3c.dom.NodeList;
 
 public class LuceneConfig {
 
+    public final static LuceneConfig DEFAULT_CONFIG = new LuceneConfig();
+
 	private final static Logger LOG = LogManager.getLogger(LuceneConfig.class);
 	
     private final static String CONFIG_ROOT = "lucene";
@@ -72,6 +74,9 @@ public class LuceneConfig {
     private List<ModuleImport> imports = null;
 
     protected FacetsConfig facetsConfig = new FacetsConfig();
+
+    public LuceneConfig() {
+    }
 
     public LuceneConfig(NodeList configNodes, Map<String, String> namespaces) throws DatabaseConfigurationException {
         parseConfig(configNodes, namespaces);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -181,6 +181,8 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             	// Create a copy of the original LuceneConfig (there's only one per db instance), 
             	// so we can safely work with it.
             	config = new LuceneConfig(config);
+        } else {
+            config = LuceneConfig.DEFAULT_CONFIG;
         }
         mode = newMode;
     }
@@ -1096,7 +1098,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 }
             }
         }
-        return null;
+        return LuceneConfig.DEFAULT_CONFIG;
     }
 
     protected QueryParserWrapper getQueryParser(String field, Analyzer analyzer, DocumentSet docs) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatchListener.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatchListener.java
@@ -89,6 +89,8 @@ public class LuceneMatchListener extends AbstractMatchListener {
         final IndexSpec indexConf = proxy.getOwnerDocument().getCollection().getIndexConfiguration(broker);
         if (indexConf != null) {
             config = (LuceneConfig) indexConf.getCustomIndexSpec(LuceneIndex.ID);
+        } else {
+            config = LuceneConfig.DEFAULT_CONFIG;
         }
 
         getTerms();

--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexConfig.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexConfig.java
@@ -18,6 +18,8 @@ import java.util.*;
 
 public class RangeIndexConfig {
 
+    public final static RangeIndexConfig DEFAULT_CONFIG = new RangeIndexConfig();
+    
     static final String CONFIG_ROOT = "range";
     static final String CREATE_ELEM = "create";
     private static final String FIELD_ELEM = "field";
@@ -30,6 +32,11 @@ public class RangeIndexConfig {
     private Analyzer analyzer;
 
     private PathIterator iterator = new PathIterator();
+
+    public RangeIndexConfig() {
+        // default analyzer
+        analyzer = new KeywordAnalyzer();
+    }
 
     public RangeIndexConfig(NodeList configNodes, Map<String, String> namespaces) {
         parse(configNodes, namespaces);
@@ -70,6 +77,8 @@ public class RangeIndexConfig {
     }
 
     private void parse(NodeList configNodes, Map<String, String> namespaces) {
+        // default analyzer
+        analyzer = new KeywordAnalyzer();
         for(int i = 0; i < configNodes.getLength(); i++) {
             Node node = configNodes.item(i);
             if (node.getNodeType() == Node.ELEMENT_NODE && CONFIG_ROOT.equals(node.getLocalName())) {
@@ -112,8 +121,6 @@ public class RangeIndexConfig {
                 }
             }
         }
-        // default analyzer
-        analyzer = new KeywordAnalyzer();
     }
 
     public Analyzer getDefaultAnalyzer() {

--- a/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexWorker.java
+++ b/extensions/indexes/range/src/main/java/org/exist/indexing/range/RangeIndexWorker.java
@@ -255,6 +255,8 @@ public class RangeIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 // Create a copy of the original RangeIndexConfig (there's only one per db instance),
                 // so we can safely work with it.
                 config = new RangeIndexConfig(config);
+        } else {
+            config = RangeIndexConfig.DEFAULT_CONFIG;
         }
         this.mode = mode;
     }


### PR DESCRIPTION
In specific cases a wrong lucene index config (potentially belonging to a different collection) was used when storing a document into a collection which did not define a lucene index at all. We need to make sure the config is cleared and set to an empty default before the worker is reused for storing another document. The same applies to the range index.