### PR TITLE
add code to disable trigger execution during expath pkg installation

### DIFF
--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -478,9 +478,10 @@ public class Deployment {
                 return Optional.ofNullable(targetCollection.getCollectionPath());
             }
         } catch (final XPathException e) {
+            throw new PackageException("Error found while processing repo.xml: " + e.getMessage(), e);
+	} finally {
             // reset possibly altered trigger state
             broker.setTriggersEnabled(triggerState);
-            throw new PackageException("Error found while processing repo.xml: " + e.getMessage(), e);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -352,6 +352,10 @@ public class Deployment {
         if (repoXML == null) {
             return Optional.empty();
         }
+
+        // remember current trigger state
+        final boolean triggerState = broker.isTriggersEnabled();
+
         try {
             // if there's a <setup> element, run the query it points to
             final Optional<ElementImpl> setup = findElement(repoXML, SETUP_ELEMENT);
@@ -393,9 +397,8 @@ public class Deployment {
                     targetCollection = XmldbURI.SYSTEM.append("repo/" + pkgColl);
                 }
 
-                // skip trigger execution and remember previous state
+                // skip trigger execution if demanded in repo.xml
                 final Optional<ElementImpl> skipTriggers = findElement(repoXML, SKIP_TRIGGERS_ELEMENT);
-                final boolean triggerState = broker.isTriggersEnabled();
                 if(skipTriggers.isPresent()) {
                     broker.setTriggersEnabled(false);
                 }
@@ -475,6 +478,8 @@ public class Deployment {
                 return Optional.ofNullable(targetCollection.getCollectionPath());
             }
         } catch (final XPathException e) {
+            // reset possibly altered trigger state
+            broker.setTriggersEnabled(triggerState);
             throw new PackageException("Error found while processing repo.xml: " + e.getMessage(), e);
         }
     }

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -462,11 +462,6 @@ public class Deployment {
 
                 storeRepoXML(broker, transaction, repoXML, targetCollection, requestedPerms);
 
-                // restore trigger execution to previous state
-                if(skipTriggers.isPresent()) {
-                    broker.setTriggersEnabled(triggerState);
-                }
-
                 // TODO: it should be safe to clean up the file system after a package
                 // has been deployed. Might be enabled after 2.0
                 //cleanup(pkgName, repo);

--- a/extensions/modules/expathrepo/src/test/java/org/exist/repo/PackageSkipTriggerTest.java
+++ b/extensions/modules/expathrepo/src/test/java/org/exist/repo/PackageSkipTriggerTest.java
@@ -1,0 +1,103 @@
+package org.exist.repo;
+
+import org.apache.commons.io.IOUtils;
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.ManagedCollectionLock;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.LockException;
+import org.exist.util.io.FastByteArrayInputStream;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.value.Sequence;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+public class PackageSkipTriggerTest {
+
+    static final String xarFile = "exist-test-expath-skiptriggers-0.99.7.xar";
+    static final XmldbURI triggerTestCollection = XmldbURI.create("/db");
+    static final XmldbURI xarUri = triggerTestCollection.append(xarFile);
+
+    @ClassRule
+    public static ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(false, true);
+
+    @BeforeClass
+    public static void setup() throws PermissionDeniedException, IOException, TriggerException, EXistException, IOException, LockException, XPathException {
+
+        final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+
+        // Create a collection to test the trigger in
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+
+            final Collection collection = broker.getOrCreateCollection(transaction, triggerTestCollection);
+            broker.saveCollection(transaction, collection);
+            transaction.commit();
+        }
+
+        // Load XAR file
+        byte[] content;
+        try (InputStream resourceAsStream = PackageSkipTriggerTest.class.getResourceAsStream(xarFile)) {
+            Assert.assertNotNull(resourceAsStream);
+            content = IOUtils.toByteArray(resourceAsStream);
+        }
+
+        // Store XAR in database
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+
+            try (final ManagedCollectionLock collectionLock = brokerPool.getLockManager().acquireCollectionWriteLock(xarUri.removeLastSegment())) {
+                final Collection collection = broker.getOrCreateCollection(transaction, xarUri.removeLastSegment());
+                try (final InputStream is = new FastByteArrayInputStream(content)) {
+
+                    collection.addBinaryResource(transaction, broker, xarUri.lastSegment(), is, "application/expath+xar", content.length);
+                    broker.saveCollection(transaction, collection);
+                }
+            }
+
+            transaction.commit();
+        }
+
+        // Install and deploy XAR
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = brokerPool.getXQueryService();
+            final Sequence result = xquery.execute(broker, "repo:install-and-deploy-from-db('/db/" + xarFile + "')", null);
+            Assert.assertEquals(1, result.getItemCount());
+        }
+    }
+
+
+    @Test
+    public void checkTriggerFiresNot() throws EXistException, PermissionDeniedException, XPathException {
+
+        final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+
+        // Verify the test document got installed
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = brokerPool.getXQueryService();
+            final Sequence result = xquery.execute(broker, "xmldb:get-child-resources('/db/apps/test-expath-skiptriggers/testdata')", null);
+            Assert.assertEquals("After trigger execution one document should be in the collection.", 1, result.getItemCount());
+        }
+
+        // Verify the triggers-log.xml file does not mention the test document
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()))) {
+            final XQuery xquery = brokerPool.getXQueryService();
+            final Sequence result = xquery.execute(broker, "doc('/db/triggers-log.xml')//triggers/trigger[@uri = '/db/apps/test-expath-skiptriggers/testdata/test.xml']", null);
+            Assert.assertEquals("No trigger execution should be logged for the test document.", 0, result.getItemCount());
+        }
+
+    }
+}


