### PR TITLE
[fix] remove deprecated fn:filter syntax

### DIFF
--- a/exist-core/src/test/xquery/xquery3/higher-order.xml
+++ b/exist-core/src/test/xquery/xquery3/higher-order.xml
@@ -476,11 +476,11 @@ return
     </test>
     <test output="text">
         <task>fn:filter function (wrong argument order: deprecated)</task>
-        <code>fn:filter(function($a) {$a mod 2 = 0}, 1 to 10)</code>
-        <expected>2 4 6 8 10</expected>
+        <code>fn:filter(function($a) {$a mod 2 = 0}, (1 to 10))</code>
+        <error>XPTY0004</error>
     </test>
     <test output="text">
-        <task>fn:filter function (correct argument order)</task>
+        <task>fn:filter function</task>
         <code>fn:filter(1 to 10, function($a) {$a mod 2 = 0})</code>
         <expected>2 4 6 8 10</expected>
     </test>

--- a/extensions/modules/expathrepo/src/main/resources/org/exist/xquery/modules/expathrepo/repair.xql
+++ b/extensions/modules/expathrepo/src/main/resources/org/exist/xquery/modules/expathrepo/repair.xql
@@ -64,7 +64,7 @@ declare %private function repair:repair-callback($collection as xs:anyURI, $incl
 };
 
 declare function repair:is-installed($name as xs:string) as xs:boolean {
-    exists(filter(function($pkg) { $pkg = $name }, repo:list()))
+    exists(filter(repo:list(), function($pkg) { $pkg = $name }))
 };
 
 (:~ Scan a collection tree recursively starting at $root. Call $func once for each collection found :)
@@ -76,9 +76,9 @@ declare %private function repair:scan-collections($root as xs:anyURI, $func as f
 };
 
 declare %private function repair:find-resources-to-zip($collection as xs:anyURI) {
-    filter(function($name) {
+    filter(xmldb:get-child-resources($collection), function($name) {
         $name = ("expath-pkg.xml", "repo.xml", "exist.xml") or starts-with($name, "icon")
-    }, xmldb:get-child-resources($collection))
+    })
 };
 
 declare %private function repair:resources-to-zip($expathConf as element(expath:package), $collection as xs:anyURI) {


### PR DESCRIPTION
### Description:

Six years ago the spec for fn:filter changed.
As it was already used in some applications like
dashboard, existdb allowed both ways to call
fn:filter.
This commit removes the special handling, where
the parameters are flipped. This will now throw
an XPTY0004 for wrong parameter type.

fixes #3370

### Reference:

Our own docs do not even mention that you could flip the arguments for fn:filter

https://exist-db.org/exist/apps/fundocs/view.html?uri=http://www.w3.org/2005/xpath-functions&location=java:org.exist.xquery.functions.fn.FnModule&details=true

### Type of tests:

One test was adapted to check for the expected error.