### PR TITLE
Include the path of any file that could not be restored in the log

### DIFF
--- a/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
@@ -383,8 +383,9 @@ public class RestoreHandler extends DefaultHandler {
             return deferredPermission;
 
         } catch(final Exception e) {
-            listener.warn(String.format("Failed to restore resource '%s'\nfrom file '%s'.\nReason: %s", name, descriptor.getSymbolicPath(name, false), e.getMessage()));
-            LOG.error(e.getMessage(), e);
+            final String message = String.format("Failed to restore resource '%s'\nfrom file '%s'.\nReason: %s", name, descriptor.getSymbolicPath(name, false), e.getMessage());
+            listener.warn(message);
+            LOG.error(message, e);
             return new SkippedEntryDeferredPermission();
         } finally {
             is.close();


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/3023

Previously the paths of any files that could not be restored and the reason why were shown in the Restore tool/dialog, however when the errors were written to the log the file paths were missing.
