### PR TITLE
Option to make Document locks hierarchical

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedDocumentLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedDocumentLock.java
@@ -21,16 +21,22 @@
 package org.exist.storage.lock;
 
 import org.exist.xmldb.XmldbURI;
+import uk.ac.ic.doc.slurp.multilock.MultiLock;
 
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
-public class ManagedDocumentLock extends ManagedLock<java.util.concurrent.locks.Lock> {
+public class ManagedDocumentLock extends ManagedLock<MultiLock[]> {
 
     private final XmldbURI documentUri;
 
-    public ManagedDocumentLock(final XmldbURI documentUri, final java.util.concurrent.locks.Lock lock, final Runnable closer) {
-        super(lock, closer);
+    public ManagedDocumentLock(final XmldbURI documentUri, final MultiLock lock, final Runnable closer) {
+        super(new MultiLock[] { lock }, closer);
+        this.documentUri = documentUri;
+    }
+
+    public ManagedDocumentLock(final XmldbURI documentUri, final MultiLock[] locks, final Runnable closer) {
+        super(locks, closer);
         this.documentUri = documentUri;
     }
 
@@ -39,6 +45,6 @@ public class ManagedDocumentLock extends ManagedLock<java.util.concurrent.locks.
     }
 
     public static ManagedDocumentLock notLocked(final XmldbURI documentUri) {
-        return new ManagedDocumentLock(documentUri, null, () -> {});
+        return new ManagedDocumentLock(documentUri, (MultiLock[])null, () -> {});
     }
 }

--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -299,9 +299,11 @@ public class Configuration implements ErrorHandler
     private void configureLockManager(final Element lockManager) throws DatabaseConfigurationException {
         final boolean upgradeCheck = parseBoolean(getConfigAttributeValue(lockManager, "upgrade-check"), false);
         final boolean warnWaitOnReadForWrite = parseBoolean(getConfigAttributeValue(lockManager, "warn-wait-on-read-for-write"), false);
+        final boolean pathsMultiWriter = parseBoolean(getConfigAttributeValue(lockManager, "paths-multi-writer"), false);
 
         config.put(LockManager.CONFIGURATION_UPGRADE_CHECK, upgradeCheck);
         config.put(LockManager.CONFIGURATION_WARN_WAIT_ON_READ_FOR_WRITE, warnWaitOnReadForWrite);
+        config.put(LockManager.CONFIGURATION_PATHS_MULTI_WRITER, pathsMultiWriter);
 
         final NodeList nlLockTable = lockManager.getElementsByTagName("lock-table");
         if(nlLockTable.getLength() > 0) {
@@ -313,20 +315,12 @@ public class Configuration implements ErrorHandler
             config.put(LockTable.CONFIGURATION_TRACE_STACK_DEPTH, lockTableTraceStackDepth);
         }
 
-        final NodeList nlCollection = lockManager.getElementsByTagName("collection");
-        if(nlCollection.getLength() > 0) {
-            final Element collection = (Element)nlCollection.item(0);
-            final boolean collectionMultipleWriters = parseBoolean(getConfigAttributeValue(collection, "multiple-writers"), false);
-
-            config.put(LockManager.CONFIGURATION_COLLECTION_MULTI_WRITER, collectionMultipleWriters);
-        }
-
         final NodeList nlDocument = lockManager.getElementsByTagName("document");
         if(nlDocument.getLength() > 0) {
             final Element document = (Element)nlDocument.item(0);
-            final boolean documentMultiLock = parseBoolean(getConfigAttributeValue(document, "multi-lock"), false);
+            final boolean documentUsePathLocks = parseBoolean(getConfigAttributeValue(document, "use-path-locks"), false);
 
-            config.put(LockManager.CONFIGURATION_DOCUMENT_MULTI_LOCK, documentMultiLock);
+            config.put(LockManager.CONFIGURATION_PATHS_MULTI_WRITER, documentUsePathLocks);
         }
     }
 

--- a/exist-core/src/test/java/org/exist/storage/lock/GetXMLResourceNoLockTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/GetXMLResourceNoLockTest.java
@@ -57,7 +57,7 @@ public class GetXMLResourceNoLockTest {
             }
 
             final LockManager lockManager = broker.getBrokerPool().getLockManager();
-            final MultiLock colLock = lockManager.getCollectionLock(testCollection.getURI().toString());
+            final MultiLock colLock = lockManager.getPathLock(testCollection.getURI().toString());
             assertEquals("Collection does not have lock!", true, colLock.getReadHoldCount() > 0);
 		}
 	}

