### PR TITLE
 fn:concat requires an arity of at least two when making a function reference

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/NamedFunctionReference.java
+++ b/exist-core/src/main/java/org/exist/xquery/NamedFunctionReference.java
@@ -32,6 +32,12 @@ public class NamedFunctionReference extends AbstractExpression {
 	}
 
 	public static FunctionCall lookupFunction(Expression self, XQueryContext context, QName funcName, int arity) throws XPathException {
+		if (Function.BUILTIN_FUNCTION_NS.equals(funcName.getNamespaceURI())
+				&& "concat".equals(funcName.getLocalPart())
+				&& arity < 2) {
+			throw new XPathException(self, ErrorCodes.XPST0017, "No such function; fn:concat requires at least two arguments");
+		}
+
 		final XQueryAST ast = new XQueryAST();
 		ast.setLine(self.getLine());
 		ast.setColumn(self.getColumn());

--- a/exist-core/src/test/xquery/xquery3/fnRefs.xql
+++ b/exist-core/src/test/xquery/xquery3/fnRefs.xql
@@ -12,3 +12,23 @@ function fnRefs:castFunctionReference() {
     return
         $as-uri("/db")
 };
+
+declare
+    %test:assertError("err:XPST0017")
+function fnRefs:concat-arity0() {
+    fn:concat#0
+};
+
+declare
+    %test:assertError("err:XPST0017")
+function fnRefs:concat-arity1() {
+    fn:concat#1
+};
+
+declare
+    %test:assertEquals(1)
+function fnRefs:concat-arity2() {
+    count(
+        fn:concat#2
+    )
+};


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/1467
