### PR TITLE
Improve XQuery test naming

### DIFF
--- a/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
@@ -41,6 +41,7 @@ import org.w3c.dom.NodeList;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -142,9 +143,43 @@ public class XQueryTestRunner extends AbstractTestRunner {
     }
 
     private String getSuiteName() {
-         return info.getNamespace();
-//        final String filename = path.getFileName().toString();
-//        return filename.substring(0, filename.indexOf('.') - 1);
+         return namespaceToPackageName(info.getNamespace());
+    }
+
+    private String namespaceToPackageName(final String namespace) {
+        try {
+            final URI uri = new URI(namespace);
+            final StringBuilder packageName = new StringBuilder();
+            hostNameToPackageName(uri.getHost(), packageName);
+            pathToPackageName(uri.getPath(), packageName);
+            packageName.insert(0, "xqts.");  // add "xqts." prefix
+            return packageName.toString();
+        } catch (final URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void hostNameToPackageName(String host, final StringBuilder buffer) {
+        while (host != null && !host.isEmpty()) {
+            if (buffer.length() > 0) {
+                buffer.append('.');
+            }
+
+            final int idx = host.lastIndexOf('.');
+            if (idx > -1) {
+                buffer.append(host.substring(idx + 1));
+                host = host.substring(0, idx);
+            } else {
+                buffer.append(host);
+                host = null;
+            }
+        }
+    }
+
+    private void pathToPackageName(String path, final StringBuilder buffer) {
+        path = path.replace('.', '_');
+        path = path.replace('/', '.');
+        buffer.append(path);
     }
 
     @Override

--- a/exist-core/src/main/resources/org/exist/xquery/lib/test.xq
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/test.xq
@@ -139,7 +139,8 @@ declare function t:run-test($test as element(test), $count as xs:integer,
       return if (count($ops2[matches(., 'highlight-matches')]))
         then string-join($ops2, ' ')
         else string-join(($ops2, $highlight-option), ' ')
-    let $_notify-start := if(not(empty($test-started-function))) then $test-started-function($test/task) else ()
+    let $test-name := ($test/@id[. ne ""], $test/task)[1]
+    let $_notify-start := if(not(empty($test-started-function))) then $test-started-function($test-name) else ()
     let $queryOutput :=
         try {
             map {
@@ -230,9 +231,9 @@ declare function t:run-test($test as element(test), $count as xs:integer,
                 if (not($OK)) then
                     let $_notify :=
                         if(not(empty($expanded("error")))) then
-                            if(not(empty($test-error-function))) then $test-error-function($test/task, $expanded("error")) else ()
+                            if(not(empty($test-error-function))) then $test-error-function($test-name, $expanded("error")) else ()
                         else
-                            if(not(empty($test-failure-function))) then $test-failure-function($test/task, map { "value": $test/expected/node(), "xpath": $test/xpath/node(), "error": $test/error/node() }, $expanded) else ()
+                            if(not(empty($test-failure-function))) then $test-failure-function($test-name, map { "value": $test/expected/node(), "xpath": $test/xpath/node(), "error": $test/error/node() }, $expanded) else ()
                     return
                         ($test/task, $test/expected, $test/xpath, <result>{$expanded("result"), if(not(empty($expanded("error")))) then $expanded("error")("description") else ()}</result>)
                 else
@@ -240,7 +241,7 @@ declare function t:run-test($test as element(test), $count as xs:integer,
             }
             </test>
             ,
-            let $_notify-finished := if(not(empty($test-finished-function))) then $test-finished-function($test/task) else ()
+            let $_notify-finished := if(not(empty($test-finished-function))) then $test-finished-function($test-name) else ()
             return ()
         )
 };
@@ -300,7 +301,8 @@ declare function t:run-testSet($set as element(TestSet), $id as xs:string?,
                 if($test[empty(@ignore) or @ignore = "no"])then
                     $test
                 else
-                    let $_notify-ignored := if(not(empty($test-ignored-function))) then $test-ignored-function($test/task) else ()
+                    let $test-name := ($test/@id[. ne ""], $test/task)[1]
+                    let $_notify-ignored := if(not(empty($test-ignored-function))) then $test-ignored-function($test-name) else ()
                     return ()
     let $result := util:expand(
            <TestSet>

--- a/extensions/indexes/range/src/test/xquery/range/field-type.xql
+++ b/extensions/indexes/range/src/test/xquery/range/field-type.xql
@@ -1,6 +1,6 @@
 xquery version "3.1";
 
-module namespace rt="combined-range-function-signature-test";
+module namespace rt="http://exist-db.org/xquery/range/combined-range-function-signature/test";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 


### PR DESCRIPTION
Improves the naming of tests expressed in XQuery and XML.

Also:
* XML test suites are now prefixed `xmts`
* XQuery test suites are now prefixed `xqts`