### PR TITLE
Fix EXPath XAR required eXist-db version calculation

### DIFF
--- a/exist-core/src/main/java/org/exist/repo/ClasspathHelper.java
+++ b/exist-core/src/main/java/org/exist/repo/ClasspathHelper.java
@@ -47,9 +47,6 @@ public class ClasspathHelper implements BrokerPoolService {
 
     private final static Logger LOG = LogManager.getLogger(ClasspathHelper.class);
 
-    // if no eXist version is specified in the expath-pkg.xml, we assume it is 2.2 or older
-    private final static PackageLoader.Version DEFAULT_VERSION = new PackageLoader.Version("1.4.0", "2.2.1");
-
     @Override
     public void prepare(final BrokerPool brokerPool) {
         final ClassLoader loader = brokerPool.getClassLoader();
@@ -110,7 +107,7 @@ public class ClasspathHelper implements BrokerPoolService {
         // determine the eXist-db version this package is compatible with
         final Collection<ProcessorDependency> processorDeps = pkg.getProcessorDeps();
         final String procVersion = SystemProperties.getInstance().getSystemProperty("product-version", "1.0");
-        PackageLoader.Version requiresExistVersion = DEFAULT_VERSION;
+        PackageLoader.Version requiresExistVersion = null;
         for (final ProcessorDependency dependency: processorDeps) {
             if (Deployment.PROCESSOR_NAME.equals(dependency.getProcessor())) {
                 if (dependency.getSemver() != null) {
@@ -123,7 +120,11 @@ public class ClasspathHelper implements BrokerPoolService {
                 break;
             }
         }
-        return requiresExistVersion.getDependencyVersion().isCompatible(procVersion);
+        if (requiresExistVersion == null) {
+            return true;
+        } else {
+            return requiresExistVersion.getDependencyVersion().isCompatible(procVersion);
+        }
     }
 
     private static void scanPackageDir(Classpath classpath, Path module) throws IOException {

--- a/exist-core/src/main/java/org/exist/repo/ClasspathHelper.java
+++ b/exist-core/src/main/java/org/exist/repo/ClasspathHelper.java
@@ -51,7 +51,7 @@ public class ClasspathHelper implements BrokerPoolService {
     private final static PackageLoader.Version DEFAULT_VERSION = new PackageLoader.Version("1.4.0", "2.2.1");
 
     @Override
-    public void prepare(final BrokerPool brokerPool) throws BrokerPoolServiceException {
+    public void prepare(final BrokerPool brokerPool) {
         final ClassLoader loader = brokerPool.getClassLoader();
         if (!(loader instanceof EXistClassLoader)) {
             return;
@@ -106,24 +106,24 @@ public class ClasspathHelper implements BrokerPoolService {
         }
     }
 
-    private static boolean isCompatible(Package pkg) throws PackageException {
+    private static boolean isCompatible(final Package pkg) throws PackageException {
         // determine the eXist-db version this package is compatible with
         final Collection<ProcessorDependency> processorDeps = pkg.getProcessorDeps();
         final String procVersion = SystemProperties.getInstance().getSystemProperty("product-version", "1.0");
-        PackageLoader.Version processorVersion = DEFAULT_VERSION;
-        for (ProcessorDependency dependency: processorDeps) {
+        PackageLoader.Version requiresExistVersion = DEFAULT_VERSION;
+        for (final ProcessorDependency dependency: processorDeps) {
             if (Deployment.PROCESSOR_NAME.equals(dependency.getProcessor())) {
                 if (dependency.getSemver() != null) {
-                    processorVersion = new PackageLoader.Version(dependency.getSemver(), true);
+                    requiresExistVersion = new PackageLoader.Version(dependency.getSemver(), true);
                 } else if (dependency.getSemverMax() != null || dependency.getSemverMin() != null) {
-                    processorVersion = new PackageLoader.Version(dependency.getSemverMin(), dependency.getSemverMax());
+                    requiresExistVersion = new PackageLoader.Version(dependency.getSemverMin(), dependency.getSemverMax());
                 } else if (dependency.getVersions() != null) {
-                    processorVersion = new PackageLoader.Version(dependency.getVersions(), false);
+                    requiresExistVersion = new PackageLoader.Version(dependency.getVersions(), false);
                 }
                 break;
             }
         }
-        return processorVersion.getDependencyVersion().isCompatible(procVersion);
+        return requiresExistVersion.getDependencyVersion().isCompatible(procVersion);
     }
 
     private static void scanPackageDir(Classpath classpath, Path module) throws IOException {


### PR DESCRIPTION
If a XAR does not specify that it requires a specific version of eXist-db. Then do not enforce eXist-db version 1.4.0 to 2.2.1. That doesn't make sense, as some packages e.g. functx, don't have a dependency on eXIst-db.

@wolfgangmm just want to check this one with you...