### PR TITLE
Fix the cardinality of fn:random-number-generator#1

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnRandomNumberGenerator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnRandomNumberGenerator.java
@@ -33,7 +33,9 @@ public class FnRandomNumberGenerator extends BasicFunction {
             FS_RANDOM_NUMBER_GENERATOR_RETURN_TYPE,
             arities(
                     arity(),
-                    arity(param("seed", Type.ATOMIC, "A seed value for the random generator"))
+                    arity(
+                            optParam("seed", Type.ATOMIC, "A seed value for the random generator")
+                    )
             )
     );
 


### PR DESCRIPTION
Cardinality according to the spec should be zero_or_one, not one.

With some small fixes to our XQTS runner, this now causes us to reach 86.36% compliance with the fn:random-number-generator tests in XQTS 3.1.


