### PR TITLE
[fix] map:remove sequence of keys

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/map/AbstractMapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/AbstractMapType.java
@@ -54,7 +54,7 @@ public abstract class AbstractMapType extends FunctionReference
 
     public abstract Sequence keys();
 
-    public abstract AbstractMapType remove(AtomicValue key);
+    public abstract AbstractMapType remove(AtomicValue[] keysAtomicValues) throws XPathException;
 
     public abstract int getKeyType();
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapFunction.java
@@ -145,9 +145,16 @@ public class MapFunction extends BasicFunction {
         return null;
     }
 
-    private Sequence remove(final Sequence[] args) {
+    private Sequence remove(final Sequence[] args) throws XPathException {
         final AbstractMapType map = (AbstractMapType) args[0].itemAt(0);
-        return map.remove((AtomicValue) args[1].itemAt(0));
+
+        final int length = args[1].getItemCount();
+        final AtomicValue[] keys = new AtomicValue[length];
+
+        for (int i = 0; i < length; i++) {
+            keys[i] = (AtomicValue) args[1].itemAt(i);
+        }
+        return map.remove(keys);
     }
 
     private Sequence keys(final Sequence[] args) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
@@ -102,12 +102,13 @@ public class MapType extends AbstractMapType {
         return seq;
     }
 
-    public AbstractMapType remove(AtomicValue key) {
-        try {
-            return new MapType(this.context, this.map.without(key), type);
-        } catch (final Exception e) {
-            return this;
+    public AbstractMapType remove(final AtomicValue[] keysAtomicValues) {
+        IPersistentMap<AtomicValue, Sequence> tempmap = this.map;
+        for (final AtomicValue key: keysAtomicValues) {
+            if (!tempmap.containsKey(key)) { continue; }
+            tempmap = tempmap.without(key);
         }
+        return new MapType(this.context, tempmap, type);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/SingleKeyMapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/SingleKeyMapType.java
@@ -1,5 +1,6 @@
 package org.exist.xquery.functions.map;
 
+import com.github.krukow.clj_lang.IPersistentMap;
 import org.exist.xquery.Constants;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
@@ -59,12 +60,18 @@ public class SingleKeyMapType extends AbstractMapType {
     }
 
     @Override
-    public AbstractMapType remove(AtomicValue key) {
-        try {
+    public AbstractMapType remove(final AtomicValue[] keysAtomicValues) throws XPathException {
+        for (final AtomicValue key: keysAtomicValues) {
+            if (key != this.key) {
+                continue;
+            }
+            this.key = null;
+            value = null;
             return new MapType(context);
-        } catch (final XPathException e) {
-            return null;
         }
+        final MapType map = new MapType(context);
+        map.add(this);
+        return map;
     }
 
     @Override

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -1,4 +1,4 @@
-xquery version "3.0";
+xquery version "3.1";
 
 module namespace mt="http://exist-db.org/xquery/test/maps";
 
@@ -274,6 +274,46 @@ function mt:removeSingleKey() {
     let $empty := map:remove(map { "Su": "Sunday" }, "Su")
     return
         map:keys($empty)
+};
+
+declare
+    %test:assertEquals("Su")
+function mt:removeSingleNonExistentKey() {
+    let $map := map:remove(map { "Su": "Sunday" }, "Xx")
+    return
+        map:keys($map)
+};
+
+declare
+    %test:assertEquals("Sa")
+function mt:removeSequenceOfStringKeys() {
+    mt:getMapFixture()
+        => map:remove(("Mo", "Tu", "We", "Th", "Fr", "Su"))
+        => map:keys()
+};
+
+declare
+    %test:assertEquals("Sa")
+function mt:removeSequenceOfStringKeysWithNonExistent() {
+    mt:getMapFixture()
+        => map:remove(("Mo", "Tu", "We", "Th", "Fr", "Su", "Xx"))
+        => map:keys()
+};
+
+declare
+    %test:assertEquals(7)
+function mt:removeRangeOfIntegerKeys() {
+    $mt:integerKeys
+        => map:remove(1 to 6)
+        => map:keys()
+};
+
+declare
+    %test:assertEquals(7)
+function mt:removeIntegerKeysWithNonExistent() {
+    $mt:integerKeys
+        => map:remove((1, 2, 3, 4, 5, 6, 10))
+        => map:keys()
 };
 
 declare


### PR DESCRIPTION
### Description:

AbstractMapType.remove and all overrides now expect an array of
AtomicValues.

MapFunction.remove was adapted to take that into account.

### Reference:

fixes #1656 

### Type of tests:

Add tests to XQsuite to ensure sequences of keys can be deleted and
the changes do not break behaviour for non existing keys.
