### PR TITLE
Fix an issue with Java equality of DLN

### DIFF
--- a/exist-core/src/main/java/org/exist/numbering/DLN.java
+++ b/exist-core/src/main/java/org/exist/numbering/DLN.java
@@ -315,11 +315,6 @@ public class DLN extends DLNBase implements NodeId {
     }
 
     @Override
-    public boolean equals(final NodeId other) {
-        return super.equals((DLNBase) other);
-    }
-
-    @Override
     public int compareTo(final NodeId otherId) {
         if(otherId == null) {
             return 1;

--- a/exist-core/src/main/java/org/exist/numbering/DLNBase.java
+++ b/exist-core/src/main/java/org/exist/numbering/DLNBase.java
@@ -479,7 +479,16 @@ public class DLNBase {
         return (int) Math.ceil(units / 8.0);
     }
 
-    public boolean equals(final DLNBase other) {
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof DLNBase)) {
+            return false;
+        }
+
+        final DLNBase other = (DLNBase) o;
         if (bitIndex != other.bitIndex) {
             return false;
         }

--- a/exist-core/src/main/java/org/exist/numbering/NodeId.java
+++ b/exist-core/src/main/java/org/exist/numbering/NodeId.java
@@ -177,8 +177,6 @@ public interface NodeId extends Comparable<NodeId> {
 
     int compareTo(NodeId other);
 
-    boolean equals(NodeId other);
-
     /**
      * Returns the size (in bytes) of this node id. Depends on
      * the concrete implementation.

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/GetFragmentBetween.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/GetFragmentBetween.java
@@ -71,15 +71,16 @@ public class GetFragmentBetween extends BasicFunction {
     public static final FunctionSignature signature =
             new FunctionSignature(
                     new QName("get-fragment-between", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
-                    "Returns an xml fragment or a sequence of nodes between two elements (normally milestone elements). " +
-                            "This function works only on documents which are stored in eXist DB." +
+                    "Serializes an XML fragment or a sequence of nodes between two elements (normally milestone elements). " +
+                            "This function works only on documents which are stored in the database itself." +
                             "The $beginning-node represents the first node/milestone element, $ending-node, the second one. " +
+                            "The results will be inclusive of $beginning-node and exclusive of the $ending-node." +
                             "The third argument, $make-fragment, is " +
                             "a boolean value for the path completion. If it is set to true() the " +
                             "result sequence is wrapped into a parent element node. " +
-                            "The fourth argument, display-root-namespace, is " +
+                            "The fourth argument  display-root-namespace (only used when $make-fragment is true()), is " +
                             "a boolean value for displaying the root node namespace. If it is set to true() the " +
-                            "attribute \"xmlns\" in the root node of the result sequence is determined explicitely from the $beginning-node. " +
+                            "attribute \"xmlns\" in the root node of the result sequence is determined from the $beginning-node. " +
                             "Example call of the function for getting the fragment between two TEI page break element nodes: " +
                             "  let $fragment := util:get-fragment-between(//pb[1], //pb[2], true(), true())",
                     new SequenceType[]{

--- a/exist-core/src/test/xquery/util/get-fragment-between.xqm
+++ b/exist-core/src/test/xquery/util/get-fragment-between.xqm
@@ -50,7 +50,29 @@ function gfb:tei-fragment() {
     let $pb1 := $pbs[1]
     let $pb2 := $pbs[2]
     return
-        util:get-fragment-between($pb1,$pb2,false(),true())
+        util:get-fragment-between($pb1, $pb2, false(), false())
+};
+
+declare
+    %test:assertEquals('<TEI><text><front><pb facs="1.jpg"></pb><p>Aus dem Leben einer Kartoffel.</p></front></text></TEI>')
+function gfb:tei-fragment-root() {
+    let $doc := doc("/db/test-gfb/doc1.xml")
+    let $pbs := $doc//tei:pb
+    let $pb1 := $pbs[1]
+    let $pb2 := $pbs[2]
+    return
+        fn:replace(util:get-fragment-between($pb1, $pb2, true(), false()), "\n", "")
+};
+
+declare
+    %test:assertEquals('<TEI xmlns="http://www.tei-c.org/ns/1.0"><text><front><pb facs="1.jpg"></pb><p>Aus dem Leben einer Kartoffel.</p></front></text></TEI>')
+function gfb:tei-fragment-root-ns() {
+    let $doc := doc("/db/test-gfb/doc1.xml")
+    let $pbs := $doc//tei:pb
+    let $pb1 := $pbs[1]
+    let $pb2 := $pbs[2]
+    return
+        fn:replace(util:get-fragment-between($pb1, $pb2, true(), true()), "\n", "")
 };
 
 declare

--- a/exist-core/src/test/xquery/util/get-fragment-between.xqm
+++ b/exist-core/src/test/xquery/util/get-fragment-between.xqm
@@ -1,0 +1,85 @@
+xquery version "3.1";
+
+module namespace gfb = "http://exist-db.org/test/util/get-fragment-between";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+declare namespace tei = "http://www.tei-c.org/ns/1.0";
+
+declare variable $gfb:DOC1 :=
+    <TEI xmlns="http://www.tei-c.org/ns/1.0">
+        <text>
+            <front>
+                <pb facs="1.jpg"/>
+                <p>Aus dem Leben einer Kartoffel.</p>
+                <pb facs="2.jpg"/>
+            </front>
+            <body>
+                <pb facs="3.jpg"/>
+                <p>Hubertus Knoll spazierte über das <pb facs="4.jpg"/> Feld.</p>
+                <pb facs="5.jpg"/>
+            </body>
+        </text>
+    </TEI>;
+
+declare variable $gfb:DOC2 :=
+    <root xmlns="http://exist-db.org/xquery/xqsuite">
+        <x/>
+        <y/>
+        <z/>
+    </root>;
+
+declare
+    %test:setUp
+function gfb:setup() {
+    xmldb:create-collection("/db", "test-gfb"),
+    xmldb:store("/db/test-gfb", "doc1.xml", $gfb:DOC1),
+    xmldb:store("/db/test-gfb", "doc2.xml", $gfb:DOC2)
+};
+
+declare
+    %test:tearDown
+function gfb:teardown() {
+    xmldb:remove("/db/test-gfb")
+};
+
+declare
+    %test:assertEquals('<pb facs="1.jpg"></pb><p>Aus dem Leben einer Kartoffel.</p>')
+function gfb:tei-fragment() {
+    let $doc := doc("/db/test-gfb/doc1.xml")
+    let $pbs := $doc//tei:pb
+    let $pb1 := $pbs[1]
+    let $pb2 := $pbs[2]
+    return
+        util:get-fragment-between($pb1,$pb2,false(),true())
+};
+
+declare
+    %test:assertEquals("<x></x>")
+function gfb:fragment-no-namespace() {
+    let $doc := doc("/db/test-gfb/doc2.xml")
+    let $elems := $doc/test:root/*
+    let $fragment := util:get-fragment-between($elems[1], $elems[2], false(), false())
+    return
+        $fragment
+};
+
+declare
+    %test:assertEquals("<root><x></x></root>")
+function gfb:wrapped-fragment-no-namespace() {
+    let $doc := doc("/db/test-gfb/doc2.xml")
+    let $elems := $doc/test:root/*
+    let $fragment := util:get-fragment-between($elems[1], $elems[2], true(), false())
+    return
+        $fragment => replace("\s", "")
+};
+
+declare
+    %test:assertTrue
+function gfb:wrapped-fragment-is-parseable() {
+    let $doc := doc("/db/test-gfb/doc2.xml")
+    let $elems := $doc/test:root/*
+    let $fragment := util:get-fragment-between($elems[1], $elems[2], true(), false())
+    let $parsed := try { parse-xml($fragment) } catch * { $err:code }
+    return
+        $parsed instance of document-node(element(root))
+};


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/2316

The following returns `true` as expected:
```Java
new DLN("1.1.1").equals(new DLN("1.1.1"))
```

However, the following unexpectedly returns `false`, when one would expect it to return `true`:
```java
Optional.of(new DLN("1.1.1").equals(Optional.of(new DLN("1.1.1"))))
```

This is due to a strange definition (and implementation) of `equals` in `NodeId`; I have removed this potentially dangerous pattern so that you get expected behaviour.

Most of the test I adapted from @joewiz. I would be happy if Joe could check he agrees with them still ;-)