### PR TITLE
Add Code Coverage

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,4 +25,9 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven Test
-        run: mvn -V -B clean verify      
+        run: mvn -V -B clean verify
+      - name: Maven Code Coverage
+        if: ${{ matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+        run: mvn -V -B jacoco:report coveralls:report

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,4 +30,6 @@ jobs:
         if: ${{ matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-        run: mvn -V -B jacoco:report coveralls:report
+        run: |
+          echo "ADAM COVERALLS_TOKEN='${COVERALLS_TOKEN}'"
+          mvn -V -B jacoco:report coveralls:report

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Build Status](https://github.com/eXist-db/exist/actions/workflows/ci-build.yml/badge.svg?branch=develop)](https://github.com/eXist-db/exist/actions/workflows/ci-build.yml)
 [![Build status](https://ci.appveyor.com/api/projects/status/ngpppvnnfu8ehjw3/branch/develop?svg=true)](https://ci.appveyor.com/project/eXistdbci/exist/branch/develop)
+[![Coverage Status](https://coveralls.io/repos/github/eXist-db/exist/badge.svg?branch=develop)](https://coveralls.io/github/eXist-db/exist?branch=develop)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/ae1c8a7eb1164e919b0ac3c8588560c6)](https://www.codacy.com/gh/eXist-db/exist/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=eXist-db/exist&amp;utm_campaign=Badge_Grade)
 [![Java 8](https://img.shields.io/badge/java-8-blue.svg)](https://adoptopenjdk.net/)
 [![License](https://img.shields.io/badge/license-LGPL%202.1-blue.svg)](https://www.gnu.org/licenses/lgpl-2.1.html)

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -990,7 +990,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                    <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                     <systemPropertyVariables>
                         <jetty.home>${project.basedir}/../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -776,6 +776,14 @@
                     <artifactId>bintray-maven-plugin</artifactId>
                     <version>1.5.20191113165555</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>4.3.0</version>
+                    <configuration>
+                        <repoToken>${env.COVERALLS_TOKEN}</repoToken>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -649,6 +649,18 @@
                     <version>0.8.6</version>
                     <configuration>
                         <propertyName>jacocoArgLine</propertyName>
+                        <excludes>
+                            <exclude>**/DeclScanner.*</exclude>
+                            <exclude>**/DeclScannerTokenTypes.*</exclude>
+                            <exclude>**/XQueryLexer.*</exclude>
+                            <exclude>**/XQueryParser.*</exclude>
+                            <exclude>**/XQueryTokenTypes.*</exclude>
+                            <exclude>**/XQueryTreeParser.*</exclude>
+                            <exclude>**/XQueryTreeParserTokenTypes.*</exclude>
+                            <exclude>**/XQDocLexer.*</exclude>
+                            <exclude>**/XQDocParser.*</exclude>
+                            <exclude>**/XQDocParserTokenTypes.*</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -897,6 +909,20 @@
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/DeclScanner.*</exclude>
+                                <exclude>**/DeclScannerTokenTypes.*</exclude>
+                                <exclude>**/XQueryLexer.*</exclude>
+                                <exclude>**/XQueryParser.*</exclude>
+                                <exclude>**/XQueryTokenTypes.*</exclude>
+                                <exclude>**/XQueryTreeParser.*</exclude>
+                                <exclude>**/XQueryTreeParserTokenTypes.*</exclude>
+                                <exclude>**/XQDocLexer.*</exclude>
+                                <exclude>**/XQDocParser.*</exclude>
+                                <exclude>**/XQDocParserTokenTypes.*</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -917,6 +943,20 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/DeclScanner.*</exclude>
+                        <exclude>**/DeclScannerTokenTypes.*</exclude>
+                        <exclude>**/XQueryLexer.*</exclude>
+                        <exclude>**/XQueryParser.*</exclude>
+                        <exclude>**/XQueryTokenTypes.*</exclude>
+                        <exclude>**/XQueryTreeParser.*</exclude>
+                        <exclude>**/XQueryTreeParserTokenTypes.*</exclude>
+                        <exclude>**/XQDocLexer.*</exclude>
+                        <exclude>**/XQDocParser.*</exclude>
+                        <exclude>**/XQDocParserTokenTypes.*</exclude>
+                    </excludes>
+                </configuration>
                 <reportSets>
                     <reportSet>
                         <reports>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -644,6 +644,14 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.6</version>
+                    <configuration>
+                        <propertyName>jacocoArgLine</propertyName>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jarsigner-plugin</artifactId>
                     <version>3.0.0</version>
@@ -658,7 +666,7 @@
                               However it can make it hard to diagnose problems if tests leak state; If you experience
                               such a problem you may want to set it to `false` whilst debugging -->
                         <reuseForks>true</reuseForks>
-                        <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                        <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                         <systemPropertyVariables>
                             <user.country>UK</user.country>
                             <user.language>en</user.language>
@@ -873,6 +881,18 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
@@ -887,8 +907,20 @@
     <reporting>
         <plugins>
             <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-report-plugin</artifactId>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <!-- select non-aggregate reports -->
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
                 <configuration>
                     <aggregate>true</aggregate>
                 </configuration>

--- a/extensions/debuggee/pom.xml
+++ b/extensions/debuggee/pom.xml
@@ -94,6 +94,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>@{jacocoArgLine}</argLine>
                     <systemPropertyVariables>
                         <java.locale.providers>JRE,CLDR,SPI</java.locale.providers>
                         <log4j.configurationFile>${project.build.testOutputDirectory}/log4j2.xml</log4j.configurationFile>

--- a/extensions/modules/file/pom.xml
+++ b/extensions/modules/file/pom.xml
@@ -178,7 +178,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                    <argLine>@{jacocoArgLine}</argLine>
                     <systemPropertyVariables>
                         <jetty.home>${project.basedir}/../../../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>

--- a/extensions/modules/persistentlogin/pom.xml
+++ b/extensions/modules/persistentlogin/pom.xml
@@ -82,7 +82,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                    <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                     <systemPropertyVariables>
                         <exist.configurationFile>${project.build.testOutputDirectory}/conf.xml</exist.configurationFile>
                         <jetty.home>${project.basedir}/../../../exist-jetty-config/target/classes/org/exist/jetty</jetty.home>


### PR DESCRIPTION
Adds support for Code Coverage reports with JaCoCo and also integrates Travis with Coveralls.io to report historical use/change of Code Coverage.

**NOTE**: There is a bug that this surfaces that we need to fix - https://github.com/jacoco/jacoco/issues/1042