### PR TITLE
Fix restoring folder backups on Windows via XML:RPC

### DIFF
--- a/exist-core/src/main/java/org/exist/util/FileUtils.java
+++ b/exist-core/src/main/java/org/exist/util/FileUtils.java
@@ -553,4 +553,15 @@ public class FileUtils {
             return bytes + " bytes";
         }
     }
+
+    /**
+     * Replaces any Windows path separators with Unix path separators.
+     *
+     * @param pathString a path string
+     *
+     * @return the updated path string
+     */
+    public static String withUnixSep(final String pathString) {
+        return pathString.replace('\\', '/');
+    }
 }

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteRestoreService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteRestoreService.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static org.exist.util.FileUtils.withUnixSep;
 import static org.exist.xmldb.RemoteCollection.MAX_UPLOAD_CHUNK;
 
 public class RemoteRestoreService implements EXistRestoreService {
@@ -245,7 +246,8 @@ public class RemoteRestoreService implements EXistRestoreService {
                     @Override
                     public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
                         final Path zipEntryPath = dir.relativize(file);
-                        zos.putNextEntry(new ZipEntry(zipEntryPath.toString()));
+                        final String zipEntryName = withUnixSep(zipEntryPath.toString());
+                        zos.putNextEntry(new ZipEntry(zipEntryName));
                         final long written = Files.copy(file, zos);
                         zos.closeEntry();
 


### PR DESCRIPTION
When restoring a backup folder via XML:RPC on Windows, the restore on the server-side failed. This was due to the Zip file which is transferred over XML:RPC containing `\` path separators, and the server expecting it to contain `/` path separators.

Closes https://github.com/eXist-db/exist/issues/3196
