### PR TITLE
[Feature] Add memory and nr of processors information to startup log.

### DIFF
--- a/exist-core/src/main/java/org/exist/jetty/JettyStart.java
+++ b/exist-core/src/main/java/org/exist/jetty/JettyStart.java
@@ -177,7 +177,7 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
                 System.getProperty("java.home", "(unknown java.home)")
             );
 
-            logger.info("Maximum amount of memory for JVM: {} MiB", Runtime.getRuntime().maxMemory() / (1024 * 1024));
+            logger.info("Approximate maximum amount of memory for JVM: {}", FileUtils.humanSize(Runtime.getRuntime().maxMemory()));
             logger.info("Number of processors available to JVM: {}", Runtime.getRuntime().availableProcessors());
 
             logger.info("Running as user '{}'", System.getProperty("user.name", "(unknown user.name)"));

--- a/exist-core/src/main/java/org/exist/jetty/JettyStart.java
+++ b/exist-core/src/main/java/org/exist/jetty/JettyStart.java
@@ -177,6 +177,9 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
                 System.getProperty("java.home", "(unknown java.home)")
             );
 
+            logger.info("Maximum amount of memory for JVM: {} MiB", Runtime.getRuntime().maxMemory() / (1024 * 1024));
+            logger.info("Number of processors available to JVM: {}", Runtime.getRuntime().availableProcessors());
+
             logger.info("Running as user '{}'", System.getProperty("user.name", "(unknown user.name)"));
             logger.info("[eXist Home : {}]", System.getProperty("exist.home", "unknown"));
             logger.info("[eXist Version : {}]", SystemProperties.getInstance().getSystemProperty("product-version", "unknown"));

--- a/exist-core/src/main/java/org/exist/util/FileUtils.java
+++ b/exist-core/src/main/java/org/exist/util/FileUtils.java
@@ -541,14 +541,14 @@ public class FileUtils {
      * @return the humane string
      */
     public static String humanSize(final long bytes) {
-        if (bytes < 1024) {
+        if (bytes < 1024L) {
             return bytes + " bytes";
-        } else if (bytes < 1024 * 1024) {
+        } else if (bytes < 1024L * 1024L) {
             return Math.round(bytes / 1024) + " KB";
-        } else if (bytes < 1024 * 1024 * 1024) {
-            return Math.round(bytes / (1024 * 1024)) + " MB";
-        } else if (bytes < 1024 * 1024 * 1024 * 1024) {
-            return Math.round(bytes / (1024 * 1024 * 1024)) + " GB";
+        } else if (bytes < 1024L * 1024L * 1024L) {
+            return Math.round(bytes / (1024L * 1024L)) + " MB";
+        } else if (bytes < 1024L * 1024L * 1024L * 1024L) {
+            return Math.round(bytes / (1024L * 1024L * 1024L)) + " GB";
         } else {
             return bytes + " bytes";
         }


### PR DESCRIPTION
Output:

```
30 Mar 2020 19:54:38,255 [main] INFO  (JettyStart.java [run]:173) - Running with Java 1.8.0_242 [AdoptOpenJDK (OpenJDK 64-Bit Server VM) in /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre] 
30 Mar 2020 19:54:38,257 [main] INFO  (JettyStart.java [run]:180) - Maximum amount of memory for JVM: 3641 MiB 
30 Mar 2020 19:54:38,258 [main] INFO  (JettyStart.java [run]:181) - Number of processors available to JVM: 8  
```