### PR TITLE
[PoC] XQuery functions to en/disable trigger execution on collections at runtime

### DIFF
--- a/exist-core/src/main/java/org/exist/collections/CollectionConfiguration.java
+++ b/exist-core/src/main/java/org/exist/collections/CollectionConfiguration.java
@@ -90,6 +90,8 @@ public class CollectionConfiguration {
 
     private final BrokerPool pool;
 
+    private boolean skipTriggers = false;
+
     public CollectionConfiguration(final BrokerPool pool) {
         this.pool = pool;
     }
@@ -205,6 +207,14 @@ public class CollectionConfiguration {
 
     public IndexSpec getIndexConfiguration() {
         return indexSpec;
+    }
+
+    public boolean getSkipTriggers() {
+        return skipTriggers;
+    }
+
+    public void setSkipTriggers(boolean skipTriggers) {
+        this.skipTriggers = skipTriggers;
     }
 
     private void configureTrigger(final ClassLoader cl, final Element triggerElement, final XmldbURI collectionConfigurationURI, final boolean testOnly) throws CollectionConfigurationException {

--- a/exist-core/src/main/java/org/exist/collections/triggers/CollectionTriggers.java
+++ b/exist-core/src/main/java/org/exist/collections/triggers/CollectionTriggers.java
@@ -34,8 +34,10 @@ import org.exist.xmldb.XmldbURI;
  *
  */
 public class CollectionTriggers implements CollectionTrigger {
-    
+
     private final List<CollectionTrigger> triggers;
+
+    private boolean triggersSuspended = false;
 
     public CollectionTriggers(DBBroker broker, Txn transaction) throws TriggerException {
         this(broker, transaction, null, null);
@@ -50,6 +52,7 @@ public class CollectionTriggers implements CollectionTrigger {
         List<TriggerProxy<? extends CollectionTrigger>> colTriggers = null;
         if (config != null) {
             colTriggers = config.collectionTriggers();
+            triggersSuspended = config.getSkipTriggers();
         }
         
         java.util.Collection<TriggerProxy<? extends CollectionTrigger>> masterTriggers = broker.getDatabase().getCollectionTriggers();
@@ -83,72 +86,88 @@ public class CollectionTriggers implements CollectionTrigger {
 
     @Override
     public void beforeCreateCollection(DBBroker broker, Txn txn, XmldbURI uri) throws TriggerException {
-        for (CollectionTrigger trigger : triggers) {
-            trigger.beforeCreateCollection(broker, txn, uri);
+        if (!triggersSuspended) {
+            for (CollectionTrigger trigger : triggers) {
+                trigger.beforeCreateCollection(broker, txn, uri);
+            }
         }
     }
 
     @Override
     public void afterCreateCollection(DBBroker broker, Txn txn, Collection collection) {
-        for (CollectionTrigger trigger : triggers) {
-            try {
-                trigger.afterCreateCollection(broker, txn, collection);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!triggersSuspended) {
+            for (CollectionTrigger trigger : triggers) {
+                try {
+                    trigger.afterCreateCollection(broker, txn, collection);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }
 
     @Override
     public void beforeCopyCollection(DBBroker broker, Txn txn, Collection collection, XmldbURI newUri) throws TriggerException {
-        for (CollectionTrigger trigger : triggers) {
-            trigger.beforeCopyCollection(broker, txn, collection, newUri);
+        if (!triggersSuspended) {
+            for (CollectionTrigger trigger : triggers) {
+                trigger.beforeCopyCollection(broker, txn, collection, newUri);
+            }
         }
     }
 
     @Override
     public void afterCopyCollection(DBBroker broker, Txn txn, Collection collection, XmldbURI oldUri) {
-        for (CollectionTrigger trigger : triggers) {
-            try {
-                trigger.afterCopyCollection(broker, txn, collection, oldUri);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!triggersSuspended) {
+            for (CollectionTrigger trigger : triggers) {
+                try {
+                    trigger.afterCopyCollection(broker, txn, collection, oldUri);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }
 
     @Override
     public void beforeMoveCollection(DBBroker broker, Txn txn, Collection collection, XmldbURI newUri) throws TriggerException {
-        for (CollectionTrigger trigger : triggers) {
-            trigger.beforeMoveCollection(broker, txn, collection, newUri);
+        if (!triggersSuspended) {
+            for (CollectionTrigger trigger : triggers) {
+                trigger.beforeMoveCollection(broker, txn, collection, newUri);
+            }
         }
     }
 
     @Override
     public void afterMoveCollection(DBBroker broker, Txn txn, Collection collection, XmldbURI oldUri) {
-        for (CollectionTrigger trigger : triggers) {
-            try {
-                trigger.afterMoveCollection(broker, txn, collection, oldUri);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!triggersSuspended) {
+            for (CollectionTrigger trigger : triggers) {
+                try {
+                    trigger.afterMoveCollection(broker, txn, collection, oldUri);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }
 
     @Override
     public void beforeDeleteCollection(DBBroker broker, Txn txn, Collection collection) throws TriggerException {
-        for (CollectionTrigger trigger : triggers) {
-            trigger.beforeDeleteCollection(broker, txn, collection);
+        if (!triggersSuspended) {
+            for (CollectionTrigger trigger : triggers) {
+                trigger.beforeDeleteCollection(broker, txn, collection);
+            }
         }
     }
 
     @Override
     public void afterDeleteCollection(DBBroker broker, Txn txn, XmldbURI uri) {
-        for (CollectionTrigger trigger : triggers) {
-            try {
-                trigger.afterDeleteCollection(broker, txn, uri);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!triggersSuspended) {
+            for (CollectionTrigger trigger : triggers) {
+                try {
+                    trigger.afterDeleteCollection(broker, txn, uri);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/collections/triggers/DocumentTriggers.java
+++ b/exist-core/src/main/java/org/exist/collections/triggers/DocumentTriggers.java
@@ -53,7 +53,9 @@ public class DocumentTriggers implements DocumentTrigger, ContentHandler, Lexica
     private SAXTrigger last = null;
     
     private final List<DocumentTrigger> triggers;
-    
+
+    private boolean skipTriggers = false;
+
     public DocumentTriggers(DBBroker broker, Txn transaction) throws TriggerException {
         this(broker, transaction, null, null, null);
     }
@@ -67,6 +69,7 @@ public class DocumentTriggers implements DocumentTrigger, ContentHandler, Lexica
         List<TriggerProxy<? extends DocumentTrigger>> docTriggers = null;
         if (config != null) {
             docTriggers = config.documentTriggers();
+            skipTriggers = config.getSkipTriggers();
         }
         
         java.util.Collection<TriggerProxy<? extends DocumentTrigger>> masterTriggers = broker.getDatabase().getDocumentTriggers();
@@ -224,108 +227,132 @@ public class DocumentTriggers implements DocumentTrigger, ContentHandler, Lexica
 
     @Override
     public void beforeCreateDocument(DBBroker broker, Txn txn, XmldbURI uri) throws TriggerException {
-        for (DocumentTrigger trigger : triggers) {
-            trigger.beforeCreateDocument(broker, txn, uri);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                trigger.beforeCreateDocument(broker, txn, uri);
+            }
         }
     }
 
     @Override
     public void afterCreateDocument(DBBroker broker, Txn txn, DocumentImpl document) {
-        for (DocumentTrigger trigger : triggers) {
-            try {
-                trigger.afterCreateDocument(broker, txn, document);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                try {
+                    trigger.afterCreateDocument(broker, txn, document);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }
 
     @Override
     public void beforeUpdateDocument(DBBroker broker, Txn txn, DocumentImpl document) throws TriggerException {
-        for (DocumentTrigger trigger : triggers) {
-            trigger.beforeUpdateDocument(broker, txn, document);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                trigger.beforeUpdateDocument(broker, txn, document);
+            }
         }
     }
 
     @Override
     public void afterUpdateDocument(DBBroker broker, Txn txn, DocumentImpl document) {
-        for (DocumentTrigger trigger : triggers) {
-            try {
-                trigger.afterUpdateDocument(broker, txn, document);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                try {
+                    trigger.afterUpdateDocument(broker, txn, document);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }
 
     @Override
     public void beforeUpdateDocumentMetadata(DBBroker broker, Txn txn, DocumentImpl document) throws TriggerException {
-        for (DocumentTrigger trigger : triggers) {
-            trigger.beforeUpdateDocumentMetadata(broker, txn, document);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                trigger.beforeUpdateDocumentMetadata(broker, txn, document);
+            }
         }
     }
 
     @Override
     public void afterUpdateDocumentMetadata(DBBroker broker, Txn txn, DocumentImpl document) {
-        for (DocumentTrigger trigger : triggers) {
-            try {
-                trigger.afterUpdateDocumentMetadata(broker, txn, document);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                try {
+                    trigger.afterUpdateDocumentMetadata(broker, txn, document);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }
 
     @Override
     public void beforeCopyDocument(DBBroker broker, Txn txn, DocumentImpl document, XmldbURI newUri) throws TriggerException {
-        for (DocumentTrigger trigger : triggers) {
-            trigger.beforeCopyDocument(broker, txn, document, newUri);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                trigger.beforeCopyDocument(broker, txn, document, newUri);
+            }
         }
     }
 
     @Override
     public void afterCopyDocument(DBBroker broker, Txn txn, DocumentImpl document, XmldbURI oldUri) {
-        for (DocumentTrigger trigger : triggers) {
-            try {
-                trigger.afterCopyDocument(broker, txn, document, oldUri);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                try {
+                    trigger.afterCopyDocument(broker, txn, document, oldUri);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }
 
     @Override
     public void beforeMoveDocument(DBBroker broker, Txn txn, DocumentImpl document, XmldbURI newUri) throws TriggerException {
-        for (DocumentTrigger trigger : triggers) {
-            trigger.beforeMoveDocument(broker, txn, document, newUri);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                trigger.beforeMoveDocument(broker, txn, document, newUri);
+            }
         }
     }
 
     @Override
     public void afterMoveDocument(DBBroker broker, Txn txn, DocumentImpl document, XmldbURI oldUri) {
-        for (DocumentTrigger trigger : triggers) {
-            try {
-                trigger.afterMoveDocument(broker, txn, document, oldUri);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                try {
+                    trigger.afterMoveDocument(broker, txn, document, oldUri);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }
 
     @Override
     public void beforeDeleteDocument(DBBroker broker, Txn txn, DocumentImpl document) throws TriggerException {
-        for (DocumentTrigger trigger : triggers) {
-            trigger.beforeDeleteDocument(broker, txn, document);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                trigger.beforeDeleteDocument(broker, txn, document);
+            }
         }
     }
 
     @Override
     public void afterDeleteDocument(DBBroker broker, Txn txn, XmldbURI uri) {
-        for (DocumentTrigger trigger : triggers) {
-            try {
-                trigger.afterDeleteDocument(broker, txn, uri);
-            } catch (Exception e) {
-                Trigger.LOG.error(e.getMessage(), e);
+        if (!skipTriggers) {
+            for (DocumentTrigger trigger : triggers) {
+                try {
+                    trigger.afterDeleteDocument(broker, txn, uri);
+                } catch (Exception e) {
+                    Trigger.LOG.error(e.getMessage(), e);
+                }
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/CollectionSuspendTriggers.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/CollectionSuspendTriggers.java
@@ -1,0 +1,126 @@
+/*
+ *  eXist Open Source Native XML Database
+ *  Copyright (C) 2001-09 Wolfgang M. Meier
+ *  wolfgang@exist-db.org
+ *  http://exist.sourceforge.net
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ *  $Id$
+ */
+package org.exist.xquery.functions.util;
+
+import java.net.URISyntaxException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.collections.CollectionConfiguration;
+import org.exist.collections.LockedCollection;
+import org.exist.dom.persistent.NodeProxy;
+import org.exist.dom.QName;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.DBBroker;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.BasicFunction;
+import org.exist.xquery.Cardinality;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.*;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.XMLDBException;
+
+/**
+ * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
+ *
+ */
+public class CollectionSuspendTriggers extends BasicFunction {
+
+    protected static final Logger logger = LogManager.getLogger(CollectionName.class);
+    private final static QName QN_COLLECTION_SUSPEND_TRIGGERS = new QName("collection-suspend-triggers", UtilModule.NAMESPACE_URI, UtilModule.PREFIX);
+    private final static QName QN_COLLECTION_ENABLE_TRIGGERS = new QName("collection-enable-triggers", UtilModule.NAMESPACE_URI, UtilModule.PREFIX);
+
+    public final static FunctionSignature signatures[] = {
+            new FunctionSignature(
+                    QN_COLLECTION_SUSPEND_TRIGGERS,
+                    "suspends triggers for a collection.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("node-or-path-string", Type.ITEM, Cardinality.ZERO_OR_ONE, "The document node or a path string.")
+                    },
+                    new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE, "current state of triggers for the collection")
+
+            ),
+            new FunctionSignature(
+                    QN_COLLECTION_ENABLE_TRIGGERS,
+                    "re-enables possibly suspended triggers for a collection.",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("node-or-path-string", Type.ITEM, Cardinality.ZERO_OR_ONE, "The document node or a path string.")
+                    },
+                    new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.ONE, "current state of triggers for the collection")
+
+            )
+    };
+
+
+    public CollectionSuspendTriggers(XQueryContext context, FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    /* (non-Javadoc)
+     * @see org.exist.xquery.BasicFunction#eval(org.exist.xquery.value.Sequence[], org.exist.xquery.value.Sequence)
+     */
+    public Sequence eval(Sequence[] args, Sequence contextSequence)
+            throws XPathException {
+
+        if(args[0].isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+        final Item item = args[0].itemAt(0);
+        final QName fnName = getSignature().getName();
+
+        boolean skipTriggers = false;
+        if(fnName.equals(QN_COLLECTION_SUSPEND_TRIGGERS)) {
+            skipTriggers = true;
+        }
+
+        if (item.getType() == Type.JAVA_OBJECT) {
+            //
+        } else if (Type.subTypeOf(item.getType(), Type.STRING)) {
+            final String path = item.getStringValue();
+            try {
+                final XmldbURI uri = XmldbURI.xmldbUriFor(path);
+                DBBroker b = context.getBroker();
+                org.exist.collections.Collection c = b.getCollection(uri);
+                CollectionConfiguration cc = null;
+                if (c != null) {
+                    c = LockedCollection.unwrapLocked(b.getCollection(uri));
+                    cc = c.getConfiguration(b);
+                    cc.setSkipTriggers(skipTriggers);
+                }
+            } catch (PermissionDeniedException | URISyntaxException e) {
+                e.printStackTrace();
+            }
+        } else if (Type.subTypeOf(item.getType(), Type.NODE)) {
+            //
+        } else {
+            throw new XPathException(this, "First argument to util:collection-suspend-triggers should be either " +
+                    "a Java object of type org.xmldb.api.base.Collection or a node; got: " +
+                    Type.getTypeName(item.getType()));
+        }
+
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+}

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
@@ -87,6 +87,8 @@ public class UtilModule extends AbstractInternalModule {
             new FunctionDef(DocumentNameOrId.absoluteResourceIdSignature, DocumentNameOrId.class),
             new FunctionDef(DocumentNameOrId.resourceByAbsoluteIdSignature, DocumentNameOrId.class),
             new FunctionDef(CollectionName.signature, CollectionName.class),
+            new FunctionDef(CollectionSuspendTriggers.signatures[0], CollectionSuspendTriggers.class),
+            new FunctionDef(CollectionSuspendTriggers.signatures[1], CollectionSuspendTriggers.class),
             new FunctionDef(LogFunction.signatures[0], LogFunction.class),
             new FunctionDef(LogFunction.signatures[1], LogFunction.class),
             new FunctionDef(LogFunction.signatures[2], LogFunction.class),


### PR DESCRIPTION
### Description:

NOTE: this patch is completely different from PR #3338 , which was focused on trigger suppression during package installation. I accidentally lumped them together in that PR, sorry for the confusion.

This is a PoC implementation of XQuery functions to disable and re-enable triggers on a collection at runtime. A typical use case would be an XQuery like this:

```
(: temporarily disable triggers on collection :)
util:collection-suspend-triggers("/db/mycollection"),

(: do things while triggers are disabled :)

(: re-enable triggers for this collection :)
util:collection-enable-triggers("/db/mycollection"),
```

Conceptually, these things need to be addressed:
- where to keep the "triggers-disabled" flag for a collection
- how to access that place from the context of an XQuery, in order to set/clear the flag
- how to provide the flag to the trigger execution logic

#### Where to keep the "triggers-disabled" Flag for a Collection

I have chosen to keep this flag in class `CollectionConfiguration` because
- IMHO it is the most obvious place, it is a collection attribute semantically similar to "permissions"
- we can easily enhance `*.xconf` file parsing to something like "this collection does not want triggers enabled"

An alternative (and possibly better, or more consistent) place would be class `MutableCollection`. However, passing that flag from class `CollectionConfiguration` would require significant changes to the API of various methods (probably changing `Tuple2` to `Tuple3` objects). I won't go that route without feedback.

#### How to access that Place from the Context of an XQuery, in order to set/clear the Flag

I have used `xquery/functions/util/CollectionName.java` as a template to create the XQuery functions `util:collection-suspend-triggers()` and `util:collection-enable-triggers()`. I may have left some artifacts..

The code accesses the `CollectionConfiguration` object of the collection representation provided by the XQuery API. Access to this object through `LockedCollection.unwrapLocked()` is brute, I'm all ears for more elegant ways. It works anyway.
Once we have the `CollectionConfiguration` object, we can use its `setSkipTriggers()` method to set the state demanded by calling XQuery function.

#### How to provide the Flag to the Trigger Execution Logic

This is a 2-step approach:
- instances of classes `CollectionTriggers` and `DocumentTriggers` are not persistent, they are throwaway objects allocated when the method executes and deallocated when the method returns. Upon instantiation a `triggersSuspended` flag is set that is derived from the collections' `CollectionConfiguration` object.
- Trigger methods in these classes honor the `triggersSuspended` flag

#### Overview of Code Changes

- `CollectionConfiguration.java` - add flag and get/set methods
- `CollectionTriggers.java` and `DocumentTriggers.java` - honor CollectionConfiguration flag on instantiation and method execution
- `UtilModule.java` and `CollectionSuspendTriggers.java` - XQuery function implementation

### Reference:

Colleagues and customers would like that functionality.

### Type of tests:

None yet.  This is PoC, I appreciate feedback before proceeding.
