### PR TITLE
(4.x-x) [bugfix] Fix illegal characters in directory name

### DIFF
--- a/exist-core/src/test/java/org/exist/storage/BrokerPoolsTest.java
+++ b/exist-core/src/test/java/org/exist/storage/BrokerPoolsTest.java
@@ -64,7 +64,7 @@ public class BrokerPoolsTest {
         for (int i = 0; i < testThreads; i ++) {
             Path datadir = createDirectory(tempDir.resolve("exist" + i));
             Path conf = datadir.resolve("conf.xml");
-            write(conf, singleton("<exist><db-connection database='native' files='\" + datadir + \"'/></exist>"));
+            write(conf, singleton("<exist><db-connection database='native' files='" + datadir + "'/></exist>"));
             BrokerPool.configure("instance" + i, 0, 1, new Configuration(conf.toString(), Optional.of(datadir)));
             shutdownTasks.add(executorService.submit(new BrokerPoolShutdownTask(acquiredLatch, shutdownLatch)));
         }


### PR DESCRIPTION
# Description:
Fixes illegal characters in path (Backport of #3153)