### PR TITLE
Group managers should be loaded from security database at startup

### DIFF
--- a/exist-core/src/main/java/org/exist/config/Configurator.java
+++ b/exist-core/src/main/java/org/exist/config/Configurator.java
@@ -415,7 +415,7 @@ public class Configurator {
                     }
                     
                     if (list == null) {
-                        list = new ArrayList<Configurable>(confs.size());
+                        list = new ArrayList(confs.size());  // has to be raw type as we don't know what it should be.
                         field.set(instance, list);
                     }
                     
@@ -931,7 +931,7 @@ public class Configurator {
             throws ConfigurationException {
         
         final Class<?> clazz = instance.getClass();
-        instance.getClass().getAnnotations();
+
         
         if (!clazz.isAnnotationPresent(ConfigurationClass.class)) {
             return; //UNDERSTAND: throw exception

--- a/exist-core/src/main/java/org/exist/security/AbstractGroup.java
+++ b/exist-core/src/main/java/org/exist/security/AbstractGroup.java
@@ -172,6 +172,22 @@ public abstract class AbstractGroup extends AbstractPrincipal implements Compara
         managers.add(new ReferenceImpl<>(getRealm().getSecurityManager(), "getAccount", name));
     }
 
+    //this method is used by Configurator
+    public final void insertManager(final int index, final String name) throws PermissionDeniedException {
+        final Subject subject = getDatabase().getActiveBroker().getCurrentSubject();
+        assertCanModifyGroup(subject);
+
+        //check the manager is not already present
+        for(final Reference<SecurityManager, Account> ref : managers) {
+            final String refName = ref.getName();
+            if(refName != null && refName.equals(name)) {
+                return;
+            }
+        }
+
+        managers.add(index, new ReferenceImpl<>(getRealm().getSecurityManager(), "getAccount", name));
+    }
+
     @Override
     public List<Account> getManagers() {
     	

--- a/exist-core/src/main/java/org/exist/security/AbstractGroup.java
+++ b/exist-core/src/main/java/org/exist/security/AbstractGroup.java
@@ -22,12 +22,8 @@
 
 package org.exist.security;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.config.Configuration;
@@ -90,7 +86,7 @@ public abstract class AbstractGroup extends AbstractPrincipal implements Compara
         buf.append("<group name=\"");
         buf.append(name);
         buf.append("\" id=\"");
-        buf.append(Integer.toString(id));
+        buf.append(id);
         buf.append("\">");
         try {
             for(final Account manager : getManagers()) {
@@ -165,7 +161,7 @@ public abstract class AbstractGroup extends AbstractPrincipal implements Compara
         final Subject subject = getDatabase().getActiveBroker().getCurrentSubject();
         assertCanModifyGroup(subject);
         
-        //check the manager is not already present`
+        //check the manager is not already present
         for(final Reference<SecurityManager, Account> ref : managers) {
             final String refName = ref.getName();
             if(refName != null && refName.equals(name)) {

--- a/exist-core/src/main/java/org/exist/security/AbstractRealm.java
+++ b/exist-core/src/main/java/org/exist/security/AbstractRealm.java
@@ -106,7 +106,8 @@ public abstract class AbstractRealm implements Realm, Configurable {
             final AbstractRealm r = this;
             
             for(final Iterator<DocumentImpl> i = collectionGroups.iterator(broker); i.hasNext(); ) {
-                final Configuration conf = Configurator.parse(broker.getBrokerPool(), i.next());
+                final DocumentImpl doc = i.next();
+                final Configuration conf = Configurator.parse(broker.getBrokerPool(), doc);
                 final String name = conf.getProperty("name");
                 
                 groupsByName.writeE(principalDb -> {

--- a/exist-core/src/test/java/org/exist/security/AbstractSecurityManagerRoundtripTest.java
+++ b/exist-core/src/test/java/org/exist/security/AbstractSecurityManagerRoundtripTest.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import org.exist.EXistException;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.xmldb.UserManagementService;
-import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Collection;
 import org.exist.security.internal.aider.GroupAider;
 import org.exist.security.internal.aider.UserAider;
@@ -22,15 +21,13 @@ import org.xmldb.api.base.XMLDBException;
  */
 public abstract class AbstractSecurityManagerRoundtripTest {
 
-    protected abstract String getBaseUri();
+    protected abstract Collection getRoot() throws XMLDBException;
 
     protected abstract void restartServer() throws XMLDBException, IOException;
 
     @Test
     public void checkGroupMembership() throws XMLDBException, PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException {
-
-        Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", "admin", "");
-        UserManagementService ums = (UserManagementService)root.getService("UserManagementService", "1.0");
+        UserManagementService ums = (UserManagementService)getRoot().getService("UserManagementService", "1.0");
 
         final String group1Name = "testGroup1";
         final String group2Name = "testGroup2";
@@ -53,8 +50,7 @@ public abstract class AbstractSecurityManagerRoundtripTest {
             restartServer();
             /**************************/
 
-            root = DatabaseManager.getCollection(getBaseUri() + "/db", "admin", "");
-            ums = (UserManagementService)root.getService("UserManagementService", "1.0");
+            ums = (UserManagementService)getRoot().getService("UserManagementService", "1.0");
 
             user = ums.getAccount(userName);
             assertNotNull(user);
@@ -88,9 +84,7 @@ public abstract class AbstractSecurityManagerRoundtripTest {
 
     @Test
     public void checkPrimaryGroupRemainsDBA() throws XMLDBException, PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException {
-
-        Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", "admin", "");
-        UserManagementService ums = (UserManagementService)root.getService("UserManagementService", "1.0");
+        UserManagementService ums = (UserManagementService)getRoot().getService("UserManagementService", "1.0");
 
         final String group1Name = "testGroup1";
         final String group2Name = "testGroup2";
@@ -114,8 +108,7 @@ public abstract class AbstractSecurityManagerRoundtripTest {
             restartServer();
             /**************************/
 
-            root = DatabaseManager.getCollection(getBaseUri() + "/db", "admin", "");
-            ums = (UserManagementService)root.getService("UserManagementService", "1.0");
+            ums = (UserManagementService)getRoot().getService("UserManagementService", "1.0");
 
             user = ums.getAccount(userName);
             assertNotNull(user);
@@ -151,8 +144,7 @@ public abstract class AbstractSecurityManagerRoundtripTest {
     @Test
     public void checkPrimaryGroupStability() throws XMLDBException, PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException {
 
-        Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", "admin", "");
-        UserManagementService ums = (UserManagementService)root.getService("UserManagementService", "1.0");
+        UserManagementService ums = (UserManagementService)getRoot().getService("UserManagementService", "1.0");
 
         final String group1Name = "testGroupA";
         final String group2Name = "testGroupB";
@@ -175,8 +167,7 @@ public abstract class AbstractSecurityManagerRoundtripTest {
             restartServer();
             /**************************/
 
-            root = DatabaseManager.getCollection(getBaseUri() + "/db", "admin", "");
-            ums = (UserManagementService)root.getService("UserManagementService", "1.0");
+            ums = (UserManagementService)getRoot().getService("UserManagementService", "1.0");
 
             user = ums.getAccount(userName);
             assertNotNull(user);

--- a/exist-core/src/test/java/org/exist/security/AbstractSecurityManagerRoundtripTest.java
+++ b/exist-core/src/test/java/org/exist/security/AbstractSecurityManagerRoundtripTest.java
@@ -1,6 +1,7 @@
 package org.exist.security;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.exist.EXistException;
 import org.exist.util.DatabaseConfigurationException;
@@ -196,6 +197,51 @@ public abstract class AbstractSecurityManagerRoundtripTest {
             if (g2 != null) {
                 ums.removeGroup(g2);
             }
+        }
+    }
+
+    @Test
+    public void checkGroupManagerStability() throws XMLDBException, PermissionDeniedException, IOException {
+        UserManagementService ums = (UserManagementService)getRoot().getService("UserManagementService", "1.0");
+
+        final String commonGroupName = "commonGroup";
+        Group commonGroup = new GroupAider(commonGroupName);
+
+        final String userName = "testUserA";
+        final Group userGroup = new GroupAider(userName);
+        final Account userAccount = new UserAider(userName, userGroup); //set users primary group as personal group
+
+        try {
+            // create a user with personal group
+            ums.addGroup(userGroup);
+            ums.addAccount(userAccount);
+
+            //add user1 as a manager of common group
+            ums.addGroup(commonGroup);
+            commonGroup.addManager(userAccount);
+            ums.updateGroup(commonGroup);
+
+            /*** RESTART THE SERVER ***/
+            restartServer();
+            /**************************/
+
+            ums = (UserManagementService)getRoot().getService("UserManagementService", "1.0");
+
+            // get the common group
+            commonGroup = ums.getGroup(commonGroupName);
+            assertNotNull(commonGroup);
+
+            // assert that user1 is still a manager of the common group
+            final List<Account> commonGroupManagers = commonGroup.getManagers();
+            assertNotNull(commonGroupManagers);
+            assertEquals(1, commonGroupManagers.size());
+            assertEquals(commonGroupManagers.get(0).getName(), userName);
+
+        } finally {
+            //cleanup
+            try { ums.removeGroup(commonGroup); } catch(Exception e) {}
+            try { ums.removeAccount(userAccount); } catch(Exception e) {}
+            try { ums.removeGroup(userGroup); } catch(Exception e) {}
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/security/LocalSecurityManagerRoundtripTest.java
+++ b/exist-core/src/test/java/org/exist/security/LocalSecurityManagerRoundtripTest.java
@@ -22,6 +22,7 @@ package org.exist.security;
 
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.ClassRule;
+import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.ErrorCodes;
 import org.xmldb.api.base.XMLDBException;
 
@@ -38,8 +39,8 @@ public class LocalSecurityManagerRoundtripTest extends AbstractSecurityManagerRo
     public static final ExistXmldbEmbeddedServer existXmldbEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
 
     @Override
-    protected String getBaseUri() {
-        return "xmldb:exist://";
+    protected Collection getRoot() {
+        return existXmldbEmbeddedServer.getRoot();
     }
 
     @Override

--- a/exist-core/src/test/java/org/exist/security/RemoteSecurityManagerRoundtripTest.java
+++ b/exist-core/src/test/java/org/exist/security/RemoteSecurityManagerRoundtripTest.java
@@ -22,6 +22,9 @@ package org.exist.security;
 
 import org.exist.test.ExistWebServer;
 import org.junit.ClassRule;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.XMLDBException;
 
 /**
  * Security Manager round trip tests against the XML:DB Remote API
@@ -34,8 +37,9 @@ public class RemoteSecurityManagerRoundtripTest extends AbstractSecurityManagerR
     public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
 
     @Override
-    protected String getBaseUri() {
-        return "xmldb:exist://localhost:" + Integer.toString(existWebServer.getPort()) + "/xmlrpc";
+    protected Collection getRoot() throws XMLDBException {
+        final String baseUri = "xmldb:exist://localhost:" + Integer.toString(existWebServer.getPort()) + "/xmlrpc";
+        return DatabaseManager.getCollection(baseUri + "/db", "admin", "");
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/pull/1578

Previously you could add group managers, and save them. They were correctly persisted to the database. However, at the next database startup they were not loaded correctly and then removed from persistent storage; effectively that deleted any group managers... Ouch! Since at least 2017?!?