### PR TITLE
Fix issues with types and comparisons

### DIFF
--- a/exist-core/src/main/java/org/exist/util/serializer/json/JSONSerializer.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/json/JSONSerializer.java
@@ -75,7 +75,7 @@ public class JSONSerializer {
         } else if (item.getType() == Type.MAP) {
             serializeMap((MapType) item, generator);
         } else if (Type.subTypeOf(item.getType(), Type.ATOMIC)) {
-            if (Type.subTypeOf(item.getType(), Type.NUMBER)) {
+            if (Type.subTypeOfUnion(item.getType(), Type.NUMBER)) {
                 generator.writeNumber(item.getStringValue());
             } else {
                 switch (item.getType()) {

--- a/exist-core/src/main/java/org/exist/xquery/DynamicTypeCheck.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicTypeCheck.java
@@ -99,7 +99,7 @@ public class DynamicTypeCheck extends AbstractExpression {
             	item = item.convertTo(Type.STRING);
             //Then, if numeric, try to refine the type
             //xs:decimal(3) treat as xs:integer
-            } else if (Type.subTypeOf(requiredType, Type.NUMBER) && Type.subTypeOf(type, requiredType)) {
+            } else if (Type.subTypeOfUnion(requiredType, Type.NUMBER) && Type.subTypeOf(type, requiredType)) {
                 try {
                     item = item.convertTo(requiredType);
                 //No way

--- a/exist-core/src/main/java/org/exist/xquery/Function.java
+++ b/exist-core/src/main/java/org/exist/xquery/Function.java
@@ -339,8 +339,7 @@ public abstract class Function extends PathExpr {
             }
             argument = new AtomicToString(context, argument);
             returnType = Type.STRING;
-        } else if (argType.getPrimaryType() == Type.NUMBER
-                || Type.subTypeOf(argType.getPrimaryType(), Type.DOUBLE)) {
+        } else if (Type.subTypeOfUnion(argType.getPrimaryType(), Type.NUMBER)) {
             if (!Type.subTypeOf(returnType, Type.ATOMIC)) {
                 argument = new Atomize(context, argument);
             }

--- a/exist-core/src/main/java/org/exist/xquery/FunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionCall.java
@@ -91,7 +91,7 @@ public class FunctionCall extends Function {
                 expression = new Atomize(context, expression);
         }
         
-        if(Type.subTypeOf(returnType.getPrimaryType(), Type.NUMBER)) {
+        if(Type.subTypeOfUnion(returnType.getPrimaryType(), Type.NUMBER)) {
                 expression = new UntypedValueCheck(context, returnType.getPrimaryType(), expression, new Error(Error.FUNC_RETURN_TYPE));
         } else if(returnType.getPrimaryType() != Type.ITEM) {
                 expression = new DynamicTypeCheck(context, returnType.getPrimaryType(), expression);
@@ -410,7 +410,7 @@ public class FunctionCall extends Function {
                 expression = new Atomize(context, expression);
             }
 
-            if(Type.subTypeOf(returnType.getPrimaryType(), Type.NUMBER)) {
+            if(Type.subTypeOfUnion(returnType.getPrimaryType(), Type.NUMBER)) {
                 expression = new UntypedValueCheck(context, returnType.getPrimaryType(), expression, new Error(Error.FUNC_RETURN_TYPE));
             } else if(returnType.getPrimaryType() != Type.ITEM) {
                 expression = new DynamicTypeCheck(context, returnType.getPrimaryType(), expression);

--- a/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
@@ -1004,7 +1004,7 @@ public class GeneralComparison extends BinaryOp implements Optimizable, IndexUse
                     i. If T is a numeric type or is derived from a numeric type,
                     then V is cast to xs:double.
                  */
-                if (Type.subTypeOf(otherType, Type.NUMBER)) {
+                if (Type.subTypeOfUnion(otherType, Type.NUMBER)) {
                     return value.convertTo(Type.DOUBLE);
                 }
 

--- a/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
@@ -1,23 +1,23 @@
 /*
- *  eXist Open Source Native XML Database
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
  *
- *  Copyright (C) 2000-03, Wolfgang M. Meier (meier@ifs. tu- darmstadt. de)
+ * info@exist-db.org
+ * http://www.exist-db.org
  *
- *  This library is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Library General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- * $Id$
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.xquery;
 

--- a/exist-core/src/main/java/org/exist/xquery/OpNumeric.java
+++ b/exist-core/src/main/java/org/exist/xquery/OpNumeric.java
@@ -55,7 +55,7 @@ public class OpNumeric extends BinaryOp {
         this.operator = operator;
         int ltype = left.returnsType();
         int rtype = right.returnsType();
-        if (Type.subTypeOf(ltype, Type.NUMBER) && Type.subTypeOf(rtype, Type.NUMBER)) {
+        if (Type.subTypeOfUnion(ltype, Type.NUMBER) && Type.subTypeOfUnion(rtype, Type.NUMBER)) {
             if (ltype > rtype) {
                 right = new UntypedValueCheck(context, ltype, right);
             } else if (rtype > ltype) {
@@ -69,8 +69,8 @@ public class OpNumeric extends BinaryOp {
                 returnType = Math.max(ltype, rtype);
             }
         } else {
-            if (Type.subTypeOf(ltype, Type.NUMBER)) {ltype = Type.NUMBER;}
-            if (Type.subTypeOf(rtype, Type.NUMBER)) {rtype = Type.NUMBER;}
+            if (Type.subTypeOfUnion(ltype, Type.NUMBER)) {ltype = Type.NUMBER;}
+            if (Type.subTypeOfUnion(rtype, Type.NUMBER)) {rtype = Type.NUMBER;}
             final OpEntry entry = OP_TYPES.get(new OpEntry(operator, ltype, rtype));
             if (entry != null) {
                 returnType = entry.typeResult;
@@ -141,10 +141,10 @@ public class OpNumeric extends BinaryOp {
                         operator.symbol);}
                 //TODO : move to implementations
                 if (operator == ArithmeticOperator.DIVISION_INTEGER) {
-                    if (!Type.subTypeOf(lvalue.getType(), Type.NUMBER))
+                    if (!Type.subTypeOfUnion(lvalue.getType(), Type.NUMBER))
                         {throw new XPathException(this, ErrorCodes.XPTY0004, "'" +
                             Type.getTypeName(lvalue.getType()) + "(" + lvalue + ")' can not be an operand for " + operator.symbol);}
-                    if (!Type.subTypeOf(rvalue.getType(), Type.NUMBER))
+                    if (!Type.subTypeOfUnion(rvalue.getType(), Type.NUMBER))
                         {throw new XPathException(this, ErrorCodes.XPTY0004, "'" +
                             Type.getTypeName(rvalue.getType()) + "(" + rvalue + ")' can not be an operand for " + operator.symbol);}
                     //If the divisor is (positive or negative) zero, then an error is raised [err:FOAR0001]
@@ -189,10 +189,10 @@ public class OpNumeric extends BinaryOp {
             case MULTIPLICATION: return left.mult(right);
             case DIVISION: return left.div(right);
             case MODULUS: {
-                if (!Type.subTypeOf(left.getType(), Type.NUMBER))
+                if (!Type.subTypeOfUnion(left.getType(), Type.NUMBER))
                     {throw new XPathException(this, ErrorCodes.XPTY0004, "'" +
                         Type.getTypeName(left.getType()) + "(" + left + ")' is not numeric");}
-                if (!Type.subTypeOf(right.getType(), Type.NUMBER))
+                if (!Type.subTypeOfUnion(right.getType(), Type.NUMBER))
                     {throw new XPathException(this, ErrorCodes.XPTY0004, "'" +
                         Type.getTypeName(right.getType()) + "(" + right + ")' is not numeric");}
                 return ((NumericValue) left).mod((NumericValue) right);

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -257,7 +257,7 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                                 Dependency.dependsOn(exprDeps, Dependency.CONTEXT_POSITION)) &&
                                 //A positional predicate will be evaluated one time
                                 //TODO : reconsider since that may be expensive (type evaluation)
-                                !(this instanceof Predicate && Type.subTypeOf(this.returnsType(), Type.NUMBER)) &&
+                                !(this instanceof Predicate && Type.subTypeOfUnion(this.returnsType(), Type.NUMBER)) &&
                                 currentContext != null && !currentContext.isEmpty())) {
                     Sequence exprResult = new ValueSequence(Type.subTypeOf(expr.returnsType(), Type.NODE));
                     ((ValueSequence) exprResult).keepUnOrdered(unordered);

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -106,7 +106,7 @@ public class Predicate extends PathExpr {
             executionMode = NODE;
             // Case 2: predicate expression returns a unique number and has no
             // dependency with the context item.
-        } else if (Type.subTypeOf(innerType, Type.NUMBER) &&
+        } else if (Type.subTypeOfUnion(innerType, Type.NUMBER) &&
                 !Dependency.dependsOn(inner, Dependency.CONTEXT_ITEM) &&
                     inner.getCardinality().isSuperCardinalityOrEqualOf(Cardinality.EXACTLY_ONE)) {
             executionMode = POSITIONAL;
@@ -220,7 +220,7 @@ public class Predicate extends PathExpr {
             // the inner sequence
             if (executionMode == NODE && !(contextSequence instanceof VirtualNodeSet)) {
                 // (1,2,2,4)[.]
-                if (Type.subTypeOf(contextSequence.getItemType(), Type.NUMBER)) {
+                if (Type.subTypeOfUnion(contextSequence.getItemType(), Type.NUMBER)) {
                     recomputedExecutionMode = POSITIONAL;
                 } else {
                     recomputedExecutionMode = BOOLEAN;
@@ -236,7 +236,7 @@ public class Predicate extends PathExpr {
                 innerSeq = inner.eval(contextSequence);
                 // Only if we have an actual *singleton* of numeric items
                 if (innerSeq.hasOne()
-                        && Type.subTypeOf(innerSeq.getItemType(), Type.NUMBER)) {
+                        && Type.subTypeOfUnion(innerSeq.getItemType(), Type.NUMBER)) {
                     recomputedExecutionMode = POSITIONAL;
                 }
             }
@@ -258,7 +258,7 @@ public class Predicate extends PathExpr {
                     // Try to promote a boolean evaluation to a positional one
                     // Only if we have an actual *singleton* of numeric items
                 } else if (innerSeq.hasOne()
-                        && Type.subTypeOf(innerSeq.getItemType(), Type.NUMBER)) {
+                        && Type.subTypeOfUnion(innerSeq.getItemType(), Type.NUMBER)) {
                     recomputedExecutionMode = POSITIONAL;
                 }
             }
@@ -306,7 +306,7 @@ public class Predicate extends PathExpr {
             // TODO : is this block also accurate in reverse-order processing ?
             // Compute each position in the boolean-like way...
             // ... but grab some context positions ! -<8-P
-            if (Type.subTypeOf(inner.returnsType(), Type.NUMBER)
+            if (Type.subTypeOfUnion(inner.returnsType(), Type.NUMBER)
                     && Dependency.dependsOn(inner, Dependency.CONTEXT_ITEM)) {
                 final Set<NumericValue> positions = new TreeSet<>();
                 for (final SequenceIterator i = contextSequence.iterate(); i.hasNext(); p++) {
@@ -336,7 +336,7 @@ public class Predicate extends PathExpr {
                     final Item item = i.nextItem();
                     final Sequence innerSeq = inner.eval(contextSequence, item);
                     if (innerSeq.hasOne()
-                            && Type.subTypeOf(innerSeq.getItemType(), Type.NUMBER)) {
+                            && Type.subTypeOfUnion(innerSeq.getItemType(), Type.NUMBER)) {
                         // TODO : introduce a check in innerSeq.hasOne() ?
                         final NumericValue nv = (NumericValue) innerSeq;
                         // Non integers return... nothing, not even an error !

--- a/exist-core/src/main/java/org/exist/xquery/Step.java
+++ b/exist-core/src/main/java/org/exist/xquery/Step.java
@@ -119,7 +119,7 @@ public abstract class Step extends AbstractExpression {
             final Expression predExpr = predicate.getFirst();
             // only apply optimization if the static return type is a single number
             // and there are no dependencies on the context item
-            if (Type.subTypeOf(predExpr.returnsType(), Type.NUMBER) &&
+            if (Type.subTypeOfUnion(predExpr.returnsType(), Type.NUMBER) &&
                     !Dependency.dependsOn(predExpr, Dependency.CONTEXT_POSITION)) {
                 return true;
             }

--- a/exist-core/src/main/java/org/exist/xquery/UnaryExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/UnaryExpr.java
@@ -71,7 +71,7 @@ public class UnaryExpr extends PathExpr {
         	{return item;}
         
 		final NumericValue value;
-        if (Type.subTypeOf(item.getItemType(), Type.NUMBER)) {
+        if (Type.subTypeOfUnion(item.getItemType(), Type.NUMBER)) {
         	if (item instanceof NumericValue) {
 				value = (NumericValue) item;
 			} else {

--- a/exist-core/src/main/java/org/exist/xquery/UntypedValueCheck.java
+++ b/exist-core/src/main/java/org/exist/xquery/UntypedValueCheck.java
@@ -102,7 +102,7 @@ public class UntypedValueCheck extends AbstractExpression {
 	}
 
     private Item convert(Item item) throws XPathException {
-        if (atomize || item.getType() == Type.UNTYPED_ATOMIC || Type.subTypeOf(requiredType, Type.NUMBER) && Type.subTypeOf(item.getType(), Type.NUMBER)) {
+        if (atomize || item.getType() == Type.UNTYPED_ATOMIC || Type.subTypeOfUnion(requiredType, Type.NUMBER) && Type.subTypeOfUnion(item.getType(), Type.NUMBER)) {
             try {
                 if (Type.subTypeOf(item.getType(), requiredType)) {
                     return item;

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatNumbers.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnFormatNumbers.java
@@ -97,7 +97,7 @@ public class FnFormatNumbers extends BasicFunction {
         final NumericValue number;
         if (args[0].isEmpty()) {
             number = new DoubleValue(Double.NaN);
-        } else if (context.isBackwardsCompatible() && !Type.subTypeOf(args[0].getItemType(), Type.NUMBER)) {
+        } else if (context.isBackwardsCompatible() && !Type.subTypeOfUnion(args[0].getItemType(), Type.NUMBER)) {
             number = new DoubleValue(Double.NaN);
         } else {
             number = (NumericValue) args[0].itemAt(0);

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAvg.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAvg.java
@@ -114,7 +114,7 @@ public class FunAvg extends Function {
                         Type.getTypeName(value.getType()) + "(" + value +
                         ") can not be an operand in a sum", value);
                 }
-                if (Type.subTypeOf(value.getType(), Type.NUMBER)) {
+                if (Type.subTypeOfUnion(value.getType(), Type.NUMBER)) {
                     if (((NumericValue)value).isInfinite())
                         {gotInfinity = true;}
                     if (((NumericValue)value).isNaN()) {
@@ -133,7 +133,7 @@ public class FunAvg extends Function {
             result = sum.div(new IntegerValue(inner.getItemCount()));
         }
         if (!gotInfinity) {
-            if (Type.subTypeOf(result.getItemType(), Type.NUMBER) &&
+            if (Type.subTypeOfUnion(result.getItemType(), Type.NUMBER) &&
                 ((NumericValue)result).isInfinite()) {
                 //Throw an overflow exception here since we get an infinity 
                 //whereas is hasn't been provided by the sequence

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDeepEqual.java
@@ -187,8 +187,8 @@ public class FunDeepEqual extends CollatingFunction {
                 try {
                     final AtomicValue av = (AtomicValue) a;
                     final AtomicValue bv = (AtomicValue) b;
-                    if (Type.subTypeOf(av.getType(), Type.NUMBER) &&
-                        Type.subTypeOf(bv.getType(), Type.NUMBER)) {
+                    if (Type.subTypeOfUnion(av.getType(), Type.NUMBER) &&
+                        Type.subTypeOfUnion(bv.getType(), Type.NUMBER)) {
                         //or if both values are NaN
                         if (((NumericValue) a).isNaN() && ((NumericValue) b).isNaN())
                             {return true;}

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDistinctValues.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunDistinctValues.java
@@ -126,7 +126,7 @@ public class FunDistinctValues extends CollatingFunction {
             item = i.nextItem();
             value = item.atomize();
             if (!set.contains(value)) {
-                if (Type.subTypeOf(value.getType(), Type.NUMBER)) {
+                if (Type.subTypeOfUnion(value.getType(), Type.NUMBER)) {
                     if (((NumericValue)value).isNaN()) {
                         //although NaN does not equal itself, if $arg 
                         //contains multiple NaN values a single NaN is returned.

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMax.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMax.java
@@ -180,9 +180,9 @@ public class FunMax extends CollatingFunction {
                     	{value = value.convertTo(Type.DOUBLE);}                	
 
                     //Numeric tests
-	                if (Type.subTypeOf(value.getType(), Type.NUMBER)) {
+	                if (Type.subTypeOfUnion(value.getType(), Type.NUMBER)) {
 	                	//Don't mix comparisons
-	                	if (!Type.subTypeOf(max.getType(), Type.NUMBER))
+	                	if (!Type.subTypeOfUnion(max.getType(), Type.NUMBER))
 	                		{throw new XPathException(this, ErrorCodes.FORG0006, "Cannot compare " + Type.getTypeName(max.getType()) +
 	                				" and " + Type.getTypeName(value.getType()), max);}
 	                	if (((NumericValue) value).isNaN()) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMin.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMin.java
@@ -178,9 +178,9 @@ public class FunMin extends CollatingFunction {
                     if (value.getType() == Type.ATOMIC) 
                     	{value = value.convertTo(Type.DOUBLE);}
                 	//Numeric tests
-	                if (Type.subTypeOf(value.getType(), Type.NUMBER)) {
+	                if (Type.subTypeOfUnion(value.getType(), Type.NUMBER)) {
 	                	//Don't mix comparisons
-	                	if (!Type.subTypeOf(min.getType(), Type.NUMBER))
+	                	if (!Type.subTypeOfUnion(min.getType(), Type.NUMBER))
 	                		{throw new XPathException(this, ErrorCodes.FORG0006, "Cannot compare " + Type.getTypeName(min.getType()) +
 	                				" and " + Type.getTypeName(value.getType()), min);}
 	                	if (((NumericValue) value).isNaN()) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSort.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSort.java
@@ -156,7 +156,7 @@ public class FunSort extends BasicFunction {
           int res = Constants.EQUAL;
           if (FunDeepEqual.deepEquals(item1, item2, collator)) {
             continue;
-          } if (Type.subTypeOf(item1.getType(), Type.NUMBER) && ((NumericValue)item1).isNaN()) {
+          } if (Type.subTypeOfUnion(item1.getType(), Type.NUMBER) && ((NumericValue)item1).isNaN()) {
             res = Constants.INFERIOR;
 
           } else if (Type.subTypeOf(item1.getType(), Type.STRING) && Type.subTypeOf(item2.getType(), Type.STRING)) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSum.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSum.java
@@ -112,7 +112,7 @@ public class FunSum extends Function {
 
             	value = check(value, sum);
     			
-        		if (Type.subTypeOf(value.getType(), Type.NUMBER)) {
+        		if (Type.subTypeOfUnion(value.getType(), Type.NUMBER)) {
     				if (((NumericValue)value).isInfinite())
     					{gotInfinity = true;}    					
     				if (((NumericValue)value).isNaN()) {
@@ -128,7 +128,7 @@ public class FunSum extends Function {
         }
         
 		if (!gotInfinity) {
-			if (Type.subTypeOf(result.getItemType(), Type.NUMBER) && ((NumericValue)result).isInfinite()) {
+			if (Type.subTypeOfUnion(result.getItemType(), Type.NUMBER) && ((NumericValue)result).isInfinite()) {
 				//Throw an overflow eception here since we get an infinity 
 				//whereas is hasn't been provided by the sequence
 			}

--- a/exist-core/src/main/java/org/exist/xquery/value/AnyURIValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/AnyURIValue.java
@@ -261,7 +261,7 @@ public class    AnyURIValue extends AtomicValue {
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "Type error: cannot cast xs:anyURI to "
                                 + Type.getTypeName(requiredType));
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/BinaryValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BinaryValue.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.util.io.FastByteArrayOutputStream;
 import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import java.io.*;
@@ -193,7 +194,7 @@ public abstract class BinaryValue extends AtomicValue implements Closeable {
                     result = new StringValue(getStringValue());
                     break;
                 default:
-                    throw new XPathException("cannot convert " + Type.getTypeName(getType()) + " to " + Type.getTypeName(requiredType));
+                    throw new XPathException(ErrorCodes.FORG0001, "cannot convert " + Type.getTypeName(getType()) + " to " + Type.getTypeName(requiredType));
             }
         }
         return result;

--- a/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
@@ -22,6 +22,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
@@ -134,7 +135,7 @@ public class DateTimeValue extends AbstractDateTimeValue {
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "Type error: cannot cast xs:dateTime to "
                                 + Type.getTypeName(requiredType));
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
@@ -28,7 +28,9 @@ import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.util.function.IntSupplier;
 
 public class DoubleValue extends NumericValue {
     // m × 2^e, where m is an integer whose absolute value is less than 2^53,
@@ -39,7 +41,7 @@ public class DoubleValue extends NumericValue {
     public static final DoubleValue NEGATIVE_INFINITY = new DoubleValue(Double.NEGATIVE_INFINITY);
     public static final DoubleValue NaN = new DoubleValue(Double.NaN);
 
-    private final double value;
+    final double value;
 
     public DoubleValue(final double value) {
         this.value = value;
@@ -122,6 +124,23 @@ public class DoubleValue extends NumericValue {
     @Override
     public boolean isPositive() {
         return (Double.compare(value, 0.0) > Constants.EQUAL);
+    }
+
+    @Override
+    protected @Nullable IntSupplier createComparisonWith(final NumericValue other) {
+        final IntSupplier comparison;
+        if (other instanceof IntegerValue) {
+            comparison = () -> BigDecimal.valueOf(value).compareTo(new BigDecimal(((IntegerValue)other).value));
+        } else if (other instanceof DecimalValue) {
+            comparison = () -> BigDecimal.valueOf(value).compareTo(((DecimalValue)other).value);
+        } else if (other instanceof DoubleValue) {
+            comparison = () -> Double.compare(value, ((DoubleValue)other).value);
+        } else if (other instanceof FloatValue) {
+            comparison = () -> Double.compare(value, ((FloatValue)other).value);
+        } else {
+            return null;
+        }
+        return comparison;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
@@ -293,7 +293,7 @@ public class DoubleValue extends NumericValue {
 
     @Override
     public ComputableValue div(final ComputableValue other) throws XPathException {
-        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+        if (Type.subTypeOfUnion(other.getType(), Type.NUMBER)) {
             //Positive or negative zero divided by positive or negative zero returns NaN.
             if (this.isZero() && ((NumericValue) other).isZero()) {
                 return NaN;

--- a/exist-core/src/main/java/org/exist/xquery/value/DurationValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DurationValue.java
@@ -302,7 +302,7 @@ public class DurationValue extends ComputableValue {
                 canonicalize();
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "Type error: cannot cast ' + Type.getTypeName(getType()) 'to "
                                 + Type.getTypeName(requiredType));
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
@@ -28,7 +28,9 @@ import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.util.function.IntSupplier;
 
 /**
  * @author wolf
@@ -42,7 +44,7 @@ public class FloatValue extends NumericValue {
     public final static FloatValue NEGATIVE_INFINITY = new FloatValue(Float.NEGATIVE_INFINITY);
     public final static FloatValue ZERO = new FloatValue(0.0E0f);
 
-    protected float value;
+    final float value;
 
     public FloatValue(float value) {
         this.value = value;
@@ -126,6 +128,23 @@ public class FloatValue extends NumericValue {
 
     public boolean isPositive() {
         return (Float.compare(value, 0f) > Constants.EQUAL);
+    }
+
+    @Override
+    protected @Nullable IntSupplier createComparisonWith(final NumericValue other) {
+        final IntSupplier comparison;
+        if (other instanceof IntegerValue) {
+            comparison = () -> BigDecimal.valueOf(value).compareTo(new BigDecimal(((IntegerValue)other).value));
+        } else if (other instanceof DecimalValue) {
+            comparison = () -> BigDecimal.valueOf(value).compareTo(((DecimalValue)other).value);
+        } else if (other instanceof DoubleValue) {
+            comparison = () -> BigDecimal.valueOf(value).compareTo(BigDecimal.valueOf(((DoubleValue)other).value));
+        } else if (other instanceof FloatValue) {
+            comparison = () -> Float.compare(value, ((FloatValue)other).value);
+        } else {
+            return null;
+        }
+        return comparison;
     }
 
     public boolean hasFractionalPart() {

--- a/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
@@ -290,7 +290,7 @@ public class FloatValue extends NumericValue {
      * @see org.exist.xquery.value.NumericValue#div(org.exist.xquery.value.NumericValue)
      */
     public ComputableValue div(ComputableValue other) throws XPathException {
-        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+        if (Type.subTypeOfUnion(other.getType(), Type.NUMBER)) {
             //Positive or negative zero divided by positive or negative zero returns NaN.
             if (this.isZero() && ((NumericValue) other).isZero()) {
                 return NaN;

--- a/exist-core/src/main/java/org/exist/xquery/value/FunctionReference.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FunctionReference.java
@@ -138,7 +138,7 @@ public class FunctionReference extends AtomicValue implements AutoCloseable {
         if (requiredType == Type.FUNCTION_REFERENCE) {
             return this;
         }
-        throw new XPathException("cannot convert function reference to " + Type.getTypeName(requiredType));
+        throw new XPathException(ErrorCodes.FORG0001, "cannot convert function reference to " + Type.getTypeName(requiredType));
     }
 
     public boolean effectiveBooleanValue() throws XPathException {

--- a/exist-core/src/main/java/org/exist/xquery/value/GDayValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/GDayValue.java
@@ -23,6 +23,7 @@ package org.exist.xquery.value;
 
 import com.ibm.icu.text.Collator;
 import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
@@ -73,7 +74,7 @@ public class GDayValue extends AbstractDateTimeValue {
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "Type error: cannot cast xs:time to "
                                 + Type.getTypeName(requiredType));
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/GMonthDayValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/GMonthDayValue.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
@@ -70,7 +71,7 @@ public class GMonthDayValue extends AbstractDateTimeValue {
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "Type error: cannot cast xs:time to "
                                 + Type.getTypeName(requiredType));
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/GMonthValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/GMonthValue.java
@@ -24,6 +24,7 @@ package org.exist.xquery.value;
 import com.ibm.icu.text.Collator;
 import org.exist.xquery.Constants;
 import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
@@ -107,7 +108,7 @@ public class GMonthValue extends AbstractDateTimeValue {
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "Type error: cannot cast xs:gMonth to "
                                 + Type.getTypeName(requiredType));
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/GYearMonthValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/GYearMonthValue.java
@@ -23,6 +23,7 @@ package org.exist.xquery.value;
 
 import com.ibm.icu.text.Collator;
 import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
@@ -72,7 +73,7 @@ public class GYearMonthValue extends AbstractDateTimeValue {
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "Type error: cannot cast xs:time to "
                                 + Type.getTypeName(requiredType));
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/GYearValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/GYearValue.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
@@ -71,7 +72,7 @@ public class GYearValue extends AbstractDateTimeValue {
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "Type error: cannot cast xs:time to "
                                 + Type.getTypeName(requiredType));
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/IntegerValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/IntegerValue.java
@@ -22,11 +22,14 @@
 package org.exist.xquery.value;
 
 import com.ibm.icu.text.Collator;
+import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.function.IntSupplier;
 
 /**
  * Definition: integer is derived from decimal by fixing the value of fractionDigits to be 0.
@@ -66,7 +69,7 @@ public class IntegerValue extends NumericValue {
 
     private static final BigInteger LARGEST_UNSIGNED_BYTE = new BigInteger("255");
 
-    private final BigInteger value;
+    final BigInteger value;
     private final int type;
 
     public IntegerValue(final long value) {
@@ -218,6 +221,23 @@ public class IntegerValue extends NumericValue {
     @Override
     public boolean isPositive() {
         return value.signum() > 0;
+    }
+
+    @Override
+    protected @Nullable IntSupplier createComparisonWith(final NumericValue other) {
+        final IntSupplier comparison;
+        if (other instanceof IntegerValue) {
+            comparison = () -> value.compareTo(((IntegerValue)other).value);
+        } else if (other instanceof DecimalValue) {
+            comparison = () -> new BigDecimal(value).compareTo(((DecimalValue)other).value);
+        } else if (other instanceof DoubleValue) {
+            comparison = () -> new BigDecimal(value).compareTo(BigDecimal.valueOf(((DoubleValue)other).value));
+        } else if (other instanceof FloatValue) {
+            comparison = () -> new BigDecimal(value).compareTo(BigDecimal.valueOf(((FloatValue)other).value));
+        } else {
+            return null;
+        }
+        return comparison;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/value/JavaObjectValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/JavaObjectValue.java
@@ -24,6 +24,7 @@ package org.exist.xquery.value;
 
 import com.ibm.icu.text.Collator;
 import org.exist.xquery.Constants.Comparison;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 /**
@@ -65,7 +66,7 @@ public class JavaObjectValue extends AtomicValue {
         if (requiredType == Type.JAVA_OBJECT) {
             return this;
         }
-        throw new XPathException(
+        throw new XPathException(ErrorCodes.FORG0001,
                 "cannot convert Java object to " + Type.getTypeName(requiredType));
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/NumericValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/NumericValue.java
@@ -47,7 +47,8 @@ public abstract class NumericValue extends ComputableValue {
             //Never equal, or inequal...
             return false;
         }
-        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+
+        if (Type.subTypeOfUnion(other.getType(), Type.NUMBER)) {
             if (isNaN()) {
                 //NaN does not equal itself.
                 if (((NumericValue) other).isNaN()) {
@@ -80,7 +81,7 @@ public abstract class NumericValue extends ComputableValue {
 
     @Override
     public int compareTo(final Collator collator, final AtomicValue other) throws XPathException {
-        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+        if (Type.subTypeOfUnion(other.getType(), Type.NUMBER)) {
             if (isNaN()) {
                 //NaN does not equal itself.
                 if (((NumericValue) other).isNaN()) {

--- a/exist-core/src/main/java/org/exist/xquery/value/NumericValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/NumericValue.java
@@ -6,6 +6,9 @@ import org.exist.xquery.Constants.Comparison;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
+import javax.annotation.Nullable;
+import java.util.function.IntSupplier;
+
 public abstract class NumericValue extends ComputableValue {
 
     public double getDouble() throws XPathException {
@@ -41,7 +44,7 @@ public abstract class NumericValue extends ComputableValue {
     }
 
     @Override
-    public boolean compareTo(final Collator collator, final Comparison operator, final AtomicValue other)
+    public final boolean compareTo(final Collator collator, final Comparison operator, final AtomicValue other)
             throws XPathException {
         if (other.isEmpty()) {
             //Never equal, or inequal...
@@ -55,32 +58,52 @@ public abstract class NumericValue extends ComputableValue {
                     return operator == Comparison.NEQ;
                 }
             }
-            final double otherVal = ((NumericValue) other).getDouble();
-            final double val = getDouble();
+
+            final IntSupplier comparison = createComparisonWith((NumericValue) other);
+            if (comparison == null) {
+                throw new XPathException(ErrorCodes.XPTY0004, "Type error: cannot apply operator to numeric value");
+            }
+
             switch (operator) {
                 case EQ:
-                    return val == otherVal;
+                    return comparison.getAsInt() == 0;
                 case NEQ:
-                    return val != otherVal;
+                    return comparison.getAsInt() != 0;
                 case GT:
-                    return val > otherVal;
+                    return comparison.getAsInt() > 0;
                 case GTEQ:
-                    return val >= otherVal;
+                    return comparison.getAsInt() >= 0;
                 case LT:
-                    return val < otherVal;
+                    return comparison.getAsInt() < 0;
                 case LTEQ:
-                    return val <= otherVal;
+                    return comparison.getAsInt() <= 0;
                 default:
-                    throw new XPathException("Type error: cannot apply operator to numeric value");
+                    throw new XPathException(ErrorCodes.XPTY0004, "Type error: cannot apply operator to numeric value");
             }
         }
+
         throw new XPathException(ErrorCodes.XPTY0004, "Type error: cannot compare operands: " +
                 Type.getTypeName(getType()) + " and " +
                 Type.getTypeName(other.getType()));
     }
 
+    /**
+     * Creates a function which when called performs a comparison between this NumericValue
+     * and the {@code other} NumericValue.
+     *
+     * @param other the other numberic value to compare this against.
+     *
+     * @return the comparison function or null.
+     */
+    protected abstract @Nullable IntSupplier createComparisonWith(final NumericValue other);
+
     @Override
-    public int compareTo(final Collator collator, final AtomicValue other) throws XPathException {
+    public final int compareTo(final Collator collator, final AtomicValue other) throws XPathException {
+        if (other.isEmpty()) {
+            //Never equal, or inequal...
+            return Constants.INFERIOR;
+        }
+
         if (Type.subTypeOfUnion(other.getType(), Type.NUMBER)) {
             if (isNaN()) {
                 //NaN does not equal itself.
@@ -88,11 +111,15 @@ public abstract class NumericValue extends ComputableValue {
                     return Constants.INFERIOR;
                 }
             }
-            final double otherVal = ((NumericValue) other).getDouble();
-            final double val = getDouble();
-            return Double.compare(val, otherVal);
+
+            final IntSupplier comparison = createComparisonWith((NumericValue) other);
+            if (comparison == null) {
+                throw new XPathException(ErrorCodes.XPTY0004, "Type error: cannot apply operator to numeric value");
+            }
+
+            return comparison.getAsInt();
         } else {
-            throw new XPathException("cannot compare numeric value to non-numeric value");
+            throw new XPathException(ErrorCodes.XPTY0004, "cannot compare numeric value to non-numeric value");
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/OrderedDurationValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/OrderedDurationValue.java
@@ -205,7 +205,7 @@ abstract class OrderedDurationValue extends DurationValue {
      * @throws XPathException if the value is not of a numeric type
      */
     protected BigDecimal numberToBigDecimal(ComputableValue x, String exceptionMessagePrefix) throws XPathException {
-        if (!Type.subTypeOf(x.getType(), Type.NUMBER)) {
+        if (!Type.subTypeOfUnion(x.getType(), Type.NUMBER)) {
             throw new XPathException(exceptionMessagePrefix + Type.getTypeName(x.getType()));
         }
         if (((NumericValue) x).isInfinite() || ((NumericValue) x).isNaN()) {

--- a/exist-core/src/main/java/org/exist/xquery/value/OrderedValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/OrderedValueSequence.java
@@ -324,8 +324,8 @@ public class OrderedValueSequence extends AbstractSequence {
                 try {
                     final AtomicValue a = values[i];
                     final AtomicValue b = other.values[i];
-                    final boolean aIsEmpty = (a.isEmpty() || (Type.subTypeOf(a.getType(), Type.NUMBER) && ((NumericValue) a).isNaN()));
-                    final boolean bIsEmpty = (b.isEmpty() || (Type.subTypeOf(b.getType(), Type.NUMBER) && ((NumericValue) b).isNaN()));
+                    final boolean aIsEmpty = (a.isEmpty() || (Type.subTypeOfUnion(a.getType(), Type.NUMBER) && ((NumericValue) a).isNaN()));
+                    final boolean bIsEmpty = (b.isEmpty() || (Type.subTypeOfUnion(b.getType(), Type.NUMBER) && ((NumericValue) b).isNaN()));
                     if (aIsEmpty) {
                         if (bIsEmpty)
                         // both values are empty

--- a/exist-core/src/main/java/org/exist/xquery/value/QNameValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/QNameValue.java
@@ -127,7 +127,7 @@ public class QNameValue extends AtomicValue {
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "A QName cannot be converted to " + Type.getTypeName(requiredType));
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/StringValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/StringValue.java
@@ -459,7 +459,7 @@ public class StringValue extends AtomicValue {
                 } else if ("1".equals(trimmed) || "true".equals(trimmed)) {
                     return BooleanValue.TRUE;
                 } else {
-                    throw new XPathException(
+                    throw new XPathException(ErrorCodes.FORG0001,
                             "cannot convert string '" + value + "' to boolean");
                 }
             case Type.FLOAT:

--- a/exist-core/src/main/java/org/exist/xquery/value/StringValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/StringValue.java
@@ -636,7 +636,7 @@ public class StringValue extends AtomicValue {
 
     @Override
     public int compareTo(Collator collator, AtomicValue other) throws XPathException {
-        if (Type.subTypeOf(other.getType(), Type.NUMBER)) {
+        if (Type.subTypeOfUnion(other.getType(), Type.NUMBER)) {
             //No possible comparisons
             if (((NumericValue) other).isNaN()) {
                 return Constants.INFERIOR;

--- a/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
@@ -22,6 +22,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import javax.xml.datatype.DatatypeConstants;
@@ -87,7 +88,7 @@ public class TimeValue extends AbstractDateTimeValue {
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
             default:
-                throw new XPathException(
+                throw new XPathException(ErrorCodes.FORG0001,
                         "Type error: cannot cast xs:time to "
                                 + Type.getTypeName(requiredType));
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/Type.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Type.java
@@ -108,11 +108,13 @@ public class Type {
     public final static int ARRAY = 103;
     private final static Logger LOG = LogManager.getLogger(Type.class);
 
+    private static int NO_SUCH_VALUE = -99;
+
     private final static int[] superTypes = new int[512];
     private final static Int2ObjectOpenHashMap<String[]> typeNames = new Int2ObjectOpenHashMap<>(100);
     private final static Object2IntOpenHashMap<String> typeCodes = new Object2IntOpenHashMap<>(100);
     static {
-        typeCodes.defaultReturnValue(-1);
+        typeCodes.defaultReturnValue(NO_SUCH_VALUE);
     }
     private final static Int2ObjectMap<IntArraySet> unionTypes = new Int2ObjectArrayMap<>(1);
 
@@ -356,7 +358,7 @@ public class Type {
         //if (name.equals("node"))
         //	return NODE;
         final int code = typeCodes.getInt(name);
-        if (code == -1) {
+        if (code == NO_SUCH_VALUE) {
             throw new XPathException("Type: " + name + " is not defined");
         }
         return code;

--- a/exist-core/src/main/java/org/exist/xquery/value/Type.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Type.java
@@ -115,6 +115,7 @@ public class Type {
         defineSubType(ANY_TYPE, ANY_SIMPLE_TYPE);
         defineSubType(ANY_TYPE, UNTYPED);
         defineSubType(ANY_SIMPLE_TYPE, ATOMIC);
+        defineSubType(ANY_SIMPLE_TYPE, NUMBER);
         defineSubType(NODE, ELEMENT);
         defineSubType(NODE, ATTRIBUTE);
         defineSubType(NODE, TEXT);
@@ -131,7 +132,6 @@ public class Type {
         defineSubType(ATOMIC, BOOLEAN);
         defineSubType(ATOMIC, QNAME);
         defineSubType(ATOMIC, ANY_URI);
-        defineSubType(ATOMIC, NUMBER);
         defineSubType(ATOMIC, UNTYPED_ATOMIC);
         defineSubType(ATOMIC, JAVA_OBJECT);
         defineSubType(ATOMIC, DATE_TIME);

--- a/exist-core/src/main/java/org/exist/xquery/value/Type.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Type.java
@@ -25,6 +25,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArraySet;
+import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -111,8 +112,8 @@ public class Type {
     private static int NO_SUCH_VALUE = -99;
 
     private final static int[] superTypes = new int[512];
-    private final static Int2ObjectOpenHashMap<String[]> typeNames = new Int2ObjectOpenHashMap<>(100);
-    private final static Object2IntOpenHashMap<String> typeCodes = new Object2IntOpenHashMap<>(100);
+    private final static Int2ObjectOpenHashMap<String[]> typeNames = new Int2ObjectOpenHashMap<>(64, Hash.FAST_LOAD_FACTOR);
+    private final static Object2IntOpenHashMap<String> typeCodes = new Object2IntOpenHashMap<>(100, Hash.FAST_LOAD_FACTOR);
     static {
         typeCodes.defaultReturnValue(NO_SUCH_VALUE);
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/Type.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Type.java
@@ -150,9 +150,9 @@ public class Type {
         defineSubType(DURATION, YEAR_MONTH_DURATION);
         defineSubType(DURATION, DAY_TIME_DURATION);
 
-        defineSubType(NUMBER, DECIMAL);
-        defineSubType(NUMBER, FLOAT);
-        defineSubType(NUMBER, DOUBLE);
+        defineSubType(ATOMIC, DECIMAL);
+        defineSubType(ATOMIC, FLOAT);
+        defineSubType(ATOMIC, DOUBLE);
 
         defineSubType(DECIMAL, INTEGER);
 

--- a/exist-core/src/main/java/org/exist/xquery/value/Type.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Type.java
@@ -1,23 +1,23 @@
 /*
- * eXist Open Source Native XML Database
- * Copyright (C) 2001-2009 The eXist Project
- * http://exist-db.org
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *  
- * This program is distributed in the hope that it will be useful,
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
- *  $Id$
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.xquery.value;
 
@@ -275,14 +275,26 @@ public class Type {
     }
 
     /**
+     * Define built-in type.
+     *
      * @param type the type constant
      * @param name The first name is the default name, any other names are aliases.
      */
-    public static void defineBuiltInType(int type, String... name) {
+    private static void defineBuiltInType(final int type, final String... name) {
         typeNames.put(type, name);
         for (final String n : name) {
             typeCodes.put(n, type);
         }
+    }
+
+    /**
+     * Define supertype/subtype relation.
+     *
+     * @param supertype type constant of the super type
+     * @param subtype the subtype
+     */
+    private static void defineSubType(final int supertype, final int subtype) {
+        superTypes[subtype] = supertype;
     }
 
     /**
@@ -345,16 +357,6 @@ public class Type {
             default:
                 return getType(qname.getLocalPart());
         }
-    }
-
-    /**
-     * Define supertype/subtype relation.
-     *
-     * @param supertype type constant of the super type
-     * @param subtype the subtype
-     */
-    public static void defineSubType(int supertype, int subtype) {
-        superTypes[subtype] = supertype;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/value/Type.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Type.java
@@ -30,7 +30,7 @@ import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.xquery.XPathException;
 
-import java.util.HashSet;
+import javax.annotation.Nullable;
 
 /**
  * Defines all built-in types and their relations.
@@ -121,87 +121,120 @@ public class Type {
     }
 
     static {
+        // ANY types
         defineSubType(ANY_TYPE, ANY_SIMPLE_TYPE);
         defineSubType(ANY_TYPE, UNTYPED);
+
+        // ANY_SIMPLE types
         defineSubType(ANY_SIMPLE_TYPE, ATOMIC);
         defineSubType(ANY_SIMPLE_TYPE, NUMBER);
-        defineSubType(NODE, ELEMENT);
-        defineSubType(NODE, ATTRIBUTE);
-        defineSubType(NODE, TEXT);
-        defineSubType(NODE, PROCESSING_INSTRUCTION);
-        defineSubType(NODE, COMMENT);
-        defineSubType(NODE, DOCUMENT);
-        defineSubType(NODE, NAMESPACE);
-        defineSubType(NODE, CDATA_SECTION);
 
-        //THIS type system is broken - some of the below should be sub-types of ANY_SIMPLE_TYPE
-        //and some should not!
+        // ITEM sub-types
         defineSubType(ITEM, ATOMIC);
-        defineSubType(ATOMIC, STRING);
-        defineSubType(ATOMIC, BOOLEAN);
-        defineSubType(ATOMIC, QNAME);
+        defineSubType(ITEM, FUNCTION_REFERENCE);
+        //defineSubType(ITEM, NODE);                // TODO(AR) this appears in the XDM 3.1, but uncommenting this breaks a lot of stuff in eXist-db
+
+        // ATOMIC sub-types
         defineSubType(ATOMIC, ANY_URI);
-        defineSubType(ATOMIC, UNTYPED_ATOMIC);
-        defineSubType(ATOMIC, JAVA_OBJECT);
-        defineSubType(ATOMIC, DATE_TIME);
-        defineSubType(ATOMIC, DATE);
-        defineSubType(ATOMIC, TIME);
-        defineSubType(ATOMIC, DURATION);
-        defineSubType(ATOMIC, GYEAR);
-        defineSubType(ATOMIC, GMONTH);
-        defineSubType(ATOMIC, GDAY);
-        defineSubType(ATOMIC, GYEARMONTH);
-        defineSubType(ATOMIC, GMONTHDAY);
         defineSubType(ATOMIC, BASE64_BINARY);
-        defineSubType(ATOMIC, HEX_BINARY);
-        defineSubType(ATOMIC, NOTATION);
-
-        defineSubType(DURATION, YEAR_MONTH_DURATION);
-        defineSubType(DURATION, DAY_TIME_DURATION);
-
+        defineSubType(ATOMIC, BOOLEAN);
+        defineSubType(ATOMIC, DATE);
+        defineSubType(ATOMIC, DATE_TIME);
         defineSubType(ATOMIC, DECIMAL);
-        defineSubType(ATOMIC, FLOAT);
         defineSubType(ATOMIC, DOUBLE);
+        defineSubType(ATOMIC, DURATION);
+        defineSubType(ATOMIC, FLOAT);
+        defineSubType(ATOMIC, GDAY);
+        defineSubType(ATOMIC, GMONTH);
+        defineSubType(ATOMIC, GMONTHDAY);
+        defineSubType(ATOMIC, GYEAR);
+        defineSubType(ATOMIC, GYEARMONTH);
+        defineSubType(ATOMIC, HEX_BINARY);
+        defineSubType(ATOMIC, JAVA_OBJECT);
+        defineSubType(ATOMIC, NOTATION);
+        defineSubType(ATOMIC, QNAME);
+        defineSubType(ATOMIC, STRING);
+        defineSubType(ATOMIC, TIME);
+        defineSubType(ATOMIC, UNTYPED_ATOMIC);
 
+        // DATE_TIME sub-types
+        //defineSubType(DATE_TIME, DATE_TIME_STAMP);
+
+        // DURATION sub-types
+        defineSubType(DURATION, DAY_TIME_DURATION);
+        defineSubType(DURATION, YEAR_MONTH_DURATION);
+
+        // DECIMAL sub-types
         defineSubType(DECIMAL, INTEGER);
 
-        defineSubType(INTEGER, NON_POSITIVE_INTEGER);
-        defineSubType(NON_POSITIVE_INTEGER, NEGATIVE_INTEGER);
-
+        // INTEGER sub-types
         defineSubType(INTEGER, LONG);
+        defineSubType(INTEGER, NON_NEGATIVE_INTEGER);
+        defineSubType(INTEGER, NON_POSITIVE_INTEGER);
+
+        // LONG sub-types
         defineSubType(LONG, INT);
+
+        // INT sub-types
         defineSubType(INT, SHORT);
+
+        // SHORT sub-types
         defineSubType(SHORT, BYTE);
 
-        defineSubType(INTEGER, NON_NEGATIVE_INTEGER);
+        // NON_NEGATIVE_INTEGER sub-types
         defineSubType(NON_NEGATIVE_INTEGER, POSITIVE_INTEGER);
-
         defineSubType(NON_NEGATIVE_INTEGER, UNSIGNED_LONG);
+
+        // UNSIGNED_LONG sub-types
         defineSubType(UNSIGNED_LONG, UNSIGNED_INT);
+
+        // UNSIGNED_INT sub-types
         defineSubType(UNSIGNED_INT, UNSIGNED_SHORT);
+
+        // UNSIGNED_SHORT sub-types
         defineSubType(UNSIGNED_SHORT, UNSIGNED_BYTE);
 
+        // NON_POSITIVE_INTEGER sub-types
+        defineSubType(NON_POSITIVE_INTEGER, NEGATIVE_INTEGER);
+
+        // STRING sub-types
         defineSubType(STRING, NORMALIZED_STRING);
+
+        // NORMALIZED_STRING sub-types
         defineSubType(NORMALIZED_STRING, TOKEN);
+
+        // TOKEN sub-types
         defineSubType(TOKEN, LANGUAGE);
-        defineSubType(TOKEN, NMTOKEN);
         defineSubType(TOKEN, NAME);
+        defineSubType(TOKEN, NMTOKEN);
+
+        // NAME sub-types
         defineSubType(NAME, NCNAME);
+
+        // NCNAME sub-types
+        defineSubType(NCNAME, ENTITY);
         defineSubType(NCNAME, ID);
         defineSubType(NCNAME, IDREF);
-        defineSubType(NCNAME, ENTITY);
 
-        defineSubType(ITEM, FUNCTION_REFERENCE);
+        // FUNCTION_REFERENCE sub-types
         defineSubType(FUNCTION_REFERENCE, MAP);
         defineSubType(FUNCTION_REFERENCE, ARRAY);
+
+        // NODE types
+        defineSubType(NODE, ATTRIBUTE);
+        defineSubType(NODE, CDATA_SECTION);  // TODO(AR) this doesn't appear in the XDM 3.1
+        defineSubType(NODE, COMMENT);
+        defineSubType(NODE, DOCUMENT);
+        defineSubType(NODE, ELEMENT);
+        defineSubType(NODE, NAMESPACE);
+        defineSubType(NODE, PROCESSING_INSTRUCTION);
+        defineSubType(NODE, TEXT);
     }
 
     static {
-        //TODO : use NODETYPES above ?
-        //TODO use parentheses after the nodes name  ?
         defineBuiltInType(NODE, "node()");
         defineBuiltInType(ITEM, "item()");
-        defineBuiltInType(EMPTY, "empty-sequence()","empty()"); // keep empty() for backward compatibility
+        defineBuiltInType(EMPTY, "empty-sequence()", "empty()");                                // keep `empty()` for backward compatibility
 
         defineBuiltInType(ELEMENT, "element()");
         defineBuiltInType(DOCUMENT, "document-node()");
@@ -214,19 +247,17 @@ public class Type {
 
         defineBuiltInType(JAVA_OBJECT, "object");
         defineBuiltInType(FUNCTION_REFERENCE, "function(*)", "function");
-        defineBuiltInType(MAP, "map(*)", "map"); // keep map for backward compatibility
+        defineBuiltInType(MAP, "map(*)", "map");                                                // keep `map` for backward compatibility
         defineBuiltInType(ARRAY, "array(*)","array");
-        defineBuiltInType(NUMBER, "xs:numeric", "numeric"); // keep numeric for backward compatibility
+        defineBuiltInType(NUMBER, "xs:numeric", "numeric");                                     // keep `numeric` for backward compatibility
 
         defineBuiltInType(ANY_TYPE, "xs:anyType");
         defineBuiltInType(ANY_SIMPLE_TYPE, "xs:anySimpleType");
         defineBuiltInType(UNTYPED, "xs:untyped");
 
-        //Duplicate definition : new one first
-        defineBuiltInType(ATOMIC, "xs:anyAtomicType", "xdt:anyAtomicType");
+        defineBuiltInType(ATOMIC, "xs:anyAtomicType", "xdt:anyAtomicType");                     // keep `xdt:anyAtomicType` for backward compatibility
 
-        //Duplicate definition : new one first
-        defineBuiltInType(UNTYPED_ATOMIC, "xs:untypedAtomic", "xdt:untypedAtomic");
+        defineBuiltInType(UNTYPED_ATOMIC, "xs:untypedAtomic", "xdt:untypedAtomic");             // keep `xdt:untypedAtomic` for backward compatibility
 
         defineBuiltInType(BOOLEAN, "xs:boolean");
         defineBuiltInType(DECIMAL, "xs:decimal");
@@ -266,10 +297,8 @@ public class Type {
         defineBuiltInType(GYEARMONTH, "xs:gYearMonth");
         defineBuiltInType(GMONTHDAY, "xs:gMonthDay");
 
-        //Duplicate definition : new one first
-        defineBuiltInType(YEAR_MONTH_DURATION, "xs:yearMonthDuration", "xdt:yearMonthDuration");
-        //Duplicate definition : new one first
-        defineBuiltInType(DAY_TIME_DURATION, "xs:dayTimeDuration", "xdt:dayTimeDuration");
+        defineBuiltInType(YEAR_MONTH_DURATION, "xs:yearMonthDuration", "xdt:yearMonthDuration");    // keep `xdt:yearMonthDuration` for backward compatibility
+        defineBuiltInType(DAY_TIME_DURATION, "xs:dayTimeDuration", "xdt:dayTimeDuration");          // keep `xdt:dayTimeDuration` for backward compatibility
 
         defineBuiltInType(NORMALIZED_STRING, "xs:normalizedString");
         defineBuiltInType(TOKEN, "xs:token");
@@ -399,8 +428,12 @@ public class Type {
      * @param type the type constant
      * @return name of the type
      */
-    public static String getTypeName(int type) {
-        return typeNames.get(type)[0];
+    public static @Nullable String getTypeName(final int type) {
+        final String[] names = typeNames.get(type);
+        if (names != null) {
+            return names[0];
+        }
+        return null;
     }
 
     /**
@@ -409,7 +442,7 @@ public class Type {
      * @param type the type constant
      * @return one or more alias names
      */
-    public static String[] getTypeAliases(int type) {
+    public static @Nullable String[] getTypeAliases(final int type) {
         final String names[] = typeNames.get(type);
         if (names != null && names.length > 1) {
             final String aliases[] = new String[names.length - 1];
@@ -426,9 +459,7 @@ public class Type {
      * @return type constant
      * @throws XPathException in case of dynamic error
      */
-    public static int getType(String name) throws XPathException {
-        //if (name.equals("node"))
-        //	return NODE;
+    public static int getType(final String name) throws XPathException {
         final int code = typeCodes.getInt(name);
         if (code == NO_SUCH_VALUE) {
             throw new XPathException("Type: " + name + " is not defined");
@@ -443,7 +474,7 @@ public class Type {
      * @return type constant
      * @throws XPathException in case of dynamic error
      */
-    public static int getType(QName qname) throws XPathException {
+    public static int getType(final QName qname) throws XPathException {
         final String uri = qname.getNamespaceURI();
         switch (uri) {
             case Namespaces.SCHEMA_NS:
@@ -526,7 +557,7 @@ public class Type {
      * @param type2 type constant for the second type
      * @return common super type or {@link Type#ITEM} if none
      */
-    public static int getCommonSuperType(int type1, int type2) {
+    public static int getCommonSuperType(final int type1, final int type2) {
         //Super shortcut
         if (type1 == type2) {
             return type1;
@@ -542,7 +573,7 @@ public class Type {
         //TODO : optimize by swapping the arguments based on their numeric values ?
         //Processing lower value first *should* reduce the size of the Set
         //Collect type1's super-types
-        final HashSet<Integer> t1 = new HashSet<>();
+        final IntSet t1 = new IntOpenHashSet(Hash.DEFAULT_INITIAL_SIZE, Hash.VERY_FAST_LOAD_FACTOR);
         //Don't introduce a shortcut (starting at getSuperType(type1) here
         //type2 might be a super-type of type1
         int t;

--- a/exist-core/src/main/java/org/exist/xquery/value/Type.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Type.java
@@ -21,9 +21,7 @@
  */
 package org.exist.xquery.value;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -105,9 +103,10 @@ public class Type {
     public final static int MAP = 102;
     public final static int ARRAY = 103;
     private final static Logger LOG = LogManager.getLogger(Type.class);
+
     private final static int[] superTypes = new int[512];
-    private final static Int2ObjectMap<String[]> typeNames = new Int2ObjectOpenHashMap<>(100);
-    private final static Object2IntMap<String> typeCodes = new Object2IntOpenHashMap<>(100);
+    private final static Int2ObjectOpenHashMap<String[]> typeNames = new Int2ObjectOpenHashMap<>(100);
+    private final static Object2IntOpenHashMap<String> typeCodes = new Object2IntOpenHashMap<>(100);
     static {
         typeCodes.defaultReturnValue(-1);
     }
@@ -272,6 +271,10 @@ public class Type {
         defineBuiltInType(ID, "xs:ID");
         defineBuiltInType(IDREF, "xs:IDREF");
         defineBuiltInType(ENTITY, "xs:ENTITY");
+
+        // reduce any unused space
+        typeNames.trim();
+        typeCodes.trim();
     }
 
     /**

--- a/exist-core/src/test/xquery/numbers.xqm
+++ b/exist-core/src/test/xquery/numbers.xqm
@@ -1,0 +1,53 @@
+xquery version "3.1";
+
+module namespace nums = "http://exist-db.org/xquery/test/numbers";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+
+declare
+    %test:args(10000000000000001,  10000000000000002)
+    %test:assertFalse
+    %test:args(100000000000000001, 100000000000000002)
+    %test:assertFalse
+    %test:args(100000000000000010, 100000000000000020)
+    %test:assertFalse
+    %test:args(100000000000000100, 100000000000000200)
+    %test:assertFalse
+    %test:args(310000000000920000300, 310000000000920000200)
+    %test:assertFalse
+function nums:compare-eq($a, $b) {
+    $a eq $b
+};
+
+declare
+  %test:assertEquals(
+      310000000000920000200,
+      310000000000920000300,
+      310000000000930001700,
+      310000000000930001800,
+      310000000000930002800,
+      310000000000930003800,
+      310000000000930003900,
+      310000000000930004900,
+      310000000000970000300,
+      310000000000970000400
+  )
+function nums:order() {
+  let $data := (
+    310000000000920000300,
+    310000000000930001800,
+    310000000000930003900,
+    310000000000970000400,
+    310000000000930002800,
+    310000000000920000200,
+    310000000000930001700,
+    310000000000930004900,
+    310000000000930003800,
+    310000000000970000300
+  )
+  return
+    for $i in $data
+    order by $i
+    return $i
+};

--- a/exist-core/src/test/xquery/numbers/format-numbers.xql
+++ b/exist-core/src/test/xquery/numbers/format-numbers.xql
@@ -209,7 +209,7 @@ declare
     %test:pending("It is not clear why this should be invalid according to the XQ3.1 spec")
     %test:args("12345.6")
     %test:assertError("FODF1310")
-function fd:invalid-picture($number as numeric) {
+function fd:invalid-picture($number as xs:numeric) {
     format-number($number, "#.###,00")
 };
 

--- a/extensions/indexes/sort/src/main/java/org/exist/xquery/modules/sort/CreateOrderIndex.java
+++ b/extensions/indexes/sort/src/main/java/org/exist/xquery/modules/sort/CreateOrderIndex.java
@@ -175,8 +175,8 @@ public class CreateOrderIndex extends BasicFunction {
             int cmp = 0;
             final AtomicValue a = this.value;
             final AtomicValue b = other.getValue();
-            final boolean aIsEmpty = (a.isEmpty() || (Type.subTypeOf(a.getType(), Type.NUMBER) && ((NumericValue) a).isNaN()));
-            final boolean bIsEmpty = (b.isEmpty() || (Type.subTypeOf(b.getType(), Type.NUMBER) && ((NumericValue) b).isNaN()));
+            final boolean aIsEmpty = (a.isEmpty() || (Type.subTypeOfUnion(a.getType(), Type.NUMBER) && ((NumericValue) a).isNaN()));
+            final boolean bIsEmpty = (b.isEmpty() || (Type.subTypeOfUnion(b.getType(), Type.NUMBER) && ((NumericValue) b).isNaN()));
             if (aIsEmpty) {
                 if (bIsEmpty)
                     // both values are empty


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/1176

Cleans up value and general comparisons to bring them inline with the XQuery spec. 

Some highlights:

1. eXist-db's Type Hierarchy had a bit of a nasty hack around numeric types because it was unable to represent union types. Previously eXist-db modelled `xs:decimal`, `xs:float`, and `xs:double`, as sub-types of the union type `xs:numeric` which was incorrect. The XDM specifies that they are sub-types of `xs:anyAtomicType`, and that `xs:numeric` is a union type whose members are the set of `xs:decimal`, `xs:float`, and `xs:double`. This PR adds support for modelling Union Types from the XDM and corrects the type hierarchy in eXist-db. See - https://www.w3.org/TR/xpath-datamodel-31/#types-hierarchy

2. When performing Value and General comparisons, eXist-db's type coercion was incorrect. The XQuery spec specifies the following algorithms: [Value Comparisons](https://www.w3.org/TR/xquery-31/#id-value-comparisons), and [General Comparisons](https://www.w3.org/TR/xquery-31/#id-general-comparisons). This PR replaces the existing type coercion in eXist-db with a new version which is inline with the XQuery specification.

3. Comparisons between the values backing numbers in eXist-db were always down-cast to a Java `double` value. This meant a loss of precision when comparing larger numbers. This PR replaces that with an up-cast and lambda pass method; This accommodates the smallest common Java type, thus ensuring no truncation/rounding of numeric data.