### PR TITLE
Fix  polluted context when dynamically compiling query

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -46,7 +46,7 @@ public class FunctionFactory {
         try {
             qname = QName.parse(context, ast.getText(), context.getDefaultFunctionNamespace());
         } catch(final QName.IllegalQNameException xpe) {
-            throw new XPathException(parent, ErrorCodes.XPST0081, "Invalid qname " +  ast.getText() + ". " + xpe.getMessage());
+            throw new XPathException(ast, ErrorCodes.XPST0081, "Invalid qname " +  ast.getText() + ". " + xpe.getMessage());
         }
         return createFunction(context, qname, ast, parent, params);
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Compile.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Compile.java
@@ -120,7 +120,6 @@ public class Compile extends BasicFunction {
 		
 		final XQueryContext pContext = 
 			new XQueryContext(context.getBroker().getBrokerPool());
-		
 		if (getArgumentCount() == 2 && args[1].hasOne()) {
 			pContext.setModuleLoadPath(args[1].getStringValue());
 		}
@@ -138,9 +137,7 @@ public class Compile extends BasicFunction {
 			final AST ast = parser.getAST();
 			
 			final PathExpr path = new PathExpr(pContext);
-			path.add(this);
-
-			astParser.xpath(ast, this);
+			astParser.xpath(ast, path);
 			if(astParser.foundErrors()) {
 				throw astParser.getLastException();
 			}

--- a/exist-core/src/test/xquery/errors.xql
+++ b/exist-core/src/test/xquery/errors.xql
@@ -139,3 +139,60 @@ function et:nl-in-comment() {
         $err:line-number
     }
 };
+
+declare 
+    %test:assertXPath("/error[@line='2'][contains(., 'Invalid qname console:log')]")
+function et:compile-query-unknown-func() {
+    let $query := ``[
+        console:log('foo')
+    ]``
+    return
+        util:compile-query($query, "xmldb:exist://")
+};
+
+declare 
+    %test:assertXPath("/self::info[@result='pass']")
+function et:compile-query-variable-decl-pass() {
+    let $query := ``[
+        declare variable $v := map {
+            "a": "b",
+            "f": function() {
+                ()
+            }
+        };
+        $v?f()
+    ]``
+    return
+        util:compile-query($query, "xmldb:exist://")
+};
+
+(: Should not result in an NPE, see https://github.com/eXist-db/exist/pull/1520#issuecomment-604514099 :)
+declare 
+    %test:assertXPath("/error[@line='5'][contains(., 'Invalid qname console:log')]")
+function et:compile-query-variable-decl() {
+    let $query := ``[
+        declare variable $v := map {
+            "a": "b",
+            "f": function() {
+                console:log('foo')
+            }
+        };
+        $v?f()
+    ]``
+    return
+        util:compile-query($query, "xmldb:exist://")
+};
+
+declare 
+    %test:assertXPath("/error[@line='6'][contains(., 'local:test')]")
+function et:compile-query-func-decl() {
+    let $query := ``[
+        declare function local:test($x) {
+            $x
+        };
+
+        local:test(123, 345)
+    ]``
+    return
+        util:compile-query($query, "xmldb:exist://")
+};


### PR DESCRIPTION
#3265 introduced an NPE in the `analyze` chain by adding the calling expression (which has a different context!) to the path expression passed to the parser. See the discussion in https://github.com/eXist-db/exist/pull/1520#issuecomment-604084477.

This PR fixes the original issue #1583 without polluting the context and reports the correct line numbers for errors. Some tests were added as well.