### PR TITLE
Docker HEALTHCHECK should use `guest` account not `admin`

### DIFF
--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -70,7 +70,9 @@ ENV JAVA_TOOL_OPTIONS \
 
 HEALTHCHECK CMD [ "java", \
     "org.exist.start.Main", "client", \
-    "--no-gui",  "--xpath", "system:get-version()" ]
+    "--no-gui",  \
+    "--user", "guest", "--password", "guest", \
+    "--xpath", "system:get-version()" ]
 
 ENTRYPOINT [ "java", \
     "org.exist.start.Main", "jetty" ]


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/3165

Previously the Docker HEALTHCHECK command would use the `admin` account to query the server. As @ambs pointed out, every sensible user is going to change the `admin` password, which means they then need to create custom Docker images. Instead, we now use the `guest` account by default which is unlikely to change.