### PR TITLE
Tests for context item in functions

### DIFF
--- a/exist-core/src/test/java/org/exist/xquery/ContextItemTests.java
+++ b/exist-core/src/test/java/org/exist/xquery/ContextItemTests.java
@@ -1,0 +1,90 @@
+package org.exist.xquery;
+
+import com.evolvedbinary.j8fu.Either;
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.value.Sequence;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static com.evolvedbinary.j8fu.Either.Left;
+import static com.evolvedbinary.j8fu.Either.Right;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ContextItemTests {
+
+    @ClassRule
+    public static final ExistEmbeddedServer server = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void staticFunctionNoContextItem() throws EXistException, PermissionDeniedException {
+        final String query =
+                "declare function local:x() {" +
+                "  //x" +
+                "};" +
+                "local:x()";
+
+        final Either<XPathException, Sequence> result = executeQuery(query);
+        assertXQueryError(ErrorCodes.XPDY0002, result);
+    }
+
+    @Test
+    public void staticFunctionNoInheritContextItem() throws EXistException, PermissionDeniedException {
+        final String query =
+                "declare function local:x() {" +
+                "  //x" +
+                "};" +
+                "<doc><x>1</x><x>2</x></doc>/local:x()";
+
+        final Either<XPathException, Sequence> result = executeQuery(query);
+        assertXQueryError(ErrorCodes.XPDY0002, result);
+    }
+
+    @Test
+    public void dynamicFunctionNoContextItem() throws EXistException, PermissionDeniedException {
+        final String query =
+                "declare function local:x() {" +
+                "  //x" +
+                "};" +
+                "let $ref := local:x#0 return" +
+                "  $ref()";
+
+        final Either<XPathException, Sequence> result = executeQuery(query);
+        assertXQueryError(ErrorCodes.XPDY0002, result);
+    }
+
+    @Test
+    public void dynamicFunctionNoInheritContextItem() throws EXistException, PermissionDeniedException {
+        final String query =
+                "declare function local:x() {" +
+                "  //x" +
+                "};" +
+                "let $ref := local:x#0 return" +
+                "  <doc><x>1</x><x>2</x></doc>/$ref()";
+
+        final Either<XPathException, Sequence> result = executeQuery(query);
+        assertXQueryError(ErrorCodes.XPDY0002, result);
+    }
+
+    private static void assertXQueryError(final ErrorCodes.ErrorCode expected, final Either<XPathException, Sequence> actual) {
+        assertTrue("Expected: " + expected.getErrorQName() + ", but got result: " + actual.toString(), actual.isLeft());
+        final XPathException xpe = actual.left().get();
+        assertEquals(expected, xpe.getErrorCode());
+    }
+
+    private Either<XPathException, Sequence> executeQuery(final String string) throws EXistException, PermissionDeniedException {
+        final BrokerPool pool = server.getBrokerPool();
+        final XQuery xqueryService = pool.getXQueryService();
+        try (final DBBroker broker = pool.getBroker()) {
+            try {
+                return Right(xqueryService.execute(broker, string, null));
+            } catch (final XPathException e) {
+                return Left(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
These tests show that eXist-db is incorrectly setting the context item inside both static and dynamic function calls.

According to https://www.w3.org/TR/xquery-31/#id-eval-function-call when evaluating the body of a function:
> The focus (context item, context position, and context size) is absent

Unfortunately these tests show otherwise :-(

The issue is predominantly with `RootNode.java` which always establishes a context item, i.e. it is unaware of when it is inside a `UserDefinedFunction.java`.

I am not sure of the best way to fix this? I can see two options at the moment:
1) we make `RootNode.java` aware that it is being called inside a function, and have it always throw `XPDY0002` in that case.
2) we modify `XQueryContext` so that the "focus (context item, context position, and context size)" is stack based and gets pushed down in `UserDefinedFunction` before the body is eval'd, so that it is unavailable to the RootNode.

@wolfgangmm thoughts please? it would be good to discuss it. Some of your XQSuite tests for the Range Index (`extensions/indexes/range/src/test/xquery/range/range.xql`) are relying on this incorrect behaviour, but I think they could be rewritten to start with `fn:collection(...)`.

In addition in `UserDefinedFunction`, the function body is evaluated like so:
```java
result = body.eval(contextSequence, contextItem);
```

I suspect that should also be adjusted to:
```java
result = body.eval(null, null);
```
