### PR TITLE
Fix an issue with jetty closing sockets

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -1755,11 +1755,13 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
     }
 
     private void clearThreadLocals() {
-        for (final Thread thread : Thread.getAllStackTraces().keySet()){
+        for (final Thread thread : Thread.getAllStackTraces().keySet()) {
             try {
                 cleanThreadLocalsForThread(thread);
             } catch (final EXistException ex) {
-                LOG.warn("Could not clear ThreadLocals for thread: " + thread.getName());
+                if (LOG.isDebugEnabled()) {
+                    LOG.warn("Could not clear ThreadLocals for thread: " + thread.getName());
+                }
             }
         }
     }

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-bytebufferpool.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-bytebufferpool.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<Configure>
+  <New id="byteBufferPool" class="org.eclipse.jetty.io.ArrayByteBufferPool">
+    <Arg type="int"><Property name="jetty.byteBufferPool.minCapacity" default="0"/></Arg>
+    <Arg type="int"><Property name="jetty.byteBufferPool.factor" default="1024"/></Arg>
+    <Arg type="int"><Property name="jetty.byteBufferPool.maxCapacity" default="65536"/></Arg>
+    <Arg type="int"><Property name="jetty.byteBufferPool.maxQueueLength" default="-1"/></Arg>
+    <Arg type="long"><Property name="jetty.byteBufferPool.maxHeapMemory" default="-1"/></Arg>
+    <Arg type="long"><Property name="jetty.byteBufferPool.maxDirectMemory" default="-1"/></Arg>
+  </New>
+</Configure>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-gzip.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-gzip.xml
@@ -12,52 +12,53 @@
   <Call name="insertHandler">
     <Arg>
       <New id="GzipHandler" class="org.eclipse.jetty.server.handler.gzip.GzipHandler">
-	<Set name="minGzipSize"><Property name="jetty.gzip.minGzipSize" deprecated="gzip.minGzipSize" default="2048"/></Set>
-	<Set name="checkGzExists"><Property name="jetty.gzip.checkGzExists" deprecated="gzip.checkGzExists" default="false"/></Set>
-	<Set name="compressionLevel"><Property name="jetty.gzip.compressionLevel" deprecated="gzip.compressionLevel" default="-1"/></Set>
-	<Set name="excludedAgentPatterns">
-	  <Array type="String">
-	    <Item><Property name="jetty.gzip.excludedUserAgent" deprecated="gzip.excludedUserAgent" default=".*MSIE.6\.0.*"/></Item>
-	  </Array>
-	</Set>
+        <Set name="minGzipSize"><Property name="jetty.gzip.minGzipSize" deprecated="gzip.minGzipSize" default="2048"/></Set>
+        <Set name="checkGzExists"><Property name="jetty.gzip.checkGzExists" deprecated="gzip.checkGzExists" default="false"/></Set>
+        <Set name="compressionLevel"><Property name="jetty.gzip.compressionLevel" deprecated="gzip.compressionLevel" default="-1"/></Set>
+        <Set name="inflateBufferSize"><Property name="jetty.gzip.inflateBufferSize" default="0"/></Set>
+        <Set name="deflaterPoolCapacity"><Property name="jetty.gzip.deflaterPoolCapacity" default="-1"/></Set>
+        <Set name="syncFlush"><Property name="jetty.gzip.syncFlush" default="false" /></Set>
 
-	<Set name="includedMethods">
-	  <Array type="String">
-	    <Item>GET</Item>
-	  </Array>
-	</Set>
+        <Set name="excludedAgentPatterns">
+          <Array type="String">
+            <Item><Property name="jetty.gzip.excludedUserAgent" deprecated="gzip.excludedUserAgent" default=".*MSIE.6\.0.*"/></Item>
+          </Array>
+        </Set>
 
-	<!--
-	<Set name="includedPaths">
-	  <Array type="String">
-	    <Item>/*</Item>
-	  </Array>
-	</Set>
-	-->
+        <Set name="includedMethodList"><Property name="jetty.gzip.includedMethodList" default="GET" /></Set>
+        <Set name="excludedMethodList"><Property name="jetty.gzip.excludedMethodList" default="" /></Set>
 
-	<!--
-	<Set name="excludedPaths">
-	  <Array type="String">
-	    <Item>*.gz</Item>
-	  </Array>
-	</Set>
-	-->
+<!--
+        <Set name="includedMethods">
+          <Array type="String">
+            <Item>GET</Item>
+          </Array>
+        </Set>
 
-	<!--
-	<Call name="addIncludedMimeTypes">
-	  <Arg><Array type="String">
-	    <Item>some/type</Item>
-	  </Array></Arg>
-	</Call>
-	-->
+        <Set name="includedPaths">
+          <Array type="String">
+            <Item>/*</Item>
+          </Array>
+        </Set>
 
-	<!--
-	<Call name="addExcludedMimeTypes">
-	  <Arg><Array type="String">
-	    <Item>some/type</Item>
-	  </Array></Arg>
-	</Call>
-	-->
+        <Set name="excludedPaths">
+          <Array type="String">
+            <Item>*.gz</Item>
+          </Array>
+        </Set>
+
+        <Call name="addIncludedMimeTypes">
+          <Arg><Array type="String">
+            <Item>some/type</Item>
+          </Array></Arg>
+        </Call>
+
+        <Call name="addExcludedMimeTypes">
+          <Arg><Array type="String">
+            <Item>some/type</Item>
+          </Array></Arg>
+        </Call>
+-->
 
       </New>
     </Arg>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-http.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-http.xml
@@ -9,7 +9,7 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add a HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                       -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -29,7 +29,7 @@
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
                 <Arg name="config"><Ref refid="httpConfig" /></Arg>
-                <Arg name="compliance"><Call class="org.eclipse.jetty.http.HttpCompliance" name="valueOf"><Arg><Property name="jetty.http.compliance" default="RFC7230"/></Arg></Call></Arg>
+                <Arg name="compliance"><Call class="org.eclipse.jetty.http.HttpCompliance" name="valueOf"><Arg><Property name="jetty.http.compliance" default="RFC7230_LEGACY"/></Arg></Call></Arg>
               </New>
             </Item>
           </Array>
@@ -37,9 +37,11 @@
         <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port"><Default><SystemProperty name="jetty.port" default="8080"/></Default></Property></Set>
         <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.http.soLingerTime" deprecated="http.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>
+        <Get name="SelectorManager">
+          <Set name="connectTimeout"><Property name="jetty.http.connectTimeout" default="15000"/></Set>
+        </Get>
       </New>
     </Arg>
   </Call>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-https.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-https.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- ============================================================= -->
-<!-- Configure a HTTPS connector.                                  -->
+<!-- Configure an HTTPS connector.                                  -->
 <!-- This configuration must be used in conjunction with jetty.xml -->
 <!-- and jetty-ssl.xml.                                            -->
 <!-- ============================================================= -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-jaas.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-jaas.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-jmx.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-jmx.xml
@@ -4,13 +4,13 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Get the platform mbean server                               -->
+  <!-- Get the platform MBeanServer                                -->
   <!-- =========================================================== -->
   <Call id="MBeanServer" class="java.lang.management.ManagementFactory"
     name="getPlatformMBeanServer" />
 
   <!-- =========================================================== -->
-  <!-- Initialize the Jetty MBean container -->
+  <!-- Initialize the Jetty MBeanContainer                         -->
   <!-- =========================================================== -->
   <Call name="addBean">
     <Arg>
@@ -25,7 +25,7 @@
   <!-- Add the static log -->
   <Call name="addBean">
     <Arg>
-      <New class="org.eclipse.jetty.util.log.Log" />
+      <Get class="org.eclipse.jetty.util.log.Log" name="Log" />
     </Arg>
   </Call>
 </Configure>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-plus.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-plus.xml
@@ -22,5 +22,9 @@
     </Call>
   </Call>
 
+  <Call name="addBean">
+    <Arg><New class="org.eclipse.jetty.plus.jndi.NamingDump"/></Arg>
+  </Call>
+
 </Configure>
 

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-requestlog.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-requestlog.xml
@@ -24,6 +24,7 @@
       <Set name="extended"><Property name="jetty.requestlog.extended" deprecated="requestlog.extended" default="false"/></Set>
       <Set name="logCookies"><Property name="jetty.requestlog.cookies" deprecated="requestlog.cookies" default="false"/></Set>
       <Set name="LogTimeZone"><Property name="jetty.requestlog.timezone" deprecated="requestlog.timezone" default="GMT"/></Set>
+      <Set name="LogLatency"><Property name="jetty.requestlog.loglatency" default="false"/></Set>
     </New>
   </Set>
 </Configure>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl-context.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl-context.xml
@@ -10,7 +10,8 @@
      https://www.eclipse.org/jetty/documentation/current/configuring-ssl.html#configuring-sslcontextfactory-cipherSuites
 -->
 
-<Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+<Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
+  <Set name="Provider"><Property name="jetty.sslContext.provider"/></Set>
   <Set name="KeyStorePath"><Property name="jetty.base" default="." />/<Property name="jetty.sslContext.keyStorePath" deprecated="jetty.keystore" default="etc/keystore"/></Set>
   <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword" deprecated="jetty.keystore.password" default="OBF:1yta1t331v8w1v9q1t331ytc"/></Set>
   <Set name="KeyStoreType"><Property name="jetty.sslContext.keyStoreType" default="JKS"/></Set>
@@ -20,10 +21,35 @@
   <Set name="TrustStorePassword"><Property name="jetty.sslContext.trustStorePassword" deprecated="jetty.truststore.password" default="OBF:1yta1t331v8w1v9q1t331ytc"/></Set>
   <Set name="TrustStoreType"><Property name="jetty.sslContext.trustStoreType"/></Set>
   <Set name="TrustStoreProvider"><Property name="jetty.sslContext.trustStoreProvider"/></Set>
-  <Set name="EndpointIdentificationAlgorithm"></Set>
+  <Set name="EndpointIdentificationAlgorithm"><Property name="jetty.sslContext.endpointIdentificationAlgorithm"/></Set>
   <Set name="NeedClientAuth"><Property name="jetty.sslContext.needClientAuth" deprecated="jetty.ssl.needClientAuth" default="false"/></Set>
   <Set name="WantClientAuth"><Property name="jetty.sslContext.wantClientAuth" deprecated="jetty.ssl.wantClientAuth" default="false"/></Set>
   <Set name="useCipherSuitesOrder"><Property name="jetty.sslContext.useCipherSuitesOrder" default="true"/></Set>
   <Set name="sslSessionCacheSize"><Property name="jetty.sslContext.sslSessionCacheSize" default="-1"/></Set>
   <Set name="sslSessionTimeout"><Property name="jetty.sslContext.sslSessionTimeout" default="-1"/></Set>
+  <Set name="RenegotiationAllowed"><Property name="jetty.sslContext.renegotiationAllowed" default="true"/></Set>
+  <Set name="RenegotiationLimit"><Property name="jetty.sslContext.renegotiationLimit" default="5"/></Set>
+  <Set name="SniRequired"><Property name="jetty.sslContext.sniRequired" default="false"/></Set>
+ 
+  <!-- Example of how to configure a PKIX Certificate Path revocation Checker
+  <Call id="pkixPreferCrls" class="java.security.cert.PKIXRevocationChecker$Option" name="valueOf"><Arg>PREFER_CRLS</Arg></Call>
+  <Call id="pkixSoftFail" class="java.security.cert.PKIXRevocationChecker$Option" name="valueOf"><Arg>SOFT_FAIL</Arg></Call>
+  <Call id="pkixNoFallback" class="java.security.cert.PKIXRevocationChecker$Option" name="valueOf"><Arg>NO_FALLBACK</Arg></Call>
+  <Call class="java.security.cert.CertPathBuilder" name="getInstance">
+    <Arg>PKIX</Arg>
+    <Call id="pkixRevocationChecker" name="getRevocationChecker">
+      <Call name="setOptions">
+        <Arg>
+          <Call class="java.util.EnumSet" name="of">
+            <Arg><Ref refid="pkixPreferCrls"/></Arg>
+            <Arg><Ref refid="pkixSoftFail"/></Arg>
+            <Arg><Ref refid="pkixNoFallback"/></Arg>
+          </Call>
+        </Arg>
+      </Call>
+    </Call>
+  </Call>
+  <Set name="PkixCertPathChecker"><Ref refid="pkixRevocationChecker"/></Set>
+  -->
+  
 </Configure>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl.xml
@@ -9,7 +9,7 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add a SSL Connector with no protocol factories              -->
+  <!-- Add an SSL Connector with no protocol factories              -->
   <!-- =========================================================== -->
   <Call  name="addConnector">
     <Arg>
@@ -29,9 +29,11 @@
         <Set name="host"><Property name="jetty.ssl.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.ssl.port" deprecated="ssl.port"><Default><SystemProperty name="jetty.ssl.port" deprecated="ssl.port" default="8443"/></Default></Property></Set>
         <Set name="idleTimeout"><Property name="jetty.ssl.idleTimeout" deprecated="ssl.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.ssl.soLingerTime" deprecated="ssl.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.ssl.acceptorPriorityDelta" deprecated="ssl.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.ssl.acceptQueueSize" deprecated="ssl.acceptQueueSize" default="0"/></Set>
+        <Get name="SelectorManager">
+          <Set name="connectTimeout"><Property name="jetty.ssl.connectTimeout" default="15000"/></Set>
+        </Get>
       </New>
     </Arg>
   </Call>
@@ -47,6 +49,7 @@
     <Call name="addCustomizer">
       <Arg>
         <New class="org.eclipse.jetty.server.SecureRequestCustomizer">
+          <Arg name="sniRequired" type="boolean"><Property name="jetty.ssl.sniRequired" default="false"/></Arg>
           <Arg name="sniHostCheck" type="boolean"><Property name="jetty.ssl.sniHostCheck" default="true"/></Arg>
           <Arg name="stsMaxAgeSeconds" type="int"><Property name="jetty.ssl.stsMaxAgeSeconds" default="-1"/></Arg>
           <Arg name="stsIncludeSubdomains" type="boolean"><Property name="jetty.ssl.stsIncludeSubdomains" default="false"/></Arg>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-threadpool.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-threadpool.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure>
+  <!-- =========================================================== -->
+  <!-- Configure the Server Thread Pool.                           -->
+  <!-- The server holds a common thread pool which is used by      -->
+  <!-- default as the executor used by all connectors and servlet  -->
+  <!-- dispatches.                                                 -->
+  <!--                                                             -->
+  <!-- Configuring a fixed thread pool is vital to controlling the -->
+  <!-- maximal memory footprint of the server and is a key tuning  -->
+  <!-- parameter for tuning.  In an application that rarely blocks -->
+  <!-- then maximal threads may be close to the number of 5*CPUs.  -->
+  <!-- In an application that frequently blocks, then maximal      -->
+  <!-- threads should be set as high as possible given the memory  -->
+  <!-- available.                                                  -->
+  <!--                                                             -->
+  <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
+  <!-- for all configuration that may be set here.                 -->
+  <!-- =========================================================== -->
+  <New id="threadPool" class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+    <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+    <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+    <Set name="reservedThreads" type="int"><Property name="jetty.threadPool.reservedThreads" default="-1"/></Set>
+    <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+    <Set name="detailedDump" type="boolean"><Property name="jetty.threadPool.detailedDump" default="false"/></Set>
+  </New>
+</Configure>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty.xml
@@ -3,7 +3,7 @@
 
 <!-- =============================================================== -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!-- https://www.eclipse.org/jetty/documentation/current/            -->
 <!--                                                                 -->
 <!-- Additional configuration files are available in $JETTY_HOME/etc -->
 <!-- and can be mixed in. See start.ini file for the default         -->
@@ -24,40 +24,22 @@
 <!-- configuration that may be set here.                             -->
 <!-- =============================================================== -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Arg name="threadpool"><Ref refid="threadPool"/></Arg>
 
-    <!-- =========================================================== -->
-    <!-- Configure the Server Thread Pool.                           -->
-    <!-- The server holds a common thread pool which is used by      -->
-    <!-- default as the executor used by all connectors and servlet  -->
-    <!-- dispatches.                                                 -->
-    <!--                                                             -->
-    <!-- Configuring a fixed thread pool is vital to controlling the -->
-    <!-- maximal memory footprint of the server and is a key tuning  -->
-    <!-- parameter for tuning.  In an application that rarely blocks -->
-    <!-- then maximal threads may be close to the number of 5*CPUs.  -->
-    <!-- In an application that frequently blocks, then maximal      -->
-    <!-- threads should be set as high as possible given the memory  -->
-    <!-- available.                                                  -->
-    <!--                                                             -->
-    <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
-    <!-- for all configuration that may be set here.                 -->
-    <!-- =========================================================== -->
-    <!-- uncomment to change type of threadpool
-    <Arg name="threadpool"><New id="threadpool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"/></Arg>
-    -->
-    <Get name="ThreadPool">
-      <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
-      <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
-      <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
-      <Set name="detailedDump">false</Set>
-    </Get>
+    <Call name="addBean">
+      <Arg><Ref refid="byteBufferPool"/></Arg>
+    </Call>
 
     <!-- =========================================================== -->
     <!-- Add shared Scheduler instance                               -->
     <!-- =========================================================== -->
     <Call name="addBean">
       <Arg>
-        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler"/>
+        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler">
+          <Arg name="name"><Property name="jetty.scheduler.name"/></Arg>
+          <Arg name="daemon" type="boolean"><Property name="jetty.scheduler.daemon" default="false" /></Arg>
+          <Arg name="threads" type="int"><Property name="jetty.scheduler.threads" default="-1" /></Arg>
+        </New>
       </Arg>
     </Call>
 
@@ -85,11 +67,14 @@
       <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
       <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true" /></Set>
       <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="true" /></Set>
-      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
+      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="1024" /></Set>
       <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
       <Set name="maxErrorDispatches"><Property name="jetty.httpConfig.maxErrorDispatches" default="10"/></Set>
-      <Set name="blockingTimeout"><Property name="jetty.httpConfig.blockingTimeout" default="-1"/></Set>
+      <Set name="blockingTimeout"><Property deprecated="jetty.httpConfig.blockingTimeout" name="jetty.httpConfig.blockingTimeout.DEPRECATED" default="-1"/></Set>
       <Set name="persistentConnectionsEnabled"><Property name="jetty.httpConfig.persistentConnectionsEnabled" default="true"/></Set>
+      <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" deprecated="jetty.httpConfig.cookieCompliance" default="RFC6265"/></Arg></Call></Set>
+      <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
+      <Set name="multiPartFormDataCompliance"><Call class="org.eclipse.jetty.server.MultiPartFormDataCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.multiPartFormDataCompliance" default="RFC7578"/></Arg></Call></Set>
     </New>
 
     <!-- =========================================================== -->
@@ -122,30 +107,8 @@
     <!-- extra server options                                        -->
     <!-- =========================================================== -->
     <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
-    <Set name="stopTimeout">5000</Set>
+    <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
     <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
     <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
-
-    <!-- =============================================================== -->
-    <!-- Add a ContextProvider to the deployment manager                 -->
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <!-- This scans the webapps directory for war files and directories  -->
-    <!-- to deploy.                                                      -->
-    <!-- This configuration must be used with jetty-deploy.xml, which    -->
-    <!-- creates the deployment manager instance                         -->
-    <!-- =============================================================== -->
-    <!-- from: jetty-contexts.xml -->
-
-    <!-- TODO(AR) do we need this??? -->
-    <!-- Ref id="DeploymentManager">
-      <Call name="addAppProvider">
-        <Arg>
-          <New class="org.eclipse.jetty.deploy.providers.ContextProvider">
-            <Set name="monitoredDirName"><Property name="jetty.base" default="." />/contexts</Set>
-            <Set name="scanInterval">10</Set>
-          </New>
-        </Arg>
-      </Call>
-    </Ref -->
 
 </Configure>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-http.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-http.xml
@@ -9,7 +9,7 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add a HTTP Connector.                                       -->
+  <!-- Add an HTTP Connector.                                       -->
   <!-- Configure an o.e.j.server.ServerConnector with a single     -->
   <!-- HttpConnectionFactory instance using the common httpConfig  -->
   <!-- instance defined in jetty.xml                               -->
@@ -29,7 +29,7 @@
             <Item>
               <New class="org.eclipse.jetty.server.HttpConnectionFactory">
                 <Arg name="config"><Ref refid="httpConfig" /></Arg>
-                <Arg name="compliance"><Call class="org.eclipse.jetty.http.HttpCompliance" name="valueOf"><Arg><Property name="jetty.http.compliance" default="RFC7230"/></Arg></Call></Arg>
+                <Arg name="compliance"><Call class="org.eclipse.jetty.http.HttpCompliance" name="valueOf"><Arg><Property name="jetty.http.compliance" default="RFC7230_LEGACY"/></Arg></Call></Arg>
               </New>
             </Item>
           </Array>
@@ -37,9 +37,11 @@
         <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port"><Default><SystemProperty name="jetty.port" default="8088"/></Default></Property></Set>
         <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.http.soLingerTime" deprecated="http.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>
+        <Get name="SelectorManager">
+          <Set name="connectTimeout"><Property name="jetty.http.connectTimeout" default="15000"/></Set>
+        </Get>
       </New>
     </Arg>
   </Call>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-ssl.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-ssl.xml
@@ -9,7 +9,7 @@
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 
   <!-- =========================================================== -->
-  <!-- Add a SSL Connector with no protocol factories              -->
+  <!-- Add an SSL Connector with no protocol factories              -->
   <!-- =========================================================== -->
   <Call  name="addConnector">
     <Arg>
@@ -29,9 +29,11 @@
         <Set name="host"><Property name="jetty.ssl.host" deprecated="jetty.host" /></Set>
         <Set name="port"><Property name="jetty.ssl.port" deprecated="ssl.port"><Default><SystemProperty name="jetty.ssl.port" deprecated="ssl.port" default="8451"/></Default></Property></Set>
         <Set name="idleTimeout"><Property name="jetty.ssl.idleTimeout" deprecated="ssl.timeout" default="30000"/></Set>
-        <Set name="soLingerTime"><Property name="jetty.ssl.soLingerTime" deprecated="ssl.soLingerTime" default="-1"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.ssl.acceptorPriorityDelta" deprecated="ssl.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.ssl.acceptQueueSize" deprecated="ssl.acceptQueueSize" default="0"/></Set>
+        <Get name="SelectorManager">
+          <Set name="connectTimeout"><Property name="jetty.ssl.connectTimeout" default="15000"/></Set>
+        </Get>
       </New>
     </Arg>
   </Call>
@@ -47,6 +49,7 @@
     <Call name="addCustomizer">
       <Arg>
         <New class="org.eclipse.jetty.server.SecureRequestCustomizer">
+          <Arg name="sniRequired" type="boolean"><Property name="jetty.ssl.sniRequired" default="false"/></Arg>
           <Arg name="sniHostCheck" type="boolean"><Property name="jetty.ssl.sniHostCheck" default="true"/></Arg>
           <Arg name="stsMaxAgeSeconds" type="int"><Property name="jetty.ssl.stsMaxAgeSeconds" default="-1"/></Arg>
           <Arg name="stsIncludeSubdomains" type="boolean"><Property name="jetty.ssl.stsIncludeSubdomains" default="false"/></Arg>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty.xml
@@ -3,7 +3,7 @@
 
 <!-- =============================================================== -->
 <!-- Documentation of this file format can be found at:              -->
-<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!-- https://www.eclipse.org/jetty/documentation/current/            -->
 <!--                                                                 -->
 <!-- Additional configuration files are available in $JETTY_HOME/etc -->
 <!-- and can be mixed in. See start.ini file for the default         -->
@@ -24,40 +24,22 @@
 <!-- configuration that may be set here.                             -->
 <!-- =============================================================== -->
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Arg name="threadpool"><Ref refid="threadPool"/></Arg>
 
-    <!-- =========================================================== -->
-    <!-- Configure the Server Thread Pool.                           -->
-    <!-- The server holds a common thread pool which is used by      -->
-    <!-- default as the executor used by all connectors and servlet  -->
-    <!-- dispatches.                                                 -->
-    <!--                                                             -->
-    <!-- Configuring a fixed thread pool is vital to controlling the -->
-    <!-- maximal memory footprint of the server and is a key tuning  -->
-    <!-- parameter for tuning.  In an application that rarely blocks -->
-    <!-- then maximal threads may be close to the number of 5*CPUs.  -->
-    <!-- In an application that frequently blocks, then maximal      -->
-    <!-- threads should be set as high as possible given the memory  -->
-    <!-- available.                                                  -->
-    <!--                                                             -->
-    <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
-    <!-- for all configuration that may be set here.                 -->
-    <!-- =========================================================== -->
-    <!-- uncomment to change type of threadpool
-    <Arg name="threadpool"><New id="threadpool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"/></Arg>
-    -->
-    <Get name="ThreadPool">
-      <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
-      <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
-      <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
-      <Set name="detailedDump">false</Set>
-    </Get>
+    <Call name="addBean">
+      <Arg><Ref refid="byteBufferPool"/></Arg>
+    </Call>
 
     <!-- =========================================================== -->
     <!-- Add shared Scheduler instance                               -->
     <!-- =========================================================== -->
     <Call name="addBean">
       <Arg>
-        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler"/>
+        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler">
+          <Arg name="name"><Property name="jetty.scheduler.name"/></Arg>
+          <Arg name="daemon" type="boolean"><Property name="jetty.scheduler.daemon" default="false" /></Arg>
+          <Arg name="threads" type="int"><Property name="jetty.scheduler.threads" default="-1" /></Arg>
+        </New>
       </Arg>
     </Call>
 
@@ -85,11 +67,14 @@
       <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
       <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true" /></Set>
       <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="true" /></Set>
-      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
+      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="1024" /></Set>
       <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
       <Set name="maxErrorDispatches"><Property name="jetty.httpConfig.maxErrorDispatches" default="10"/></Set>
-      <Set name="blockingTimeout"><Property name="jetty.httpConfig.blockingTimeout" default="-1"/></Set>
+      <Set name="blockingTimeout"><Property deprecated="jetty.httpConfig.blockingTimeout" name="jetty.httpConfig.blockingTimeout.DEPRECATED" default="-1"/></Set>
       <Set name="persistentConnectionsEnabled"><Property name="jetty.httpConfig.persistentConnectionsEnabled" default="true"/></Set>
+      <Set name="requestCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.requestCookieCompliance" deprecated="jetty.httpConfig.cookieCompliance" default="RFC6265"/></Arg></Call></Set>
+      <Set name="responseCookieCompliance"><Call class="org.eclipse.jetty.http.CookieCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.responseCookieCompliance" default="RFC6265"/></Arg></Call></Set>
+      <Set name="multiPartFormDataCompliance"><Call class="org.eclipse.jetty.server.MultiPartFormDataCompliance" name="valueOf"><Arg><Property name="jetty.httpConfig.multiPartFormDataCompliance" default="RFC7578"/></Arg></Call></Set>
     </New>
 
     <!-- =========================================================== -->
@@ -122,30 +107,8 @@
     <!-- extra server options                                        -->
     <!-- =========================================================== -->
     <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
-    <Set name="stopTimeout">5000</Set>
+    <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="5000"/></Set>
     <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
     <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
-
-    <!-- =============================================================== -->
-    <!-- Add a ContextProvider to the deployment manager                 -->
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <!-- This scans the webapps directory for war files and directories  -->
-    <!-- to deploy.                                                      -->
-    <!-- This configuration must be used with jetty-deploy.xml, which    -->
-    <!-- creates the deployment manager instance                         -->
-    <!-- =============================================================== -->
-    <!-- from: jetty-contexts.xml -->
-
-    <!-- TODO(AR) do we need this??? -->
-    <!-- Ref id="DeploymentManager">
-      <Call name="addAppProvider">
-        <Arg>
-          <New class="org.eclipse.jetty.deploy.providers.ContextProvider">
-            <Set name="monitoredDirName"><Property name="jetty.base" default="." />/contexts</Set>
-            <Set name="scanInterval">10</Set>
-          </New>
-        </Arg>
-      </Call>
-    </Ref -->
 
 </Configure>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone.enabled-jetty-configs
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone.enabled-jetty-configs
@@ -13,6 +13,8 @@
 
 
 ### Main Server Config
+jetty-bytebufferpool.xml
+jetty-threadpool.xml
 standalone-jetty.xml
 
 

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standard.enabled-jetty-configs
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standard.enabled-jetty-configs
@@ -13,6 +13,8 @@
 
 
 ### Main Server Config
+jetty-bytebufferpool.xml
+jetty-threadpool.xml
 jetty.xml
 
 

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/webdefault.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/webdefault.xml
@@ -26,7 +26,7 @@
 
   <description>
     Default web.xml file.  
-    This file is applied to a Web application before it's own WEB_INF/web.xml file
+    This file is applied to a Web application before its own WEB_INF/web.xml file
   </description>
 
   <!-- ==================================================================== -->
@@ -109,7 +109,15 @@
  *
  *  gzip              If set to true, then static content will be served as
  *                    gzip content encoded if a matching resource is
- *                    found ending with ".gz"
+ *                    found ending with ".gz" (default false) 
+ *                    (deprecated: use precompressed)
+ *                    
+ *  precompressed     If set to a comma separated list of encoding types (that may be
+ *                    listed in a requests Accept-Encoding header) to file
+ *                    extension mappings to look for and serve. For example:
+ *                    "br=.br,gzip=.gz,bzip2=.bz".
+ *                    If set to a boolean True, then a default set of compressed formats
+ *                    will be used, otherwise no precompressed formats.
  *
  *  resourceBase      Set to replace the context resource base
  *
@@ -125,9 +133,6 @@
  *
  *  stylesheet        Set with the location of an optional stylesheet that will be used
  *                    to decorate the directory listing html.
- *
- *  aliases           If True, aliases of resources are allowed (eg. symbolic
- *                    links and caps variations). May bypass security constraints.
  *                    
  *  etags             If True, weak etags will be generated and handled.
  *
@@ -144,15 +149,17 @@
  *  cacheControl      If set, all static content will have this value set as the cache-control
  *                    header.
  *
+ * encodingHeaderCacheSize
+ *                    Max entries in a cache of ACCEPT-ENCODING headers.
+ *
+ * otherGzipFileExtensions  
+ *                    defaults to .svgz but a comma separated list of gzip equivalent file extensions can be supplied
+ *
  -->
  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
   <servlet>
     <servlet-name>default</servlet-name>
     <servlet-class>org.eclipse.jetty.servlet.DefaultServlet</servlet-class>
-    <init-param>
-      <param-name>aliases</param-name>
-      <param-value>false</param-value>
-    </init-param>
     <init-param>
       <param-name>acceptRanges</param-name>
       <param-value>true</param-value>

--- a/extensions/modules/xslfo/pom.xml
+++ b/extensions/modules/xslfo/pom.xml
@@ -57,6 +57,17 @@
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>fop</artifactId>
             <version>2.4</version>
+            <exclusions>
+                <!--
+                    fop-core depends on javax.servlet:servlet-api:jar:2.2
+                    which conflicts with javax.servlet:javax.servlet-api:jar:3.1.0
+                    used by eXist-db
+                -->
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The jetty config was out of date, this could lead to Jetty leaving sockets in a lingering `CLOSE_WAIT` state and then eventually running out of file descriptors.