### PR TITLE
Take the XQJ API dependency from Maven Central

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -162,8 +162,8 @@
 
         <dependency>
             <groupId>org.exist-db.thirdparty.javax.xml.xquery</groupId>
-            <artifactId>xqjapi</artifactId>
-            <version>1.0-fr</version>
+            <artifactId>xqjri</artifactId>
+            <version>20080114-133351</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
We published the offical XQJ RI to Maven Central. So we can now use that instead of our custom build on repo.evolvedbinary.com