### PR TITLE
Fix renaming a Collection

### DIFF
--- a/exist-core/src/main/java/org/exist/client/ClientFrame.java
+++ b/exist-core/src/main/java/org/exist/client/ClientFrame.java
@@ -834,15 +834,21 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
             try {
                 final EXistCollectionManagementService service = (EXistCollectionManagementService)
                         client.current.getService("CollectionManagementService", "1.0"); //$NON-NLS-1$ //$NON-NLS-2$
-                for (ResourceDescriptor re : res) {
-                    setStatus(Messages.getString("ClientFrame.124") + re.getName() + Messages.getString("ClientFrame.125") + destinationFilename + Messages.getString("ClientFrame.126")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                    if (re.isCollection()) {
-                        service.move(re.getName(), null, destinationFilename);
-                    } else {
-                        service.moveResource(re.getName(), null, destinationFilename);
+                boolean changed = false;
+                for (final ResourceDescriptor re : res) {
+                    if (!re.getName().equals(destinationFilename)) {
+                        setStatus(Messages.getString("ClientFrame.124") + re.getName() + Messages.getString("ClientFrame.125") + destinationFilename + Messages.getString("ClientFrame.126")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                        if (re.isCollection()) {
+                            service.move(re.getName(), null, destinationFilename);
+                        } else {
+                            service.moveResource(re.getName(), null, destinationFilename);
+                        }
+                        changed = true;
                     }
                 }
-                client.reloadCollection();
+                if (changed) {
+                    client.reloadCollection();
+                }
             } catch (final XMLDBException e) {
                 showErrorMessage(e.getMessage(), e);
             }

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -1555,12 +1555,12 @@ public class NativeBroker extends DBBroker {
         for(final Iterator<XmldbURI> i = sourceCollection.collectionIteratorNoLock(this); i.hasNext(); ) {  // NOTE: we already have a WRITE lock on sourceCollection
             final XmldbURI childName = i.next();
             final XmldbURI childUri = sourceCollectionUri.append(childName);
-            try(final Collection child = getCollection(childUri)) {        // NOTE: we already have a WRITE lock on child
-                if (child == null) {
-                    throw new IOException("Child collection " + childUri + " not found");
-                } else {
-                    moveCollectionRecursive(transaction, trigger, null, child, sourceCollection, childName, true);
-                }
+
+            final Collection child = getCollectionForOpen(collectionsCache, childUri);        // NOTE: we have a write lock on the sourceCollection, which means we don't need to lock sub-collections in the tree
+            if (child == null) {
+                throw new IOException("Child collection " + childUri + " not found");
+            } else {
+                moveCollectionRecursive(transaction, trigger, null, child, sourceCollection, childName, true);
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/xmldb/EXistCollectionManagementService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/EXistCollectionManagementService.java
@@ -25,6 +25,8 @@ import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.CollectionManagementService;
 
+import javax.annotation.Nullable;
+
 
 /**
  * Extends the {@link org.xmldb.api.modules.CollectionManagementService}
@@ -36,18 +38,18 @@ import org.xmldb.api.modules.CollectionManagementService;
 public interface EXistCollectionManagementService extends CollectionManagementService {
 
     /**
-     * Move a Collection.
+     * Move and/or rename a Collection.
      *
-     * @param collection the source collection.
-     * @param destination the destination collection.
-     * @param newName the new name in the destination collection.
-     *
-     * @deprecated Use XmldbURI version instead.
+     * @param collectionName name of the collection to move/rename
+     * @param destination the destination collection, or null if just renaming
+     * @param newName the new name, or null if just moving
+
+     * @deprecated Use {@link #move(XmldbURI, XmldbURI, XmldbURI)} instead.
      *
      * @throws XMLDBException if an error occurs when moving the collection.
      */
     @Deprecated
-    void move(String collection, String destination, String newName) throws XMLDBException;
+    void move(String collectionName, @Nullable String destination, @Nullable String newName) throws XMLDBException;
 
     /**
      * Move a Resource.
@@ -106,7 +108,14 @@ public interface EXistCollectionManagementService extends CollectionManagementSe
     @Deprecated
     Collection createCollection(String collName, Date created) throws XMLDBException;
 
-    void move(XmldbURI collection, XmldbURI destination, XmldbURI newName) throws XMLDBException;
+    /**
+     * Move and/or rename a Collection.
+     *
+     * @param collectionName name of the collection to move/rename
+     * @param destination the destination collection, or null if just renaming
+     * @param newName the new name, or null if just moving
+     */
+    void move(XmldbURI collectionName, @Nullable XmldbURI destination, @Nullable XmldbURI newName) throws XMLDBException;
 
     void moveResource(XmldbURI resourcePath, XmldbURI destinationPath, XmldbURI newName) throws XMLDBException;
 

--- a/exist-core/src/main/java/org/exist/xmldb/LocalCollectionManagementService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalCollectionManagementService.java
@@ -39,6 +39,8 @@ import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.XMLDBException;
 
+import javax.annotation.Nullable;
+
 public class LocalCollectionManagementService extends AbstractLocalService implements EXistCollectionManagementService {
 
     public LocalCollectionManagementService(final Subject user, final BrokerPool pool, final LocalCollection parent) {
@@ -114,16 +116,20 @@ public class LocalCollectionManagementService extends AbstractLocalService imple
     }
 
     @Override
-    public void move(final String collectionPath, final String destinationPath, final String newName) throws XMLDBException {
+    public void move(final String collectionPath, @Nullable final String destinationPath, @Nullable final String newName) throws XMLDBException {
     	try{
-    		move(XmldbURI.xmldbUriFor(collectionPath), XmldbURI.xmldbUriFor(destinationPath), XmldbURI.xmldbUriFor(newName));
+    		move(
+    		        XmldbURI.xmldbUriFor(collectionPath),
+                    destinationPath != null ? XmldbURI.xmldbUriFor(destinationPath) : null,
+                    newName != null ? XmldbURI.xmldbUriFor(newName) : null
+            );
     	} catch(final URISyntaxException e) {
     		throw new XMLDBException(ErrorCodes.INVALID_URI,e);
     	}
     }
 
     @Override
-    public void move(final XmldbURI src, final XmldbURI dest, final XmldbURI name) throws XMLDBException {
+    public void move(final XmldbURI src, @Nullable final XmldbURI dest, @Nullable final XmldbURI name) throws XMLDBException {
     	final XmldbURI srcPath = resolve(src);
     	final XmldbURI destPath = dest == null ? srcPath.removeLastSegment() : resolve(dest);
         final XmldbURI newName;

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteCollectionManagementService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteCollectionManagementService.java
@@ -31,6 +31,8 @@ import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.XMLDBException;
 
+import javax.annotation.Nullable;
+
 
 public class RemoteCollectionManagementService extends AbstractRemote implements EXistCollectionManagementService {
 
@@ -144,9 +146,13 @@ public class RemoteCollectionManagementService extends AbstractRemote implements
      */
     @Deprecated
     @Override
-    public void move(final String collectionPath, final String destinationPath, final String newName) throws XMLDBException {
+    public void move(final String collectionPath, @Nullable final String destinationPath, @Nullable final String newName) throws XMLDBException {
         try {
-            move(XmldbURI.xmldbUriFor(collectionPath), XmldbURI.xmldbUriFor(destinationPath), XmldbURI.xmldbUriFor(newName));
+            move(
+                    XmldbURI.xmldbUriFor(collectionPath),
+                    destinationPath != null ? XmldbURI.xmldbUriFor(destinationPath) : null,
+                    newName != null ? XmldbURI.xmldbUriFor(newName) : null
+            );
         } catch (final URISyntaxException e) {
             throw new XMLDBException(ErrorCodes.INVALID_URI, e);
         }
@@ -154,7 +160,7 @@ public class RemoteCollectionManagementService extends AbstractRemote implements
 
     @Deprecated
     @Override
-    public void move(final XmldbURI src, final XmldbURI dest, final XmldbURI name) throws XMLDBException {
+    public void move(final XmldbURI src, @Nullable final XmldbURI dest, @Nullable final XmldbURI name) throws XMLDBException {
         final XmldbURI srcPath = resolve(src);
         final XmldbURI destPath = dest == null ? srcPath.removeLastSegment() : resolve(dest);
         final XmldbURI newName;

--- a/exist-core/src/test/java/org/exist/xmldb/DeleteCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/DeleteCollectionTest.java
@@ -1,0 +1,114 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xmldb;
+
+import org.exist.TestUtils;
+import org.exist.test.ExistWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+
+import java.util.Arrays;
+
+import static com.ibm.icu.impl.Assert.fail;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class DeleteCollectionTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+    private static final String PORT_PLACEHOLDER = "${PORT}";
+
+    @Parameterized.Parameters(name = "{0}")
+    public static java.util.Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "local", "xmldb:exist://" },
+                { "remote", "xmldb:exist://localhost:" + PORT_PLACEHOLDER + "/xmlrpc" }
+        });
+    }
+
+    @Parameterized.Parameter
+    public String apiName;
+
+    @Parameterized.Parameter(value = 1)
+    public String baseUri;
+
+    private static final String TEST_COLLECTION_NAME = "testDelete";
+    private static final String ZERO_COLLECTION_NAME = "00";
+    private static final String ONE_COLLECTION_NAME = "11";
+    private static final String THREE_COLLECTION_NAME = "33";
+    private Collection testCollection;
+
+    private final String getBaseUri() {
+        return baseUri.replace(PORT_PLACEHOLDER, Integer.toString(existWebServer.getPort()));
+    }
+
+    @Test
+    public void delete() throws XMLDBException {
+        /*
+         * Create the collections:
+         *
+         * /db/testDelete/00
+         * /db/testDelete/11
+         * /db/testDelete/00/33
+         */
+        EXistCollectionManagementService service = (EXistCollectionManagementService) testCollection.getService("CollectionManagementService", "1.0");
+        final Collection zeroCollection = service.createCollection(ZERO_COLLECTION_NAME);
+        assertNotNull(zeroCollection);
+
+        final Collection oneCollection = service.createCollection(ONE_COLLECTION_NAME);
+        assertNotNull(oneCollection);
+
+        service = (EXistCollectionManagementService) zeroCollection.getService("CollectionManagementService", "1.0");
+        final Collection threeCollection = service.createCollection(THREE_COLLECTION_NAME);
+        assertNotNull(threeCollection);
+
+        // delete the collection /db/test/00
+        service = (EXistCollectionManagementService) testCollection.getService("CollectionManagementService", "1.0");
+        service.removeCollection(ZERO_COLLECTION_NAME);
+    }
+
+    @Before
+    public void setUp() throws XMLDBException {
+        final Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        testCollection = service.createCollection(TEST_COLLECTION_NAME);
+        assertNotNull(testCollection);
+    }
+
+    @After
+    public void tearDown() throws XMLDBException {
+        final Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        service.removeCollection(TEST_COLLECTION_NAME);
+        testCollection = null;
+    }
+}

--- a/exist-core/src/test/java/org/exist/xmldb/MoveCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/MoveCollectionTest.java
@@ -1,0 +1,118 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xmldb;
+
+import org.exist.TestUtils;
+import org.exist.test.ExistWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(Parameterized.class)
+public class MoveCollectionTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+    private static final String PORT_PLACEHOLDER = "${PORT}";
+
+    @Parameterized.Parameters(name = "{0}")
+    public static java.util.Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "local", "xmldb:exist://" },
+                { "remote", "xmldb:exist://localhost:" + PORT_PLACEHOLDER + "/xmlrpc" }
+        });
+    }
+
+    @Parameterized.Parameter
+    public String apiName;
+
+    @Parameterized.Parameter(value = 1)
+    public String baseUri;
+
+    private static final String TEST_COLLECTION_NAME = "testMove";
+    private static final String ZERO_COLLECTION_NAME = "0";
+    private static final String ONE_COLLECTION_NAME = "1";
+    private static final String X_COLLECTION_NAME = "X";
+    private static final String Y_COLLECTION_NAME = "Y";
+    private Collection testCollection;
+
+    private final String getBaseUri() {
+        return baseUri.replace(PORT_PLACEHOLDER, Integer.toString(existWebServer.getPort()));
+    }
+
+    @Test
+    public void move() throws XMLDBException {
+        /*
+         * Create the collections:
+         *
+         * /db/testMove/0
+         * /db/testMove/1
+         * /db/testMove/0/X
+         * /db/testMove/0/X/Y
+         */
+        EXistCollectionManagementService service = (EXistCollectionManagementService) testCollection.getService("CollectionManagementService", "1.0");
+        final Collection zeroCollection = service.createCollection(ZERO_COLLECTION_NAME);
+        assertNotNull(zeroCollection);
+
+        final Collection oneCollection = service.createCollection(ONE_COLLECTION_NAME);
+        assertNotNull(oneCollection);
+
+        service = (EXistCollectionManagementService) zeroCollection.getService("CollectionManagementService", "1.0");
+        final Collection xCollection = service.createCollection(X_COLLECTION_NAME);
+        assertNotNull(xCollection);
+
+        service = (EXistCollectionManagementService) xCollection.getService("CollectionManagementService", "1.0");
+        final Collection yCollection = service.createCollection(Y_COLLECTION_NAME);
+        assertNotNull(yCollection);
+
+        // move the collection /db/testMove/0/X to /db/testMove/1
+        service = (EXistCollectionManagementService) zeroCollection.getService("CollectionManagementService", "1.0");
+        service.move(XmldbURI.create(X_COLLECTION_NAME), XmldbURI.create(oneCollection.getName()), null);
+    }
+
+    @Before
+    public void setUp() throws XMLDBException {
+        final Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        testCollection = service.createCollection(TEST_COLLECTION_NAME);
+        assertNotNull(testCollection);
+    }
+
+    @After
+    public void tearDown() throws XMLDBException {
+        final Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        service.removeCollection(TEST_COLLECTION_NAME);
+        testCollection = null;
+    }
+}

--- a/exist-core/src/test/java/org/exist/xmldb/RenameCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/RenameCollectionTest.java
@@ -1,0 +1,149 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xmldb;
+
+import org.exist.TestUtils;
+import org.exist.test.ExistWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+
+import java.util.Arrays;
+
+import static com.ibm.icu.impl.Assert.fail;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class RenameCollectionTest {
+
+    @ClassRule
+    public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+    private static final String PORT_PLACEHOLDER = "${PORT}";
+
+    @Parameterized.Parameters(name = "{0}")
+    public static java.util.Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "local", "xmldb:exist://" },
+                { "remote", "xmldb:exist://localhost:" + PORT_PLACEHOLDER + "/xmlrpc" }
+        });
+    }
+
+    @Parameterized.Parameter
+    public String apiName;
+
+    @Parameterized.Parameter(value = 1)
+    public String baseUri;
+
+    private static final String TEST_COLLECTION_NAME = "testRename";
+    private static final String ZERO_COLLECTION_NAME = "0";
+    private static final String ONE_COLLECTION_NAME = "1";
+    private static final String THREE_COLLECTION_NAME = "3";
+    private Collection testCollection;
+
+    private final String getBaseUri() {
+        return baseUri.replace(PORT_PLACEHOLDER, Integer.toString(existWebServer.getPort()));
+    }
+
+    @Test
+    public void rename_sameName() throws XMLDBException {
+        /*
+         * Create the collections:
+         *
+         * /db/testRename/0
+         * /db/testRename/1
+         * /db/testRename/0/3
+         */
+        EXistCollectionManagementService service = (EXistCollectionManagementService) testCollection.getService("CollectionManagementService", "1.0");
+        final Collection zeroCollection = service.createCollection(ZERO_COLLECTION_NAME);
+        assertNotNull(zeroCollection);
+
+        final Collection oneCollection = service.createCollection(ONE_COLLECTION_NAME);
+        assertNotNull(oneCollection);
+
+        service = (EXistCollectionManagementService) zeroCollection.getService("CollectionManagementService", "1.0");
+        final Collection threeCollection = service.createCollection(THREE_COLLECTION_NAME);
+        assertNotNull(threeCollection);
+
+        // rename the collection /db/testRename/0 to /db/testRename/zero
+        service = (EXistCollectionManagementService) testCollection.getService("CollectionManagementService", "1.0");
+
+        try {
+            service.move(XmldbURI.create(ZERO_COLLECTION_NAME), null, XmldbURI.create(ZERO_COLLECTION_NAME));
+
+            fail("It should be impossible to rename a collection to the same name");
+
+        } catch (final XMLDBException e) {
+            assertTrue(e.getMessage().indexOf("Cannot move collection to itself") > -1);
+        }
+    }
+
+    @Test
+    public void rename_differentName() throws XMLDBException {
+        /*
+         * Create the collections:
+         *
+         * /db/test/0
+         * /db/test/1
+         * /db/test/0/3
+         */
+        EXistCollectionManagementService service = (EXistCollectionManagementService) testCollection.getService("CollectionManagementService", "1.0");
+        final Collection zeroCollection = service.createCollection(ZERO_COLLECTION_NAME);
+        assertNotNull(zeroCollection);
+
+        final Collection oneCollection = service.createCollection(ONE_COLLECTION_NAME);
+        assertNotNull(oneCollection);
+
+        service = (EXistCollectionManagementService) zeroCollection.getService("CollectionManagementService", "1.0");
+        final Collection threeCollection = service.createCollection(THREE_COLLECTION_NAME);
+        assertNotNull(threeCollection);
+
+        // rename the collection /db/test/0 to /db/test/zero
+        service = (EXistCollectionManagementService) testCollection.getService("CollectionManagementService", "1.0");
+
+        final XmldbURI newName = XmldbURI.create("zero");
+        service.move(XmldbURI.create(ZERO_COLLECTION_NAME), null, newName);
+    }
+
+    @Before
+    public void setUp() throws XMLDBException {
+        final Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        testCollection = service.createCollection(TEST_COLLECTION_NAME);
+        assertNotNull(testCollection);
+    }
+
+    @After
+    public void tearDown() throws XMLDBException {
+        final Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final CollectionManagementService service = (CollectionManagementService) root.getService("CollectionManagementService", "1.0");
+        service.removeCollection(TEST_COLLECTION_NAME);
+        testCollection = null;
+    }
+}


### PR DESCRIPTION
Renaming a Collection without moving it was broken in 5.2.0, this is due to a partial regression in an earlier security fix - 4897cc2

Closes https://github.com/eXist-db/exist/issues/3310