### PR DESCRIPTION
### Description:

This patch allows to install an expath package with **trigger execution suppressed** during the installation.

There can be cases where the execution of triggers during package installation is unwanted:
- if replication triggers are being used: when a package gets upgraded to a newer version, the old package data gets deleted before re-installing newer data. And replication triggers will propagate these deletions to the replicated DB. Which spoils the idea of replication.
- similar issues with triggers interacting with Amazon AWS S3
- similar issues with triggers interacting with Github/Gitlab

#### Proposed Implementation

##### Add optional Element `skip-triggers` to file `repo.xml` of a Package

```
<?xml version="1.0" encoding="UTF-8"?>
<meta xmlns="http://exist-db.org/xquery/repo">
    <description>An app to test trigger behavior</description>
    <author>Me</author>
    <!-- other elements ... -->

    <skip-triggers/>
</meta>
```

If the empty `skip-triggers` element is present in file `repo.xml`, then triggers shall not be executed. If the element is not present, code behavior is unchanged, so this is backwards compatible.

##### Piggyback on existing `DBBroker:isTriggersEnabled()` and `DBBroker:setTriggersEnabled()` Methods

In method `Deployment:deploy()`, method `setTriggersEnabled()` is used to temporarily disable and later re-enable trigger execution state, if the `skip-triggers` element is present in file `repo.xml`.

`setTriggersEnabled()` applies to a single broker instance only. It is used during execution of method `deploy()` in the context of a single broker during package installation, so this should be good for the purpose.

##### All Trigger Usages in Class `NativeBroker` honor the `isTriggersEnabled()` Method

All trigger instantiation and usage cases honor `isTriggersEnabled()` following this pattern:
- trigger instance initialized as `null`
- instantiate trigger only if `isTriggersEnabled() == true`
- protect all uses of potential null object with `if (trigger != null)`

#### Dragons Lurking

While not strictly relevant to the problem at hand (suppress triggers during Xar install), I suspect class `MutableCollection` may need similar treatment.

Caching effects have not been considered yet.

### Reference:

Implemented to meet customer requirements.

### Type of tests:

Works for me.

Seriously: This is a working PoC implementation, comments and criticism welcome.
