### PR TITLE
Fix an issue with positional predicates that have multiple values

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -981,7 +981,7 @@ throws XPathException
 			"empty"
 			{
 				type.setPrimaryType(Type.EMPTY);
-				type.setCardinality(Cardinality.EMPTY);
+				type.setCardinality(Cardinality.EMPTY_SEQUENCE);
 			}
 		)
 		|
@@ -989,7 +989,7 @@ throws XPathException
 			"empty-sequence"
 			{
 				type.setPrimaryType(Type.EMPTY);
-				type.setCardinality(Cardinality.EMPTY);
+				type.setCardinality(Cardinality.EMPTY_SEQUENCE);
 			}
 		)
 		|
@@ -3360,7 +3360,7 @@ throws PermissionDeniedException, EXistException, XPathException
 		castAST:"cast"
 		{
 			PathExpr expr= new PathExpr(context);
-			int cardinality= Cardinality.EXACTLY_ONE;
+			Cardinality cardinality= Cardinality.EXACTLY_ONE;
 		}
 		step=expr [expr]
 		t:ATOMIC_TYPE
@@ -3386,7 +3386,7 @@ throws PermissionDeniedException, EXistException, XPathException
 		castableAST:"castable"
 		{
 			PathExpr expr= new PathExpr(context);
-			int cardinality= Cardinality.EXACTLY_ONE;
+			Cardinality cardinality= Cardinality.EXACTLY_ONE;
 		}
 		step=expr [expr]
 		t2:ATOMIC_TYPE

--- a/exist-core/src/main/java/org/exist/backup/xquery/RetrieveBackup.java
+++ b/exist-core/src/main/java/org/exist/backup/xquery/RetrieveBackup.java
@@ -46,7 +46,7 @@ public class RetrieveBackup extends BasicFunction
     public final static FunctionSignature signature = new FunctionSignature( new QName( "retrieve", BackupModule.NAMESPACE_URI, BackupModule.PREFIX ), "Retrieves a zipped backup archive, $name, and directly streams it to the HTTP response. " + "For security reasons, the function will only read .zip files in the specified directory, $directory.", new SequenceType[] {
             new FunctionParameterSequenceType( "directory", Type.STRING, Cardinality.EXACTLY_ONE, "The path to the directory where the backup file is located." ),
             new FunctionParameterSequenceType( "name", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the file to retrieve." )
-        }, new SequenceType( Type.ITEM, Cardinality.EMPTY ) );
+        }, new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE ) );
 
     public RetrieveBackup(final XQueryContext context )
     {

--- a/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
@@ -626,7 +626,7 @@ public abstract class NodeImpl<T extends NodeImpl> implements INode<DocumentImpl
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return Cardinality.EXACTLY_ONE;
     }
 

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -771,7 +771,7 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return Cardinality.EXACTLY_ONE;
     }
 

--- a/exist-core/src/main/java/org/exist/repo/ExistRepository.java
+++ b/exist-core/src/main/java/org/exist/repo/ExistRepository.java
@@ -170,8 +170,13 @@ public class ExistRepository extends Observable implements BrokerPoolService {
                 Thread.currentThread().interrupt();
             }
 
