### PR TITLE
(4.x.x) [bugfix] Memory leak on shutdown

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -1666,6 +1666,8 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
                         if(broker != null) {
                             broker.popSubject();
                         }
+                        // remove all remaining inactive brokers as we do shutdown now and no loner need those
+                        inactiveBrokers.clear();
                     }
 
                     // final notification to database services to shutdown
@@ -1710,7 +1712,7 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
                 securityManager = null;
                 notificationService = null;
                 statusObservers.clear();
-
+                startupTriggersManager = null;
                 statusReporter.terminate();
                 statusReporter = null;
 

--- a/exist-core/src/main/java/org/exist/storage/BrokerPoolServicesManager.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPoolServicesManager.java
@@ -294,5 +294,7 @@ class BrokerPoolServicesManager {
             }
             brokerPoolService.shutdown();
         }
+
+        brokerPoolServices.clear();
     }
 }

--- a/exist-core/src/main/java/org/exist/storage/ContentLoadingObserver.java
+++ b/exist-core/src/main/java/org/exist/storage/ContentLoadingObserver.java
@@ -87,7 +87,7 @@ public interface ContentLoadingObserver extends AutoCloseable {
 	@Override
 	void close() throws DBException;
 	
-	void closeAndRemove();
+	void closeAndRemove() throws DBException;
 	
 	void printStatistics();
 	

--- a/exist-core/src/main/java/org/exist/storage/DefaultCacheManager.java
+++ b/exist-core/src/main/java/org/exist/storage/DefaultCacheManager.java
@@ -33,6 +33,7 @@ import org.exist.util.DatabaseConfigurationException;
 import java.text.NumberFormat;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 
@@ -172,13 +173,10 @@ public class DefaultCacheManager implements CacheManager, BrokerPoolService
     @Override
     public void deregisterCache( Cache cache )
     {
-        Cache next;
-
-        for( int i = 0; i < caches.size(); i++ ) {
-            next = (Cache)caches.get( i );
-
-            if( cache == next ) {
-                caches.remove( i );
+        for (Iterator<Cache> cacheIt = caches.iterator(); cacheIt.hasNext(); ) {
+            if (cache == cacheIt.next()) {
+                cache.setCacheManager( null );
+                cacheIt.remove();
                 break;
             }
         }

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -363,7 +363,7 @@ public class NativeBroker extends DBBroker {
         clearContentLoadingObservers();
     }
 
-    private void notifyCloseAndRemove() {
+    private void notifyCloseAndRemove() throws DBException {
         for(final ContentLoadingObserver observer : contentLoadingObservers) {
             observer.closeAndRemove();
         }
@@ -3460,8 +3460,8 @@ public class NativeBroker extends DBBroker {
         }
 
         LOG.info("Removing index files ...");
-        notifyCloseAndRemove();
         try {
+            notifyCloseAndRemove();
             pool.getIndexManager().removeIndexes();
         } catch(final DBException e) {
             LOG.error("Failed to remove index files during repair: " + e.getMessage(), e);

--- a/exist-core/src/main/java/org/exist/storage/NativeValueIndex.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeValueIndex.java
@@ -1086,7 +1086,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
     }
 
     @Override
-    public void closeAndRemove() {
+    public void closeAndRemove() throws DBException {
         final Lock lock = dbValues.getLock();
         try {
             lock.acquire(LockMode.WRITE_LOCK);

--- a/exist-core/src/main/java/org/exist/storage/btree/BTree.java
+++ b/exist-core/src/main/java/org/exist/storage/btree/BTree.java
@@ -218,12 +218,6 @@ public class BTree extends Paged implements Lockable {
         }
     }
 
-    @Override
-    public void closeAndRemove() {
-        super.closeAndRemove();
-        cacheManager.deregisterCache(cache);
-    }
-
     /**
      * Get the active Lock object for this file.
      *
@@ -546,6 +540,7 @@ public class BTree extends Paged implements Lockable {
             flush();
         }
         super.close();
+        cacheManager.deregisterCache(cache);
     }
 
     protected void dumpValue(final Writer writer, final Value value, final int status) throws IOException {

--- a/exist-core/src/main/java/org/exist/storage/btree/Paged.java
+++ b/exist-core/src/main/java/org/exist/storage/btree/Paged.java
@@ -171,6 +171,15 @@ public abstract class Paged implements AutoCloseable {
         }
     }
 
+    /**
+     * Completely close down the instance and
+     * all underlying resources and caches.
+     */
+    public final void closeAndRemove() throws DBException {
+        close();
+        FileUtils.deleteQuietly(file);
+    }
+
     public boolean create() throws DBException {
         try {
             fileHeader.write();
@@ -251,20 +260,6 @@ public abstract class Paged implements AutoCloseable {
      */
     public FileHeader getFileHeader() {
         return fileHeader;
-    }
-
-    /**
-     * Completely close down the instance and
-     * all underlying resources and caches.
-     */
-    public void closeAndRemove() {
-        try {
-            raf.close();
-        } catch (final IOException e) {
-            //TODO : forward the exception ? -pb
-            LOG.error("Failed to close data file: " + file.toAbsolutePath().toString());
-        }
-        FileUtils.deleteQuietly(file);
     }
 
     protected final Page getFreePage() throws IOException {

--- a/exist-core/src/main/java/org/exist/storage/dom/DOMFile.java
+++ b/exist-core/src/main/java/org/exist/storage/dom/DOMFile.java
@@ -306,15 +306,10 @@ public class DOMFile extends BTree implements Lockable {
         if (!isReadOnly()) {
             flush();
         }
-        super.close();
-    }
-
-    @Override
-    public void closeAndRemove() {
         if (!lock.isLockedForWrite()) {
             LOG.warn("The file doesn't own a write lock");
         }
-        super.closeAndRemove();
+        super.close();
         cacheManager.deregisterCache(dataCache);
     }
 

--- a/exist-core/src/main/java/org/exist/storage/index/BFile.java
+++ b/exist-core/src/main/java/org/exist/storage/index/BFile.java
@@ -272,8 +272,8 @@ public class BFile extends BTree {
     }
 
     @Override
-    public void closeAndRemove() {
-        super.closeAndRemove();
+    public void close() throws DBException {
+        super.close();
         cacheManager.deregisterCache(dataCache);
     }
 


### PR DESCRIPTION
### Description:
If an embedded database is fired up and shut down multiple times, not all resources are being given back leading to a memory leak in this case.

**NOTE**: Superseded by https://github.com/eXist-db/exist/pull/3172

We found out about this by restoring a complete database multiple times in a row within the same JVM instance. The changes made within this PR fix this. Also some minor clean ups have been done within the `org.exist.management.implJMXAgent` removing the static `getInstance()` method as the actual instance will be created within the `org.exist.management.AgentFactory`