--- a/exist-core/src/test/java/org/exist/storage/lock/LockManagerTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/LockManagerTest.java
@@ -2,7 +2,6 @@ package org.exist.storage.lock;
 
 import com.evolvedbinary.j8fu.function.RunnableE;
 import net.jcip.annotations.ThreadSafe;
-import org.exist.storage.lock.LockManager.DocumentLock;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
@@ -28,7 +27,7 @@ public class LockManagerTest {
 
     private static final int CONCURRENCY_LEVEL = 100;
     private static String previousLockEventsState = null;
-    private static String previousCollectionsMultiWriterState = null;
+    private static String previousPathsMultiWriterState = null;
 
     @Parameterized.Parameters(name = "{0}")
     public static java.util.Collection<Object[]> data() {
@@ -42,18 +41,18 @@ public class LockManagerTest {
     public String apiName;
 
     @Parameterized.Parameter(value = 1)
-    public boolean enableCollectionsMultiWriterState;
+    public boolean enablePathsMultiWriterState;
 
     @Before
     public void enableLockEventsState() {
         previousLockEventsState = System.setProperty(LockTable.PROP_DISABLE, "false");
-        previousCollectionsMultiWriterState = System.setProperty(LockManager.PROP_ENABLE_COLLECTIONS_MULTI_WRITER, Boolean.toString(enableCollectionsMultiWriterState));
+        previousPathsMultiWriterState = System.setProperty(LockManager.PROP_ENABLE_PATHS_MULTI_WRITER, Boolean.toString(enablePathsMultiWriterState));
     }
 
     @After
     public void restoreLockEventsState() {
         restorePreviousPropertyState(LockTable.PROP_DISABLE, previousLockEventsState);
-        restorePreviousPropertyState(LockManager.PROP_ENABLE_COLLECTIONS_MULTI_WRITER, previousCollectionsMultiWriterState);
+        restorePreviousPropertyState(LockManager.PROP_ENABLE_PATHS_MULTI_WRITER, previousPathsMultiWriterState);
     }
 
     private static void restorePreviousPropertyState(final String propertyName, final String previousValue) {
@@ -68,19 +67,19 @@ public class LockManagerTest {
     public void getCollectionLock_isStripedByPath() {
         final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
 
-        final MultiLock dbLock1 = lockManager.getCollectionLock("/db");
+        final MultiLock dbLock1 = lockManager.getPathLock("/db");
         assertNotNull(dbLock1);
 
-        final MultiLock dbLock2 = lockManager.getCollectionLock("/db");
+        final MultiLock dbLock2 = lockManager.getPathLock("/db");
         assertNotNull(dbLock2);
 
         assertTrue(dbLock1 == dbLock2);
 
-        final MultiLock abcLock = lockManager.getCollectionLock("/db/a/b/c");
+        final MultiLock abcLock = lockManager.getPathLock("/db/a/b/c");
         assertNotNull(abcLock);
         assertFalse(dbLock1 == abcLock);
 
-        final MultiLock defLock = lockManager.getCollectionLock("/db/d/e/f");
+        final MultiLock defLock = lockManager.getPathLock("/db/d/e/f");
         assertNotNull(defLock);
         assertFalse(dbLock1 == defLock);
 
@@ -560,19 +559,19 @@ public class LockManagerTest {
     public void getDocumentLock_isStripedByPath() {
         final LockManager lockManager = new LockManager(CONCURRENCY_LEVEL);
 
-        final DocumentLock doc1Lock1 = lockManager.getDocumentLock("/db/1.xml");
+        final MultiLock doc1Lock1 = lockManager.getDocumentLock("/db/1.xml");
         assertNotNull(doc1Lock1);
 
-        final DocumentLock doc1Lock2 = lockManager.getDocumentLock("/db/1.xml");
+        final MultiLock doc1Lock2 = lockManager.getDocumentLock("/db/1.xml");
         assertNotNull(doc1Lock2);
 
         assertTrue(doc1Lock1 == doc1Lock2);
 
-        final DocumentLock doc2Lock = lockManager.getDocumentLock("/db/a/b/c/2.xml");
+        final MultiLock doc2Lock = lockManager.getDocumentLock("/db/a/b/c/2.xml");
         assertNotNull(doc2Lock);
         assertFalse(doc1Lock1 == doc2Lock);
 
-        final DocumentLock doc3Lock = lockManager.getDocumentLock("/db/d/e/f/3.xml");
+        final MultiLock doc3Lock = lockManager.getDocumentLock("/db/d/e/f/3.xml");
         assertNotNull(doc3Lock);
         assertFalse(doc1Lock1 == doc3Lock);
 
@@ -766,7 +765,7 @@ public class LockManagerTest {
     }
 
     private void assertIntentionWriteOrWriteMode(final Lock.LockMode lockMode) {
-        final Lock.LockMode writeMode = enableCollectionsMultiWriterState ? Lock.LockMode.INTENTION_WRITE : Lock.LockMode.WRITE_LOCK;
+        final Lock.LockMode writeMode = enablePathsMultiWriterState ? Lock.LockMode.INTENTION_WRITE : Lock.LockMode.WRITE_LOCK;
         assertEquals(writeMode, lockMode);
     }
 

--- a/exist-distribution/src/main/config/conf.xml
+++ b/exist-distribution/src/main/config/conf.xml
@@ -397,10 +397,26 @@
 
             This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
                 or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
     -->
     <lock-manager
             upgrade-check="false"
-            warn-wait-on-read-for-write="false">
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
 
         <!--
             Settings for the Lock Table
@@ -428,39 +444,20 @@
         <lock-table disabled="false" trace-stack-depth="0"/>
 
 
-        <!--
-            Settings for Collection Locking
-
-            - multiple-writers
-                Set to true to enable Multi-Writer/Multi-Reader semantics for
-                the Collection Hierarchy as opposed to the default (false) for Single-Writer/Multi-Reader.
-
-                NOTE: Whilst enabling Multiple-Writers on the Collection Hierarchy can improve concurrent
-                through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
-                Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
-                It is highly recommended that users leave this as the default setting. For more information, see:
-                "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
-                https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
-
-                This can also be set via the Java System Properties `org.exist.lock-manager.collection.multiple-writers`,
-                or (legacy) `exist.lockmanager.collections.multiwriter`.
-        -->
-        <collection multiple-writers="false"/>
-
-
         <!-- Settings for Document Locking
 
-            - multi-lock
-                Set to true to use the "Fast Multi-Level locks" implementation
-                (uk.ac.ic.doc.slurp.multilock.MultiLock) for locking documents, instead of the default of Java's
-                Reentrant Read Write Lock implementation (java.util.concurrent.locks.ReentrantReadWriteLock).
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
 
-                NOTE: At present changing this option has little effect.
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
 
-                This can also be set via the Java System Properties `org.exist.lock-manager.document.multi-lock`,
-                or (legacy) `exist.lockmanager.documents.multilock`.
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
         -->
-        <document multi-lock="false"/>
+        <document use-path-locks="false"/>
 
     </lock-manager>
 


### PR DESCRIPTION
This adds a new option to `conf.xml`:

```xml
<document use-path-locks="false"/>
```

When this is enabled, document and collection locks participate in the same locking hierarchy. This means that it becomes impossible for deadlocks to occur between documents and collections.

This should likely be enabled by default in future.