### PR TITLE
Fix reporting of Restored Documents when restoring a backup

### DIFF
--- a/exist-core/src/main/java/org/exist/backup/DescriptorResourceCounter.java
+++ b/exist-core/src/main/java/org/exist/backup/DescriptorResourceCounter.java
@@ -1,0 +1,78 @@
+/*
+ * eXist Open Source Native XML Database
+ * Copyright (C) 2001-2020 The eXist-dh Project
+ * http://exist-db.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exist.backup;
+
+import net.jcip.annotations.NotThreadSafe;
+import org.exist.Namespaces;
+import org.exist.util.ExistSAXParserFactory;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+@NotThreadSafe
+public class DescriptorResourceCounter {
+
+    private final static SAXParserFactory saxFactory = ExistSAXParserFactory.getSAXParserFactory();
+    static {
+        saxFactory.setNamespaceAware(true);
+    }
+
+    private final XMLReader xmlReader;
+    private final CounterHandler counterHandler;
+
+    public DescriptorResourceCounter() throws ParserConfigurationException, SAXException {
+        final SAXParser saxParser = saxFactory.newSAXParser();
+        this.xmlReader = saxParser.getXMLReader();
+        this.counterHandler = new CounterHandler();
+
+        xmlReader.setContentHandler(counterHandler);
+    }
+
+    public long count(final InputStream descriptorInputStream) throws IOException, SAXException {
+        xmlReader.parse(new InputSource(descriptorInputStream));
+        final long numberOfFiles = counterHandler.numberOfFiles;
+
+        // reset
+        counterHandler.numberOfFiles = 0;
+        return numberOfFiles;
+    }
+
+    private static class CounterHandler extends DefaultHandler {
+        long numberOfFiles = 0;
+
+        @Override
+        public void startElement(final String uri, final String localName, final String qName, final Attributes attributes) throws SAXException {
+            if (Namespaces.EXIST_NS.equals(uri) && "resource".equals(localName)) {
+                numberOfFiles++;
+            }
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/backup/GuiRestoreServiceTaskListener.java
+++ b/exist-core/src/main/java/org/exist/backup/GuiRestoreServiceTaskListener.java
@@ -101,6 +101,12 @@ public class GuiRestoreServiceTaskListener extends AbstractRestoreServiceTaskLis
     }
 
     @Override
+    public void skipResources(final String message, final long count) {
+        SwingUtilities.invokeLater(() -> dialog.incrementFileCounter(count));
+        super.skipResources(message, count);
+    }
+
+    @Override
     public void processingDescriptor(final String backupDescriptor) {
         SwingUtilities.invokeLater(() -> dialog.setBackup(backupDescriptor));
         super.processingDescriptor(backupDescriptor);

--- a/exist-core/src/main/java/org/exist/backup/GuiRestoreServiceTaskListener.java
+++ b/exist-core/src/main/java/org/exist/backup/GuiRestoreServiceTaskListener.java
@@ -82,6 +82,11 @@ public class GuiRestoreServiceTaskListener extends AbstractRestoreServiceTaskLis
         super.processingDescriptor(backupDescriptor);
     }
 
+    public void enableDismissDialogButton() {
+        dialog.dismissButton.setEnabled(true);
+        dialog.dismissButton.grabFocus();
+    }
+
     public void hideDialog() {
         dialog.setVisible(false);
     }

--- a/exist-core/src/main/java/org/exist/backup/GuiRestoreServiceTaskListener.java
+++ b/exist-core/src/main/java/org/exist/backup/GuiRestoreServiceTaskListener.java
@@ -41,6 +41,18 @@ public class GuiRestoreServiceTaskListener extends AbstractRestoreServiceTaskLis
     }
 
     @Override
+    public void startedZipForTransfer(final long totalUncompressedSize) {
+        dialog.setTotalRestoreUncompressedSize(totalUncompressedSize);
+        super.startedZipForTransfer(totalUncompressedSize);
+    }
+
+    @Override
+    public void startedTransfer(final long transferSize) {
+        dialog.setTotalTransferSize(transferSize);
+        super.startedTransfer(transferSize);
+    }
+
+    @Override
     public void started(final long numberOfFiles) {
         dialog.setTotalNumberOfFiles(numberOfFiles);
         super.started(numberOfFiles);
@@ -70,10 +82,22 @@ public class GuiRestoreServiceTaskListener extends AbstractRestoreServiceTaskLis
     }
 
     @Override
+    public void addedFileToZipForTransfer(final long uncompressedSize) {
+        SwingUtilities.invokeLater(() -> dialog.addedFileToZip(uncompressedSize));
+        super.addedFileToZipForTransfer(uncompressedSize);
+    }
+
+    @Override
+    public void transferred(final long chunkSize) {
+        SwingUtilities.invokeLater(() -> dialog.transferred(chunkSize));
+        super.transferred(chunkSize);
+    }
+
+    @Override
     public void restoredResource(final String resource) {
         SwingUtilities.invokeLater(() -> dialog.setResource(resource));
-        super.restoredResource(resource);
         SwingUtilities.invokeLater(dialog::incrementFileCounter);
+        super.restoredResource(resource);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/backup/Main.java
+++ b/exist-core/src/main/java/org/exist/backup/Main.java
@@ -368,7 +368,7 @@ public class Main {
                 final EXistRestoreService service = (EXistRestoreService) collection.getService("RestoreService", "1.0");
                 service.restore(f.toAbsolutePath().toString(), dbaPassword.orElse(null), listener, overwriteApps);
 
-                listener.hideDialog();
+                listener.enableDismissDialogButton();
 
                 if (JOptionPane.showConfirmDialog(null, "Would you like to rebuild the application repository?\nThis is only necessary if application packages were restored.", "Rebuild App Repository?",
                         JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {

--- a/exist-core/src/main/java/org/exist/backup/Restore.java
+++ b/exist-core/src/main/java/org/exist/backup/Restore.java
@@ -85,8 +85,8 @@ public class Restore {
             while(!descriptors.isEmpty()) {
                 final BackupDescriptor descriptor = descriptors.pop();
                 if (appsToSkip.contains(descriptor.getSymbolicPath())) {
-                    listener.info("Skipping app path " + descriptor.getSymbolicPath() + ". Newer version " +
-                            "is already installed.");
+                    listener.skipResources("Skipping app path " + descriptor.getSymbolicPath() + ". Newer version " +
+                            "is already installed.", descriptor.getNumberOfFiles());
                 } else {
                     final EXistInputSource is = descriptor.getInputSource();
                     is.setEncoding(UTF_8.displayName());

--- a/exist-core/src/main/java/org/exist/backup/RestoreDialog.java
+++ b/exist-core/src/main/java/org/exist/backup/RestoreDialog.java
@@ -226,7 +226,16 @@ public class RestoreDialog extends JDialog {
      * Increment the number of files that are restored and display the value.
      */
     public void incrementFileCounter() {
-        fileCounter++;
+        incrementFileCounter(1);
+    }
+
+    /**
+     * Increment the number of files that are restored and display the value.
+     *
+     * @param step the amount to increment by
+     */
+    public void incrementFileCounter(final long step) {
+        fileCounter += step;
 
         if (totalNumberOfFiles == 0L) {
             progress.setString("N/A");

--- a/exist-core/src/main/java/org/exist/backup/RestoreDialog.java
+++ b/exist-core/src/main/java/org/exist/backup/RestoreDialog.java
@@ -21,6 +21,8 @@ package org.exist.backup;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 
 public class RestoreDialog extends JDialog {
@@ -31,6 +33,7 @@ public class RestoreDialog extends JDialog {
     JTextField resource;
     JTextArea messages;
     JProgressBar progress;
+    JButton dismissButton;
 
     private long totalNumberOfFiles = 0;
     private long fileCounter = 0;
@@ -143,6 +146,16 @@ public class RestoreDialog extends JDialog {
         c.weighty = 1.0;
         grid.setConstraints(scroll, c);
         getContentPane().add(scroll);
+
+        dismissButton = new JButton("Dismiss");
+        dismissButton.setEnabled(false);
+        dismissButton.addActionListener(e -> setVisible(false));
+        c.gridx = 0;
+        c.gridy = 5;
+        c.anchor = GridBagConstraints.CENTER;
+        c.fill = GridBagConstraints.NONE;
+        grid.setConstraints(dismissButton, c);
+        getContentPane().add(dismissButton);
     }
 
     public void setBackup(final String backup) {

--- a/exist-core/src/main/java/org/exist/backup/RestoreDialog.java
+++ b/exist-core/src/main/java/org/exist/backup/RestoreDialog.java
@@ -21,12 +21,12 @@ package org.exist.backup;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.text.DecimalFormat;
 
 
 public class RestoreDialog extends JDialog {
     private static final long serialVersionUID = 3773486348231766907L;
+    private static final DecimalFormat PERCENTAGE_FORMAT = new DecimalFormat("###.##%");
 
     JTextField currentCollection;
     JTextField currentBackup;
@@ -194,9 +194,9 @@ public class RestoreDialog extends JDialog {
         if (totalNumberOfFiles == 0L) {
             progress.setString("N/A");
         } else {
-            final int percentage = (int) (fileCounter * 100 / totalNumberOfFiles);
-            progress.setString(percentage + "%");
-            progress.setValue(percentage);
+            final double percentage = fileCounter / (double)totalNumberOfFiles;
+            progress.setString(PERCENTAGE_FORMAT.format(percentage));
+            progress.setValue((int)(percentage * 100));
         }
     }
 

--- a/exist-core/src/main/java/org/exist/backup/RestoreDialog.java
+++ b/exist-core/src/main/java/org/exist/backup/RestoreDialog.java
@@ -35,6 +35,12 @@ public class RestoreDialog extends JDialog {
     JProgressBar progress;
     JButton dismissButton;
 
+    private long totalRestoreUncompressedSize = 0;
+    private long zippedUncompressedSize = 0;
+
+    private long totalTransferSize = 0;
+    private long transferredSize = 0;
+
     private long totalNumberOfFiles = 0;
     private long fileCounter = 0;
 
@@ -175,20 +181,51 @@ public class RestoreDialog extends JDialog {
         messages.setCaretPosition(messages.getDocument().getLength());
     }
 
+    public void setTotalRestoreUncompressedSize(final long totalRestoreUncompressedSize) {
+        this.totalRestoreUncompressedSize = totalRestoreUncompressedSize;
+    }
+
+    public void setTotalTransferSize(final long totalTransferSize) {
+        this.totalTransferSize = totalTransferSize;
+    }
+
     /**
      *  Set the total number of files in the backup.
      *
-     * @param nr Number of files.
+     * @param totalNumberOfFiles Number of files.
      */
-    public void setTotalNumberOfFiles(final long nr) {
-        totalNumberOfFiles = nr;
+    public void setTotalNumberOfFiles(final long totalNumberOfFiles) {
+        this.totalNumberOfFiles = totalNumberOfFiles;
+    }
+
+    public void addedFileToZip(final long uncompressedSize) {
+        zippedUncompressedSize += uncompressedSize;
+
+        if (totalRestoreUncompressedSize < 0L) {
+            progress.setString("N/A");
+        } else {
+            final double percentage = zippedUncompressedSize / (double)totalRestoreUncompressedSize;
+            progress.setString(PERCENTAGE_FORMAT.format(percentage));
+            progress.setValue((int)(percentage * 100));
+        }
+    }
+
+    public void transferred(final long chunkSize) {
+        transferredSize += chunkSize;
+
+        if (totalTransferSize < 0L) {
+            progress.setString("N/A");
+        } else {
+            final double percentage = transferredSize / (double)totalTransferSize;
+            progress.setString(PERCENTAGE_FORMAT.format(percentage));
+            progress.setValue((int)(percentage * 100));
+        }
     }
 
     /**
      * Increment the number of files that are restored and display the value.
      */
     public void incrementFileCounter() {
-
         fileCounter++;
 
         if (totalNumberOfFiles == 0L) {

--- a/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
@@ -410,8 +410,8 @@ public class RestoreHandler extends DefaultHandler {
         final BackupDescriptor subDescriptor = descriptor.getChildBackupDescriptor(name);
         if(subDescriptor != null) {
             if (pathsToIgnore.contains(subDescriptor.getSymbolicPath())) {
-                listener.info("Skipping app path " + subDescriptor.getSymbolicPath() + ". Newer version " +
-                        "is already installed.");
+                listener.skipResources("Skipping app path " + subDescriptor.getSymbolicPath() + ". Newer version " +
+                        "is already installed.", subDescriptor.getNumberOfFiles());
                 return;
             }
             final XMLReaderPool parserPool = broker.getBrokerPool().getParserPool();

--- a/exist-core/src/main/java/org/exist/backup/restore/listener/AbstractRestoreListener.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/listener/AbstractRestoreListener.java
@@ -42,6 +42,11 @@ public abstract class AbstractRestoreListener implements RestoreListener {
     }
 
     @Override
+    public void skipResources(final String message, final long count) {
+        warn("Skipping " + count + " resources. " + message);
+    }
+
+    @Override
     public void restoredResource(final String resource) {
         info("Restored " + resource);
     }

--- a/exist-core/src/main/java/org/exist/backup/restore/listener/RestoreListener.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/listener/RestoreListener.java
@@ -36,6 +36,8 @@ public interface RestoreListener {
 
     void restoredResource(String resource);
 
+    void skipResources(String message, final long count);
+
     void info(String message);
 
     void warn(String message);

--- a/exist-core/src/main/java/org/exist/client/ClientFrame.java
+++ b/exist-core/src/main/java/org/exist/client/ClientFrame.java
@@ -1133,7 +1133,7 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
                     setStatus(Messages.getString("ClientFrame.226"));
                 }
 
-                listener.hideDialog();
+                listener.enableDismissDialogButton();
 
                 if (properties.getProperty(InteractiveClient.USER, SecurityManager.DBA_USER).equals(SecurityManager.DBA_USER) && dbaPassword != null) {
                     properties.setProperty(InteractiveClient.PASSWORD, dbaPassword);

--- a/exist-core/src/main/java/org/exist/util/FileUtils.java
+++ b/exist-core/src/main/java/org/exist/util/FileUtils.java
@@ -534,7 +534,7 @@ public class FileUtils {
 		};
 	}
 
-	/**
+    /**
      * Provides a humane string describing the number of bytes.
      *
      * @param bytes the number of bytes

--- a/exist-core/src/main/java/org/exist/xmldb/AbstractRestoreServiceTaskListener.java
+++ b/exist-core/src/main/java/org/exist/xmldb/AbstractRestoreServiceTaskListener.java
@@ -75,6 +75,11 @@ public abstract class AbstractRestoreServiceTaskListener implements RestoreServi
     }
 
     @Override
+    public void skipResources(final String message, final long count) {
+        warn("Skipping " + count + " resources. " + message);
+    }
+
+    @Override
     public void finished() {
         info("Finished restore of backup.");
     }

--- a/exist-core/src/main/java/org/exist/xmldb/AbstractRestoreServiceTaskListener.java
+++ b/exist-core/src/main/java/org/exist/xmldb/AbstractRestoreServiceTaskListener.java
@@ -20,7 +20,39 @@
 
 package org.exist.xmldb;
 
+import org.exist.util.FileUtils;
+
 public abstract class AbstractRestoreServiceTaskListener implements RestoreServiceTaskListener {
+
+    @Override
+    public void startedZipForTransfer(final long totalUncompressedSize) {
+        info("Creating Zip of restore data (uncompressed=" + FileUtils.humanSize(totalUncompressedSize)  + ")...");
+    }
+
+    @Override
+    public void addedFileToZipForTransfer(final long uncompressedSize) {
+        //no-op
+    }
+
+    @Override
+    public void finishedZipForTransfer() {
+        info("Finished creating Zip of restore data.");
+    }
+
+    @Override
+    public void startedTransfer(final long transferSize) {
+        info("Transferring restore data to remote server (size=" + FileUtils.humanSize(transferSize)  + ")...");
+    }
+
+    @Override
+    public void transferred(final long chunkSize) {
+        //no-op
+    }
+
+    @Override
+    public void finishedTransfer() {
+        info("Finished transferring restore data to remote server.");
+    }
 
     @Override
     public void started(final long numberOfFiles) {

--- a/exist-core/src/main/java/org/exist/xmldb/LocalRestoreService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalRestoreService.java
@@ -99,6 +99,11 @@ public class LocalRestoreService extends AbstractLocalService implements EXistRe
         }
 
         @Override
+        public void skipResources(final String message, final long count) {
+            restoreListener.skipResources(message, count);
+        }
+
+        @Override
         public void info(final String message) {
             restoreListener.info(message);
         }

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteRestoreService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteRestoreService.java
@@ -155,6 +155,12 @@ public class RemoteRestoreService implements EXistRestoreService {
                         restoreListener.restoredResource(event.substring(1));
                         break;
 
+                    case SKIP_RESOURCES:
+                        final int sep = event.indexOf('@');
+                        final String strCount = event.substring(1, sep);
+                        final String message = event.substring(sep + 1);
+                        restoreListener.skipResources(message, Long.valueOf(strCount));
+
                     case INFO:
                         restoreListener.info(event.substring(1));
                         break;

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteRestoreService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteRestoreService.java
@@ -79,18 +79,18 @@ public class RemoteRestoreService implements EXistRestoreService {
         final String remoteFileName;
         final String backupFileName = FileUtils.fileName(backupPath);
         if (backupFileName.endsWith(".zip")) {
-            remoteFileName = uploadBackupFile(backupPath);
+            remoteFileName = uploadBackupFile(backupPath, restoreListener);
         } else if (Files.isDirectory(backupPath)) {
-            final Path tmpZipFile = zipBackupDir(backupPath);
+            final Path tmpZipFile = zipBackupDir(backupPath, restoreListener);
             try {
-                remoteFileName = uploadBackupFile(tmpZipFile);
+                remoteFileName = uploadBackupFile(tmpZipFile, restoreListener);
             } finally {
                 FileUtils.deleteQuietly(tmpZipFile);
             }
         } else if (backupFileName.equals("__contents__.xml")) {
-            final Path tmpZipFile = zipBackupDir(backupPath.getParent());
+            final Path tmpZipFile = zipBackupDir(backupPath.getParent(), restoreListener);
             try {
-                remoteFileName = uploadBackupFile(tmpZipFile);
+                remoteFileName = uploadBackupFile(tmpZipFile, restoreListener);
             } finally {
                 FileUtils.deleteQuietly(tmpZipFile);
             }
@@ -198,10 +198,14 @@ public class RemoteRestoreService implements EXistRestoreService {
         }
     }
 
-    private String uploadBackupFile(final Path backupZipFile) throws XMLDBException {
+    private String uploadBackupFile(final Path backupZipFile, final RestoreServiceTaskListener restoreListener) throws XMLDBException {
         try {
+            final long backupZipFileSize = Files.size(backupZipFile);
+
+            restoreListener.startedTransfer(backupZipFileSize);
+
             String fileName = null;
-            final byte[] chunk = new byte[(int) Math.min(Files.size(backupZipFile), MAX_UPLOAD_CHUNK)];
+            final byte[] chunk = new byte[(int) Math.min(backupZipFileSize, MAX_UPLOAD_CHUNK)];
             try (final InputStream is = Files.newInputStream(backupZipFile)) {
                 int len = -1;
                 while ((len = is.read(chunk)) > -1) {
@@ -212,8 +216,12 @@ public class RemoteRestoreService implements EXistRestoreService {
                     params.add(chunk);
                     params.add(len);
                     fileName = (String) remoteCallSite.execute("upload", params);
+
+                    restoreListener.transferred(len);
                 }
             }
+
+            restoreListener.finishedTransfer();
 
             return fileName;
         } catch (final IOException e) {
@@ -221,7 +229,8 @@ public class RemoteRestoreService implements EXistRestoreService {
         }
     }
 
-    private Path zipBackupDir(final Path dir) throws XMLDBException {
+    private Path zipBackupDir(final Path dir, final RestoreServiceTaskListener restoreListener) throws XMLDBException {
+        restoreListener.startedZipForTransfer(FileUtils.sizeQuietly(dir));
         try {
             final Path zipFile = Files.createTempFile("remote-restore-service", "zip");
             try (final OutputStream fos = Files.newOutputStream(zipFile);
@@ -231,12 +240,16 @@ public class RemoteRestoreService implements EXistRestoreService {
                     public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
                         final Path zipEntryPath = dir.relativize(file);
                         zos.putNextEntry(new ZipEntry(zipEntryPath.toString()));
-                        Files.copy(file, zos);
+                        final long written = Files.copy(file, zos);
                         zos.closeEntry();
+
+                        restoreListener.addedFileToZipForTransfer(written);
+
                         return FileVisitResult.CONTINUE;
                     }
                 });
             }
+            restoreListener.finishedZipForTransfer();
             return zipFile;
         } catch (final IOException e) {
             throw new XMLDBException(ErrorCodes.VENDOR_ERROR, "Unable to zip backup dir: " + e.getMessage());

--- a/exist-core/src/main/java/org/exist/xmldb/RestoreServiceTaskListener.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RestoreServiceTaskListener.java
@@ -21,6 +21,14 @@
 package org.exist.xmldb;
 
 public interface RestoreServiceTaskListener {
+    void startedZipForTransfer(final long totalUncompressedSize);
+    void addedFileToZipForTransfer(final long uncompressedSize);
+    void finishedZipForTransfer();
+
+    void startedTransfer(final long transferSize);
+    void transferred(final long chunkSize);
+    void finishedTransfer();
+
     void started(long numberOfFiles);
     void processingDescriptor(String backupDescriptor);
     void createdCollection(String collectionUri);

--- a/exist-core/src/main/java/org/exist/xmldb/RestoreServiceTaskListener.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RestoreServiceTaskListener.java
@@ -33,6 +33,7 @@ public interface RestoreServiceTaskListener {
     void processingDescriptor(String backupDescriptor);
     void createdCollection(String collectionUri);
     void restoredResource(String resourceUri);
+    void skipResources(String message, long count);
 
     void info(String message);
     void warn(String message);

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcAPI.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcAPI.java
@@ -1003,6 +1003,7 @@ public interface RpcAPI {
         PROCESSING_DESCRIPTOR('2'),
         CREATED_COLLECTION('3'),
         RESTORED_RESOURCE('4'),
+        SKIP_RESOURCES('9'),
         INFO('5'),
         WARN('6'),
         ERROR('7'),

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -19,7 +19,6 @@
  */
 package org.exist.xmlrpc;
 
-import com.evolvedbinary.j8fu.lazy.LazyVal;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.backup.Restore;
@@ -3737,6 +3736,12 @@ public class RpcConnection implements RpcAPI {
         @Override
         public void restoredResource(final String resource) {
             add(RestoreTaskEvent.RESTORED_RESOURCE, resource);
+        }
+
+        @Override
+        public void skipResources(final String message, final long count) {
+            final String strCount = Long.toString(count);
+            add(RestoreTaskEvent.SKIP_RESOURCES, strCount + '@' + message);
         }
 
         @Override

--- a/exist-core/src/test/java/org/exist/backup/RestoreAppsTest.java
+++ b/exist-core/src/test/java/org/exist/backup/RestoreAppsTest.java
@@ -194,10 +194,10 @@ public class RestoreAppsTest {
             restore.restore(broker, transaction, null, backup, listener, false);
 
             if (expectedMessage != null) {
-                assertEquals(1, listener.info.size());
-                assertTrue(listener.info.get(0).endsWith(expectedMessage));
+                assertEquals(1, listener.skipped.size());
+                assertTrue(listener.skipped.get(0).endsWith(expectedMessage));
             } else {
-                assertEquals(0, listener.info.size());
+                assertEquals(0, listener.skipped.size());
             }
         }
         existEmbeddedServer.restart(true);
@@ -266,6 +266,7 @@ public class RestoreAppsTest {
     class TestRestoreListener implements RestoreListener {
 
         private List<String> info = new ArrayList<>();
+        private List<String> skipped = new ArrayList<>();
 
         @Override
         public void started(long numberOfFiles) {
@@ -285,6 +286,11 @@ public class RestoreAppsTest {
         @Override
         public void restoredResource(String resource) {
             // unused
+        }
+
+        @Override
+        public void skipResources(String message, long count) {
+            skipped.add(message);
         }
 
         @Override


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/3024

* Allow the user to see the result of the restore process before dismissing the restore dialog.
* Improve/correct percentage display in Restore Dialog.
* Make sure to report Zip and Transfer process when restoring backups to a remote server, otherwise to the user the restore process can appear to be doing nothing.
* Get the correct total of files to be restored
* When skipping packages during restore (due to newer version), skipped documents must be counted too (for progress)