### PR TITLE
[fix] java exception on higher order functions

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
@@ -17,95 +17,83 @@ import javax.annotation.Nullable;
 
 public class FunHigherOrderFun extends BasicFunction {
 
-	public final static FunctionSignature FN_FOR_EACH =
-        new FunctionSignature(
+    public final static FunctionSignature FN_FOR_EACH = new FunctionSignature(
             new QName("for-each", Function.BUILTIN_FUNCTION_NS),
             "Applies the function item $function to every item from the sequence " +
                     "$sequence in turn, returning the concatenation of the resulting sequences in order.",
-            new SequenceType[] {
+            new SequenceType[]{
                     new FunctionParameterSequenceType("sequence", Type.ITEM, Cardinality.ZERO_OR_MORE, "the sequence on which to apply the function"),
                     new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call")
             },
-            new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
-                    "result of applying the function to each item of the sequence")
-		);
+            new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "result of applying the function to each item of the sequence")
+    );
 
-	public final static FunctionSignature FN_FOR_EACH_PAIR =
-        new FunctionSignature(
+    public final static FunctionSignature FN_FOR_EACH_PAIR = new FunctionSignature(
             new QName("for-each-pair", Function.BUILTIN_FUNCTION_NS),
-                "Applies the function item $f to successive pairs of items taken one from $seq1 and one from $seq2, " +
-                "returning the concatenation of the resulting sequences in order.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("seq1", Type.ITEM, Cardinality.ZERO_OR_MORE, "first sequence to take items from"),
-                new FunctionParameterSequenceType("seq2", Type.ITEM, Cardinality.ZERO_OR_MORE, "second sequence to take items from"),
-                new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call")
+            "Applies the function item $f to successive pairs of items taken one from $seq1 and one from $seq2, " +
+                    "returning the concatenation of the resulting sequences in order.",
+            new SequenceType[]{
+                    new FunctionParameterSequenceType("seq1", Type.ITEM, Cardinality.ZERO_OR_MORE, "first sequence to take items from"),
+                    new FunctionParameterSequenceType("seq2", Type.ITEM, Cardinality.ZERO_OR_MORE, "second sequence to take items from"),
+                    new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call")
             },
-            new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
-                    "concatenation of resulting sequences")
-		);
+            new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "concatenation of resulting sequences")
+    );
 
+    public final static FunctionSignature FN_FILTER = new FunctionSignature(
+            new QName("filter", Function.BUILTIN_FUNCTION_NS),
+            "Returns those items from the sequence $sequence for which the supplied function $function returns true.",
+            new SequenceType[]{
+                    new FunctionParameterSequenceType("sequence", Type.ITEM, Cardinality.ZERO_OR_MORE, "the sequence to filter"),
+                    new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call")
+            },
+            new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "result of filtering the sequence")
+    );
 
-	public final static FunctionSignature FN_FILTER =
-		new FunctionSignature(
-			new QName("filter", Function.BUILTIN_FUNCTION_NS),
-			"Returns those items from the sequence $sequence for which the supplied function $function returns true.",
-			new SequenceType[] {
-				new FunctionParameterSequenceType("sequence", Type.ITEM, Cardinality.ZERO_OR_MORE, "the sequence to filter"),
-				new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call")
-			},
-			new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
-				"result of filtering the sequence")
-	);
+    public final static FunctionSignature FN_FOLD_LEFT = new FunctionSignature(
+            new QName("fold-left", Function.BUILTIN_FUNCTION_NS),
+            "Processes the supplied sequence from left to right, applying the supplied function repeatedly to each " +
+                    "item in turn, together with an accumulated result value.",
+            new SequenceType[]{
+                    new FunctionParameterSequenceType("sequence", Type.ITEM, Cardinality.ZERO_OR_MORE, "the sequence to filter"),
+                    new FunctionParameterSequenceType("zero", Type.ITEM, Cardinality.ZERO_OR_MORE, "initial value to start with"),
+                    new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call")
+            },
+            new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "result of the fold-left operation")
+    );
 