-            throw new XPathException("Unable to instantiate module from EXPath" +
-                    "repository: " + clazz.getName(), e);
+            final String msg = "Unable to instantiate module from EXPath" +
+                    "repository: " + clazz.getName();
+
+            // need to log here, otherwise details are swallowed by XQueryTreeParser
+            LOG.error(e.getMessage(), e);
+
+            throw new XPathException(msg, e);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/AbstractExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/AbstractExpression.java
@@ -86,7 +86,7 @@ public abstract class AbstractExpression implements Expression {
      * The default cardinality is {@link Cardinality#EXACTLY_ONE}.
      */
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return Cardinality.EXACTLY_ONE; // default cardinality
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
+++ b/exist-core/src/main/java/org/exist/xquery/ArrowOperator.java
@@ -131,7 +131,7 @@ public class ArrowOperator extends AbstractExpression {
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return fcall == null ? super.getCardinality() : fcall.getCardinality();
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/Cardinality.java
+++ b/exist-core/src/main/java/org/exist/xquery/Cardinality.java
@@ -176,6 +176,26 @@ public enum Cardinality {
         }
     }
 
+    /**
+     * Get the Cardinality from an integer representation.
+     *
+     * @param intValue integer representation of cardinality
+     *
+     * @return the cardinality
+     *
+     * @deprecated You should not pass cardinality as integer values,
+     *     this is for backwards compatibility with eXist-db
+     */
+    @Deprecated
+    public static Cardinality fromInt(final int intValue) {
+        for (final Cardinality cardinality : Cardinality.values()) {
+            if (cardinality.val == intValue) {
+                return cardinality;
+            }
+        }
+        throw new IllegalArgumentException("No know cardinality for intValue: " + intValue);
+    }
+
     static class InternalValue {
         static final byte ZERO = 1;
         static final byte ONE = 2;

--- a/exist-core/src/main/java/org/exist/xquery/Cardinality.java
+++ b/exist-core/src/main/java/org/exist/xquery/Cardinality.java
@@ -1,91 +1,184 @@
 /*
- *  eXist Open Source Native XML Database
- *  Copyright (C) 2001-06 Wolfgang M. Meier
- *  wolfgang@exist-db.org
- *  http://exist.sourceforge.net
- *  
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
- *  
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
- *  
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- *  
- *  $Id$
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.xquery;
 
-/**
- * Defines occurrence indicators (*,?,+).
- * 
- * @author wolf
- */
-public class Cardinality {
+import static org.exist.xquery.Cardinality.InternalValue.*;
 
-	public final static int ZERO = 1;	
-	public final static int ONE = 2;	
-	public final static int MANY = 4;	
-	public final static int EMPTY = ZERO;
-	public final static int EXACTLY_ONE = ONE;
-	/** indicator '+' **/
-	public final static int ONE_OR_MORE = ONE | MANY;
-	/** indicator '*' **/
-	public final static int ZERO_OR_MORE = ZERO | ONE | MANY;
-	/** indicator '?' **/
-	public final static int ZERO_OR_ONE = ZERO | ONE;
-    
-    public final static String toString(int cardinality) {
-        switch(cardinality) {
-            case EMPTY:
+/**
+ * Defines <a href="https://www.w3.org/TR/xpath-31/#prod-xpath31-OccurrenceIndicator">XPath Occurrence Indicators</a>
+ * (*,?,+), and additionally defines {@link #EMPTY_SEQUENCE}, and {@link #EXACTLY_ONE} for convenience.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public enum Cardinality {
+
+    EMPTY_SEQUENCE(ZERO),
+
+    //TODO(AR) can we eliminate this?
+    EXACTLY_ONE(ONE),
+
+    //TODO(AR) eliminate this in favour of probably ONE_OR_MORE
+    _MANY(MANY),
+
+    /**
+     * indicator '?'
+     */
+    ZERO_OR_ONE((byte)(ZERO | ONE)),
+
+    /**
+     * indicator '+'
+     */
+    ONE_OR_MORE((byte)(ONE | MANY)),
+
+    /**
+     * indicator '*'
+     */
+    ZERO_OR_MORE((byte)(ZERO | ONE | MANY));
+
+
+    private final byte val;
+
+    Cardinality(final byte val) {
+        this.val = val;
+    }
+
+    /**
+     * The cardinality represents a sequence of at least one value.
+     *
+     * @return true if the cardinality represents a sequence of at least one value, or false otherwise.
+     */
+    public boolean atLeastOne() {
+        return (val & ZERO) == 0;
+    }
+
+    /**
+     * The cardinality represents a sequence of at most one value.
+     *
+     * @return true if the cardinality represents a sequence of at most one value, or false otherwise.
+     */
+    public boolean atMostOne() {
+        return (val & MANY) == 0;
+    }
+
+    /**
+     * Tests whether this Cardinality is a sub-cardinality or equal
+     * of {@code other}.
+     *
+     * @param other the other cardinality
+     *
+     * @return true if this is a sub-cardinality or equal cardinality of {@code other}.
+     */
+    public boolean isSubCardinalityOrEqualOf(final Cardinality other) {
+        return (val | other.val) == other.val;
+    }
+
+    /**
+     * Tests whether this Cardinality is a super-cardinality or equal
+     * of {@code other}.
+     *
+     * @param other the other cardinality
+     *
+     * @return true if this is a super-cardinality or equal cardinality of {@code other}.
+     */
+    public boolean isSuperCardinalityOrEqualOf(final Cardinality other) {
+        return (val & other.val) == other.val;
+    }
+
+    /**
+     * Given two cardinalities, return a cardinality that is capable of
+     * representing both,
+     * i.e.: {@code a.isSubCardinalityOrEqualOf(max(a, b)) && b.isSubCardinalityOrEqualOf(max(a, b)) && b.max(a, b))
+     *
+     * @param a the first cardinality
+     * @param b the second cardinality
+     */
+    public static Cardinality superCardinalityOf(final Cardinality a, final Cardinality b) {
+        final byte max = (byte)(a.val | b.val);
+        for (final Cardinality cardinality : Cardinality.values()) {
+            if (cardinality.val == max) {
+                return cardinality;
+            }
+        }
+        throw new IllegalStateException();
+    }
+
+    /**
+     * Get an XQuery notation representation of the cardinality.
+     *
+     * @return the XQuery notation
+     */
+    public String toXQueryCardinalityString() {
+        switch (this) {
+            case EMPTY_SEQUENCE:
                 return "empty-sequence()";
 
             case EXACTLY_ONE:
-                return ""; 
+                return "";
 
-            case MANY:
+            case ZERO_OR_ONE:
+                return "?";
+
+            case _MANY:
             case ONE_OR_MORE:
                 return "+";
 
             case ZERO_OR_MORE:
                 return "*";
 
-            case ZERO_OR_ONE:
-                return "?";
-
             default:
                 // impossible
-                throw new IllegalArgumentException("unknown cardinality: " + cardinality);
+                throw new IllegalArgumentException("Unknown cardinality: " + name());
         }
     }
-    
-    public final static String getDescription(int cardinality) {
-        switch(cardinality) {
-            case EMPTY:
+
+    /**
+     * Get a human pronounceable description of the cardinality.
+     *
+     * @return a pronounceable description
+     */
+    public String getHumanDescription() {
+        switch (this) {
+            case EMPTY_SEQUENCE:
                 return "empty";
             case EXACTLY_ONE:
-                return "exactly one"; 
-            case ONE_OR_MORE:
-                return "one or more";
-            case ZERO_OR_MORE:
-                return "zero or more";
+                return "exactly one";
             case ZERO_OR_ONE:
                 return "zero or one";
-            case MANY:
-                return "many";
+
+            case _MANY:
+            case ONE_OR_MORE:
+                return "one or more";
+
+            case ZERO_OR_MORE:
+                return "zero or more";
             default:
                 // impossible
-                throw new IllegalArgumentException("unknown cardinality: " + cardinality);
+                throw new IllegalArgumentException("Unknown cardinality: " + name());
         }
     }
-    
-    public final static boolean checkCardinality(int required, int cardinality) {
-        return ((required & cardinality) == cardinality);
+
+    static class InternalValue {
+        static final byte ZERO = 1;
+        static final byte ONE = 2;
+        static final byte MANY = 4;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/CastExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/CastExpression.java
@@ -38,7 +38,7 @@ import java.util.List;
 public class CastExpression extends AbstractExpression {
     
     private Expression expression;
-	private int cardinality = Cardinality.EXACTLY_ONE;
+	private Cardinality cardinality;
 	private final int requiredType;
 
     /**
@@ -50,7 +50,7 @@ public class CastExpression extends AbstractExpression {
      * @param requiredType the {@link Type} expected
      * @param cardinality the {@link Cardinality} expected
 	 */
-	public CastExpression(XQueryContext context, Expression expr, int requiredType, int cardinality) {
+	public CastExpression(final XQueryContext context, final Expression expr, final int requiredType, final Cardinality cardinality) {
 		super(context);
 		this.requiredType = requiredType;
 		this.cardinality = cardinality;
@@ -96,7 +96,7 @@ public class CastExpression extends AbstractExpression {
         Sequence result;
 		final Sequence seq = Atomize.atomize(expression.eval(contextSequence, contextItem));
 		if (seq.isEmpty()) {
-			if ((cardinality & Cardinality.ZERO) == 0)
+			if (cardinality.atLeastOne())
 				{throw new XPathException(this, "Type error: empty sequence is not allowed here");}
 			else
                 {result = Sequence.EMPTY_SEQUENCE;}
@@ -163,10 +163,8 @@ public class CastExpression extends AbstractExpression {
         return expression.getDependencies() | Dependency.CONTEXT_ITEM;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.AbstractExpression#getCardinality()
-	 */
-	public int getCardinality() {
+	@Override
+	public Cardinality getCardinality() {
 		return Cardinality.ZERO_OR_ONE;
 	}
 	

--- a/exist-core/src/main/java/org/exist/xquery/CastableExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/CastableExpression.java
@@ -35,10 +35,10 @@ import org.exist.xquery.value.Type;
  */
 public class CastableExpression extends AbstractExpression {
 
-	private Expression expression;	
-	private int requiredCardinality;
+	private final Expression expression;
+	private final Cardinality requiredCardinality;
 	private final int requiredType;
-	
+
 	/**
      * Wrap a CastableExpression around an expression, expecting the given type and
 	 * cardinality.
@@ -48,7 +48,8 @@ public class CastableExpression extends AbstractExpression {
      * @param expr the expression to be wrapped
      * @param requiredType the {@link Type} expected
      */
-	public CastableExpression(XQueryContext context, Expression expr, int requiredType, int requiredCardinality) {
+	public CastableExpression(final XQueryContext context, final Expression expr, final int requiredType,
+			final Cardinality requiredCardinality) {
 		super(context);
 		this.expression = expr;
 		this.requiredType = requiredType;
@@ -62,10 +63,8 @@ public class CastableExpression extends AbstractExpression {
 		return Type.BOOLEAN;
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.AbstractExpression#getCardinality()
-	 */
-	public int getCardinality() {
+	@Override
+	public Cardinality getCardinality() {
 		return Cardinality.EXACTLY_ONE;
 	}
 	
@@ -110,7 +109,7 @@ public class CastableExpression extends AbstractExpression {
 			final Sequence seq = Atomize.atomize(expression.eval(contextSequence, contextItem));
 			if(seq.isEmpty()) {
 				//If ? is specified after the target type, the result of the cast expression is an empty sequence.
-				if (Cardinality.checkCardinality(requiredCardinality, Cardinality.ZERO))
+				if (requiredCardinality.isSuperCardinalityOrEqualOf(Cardinality.EMPTY_SEQUENCE))
 	                {result = BooleanValue.TRUE;}
 				//If ? is not specified after the target type, a type error is raised [err:XPTY0004].
 				else
@@ -121,7 +120,7 @@ public class CastableExpression extends AbstractExpression {
 	    		try {
 	    			seq.itemAt(0).convertTo(requiredType);
 	    			//If ? is specified after the target type, the result of the cast expression is an empty sequence.
-	    			if (Cardinality.checkCardinality(requiredCardinality, seq.getCardinality()))
+	    			if (requiredCardinality.isSuperCardinalityOrEqualOf(seq.getCardinality()))
 	    				{result = BooleanValue.TRUE;}
 	    			//If ? is not specified after the target type, a type error is raised [err:XPTY0004].
 	    			else

--- a/exist-core/src/main/java/org/exist/xquery/ConcatExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/ConcatExpr.java
@@ -63,7 +63,7 @@ public class ConcatExpr extends PathExpr {
 	}
 	
 	@Override
-	public int getCardinality() {
+	public Cardinality getCardinality() {
 		return Cardinality.EXACTLY_ONE;
 	}
 

--- a/exist-core/src/main/java/org/exist/xquery/ConditionalExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/ConditionalExpression.java
@@ -66,11 +66,9 @@ public class ConditionalExpression extends AbstractExpression implements Rewrita
         return elseExpr;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#getCardinality()
-     */
-    public int getCardinality() {
-        return thenExpr.getCardinality() | elseExpr.getCardinality();
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.superCardinalityOf(thenExpr.getCardinality(), elseExpr.getCardinality());
     }
 
     /* (non-Javadoc)

--- a/exist-core/src/main/java/org/exist/xquery/DebuggableExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/DebuggableExpression.java
@@ -77,7 +77,8 @@ public class DebuggableExpression implements Expression, RewritableExpression {
         return expression.returnsType();
     }
 
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         return expression.getCardinality();
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/DeferredFunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/DeferredFunctionCall.java
@@ -95,14 +95,15 @@ public abstract class DeferredFunctionCall implements Sequence {
         return sequence.effectiveBooleanValue();
     }
 
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         try {
             realize();
             return sequence.getCardinality();
         } catch (XPathException e) {
             caughtException = e;
             LOG.error("Exception in deferred function: " + e.getMessage());
-            return 0;
+            return Cardinality.EMPTY_SEQUENCE;
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/DynamicCardinalityCheck.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicCardinalityCheck.java
@@ -36,11 +36,11 @@ import org.exist.xquery.value.Sequence;
 public class DynamicCardinalityCheck extends AbstractExpression {
 
     final private Expression expression;
-    final private int requiredCardinality;
+    final private Cardinality requiredCardinality;
     private Error error;
 
-    public DynamicCardinalityCheck(XQueryContext context, int requiredCardinality,
-            Expression expr, Error error) {
+    public DynamicCardinalityCheck(final XQueryContext context, final Cardinality requiredCardinality,
+            final Expression expr, final Error error) {
         super(context);
         this.requiredCardinality = requiredCardinality;
         this.expression = expr;
@@ -72,16 +72,16 @@ public class DynamicCardinalityCheck extends AbstractExpression {
                 "CONTEXT ITEM", contextItem.toSequence());}
         }
         final Sequence seq = expression.eval(contextSequence, contextItem);
-        int actualCardinality;
+        Cardinality actualCardinality;
         if (seq.isEmpty())
-            {actualCardinality = Cardinality.EMPTY;}
+            {actualCardinality = Cardinality.EMPTY_SEQUENCE;}
         else if (seq.hasMany())
-            {actualCardinality = Cardinality.MANY;}
+            {actualCardinality = Cardinality._MANY;}
         else
-            {actualCardinality = Cardinality.ONE;}
-        if (!Cardinality.checkCardinality(requiredCardinality, actualCardinality)) {
+            {actualCardinality = Cardinality.EXACTLY_ONE;}
+        if (!requiredCardinality.isSuperCardinalityOrEqualOf(actualCardinality)) {
             error.addArgs(ExpressionDumper.dump(expression),
-                Cardinality.getDescription(requiredCardinality),
+                requiredCardinality.getHumanDescription(),
                     seq.getItemCount());
             throw new XPathException(this, error.toString());
         }
@@ -97,7 +97,7 @@ public class DynamicCardinalityCheck extends AbstractExpression {
         if(dumper.verbosity() > 1) {
             dumper.display("dynamic-cardinality-check"); 
             dumper.display("("); 
-            dumper.display("\"" + Cardinality.getDescription(requiredCardinality) + "\"");
+            dumper.display("\"" + requiredCardinality.getHumanDescription() + "\"");
             dumper.display(", ");
         }
         expression.dump(dumper);

--- a/exist-core/src/main/java/org/exist/xquery/DynamicVariable.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicVariable.java
@@ -95,7 +95,7 @@ public class DynamicVariable implements Variable {
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return getValue().getCardinality();
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/EmptySequenceExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/EmptySequenceExpr.java
@@ -29,8 +29,8 @@ public class EmptySequenceExpr extends AbstractExpression {
     }
 
     @Override
-    public int getCardinality() {
-        return Cardinality.ZERO;
+    public Cardinality getCardinality() {
+        return Cardinality.EMPTY_SEQUENCE;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/Expression.java
+++ b/exist-core/src/main/java/org/exist/xquery/Expression.java
@@ -180,7 +180,7 @@ public interface Expression {
      *
      * @return the cardinality.
      */
-    public int getCardinality();
+    public Cardinality getCardinality();
 
     /**
      * Returns a set of bit-flags, indicating some of the parameters

--- a/exist-core/src/main/java/org/exist/xquery/ExtensionExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExtensionExpression.java
@@ -124,10 +124,8 @@ public class ExtensionExpression extends AbstractExpression {
         return innerExpression.getDependencies();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#getCardinality()
-     */
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         return innerExpression.getCardinality();
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/FilteredExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/FilteredExpression.java
@@ -110,7 +110,7 @@ public class FilteredExpression extends AbstractExpression {
             //to /descendant-or-self::node()/a[1], so we need to return the
             //1st a from any parent of a.
             // If the predicate is known to return a node set, no special treatment is required.
-            if (abbreviated && (pred.getExecutionMode() != Predicate.NODE ||
+            if (abbreviated && (pred.getExecutionMode() != Predicate.ExecutionMode.NODE ||
                     !seq.isPersistentSet())) {
                 result = new ValueSequence();
                 if (seq.isPersistentSet()) {

--- a/exist-core/src/main/java/org/exist/xquery/ForExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/ForExpr.java
@@ -172,12 +172,11 @@ public class ForExpr extends BindingExpression {
             //Type.EMPTY is *not* a subtype of other types ;
             //the tests below would fail without this prior cardinality check
             if (in.isEmpty() && sequenceType != null &&
-                    !Cardinality.checkCardinality(sequenceType.getCardinality(),
-                            Cardinality.EMPTY)) {
+                    !sequenceType.getCardinality().isSuperCardinalityOrEqualOf(Cardinality.EMPTY_SEQUENCE)) {
                 throw new XPathException(this, ErrorCodes.XPTY0004,
                         "Invalid cardinality for variable $" + varName +
-                                ". Expected " + Cardinality.getDescription(sequenceType.getCardinality()) +
-                                ", got " + Cardinality.getDescription(in.getCardinality()));
+                                ". Expected " + sequenceType.getCardinality().getHumanDescription() +
+                                ", got " + in.getCardinality().getHumanDescription());
             }
 
             // Loop through each variable binding
@@ -201,12 +200,11 @@ public class ForExpr extends BindingExpression {
             //Type.EMPTY is *not* a subtype of other types ; checking cardinality first
             //only a check on empty sequence is accurate here
             if (resultSequence.isEmpty() &&
-                    !Cardinality.checkCardinality(sequenceType.getCardinality(),
-                    Cardinality.EMPTY))
+                    !sequenceType.getCardinality().isSuperCardinalityOrEqualOf(Cardinality.EMPTY_SEQUENCE))
                 {throw new XPathException(this, ErrorCodes.XPTY0004,
                     "Invalid cardinality for variable $" + varName + ". Expected " +
-                    Cardinality.getDescription(sequenceType.getCardinality()) +
-                    ", got " + Cardinality.getDescription(Cardinality.EMPTY));}
+                    sequenceType.getCardinality().getHumanDescription() +
+                    ", got " + Cardinality.EMPTY_SEQUENCE.getHumanDescription());}
             //TODO : ignore nodes right now ; they are returned as xs:untypedAtomicType
             if (!Type.subTypeOf(sequenceType.getPrimaryType(), Type.NODE)) {
                 if (!resultSequence.isEmpty() &&

--- a/exist-core/src/main/java/org/exist/xquery/FunctionDSL.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionDSL.java
@@ -325,6 +325,24 @@ public class FunctionDSL {
     }
 
     /**
+     * Creates a Function Parameter
+     *
+     * @param name The name of the parameter
+     * @param type The XDM type of the parameter, i.e. one of {@link org.exist.xquery.value.Type}
+     * @param cardinality The cardinality of the parameter
+     * @param description A description of the parameter
+     *
+     * @return The function parameter object
+     *
+     * @deprecated Use {@link #param(String, int, Cardinality, String)}
+     */
+    @Deprecated
+    public static FunctionParameterSequenceType param(final String name, final int type, final int cardinality,
+            final String description) {
+        return new FunctionParameterSequenceType(name, type, cardinality, description);
+    }
+
+    /**
      * Creates a Function Return Type which has a cardinality of {@link Cardinality#ZERO_OR_ONE}
      *
      * @param type The XDM type of the return value, i.e. one of {@link org.exist.xquery.value.Type}
@@ -441,12 +459,43 @@ public class FunctionDSL {
      * Creates a Function Return Type
      *
      * @param type The XDM type of the return value, i.e. one of {@link org.exist.xquery.value.Type}
+     * @param cardinality The cardinality of the return type
+     *
+     * @return The function return type object
+     *
+     * @deprecated Use {@link #returns(int, Cardinality)}
+     */
+    @Deprecated
+    public static FunctionReturnSequenceType returns(final int type, final int cardinality) {
+        return returns(type, cardinality, null);
+    }
+
+    /**
+     * Creates a Function Return Type
+     *
+     * @param type The XDM type of the return value, i.e. one of {@link org.exist.xquery.value.Type}
      * @param cardinality The cardinality of the return type, i.e. one of {@link Cardinality}
      * @param description A description of the parameter
      *
      * @return The function return type object
      */
     public static FunctionReturnSequenceType returns(final int type, final Cardinality cardinality, final String description) {
+        return new FunctionReturnSequenceType(type, cardinality, description);
+    }
+
+    /**
+     * Creates a Function Return Type
+     *
+     * @param type The XDM type of the return value, i.e. one of {@link org.exist.xquery.value.Type}
+     * @param cardinality The cardinality of the return type
+     * @param description A description of the parameter
+     *
+     * @return The function return type object
+     *
+     * @deprecated Use {@link #returns(int, Cardinality, String)}
+     */
+    @Deprecated
+    public static FunctionReturnSequenceType returns(final int type, final int cardinality, final String description) {
         return new FunctionReturnSequenceType(type, cardinality, description);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/FunctionDSL.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionDSL.java
@@ -319,7 +319,7 @@ public class FunctionDSL {
      *
      * @return The function parameter object
      */
-    public static FunctionParameterSequenceType param(final String name, final int type, final int cardinality,
+    public static FunctionParameterSequenceType param(final String name, final int type, final Cardinality cardinality,
             final String description) {
         return new FunctionParameterSequenceType(name, type, cardinality, description);
     }
@@ -419,10 +419,10 @@ public class FunctionDSL {
     /**
      * Creates a Function Return Type which describes no result.
      *
-     * @return a Function Return Type which has a cardinality of {@link Cardinality#EMPTY} and {@link Type#EMPTY}
+     * @return a Function Return Type which has a cardinality of {@link Cardinality#EMPTY_SEQUENCE} and {@link Type#EMPTY}
      */
     public static FunctionReturnSequenceType returnsNothing() {
-        return new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY, null);
+        return new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE, null);
     }
 
     /**
@@ -433,7 +433,7 @@ public class FunctionDSL {
      *
      * @return The function return type object
      */
-    public static FunctionReturnSequenceType returns(final int type, final int cardinality) {
+    public static FunctionReturnSequenceType returns(final int type, final Cardinality cardinality) {
         return returns(type, cardinality, null);
     }
 
@@ -446,7 +446,7 @@ public class FunctionDSL {
      *
      * @return The function return type object
      */
-    public static FunctionReturnSequenceType returns(final int type, final int cardinality, final String description) {
+    public static FunctionReturnSequenceType returns(final int type, final Cardinality cardinality, final String description) {
         return new FunctionReturnSequenceType(type, cardinality, description);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
@@ -1208,7 +1208,8 @@ public class GeneralComparison extends BinaryOp implements Optimizable, IndexUse
             switchOperands();
         }
         //Prefer fewer items at the left hand
-        else if( ( Cardinality.checkCardinality( Cardinality.MANY, getLeft().getCardinality() ) ) && !( Cardinality.checkCardinality( Cardinality.MANY, getRight().getCardinality() ) ) ) {
+        else if (Cardinality._MANY.isSuperCardinalityOrEqualOf(getLeft().getCardinality())
+                && !Cardinality._MANY.isSuperCardinalityOrEqualOf(getRight().getCardinality())) {
             switchOperands();
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/GroupByClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/GroupByClause.java
@@ -78,8 +78,7 @@ public class GroupByClause extends AbstractFLWORClause {
                     .atomize();
             if (!data.initialized) {
                 final LocalVariable groupingVar = new LocalVariable(spec.getKeyVarName());
-                groupingVar.setSequenceType(new SequenceType(Type.ATOMIC, groupingValue.isEmpty() ? Cardinality
-                        .EMPTY : Cardinality.EXACTLY_ONE));
+                groupingVar.setSequenceType(new SequenceType(Type.ATOMIC, groupingValue.isEmpty() ? Cardinality.EMPTY_SEQUENCE : Cardinality.EXACTLY_ONE));
                 groupingVar.setStaticType(groupingValue.getType());
                 data.groupingVars.add(groupingVar);
             }

--- a/exist-core/src/main/java/org/exist/xquery/InstanceOfExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/InstanceOfExpression.java
@@ -62,12 +62,12 @@ public class InstanceOfExpression extends AbstractExpression {
         Sequence result = BooleanValue.TRUE;
 		final Sequence seq = expression.eval(contextSequence, contextItem);
         
-		final int requiredCardinality = type.getCardinality();
-		if (!seq.isEmpty() && requiredCardinality == Cardinality.EMPTY)
+		final Cardinality requiredCardinality = type.getCardinality();
+		if (!seq.isEmpty() && requiredCardinality == Cardinality.EMPTY_SEQUENCE)
             {result = BooleanValue.FALSE;}
-        else if (seq.isEmpty() && (requiredCardinality & Cardinality.ZERO) == 0)
+        else if (seq.isEmpty() && requiredCardinality.atLeastOne())
             {result = BooleanValue.FALSE;}
-		else if (seq.hasMany() && (requiredCardinality & Cardinality.MANY) == 0)
+		else if (seq.hasMany() && requiredCardinality.atMostOne())
             {result = BooleanValue.FALSE;}
         else {
     		for(final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
@@ -106,10 +106,8 @@ public class InstanceOfExpression extends AbstractExpression {
 		return Type.BOOLEAN;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.AbstractExpression#getCardinality()
-	 */
-	public int getCardinality() {
+	@Override
+	public Cardinality getCardinality() {
 		return Cardinality.EXACTLY_ONE;
 	}
 	

--- a/exist-core/src/main/java/org/exist/xquery/InternalFunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/InternalFunctionCall.java
@@ -67,8 +67,9 @@ public class InternalFunctionCall extends Function
 	{
 		return function.returnsType();
 	}
-	public int getCardinality()
-	{
+
+	@Override
+	public Cardinality getCardinality() {
 		return function.getCardinality();
 	}
 	

--- a/exist-core/src/main/java/org/exist/xquery/JavaCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/JavaCall.java
@@ -106,10 +106,8 @@ public class JavaCall extends Function {
 		return qname;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.AbstractExpression#getCardinality()
-	 */
-	public int getCardinality() {
+	@Override
+	public Cardinality getCardinality() {
 		return Cardinality.ZERO_OR_MORE;
 	}
 	

--- a/exist-core/src/main/java/org/exist/xquery/LetExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/LetExpr.java
@@ -111,17 +111,17 @@ public class LetExpr extends BindingExpression {
                 resultSequence = returnExpr.eval(contextSequence, null);
 
                 if (sequenceType != null) {
-                    int actualCardinality;
-                    if (var.getValue().isEmpty()) {actualCardinality = Cardinality.EMPTY;}
-                    else if (var.getValue().hasMany()) {actualCardinality = Cardinality.MANY;}
-                    else {actualCardinality = Cardinality.ONE;}
+                    Cardinality actualCardinality;
+                    if (var.getValue().isEmpty()) {actualCardinality = Cardinality.EMPTY_SEQUENCE;}
+                    else if (var.getValue().hasMany()) {actualCardinality = Cardinality._MANY;}
+                    else {actualCardinality = Cardinality.EXACTLY_ONE;}
                     //Type.EMPTY is *not* a subtype of other types ; checking cardinality first
-                    if (!Cardinality.checkCardinality(sequenceType.getCardinality(), actualCardinality))
+                    if (!sequenceType.getCardinality().isSuperCardinalityOrEqualOf(actualCardinality))
                         {throw new XPathException(this, ErrorCodes.XPTY0004,
                             "Invalid cardinality for variable $" + varName +
                             ". Expected " +
-                            Cardinality.getDescription(sequenceType.getCardinality()) +
-                            ", got " + Cardinality.getDescription(actualCardinality), in);}
+                            sequenceType.getCardinality().getHumanDescription() +
+                            ", got " + actualCardinality.getHumanDescription(), in);}
                     //TODO : ignore nodes right now ; they are returned as xs:untypedAtomicType
                     if (!Type.subTypeOf(sequenceType.getPrimaryType(), Type.NODE)) {
                         if (!var.getValue().isEmpty() && !Type.subTypeOf(var.getValue()

--- a/exist-core/src/main/java/org/exist/xquery/LiteralValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/LiteralValue.java
@@ -106,10 +106,8 @@ public class LiteralValue extends AbstractExpression {
 		return Dependency.NO_DEPENDENCY;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.AbstractExpression#getCardinality()
-	 */
-	public int getCardinality() {
+	@Override
+	public Cardinality getCardinality() {
 		return Cardinality.EXACTLY_ONE;
 	}
 

--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -184,7 +184,7 @@ public class LocationStep extends Step {
         // If the predicate is known to return a node set, no special treatment
         // is required.
         if (abbreviatedStep
-                && (pred.getExecutionMode() != Predicate.NODE || !contextSequence
+                && (pred.getExecutionMode() != Predicate.ExecutionMode.NODE || !contextSequence
                 .isPersistentSet())) {
             result = new ValueSequence();
             ((ValueSequence) result).keepUnOrdered(unordered);

--- a/exist-core/src/main/java/org/exist/xquery/Lookup.java
+++ b/exist-core/src/main/java/org/exist/xquery/Lookup.java
@@ -110,7 +110,7 @@ public class Lookup extends AbstractExpression {
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return Cardinality.ZERO_OR_MORE;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/NodeComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/NodeComparison.java
@@ -43,7 +43,7 @@ public class NodeComparison extends BinaryOp {
     public NodeComparison(XQueryContext context, Expression left, Expression right, NodeComparisonOperator relation) {
         super(context);
         this.relation = relation;
-        add(new DynamicCardinalityCheck(context, Cardinality.ZERO_OR_ONE, left, 
+        add(new DynamicCardinalityCheck(context, Cardinality.ZERO_OR_ONE, left,
                 new Error(Error.NODE_COMP_TYPE_MISMATCH)));
         add(right);
         //add(new DynamicCardinalityCheck(context, Cardinality.ZERO_OR_ONE, right,
@@ -58,10 +58,8 @@ public class NodeComparison extends BinaryOp {
         return Dependency.CONTEXT_SET | Dependency.CONTEXT_ITEM;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#getCardinality()
-     */
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         return Cardinality.ZERO_OR_ONE;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/OpSimpleMap.java
+++ b/exist-core/src/main/java/org/exist/xquery/OpSimpleMap.java
@@ -50,7 +50,7 @@ public class OpSimpleMap extends AbstractExpression {
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return Cardinality.ZERO_OR_MORE;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/PartialFunctionApplication.java
+++ b/exist-core/src/main/java/org/exist/xquery/PartialFunctionApplication.java
@@ -48,7 +48,7 @@ public class PartialFunctionApplication extends AbstractExpression {
 	}
 	
 	@Override
-	public int getCardinality() {
+	public Cardinality getCardinality() {
 		return Cardinality.EXACTLY_ONE;
 	}
 	

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -242,7 +242,7 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                     throw new XPathException(this, ErrorCodes.XPTY0019,
                             "left operand of '/' must be a node. Got '" +
                                     Type.getTypeName(result.getItemType()) +
-                                    Cardinality.toString(result.getCardinality()) + "'");
+                                    result.getCardinality().getHumanDescription() + "'");
                 }
                 //contextDocs == null *is* significant
                 expr.setContextDocSet(contextDocs);
@@ -450,9 +450,9 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         if (steps.size() == 0) {
-            return Cardinality.ZERO;
+            return Cardinality.EMPTY_SEQUENCE;
         }
         return (steps.get(steps.size() - 1)).getCardinality();
     }

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -15,7 +15,7 @@
  *  You should have received a copy of the GNU Library General Public
  *  License along with this program; if not, write to the Free Software
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- * 
+ *
  *  $Id$
  */
 package org.exist.xquery;
@@ -35,14 +35,13 @@ import org.exist.xquery.value.SequenceIterator;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 
-import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
 
 /**
  * Handles predicate expressions.
- * 
- *@author Wolfgang Meier
+ *
+ * @author Wolfgang Meier
  */
 public class Predicate extends PathExpr {
 
@@ -59,12 +58,12 @@ public class Predicate extends PathExpr {
 
     private Expression parent;
 
-    public Predicate(XQueryContext context) {
+    public Predicate(final XQueryContext context) {
         super(context);
     }
 
     @Override
-    public void addPath(PathExpr path) {
+    public void addPath(final PathExpr path) {
         if (path.getLength() == 1) {
             add(path.getExpression(0));
         } else {
@@ -72,13 +71,9 @@ public class Predicate extends PathExpr {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.exist.xquery.PathExpr#getDependencies()
-     */
+    @Override
     public int getDependencies() {
-        int deps = 0;
+        final int deps;
         if (getLength() == 1) {
             deps = getExpression(0).getDependencies();
         } else {
@@ -87,20 +82,15 @@ public class Predicate extends PathExpr {
         return deps;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.exist.xquery.PathExpr#analyze(org.exist.xquery.AnalyzeContextInfo)
-     */
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         parent = contextInfo.getParent();
         AnalyzeContextInfo newContextInfo = createContext(contextInfo);
         super.analyze(newContextInfo);
         final Expression inner = getExpression(0);
         final int staticReturnType = newContextInfo.getStaticReturnType();
         final int innerType = staticReturnType != Type.ITEM ?
-            staticReturnType : inner.returnsType();
+                staticReturnType : inner.returnsType();
         // Case 1: predicate expression returns a node set.
         // Check the returned node set against the context set
         // and return all nodes from the context, for which the
@@ -108,15 +98,17 @@ public class Predicate extends PathExpr {
         if (Type.subTypeOf(innerType, Type.NODE)
                 && !Dependency.dependsOn(inner, Dependency.CONTEXT_ITEM)) {
             executionMode = NODE;
-        // Case 2: predicate expression returns a unique number and has no
-        // dependency with the context item.
+            // Case 2: predicate expression returns a unique number and has no
+            // dependency with the context item.
         } else if (Type.subTypeOf(innerType, Type.NUMBER) &&
-            !Dependency.dependsOn(inner, Dependency.CONTEXT_ITEM) &&
-            Cardinality.checkCardinality(inner.getCardinality(), Cardinality.EXACTLY_ONE))
-            {executionMode = POSITIONAL;}
+                !Dependency.dependsOn(inner, Dependency.CONTEXT_ITEM) &&
+                Cardinality.checkCardinality(inner.getCardinality(), Cardinality.EXACTLY_ONE)) {
+            executionMode = POSITIONAL;
+        }
         // Case 3: all other cases, boolean evaluation (that can be "promoted" later)
-        else
-            {executionMode = BOOLEAN;}
+        else {
+            executionMode = BOOLEAN;
+        }
         if (executionMode == BOOLEAN) {
             // need to re-analyze:
             newContextInfo = createContext(contextInfo);
@@ -125,10 +117,10 @@ public class Predicate extends PathExpr {
         }
     }
 
-    private AnalyzeContextInfo createContext(AnalyzeContextInfo contextInfo) {
+    private AnalyzeContextInfo createContext(final AnalyzeContextInfo contextInfo) {
         final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
         // set flag to signal subexpression that we are in a predicate
-        newContextInfo.addFlag(IN_PREDICATE); 
+        newContextInfo.addFlag(IN_PREDICATE);
         newContextInfo.removeFlag(IN_WHERE_CLAUSE); // remove where clause flag
         newContextInfo.removeFlag(DOT_TEST);
         outerContextId = newContextInfo.getContextId();
@@ -143,21 +135,22 @@ public class Predicate extends PathExpr {
         return inner.eval(null);
     }
 
-    public Boolean matchPredicate(Sequence contextSequence,
-            Item contextItem, int mode) throws XPathException {
+    public Boolean matchPredicate(final Sequence contextSequence,
+                                  final Item contextItem, final int mode) throws XPathException {
         if (context.getProfiler().isEnabled()) {
             context.getProfiler().start(this);
             context.getProfiler().message(this, Profiler.DEPENDENCIES, "DEPENDENCIES",
-                Dependency.getDependenciesName(this.getDependencies()));
-            if (contextSequence != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES,
-                    "CONTEXT SEQUENCE", contextSequence);}
+                    Dependency.getDependenciesName(this.getDependencies()));
+            if (contextSequence != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES,
+                        "CONTEXT SEQUENCE", contextSequence);
+            }
         }
         boolean result = false;
         final Expression inner = steps.size() == 1 ? getExpression(0) : this;
-        if (inner == null)
-            {result = false;}
-        else {
+        if (inner == null) {
+            result = false;
+        } else {
             int recomputedExecutionMode = executionMode;
             Sequence innerSeq = null;
             // Atomic context sequences :
@@ -178,7 +171,7 @@ public class Predicate extends PathExpr {
                         // TODO : try to remove this since our dependency
                         // computation should now be better
                         !((inner instanceof GeneralComparison) &&
-                        ((GeneralComparison) inner).invalidNodeEvaluation)) {
+                                ((GeneralComparison) inner).invalidNodeEvaluation)) {
                     innerSeq = inner.eval(contextSequence);
                     // Only if we have an actual *singleton* of numeric items
                     if (innerSeq.hasOne()
@@ -191,7 +184,7 @@ public class Predicate extends PathExpr {
             } else {
                 if (executionMode == BOOLEAN && !Dependency.dependsOn(inner, Dependency.CONTEXT_ITEM)) {
                     /*
-                     * 
+                     *
                      * WARNING : this sequence will be evaluated with
                      * preloadable nodesets !
                      */
@@ -201,8 +194,8 @@ public class Predicate extends PathExpr {
                     if (Type.subTypeOf(innerSeq.getItemType(), Type.NODE)
                             && innerSeq.isPersistentSet()) {
                         recomputedExecutionMode = NODE;
-                    // Try to promote a boolean evaluation to a positional one
-                    // Only if we have an actual *singleton* of numeric items
+                        // Try to promote a boolean evaluation to a positional one
+                        // Only if we have an actual *singleton* of numeric items
                     } else if (innerSeq.hasOne()
                             && Type.subTypeOf(innerSeq.getItemType(), Type.NUMBER)) {
                         recomputedExecutionMode = POSITIONAL;
@@ -210,56 +203,62 @@ public class Predicate extends PathExpr {
                 }
             }
             switch (recomputedExecutionMode) {
-            case NODE:
-                if (context.getProfiler().isEnabled())
-                    {context.getProfiler().message(this,
-                        Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Node selection");}
+                case NODE:
+                    if (context.getProfiler().isEnabled()) {
+                        context.getProfiler().message(this,
+                                Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Node selection");
+                    }
                     //TODO: result = selectByNodeSet(contextSequence);
-                break;
-            case BOOLEAN:
-                if (context.getProfiler().isEnabled())
-                    {context.getProfiler().message(this,
-                        Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Boolean evaluation");}
-                //TODO: result = evalBoolean(contextSequence, inner);
-                break;
-            case POSITIONAL:
-                if (context.getProfiler().isEnabled())
-                    {context.getProfiler().message(this,
-                        Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE",
-                        "Positional evaluation");}
-                // In case it hasn't been evaluated above
-                if (innerSeq == null) {
-                    innerSeq = inner.eval(contextSequence);
-                }
-                //TODO: result = selectByPosition(outerSequence, contextSequence, mode, innerSeq);
-                break;
-            default:
-                throw new IllegalArgumentException(
-                    "Unsupported execution mode: '" + recomputedExecutionMode + "'");
+                    break;
+                case BOOLEAN:
+                    if (context.getProfiler().isEnabled()) {
+                        context.getProfiler().message(this,
+                                Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Boolean evaluation");
+                    }
+                    //TODO: result = evalBoolean(contextSequence, inner);
+                    break;
+                case POSITIONAL:
+                    if (context.getProfiler().isEnabled()) {
+                        context.getProfiler().message(this,
+                                Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE",
+                                "Positional evaluation");
+                    }
+                    // In case it hasn't been evaluated above
+                    if (innerSeq == null) {
+                        innerSeq = inner.eval(contextSequence);
+                    }
+                    //TODO: result = selectByPosition(outerSequence, contextSequence, mode, innerSeq);
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                            "Unsupported execution mode: '" + recomputedExecutionMode + "'");
             }
         }
-        if (context.getProfiler().isEnabled())
-            {context.getProfiler().end(this, "", null);}
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", null);
+        }
         return result;
     }
 
-    public Sequence evalPredicate(Sequence outerSequence,
-            Sequence contextSequence, int mode) throws XPathException {
+    public Sequence evalPredicate(final Sequence outerSequence,
+            final Sequence contextSequence, final int mode) throws XPathException {
         if (context.getProfiler().isEnabled()) {
             context.getProfiler().start(this);
             context.getProfiler().message(this, Profiler.DEPENDENCIES, "DEPENDENCIES",
-                Dependency.getDependenciesName(this.getDependencies()));
-            if (contextSequence != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES,
-                    "CONTEXT SEQUENCE", contextSequence);}
+                    Dependency.getDependenciesName(this.getDependencies()));
+            if (contextSequence != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES,
+                        "CONTEXT SEQUENCE", contextSequence);
+            }
         }
         Sequence result;
         final Expression inner = steps.size() == 1 ? getExpression(0) : this;
-        if (inner == null)
-            {result = Sequence.EMPTY_SEQUENCE;}
-        else {
-            if (executionMode == UNKNOWN)
-                {executionMode = BOOLEAN;}
+        if (inner == null) {
+            result = Sequence.EMPTY_SEQUENCE;
+        } else {
+            if (executionMode == UNKNOWN) {
+                executionMode = BOOLEAN;
+            }
             int recomputedExecutionMode = executionMode;
             Sequence innerSeq = null;
             // Atomic context sequences :
@@ -282,21 +281,21 @@ public class Predicate extends PathExpr {
                         // TODO : try to remove this since our dependency
                         // computation should now be better
                         !((inner instanceof GeneralComparison) &&
-                        ((GeneralComparison) inner).invalidNodeEvaluation)) {
+                                ((GeneralComparison) inner).invalidNodeEvaluation)) {
                     innerSeq = inner.eval(contextSequence);
                     // Only if we have an actual *singleton* of numeric items
                     if (innerSeq.hasOne()
-                        && Type.subTypeOf(innerSeq.getItemType(), Type.NUMBER)) {
+                            && Type.subTypeOf(innerSeq.getItemType(), Type.NUMBER)) {
                         recomputedExecutionMode = POSITIONAL;
                     }
                 }
             } else if (executionMode == NODE && !contextSequence.isPersistentSet()) {
                 recomputedExecutionMode = BOOLEAN;
             } else {
-                if (executionMode == BOOLEAN && 
+                if (executionMode == BOOLEAN &&
                         !Dependency.dependsOn(inner, Dependency.CONTEXT_ITEM)) {
                     /*
-                     * 
+                     *
                      * WARNING : this sequence will be evaluated with
                      * preloadable nodesets !
                      */
@@ -315,39 +314,43 @@ public class Predicate extends PathExpr {
                 }
             }
             switch (recomputedExecutionMode) {
-            case NODE:
-                if (context.getProfiler().isEnabled())
-                    {context.getProfiler().message(this,
-                        Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Node selection");}
-                result = selectByNodeSet(contextSequence);
-                break;
-            case BOOLEAN:
-                if (context.getProfiler().isEnabled())
-                    {context.getProfiler().message(this,
-                        Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Boolean evaluation");}
-                result = evalBoolean(contextSequence, inner, mode);
-                break;
-            case POSITIONAL:
-                if (context.getProfiler().isEnabled())
-                    {context.getProfiler().message(this,
-                        Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Positional evaluation");}
-                // In case it hasn't been evaluated above
-                if (innerSeq == null) {
-                    // for a positional predicate, check if it depends on the context item
-                    // if not, do not pass the context sequence to avoid cardinality errors
-                    context.setContextSequencePosition(0, contextSequence);
-                    innerSeq = inner.eval(Dependency.dependsOn(inner.getDependencies(), Dependency.CONTEXT_ITEM)
-                            ? contextSequence : null);
-                }
-                result = selectByPosition(outerSequence, contextSequence, mode, innerSeq);
-                break;
-            default:
-                throw new IllegalArgumentException(
-                    "Unsupported execution mode: '" + recomputedExecutionMode + "'");
+                case NODE:
+                    if (context.getProfiler().isEnabled()) {
+                        context.getProfiler().message(this,
+                                Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Node selection");
+                    }
+                    result = selectByNodeSet(contextSequence);
+                    break;
+                case BOOLEAN:
+                    if (context.getProfiler().isEnabled()) {
+                        context.getProfiler().message(this,
+                                Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Boolean evaluation");
+                    }
+                    result = evalBoolean(contextSequence, inner, mode);
+                    break;
+                case POSITIONAL:
+                    if (context.getProfiler().isEnabled()) {
+                        context.getProfiler().message(this,
+                                Profiler.OPTIMIZATION_FLAGS, "OPTIMIZATION CHOICE", "Positional evaluation");
+                    }
+                    // In case it hasn't been evaluated above
+                    if (innerSeq == null) {
+                        // for a positional predicate, check if it depends on the context item
+                        // if not, do not pass the context sequence to avoid cardinality errors
+                        context.setContextSequencePosition(0, contextSequence);
+                        innerSeq = inner.eval(Dependency.dependsOn(inner.getDependencies(), Dependency.CONTEXT_ITEM)
+                                ? contextSequence : null);
+                    }
+                    result = selectByPosition(outerSequence, contextSequence, mode, innerSeq);
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                            "Unsupported execution mode: '" + recomputedExecutionMode + "'");
             }
         }
-        if (context.getProfiler().isEnabled())
-            {context.getProfiler().end(this, "", result);}
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", result);
+        }
         return result;
     }
 
@@ -357,7 +360,7 @@ public class Predicate extends PathExpr {
      * @return The result of the boolean evaluation of the predicate.
      * @throws XPathException
      */
-    private Sequence evalBoolean(Sequence contextSequence, Expression inner, int mode)
+    private Sequence evalBoolean(final Sequence contextSequence, final Expression inner, final int mode)
             throws XPathException {
         final Sequence result = new ValueSequence();
         int p;
@@ -370,8 +373,9 @@ public class Predicate extends PathExpr {
                 context.setContextSequencePosition(p - 1, contextSequence);
                 final Item item = i.nextItem();
                 final Sequence innerSeq = inner.eval(contextSequence, item);
-                if (innerSeq.effectiveBooleanValue())
-                    {result.add(item);}
+                if (innerSeq.effectiveBooleanValue()) {
+                    result.add(item);
+                }
             }
         } else {
             // 0-based
@@ -393,23 +397,25 @@ public class Predicate extends PathExpr {
                     final Item item = i.nextItem();
                     final Sequence innerSeq = inner.eval(contextSequence, item);
                     if (innerSeq.hasOne()) {
-	                    final NumericValue nv = (NumericValue) innerSeq.itemAt(0);
-	                    // Non integers return... nothing, not even an error !
-	                    if (!nv.hasFractionalPart() && !nv.isZero())
-	                        {positions.add(nv);}
-                    } 
+                        final NumericValue nv = (NumericValue) innerSeq.itemAt(0);
+                        // Non integers return... nothing, not even an error !
+                        if (!nv.hasFractionalPart() && !nv.isZero()) {
+                            positions.add(nv);
+                        }
+                    }
                     //XXX: else error or nothing?
                 }
                 for (final NumericValue pos : positions) {
                     final int position = (reverseAxis ? contextSequence.getItemCount() - pos.getInt() : pos.getInt() - 1);
                     // TODO : move this test above ?
-                    if (position <= contextSequence.getItemCount())
-                        {result.add(contextSequence.itemAt(position));}
+                    if (position <= contextSequence.getItemCount()) {
+                        result.add(contextSequence.itemAt(position));
+                    }
                 }
             } else {
                 final Set<NumericValue> positions = new TreeSet<>();
                 for (final SequenceIterator i = contextSequence.iterate(); i.hasNext(); p++) {
-                    context.setContextSequencePosition((reverseAxis ? contextSequence.getItemCount() - p - 1: p), contextSequence);
+                    context.setContextSequencePosition((reverseAxis ? contextSequence.getItemCount() - p - 1 : p), contextSequence);
                     final Item item = i.nextItem();
                     final Sequence innerSeq = inner.eval(contextSequence, item);
                     if (innerSeq.hasOne()
@@ -417,16 +423,19 @@ public class Predicate extends PathExpr {
                         // TODO : introduce a check in innerSeq.hasOne() ?
                         final NumericValue nv = (NumericValue) innerSeq;
                         // Non integers return... nothing, not even an error !
-                        if (!nv.hasFractionalPart() && !nv.isZero())
-                            {positions.add(nv);}
-                    } else if (innerSeq.effectiveBooleanValue())
-                        {result.add(item);}
+                        if (!nv.hasFractionalPart() && !nv.isZero()) {
+                            positions.add(nv);
+                        }
+                    } else if (innerSeq.effectiveBooleanValue()) {
+                        result.add(item);
+                    }
                 }
                 for (final NumericValue pos : positions) {
                     final int position = (reverseAxis ? contextSequence.getItemCount() - pos.getInt() : pos.getInt() - 1);
                     // TODO : move this test above ?
-                    if (position <= contextSequence.getItemCount())
-                        {result.add(contextSequence.itemAt(position));}
+                    if (position <= contextSequence.getItemCount()) {
+                        result.add(contextSequence.itemAt(position));
+                    }
                 }
             }
         }
@@ -438,7 +447,7 @@ public class Predicate extends PathExpr {
      * @return The result of the node set evaluation of the predicate.
      * @throws XPathException
      */
-    private Sequence selectByNodeSet(Sequence contextSequence) throws XPathException {
+    private Sequence selectByNodeSet(final Sequence contextSequence) throws XPathException {
         final NewArrayNodeSet result = new NewArrayNodeSet();
         final NodeSet contextSet = contextSequence.toNodeSet();
         final boolean contextIsVirtual = contextSet instanceof VirtualNodeSet;
@@ -449,9 +458,10 @@ public class Predicate extends PathExpr {
          * also return the cached result.
          */
         if (cached != null && cached.isValid(contextSequence, null) && nodes.isCached()) {
-            if (context.getProfiler().isEnabled())
-                {context.getProfiler().message(this, Profiler.OPTIMIZATIONS,
-                        "Using cached results", result);}
+            if (context.getProfiler().isEnabled()) {
+                context.getProfiler().message(this, Profiler.OPTIMIZATIONS,
+                        "Using cached results", result);
+            }
             return cached.getResult();
         }
         DocumentImpl lastDoc = null;
@@ -479,8 +489,9 @@ public class Predicate extends PathExpr {
                 contextItem = contextItem.getNextDirect();
             }
         }
-        if (contextSequence.isCacheable())
-            {cached = new CachedResult(contextSequence, null, result);}
+        if (contextSequence.isCacheable()) {
+            cached = new CachedResult(contextSequence, null, result);
+        }
         contextSet.setTrackMatches(true);
         return result;
     }
@@ -493,9 +504,8 @@ public class Predicate extends PathExpr {
      * @return The result of the positional evaluation of the predicate.
      * @throws XPathException
      */
-    private Sequence selectByPosition(Sequence outerSequence,
-            Sequence contextSequence, int mode, Sequence innerSeq)
-            throws XPathException {
+    private Sequence selectByPosition(final Sequence outerSequence,
+        final Sequence contextSequence, final int mode, final Sequence innerSeq) throws XPathException {
         if (outerSequence != null && !outerSequence.isEmpty()
                 && Type.subTypeOf(contextSequence.getItemType(), Type.NODE)
                 && contextSequence.isPersistentSet()
@@ -503,120 +513,124 @@ public class Predicate extends PathExpr {
             final Sequence result = new NewArrayNodeSet();
             final NodeSet contextSet = contextSequence.toNodeSet();
             switch (mode) {
-            case Constants.CHILD_AXIS:
-            case Constants.ATTRIBUTE_AXIS:
-            case Constants.DESCENDANT_AXIS:
-            case Constants.DESCENDANT_SELF_AXIS:
-            case Constants.DESCENDANT_ATTRIBUTE_AXIS: {
-                final NodeSet outerNodeSet = outerSequence.toNodeSet();
-                // TODO: in some cases, especially with in-memory nodes,
-                // outerSequence.toNodeSet() will generate a document
-                // which will be different from the one(s) in contextSet
-                // ancestors will thus be empty :-(
-                // A special treatment of VirtualNodeSet does not seem to be
-                // required anymore
-                final Sequence ancestors = outerNodeSet.selectAncestors(contextSet,
-                        true, getExpressionId());
-                if (contextSet.getDocumentSet().intersection(
-                        outerNodeSet.getDocumentSet()).getDocumentCount() == 0)
-                        {LOG.info("contextSet and outerNodeSet don't share any document");}
-                final NewArrayNodeSet temp = new NewArrayNodeSet();
-                for (final SequenceIterator i = ancestors.iterate(); i.hasNext();) {
-                    NodeProxy p = (NodeProxy) i.nextItem();
-                    ContextItem contextNode = p.getContext();
-                    temp.reset();
-                    while (contextNode != null) {
-                        if (contextNode.getContextId() == getExpressionId())
-                            {temp.add(contextNode.getNode());}
-                        contextNode = contextNode.getNextDirect();
+                case Constants.CHILD_AXIS:
+                case Constants.ATTRIBUTE_AXIS:
+                case Constants.DESCENDANT_AXIS:
+                case Constants.DESCENDANT_SELF_AXIS:
+                case Constants.DESCENDANT_ATTRIBUTE_AXIS: {
+                    final NodeSet outerNodeSet = outerSequence.toNodeSet();
+                    // TODO: in some cases, especially with in-memory nodes,
+                    // outerSequence.toNodeSet() will generate a document
+                    // which will be different from the one(s) in contextSet
+                    // ancestors will thus be empty :-(
+                    // A special treatment of VirtualNodeSet does not seem to be
+                    // required anymore
+                    final Sequence ancestors = outerNodeSet.selectAncestors(contextSet,
+                            true, getExpressionId());
+                    if (contextSet.getDocumentSet().intersection(
+                            outerNodeSet.getDocumentSet()).getDocumentCount() == 0) {
+                        LOG.info("contextSet and outerNodeSet don't share any document");
                     }
-                    p.clearContext(getExpressionId());
-                    // TODO : understand why we sort here...
-                    temp.sortInDocumentOrder();
-                    for (final SequenceIterator j = innerSeq.iterate(); j.hasNext();) {
-                        final NumericValue v = (NumericValue) j.nextItem();
-                        // Non integers return... nothing, not even an error !
-                        if (!v.hasFractionalPart() && !v.isZero()) {
-                            // ... whereas we don't want a sorted array here
-                            // TODO : rename this method as getInDocumentOrder ? -pb
-                            p = temp.get(v.getInt() - 1);
-                            if (p != null) {
-                                result.add(p);
+                    final NewArrayNodeSet temp = new NewArrayNodeSet();
+                    for (final SequenceIterator i = ancestors.iterate(); i.hasNext(); ) {
+                        NodeProxy p = (NodeProxy) i.nextItem();
+                        ContextItem contextNode = p.getContext();
+                        temp.reset();
+                        while (contextNode != null) {
+                            if (contextNode.getContextId() == getExpressionId()) {
+                                temp.add(contextNode.getNode());
                             }
-                            // TODO : does null make sense here ? Well... sometimes ;-)
+                            contextNode = contextNode.getNextDirect();
                         }
-                    }
-                }
-                break;
-            }
-            default:
-                for (final SequenceIterator i = outerSequence.iterate(); i.hasNext();) {
-                    NodeProxy p = (NodeProxy) i.nextItem();
-                    Sequence temp;
-                    boolean reverseAxis = true;
-                    switch (mode) {
-                    case Constants.ANCESTOR_AXIS:
-                        temp = contextSet.selectAncestors(p, false, Expression.IGNORE_CONTEXT);
-                        break;
-                    case Constants.ANCESTOR_SELF_AXIS:
-                        temp = contextSet.selectAncestors(p, true, Expression.IGNORE_CONTEXT);
-                        break;
-                    case Constants.PARENT_AXIS:
-                        // TODO : understand why the contextSet is not involved
-                        // here
-                        // NodeProxy.getParent returns a *theoretical* parent
-                        // which is *not* guaranteed to be in the context set !
-                        temp = p.getParents(Expression.NO_CONTEXT_ID);
-                        break;
-                    case Constants.PRECEDING_AXIS:
-                        temp = contextSet.selectPreceding(p, Expression.IGNORE_CONTEXT);
-                        break;
-                    case Constants.PRECEDING_SIBLING_AXIS:
-                        temp = contextSet.selectPrecedingSiblings(p, Expression.IGNORE_CONTEXT);
-                        break;
-                    case Constants.FOLLOWING_SIBLING_AXIS:
-                        temp = contextSet.selectFollowingSiblings(p, Expression.IGNORE_CONTEXT);
-                        reverseAxis = false;
-                        break;
-                    case Constants.FOLLOWING_AXIS:
-                        temp = contextSet.selectFollowing(p, Expression.IGNORE_CONTEXT);
-                        reverseAxis = false;
-                        break;
-                    case Constants.SELF_AXIS:
-                        temp = p;
-                        reverseAxis = false;
-                        break;
-                    default:
-                        throw new IllegalArgumentException("Tried to test unknown axis");
-                    }
-                    if (!temp.isEmpty()) {
-                        for (final SequenceIterator j = innerSeq.iterate(); j.hasNext();) {
+                        p.clearContext(getExpressionId());
+                        // TODO : understand why we sort here...
+                        temp.sortInDocumentOrder();
+                        for (final SequenceIterator j = innerSeq.iterate(); j.hasNext(); ) {
                             final NumericValue v = (NumericValue) j.nextItem();
                             // Non integers return... nothing, not even an error !
                             if (!v.hasFractionalPart() && !v.isZero()) {
-                                final int pos = (reverseAxis ?
-                                    temp.getItemCount() - v.getInt() : v.getInt() - 1);
-                                // Other positions are ignored
-                                if (pos >= 0 && pos < temp.getItemCount()) {
-                                    final NodeProxy t = (NodeProxy) temp.itemAt(pos);
-                                    // for the current context: filter out those
-                                    // context items not selected by the positional predicate
-                                    ContextItem ctx = t.getContext();
-                                    t.clearContext(Expression.IGNORE_CONTEXT);
-                                    while (ctx != null) {
-                                        if (ctx.getContextId() == outerContextId) {
-                                            if (ctx.getNode().getNodeId().equals(p.getNodeId()))
-                                                {t.addContextNode(outerContextId, ctx.getNode());}
-                                        } else
-                                            {t.addContextNode(ctx.getContextId(), ctx.getNode());}
-                                        ctx = ctx.getNextDirect();
+                                // ... whereas we don't want a sorted array here
+                                // TODO : rename this method as getInDocumentOrder ? -pb
+                                p = temp.get(v.getInt() - 1);
+                                if (p != null) {
+                                    result.add(p);
+                                }
+                                // TODO : does null make sense here ? Well... sometimes ;-)
+                            }
+                        }
+                    }
+                    break;
+                }
+                default:
+                    for (final SequenceIterator i = outerSequence.iterate(); i.hasNext(); ) {
+                        NodeProxy p = (NodeProxy) i.nextItem();
+                        Sequence temp;
+                        boolean reverseAxis = true;
+                        switch (mode) {
+                            case Constants.ANCESTOR_AXIS:
+                                temp = contextSet.selectAncestors(p, false, Expression.IGNORE_CONTEXT);
+                                break;
+                            case Constants.ANCESTOR_SELF_AXIS:
+                                temp = contextSet.selectAncestors(p, true, Expression.IGNORE_CONTEXT);
+                                break;
+                            case Constants.PARENT_AXIS:
+                                // TODO : understand why the contextSet is not involved
+                                // here
+                                // NodeProxy.getParent returns a *theoretical* parent
+                                // which is *not* guaranteed to be in the context set !
+                                temp = p.getParents(Expression.NO_CONTEXT_ID);
+                                break;
+                            case Constants.PRECEDING_AXIS:
+                                temp = contextSet.selectPreceding(p, Expression.IGNORE_CONTEXT);
+                                break;
+                            case Constants.PRECEDING_SIBLING_AXIS:
+                                temp = contextSet.selectPrecedingSiblings(p, Expression.IGNORE_CONTEXT);
+                                break;
+                            case Constants.FOLLOWING_SIBLING_AXIS:
+                                temp = contextSet.selectFollowingSiblings(p, Expression.IGNORE_CONTEXT);
+                                reverseAxis = false;
+                                break;
+                            case Constants.FOLLOWING_AXIS:
+                                temp = contextSet.selectFollowing(p, Expression.IGNORE_CONTEXT);
+                                reverseAxis = false;
+                                break;
+                            case Constants.SELF_AXIS:
+                                temp = p;
+                                reverseAxis = false;
+                                break;
+                            default:
+                                throw new IllegalArgumentException("Tried to test unknown axis");
+                        }
+                        if (!temp.isEmpty()) {
+                            for (final SequenceIterator j = innerSeq.iterate(); j.hasNext(); ) {
+                                final NumericValue v = (NumericValue) j.nextItem();
+                                // Non integers return... nothing, not even an error !
+                                if (!v.hasFractionalPart() && !v.isZero()) {
+                                    final int pos = (reverseAxis ?
+                                            temp.getItemCount() - v.getInt() : v.getInt() - 1);
+                                    // Other positions are ignored
+                                    if (pos >= 0 && pos < temp.getItemCount()) {
+                                        final NodeProxy t = (NodeProxy) temp.itemAt(pos);
+                                        // for the current context: filter out those
+                                        // context items not selected by the positional predicate
+                                        ContextItem ctx = t.getContext();
+                                        t.clearContext(Expression.IGNORE_CONTEXT);
+                                        while (ctx != null) {
+                                            if (ctx.getContextId() == outerContextId) {
+                                                if (ctx.getNode().getNodeId().equals(p.getNodeId())) {
+                                                    t.addContextNode(outerContextId, ctx.getNode());
+                                                }
+                                            } else {
+                                                t.addContextNode(ctx.getContextId(), ctx.getNode());
+                                            }
+                                            ctx = ctx.getNextDirect();
+                                        }
+                                        result.add(t);
                                     }
-                                    result.add(t);
                                 }
                             }
                         }
                     }
-                }
             }
             return result;
         } else {
@@ -626,12 +640,12 @@ public class Predicate extends PathExpr {
                     mode == Constants.PRECEDING_AXIS || mode == Constants.PRECEDING_SIBLING_AXIS);
             final Set<NumericValue> set = new TreeSet<>();
             final ValueSequence result = new ValueSequence();
-            for (final SequenceIterator i = innerSeq.iterate(); i.hasNext();) {
+            for (final SequenceIterator i = innerSeq.iterate(); i.hasNext(); ) {
                 final NumericValue v = (NumericValue) i.nextItem();
                 // Non integers return... nothing, not even an error !
                 if (!v.hasFractionalPart() && !v.isZero()) {
                     final int pos = (reverseAxis ? contextSequence.getItemCount()
-                        - v.getInt() : v.getInt() - 1);
+                            - v.getInt() : v.getInt() - 1);
                     // Other positions are ignored
                     if (pos >= 0 && pos < contextSequence.getItemCount() && !set.contains(v)) {
                         result.add(contextSequence.itemAt(pos));
@@ -643,41 +657,44 @@ public class Predicate extends PathExpr {
         }
     }
 
-    public void setContextDocSet(DocumentSet contextSet) {
+    @Override
+    public void setContextDocSet(final DocumentSet contextSet) {
         super.setContextDocSet(contextSet);
-        if (getLength() > 0)
-            {getExpression(0).setContextDocSet(contextSet);}
+        if (getLength() > 0) {
+            getExpression(0).setContextDocSet(contextSet);
+        }
     }
 
     public int getExecutionMode() {
         return executionMode;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.exist.xquery.PathExpr#resetState()
-     */
-    public void resetState(boolean postOptimization) {
+    @Override
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
-        if (!postOptimization)
-            {cached = null;}
+        if (!postOptimization) {
+            cached = null;
+        }
     }
 
+    @Override
     public Expression getParent() {
         return parent;
     }
 
-    public void accept(ExpressionVisitor visitor) {
+    @Override
+    public void accept(final ExpressionVisitor visitor) {
         visitor.visitPredicate(this);
     }
 
-    public void dump(ExpressionDumper dumper) {
+    @Override
+    public void dump(final ExpressionDumper dumper) {
         dumper.display("[");
         super.dump(dumper);
         dumper.display("]");
     }
 
+    @Override
     public String toString() {
         return "[" + super.toString() + "]";
     }

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -261,10 +261,14 @@ public class Predicate extends PathExpr {
     }
 
     /**
-     * @param contextSequence
-     * @param inner
+     * Evaluate the inner part of the predicate as a boolean.
+     *
+     * @param contextSequence the context sequence
+     * @param inner the inner expression
+     *
      * @return The result of the boolean evaluation of the predicate.
-     * @throws XPathException
+     *
+     * @throws XPathException if an error occurs
      */
     private Sequence evalBoolean(final Sequence contextSequence, final Expression inner, final int mode)
             throws XPathException {
@@ -349,9 +353,11 @@ public class Predicate extends PathExpr {
     }
 
     /**
-     * @param contextSequence
+     * @param contextSequence the context sequence
+     *
      * @return The result of the node set evaluation of the predicate.
-     * @throws XPathException
+     *
+     * @throws XPathException if an error occurs
      */
     private Sequence selectByNodeSet(final Sequence contextSequence) throws XPathException {
         final NewArrayNodeSet result = new NewArrayNodeSet();
@@ -403,12 +409,14 @@ public class Predicate extends PathExpr {
     }
 
     /**
-     * @param outerSequence
-     * @param contextSequence
-     * @param mode
-     * @param innerSeq
+     * @param outerSequence the outer sequence
+     * @param contextSequence the context sequence
+     * @param mode the mode
+     * @param innerSeq the inner sequence
+     *
      * @return The result of the positional evaluation of the predicate.
-     * @throws XPathException
+     *
+     * @throws XPathException if an error occurs
      */
     private Sequence selectByPosition(final Sequence outerSequence,
         final Sequence contextSequence, final int mode, final Sequence innerSeq) throws XPathException {

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -64,8 +64,8 @@ public class Predicate extends PathExpr {
 
     @Override
     public void addPath(final PathExpr path) {
-        if (path.getLength() == 1) {
-            add(path.getExpression(0));
+        if (path.getSubExpressionCount() == 1) {
+            add(path.getSubExpression(0));
         } else {
             super.addPath(path);
         }
@@ -74,8 +74,8 @@ public class Predicate extends PathExpr {
     @Override
     public int getDependencies() {
         final int deps;
-        if (getLength() == 1) {
-            deps = getExpression(0).getDependencies();
+        if (getSubExpressionCount() == 1) {
+            deps = getSubExpression(0).getDependencies();
         } else {
             deps = super.getDependencies();
         }
@@ -87,7 +87,7 @@ public class Predicate extends PathExpr {
         parent = contextInfo.getParent();
         AnalyzeContextInfo newContextInfo = createContext(contextInfo);
         super.analyze(newContextInfo);
-        final Expression inner = getExpression(0);
+        final Expression inner = getSubExpression(0);
         final int staticReturnType = newContextInfo.getStaticReturnType();
         final int innerType = staticReturnType != Type.ITEM ?
                 staticReturnType : inner.returnsType();
@@ -131,7 +131,7 @@ public class Predicate extends PathExpr {
     }
 
     public Sequence preprocess() throws XPathException {
-        final Expression inner = steps.size() == 1 ? getExpression(0) : this;
+        final Expression inner = steps.size() == 1 ? getSubExpression(0) : this;
         return inner.eval(null);
     }
 
@@ -660,8 +660,8 @@ public class Predicate extends PathExpr {
     @Override
     public void setContextDocSet(final DocumentSet contextSet) {
         super.setContextDocSet(contextSet);
-        if (getLength() > 0) {
-            getExpression(0).setContextDocSet(contextSet);
+        if (getSubExpressionCount() > 0) {
+            getSubExpression(0).setContextDocSet(contextSet);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -108,7 +108,7 @@ public class Predicate extends PathExpr {
             // dependency with the context item.
         } else if (Type.subTypeOf(innerType, Type.NUMBER) &&
                 !Dependency.dependsOn(inner, Dependency.CONTEXT_ITEM) &&
-                inner.getCardinality().isSuperCardinalityOrEqualOf(Cardinality.EXACTLY_ONE)) {
+                    inner.getCardinality().isSuperCardinalityOrEqualOf(Cardinality.EXACTLY_ONE)) {
             executionMode = POSITIONAL;
         }
         // Case 3: all other cases, boolean evaluation (that can be "promoted" later)
@@ -193,7 +193,11 @@ public class Predicate extends PathExpr {
                         innerSeq = inner.eval(Dependency.dependsOn(inner.getDependencies(), Dependency.CONTEXT_ITEM)
                                 ? contextSequence : null);
                     }
-                    result = selectByPosition(outerSequence, contextSequence, mode, innerSeq);
+                    if (innerSeq.getCardinality().isSubCardinalityOrEqualOf(Cardinality.EXACTLY_ONE)) {
+                        result = selectByPosition(outerSequence, contextSequence, mode, innerSeq);
+                    } else {
+                        throw new XPathException(this, ErrorCodes.FORG0006, "Effective boolean value is not defined for a sequence of two or more items starting with a " + Type.getTypeName(innerSeq.itemAt(0).getType()) + " value");
+                    }
                     break;
                 default:
                     throw new IllegalArgumentException(

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -108,7 +108,7 @@ public class Predicate extends PathExpr {
             // dependency with the context item.
         } else if (Type.subTypeOf(innerType, Type.NUMBER) &&
                 !Dependency.dependsOn(inner, Dependency.CONTEXT_ITEM) &&
-                Cardinality.checkCardinality(inner.getCardinality(), Cardinality.EXACTLY_ONE)) {
+                inner.getCardinality().isSuperCardinalityOrEqualOf(Cardinality.EXACTLY_ONE)) {
             executionMode = POSITIONAL;
         }
         // Case 3: all other cases, boolean evaluation (that can be "promoted" later)

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -39,6 +39,7 @@ import org.exist.xquery.value.ValueSequence;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static org.exist.xquery.Predicate.ExecutionMode.*;
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 
 /**
@@ -48,14 +49,16 @@ import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
  */
 public class Predicate extends PathExpr {
 
-    public final static int UNKNOWN = -1;
-    public final static int NODE = 0;
-    public final static int BOOLEAN = 1;
-    public final static int POSITIONAL = 2;
+    public enum ExecutionMode {
+        UNKNOWN,
+        NODE,
+        BOOLEAN,
+        POSITIONAL;
+    }
 
     private CachedResult cached = null;
 
-    private int executionMode = UNKNOWN;
+    private ExecutionMode executionMode = UNKNOWN;
 
     private int outerContextId;
 
@@ -158,8 +161,8 @@ public class Predicate extends PathExpr {
                 executionMode = BOOLEAN;
             }
 
-            final Tuple2<Integer, Sequence> recomputed = recomputeExecutionMode(contextSequence, inner);
-            final int recomputedExecutionMode = recomputed._1;
+            final Tuple2<ExecutionMode, Sequence> recomputed = recomputeExecutionMode(contextSequence, inner);
+            final ExecutionMode recomputedExecutionMode = recomputed._1;
             Sequence innerSeq = recomputed._2;
 
             switch (recomputedExecutionMode) {
@@ -203,8 +206,8 @@ public class Predicate extends PathExpr {
         return result;
     }
 
-    private Tuple2<Integer, Sequence> recomputeExecutionMode(final Sequence contextSequence, final Expression inner) throws XPathException {
-        int recomputedExecutionMode = executionMode;
+    private Tuple2<ExecutionMode, Sequence> recomputeExecutionMode(final Sequence contextSequence, final Expression inner) throws XPathException {
+        ExecutionMode recomputedExecutionMode = executionMode;
         Sequence innerSeq = null;
 
         // Atomic context sequences :
@@ -579,7 +582,7 @@ public class Predicate extends PathExpr {
         }
     }
 
-    public int getExecutionMode() {
+    public ExecutionMode getExecutionMode() {
         return executionMode;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/RangeSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/RangeSequence.java
@@ -152,15 +152,15 @@ public class RangeSequence extends AbstractSequence {
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         final long itemCount = getItemCountLong();
         if (itemCount <= 0) {
-            return Cardinality.EMPTY;
+            return Cardinality.EMPTY_SEQUENCE;
         }
         if (itemCount == 1) {
             return Cardinality.EXACTLY_ONE;
         }
-        return Cardinality.MANY;
+        return Cardinality._MANY;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
@@ -129,10 +129,8 @@ public class SequenceConstructor extends PathExpr {
         return Type.ITEM;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#getCardinality()
-     */
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         return Cardinality.ZERO_OR_MORE;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/Step.java
+++ b/exist-core/src/main/java/org/exist/xquery/Step.java
@@ -195,7 +195,8 @@ public abstract class Step extends AbstractExpression {
             {return Type.NODE;}
     }
 
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         return Cardinality.ZERO_OR_MORE;
    }
 

--- a/exist-core/src/main/java/org/exist/xquery/StringConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/StringConstructor.java
@@ -75,7 +75,7 @@ public class StringConstructor extends AbstractExpression {
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return Cardinality.EXACTLY_ONE;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/SwitchExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/SwitchExpression.java
@@ -125,8 +125,9 @@ public class SwitchExpression extends AbstractExpression {
     public int getDependencies() {
         return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
     }
-    
-    public int getCardinality() {
+
+    @Override
+    public Cardinality getCardinality() {
         return Cardinality.ZERO_OR_MORE;
     }
     

--- a/exist-core/src/main/java/org/exist/xquery/TreatAsExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/TreatAsExpression.java
@@ -48,7 +48,8 @@ public class TreatAsExpression extends AbstractExpression {
         return type.getPrimaryType();
     }
 
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         return type.getCardinality();
     }
     

--- a/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
@@ -104,7 +104,7 @@ public class TryCatchExpression extends AbstractExpression {
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return Cardinality.ZERO_OR_MORE;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/TypeswitchExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/TypeswitchExpression.java
@@ -131,13 +131,13 @@ public class TypeswitchExpression extends AbstractExpression {
     }
 
     private boolean checkType(SequenceType type, Sequence seq) throws XPathException {
-        final int requiredCardinality = type.getCardinality();
-        int actualCardinality;
-        if (seq.isEmpty()) {actualCardinality = Cardinality.EMPTY;}
-        else if (seq.hasMany()) {actualCardinality = Cardinality.MANY;}
-        else {actualCardinality = Cardinality.ONE;}
+        final Cardinality requiredCardinality = type.getCardinality();
+        Cardinality actualCardinality;
+        if (seq.isEmpty()) {actualCardinality = Cardinality.EMPTY_SEQUENCE;}
+        else if (seq.hasMany()) {actualCardinality = Cardinality._MANY;}
+        else {actualCardinality = Cardinality.EXACTLY_ONE;}
         
-        if (!Cardinality.checkCardinality(requiredCardinality, actualCardinality))
+        if (!requiredCardinality.isSuperCardinalityOrEqualOf(actualCardinality))
             {return false;}
         for(final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
             final Item next = i.nextItem();
@@ -155,8 +155,9 @@ public class TypeswitchExpression extends AbstractExpression {
     public int getDependencies() {
         return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
     }
-    
-    public int getCardinality() {
+
+    @Override
+    public Cardinality getCardinality() {
         return Cardinality.ZERO_OR_MORE;
     }
     

--- a/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/UserDefinedFunction.java
@@ -149,14 +149,14 @@ public class UserDefinedFunction extends Function implements Cloneable {
 					{var.setContextDocs(contextDocs[i]);}
 				context.declareVariableBinding(var);
 				
-				int actualCardinality;
-				if (currentArguments[j].isEmpty()) {actualCardinality = Cardinality.EMPTY;}
-				else if (currentArguments[j].hasMany()) {actualCardinality = Cardinality.MANY;}
-				else {actualCardinality = Cardinality.ONE;}
+				Cardinality actualCardinality;
+				if (currentArguments[j].isEmpty()) {actualCardinality = Cardinality.EMPTY_SEQUENCE;}
+				else if (currentArguments[j].hasMany()) {actualCardinality = Cardinality._MANY;}
+				else {actualCardinality = Cardinality.EXACTLY_ONE;}
 				
-				if (!Cardinality.checkCardinality(getSignature().getArgumentTypes()[j].getCardinality(), actualCardinality))
+				if (!getSignature().getArgumentTypes()[j].getCardinality().isSuperCardinalityOrEqualOf(actualCardinality))
 					{throw new XPathException(this, ErrorCodes.XPTY0004, "Invalid cardinality for parameter $" + varName +  
- 						". Expected " + Cardinality.getDescription(getSignature().getArgumentTypes()[j].getCardinality()) + 
+ 						". Expected " + getSignature().getArgumentTypes()[j].getCardinality().getHumanDescription() +
  						", got " + currentArguments[j].getItemCount());}
 			}
 			result = body.eval(contextSequence, contextItem);

--- a/exist-core/src/main/java/org/exist/xquery/Variable.java
+++ b/exist-core/src/main/java/org/exist/xquery/Variable.java
@@ -57,7 +57,7 @@ public interface Variable {
 	
 	public int getDependencies(XQueryContext context);
 	
-	public int getCardinality();
+	public Cardinality getCardinality();
 	
 	public void setStackPosition(int position);
 	

--- a/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
+++ b/exist-core/src/main/java/org/exist/xquery/VariableDeclaration.java
@@ -215,10 +215,8 @@ public class VariableDeclaration extends AbstractExpression implements Rewritabl
 		return Dependency.CONTEXT_SET;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.AbstractExpression#getCardinality()
-	 */
-	public int getCardinality() {
+	@Override
+	public Cardinality getCardinality() {
 		return expression.isPresent() ? expression.get().getCardinality() : Cardinality.ONE_OR_MORE;
 	}
 

--- a/exist-core/src/main/java/org/exist/xquery/VariableImpl.java
+++ b/exist-core/src/main/java/org/exist/xquery/VariableImpl.java
@@ -103,7 +103,7 @@ public class VariableImpl implements Variable {
 		if (type != null) {
 			return type.toString();
 		} else {
-			return Type.getTypeName(Type.ITEM) + Cardinality.toString(getCardinality());
+			return Type.getTypeName(Type.ITEM) + getCardinality().toXQueryCardinalityString();
 		}
 	}
     
@@ -112,16 +112,16 @@ public class VariableImpl implements Variable {
     	//Check the value's type if it is already assigned : happens with external variables    	
     	if (getValue() != null) {
             if (getSequenceType() != null) {
-                int actualCardinality;
-                if (getValue().isEmpty()) {actualCardinality = Cardinality.EMPTY;}
-                else if (getValue().hasMany()) {actualCardinality = Cardinality.MANY;}
-                else {actualCardinality = Cardinality.ONE;}                	
+                Cardinality actualCardinality;
+                if (getValue().isEmpty()) {actualCardinality = Cardinality.EMPTY_SEQUENCE;}
+                else if (getValue().hasMany()) {actualCardinality = Cardinality._MANY;}
+                else {actualCardinality = Cardinality.EXACTLY_ONE;}
             	//Type.EMPTY is *not* a subtype of other types ; checking cardinality first
-        		if (!Cardinality.checkCardinality(getSequenceType().getCardinality(), actualCardinality))
+        		if (!getSequenceType().getCardinality().isSuperCardinalityOrEqualOf(actualCardinality))
     				{throw new XPathException("XPTY0004: Invalid cardinality for variable $" + getQName() +
     						". Expected " +
-    						Cardinality.getDescription(getSequenceType().getCardinality()) +
-    						", got " + Cardinality.getDescription(actualCardinality));}
+    						getSequenceType().getCardinality().getHumanDescription() +
+    						", got " + actualCardinality.getHumanDescription());}
         		//TODO : ignore nodes right now ; they are returned as xs:untypedAtomicType
         		if (!Type.subTypeOf(getSequenceType().getPrimaryType(), Type.NODE)) {
             		if (!getValue().isEmpty() && !Type.subTypeOf(getValue().getItemType(), getSequenceType().getPrimaryType()))
@@ -195,8 +195,9 @@ public class VariableImpl implements Variable {
 		else
 			{return Dependency.CONTEXT_SET + Dependency.LOCAL_VARS;}
 	}
-	
-	public int getCardinality() {
+
+	@Override
+	public Cardinality getCardinality() {
 		if (type != null) {
 			return type.getCardinality();
 		} else {

--- a/exist-core/src/main/java/org/exist/xquery/VariableReference.java
+++ b/exist-core/src/main/java/org/exist/xquery/VariableReference.java
@@ -160,14 +160,12 @@ public class VariableReference extends AbstractExpression {
         return Dependency.CONTEXT_SET + Dependency.CONTEXT_ITEM;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#getCardinality()
-     */
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         try {
             final Variable var = context.resolveVariable(qname);
             if (var != null && var.getValue() != null) {
-                final int card = var.getValue().getCardinality();
+                final Cardinality card = var.getValue().getCardinality();
                 return card;
             }
         } catch (final XPathException e) {

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -1741,19 +1741,19 @@ public class XQueryContext implements BinaryValueManager, Context {
         }
 
         if (var.getSequenceType() != null) {
-            int actualCardinality;
+            final Cardinality actualCardinality;
 
             if (val.isEmpty()) {
-                actualCardinality = Cardinality.EMPTY;
+                actualCardinality = Cardinality.EMPTY_SEQUENCE;
             } else if (val.hasMany()) {
-                actualCardinality = Cardinality.MANY;
+                actualCardinality = Cardinality._MANY;
             } else {
-                actualCardinality = Cardinality.ONE;
+                actualCardinality = Cardinality.EXACTLY_ONE;
             }
 
             //Type.EMPTY is *not* a subtype of other types ; checking cardinality first
-            if (!Cardinality.checkCardinality(var.getSequenceType().getCardinality(), actualCardinality)) {
-                throw new XPathException("XPTY0004: Invalid cardinality for variable $" + var.getQName() + ". Expected " + Cardinality.getDescription(var.getSequenceType().getCardinality()) + ", got " + Cardinality.getDescription(actualCardinality));
+            if (!var.getSequenceType().getCardinality().isSuperCardinalityOrEqualOf(actualCardinality)) {
+                throw new XPathException("XPTY0004: Invalid cardinality for variable $" + var.getQName() + ". Expected " + var.getSequenceType().getCardinality().getHumanDescription() + ", got " + actualCardinality.getHumanDescription());
             }
 
             //TODO : ignore nodes right now ; they are returned as xs:untypedAtomicType

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunBoolean.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunBoolean.java
@@ -51,7 +51,7 @@ public class FunBoolean extends Function {
                 new FunctionParameterSequenceType("items", Type.ITEM,
                     Cardinality.ZERO_OR_MORE, "The items")
             },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE,
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "The boolean value, ebv, of the items")
         );
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunContains.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunContains.java
@@ -55,7 +55,7 @@ public class FunContains extends CollatingFunction {
                 new FunctionParameterSequenceType("substring", Type.STRING,
                     Cardinality.ZERO_OR_ONE, "The substring")
             },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE,
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "true() if $source-string contains $substring, false() otherwise")),
         new FunctionSignature(
             new QName("contains", Function.BUILTIN_FUNCTION_NS),
@@ -73,7 +73,7 @@ public class FunContains extends CollatingFunction {
                 new FunctionParameterSequenceType("collation-uri", Type.STRING,
                     Cardinality.EXACTLY_ONE, "The collation URI")
             },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE,
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "true() if $source-string contains $substring, false() otherwise"))
     };
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCount.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCount.java
@@ -47,7 +47,7 @@ public class FunCount extends Function {
                             new FunctionParameterSequenceType("items", Type.ITEM,
                                     Cardinality.ZERO_OR_MORE, "The items")
                     },
-                    new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ONE,
+                    new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE,
                             "The number of items in the argument sequence")
             );
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
@@ -72,11 +72,11 @@ public class FunDeepEqual extends CollatingFunction {
             "If both $items-1 and $items-2 are the empty sequence, returns true(). ",
             new SequenceType[] {
                 new FunctionParameterSequenceType("items-1", Type.ITEM,
-                    Cardinality.ZERO_OR_MORE, "The first item sequence"), 
+                    Cardinality.ZERO_OR_MORE, "The first item sequence"),
                 new FunctionParameterSequenceType("items-2", Type.ITEM,
                     Cardinality.ZERO_OR_MORE, "The second item sequence")
             },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE,
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "true() if the sequences are deep-equal, false() otherwise")
             ),
         new FunctionSignature(
@@ -88,13 +88,13 @@ public class FunDeepEqual extends CollatingFunction {
             THIRD_REL_COLLATION_ARG_EXAMPLE,
             new SequenceType[] {
                 new FunctionParameterSequenceType("items-1", Type.ITEM,
-                    Cardinality.ZERO_OR_MORE, "The first item sequence"), 
+                    Cardinality.ZERO_OR_MORE, "The first item sequence"),
                 new FunctionParameterSequenceType("items-2", Type.ITEM,
                     Cardinality.ZERO_OR_MORE, "The second item sequence"),
                 new FunctionParameterSequenceType("collation-uri", Type.STRING,
                     Cardinality.EXACTLY_ONE, "The collation URI")
             },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE,
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "true() if the sequences are deep-equal, false() otherwise")
         )
     };

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEnvironment.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEnvironment.java
@@ -48,7 +48,7 @@ public class FunEnvironment extends BasicFunction {
             new QName("available-environment-variables", Function.BUILTIN_FUNCTION_NS),
             "Returns a list of environment variable names.",
             null,
-            new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_MORE, 
+            new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_MORE,
             "Returns a sequence of strings, being the names of the environment variables. User must be DBA.")
         ),
         new FunctionSignature(

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEquals.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunEquals.java
@@ -56,7 +56,7 @@ public class FunEquals extends CollatingFunction {
                 new FunctionParameterSequenceType("substring", Type.STRING,
                     Cardinality.ZERO_OR_ONE, "The substring")
             },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE,
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "true() if $source-string equals $substring, false() otherwise")
         ),
         new FunctionSignature(
@@ -75,7 +75,7 @@ public class FunEquals extends CollatingFunction {
                 new FunctionParameterSequenceType("collation-uri", Type.STRING,
                     Cardinality.EXACTLY_ONE, "The collation URI")
             },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE, 
+            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                 "true() if $source-string equals $substring, false() otherwise"))
     };
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunError.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunError.java
@@ -53,7 +53,7 @@ public class FunError extends BasicFunction {
             "the default qname, 'http://www.w3.org/2004/07/xqt-errors#err:FOER0000', " +
             "and the default error message, 'An error has been raised by the query'.",
             null,
-            new SequenceType(Type.EMPTY, Cardinality.ZERO)
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
         ),
         new FunctionSignature(
             new QName("error", Function.BUILTIN_FUNCTION_NS),
@@ -64,7 +64,7 @@ public class FunError extends BasicFunction {
                 new FunctionParameterSequenceType("qname", Type.QNAME,
                     Cardinality.ZERO_OR_ONE, "The qname")
             },
-            new SequenceType(Type.EMPTY, Cardinality.ZERO)
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
         ),
         new FunctionSignature(
             new QName("error", Function.BUILTIN_FUNCTION_NS),
@@ -77,7 +77,7 @@ public class FunError extends BasicFunction {
                 new FunctionParameterSequenceType("message", Type.STRING,
                     Cardinality.EXACTLY_ONE, "The message")
             },
-            new SequenceType(Type.EMPTY, Cardinality.ZERO)),
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
         new FunctionSignature(
             new QName("error", Function.BUILTIN_FUNCTION_NS),
             "Indicates that an irrecoverable error has occurred. " +
@@ -91,7 +91,7 @@ public class FunError extends BasicFunction {
                 new FunctionParameterSequenceType("error-object", Type.ITEM,
                     Cardinality.ZERO_OR_MORE, "The error object")
             },
-            new SequenceType(Type.EMPTY, Cardinality.ZERO)),
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
     };
 
     public FunError(XQueryContext context, FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
@@ -65,7 +65,7 @@ public class FunHigherOrderFun extends BasicFunction {
                 new FunctionParameterSequenceType("zero", Type.ITEM, Cardinality.ZERO_OR_MORE, "initial value to start with"),
 	            new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call")
 	        },
-	        new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, 
+	        new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
 	        		"result of the fold-left operation")
 		);
 
@@ -79,7 +79,7 @@ public class FunHigherOrderFun extends BasicFunction {
                 new FunctionParameterSequenceType("zero", Type.ITEM, Cardinality.ZERO_OR_MORE, "initial value to start with"),
 	            new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call"),
 	        },
-	        new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, 
+	        new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
 	        		"result of the fold-right operation")
 		);
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInsertBefore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunInsertBefore.java
@@ -69,7 +69,7 @@ public class FunInsertBefore extends Function {
 			FUNCTION_DESCRIPTION,
 			new SequenceType[] {
 					new FunctionParameterSequenceType("target", Type.ITEM, Cardinality.ZERO_OR_MORE, "The target"),
-					new FunctionParameterSequenceType("position", Type.INTEGER, Cardinality.ONE, "The position to insert before"),
+					new FunctionParameterSequenceType("position", Type.INTEGER, Cardinality.EXACTLY_ONE, "The position to insert before"),
 					new FunctionParameterSequenceType("inserts", Type.ITEM, Cardinality.ZERO_OR_MORE, "The data to insert")
 			},
 			new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "the new sequence"));

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLang.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLang.java
@@ -78,7 +78,7 @@ public class FunLang extends Function {
 			new SequenceType[] {
 				 new FunctionParameterSequenceType("lang", Type.STRING, Cardinality.ZERO_OR_ONE, "The language code")
 			},
-			new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE, "true if the language code matches, false otherwise")
+			new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if the language code matches, false otherwise")
 		),
 		new FunctionSignature(
 				new QName("lang", Function.BUILTIN_FUNCTION_NS),
@@ -87,7 +87,7 @@ public class FunLang extends Function {
 					 new FunctionParameterSequenceType("lang", Type.STRING, Cardinality.ZERO_OR_ONE, "The language code"),
 					 new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE, "The node")
 				},
-				new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE, "true if the language code matches, false otherwise")
+				new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if the language code matches, false otherwise")
 		)		
 	};
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNormalizeUnicode.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNormalizeUnicode.java
@@ -84,8 +84,8 @@ public class FunNormalizeUnicode extends Function {
 		"supported by the implementation, then an error is raised [err:FOCH0003].";
 
 	protected static final FunctionParameterSequenceType ARG_PARAM = new FunctionParameterSequenceType("arg", Type.STRING, Cardinality.ZERO_OR_ONE, "The unicode string to normalize");
-	protected static final FunctionParameterSequenceType NF_PARAM = new FunctionParameterSequenceType("normalization-form", Type.STRING, Cardinality.ONE, "The normalization form");
-	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.STRING, Cardinality.ONE, "the normalized text");
+	protected static final FunctionParameterSequenceType NF_PARAM = new FunctionParameterSequenceType("normalization-form", Type.STRING, Cardinality.EXACTLY_ONE, "The normalization form");
+	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the normalized text");
 
 	public final static FunctionSignature signatures [] = {
     	new FunctionSignature(

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunOnFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunOnFunctions.java
@@ -30,7 +30,7 @@ public class FunOnFunctions extends BasicFunction {
             new SequenceType[] {
                 new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "The function item")
             },
-            new FunctionReturnSequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE, 
+            new FunctionReturnSequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE,
             		"The name of the function or the empty sequence if $function is an anonymous function.")),
 		new FunctionSignature(
             new QName("function-arity", Function.BUILTIN_FUNCTION_NS),

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunRemove.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunRemove.java
@@ -59,7 +59,7 @@ public class FunRemove extends Function {
 			"is returned.",
 			new SequenceType[] {
 					new FunctionParameterSequenceType("target", Type.ITEM, Cardinality.ZERO_OR_MORE, "The input sequence"),
-					new FunctionParameterSequenceType("position", Type.INTEGER, Cardinality.ONE, "The position of the value to be removed")
+					new FunctionParameterSequenceType("position", Type.INTEGER, Cardinality.EXACTLY_ONE, "The position of the value to be removed")
 			},
 			new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "the new sequence with the item at the position specified by the value of $position removed."));
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunResolveQName.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunResolveQName.java
@@ -68,7 +68,7 @@ public class FunResolveQName extends BasicFunction {
     			"resulting expanded-QName has no namespace part.\n\nThe prefix (or absence of a prefix) in the " +
     			"supplied $qname argument is retained in the returned expanded-QName.", 
     			new SequenceType[] { 
-    				new FunctionParameterSequenceType("qname", Type.STRING, Cardinality.ZERO_OR_ONE, "The QName name"), 
+    				new FunctionParameterSequenceType("qname", Type.STRING, Cardinality.ZERO_OR_ONE, "The QName name"),
     				new FunctionParameterSequenceType("element", Type.ELEMENT, Cardinality.EXACTLY_ONE, "The element") 
     			}, 
     			new FunctionReturnSequenceType(Type.QNAME, Cardinality.ZERO_OR_ONE, "the QName of $element with lexical form $qname")

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunResolveURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunResolveURI.java
@@ -69,7 +69,7 @@ public class FunResolveURI extends Function {
 		"If $relative is the empty sequence, the empty sequence is returned.";
 	
 	protected static final FunctionParameterSequenceType RELATIVE_ARG = new FunctionParameterSequenceType("relative", Type.STRING, Cardinality.ZERO_OR_ONE, "The relative URI");
-	protected static final FunctionParameterSequenceType BASE_ARG = new FunctionParameterSequenceType("base", Type.STRING, Cardinality.ONE, "The base URI");
+	protected static final FunctionParameterSequenceType BASE_ARG = new FunctionParameterSequenceType("base", Type.STRING, Cardinality.EXACTLY_ONE, "The base URI");
 	protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.ZERO_OR_ONE, "the absolute URI");
 	
     public final static FunctionSignature signatures [] = {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSort.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSort.java
@@ -64,7 +64,7 @@ public class FunSort extends BasicFunction {
         new SequenceType[] {
             new FunctionParameterSequenceType("input", Type.ITEM, Cardinality.ZERO_OR_MORE, ""),
             new FunctionParameterSequenceType("collation", Type.STRING, Cardinality.ZERO_OR_ONE, ""),
-            new FunctionParameterSequenceType("key", Type.FUNCTION_REFERENCE, Cardinality.ONE, "")
+            new FunctionParameterSequenceType("key", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "")
         },
         new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "the resulting sequence")
     )

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTrueOrFalse.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTrueOrFalse.java
@@ -64,10 +64,8 @@ public class FunTrueOrFalse extends BasicFunction {
         return Dependency.NO_DEPENDENCY;
     }
     
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Function#getCardinality()
-     */
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         return Cardinality.EXACTLY_ONE;
     }
     

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnordered.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnordered.java
@@ -89,10 +89,8 @@ public class FunUnordered extends Function {
     }
 
     
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Function#getCardinality()
-     */
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         return getArgument(0).getCardinality();
     }
     

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/ParsingFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/ParsingFunctions.java
@@ -48,7 +48,7 @@ public class ParsingFunctions extends BasicFunction {
 	protected static final FunctionReturnSequenceType RESULT_TYPE_FOR_PARSE_XML = new FunctionReturnSequenceType(Type.DOCUMENT,
 			Cardinality.ZERO_OR_ONE, "the parsed document");
 	protected static final FunctionReturnSequenceType RESULT_TYPE_FOR_PARSE_XML_FRAGMENT = new FunctionReturnSequenceType(Type.DOCUMENT,
-			Cardinality.ZERO_OR_ONE, "the parsed document fragment");	
+			Cardinality.ZERO_OR_ONE, "the parsed document fragment");
 
 	protected static final FunctionParameterSequenceType TO_BE_PARSED_PARAMETER = new FunctionParameterSequenceType(
 			"arg", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be parsed");

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectFunction.java
@@ -83,7 +83,7 @@ public class InspectFunction extends BasicFunction {
         if (returnType != null) {
             attribs.clear();
             attribs.addAttribute("", "type", "type", "CDATA", Type.getTypeName(returnType.getPrimaryType()));
-            attribs.addAttribute("", "cardinality", "cardinality", "CDATA", Cardinality.getDescription(returnType.getCardinality()));
+            attribs.addAttribute("", "cardinality", "cardinality", "CDATA", returnType.getCardinality().getHumanDescription());
             builder.startElement(RETURN_QNAME, attribs);
             if (returnType instanceof FunctionReturnSequenceType) {
                 final FunctionReturnSequenceType type = (FunctionReturnSequenceType) returnType;
@@ -124,7 +124,7 @@ public class InspectFunction extends BasicFunction {
             for (final SequenceType type: arguments) {
                 attribs.clear();
                 attribs.addAttribute("", "type", "type", "CDATA", Type.getTypeName(type.getPrimaryType()));
-                attribs.addAttribute("", "cardinality", "cardinality", "CDATA", Cardinality.getDescription(type.getCardinality()));
+                attribs.addAttribute("", "cardinality", "cardinality", "CDATA", type.getCardinality().getHumanDescription());
                 if (type instanceof FunctionParameterSequenceType)
                     {attribs.addAttribute("", "var", "var", "CDATA", ((FunctionParameterSequenceType)type).getAttributeName());}
                 builder.startElement(ARGUMENT_QNAME, attribs);

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
@@ -98,7 +98,7 @@ public class InspectModule extends BasicFunction {
                     final SequenceType type = var.getSequenceType();
                     if (type != null) {
                         attribs.addAttribute("", "type", "type", "CDATA", Type.getTypeName(type.getPrimaryType()));
-                        attribs.addAttribute("", "cardinality", "cardinality", "CDATA", Cardinality.getDescription(type.getCardinality()));
+                        attribs.addAttribute("", "cardinality", "cardinality", "CDATA", type.getCardinality().getHumanDescription());
                     }
                     builder.startElement(VARIABLE_QNAME, attribs);
                     builder.endElement();

--- a/exist-core/src/main/java/org/exist/xquery/functions/request/SetAttribute.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/request/SetAttribute.java
@@ -49,7 +49,7 @@ public class SetAttribute extends StrictRequestFunction {
 				new FunctionParameterSequenceType( "name", Type.STRING, Cardinality.EXACTLY_ONE, "The attribute name" ),
 				new FunctionParameterSequenceType( "value", Type.ITEM, Cardinality.ZERO_OR_MORE, "The attribute value" )
 				},
-			new SequenceType( Type.ITEM, Cardinality.EMPTY )
+			new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE )
 		);
 	
 	public SetAttribute(final XQueryContext context)

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/RedirectTo.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/RedirectTo.java
@@ -50,7 +50,7 @@ public class RedirectTo extends StrictResponseFunction {
 			new QName("redirect-to", ResponseModule.NAMESPACE_URI, ResponseModule.PREFIX),
 			"Sends a HTTP redirect response (302) to the client.",
 			new SequenceType[] { new FunctionParameterSequenceType("uri", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The URI to redirect the client to") },
-			new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+			new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public RedirectTo(final XQueryContext context)
     {

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/SetCookie.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/SetCookie.java
@@ -62,17 +62,17 @@ public class SetCookie extends StrictResponseFunction {
                     new QName("set-cookie", ResponseModule.NAMESPACE_URI, ResponseModule.PREFIX),
                     "Sets a HTTP Cookie on the HTTP Response.",
                     new SequenceType[]{NAME_PARAM, VALUE_PARAM},
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY)),
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
             new FunctionSignature(
                     new QName("set-cookie", ResponseModule.NAMESPACE_URI, ResponseModule.PREFIX),
                     "Sets a HTTP Cookie on the HTTP Response.",
                     new SequenceType[]{NAME_PARAM, VALUE_PARAM, MAX_AGE_PARAM, SECURE_PARAM},
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY)),
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
             new FunctionSignature(
                     new QName("set-cookie", ResponseModule.NAMESPACE_URI, ResponseModule.PREFIX),
                     "Sets a HTTP Cookie on the HTTP Response.",
                     new SequenceType[]{NAME_PARAM, VALUE_PARAM, MAX_AGE_PARAM, SECURE_PARAM, DOMAIN_PARAM, PATH_PARAM},
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY))
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE))
     };
 
     public SetCookie(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/SetDateHeader.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/SetDateHeader.java
@@ -53,7 +53,7 @@ public class SetDateHeader extends StrictResponseFunction {
                     new QName("set-date-header", ResponseModule.NAMESPACE_URI, ResponseModule.PREFIX),
                     "Sets a HTTP Header on the HTTP Response.",
                     new SequenceType[]{NAME_PARAM, VALUE_PARAM},
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public SetDateHeader(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/SetHeader.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/SetHeader.java
@@ -53,7 +53,7 @@ public class SetHeader extends StrictResponseFunction {
                     new QName("set-header", ResponseModule.NAMESPACE_URI, ResponseModule.PREFIX),
                     "Sets a HTTP Header on the HTTP Response.",
                     new SequenceType[]{NAME_PARAM, VALUE_PARAM},
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public SetHeader(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/SetStatusCode.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/SetStatusCode.java
@@ -53,7 +53,7 @@ public class SetStatusCode extends StrictResponseFunction {
                     new SequenceType[]{
                             new FunctionParameterSequenceType("code", Type.INTEGER, Cardinality.EXACTLY_ONE, "The status code")
                     },
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public SetStatusCode(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/Stream.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/Stream.java
@@ -58,7 +58,7 @@ public class Stream extends StrictResponseFunction {
                     new SequenceType[]{
                             new FunctionParameterSequenceType("content", Type.ITEM, Cardinality.ZERO_OR_MORE, "The source sequence"),
                             new FunctionParameterSequenceType("serialization-options", Type.STRING, Cardinality.EXACTLY_ONE, "The serialization options")},
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY)
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
             );
 
     public Stream(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/StreamBinary.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/StreamBinary.java
@@ -52,7 +52,7 @@ public class StreamBinary extends StrictResponseFunction {
             + "Note: the servlet output stream will be closed afterwards and mime-type settings in the prolog "
             + "will not be passed.",
             new SequenceType[]{BINARY_DATA_PARAM, CONTENT_TYPE_PARAM, FILENAME_PARAM},
-            new SequenceType(Type.EMPTY, Cardinality.EMPTY),
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE),
             true);
 
     public StreamBinary(final XQueryContext context) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/AccountManagementFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/AccountManagementFunction.java
@@ -51,7 +51,7 @@ public class AccountManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("primary-group", Type.STRING, Cardinality.EXACTLY_ONE, "The primary group of the user."),
             new FunctionParameterSequenceType("groups", Type.STRING, Cardinality.ZERO_OR_MORE, "Any supplementary groups of which the user should be a member.")
             }, 
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_CREATE_ACCOUNT_WITH_METADATA = new FunctionSignature(
@@ -65,7 +65,7 @@ public class AccountManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("full-name", Type.STRING, Cardinality.EXACTLY_ONE, "The full name of the user."),
             new FunctionParameterSequenceType("description", Type.STRING, Cardinality.EXACTLY_ONE, "A description of the user.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_CREATE_ACCOUNT_WITH_PERSONAL_GROUP = new FunctionSignature(
@@ -76,7 +76,7 @@ public class AccountManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("password", Type.STRING, Cardinality.EXACTLY_ONE, "The User's password."),
             new FunctionParameterSequenceType("groups", Type.STRING, Cardinality.ZERO_OR_MORE, "Any supplementary groups of which the user should be a member.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_CREATE_ACCOUNT_WITH_PERSONAL_GROUP_WITH_METADATA = new FunctionSignature(
@@ -89,7 +89,7 @@ public class AccountManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("full-name", Type.STRING, Cardinality.EXACTLY_ONE, "The full name of the user."),
             new FunctionParameterSequenceType("description", Type.STRING, Cardinality.EXACTLY_ONE, "A description of the user.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_REMOVE_ACCOUNT = new FunctionSignature(
@@ -98,7 +98,7 @@ public class AccountManagementFunction extends BasicFunction {
         new SequenceType[] {
             new FunctionParameterSequenceType("username", Type.STRING, Cardinality.EXACTLY_ONE, "The User's username.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_PASSWD = new FunctionSignature(
@@ -108,7 +108,7 @@ public class AccountManagementFunction extends BasicFunction {
                 new FunctionParameterSequenceType("username", Type.STRING, Cardinality.EXACTLY_ONE, "The User's username."),
                 new FunctionParameterSequenceType("password", Type.STRING, Cardinality.EXACTLY_ONE, "The User's new password."),
             },
-            new SequenceType(Type.EMPTY, Cardinality.ZERO)
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_PASSWD_HASH = new FunctionSignature(
@@ -118,7 +118,7 @@ public class AccountManagementFunction extends BasicFunction {
                 new FunctionParameterSequenceType("username", Type.STRING, Cardinality.EXACTLY_ONE, "The User's username."),
                 new FunctionParameterSequenceType("password-digest", Type.STRING, Cardinality.EXACTLY_ONE, "The encoded digest of the User's new password (assumes eXist's default digest algorithm)."),
             },
-            new SequenceType(Type.EMPTY, Cardinality.ZERO)
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/AccountStatusFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/AccountStatusFunction.java
@@ -63,7 +63,7 @@ public class AccountStatusFunction extends BasicFunction {
             new FunctionParameterSequenceType("username", Type.STRING, Cardinality.EXACTLY_ONE, "The username of the account to enable or disable."),
             new FunctionParameterSequenceType("enabled", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true to enable the account, false to disable the account.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public AccountStatusFunction(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/GroupManagementFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/GroupManagementFunction.java
@@ -50,7 +50,7 @@ public class GroupManagementFunction extends BasicFunction {
         new SequenceType[]{
             new FunctionParameterSequenceType("group-name", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the group to create.")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY)
+        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_CREATE_GROUP_WITH_METADATA = new FunctionSignature(
@@ -60,7 +60,7 @@ public class GroupManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("group-name", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the group to create."),
             new FunctionParameterSequenceType("description", Type.STRING, Cardinality.EXACTLY_ONE, "A description of the group.")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY)
+        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_CREATE_GROUP_WITH_MANAGERS_WITH_METADATA = new FunctionSignature(
@@ -71,7 +71,7 @@ public class GroupManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("managers", Type.STRING, Cardinality.ONE_OR_MORE, "The usernames of users that will be a manager of this group."),
             new FunctionParameterSequenceType("description", Type.STRING, Cardinality.EXACTLY_ONE, "A description of the group.")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY)
+        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_REMOVE_GROUP = new FunctionSignature(
@@ -80,7 +80,7 @@ public class GroupManagementFunction extends BasicFunction {
         new SequenceType[]{
             new FunctionParameterSequenceType("group-name", Type.STRING, Cardinality.EXACTLY_ONE, "The group-id to delete")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY)
+        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
     );
 
     //TODO implement later
@@ -91,7 +91,7 @@ public class GroupManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("group-id", Type.STRING, Cardinality.EXACTLY_ONE, "The group-id to delete"),
             new FunctionParameterSequenceType("successor-group-id", Type.STRING, Cardinality.EXACTLY_ONE, "The group-id that should take over ownership of any resources")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY)
+        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
     ); */
 
     public GroupManagementFunction(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/GroupMembershipFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/GroupMembershipFunction.java
@@ -57,7 +57,7 @@ public class GroupMembershipFunction extends BasicFunction {
             new FunctionParameterSequenceType("group", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the group whoose membership you wish to modify."),
             new FunctionParameterSequenceType("member", Type.STRING, Cardinality.ONE_OR_MORE, "The user(s) to add to the group membership.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.EMPTY)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_REMOVE_GROUP_MEMBER = new FunctionSignature(
@@ -67,7 +67,7 @@ public class GroupMembershipFunction extends BasicFunction {
             new FunctionParameterSequenceType("group", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the group whoose membership you wish to modify."),
             new FunctionParameterSequenceType("member", Type.STRING, Cardinality.ONE_OR_MORE, "The user(s) to remove from the group membership.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.EMPTY)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_GET_GROUP_MEMBERS = new FunctionSignature(
@@ -86,7 +86,7 @@ public class GroupMembershipFunction extends BasicFunction {
                 new FunctionParameterSequenceType("group", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the group to which you wish to add a manager(s)."),
                 new FunctionParameterSequenceType("manager", Type.STRING, Cardinality.ONE_OR_MORE, "The user(s) to add to the group managers.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.EMPTY)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_REMOVE_GROUP_MANAGER = new FunctionSignature(
@@ -96,7 +96,7 @@ public class GroupMembershipFunction extends BasicFunction {
                 new FunctionParameterSequenceType("group", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the group from which you wish to remove a manager(s)"),
                 new FunctionParameterSequenceType("manager", Type.STRING, Cardinality.ONE_OR_MORE, "The user(s) to remove from the group managers.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.EMPTY)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_GET_GROUP_MANAGERS = new FunctionSignature(
@@ -124,7 +124,7 @@ public class GroupMembershipFunction extends BasicFunction {
             new FunctionParameterSequenceType("username", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the user account to set the primary group for."),
             new FunctionParameterSequenceType("group", Type.STRING, Cardinality.EXACTLY_ONE, "The group to set as the primary group for the user.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.EMPTY)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public GroupMembershipFunction(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/IdFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/IdFunction.java
@@ -44,7 +44,7 @@ public class IdFunction extends BasicFunction {
         "and effective account details are returned, otherwise only the real " +
         "account details are returned.",
         null,
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "Example output when an XQuery is running setUid <id xmlns=\"http://exist-db.org/xquery/securitymanager\"><real><username>guest</username><groups><group>guest</group></groups></real><effective><username>admin</username><groups><group>dba</group></groups></effective></id>.")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "Example output when an XQuery is running setUid <id xmlns=\"http://exist-db.org/xquery/securitymanager\"><real><username>guest</username><groups><group>guest</group></groups></real><effective><username>admin</username><groups><group>dba</group></groups></effective></id>.")
     );
 
     public IdFunction(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/PermissionsFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/PermissionsFunction.java
@@ -78,7 +78,7 @@ public class PermissionsFunction extends BasicFunction {
         new SequenceType[] {
             new FunctionParameterSequenceType("path", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The path to the resource or collection to get permissions of.")
         },
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "The permissions of the resource or collection")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "The permissions of the resource or collection")
     );
     
     public final static FunctionSignature FNS_ADD_USER_ACE = new FunctionSignature(
@@ -90,7 +90,7 @@ public class PermissionsFunction extends BasicFunction {
             new FunctionParameterSequenceType("allowed", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true() if the ACE is allowing the permission mode, or false() if we are denying the permission mode"),
             new FunctionParameterSequenceType("mode", Type.STRING, Cardinality.EXACTLY_ONE, "The mode to set on the ACE e.g. 'rwx'"),
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_ADD_GROUP_ACE = new FunctionSignature(
@@ -102,7 +102,7 @@ public class PermissionsFunction extends BasicFunction {
             new FunctionParameterSequenceType("allowed", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true() if the ACE is allowing the permission mode, or false() if we are denying the permission mode"),
             new FunctionParameterSequenceType("mode", Type.STRING, Cardinality.EXACTLY_ONE, "The mode to set on the ACE e.g. 'rwx'"),
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_INSERT_USER_ACE = new FunctionSignature(
@@ -115,7 +115,7 @@ public class PermissionsFunction extends BasicFunction {
             new FunctionParameterSequenceType("allowed", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true() if the ACE is allowing the permission mode, or false() if we are denying the permission mode"),
             new FunctionParameterSequenceType("mode", Type.STRING, Cardinality.EXACTLY_ONE, "The mode to set on the ACE e.g. 'rwx'"),
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_INSERT_GROUP_ACE = new FunctionSignature(
@@ -128,7 +128,7 @@ public class PermissionsFunction extends BasicFunction {
             new FunctionParameterSequenceType("allowed", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true() if the ACE is allowing the permission mode, or false() if we are denying the permission mode"),
             new FunctionParameterSequenceType("mode", Type.STRING, Cardinality.EXACTLY_ONE, "The mode to set on the ACE e.g. 'rwx'"),
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_MODIFY_ACE = new FunctionSignature(
@@ -140,7 +140,7 @@ public class PermissionsFunction extends BasicFunction {
             new FunctionParameterSequenceType("allowed", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true() if the ACE is allowing the permission mode, or false() if we are denying the permission mode"),
             new FunctionParameterSequenceType("mode", Type.STRING, Cardinality.EXACTLY_ONE, "The mode to set on the ACE e.g. 'rwx'"),
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_REMOVE_ACE = new FunctionSignature(
@@ -150,7 +150,7 @@ public class PermissionsFunction extends BasicFunction {
             new FunctionParameterSequenceType("path", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The path to the resource or collection whose ACL you wish to remove the ACE from."),
             new FunctionParameterSequenceType("index", Type.INT, Cardinality.EXACTLY_ONE, "The index of the ACE in the ACL to remove, subsequent entries will be renumbered")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_CLEAR_ACL = new FunctionSignature(
@@ -159,7 +159,7 @@ public class PermissionsFunction extends BasicFunction {
         new SequenceType[] {
             new FunctionParameterSequenceType("path", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The path to the resource or collection whose ACL you wish to clear.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_CHMOD = new FunctionSignature(
@@ -169,7 +169,7 @@ public class PermissionsFunction extends BasicFunction {
             new FunctionParameterSequenceType("path", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The path to the resource or collection whose mode you wish to set"),
             new FunctionParameterSequenceType("mode", Type.STRING, Cardinality.EXACTLY_ONE, "The mode to set on the resource or collection e.g. 'rwxrwxrwx'"),
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_CHOWN = new FunctionSignature(
@@ -179,7 +179,7 @@ public class PermissionsFunction extends BasicFunction {
             new FunctionParameterSequenceType("path", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The path to the resource or collection whose owner you wish to set"),
             new FunctionParameterSequenceType("owner", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the user owner to set on the resource or collection e.g. 'guest'. You may also provide a group owner, by using the syntax 'user:group' if you wish."),
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_CHGRP = new FunctionSignature(
@@ -189,7 +189,7 @@ public class PermissionsFunction extends BasicFunction {
             new FunctionParameterSequenceType("path", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The path to the resource or collection whose group owner you wish to set"),
             new FunctionParameterSequenceType("group-name", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the user group owner to set on the resource or collection e.g. 'guest'"),
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_HAS_ACCESS = new FunctionSignature(

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/SetPrincipalMetadataFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/SetPrincipalMetadataFunction.java
@@ -53,7 +53,7 @@ public class SetPrincipalMetadataFunction extends BasicFunction {
             new FunctionParameterSequenceType("attribute", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The metadata attribute key."),
             new FunctionParameterSequenceType("value", Type.STRING, Cardinality.EXACTLY_ONE, "The metadata value,")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public final static FunctionSignature FNS_SET_GROUP_METADATA = new FunctionSignature(
@@ -64,7 +64,7 @@ public class SetPrincipalMetadataFunction extends BasicFunction {
             new FunctionParameterSequenceType("attribute", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The metadata attribute key."),
             new FunctionParameterSequenceType("value", Type.STRING, Cardinality.EXACTLY_ONE, "The metadata value,")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public SetPrincipalMetadataFunction(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/UMaskFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/UMaskFunction.java
@@ -64,7 +64,7 @@ public class UMaskFunction extends BasicFunction {
             new FunctionParameterSequenceType("username", Type.STRING, Cardinality.EXACTLY_ONE, "The username of the account to set the umask for."),
             new FunctionParameterSequenceType("umask", Type.INT, Cardinality.EXACTLY_ONE, "The umask to set as an integer.")
         },
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
     
     public UMaskFunction(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/Clear.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/Clear.java
@@ -44,7 +44,7 @@ public class Clear extends StrictSessionFunction {
                     new QName("clear", SessionModule.NAMESPACE_URI, SessionModule.PREFIX),
                     "Removes all attributes from the current HTTP session. Does NOT invalidate the session.",
                     null,
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public Clear(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/Create.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/Create.java
@@ -44,7 +44,7 @@ public class Create extends SessionFunction {
                     new QName("create", SessionModule.NAMESPACE_URI, SessionModule.PREFIX),
                     "Initialize an HTTP session if not already present",
                     null,
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public Create(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/Invalidate.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/Invalidate.java
@@ -42,7 +42,7 @@ public class Invalidate extends SessionFunction {
                     new QName("invalidate", SessionModule.NAMESPACE_URI, SessionModule.PREFIX),
                     "Invalidate (remove) the current HTTP session if present",
                     null,
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public Invalidate(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/RemoveAttribute.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/RemoveAttribute.java
@@ -45,7 +45,7 @@ public class RemoveAttribute extends StrictSessionFunction {
                     new SequenceType[]{
                             new FunctionParameterSequenceType("name", Type.STRING, Cardinality.EXACTLY_ONE, "The attribute name")
                     },
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public RemoveAttribute(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/SetAttribute.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/SetAttribute.java
@@ -46,7 +46,7 @@ public class SetAttribute extends SessionFunction {
                             new FunctionParameterSequenceType("name", Type.STRING, Cardinality.EXACTLY_ONE, "The attribute name"),
                             new FunctionParameterSequenceType("value", Type.ITEM, Cardinality.ZERO_OR_MORE, "The value to be stored in the session by the attribute name")
                     },
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
 
     public SetAttribute(final XQueryContext context) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/SetMaxInactiveInterval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/SetMaxInactiveInterval.java
@@ -49,7 +49,7 @@ public class SetMaxInactiveInterval extends SessionFunction {
                     new SequenceType[]{
                             new FunctionParameterSequenceType("interval", Type.INT, Cardinality.EXACTLY_ONE, "The maximum inactive interval (in seconds) before closing the session")
                     },
-                    new SequenceType(Type.EMPTY, Cardinality.EMPTY));
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public SetMaxInactiveInterval(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/ClearXQueryCache.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/ClearXQueryCache.java
@@ -45,7 +45,7 @@ public class ClearXQueryCache extends BasicFunction {
         new QName("clear-xquery-cache", SystemModule.NAMESPACE_URI, SystemModule.PREFIX),
         "Clear XQuery cache.",
         FunctionSignature.NO_ARGS,
-        new SequenceType(Type.EMPTY, Cardinality.ZERO)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public ClearXQueryCache(XQueryContext context) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/FunctionAvailable.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/FunctionAvailable.java
@@ -55,8 +55,8 @@ public class FunctionAvailable extends BasicFunction {
             new QName("function-available", SystemModule.NAMESPACE_URI, SystemModule.PREFIX),
             "Returns whether a function is available.",
             new SequenceType[]{
-                new FunctionParameterSequenceType("function-name", Type.QNAME, Cardinality.ONE, "The fully qualified name of the function"),
-                new FunctionParameterSequenceType("arity", Type.INTEGER, Cardinality.ONE, "The arity of the function")
+                new FunctionParameterSequenceType("function-name", Type.QNAME, Cardinality.EXACTLY_ONE, "The fully qualified name of the function"),
+                new FunctionParameterSequenceType("arity", Type.INTEGER, Cardinality.EXACTLY_ONE, "The arity of the function")
             },
             new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true() if the function exists, false() otherwise."));
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/FunctionTrace.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/FunctionTrace.java
@@ -45,7 +45,7 @@ public class FunctionTrace extends BasicFunction {
                 new QName( "enable-tracing", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
                 "Enable function tracing on the database instance.",
                 new SequenceType[] { new FunctionParameterSequenceType("enable", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "The boolean flag to enable/disable function tracing") },
-                new SequenceType(Type.ITEM, Cardinality.EMPTY)
+                new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
         ),
         new FunctionSignature(
                 new QName( "enable-tracing", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
@@ -55,7 +55,7 @@ public class FunctionTrace extends BasicFunction {
                     new FunctionParameterSequenceType("tracelog", Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                         "The tracelog boolean flag: if set to true, entering/exiting a function will be logged to the logger 'xquery.profiling'")
                 },
-                new SequenceType(Type.ITEM, Cardinality.EMPTY)
+                new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
         ),
         new FunctionSignature(
                 new QName( "tracing-enabled", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
@@ -67,7 +67,7 @@ public class FunctionTrace extends BasicFunction {
                 new QName( "clear-trace", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
                 "Clear the global trace log.",
                 null,
-                new SequenceType(Type.ITEM, Cardinality.EMPTY)
+                new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
         )
     };
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/KillRunningXQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/KillRunningXQuery.java
@@ -59,14 +59,14 @@ public class KillRunningXQuery extends BasicFunction
 			new QName( "kill-running-xquery", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
 			"Kill a running XQuey (dba role only).",
 			new SequenceType[] { XQUERY_ID_PARAM },
-			new SequenceType( Type.ITEM, Cardinality.EMPTY )
+			new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE )
 		),
 		
 		new FunctionSignature(
 			new QName( "kill-running-xquery", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
 			"Kill a running XQuey (dba role only).",
 			new SequenceType[] { XQUERY_ID_PARAM, WAIT_TIME_PARAM },
-			new SequenceType( Type.ITEM, Cardinality.EMPTY )
+			new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE )
 		),
 	};
 		

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/Shutdown.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/Shutdown.java
@@ -55,7 +55,7 @@ public class Shutdown extends BasicFunction
 			new QName("shutdown", SystemModule.NAMESPACE_URI, SystemModule.PREFIX),
 			"Shutdown eXist immediately.  This method is only available to the DBA role.",
 			null,
-			new SequenceType(Type.ITEM, Cardinality.EMPTY)
+			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
 		),
 		
 		new FunctionSignature(
@@ -64,7 +64,7 @@ public class Shutdown extends BasicFunction
 			new SequenceType[] {
 					new FunctionParameterSequenceType("delay", Type.LONG, Cardinality.EXACTLY_ONE, "The delay in milliseconds before eXist starts to shutdown.")
 			},
-			new SequenceType(Type.ITEM, Cardinality.EMPTY)
+			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
 		)
 	};
 		

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/TriggerSystemTask.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/TriggerSystemTask.java
@@ -56,7 +56,7 @@ public class TriggerSystemTask extends BasicFunction {
                 new FunctionParameterSequenceType("java-classname", Type.STRING, Cardinality.EXACTLY_ONE, "The full name of the Java class to execute.  It must implement org.exist.storage.SystemTask"),
                 new FunctionParameterSequenceType("task-parameters", Type.NODE, Cardinality.ZERO_OR_ONE, "The XML fragment with the following structure: <parameters><param name=\"param-name1\" value=\"param-value1\"/></parameters>")
             },
-			new SequenceType(Type.ITEM, Cardinality.EMPTY));
+			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE));
 
 
     public TriggerSystemTask(XQueryContext context) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/UpdateStatistics.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/UpdateStatistics.java
@@ -47,7 +47,7 @@ public class UpdateStatistics extends BasicFunction {
         "yet usable in a normal eXist setup. update-statistics rebuilds index statistics " +
         "for the entire database.",
         null,
-        new SequenceType(Type.EMPTY, Cardinality.ZERO));
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
     public UpdateStatistics(XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
@@ -119,7 +119,7 @@ public class Transform extends BasicFunction {
                             new FunctionParameterSequenceType("stylesheet", Type.ITEM, Cardinality.EXACTLY_ONE, "The XSL stylesheet"),
                             new FunctionParameterSequenceType("parameters", Type.NODE, Cardinality.ZERO_OR_ONE, "The transformer parameters")
                     },
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY)),
+                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
             new FunctionSignature(
                     new QName("stream-transform", TransformModule.NAMESPACE_URI, TransformModule.PREFIX),
                     "Applies an XSL stylesheet to the node tree passed as first argument. The parameters are the same " +
@@ -132,7 +132,7 @@ public class Transform extends BasicFunction {
                             new FunctionParameterSequenceType("parameters", Type.NODE, Cardinality.ZERO_OR_ONE, "The transformer parameters"),
                             new FunctionParameterSequenceType("attributes", Type.NODE, Cardinality.ZERO_OR_ONE, "Attributes to pass to the transformation factory"),
                             new FunctionParameterSequenceType("serialization-options", Type.STRING, Cardinality.ZERO_OR_ONE, "The serialization options")},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY))
+                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE))
     };
 
     private static final Logger logger = LogManager.getLogger(Transform.class);

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/GetFragmentBetween.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/GetFragmentBetween.java
@@ -84,12 +84,12 @@ public class GetFragmentBetween extends BasicFunction {
                             "Example call of the function for getting the fragment between two TEI page break element nodes: " +
                             "  let $fragment := util:get-fragment-between(//pb[1], //pb[2], true(), true())",
                     new SequenceType[]{
-                            new FunctionParameterSequenceType("beginning-node", Type.NODE, Cardinality.ONE, "The first node/milestone element"),
+                            new FunctionParameterSequenceType("beginning-node", Type.NODE, Cardinality.EXACTLY_ONE, "The first node/milestone element"),
                             new FunctionParameterSequenceType("ending-node", Type.NODE, Cardinality.ZERO_OR_ONE, "The second node/milestone element"),
                             new FunctionParameterSequenceType("make-fragment", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, "The flag make a fragment."),
                             new FunctionParameterSequenceType("display-root-namespace", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, "Display the namespace of the root node of the fragment.")
                     },
-                    new FunctionReturnSequenceType(Type.STRING, Cardinality.ONE, "the string containing the fragment between the two node/milestone elements."), true);
+                    new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the string containing the fragment between the two node/milestone elements."), true);
 
     public GetFragmentBetween(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/IndexType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/IndexType.java
@@ -52,7 +52,7 @@ public class IndexType extends BasicFunction {
             new QName("index-type", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                 "Returns the range index type for a set of nodes or an empty sequence if no index is defined. ", 
                 new SequenceType[] {
-                    new FunctionParameterSequenceType("set-of-nodes", Type.NODE, Cardinality.ZERO_OR_MORE, "The set of nodes") 
+                    new FunctionParameterSequenceType("set-of-nodes", Type.NODE, Cardinality.ZERO_OR_MORE, "The set of nodes")
                     },
             new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the range index type"));
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/LineNumber.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/LineNumber.java
@@ -33,7 +33,7 @@ public class LineNumber extends BasicFunction {
             new QName("line-number", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
             "Retrieves the line number of the expression",
             null,
-            new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ONE, "The line number of this expression")
+            new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE, "The line number of this expression")
     );
 
     public LineNumber(final XQueryContext context) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/LockFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/LockFunction.java
@@ -28,10 +28,7 @@ import org.exist.collections.ManagedLocks;
 import org.exist.dom.persistent.DocumentSet;
 import org.exist.storage.lock.ManagedDocumentLock;
 import org.exist.util.LockException;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 
@@ -63,10 +60,8 @@ public abstract class LockFunction extends Function {
     }
     
     
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Function#getCardinality()
-     */
-    public int getCardinality() {
+    @Override
+    public Cardinality getCardinality() {
         return getArgument(1).getCardinality();
     }
     

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/LogFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/LogFunction.java
@@ -61,25 +61,25 @@ public class LogFunction extends BasicFunction {
                     new QName(FUNCTION_LOG, UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Logs the message to the current logger.",
                     new SequenceType[]{PRIORITY_PARAMETER, MESSAGE_PARAMETER},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY)
+                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
             ),
             new FunctionSignature(
                     new QName(FUNCTION_LOG_SYSTEM_OUT, UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Logs the message to System.out.",
                     new SequenceType[]{MESSAGE_PARAMETER},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY)
+                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
             ),
             new FunctionSignature(
                     new QName(FUNCTION_LOG_SYSTEM_ERR, UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Logs the message to System.err.",
                     new SequenceType[]{MESSAGE_PARAMETER},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY)
+                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
             ),
             new FunctionSignature(
                     new QName(FUNCTION_LOGAPP, UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Logs the message to the named logger",
                     new SequenceType[]{PRIORITY_PARAMETER, LOGGER_NAME_PARAMETER, MESSAGE_PARAMETER},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY)
+                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
             )
     };
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/ModuleInfo.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/ModuleInfo.java
@@ -94,14 +94,14 @@ public class ModuleInfo extends BasicFunction {
 			new QName("map-module", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
 			"Map the module to a source location. This function is only available to the DBA role.",
 			new SequenceType[] { NAMESPACE_URI_PARAMETER, LOCATION_URI_PARAMETER },
-			new FunctionReturnSequenceType( Type.ITEM, Cardinality.EMPTY, "Returns an empty sequence" ));
+			new FunctionReturnSequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE, "Returns an empty sequence" ));
 
 	public final static FunctionSignature unmapModuleSig =
 		new FunctionSignature(
 			new QName("unmap-module", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
 			"Remove relation between module namespace and source location. This function is only available to the DBA role.",
 			new SequenceType[] { NAMESPACE_URI_PARAMETER },
-			new FunctionReturnSequenceType( Type.ITEM, Cardinality.EMPTY, "Returns an empty sequence" ));
+			new FunctionReturnSequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE, "Returns an empty sequence" ));
 
 	public final static FunctionSignature moduleDescriptionSig =
 		new FunctionSignature(

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Profile.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Profile.java
@@ -50,12 +50,12 @@ public class Profile extends BasicFunction {
             new SequenceType[] {
                 new FunctionParameterSequenceType("verbosity", Type.INT, Cardinality.EXACTLY_ONE, "The verbosity of the profiling"),
             },
-            new SequenceType(Type.ITEM, Cardinality.EMPTY)),
+            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
         new FunctionSignature(
             new QName("disable-profiling", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
             "Disable profiling output within the query.",
             null,
-            new SequenceType(Type.ITEM, Cardinality.EMPTY))
+            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE))
     };
     
     public Profile(XQueryContext context, FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/PrologFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/PrologFunctions.java
@@ -48,7 +48,7 @@ public class PrologFunctions extends BasicFunction {
 				new FunctionParameterSequenceType("prefix", Type.STRING, Cardinality.EXACTLY_ONE, "The prefix to be assigned to the namespace"),
 				new FunctionParameterSequenceType("location", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The location of the module")
 			},
-			new SequenceType(Type.ITEM, Cardinality.EMPTY),
+			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE),
 			LoadXQueryModule.LOAD_XQUERY_MODULE_2),
 		new FunctionSignature(
 			new QName("declare-namespace", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
@@ -57,7 +57,7 @@ public class PrologFunctions extends BasicFunction {
 				new FunctionParameterSequenceType("prefix", Type.STRING, Cardinality.EXACTLY_ONE, "The prefix to be assigned to the namespace"),
 				new FunctionParameterSequenceType("namespace-uri", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The namespace URI")
 			},
-			new SequenceType(Type.ITEM, Cardinality.EMPTY)),
+			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
 		new FunctionSignature(
 			new QName("declare-option", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
 			"Dynamically declares a serialization option as with 'declare option'.",
@@ -65,7 +65,7 @@ public class PrologFunctions extends BasicFunction {
 				new FunctionParameterSequenceType("name", Type.STRING, Cardinality.EXACTLY_ONE, "The serialization option name"),
 				new FunctionParameterSequenceType("option", Type.STRING, Cardinality.EXACTLY_ONE, "The serialization option value")
 			},
-			new SequenceType(Type.ITEM, Cardinality.EMPTY)),
+			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
                 new FunctionSignature(
                     new QName("get-option", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Gets the value of a serialization option as set with 'declare option'.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Wait.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Wait.java
@@ -46,7 +46,7 @@ public class Wait extends BasicFunction
                     new SequenceType[]{
                         new FunctionParameterSequenceType( "interval", Type.INTEGER, Cardinality.EXACTLY_ONE, "Number of milliseconds to wait." ),
                     },
-                   new FunctionReturnSequenceType( Type.ITEM, Cardinality.EMPTY, "Returns an empty sequence" )
+                   new FunctionReturnSequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE, "Returns an empty sequence" )
                 )
     };
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxv.java
@@ -101,7 +101,7 @@ public class Jaxv extends BasicFunction  {
                         instanceText),
                     new FunctionParameterSequenceType("grammars", Type.ITEM, Cardinality.ONE_OR_MORE,
                         grammarText),
-                    new FunctionParameterSequenceType("language", Type.STRING, Cardinality.ONE,
+                    new FunctionParameterSequenceType("language", Type.STRING, Cardinality.EXACTLY_ONE,
                         languageText),
                     
                 },
@@ -131,7 +131,7 @@ public class Jaxv extends BasicFunction  {
                         instanceText),
                     new FunctionParameterSequenceType("grammars", Type.ITEM, Cardinality.ONE_OR_MORE,
                         grammarText),
-                    new FunctionParameterSequenceType("language", Type.STRING, Cardinality.ONE,
+                    new FunctionParameterSequenceType("language", Type.STRING, Cardinality.EXACTLY_ONE,
                         languageText),
                    },
                 new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE,

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBDefragment.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBDefragment.java
@@ -65,7 +65,7 @@ public class XMLDBDefragment extends BasicFunction {
 			new FunctionParameterSequenceType("integer", Type.INTEGER, Cardinality.EXACTLY_ONE,
                     "The minimum number of fragmented pages required before defragmenting")
                     },
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY)),
+                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
             new FunctionSignature(
                     new QName("defragment", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
                     "Start a defragmentation run on each document which has a node in $nodes. " +
@@ -78,7 +78,7 @@ public class XMLDBDefragment extends BasicFunction {
 			new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ONE_OR_MORE,
                     "The sequence of nodes from the documents to defragment"),
                     },
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY))
+                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE))
     };
 
     public XMLDBDefragment(XQueryContext context, FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBMove.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBMove.java
@@ -60,7 +60,7 @@ public class XMLDBMove extends XMLDBAbstractCollectionManipulator {
         "$target-collection-uri. " + 
         XMLDBModule.COLLECTION_URI,
         new SequenceType[]{ ARG_SOURCE, ARG_TARGET },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY)),
+        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
 
         new FunctionSignature(
         new QName("move", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
@@ -68,7 +68,7 @@ public class XMLDBMove extends XMLDBAbstractCollectionManipulator {
         "into collection $target-collection-uri. " +
         XMLDBModule.COLLECTION_URI,
         new SequenceType[]{ ARG_SOURCE, ARG_TARGET, ARG_RESOURCE },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY))
+        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE))
     };
 
     public XMLDBMove(XQueryContext context, FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRemove.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRemove.java
@@ -51,7 +51,7 @@ public class XMLDBRemove extends XMLDBAbstractCollectionManipulator {
             XMLDBModule.COLLECTION_URI,
             new SequenceType[] {
                 new FunctionParameterSequenceType("collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collection URI")},
-            new SequenceType(Type.ITEM, Cardinality.EMPTY)
+            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
 		),
 		new FunctionSignature(
 			new QName("remove", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
@@ -60,7 +60,7 @@ public class XMLDBRemove extends XMLDBAbstractCollectionManipulator {
 			new SequenceType[] {
                 new FunctionParameterSequenceType("collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collection URI"),
                 new FunctionParameterSequenceType("resource", Type.STRING, Cardinality.EXACTLY_ONE, "The resource")},
-            new SequenceType(Type.ITEM, Cardinality.EMPTY)
+            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
 		)
 	};
 	

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRename.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRename.java
@@ -55,7 +55,7 @@ public class XMLDBRename extends XMLDBAbstractCollectionManipulator {
 				new SequenceType[] {
                 new FunctionParameterSequenceType("source-collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The source collection URI"),
                 new FunctionParameterSequenceType("new-collection-name", Type.STRING, Cardinality.EXACTLY_ONE, "The new collection name")},
-            new SequenceType(Type.ITEM, Cardinality.EMPTY)
+            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
 		),
 		new FunctionSignature(
 			new QName("rename", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
@@ -65,7 +65,7 @@ public class XMLDBRename extends XMLDBAbstractCollectionManipulator {
                 new FunctionParameterSequenceType("collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collection URI"),
                 new FunctionParameterSequenceType("resource", Type.STRING, Cardinality.EXACTLY_ONE, "The resource"),
                 new FunctionParameterSequenceType("new-resource-name", Type.STRING, Cardinality.EXACTLY_ONE, "The new resource name")},
-            new SequenceType(Type.ITEM, Cardinality.EMPTY)
+            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
 		)
 	};
 	

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBSetMimeType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBSetMimeType.java
@@ -60,7 +60,7 @@ public class XMLDBSetMimeType extends BasicFunction {
                 new FunctionParameterSequenceType("resource-uri", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The resource URI"),
                 new FunctionParameterSequenceType("mime-type", Type.STRING, Cardinality.ZERO_OR_ONE, "The new mime-type, use empty sequence to set default value.")
 			},
-			new SequenceType(Type.EMPTY, Cardinality.EMPTY)
+			new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
 		);
 	
     public XMLDBSetMimeType(XQueryContext context, FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/update/Modification.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/Modification.java
@@ -85,8 +85,9 @@ public abstract class Modification extends AbstractExpression
         this.triggers = new Int2ObjectOpenHashMap<>();
     }
 
-    public int getCardinality() {
-        return Cardinality.EMPTY;
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.EMPTY_SEQUENCE;
     }
 
     /* (non-Javadoc)

--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -55,10 +55,10 @@ public class SerializerUtils {
 
         final String parameterName;
         final int type;
-        final int cardinality;
+        final Cardinality cardinality;
         final Sequence defaultValue;
 
-        ParameterConvention(final String parameterName, final int type, final int cardinality, final Sequence defaultValue) {
+        ParameterConvention(final String parameterName, final int type, final Cardinality cardinality, final Sequence defaultValue) {
             this.parameterName = parameterName;
             this.type = type;
             this.cardinality = cardinality;
@@ -247,7 +247,7 @@ public class SerializerUtils {
      * @return true if the types are suitable, false otherwise
      */
     private static boolean checkTypes(final ParameterConvention parameterConvention, final Sequence sequence) throws XPathException {
-        if(Cardinality.checkCardinality(parameterConvention.cardinality, sequence.getCardinality())) {
+        if(parameterConvention.cardinality.isSuperCardinalityOrEqualOf(sequence.getCardinality())) {
             final SequenceIterator iterator = sequence.iterate();
             while(iterator.hasNext()) {
                 final Item item = iterator.nextItem();
@@ -281,7 +281,7 @@ public class SerializerUtils {
             properties.setProperty(parameterConvention.parameterName, ((DecimalValue) parameterValue.itemAt(0)).getStringValue());
         } else if(Type.QNAME == parameterConvention.type) {
             if(!parameterValue.isEmpty()) {
-                if (Cardinality.checkCardinality(Cardinality.MANY, parameterConvention.cardinality)) {
+                if (Cardinality._MANY.isSuperCardinalityOrEqualOf(parameterConvention.cardinality)) {
                     final SequenceIterator iterator = parameterValue.iterate();
                     while (iterator.hasNext()) {
                         final String existingValue = (String) properties.get(parameterConvention.parameterName);

--- a/exist-core/src/main/java/org/exist/xquery/value/AbstractSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/AbstractSequence.java
@@ -54,15 +54,15 @@ public abstract class AbstractSequence implements Sequence {
     protected boolean hasOne = false;
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         if (isEmpty()) {
-            return Cardinality.EMPTY;
+            return Cardinality.EMPTY_SEQUENCE;
         }
         if (hasOne()) {
             return Cardinality.EXACTLY_ONE;
         }
         if (hasMany()) {
-            return Cardinality.MANY;
+            return Cardinality._MANY;
         }
         throw new IllegalArgumentException("Illegal argument");
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/AtomicValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/AtomicValue.java
@@ -127,7 +127,7 @@ public abstract class AtomicValue implements Item, Sequence, Indexable {
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return Cardinality.EXACTLY_ONE;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/FunctionParameterSequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FunctionParameterSequenceType.java
@@ -3,6 +3,8 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.xquery.Cardinality;
+
 /**
  * This class is used to specify the name and description of an XQuery function parameter.
  *
@@ -20,12 +22,12 @@ public class FunctionParameterSequenceType extends FunctionReturnSequenceType {
      * @param description   A description of the parameter in the <strong>FunctionSignature</strong>.
      * @see org.exist.xquery.FunctionSignature @see Type @see org.exist.xquery.Cardinality
      */
-    public FunctionParameterSequenceType(String attributeName, int primaryType, int cardinality, String description) {
+    public FunctionParameterSequenceType(final String attributeName, final int primaryType, final Cardinality cardinality, final String description) {
         super(primaryType, cardinality, description);
         this.attributeName = attributeName;
     }
 
-    public FunctionParameterSequenceType(String attributeName) {
+    public FunctionParameterSequenceType(final String attributeName) {
         super();
         this.attributeName = attributeName;
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/FunctionParameterSequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FunctionParameterSequenceType.java
@@ -27,6 +27,21 @@ public class FunctionParameterSequenceType extends FunctionReturnSequenceType {
         this.attributeName = attributeName;
     }
 
+    /**
+     * @param attributeName The name of the parameter in the <strong>FunctionSignature</strong>.
+     * @param primaryType   The <strong>Type</strong> of the parameter.
+     * @param cardinality   The <strong>Cardinality</strong> of the parameter.
+     * @param description   A description of the parameter in the <strong>FunctionSignature</strong>.
+     * @see org.exist.xquery.FunctionSignature @see Type @see org.exist.xquery.Cardinality
+     *
+     * @deprecated Use {@link #FunctionParameterSequenceType(String, int, Cardinality, String)}
+     */
+    @Deprecated
+    public FunctionParameterSequenceType(final String attributeName, final int primaryType, final int cardinality, final String description) {
+        super(primaryType, Cardinality.fromInt(cardinality), description);
+        this.attributeName = attributeName;
+    }
+
     public FunctionParameterSequenceType(final String attributeName) {
         super();
         this.attributeName = attributeName;

--- a/exist-core/src/main/java/org/exist/xquery/value/FunctionReturnSequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FunctionReturnSequenceType.java
@@ -3,6 +3,8 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.xquery.Cardinality;
+
 /**
  * This class is used to specify the name and description of an XQuery function parameter.
  *
@@ -19,7 +21,7 @@ public class FunctionReturnSequenceType extends SequenceType {
      * @param description A description of the parameter in the <strong>FunctionSignature</strong>.
      * @see org.exist.xquery.FunctionSignature @see Type @see org.exist.xquery.Cardinality
      */
-    public FunctionReturnSequenceType(int primaryType, int cardinality, String description) {
+    public FunctionReturnSequenceType(final int primaryType, final Cardinality cardinality, final String description) {
         super(primaryType, cardinality);
         this.description = description;
     }
@@ -38,7 +40,7 @@ public class FunctionReturnSequenceType extends SequenceType {
     /**
      * @param description the description to set
      */
-    public void setDescription(String description) {
+    public void setDescription(final String description) {
         this.description = description;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/FunctionReturnSequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FunctionReturnSequenceType.java
@@ -26,6 +26,20 @@ public class FunctionReturnSequenceType extends SequenceType {
         this.description = description;
     }
 
+    /**
+     * @param primaryType The <strong>Type</strong> of the parameter.
+     * @param cardinality The <strong>Cardinality</strong> of the parameter.
+     * @param description A description of the parameter in the <strong>FunctionSignature</strong>.
+     * @see org.exist.xquery.FunctionSignature @see Type @see org.exist.xquery.Cardinality
+     *
+     * @deprecated Use {@link #FunctionReturnSequenceType(int, Cardinality, String)}
+     */
+    @Deprecated
+    public FunctionReturnSequenceType(final int primaryType, final int cardinality, final String description) {
+        super(primaryType, Cardinality.fromInt(cardinality));
+        this.description = description;
+    }
+
     public FunctionReturnSequenceType() {
         super();
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/Sequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Sequence.java
@@ -25,6 +25,7 @@ import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.NodeHandle;
 import org.exist.dom.persistent.NodeSet;
 import org.exist.numbering.NodeId;
+import org.exist.xquery.Cardinality;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 
@@ -173,7 +174,7 @@ public interface Sequence {
      *
      * @see org.exist.xquery.Cardinality
      */
-    int getCardinality();
+    Cardinality getCardinality();
 
     /**
      * Returns the item located at the specified position within

--- a/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
@@ -38,7 +38,7 @@ import org.w3c.dom.Node;
 public class SequenceType {
 
     private int primaryType = Type.ITEM;
-    private int cardinality = Cardinality.EXACTLY_ONE;
+    private Cardinality cardinality = Cardinality.EXACTLY_ONE;
     private QName nodeName = null;
 
     public SequenceType() {
@@ -51,7 +51,7 @@ public class SequenceType {
      * @param primaryType one of the constants defined in {@link Type}
      * @param cardinality one of the constants defined in {@link Cardinality}
      */
-    public SequenceType(int primaryType, int cardinality) {
+    public SequenceType(final int primaryType, final Cardinality cardinality) {
         this.primaryType = primaryType;
         this.cardinality = cardinality;
     }
@@ -76,11 +76,11 @@ public class SequenceType {
      *
      * @return expected cardinality, one of {@link Cardinality}
      */
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         return cardinality;
     }
 
-    public void setCardinality(int cardinality) {
+    public void setCardinality(Cardinality cardinality) {
         this.cardinality = cardinality;
     }
 
@@ -205,20 +205,20 @@ public class SequenceType {
      * @throws XPathException if cardinality does not match
      */
     public void checkCardinality(Sequence seq) throws XPathException {
-        if (!seq.isEmpty() && cardinality == Cardinality.EMPTY) {
+        if (!seq.isEmpty() && cardinality == Cardinality.EMPTY_SEQUENCE) {
             throw new XPathException("Empty sequence expected; got " + seq.getItemCount());
         }
-        if (seq.isEmpty() && (cardinality & Cardinality.ZERO) == 0) {
+        if (seq.isEmpty() && cardinality.atLeastOne()) {
             throw new XPathException("Empty sequence is not allowed here");
-        } else if (seq.hasMany() && (cardinality & Cardinality.MANY) == 0) {
+        } else if (seq.hasMany() && cardinality.atMostOne()) {
             throw new XPathException("Sequence with more than one item is not allowed here");
         }
     }
 
     @Override
     public String toString() {
-        if (cardinality == Cardinality.EMPTY) {
-            return Cardinality.toString(cardinality);
+        if (cardinality == Cardinality.EMPTY_SEQUENCE) {
+            return cardinality.toXQueryCardinalityString();
         }
 
         final String str;
@@ -228,7 +228,7 @@ public class SequenceType {
             str = Type.getTypeName(primaryType);
         }
 
-        return str + Cardinality.toString(cardinality);
+        return str + cardinality.toXQueryCardinalityString();
     }
 
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
@@ -57,6 +57,21 @@ public class SequenceType {
     }
 
     /**
+     * Construct a new SequenceType using the specified
+     * primary type and cardinality.
+     *
+     * @param primaryType one of the constants defined in {@link Type}
+     * @param cardinality the cardinality integer value
+     *                    
+     * @deprecated Use {@link #SequenceType(int, Cardinality)}
+     */
+    @Deprecated
+    public SequenceType(final int primaryType, final int cardinality) {
+        this.primaryType = primaryType;
+        this.cardinality = Cardinality.fromInt(cardinality);
+    }
+
+    /**
      * Returns the primary type as one of the
      * constants defined in {@link Type}.
      *

--- a/exist-core/src/main/java/org/exist/xquery/value/SubSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SubSequence.java
@@ -147,23 +147,23 @@ public class SubSequence extends AbstractSequence {
     }
 
     @Override
-    public int getCardinality() {
+    public Cardinality getCardinality() {
         final long length = toExclusive - fromInclusive;
         if (length < 1 || sequence.isEmpty()) {
-           return Cardinality.EMPTY;
+           return Cardinality.EMPTY_SEQUENCE;
         }
 
         final long subseqAvailable = sequence.getItemCountLong() - (fromInclusive - 1);
         if (subseqAvailable < 1) {
-            return Cardinality.EMPTY;
+            return Cardinality.EMPTY_SEQUENCE;
         }
 
         if (subseqAvailable > 0 && length == 1) {
-            return Cardinality.ONE;
+            return Cardinality.EXACTLY_ONE;
         }
 
         if (subseqAvailable > 1 && length > 1) {
-            return Cardinality.MANY;
+            return Cardinality._MANY;
         }
 
         throw new IllegalStateException("Unknown Cardinality of: " + toString());

--- a/exist-core/src/test/java/org/exist/storage/util/PauseFunction.java
+++ b/exist-core/src/test/java/org/exist/storage/util/PauseFunction.java
@@ -40,7 +40,7 @@ public class PauseFunction extends BasicFunction {
             new QName("pause", TestUtilModule.NAMESPACE_URI),
             "Pause for the specified number of seconds.",
             new SequenceType[] { new FunctionParameterSequenceType("seconds", Type.INT, Cardinality.EXACTLY_ONE, "Seconds to pause.") },
-            new SequenceType(Type.ITEM, Cardinality.EMPTY)
+            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
         );
 
     public PauseFunction(XQueryContext context) {

--- a/exist-core/src/test/java/org/exist/xquery/CardinalityTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/CardinalityTest.java
@@ -1,0 +1,170 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.exist.xquery.Cardinality.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class CardinalityTest {
+
+    @Test
+    public void atLeastOne() {
+        assertFalse(EMPTY_SEQUENCE.atLeastOne());
+        assertFalse(ZERO_OR_ONE.atLeastOne());
+        assertTrue(ONE_OR_MORE.atLeastOne());
+        assertFalse(ZERO_OR_MORE.atLeastOne());
+    }
+
+    @Test
+    public void atMostOne() {
+        assertTrue(EMPTY_SEQUENCE.atMostOne());
+        assertTrue(ZERO_OR_ONE.atMostOne());
+        assertFalse(ONE_OR_MORE.atMostOne());
+        assertFalse(ZERO_OR_MORE.atMostOne());
+    }
+
+    @Test
+    public void isSubCardinalityOrEqualOf() {
+        isSubCardinalityOrEqualOf(EMPTY_SEQUENCE, EMPTY_SEQUENCE);
+        notSubCardinalityOrEqualOf(EMPTY_SEQUENCE, EXACTLY_ONE);
+        isSubCardinalityOrEqualOf(EMPTY_SEQUENCE, ZERO_OR_ONE);
+        notSubCardinalityOrEqualOf(EMPTY_SEQUENCE, ONE_OR_MORE);
+        isSubCardinalityOrEqualOf(EMPTY_SEQUENCE, ZERO_OR_MORE);
+
+        notSubCardinalityOrEqualOf(EXACTLY_ONE, EMPTY_SEQUENCE);
+        isSubCardinalityOrEqualOf(EXACTLY_ONE, EXACTLY_ONE);
+        isSubCardinalityOrEqualOf(EXACTLY_ONE, ZERO_OR_ONE);
+        isSubCardinalityOrEqualOf(EXACTLY_ONE, ONE_OR_MORE);
+        isSubCardinalityOrEqualOf(EXACTLY_ONE, ZERO_OR_MORE);
+
+        notSubCardinalityOrEqualOf(ZERO_OR_ONE, EMPTY_SEQUENCE);
+        notSubCardinalityOrEqualOf(ZERO_OR_ONE, EXACTLY_ONE);
+        isSubCardinalityOrEqualOf(ZERO_OR_ONE, ZERO_OR_ONE);
+        notSubCardinalityOrEqualOf(ZERO_OR_ONE, ONE_OR_MORE);
+        isSubCardinalityOrEqualOf(ZERO_OR_ONE, ZERO_OR_MORE);
+
+        notSubCardinalityOrEqualOf(ONE_OR_MORE, EMPTY_SEQUENCE);
+        notSubCardinalityOrEqualOf(ONE_OR_MORE, EXACTLY_ONE);
+        notSubCardinalityOrEqualOf(ONE_OR_MORE, ZERO_OR_ONE);
+        isSubCardinalityOrEqualOf(ONE_OR_MORE, ONE_OR_MORE);
+        isSubCardinalityOrEqualOf(ONE_OR_MORE, ZERO_OR_MORE);
+
+        notSubCardinalityOrEqualOf(ZERO_OR_MORE, EMPTY_SEQUENCE);
+        notSubCardinalityOrEqualOf(ZERO_OR_MORE, EXACTLY_ONE);
+        notSubCardinalityOrEqualOf(ZERO_OR_MORE, ZERO_OR_ONE);
+        notSubCardinalityOrEqualOf(ZERO_OR_MORE, ONE_OR_MORE);
+        isSubCardinalityOrEqualOf(ZERO_OR_MORE, ZERO_OR_MORE);
+    }
+
+    private static void isSubCardinalityOrEqualOf(final Cardinality subject, final Cardinality test) {
+        assertTrue(subject.name() + ".isSubCardinalityOrEqualOf(" + test.name() + ") == false, expected true",
+                subject.isSubCardinalityOrEqualOf(test));
+    }
+
+    private static void notSubCardinalityOrEqualOf(final Cardinality subject, final Cardinality test) {
+        assertFalse(subject.name() + ".isSubCardinalityOrEqualOf(" + test.name() + ") == true, expected false",
+                subject.isSubCardinalityOrEqualOf(test));
+    }
+
+    @Test
+    public void isSuperCardinalityOf() {
+        isSuperCardinalityOrEqualOf(EMPTY_SEQUENCE, EMPTY_SEQUENCE);
+        notSuperCardinalityOrEqualOf(EMPTY_SEQUENCE, EXACTLY_ONE);
+        notSuperCardinalityOrEqualOf(EMPTY_SEQUENCE, ZERO_OR_ONE);
+        notSuperCardinalityOrEqualOf(EMPTY_SEQUENCE, ONE_OR_MORE);
+        notSuperCardinalityOrEqualOf(EMPTY_SEQUENCE, ZERO_OR_MORE);
+
+        notSuperCardinalityOrEqualOf(EXACTLY_ONE, EMPTY_SEQUENCE);
+        isSuperCardinalityOrEqualOf(EXACTLY_ONE, EXACTLY_ONE);
+        notSuperCardinalityOrEqualOf(EXACTLY_ONE, ZERO_OR_ONE);
+        notSuperCardinalityOrEqualOf(EXACTLY_ONE, ONE_OR_MORE);
+        notSuperCardinalityOrEqualOf(EXACTLY_ONE, ZERO_OR_MORE);
+
+        isSuperCardinalityOrEqualOf(ZERO_OR_ONE, EMPTY_SEQUENCE);
+        isSuperCardinalityOrEqualOf(ZERO_OR_ONE, EXACTLY_ONE);
+        isSuperCardinalityOrEqualOf(ZERO_OR_ONE, ZERO_OR_ONE);
+        notSuperCardinalityOrEqualOf(ZERO_OR_ONE, ONE_OR_MORE);
+        notSuperCardinalityOrEqualOf(ZERO_OR_ONE, ZERO_OR_MORE);
+
+        notSuperCardinalityOrEqualOf(ONE_OR_MORE, EMPTY_SEQUENCE);
+        isSuperCardinalityOrEqualOf(ONE_OR_MORE, EXACTLY_ONE);
+        notSuperCardinalityOrEqualOf(ONE_OR_MORE, ZERO_OR_ONE);
+        isSuperCardinalityOrEqualOf(ONE_OR_MORE, ONE_OR_MORE);
+        notSuperCardinalityOrEqualOf(ONE_OR_MORE, ZERO_OR_MORE);
+
+        isSuperCardinalityOrEqualOf(ZERO_OR_MORE, EMPTY_SEQUENCE);
+        isSuperCardinalityOrEqualOf(ZERO_OR_MORE, EXACTLY_ONE);
+        isSuperCardinalityOrEqualOf(ZERO_OR_MORE, ZERO_OR_ONE);
+        isSuperCardinalityOrEqualOf(ZERO_OR_MORE, ONE_OR_MORE);
+        isSuperCardinalityOrEqualOf(ZERO_OR_MORE, ZERO_OR_MORE);
+    }
+
+    private static void isSuperCardinalityOrEqualOf(final Cardinality subject, final Cardinality test) {
+        assertTrue(subject.name() + ".isSuperCardinalityOrEqualOf(" + test.name() + ") == false, expected true",
+                subject.isSuperCardinalityOrEqualOf(test));
+    }
+
+    private static void notSuperCardinalityOrEqualOf(final Cardinality subject, final Cardinality test) {
+        assertFalse(subject.name() + ".isSuperCardinalityOrEqualOf(" + test.name() + ") == true, expected false",
+                subject.isSuperCardinalityOrEqualOf(test));
+    }
+
+    @Test
+    public void superCardinalityOf() {
+        assertEquals(EMPTY_SEQUENCE, Cardinality.superCardinalityOf(EMPTY_SEQUENCE, EMPTY_SEQUENCE));
+        assertEquals(ZERO_OR_ONE, Cardinality.superCardinalityOf(EMPTY_SEQUENCE, EXACTLY_ONE));
+        assertEquals(ZERO_OR_ONE, Cardinality.superCardinalityOf(EMPTY_SEQUENCE, ZERO_OR_ONE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(EMPTY_SEQUENCE, ONE_OR_MORE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(EMPTY_SEQUENCE, ZERO_OR_MORE));
+
+        assertEquals(ZERO_OR_ONE, Cardinality.superCardinalityOf(EXACTLY_ONE, EMPTY_SEQUENCE));
+        assertEquals(EXACTLY_ONE, Cardinality.superCardinalityOf(EXACTLY_ONE, EXACTLY_ONE));
+        assertEquals(ZERO_OR_ONE, Cardinality.superCardinalityOf(EXACTLY_ONE, ZERO_OR_ONE));
+        assertEquals(ONE_OR_MORE, Cardinality.superCardinalityOf(EXACTLY_ONE, ONE_OR_MORE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(EXACTLY_ONE, ZERO_OR_MORE));
+
+        assertEquals(ZERO_OR_ONE, Cardinality.superCardinalityOf(ZERO_OR_ONE, EMPTY_SEQUENCE));
+        assertEquals(ZERO_OR_ONE, Cardinality.superCardinalityOf(ZERO_OR_ONE, EXACTLY_ONE));
+        assertEquals(ZERO_OR_ONE, Cardinality.superCardinalityOf(ZERO_OR_ONE, ZERO_OR_ONE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ZERO_OR_ONE, ONE_OR_MORE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ZERO_OR_ONE, ZERO_OR_MORE));
+
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ONE_OR_MORE, EMPTY_SEQUENCE));
+        assertEquals(ONE_OR_MORE, Cardinality.superCardinalityOf(ONE_OR_MORE, EXACTLY_ONE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ONE_OR_MORE, ZERO_OR_ONE));
+        assertEquals(ONE_OR_MORE, Cardinality.superCardinalityOf(ONE_OR_MORE, ONE_OR_MORE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ONE_OR_MORE, ZERO_OR_MORE));
+
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ZERO_OR_MORE, EMPTY_SEQUENCE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ZERO_OR_MORE, EXACTLY_ONE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ZERO_OR_MORE, ZERO_OR_ONE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ZERO_OR_MORE, ONE_OR_MORE));
+        assertEquals(ZERO_OR_MORE, Cardinality.superCardinalityOf(ZERO_OR_MORE, ZERO_OR_MORE));
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/DeferredFunctionCallTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/DeferredFunctionCallTest.java
@@ -43,7 +43,7 @@ public class DeferredFunctionCallTest {
         Item mockContextItem = EasyMock.createMock(Item.class);
         Sequence[] mockSeq = { Sequence.EMPTY_SEQUENCE };
         int nextExpressionId = 1234;
-        SequenceType[] mockArgumentTypes = { new SequenceType(Type.NODE, Cardinality.ZERO) };
+        SequenceType[] mockArgumentTypes = { new SequenceType(Type.NODE, Cardinality.EMPTY_SEQUENCE) };
         
         //mock for functionDef
         FunctionSignature mockFunctionSignature = EasyMock.createMock(FunctionSignature.class);

--- a/exist-core/src/test/java/org/exist/xquery/value/SubSequenceRangeTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/SubSequenceRangeTest.java
@@ -115,13 +115,13 @@ public class SubSequenceRangeTest {
 
     @Test
     public void getCardinality() {
-        final int expectedCardinality;
+        final Cardinality expectedCardinality;
         if (expectedSubsequenceLength == 0) {
-            expectedCardinality = Cardinality.EMPTY;
+            expectedCardinality = Cardinality.EMPTY_SEQUENCE;
         } else if (expectedSubsequenceLength == 1) {
-            expectedCardinality = Cardinality.ONE;
+            expectedCardinality = Cardinality.EXACTLY_ONE;
         } else {
-            expectedCardinality = Cardinality.MANY;
+            expectedCardinality = Cardinality._MANY;
         }
         assertEquals(expectedCardinality, getSubsequence().getCardinality());
     }

--- a/exist-core/src/test/xquery/positional.xql
+++ b/exist-core/src/test/xquery/positional.xql
@@ -78,3 +78,9 @@ declare
 function pf:computed-position-multi($offset as xs:integer) {
     $pf:XML/*[($offset - 1) * 1]/target/start/number()
 };
+
+declare
+    %test:assertError("err:FORG0006")
+function pf:multiple-positions() {
+    (3,4)[1,2]
+};

--- a/extensions/contentextraction/src/main/java/org/exist/contentextraction/xquery/ContentFunctions.java
+++ b/extensions/contentextraction/src/main/java/org/exist/contentextraction/xquery/ContentFunctions.java
@@ -66,26 +66,26 @@ public class ContentFunctions extends BasicFunction {
         new QName("get-metadata", ContentExtractionModule.NAMESPACE_URI, ContentExtractionModule.PREFIX),
         "extracts the metadata",
         new SequenceType[]{
-            new FunctionParameterSequenceType("binary", Type.BASE64_BINARY, Cardinality.ONE, "The binary data to extract from")
+            new FunctionParameterSequenceType("binary", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The binary data to extract from")
         },
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "Extracted metadata")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "Extracted metadata")
     );
 
     public final static FunctionSignature getMetadataAndContent = new FunctionSignature(
         new QName("get-metadata-and-content", ContentExtractionModule.NAMESPACE_URI, ContentExtractionModule.PREFIX),
         "extracts the metadata and contents",
         new SequenceType[]{
-            new FunctionParameterSequenceType("binary", Type.BASE64_BINARY, Cardinality.ONE, "The binary data to extract from")
+            new FunctionParameterSequenceType("binary", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The binary data to extract from")
         },
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "Extracted content and metadata")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "Extracted content and metadata")
     );
 
     public final static FunctionSignature streamContent = new FunctionSignature(
         new QName("stream-content", ContentExtractionModule.NAMESPACE_URI, ContentExtractionModule.PREFIX),
         "extracts the metadata",
         new SequenceType[]{
-            new FunctionParameterSequenceType("binary", Type.BASE64_BINARY, Cardinality.ONE, "The binary data to extract from"),
-            new FunctionParameterSequenceType("paths", Type.STRING, Cardinality.ZERO_OR_MORE, 
+            new FunctionParameterSequenceType("binary", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The binary data to extract from"),
+            new FunctionParameterSequenceType("paths", Type.STRING, Cardinality.ZERO_OR_MORE,
             		"A sequence of (simple) node paths which should be passed to the callback function"),
             new FunctionParameterSequenceType("callback", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, 
             		"The callback function. Expected signature: " +
@@ -100,7 +100,7 @@ public class ContentFunctions extends BasicFunction {
             new FunctionParameterSequenceType("userData", Type.ITEM, Cardinality.ZERO_OR_MORE,
             		"Additional data which will be passed to the callback function.")
         },
-        new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY, "Returns empty sequence")
+        new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE, "Returns empty sequence")
     );
     
     public ContentFunctions(XQueryContext context, FunctionSignature signature) {

--- a/extensions/debuggee/src/main/java/org/exist/debugger/xquery/Init.java
+++ b/extensions/debuggee/src/main/java/org/exist/debugger/xquery/Init.java
@@ -56,7 +56,7 @@ public class Init extends BasicFunction {
 			}, 
 			new FunctionReturnSequenceType(
 				Type.STRING, 
-				Cardinality.ZERO_OR_ONE, 
+				Cardinality.ZERO_OR_ONE,
 				"The debug session id"
 			)
 		)

--- a/extensions/exiftool/src/main/java/org/exist/exiftool/xquery/MetadataFunctions.java
+++ b/extensions/exiftool/src/main/java/org/exist/exiftool/xquery/MetadataFunctions.java
@@ -52,9 +52,9 @@ public class MetadataFunctions extends BasicFunction {
             new QName("get-metadata", ExiftoolModule.NAMESPACE_URI, ExiftoolModule.PREFIX),
             "extracts the metadata",
             new SequenceType[]{
-                new FunctionParameterSequenceType("binary", Type.ANY_URI, Cardinality.ONE, "The binary file from which to extract from")
+                new FunctionParameterSequenceType("binary", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The binary file from which to extract from")
             },
-            new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "Extracted metadata")
+            new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "Extracted metadata")
     );
 
     /*
@@ -62,10 +62,10 @@ public class MetadataFunctions extends BasicFunction {
         new QName("write-metadata", ExiftoolModule.NAMESPACE_URI, ExiftoolModule.PREFIX),
         "write the metadata into a binary document",
         new SequenceType[]{
-            new FunctionParameterSequenceType("doc",Type.DOCUMENT, Cardinality.ONE, " XML file containing file"),
-            new FunctionParameterSequenceType("binary", Type.BASE64_BINARY, Cardinality.ONE, "The binary data into where metadata is written")
+            new FunctionParameterSequenceType("doc",Type.DOCUMENT, Cardinality.EXACTLY_ONE, " XML file containing file"),
+            new FunctionParameterSequenceType("binary", Type.BASE64_BINARY, Cardinality.EXACTLY_ONE, "The binary data into where metadata is written")
         },
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "Extracted metadata")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "Extracted metadata")
     );
     */
     

--- a/extensions/expath/src/main/java/org/expath/exist/ZipFileFunctions.java
+++ b/extensions/expath/src/main/java/org/expath/exist/ZipFileFunctions.java
@@ -55,7 +55,7 @@ public class ZipFileFunctions extends BasicFunction {
                     new SequenceType[]{
                             ENTRY_PARAM
                     },
-                    new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY, "The empty sequence.")
+                    new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE, "The empty sequence.")
             ),*/
             //zip:update-entries($zip as element(zip:file), $output as xs:anyURI) as empty-sequence()
             new FunctionSignature(

--- a/extensions/exquery/modules/request/src/main/java/org/exist/extensions/exquery/modules/request/ConnectionFunctions.java
+++ b/extensions/exquery/modules/request/src/main/java/org/exist/extensions/exquery/modules/request/ConnectionFunctions.java
@@ -53,28 +53,28 @@ public class ConnectionFunctions extends AbstractRequestModuleFunction {
         qnAddress,
         "Gets the IP address of the server that received the HTTP Request",
         null,
-        new FunctionReturnSequenceType(Type.STRING, Cardinality.ONE, "The IP address of the server.")
+        new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "The IP address of the server.")
     );
     
     public final static FunctionSignature FNS_REMOTE_HOSTNAME = new FunctionSignature(
         qnRemoteHostname,
         "Gets the fully qualified hostname of the client or the last proxy that sent the HTTP Request. If the name of the remote host cannot be established, this method behaves as request:remote-address(), and returns the IP address.",
         null,
-        new FunctionReturnSequenceType(Type.STRING, Cardinality.ONE, "The Hostname of the client that issues the HTTP Request.")
+        new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "The Hostname of the client that issues the HTTP Request.")
     );
     
     public final static FunctionSignature FNS_REMOTE_ADDRESS = new FunctionSignature(
         qnRemoteAddress,
         "Gets the IP address of the client or the last proxy that sent the HTTP Request.",
         null,
-        new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ONE, "The IP address of the client.")
+        new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE, "The IP address of the client.")
     );
     
     public final static FunctionSignature FNS_REMOTE_PORT = new FunctionSignature(
         qnRemotePort,
         "Gets the TCP port number of the client socket or the last proxy that sent the HTTP Request..",
         null,
-        new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ONE, "The TCP port number of the client.")
+        new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE, "The TCP port number of the client.")
     );
     
     public ConnectionFunctions(final XQueryContext context, final FunctionSignature signature) {

--- a/extensions/exquery/modules/request/src/main/java/org/exist/extensions/exquery/modules/request/GeneralFunctions.java
+++ b/extensions/exquery/modules/request/src/main/java/org/exist/extensions/exquery/modules/request/GeneralFunctions.java
@@ -49,7 +49,7 @@ public class GeneralFunctions extends AbstractRequestModuleFunction {
         qnMethod,
         "Gets the HTTP Method of the Request e.g. GET.",
         null,
-        new FunctionReturnSequenceType(Type.STRING, Cardinality.ONE, "The HTTP Method.")
+        new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "The HTTP Method.")
     );
     
     public GeneralFunctions(final XQueryContext context, final FunctionSignature signature) {

--- a/extensions/exquery/modules/request/src/main/java/org/exist/extensions/exquery/modules/request/URIFunctions.java
+++ b/extensions/exquery/modules/request/src/main/java/org/exist/extensions/exquery/modules/request/URIFunctions.java
@@ -55,28 +55,28 @@ public class URIFunctions extends AbstractRequestModuleFunction {
         qnScheme,
         "Gets the Scheme of the HTTP Request e.g. https.",
         null,
-        new FunctionReturnSequenceType(Type.STRING, Cardinality.ONE, "The Scheme of the HTTP Request.")
+        new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "The Scheme of the HTTP Request.")
     );
     
     public final static FunctionSignature FNS_HOSTNAME = new FunctionSignature(
         qnHostname,
         "Gets the Hostname fragment of the Authority component of the URI of the HTTP Request.",
         null,
-        new FunctionReturnSequenceType(Type.STRING, Cardinality.ONE, "The Hostname of the HTTP Request.")
+        new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "The Hostname of the HTTP Request.")
     );
     
     public final static FunctionSignature FNS_PORT = new FunctionSignature(
         qnPort,
         "Gets the Port fragment of the Authority component of the URI of the HTTP Request. If the port is not explicitly specified in the URI, then the default port for the HTTP Scheme is returned (i.e. 21 for FTP, 80 for HTTP and 443 for HTTPS).",
         null,
-        new FunctionReturnSequenceType(Type.INTEGER, Cardinality.ONE, "The Port of the HTTP Request.")
+        new FunctionReturnSequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE, "The Port of the HTTP Request.")
     );
     
     public final static FunctionSignature FNS_PATH = new FunctionSignature(
         qnPath,
         "Gets the Path component of the URI of the HTTP Request.",
         null,
-        new FunctionReturnSequenceType(Type.STRING, Cardinality.ONE, "The Path of the URI of the HTTP Request.")
+        new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "The Path of the URI of the HTTP Request.")
     );
     
     public final static FunctionSignature FNS_QUERY = new FunctionSignature(

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/adapters/CardinalityAdapter.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/adapters/CardinalityAdapter.java
@@ -34,14 +34,21 @@ import org.exquery.xquery.Cardinality;
  */
 class CardinalityAdapter {
     
-    public static Cardinality getCardinality(int cardinality) {
-        
-        for(final Cardinality c : Cardinality.values()) {
-            if(c.getNumericValue() == cardinality) {
-                return c;
-            }
+    public static Cardinality getCardinality(final org.exist.xquery.Cardinality cardinality) {
+        switch (cardinality) {
+           case EMPTY_SEQUENCE:
+               return Cardinality.ZERO;
+           case EXACTLY_ONE:
+               return Cardinality.ONE;
+           case _MANY:
+               return Cardinality.MANY;
+           case ZERO_OR_ONE:
+               return Cardinality.ZERO_OR_ONE;
+           case ONE_OR_MORE:
+               return Cardinality.ONE_OR_MORE;
+           case ZERO_OR_MORE:
+               return Cardinality.ZERO_OR_MORE;
         }
-        
         return  null;
     }
 }

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/RegistryFunctions.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/RegistryFunctions.java
@@ -82,7 +82,7 @@ public class RegistryFunctions extends BasicFunction {
             new QName(RESOURCE_FUNCTIONS.getLocalPart(), RestXqModule.NAMESPACE_URI, RestXqModule.PREFIX),
             "Gets a list of all the registered resource functions.",
             FunctionSignature.NO_ARGS,
-            new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "The list of registered resource functions.")
+            new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "The list of registered resource functions.")
         )
     };
     

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/UriFunctions.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/UriFunctions.java
@@ -52,14 +52,14 @@ public class UriFunctions extends BasicFunction {
             new QName("base-uri", RestXqModule.NAMESPACE_URI, RestXqModule.PREFIX),
             "This function returns the implementation defined base URI of the Resource Function.",
             FunctionSignature.NO_ARGS,
-            new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.ONE, "The base URI of the Resource Function.")
+            new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.EXACTLY_ONE, "The base URI of the Resource Function.")
         ),
         
         new FunctionSignature(
             new QName("uri", RestXqModule.NAMESPACE_URI, RestXqModule.PREFIX),
             "This function is returns the complete URI that addresses the Resource Function. Typically this is the rest:base-uri() appended with the path from the Path Annotation (if present) of the Resource Function.",
             FunctionSignature.NO_ARGS,
-            new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.ONE, "The URI which addressed the Resource Function.")
+            new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.EXACTLY_ONE, "The URI which addressed the Resource Function.")
         )
     };
     

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/exist/RegistryFunctions.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/exist/RegistryFunctions.java
@@ -72,7 +72,7 @@ public class RegistryFunctions extends BasicFunction {
         new SequenceType[]{
             PARAM_MODULE
         },
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "The list of newly registered resource functions.")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "The list of newly registered resource functions.")
     );
         
     public final static FunctionSignature FNS_DEREGISTER_MODULE = new FunctionSignature(
@@ -81,7 +81,7 @@ public class RegistryFunctions extends BasicFunction {
         new SequenceType[]{
             PARAM_MODULE
         },
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "The list of deregistered resource functions.")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "The list of deregistered resource functions.")
     );
         
     public final static FunctionSignature FNS_FIND_RESOURCE_FUNCTIONS = new FunctionSignature(
@@ -90,7 +90,7 @@ public class RegistryFunctions extends BasicFunction {
         new SequenceType[]{
             PARAM_MODULE
         },
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "The list of newly registered resource functions.")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "The list of newly registered resource functions.")
     );
         
     public final static FunctionSignature FNS_REGISTER_RESOURCE_FUNCTION = new FunctionSignature(
@@ -100,7 +100,7 @@ public class RegistryFunctions extends BasicFunction {
             PARAM_MODULE,
             PARAM_RESOURCE_FUNCTION,
         },
-        new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE, "true if the function was registered, false otherwise.")
+        new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if the function was registered, false otherwise.")
     );
         
     public final static FunctionSignature FNS_DEREGISTER_RESOURCE_FUNCTION = new FunctionSignature(
@@ -110,7 +110,7 @@ public class RegistryFunctions extends BasicFunction {
             PARAM_MODULE,
             PARAM_RESOURCE_FUNCTION,
         },
-        new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE, "true if the function was deregistered, false otherwise.")
+        new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if the function was deregistered, false otherwise.")
     );
 
     public final static FunctionSignature FNS_INVALID_MODULES = new FunctionSignature(
@@ -124,14 +124,14 @@ public class RegistryFunctions extends BasicFunction {
         qnMissingDependencies,
         "Gets a list of all the missing dependencies for XQuery modules discovered by RESTXQ in the process of discovering resource functions.",
         FunctionSignature.NO_ARGS,
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "The list of missing dependencies.")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "The list of missing dependencies.")
     );
 
     public final static FunctionSignature FNS_DEPENDENCIES = new FunctionSignature(
         qnDependencies,
         "Gets a list of all the dependencies of compiled XQuery modules discovered by RESTXQ in the process of discovering resource functions.",
         FunctionSignature.NO_ARGS,
-        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.ONE, "The list of dependencies.")
+        new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "The list of dependencies.")
     );
 
     private final static QName MISSING_DEPENDENCIES = new QName("missing-dependencies", ExistRestXqModule.NAMESPACE_URI, ExistRestXqModule.PREFIX);

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Index.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Index.java
@@ -54,20 +54,20 @@ public class Index extends BasicFunction {
 	            new QName("index", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
 	            "Index an arbitrary chunk of (non-XML) data with Lucene. Syntax is inspired by Solr.",
 	            new SequenceType[] {
-	                new FunctionParameterSequenceType("documentPath", Type.STRING, Cardinality.ONE,
+	                new FunctionParameterSequenceType("documentPath", Type.STRING, Cardinality.EXACTLY_ONE,
 	                "URI path of document in database."),
 	                new FunctionParameterSequenceType("solrExression", Type.NODE, Cardinality.EXACTLY_ONE,
 	                "XML syntax expected by Solr's add expression. Element should be called 'doc', e.g."
 	                + "<doc> <field name=\"field1\">data1</field> "
 	                + "<field name=\"field2\" boost=\"value\">data2</field> </doc> ")
 	            },
-	            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.ZERO, "")
+	            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE, "")
 	        ),
             new FunctionSignature(
 	            new QName("index", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
 	            "Index an arbitrary chunk of (non-XML) data with Lucene. Syntax is inspired by Solr.",
 	            new SequenceType[]{
-	                new FunctionParameterSequenceType("documentPath", Type.STRING, Cardinality.ONE,
+	                new FunctionParameterSequenceType("documentPath", Type.STRING, Cardinality.EXACTLY_ONE,
 	                "URI path of document in database."),
 	                new FunctionParameterSequenceType("solrExression", Type.NODE, Cardinality.EXACTLY_ONE,
 	                "XML syntax expected by Solr's add expression. Element should be called 'doc', e.g."
@@ -78,7 +78,7 @@ public class Index extends BasicFunction {
 	                "new Lucene document. If false, the document remains open and is not flushed to disk. " +
 	                "Call the ft:close function to explicitely close and flush the current document.")
 	            },
-	            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.ZERO, "")
+	            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE, "")
 	        ),
     
             new FunctionSignature(
@@ -86,7 +86,7 @@ public class Index extends BasicFunction {
 	            "Close the current Lucene document and flush it to disk. Subsequent calls to " +
 	            "ft:index will write to a new Lucene document.",
 	            null,
-	            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.ZERO, ""))
+	            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE, ""))
     };
 
     /*

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Optimize.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Optimize.java
@@ -36,7 +36,7 @@ public class Optimize extends BasicFunction {
             "The optimize will block the index for other write operations and may take " +
             "some time. You need to be a user in group dba to call this function.",
             new SequenceType[0],
-            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.ZERO, "")
+            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE, "")
         );
 
     public Optimize(XQueryContext context) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -52,7 +52,7 @@ public class Query extends Function implements Optimizable {
             "Lucene's default query syntax or as an XML fragment. " +
             "See http://exist-db.org/lucene.html#N1029E for complete documentation.",
             new SequenceType[] {
-                new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ZERO_OR_MORE, 
+                new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ZERO_OR_MORE,
                 		"The node set to search using a Lucene full text index which is defined on those nodes"),
                 new FunctionParameterSequenceType("query", Type.ITEM, Cardinality.ZERO_OR_ONE,
                 		"The query to search for, provided either as a string or text in Lucene's default query " +

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
@@ -41,7 +41,7 @@ public class QueryField extends Query implements Optimizable {
             new QName("query-field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
             "Queries a Lucene field, which has to be explicitely created in the index configuration.",
             new SequenceType[] {
-                new FunctionParameterSequenceType("field", Type.STRING, Cardinality.ZERO_OR_MORE, 
+                new FunctionParameterSequenceType("field", Type.STRING, Cardinality.ZERO_OR_MORE,
                 		"The lucene field name."),
                 new FunctionParameterSequenceType("query", Type.ITEM, Cardinality.EXACTLY_ONE, 
                 		"The query to search for, provided either as a string or text in Lucene's default query " +

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/RemoveIndex.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/RemoveIndex.java
@@ -49,10 +49,10 @@ public class RemoveIndex extends BasicFunction {
             "removed. They are maintained automatically by the database. Please note that non-XML indexes " +
             "will also be removed automatically if the associated document is deleted.",
             new SequenceType[]{
-                new FunctionParameterSequenceType("documentPath", Type.STRING, Cardinality.ONE,
+                new FunctionParameterSequenceType("documentPath", Type.STRING, Cardinality.EXACTLY_ONE,
                 "URI path of document in database.")
             },
-            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.ZERO, ""));
+            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE, ""));
 	
 	public RemoveIndex(XQueryContext context) {
 		super(context, signature);

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Optimize.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Optimize.java
@@ -43,7 +43,7 @@ public class Optimize extends BasicFunction {
             "The optimize will block the index for other write operations and may take " +
             "some time. You need to be a user in group dba to call this function.",
             new SequenceType[0],
-            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.ZERO, "")
+            new FunctionReturnSequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE, "")
         );
 
     public Optimize(XQueryContext context) {

--- a/extensions/modules/counter/src/main/java/org/exist/xquery/modules/counter/CounterFunctions.java
+++ b/extensions/modules/counter/src/main/java/org/exist/xquery/modules/counter/CounterFunctions.java
@@ -40,7 +40,7 @@ public class CounterFunctions extends BasicFunction {
                 new FunctionParameterSequenceType("counter-name", Type.ITEM, Cardinality.EXACTLY_ONE,
                         "Name of the counter.")
             },
-            new FunctionReturnSequenceType(Type.LONG, Cardinality.ZERO_OR_ONE, 
+            new FunctionReturnSequenceType(Type.LONG, Cardinality.ZERO_OR_ONE,
                                                         "the value of the newly created counter."));
 
     public final static FunctionSignature createCounterAndInit =
@@ -54,7 +54,7 @@ public class CounterFunctions extends BasicFunction {
                 new FunctionParameterSequenceType("init-value", Type.LONG, Cardinality.EXACTLY_ONE,
                         "The initial value of the counter.")
             },
-            new FunctionReturnSequenceType(Type.LONG, Cardinality.ZERO_OR_ONE, 
+            new FunctionReturnSequenceType(Type.LONG, Cardinality.ZERO_OR_ONE,
                                                         "the value of the newly created counter."));
 
     public final static FunctionSignature nextValue =
@@ -65,7 +65,7 @@ public class CounterFunctions extends BasicFunction {
                 new FunctionParameterSequenceType("counter-name", Type.ITEM, Cardinality.EXACTLY_ONE,
                         "Name of the counter.")
             },
-            new FunctionReturnSequenceType(Type.LONG, Cardinality.ZERO_OR_ONE, 
+            new FunctionReturnSequenceType(Type.LONG, Cardinality.ZERO_OR_ONE,
                                                         "the new value of the specified counter," +
                                                         " or -1 if the counter does not exist."));
 

--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/GetResource.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/GetResource.java
@@ -48,7 +48,7 @@ public class GetResource extends BasicFunction {
 				new FunctionParameterSequenceType("pkgName", Type.STRING, Cardinality.EXACTLY_ONE, "package name"),
 				new FunctionParameterSequenceType("resource", Type.STRING, Cardinality.EXACTLY_ONE, "resource path")
 			},
-			new FunctionReturnSequenceType(Type.BASE64_BINARY, Cardinality.ZERO_OR_ONE, 
+			new FunctionReturnSequenceType(Type.BASE64_BINARY, Cardinality.ZERO_OR_ONE,
 					"<status result=\"ok\"/> if deployment was ok. Throws an error otherwise."));
 	
 	public GetResource(XQueryContext context) {

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Directory.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Directory.java
@@ -78,7 +78,7 @@ public class Directory extends BasicFunction {
                         Type.ITEM, Cardinality.EXACTLY_ONE, 
                         "The directory path or URI in the file system."),
             },
-            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE, 
+            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
                 "a node describing file and directory names and meta data."))
     };
 

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
@@ -63,7 +63,7 @@ public class Sync extends BasicFunction {
                 new FunctionParameterSequenceType("targetPath", Type.ITEM, 
                         Cardinality.EXACTLY_ONE, "The full path or URI to the directory"),
                 new FunctionParameterSequenceType("dateTime", Type.DATE_TIME, 
-                        Cardinality.ZERO_OR_ONE, 
+                        Cardinality.ZERO_OR_ONE,
                 		"Optional: only resources modified after the given date/time will be synchronized.")
             },
             new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if successful, false otherwise")

--- a/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/CloseContextFunction.java
+++ b/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/CloseContextFunction.java
@@ -61,7 +61,7 @@ public class CloseContextFunction extends BasicFunction
 					new SequenceType[] {
 						new FunctionParameterSequenceType( "directory-context", Type.INTEGER, Cardinality.EXACTLY_ONE, "The directory context handle from a jndi:get-dir-context() call" )
 					},
-					new SequenceType( Type.ITEM, Cardinality.EMPTY ) )
+					new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE ) )
 			};
 
 	public CloseContextFunction( XQueryContext context, FunctionSignature signature ) 

--- a/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/CreateFunction.java
+++ b/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/CreateFunction.java
@@ -73,7 +73,7 @@ public class CreateFunction extends BasicFunction
 							+ " form <attributes><attribute name=\"\" value=\"\"/></attributes>. "
 							+ " You can also optionally specify ordered=\"true\" for an attribute." ) 
 					},
-					new SequenceType( Type.ITEM, Cardinality.EMPTY ) )
+					new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE ) )
 			};
 
 	public CreateFunction( XQueryContext context, FunctionSignature signature ) 

--- a/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/DeleteFunction.java
+++ b/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/DeleteFunction.java
@@ -69,7 +69,7 @@ public class DeleteFunction extends BasicFunction
 						new FunctionParameterSequenceType( "directory-context", Type.INTEGER, Cardinality.EXACTLY_ONE, "The directory context handle from a jndi:get-dir-context() call" ), 
 						new FunctionParameterSequenceType( "dn", Type.STRING, Cardinality.EXACTLY_ONE, "The Distinguished Name" )
 					},
-					new SequenceType( Type.ITEM, Cardinality.EMPTY ) )
+					new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE ) )
 			};
 
 	public DeleteFunction( XQueryContext context, FunctionSignature signature ) 

--- a/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/GetDirContextFunction.java
+++ b/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/GetDirContextFunction.java
@@ -68,7 +68,7 @@ public class GetDirContextFunction extends BasicFunction
 					new QName( "get-dir-context", JNDIModule.NAMESPACE_URI, JNDIModule.PREFIX ),
 					"Opens a JNDI Directory Context.",
 					new SequenceType[] {
-							new FunctionParameterSequenceType( "properties", Type.ELEMENT, Cardinality.ZERO_OR_ONE, "The JNDI Directory Context environment properties to be set in the form <properties><property name=\"\" value=\"\"/></properties>." ) 
+							new FunctionParameterSequenceType( "properties", Type.ELEMENT, Cardinality.ZERO_OR_ONE, "The JNDI Directory Context environment properties to be set in the form <properties><property name=\"\" value=\"\"/></properties>." )
 					},
 					new FunctionReturnSequenceType( Type.LONG, Cardinality.ZERO_OR_ONE, "the directory context handle" ) )
 			};

--- a/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/ModifyFunction.java
+++ b/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/ModifyFunction.java
@@ -81,7 +81,7 @@ public class ModifyFunction extends BasicFunction
 							+ " form <attributes><attribute name=\"\" value=\"\" operation=\"add | replace | remove\"/></attributes>. "
 							+ " You can also optionally specify ordered=\"true\" for an attribute." ) 
 					},
-					new SequenceType( Type.ITEM, Cardinality.EMPTY ) )
+					new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE ) )
 			};
 
 	public ModifyFunction( XQueryContext context, FunctionSignature signature ) 

--- a/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/RenameFunction.java
+++ b/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/RenameFunction.java
@@ -70,7 +70,7 @@ public class RenameFunction extends BasicFunction
 						new FunctionParameterSequenceType( "old-dn", Type.STRING, Cardinality.EXACTLY_ONE, "The Distinguished Name to rename" ),
 						new FunctionParameterSequenceType( "new-dn", Type.STRING, Cardinality.EXACTLY_ONE, "The new Distinguished Name" )
 					},
-					new SequenceType( Type.ITEM, Cardinality.EMPTY ) )
+					new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE ) )
 			};
 
 	public RenameFunction( XQueryContext context, FunctionSignature signature ) 

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailFolderFunctions.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailFolderFunctions.java
@@ -78,7 +78,7 @@ public class MailFolderFunctions extends BasicFunction
 				new FunctionParameterSequenceType( "mail-folder-handle", Type.INTEGER, Cardinality.EXACTLY_ONE, "The mail folder handle retrieved from mail:get-mail-folder()" ),
 				new FunctionParameterSequenceType( "expunge", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "A boolean that specifies whether to expunge the folder on close." )
 			},
-			new SequenceType( Type.ITEM, Cardinality.EMPTY )
+			new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE )
 			)
 		};
 

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailStoreFunctions.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailStoreFunctions.java
@@ -75,7 +75,7 @@ public class MailStoreFunctions extends BasicFunction
 			{
 				new FunctionParameterSequenceType( "mail-store-handle", Type.INTEGER, Cardinality.EXACTLY_ONE, "The mail store handle retrieved from mail:get-mail-store()" )
 			},
-			new SequenceType( Type.ITEM, Cardinality.EMPTY )
+			new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE )
 			)
 		};
 

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MessageListFunctions.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MessageListFunctions.java
@@ -132,7 +132,7 @@ public class MessageListFunctions extends BasicFunction
 			{
 				new FunctionParameterSequenceType( "message-list-handle", Type.INTEGER, Cardinality.EXACTLY_ONE, "The message list handle retrieved from mail:get-message-list() or mail:search-message-list()" )
 			},
-			new SequenceType( Type.ITEM, Cardinality.EMPTY )
+			new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE )
 			)
 	};
 	

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/SendEmailFunction.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/SendEmailFunction.java
@@ -101,7 +101,7 @@ public class SendEmailFunction extends BasicFunction
 				new FunctionParameterSequenceType( "mail-handle", Type.LONG, Cardinality.EXACTLY_ONE, "The JavaMail session handle retrieved from mail:get-mail-session()" ),
                 new FunctionParameterSequenceType( "email", Type.ELEMENT, Cardinality.ONE_OR_MORE, "The email message in the following format: <mail> <from/> <reply-to/> <to/> <cc/> <bcc/> <subject/> <message> <text/> <xhtml/> </message> <attachment filename=\"\" mimetype=\"\">xs:base64Binary</attachment> </mail>.")
             },
-            new SequenceType( Type.ITEM, Cardinality.EMPTY )
+            new SequenceType( Type.ITEM, Cardinality.EMPTY_SEQUENCE )
         )
     };
 

--- a/extensions/security/ldap/src/main/java/org/exist/security/realm/ldap/xquery/AccountFunctions.java
+++ b/extensions/security/ldap/src/main/java/org/exist/security/realm/ldap/xquery/AccountFunctions.java
@@ -52,7 +52,7 @@ public class AccountFunctions extends BasicFunction {
                     new SequenceType[]{
                             new SequenceType(Type.STRING, Cardinality.EXACTLY_ONE)
                     },
-                    new SequenceType(Type.EMPTY, Cardinality.ZERO)
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
             )
     };
 


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/1168

This fixes an issue with multiple positions in a position predicate. It also ports over to eXist-db a new Cardinality class from FusionDB to replace `org.exist.xquery.Cardinality`. We have re-licensed this for eXist-db under LGPL 2.1. This new Cardinality class was crucial to helping me debug and find this issue.