### PR TITLE
Document URI was incorrectly cached during a Collection Move

### DIFF
--- a/exist-core/src/main/java/org/exist/collections/Collection.java
+++ b/exist-core/src/main/java/org/exist/collections/Collection.java
@@ -65,11 +65,22 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
     XmldbURI getURI();
 
     /**
-     * Set the URI path of the Collection
+     * Set the URI path of the Collection.
+     *
+     * Simply calls {@link #setPath(XmldbURI, boolean)}
+     * with updateChildren=false.
      *
      * @param path The URI path of the Collection
      */
     void setPath(XmldbURI path);
+
+    /**
+     * Set the URI path of the Collection
+     *
+     * @param path The URI path of the Collection
+     * @param updateChildren true if paths of child documents and collections should be updated (if needed), false otherwise
+     */
+    void setPath(XmldbURI path, boolean updateChildren);
 
     /**
      * Get the metadata of the Collection

--- a/exist-core/src/main/java/org/exist/collections/LockedCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/LockedCollection.java
@@ -105,6 +105,11 @@ public class LockedCollection implements Collection {
     }
 
     @Override
+    public void setPath(final XmldbURI path, final boolean updateChildren) {
+        collection.setPath(path, updateChildren);
+    }
+
+    @Override
     public CollectionMetadata getMetadata() {
         return collection.getMetadata();
     }

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -1538,7 +1538,7 @@ public class NativeBroker extends DBBroker {
         }
 
         // set source path to destination... source is now the destination
-        sourceCollection.setPath(destinationCollectionUri);
+        sourceCollection.setPath(destinationCollectionUri, true);
         saveCollection(transaction, sourceCollection);
 
         // add destination to target

--- a/exist-core/src/test/xquery/indexing/indexes-base-uri.xq
+++ b/exist-core/src/test/xquery/indexing/indexes-base-uri.xq
@@ -1,0 +1,95 @@
+xquery version "3.1";
+
+module namespace but="http://exist-db.org/xquery/indexes/base-uri-test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $but:XML := <item/>;
+
+declare variable $but:test-col-name := "but";
+declare variable $but:test-col-uri := "/db/" || $but:test-col-name;
+declare variable $but:test-col-a-name := "a";
+declare variable $but:test-col-a-uri := $but:test-col-uri || "/" || $but:test-col-a-name;
+declare variable $but:test-col-b-name := "b";
+declare variable $but:test-col-b-uri := $but:test-col-uri || "/" || $but:test-col-b-name;
+
+declare
+    %test:setUp
+function but:setup() {
+    xmldb:create-collection("/db", $but:test-col-name),
+    xmldb:create-collection($but:test-col-uri, $but:test-col-a-name),
+    xmldb:create-collection($but:test-col-uri, $but:test-col-b-name)
+};
+
+declare
+    %test:tearDown
+function but:tearDown() {
+    xmldb:remove($but:test-col-uri)
+};
+
+declare
+    %test:pending("Each test interferes with each other test, we need to figure out how to have but:tearDown called after every test")
+    %test:assertEquals("/db/but/a/data/test.xml", "/db/but/a/data/test.xml", "/db/but/b/data/test.xml")
+function but:base-uri-after-collection-copy() {
+    let $test-col-a-data-uri := xmldb:create-collection($but:test-col-a-uri, "data")
+    let $doc-path := xmldb:store($test-col-a-data-uri, "test.xml", $but:XML)
+    let $base-uri-before-copy := collection($but:test-col-uri)/item/base-uri(.)
+    return
+
+    let $_ := xmldb:copy-collection($test-col-a-data-uri, $but:test-col-b-uri)
+    return
+        let $base-uri-after-copy := collection($but:test-col-uri)/item/base-uri(.)
+        return
+
+            ($base-uri-before-copy, $base-uri-after-copy)
+};
+
+declare
+    %test:assertEquals("/db/but/a/data/test.xml", "/db/but/b/data/test.xml")
+function but:base-uri-after-collection-move() {
+    let $test-col-a-data-uri := xmldb:create-collection($but:test-col-a-uri, "data")
+    let $doc-path := xmldb:store($test-col-a-data-uri, "test.xml", $but:XML)
+    let $base-uri-before-move := collection($but:test-col-uri)/item/base-uri(.)
+    return
+
+    let $_ := xmldb:move($test-col-a-data-uri, $but:test-col-b-uri)
+    return
+        let $base-uri-after-move := collection($but:test-col-uri)/item/base-uri(.)
+        return
+
+            ($base-uri-before-move, $base-uri-after-move)
+};
+
+declare
+    %test:pending("Each test interferes with each other test, we need to figure out how to have but:tearDown called after every test")
+    %test:assertEquals("/db/but/a/data/test.xml", "/db/but/a/data/test.xml", "/db/but/b/test.xml")
+function but:base-uri-after-resource-copy() {
+    let $test-col-a-data-uri := xmldb:create-collection($but:test-col-a-uri, "data")
+    let $doc-path := xmldb:store($test-col-a-data-uri, "test.xml", $but:XML)
+    let $base-uri-before-copy := collection($but:test-col-uri)/item/base-uri(.)
+    return
+
+    let $_ := xmldb:copy-resource($test-col-a-data-uri, "test.xml", $but:test-col-b-uri, ())
+    return
+        let $base-uri-after-copy := collection($but:test-col-uri)/item/base-uri(.)
+        return
+
+            ($base-uri-before-copy, $base-uri-after-copy)
+};
+
+declare
+    %test:pending("Each test interferes with each other test, we need to figure out how to have but:tearDown called after every test")
+    %test:assertEquals("/db/but/a/data/test.xml", "/db/but/b/test.xml")
+function but:base-uri-after-resource-move() {
+    let $test-col-a-data-uri := xmldb:create-collection($but:test-col-a-uri, "data")
+    let $doc-path := xmldb:store($test-col-a-data-uri, "test.xml", $but:XML)
+    let $base-uri-before-move := collection($but:test-col-uri)/item/base-uri(.)
+    return
+
+    let $_ := xmldb:move($test-col-a-data-uri, $but:test-col-b-uri, "test.xml")
+    return
+        let $base-uri-after-move := collection($but:test-col-uri)/item/base-uri(.)
+        return
+
+            ($base-uri-before-move, $base-uri-after-move)
+};


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/3040

The `DocumentImpl` caches the URI which is composed of both the Collection URI and Document name. When moving a Collection, the target collection's `DocumentImpl`'s did not have their cached URIs updated correctly.

This is only a problem in 5.x.x which optimised the Collection Move operation.