-	public final static FunctionSignature FN_FOLD_LEFT =
-		new FunctionSignature(
-	        new QName("fold-left", Function.BUILTIN_FUNCTION_NS),
-	        "Processes the supplied sequence from left to right, applying the supplied function repeatedly to each " +
-	        "item in turn, together with an accumulated result value.",
-	        new SequenceType[] {
-                new FunctionParameterSequenceType("sequence", Type.ITEM, Cardinality.ZERO_OR_MORE, "the sequence to filter"),
-                new FunctionParameterSequenceType("zero", Type.ITEM, Cardinality.ZERO_OR_MORE, "initial value to start with"),
-	            new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call")
-	        },
-	        new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
-	        		"result of the fold-left operation")
-		);
+    public final static FunctionSignature FN_FOLD_RIGHT = new FunctionSignature(
+            new QName("fold-right", Function.BUILTIN_FUNCTION_NS),
+            "Processes the supplied sequence from right to left, applying the supplied function repeatedly to each " +
+                    "item in turn, together with an accumulated result value.",
+            new SequenceType[]{
+                    new FunctionParameterSequenceType("sequence", Type.ITEM, Cardinality.ZERO_OR_MORE, "the sequence to filter"),
+                    new FunctionParameterSequenceType("zero", Type.ITEM, Cardinality.ZERO_OR_MORE, "initial value to start with"),
+                    new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call"),
+            },
+            new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "result of the fold-right operation")
+    );
 
-	public final static FunctionSignature FN_FOLD_RIGHT =
-		new FunctionSignature(
-	        new QName("fold-right", Function.BUILTIN_FUNCTION_NS),
-	        "Processes the supplied sequence from right to left, applying the supplied function repeatedly to each " +
-	        "item in turn, together with an accumulated result value.",
-	        new SequenceType[] {
-                new FunctionParameterSequenceType("sequence", Type.ITEM, Cardinality.ZERO_OR_MORE, "the sequence to filter"),
-                new FunctionParameterSequenceType("zero", Type.ITEM, Cardinality.ZERO_OR_MORE, "initial value to start with"),
-	            new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call"),
-	        },
-	        new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
-	        		"result of the fold-right operation")
-		);
+    public final static FunctionSignature FN_APPLY = new FunctionSignature(
+            new QName("apply", Function.BUILTIN_FUNCTION_NS),
+            "Processes the supplied sequence from right to left, applying the supplied function repeatedly to each " +
+                    "item in turn, together with an accumulated result value.",
+            new SequenceType[]{
+                    new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call"),
+                    new FunctionParameterSequenceType("array", Type.ARRAY, Cardinality.EXACTLY_ONE, "an array containing the arguments to pass to the function")
+            },
+            new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE, "return value of the function call")
+    );
 
-	public final static FunctionSignature FN_APPLY = new FunctionSignature(
-			new QName("apply", Function.BUILTIN_FUNCTION_NS),
-			"Processes the supplied sequence from right to left, applying the supplied function repeatedly to each " +
-					"item in turn, together with an accumulated result value.",
-			new SequenceType[] {
-				new FunctionParameterSequenceType("function", Type.FUNCTION_REFERENCE, Cardinality.EXACTLY_ONE, "the function to call"),
-				new FunctionParameterSequenceType("array", Type.ARRAY, Cardinality.EXACTLY_ONE, "an array containing the arguments to pass to the function")
-			},
-			new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
-				"return value of the function call")
-	);
-    
-	private AnalyzeContextInfo cachedContextInfo;
-	
-	public FunHigherOrderFun(XQueryContext context, FunctionSignature signature) {
-		super(context, signature);
-	}
+    private AnalyzeContextInfo cachedContextInfo;
+
+    public FunHigherOrderFun(XQueryContext context, FunctionSignature signature) {
+        super(context, signature);
+    }
 
     @Override
-	protected void checkArgument(final Expression arg, @Nullable final SequenceType argType,
-			final AnalyzeContextInfo argContextInfo, final int argPosition) throws XPathException {
+    protected void checkArgument(final Expression arg, @Nullable final SequenceType argType,
+                                 final AnalyzeContextInfo argContextInfo, final int argPosition) throws XPathException {
         // hack: order of parameters for filter and other functions has changed
         // in final XQ3 spec. This would cause some core apps (dashboard) to stop
         // working. We thus switch parameters dynamically until all users can be expected to
@@ -116,29 +104,29 @@ public class FunHigherOrderFun extends BasicFunction {
     }
 
     @Override
-	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
-		cachedContextInfo = new AnalyzeContextInfo(contextInfo);
+    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+        cachedContextInfo = new AnalyzeContextInfo(contextInfo);
         super.analyze(cachedContextInfo);
-	}
+    }
 
