### PR TITLE
Correctly set the sticky bit when using a simple symbolic mode string

### DIFF
--- a/exist-core/src/main/java/org/exist/security/AbstractUnixStylePermission.java
+++ b/exist-core/src/main/java/org/exist/security/AbstractUnixStylePermission.java
@@ -245,7 +245,7 @@ public abstract class AbstractUnixStylePermission implements Permission {
 
     public static final Pattern UNIX_SYMBOLIC_MODE_PATTERN = Pattern.compile("((?:[augo]*(?:[+\\-=](?:[" + READ_CHAR + SETUID_CHAR + STICKY_CHAR + WRITE_CHAR + EXECUTE_CHAR + "])+)+),?)+");
     public static final Pattern EXIST_SYMBOLIC_MODE_PATTERN = Pattern.compile("(?:(?:" + USER_STRING + "|" + GROUP_STRING + "|" + OTHER_STRING + ")=(?:[+-](?:" + READ_STRING + "|" + WRITE_STRING + "|" + EXECUTE_STRING + "),?)+)+");
-    public static final Pattern SIMPLE_SYMBOLIC_MODE_PATTERN = Pattern.compile("(?:(?:" + READ_CHAR + "|" + UNSET_CHAR + ")(?:" + WRITE_CHAR + "|" + UNSET_CHAR + ")(?:[" + EXECUTE_CHAR + SETUID_CHAR + SETUID_CHAR_NO_EXEC + "]|" + UNSET_CHAR + ")){2}(?:" + READ_CHAR + "|" + UNSET_CHAR + ")(?:" + WRITE_CHAR + "|" + UNSET_CHAR + ")(?:[" + EXECUTE_CHAR + STICKY_CHAR + "]|" + UNSET_CHAR + ")");
+    public static final Pattern SIMPLE_SYMBOLIC_MODE_PATTERN = Pattern.compile("(?:(?:" + READ_CHAR + "|" + UNSET_CHAR + ")(?:" + WRITE_CHAR + "|" + UNSET_CHAR + ")(?:[" + EXECUTE_CHAR + SETUID_CHAR + SETUID_CHAR_NO_EXEC + "]|" + UNSET_CHAR + ")){2}(?:" + READ_CHAR + "|" + UNSET_CHAR + ")(?:" + WRITE_CHAR + "|" + UNSET_CHAR + ")(?:[" + EXECUTE_CHAR + STICKY_CHAR + STICKY_CHAR_NO_EXEC + "]|" + UNSET_CHAR + ")");
 
     /**
      * Note: we don't need @PermissionRequired(user = IS_DBA | IS_OWNER) here
@@ -312,8 +312,12 @@ public abstract class AbstractUnixStylePermission implements Permission {
                         mode |= (EXECUTE << shift);
                     }
                     break;
-                case STICKY:
+                case STICKY_CHAR_NO_EXEC:
+                case STICKY_CHAR:
                     mode |= (STICKY << 9);
+                    if (c == STICKY_CHAR) {
+                        mode |= (EXECUTE << shift);
+                    }
                     break;
 
                 case UNSET_CHAR:

--- a/exist-core/src/test/java/org/exist/security/UnixStylePermissionTest.java
+++ b/exist-core/src/test/java/org/exist/security/UnixStylePermissionTest.java
@@ -536,6 +536,14 @@ public class UnixStylePermissionTest {
         permission = new TestableUnixStylePermissionWithCurrentSubject(mockSecurityManager, ownerId, ownerGroupId, 0);
         permission.setMode("rwxrws---");
         assertEquals(02770, permission.getMode());
+
+        permission = new TestableUnixStylePermissionWithCurrentSubject(mockSecurityManager, ownerId, ownerGroupId, 0);
+        permission.setMode("rwxrwxrwt");
+        assertEquals(01777, permission.getMode());
+
+        permission = new TestableUnixStylePermissionWithCurrentSubject(mockSecurityManager, ownerId, ownerGroupId, 0);
+        permission.setMode("rwxrwxrwT");
+        assertEquals(01776, permission.getMode());
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/3157

Previously when using a simple symbolic mode string for changing permissions, the sticky bit `t` (with execute bit), or `T` (without execute bit) was not recognised. 