### PR TITLE
Multi-valued hierarchical facets

### DIFF
--- a/extensions/indexes/lucene/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/lucene/src/test/resources-filtered/conf.xml
@@ -740,6 +740,7 @@
 
             <!-- Needed for XQSuite! -->
             <module uri="http://www.w3.org/2005/xpath-functions/map" class="org.exist.xquery.functions.map.MapModule" />
+            <module uri="http://www.w3.org/2005/xpath-functions/array" class="org.exist.xquery.functions.array.ArrayModule" />
             <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule"/>
             <module uri="http://exist-db.org/xquery/response" class="org.exist.xquery.functions.response.ResponseModule" />
             <module uri="http://exist-db.org/xquery/system" class="org.exist.xquery.functions.system.SystemModule" />


### PR DESCRIPTION
Extend hierarchical facets to accept multiple values passed in via an array.

Defining a hierarchical facet on a node, it is possible that a node is a member of multiple hierarchies at the same time. For example, a text could fall into several hierarchical subject categories like science/math or humanities/history. Currently this is not supported: we only allow a single hierarchical facet per dimension.

Multiple hierarchies can be easily described as an XQuery array of sequences like `[('science', 'math'), ('humanities', 'history')]`. This PR extends the facet indexer to check if the result of the XQuery expression to obtain the facet value is an array. If it is, it is treated as a multi-valued hierarchical facet.

### Type of tests:

See extended xqsuite test.

### Documentation

https://github.com/eXist-db/documentation/commit/148bf8a8636bb16e55c4757b63f36d263c78f772