-	@Override
-	public Sequence eval(final Sequence[] args, final Sequence contextSequence)
-			throws XPathException {
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence)
+            throws XPathException {
         Sequence result = new ValueSequence();
 
         if (isCalledAs("for-each")) {
             try (final FunctionReference ref = (FunctionReference) args[1].itemAt(0)) {
-				ref.analyze(cachedContextInfo);
-				if (funcRefHasDifferentArity(ref, 1)) {
-					throw new XPathException(this, ErrorCodes.XPTY0004,
-							"The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 1");
-				}
-				for (final SequenceIterator i = args[0].iterate(); i.hasNext(); ) {
-					final Item item = i.nextItem();
-					final Sequence r = ref.evalFunction(null, null, new Sequence[]{item.toSequence()});
-					result.addAll(r);
-				}
-			}
+                ref.analyze(cachedContextInfo);
+                if (funcRefHasDifferentArity(ref, 1)) {
+                    throw new XPathException(this, ErrorCodes.XPTY0004,
+                            "The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 1");
+                }
+                for (final SequenceIterator i = args[0].iterate(); i.hasNext(); ) {
+                    final Item item = i.nextItem();
+                    final Sequence r = ref.evalFunction(null, null, new Sequence[]{item.toSequence()});
+                    result.addAll(r);
+                }
+            }
         } else if (isCalledAs("filter")) {
             final FunctionReference refParam;
             final Sequence seq;
@@ -152,85 +140,86 @@ public class FunHigherOrderFun extends BasicFunction {
             }
 
             try (final FunctionReference ref = refParam) {
-				ref.analyze(cachedContextInfo);
-				if (funcRefHasDifferentArity(ref, 1)) {
-					throw new XPathException(this, ErrorCodes.XPTY0004,
-							"The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 1");
-				}
+                ref.analyze(cachedContextInfo);
+                if (funcRefHasDifferentArity(ref, 1)) {
+                    throw new XPathException(this, ErrorCodes.XPTY0004,
+                            "The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 1");
+                }
 
-				for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
-					final Item item = i.nextItem();
-					final Sequence r = ref.evalFunction(null, null, new Sequence[]{item.toSequence()});
+                for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
+                    final Item item = i.nextItem();
+                    final Sequence r = ref.evalFunction(null, null, new Sequence[]{item.toSequence()});
 
-					// call to effectiveBooleanValue is not spec compliant
-					// spec: https://www.w3.org/TR/xpath-functions/#func-filter
-					// two pending tests in exist-core/src/test/xquery/xquery3/fnHigherOrderFunctions.xql
-					if (r.effectiveBooleanValue()) {
-						result.add(item);
-					}
-				}
-			}
+                    // call to effectiveBooleanValue is not spec compliant
+                    // spec: https://www.w3.org/TR/xpath-functions/#func-filter
+                    // two pending tests in exist-core/src/test/xquery/xquery3/fnHigherOrderFunctions.xql
+                    if (r.effectiveBooleanValue()) {
+                        result.add(item);
+                    }
+                }
+            }
         } else if (isCalledAs("fold-left")) {
             try (final FunctionReference ref = (FunctionReference) args[2].itemAt(0)) {
-				ref.analyze(cachedContextInfo);
-				if (funcRefHasDifferentArity(ref, 2)) {
-					throw new XPathException(this, ErrorCodes.XPTY0004,
-							"The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 2");
-				}
-				final Sequence seq = args[0];
-				final Sequence zero = args[1];
-				result = foldLeft(ref, zero, seq.iterate());
-			}
+                ref.analyze(cachedContextInfo);
+                if (funcRefHasDifferentArity(ref, 2)) {
+                    throw new XPathException(this, ErrorCodes.XPTY0004,
+                            "The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 2");
+                }
+                final Sequence seq = args[0];
+                final Sequence zero = args[1];
+                result = foldLeft(ref, zero, seq.iterate());
+            }
         } else if (isCalledAs("fold-right")) {
             try (final FunctionReference ref = (FunctionReference) args[2].itemAt(0)) {
-				ref.analyze(cachedContextInfo);
-				if (funcRefHasDifferentArity(ref, 2)) {
-					throw new XPathException(this, ErrorCodes.XPTY0004,
-							"The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 2");
-				}
-				final Sequence zero = args[1];
-				final Sequence seq = args[0];
-				if (seq instanceof ValueSequence) {
-					result = foldRightNonRecursive(ref, zero, ((ValueSequence) seq).iterateInReverse());
-				} else if (seq instanceof RangeSequence) {
-					result = foldRightNonRecursive(ref, zero, ((RangeSequence) seq).iterateInReverse());
-				} else {
-					result = foldRight(ref, zero, seq);
-				}
-			}
+                ref.analyze(cachedContextInfo);
+                if (funcRefHasDifferentArity(ref, 2)) {
+                    throw new XPathException(this, ErrorCodes.XPTY0004,
+                            "The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 2");
+                }
+                final Sequence zero = args[1];
+                final Sequence seq = args[0];
+                if (seq instanceof ValueSequence) {
+                    result = foldRightNonRecursive(ref, zero, ((ValueSequence) seq).iterateInReverse());
+                } else if (seq instanceof RangeSequence) {
+                    result = foldRightNonRecursive(ref, zero, ((RangeSequence) seq).iterateInReverse());
+                } else {
+                    result = foldRight(ref, zero, seq);
+                }
+            }
         } else if (isCalledAs("for-each-pair")) {
             try (final FunctionReference ref = (FunctionReference) args[2].itemAt(0)) {
-				ref.analyze(cachedContextInfo);
-				if (funcRefHasDifferentArity(ref, 2)) {
-					throw new XPathException(this, ErrorCodes.XPTY0004,
-							"The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 2");
-				}
-				final SequenceIterator i1 = args[0].iterate();
-				final SequenceIterator i2 = args[1].iterate();
-				while (i1.hasNext() && i2.hasNext()) {
-					final Sequence r = ref.evalFunction(null, null,
-							new Sequence[]{i1.nextItem().toSequence(), i2.nextItem().toSequence()});
-					result.addAll(r);
-				}
-			}
+                ref.analyze(cachedContextInfo);
+                if (funcRefHasDifferentArity(ref, 2)) {
+                    throw new XPathException(this, ErrorCodes.XPTY0004,
+                            "The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 2");
+                }
+                final SequenceIterator i1 = args[0].iterate();
+                final SequenceIterator i2 = args[1].iterate();
+                while (i1.hasNext() && i2.hasNext()) {
+                    final Sequence r = ref.evalFunction(null, null,
+                            new Sequence[]{i1.nextItem().toSequence(), i2.nextItem().toSequence()});
+                    result.addAll(r);
+                }
+            }
         } else if (isCalledAs("apply")) {
-			try (final FunctionReference ref = (FunctionReference) args[0].itemAt(0)) {
-				ref.analyze(cachedContextInfo);
-				final ArrayType array = (ArrayType) args[1].itemAt(0);
-				if (funcRefHasDifferentArity(ref, array.getSize())) {
-					throw new XPathException(this, ErrorCodes.FOAP0001, "Number of arguments supplied to fn:apply does not match function signature. Expected: " +
-							ref.getSignature().getArgumentCount() + ", got: " + array.getSize());
-				}
-				final Sequence[] fargs = array.toArray();
-				return ref.evalFunction(null, null, fargs);
-			}
-		}
-		return result;
-	}
+            try (final FunctionReference ref = (FunctionReference) args[0].itemAt(0)) {
+                ref.analyze(cachedContextInfo);
+                final ArrayType array = (ArrayType) args[1].itemAt(0);
+                if (funcRefHasDifferentArity(ref, array.getSize())) {
+                    throw new XPathException(this, ErrorCodes.FOAP0001,
+                            "Number of arguments supplied to fn:apply does not match function signature. Expected: " +
+                                    ref.getSignature().getArgumentCount() + ", got: " + array.getSize());
+                }
+                final Sequence[] fargs = array.toArray();
+                return ref.evalFunction(null, null, fargs);
+            }
+        }
+        return result;
+    }
 
     private Sequence foldLeft(final FunctionReference ref, Sequence accum, final SequenceIterator seq) throws XPathException {
         final Sequence refArgs[] = new Sequence[2];
-        while(seq.hasNext()) {
+        while (seq.hasNext()) {
             refArgs[0] = accum;
             refArgs[1] = seq.nextItem().toSequence();
             accum = ref.evalFunction(null, null, refArgs);
@@ -254,16 +243,17 @@ public class FunHigherOrderFun extends BasicFunction {
         return accum;
     }
 
-	private Sequence foldRight(final FunctionReference ref, final Sequence zero, final Sequence seq) throws XPathException {
+    private Sequence foldRight(final FunctionReference ref, final Sequence zero, final Sequence seq) throws XPathException {
         if (seq.isEmpty()) {
             return zero;
         }
-		final Sequence head = seq.itemAt(0).toSequence();
-		final Sequence tailResult = foldRight(ref, zero, seq.tail());
-		return ref.evalFunction(null, null, new Sequence[] { head, tailResult });
-	}
+        final Sequence head = seq.itemAt(0).toSequence();
+        final Sequence tailResult = foldRight(ref, zero, seq.tail());
+        return ref.evalFunction(null, null, new Sequence[]{head, tailResult});
+    }
 
-	private boolean funcRefHasDifferentArity(final FunctionReference ref, final int n) {
-		return (!ref.getSignature().isOverloaded() && ref.getSignature().getArgumentCount() != n);
-	}
+    private boolean funcRefHasDifferentArity(final FunctionReference ref, final int n) {
+        return (!ref.getSignature().isOverloaded() &&
+                ref.getSignature().getArgumentCount() != n);
+    }
 }

--- a/exist-core/src/test/xquery/xquery3/fnHigherOrderFunctions.xql
+++ b/exist-core/src/test/xquery/xquery3/fnHigherOrderFunctions.xql
@@ -1,0 +1,149 @@
+xquery version "3.1";
+
+module namespace hofs="http://exist-db.org/xquery/test/higher-order-functions";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+
+declare %private function hofs:declared-function ($a) { true() };
+
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:for-each-function-arity-0 () {
+    for-each((1 to 3), function () { 1 })
+};
+
+declare
+    %test:assertEquals(1, 1, 1)
+function hofs:for-each-function-arity-1 () {
+    for-each((1 to 3), function ($a) { 1 })
+};
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:for-each-function-arity-2 () {
+    for-each((1 to 3), function ($a, $b) { 1 })
+};
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:for-each-pair-function-arity-0 () {
+    for-each-pair((1 to 3), (1 to 3),
+        function () { 1 })
+};
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:for-each-pair-function-arity-1 () {
+    for-each-pair((1 to 3), (1 to 3),
+        function ($a) { 1 })
+};
+
+declare
+    %test:assertEquals(2, 4, 6)
+function hofs:for-each-pair-function-arity-2 () {
+    for-each-pair((1 to 3), (1 to 3),
+        function ($a, $b) { $a + $b })
+};
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:filter-function-arity-0 () {
+    filter((1 to 3), function () { true() })
+};
+
+declare
+    %test:assertEquals(1,2,3)
+function hofs:filter-function-arity-1 () {
+    filter((1 to 3), function ($a) { true() })
+};
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:filter-function-arity-2 () {
+    filter((1 to 3), function ($a, $b) { true() })
+};
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:fold-left-function-arity-0 () {
+    fold-left((1 to 3), 0, function () { true() })
+};
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:fold-left-function-arity-1 () {
+    fold-left((1 to 3), 0,function ($a) { true() })
+};
+
+declare
+    %test:assertTrue
+function hofs:fold-left-function-arity-2 () {
+    fold-left((1 to 3), 0,function ($r, $n) { true() })
+};
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:fold-right-function-arity-0 () {
+    fold-right((1 to 3), 0, function () { true() })
+};
+
+declare
+    %test:assertError("XPTY0004")
+function hofs:fold-right-function-arity-1 () {
+    fold-right((1 to 3), 0,function ($a) { true() })
+};
+
+declare
+    %test:assertTrue
+function hofs:fold-right-function-arity-2 () {
+    fold-right((1 to 3), 0,function ($r, $n) { true() })
+};
+
+declare
+    %test:assertEquals(1, 2, 3)
+function hofs:declared-function-test () {
+    filter((1 to 3), hofs:declared-function#1)
+};
+
+(: https://github.com/eXist-db/exist/issues/3382 :)
+declare
+    %test:pending
+    %test:assertError("XPTY0004")
+function hofs:function-has-wrong-return-type () {
+    filter((0 to 1), function ($a) { $a })
+};
+
+(: https://github.com/eXist-db/exist/issues/3382 :)
+declare
+    %test:pending
+    %test:assertError("XPTY0004")
+function hofs:return-mixed-types () {
+    filter((true(), false(), 1, ""), function ($a) { $a })
+};
+
+declare
+    %test:assertTrue
+function hofs:return-boolean () {
+    filter((true(), false()), function ($a) { $a })
+};
+
+declare
+    %test:assertEquals(1)
+function hofs:function-correct-return-type () {
+    filter((0 to 1), function ($a) as xs:boolean { xs:boolean($a) })
+};
+
+declare
+    %test:assertEquals(1)
+function hofs:partially-applied-function () {
+    filter((0 to 1), function ($a, $b) as xs:boolean {
+        $a and $b }(?, true()))
+};
+
+declare
+    %test:assertEquals(1)
+function hofs:type-constructor () {
+    filter((0 to 1), xs:boolean(?))
+};


### PR DESCRIPTION
### Description:

Fixes #3358 ArrayOutOfBoundException when a function reference supplied to a higher order
function has the wrong arity. 

This will now throw error XPTY0004.

New method `funcRefHasDifferentArity` added to class `FunHigherOrderFun` for readability and code re-use.

### Reference:

https://www.w3.org/TR/xpath-functions/#func-filter

Error messages are in line with Saxon 10

### Type of tests:

A new XQSuite for higher order functions is added.
Old tests left in place for now.
