### PR TITLE
Switch to `empty least` as default ordering behaviour in XQuery

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -751,6 +751,7 @@
                                 <exclude>src/test/java/org/exist/xquery/value/SubSequenceRangeTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/value/SubSequenceTest.java</exclude>
                                 <exclude>src/test/xquery/binary-value.xqm</exclude>
+                                <exclude>src/test/xquery/order.xqm</exclude>
 
                                 <!--
                                     Derivative work licensed under dbXML 1.0 and LGPL 2.1
@@ -901,6 +902,7 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/test/java/org/exist/xquery/value/SubSequenceRangeTest.java</include>
                                 <include>src/test/java/org/exist/xquery/value/SubSequenceTest.java</include>
                                 <include>src/test/xquery/binary-value.xqm</include>
+                                <include>src/test/xquery/order.xqm</include>
                             </includes>
 
                         </licenseSet>

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -320,7 +320,7 @@ public class XQueryContext implements BinaryValueManager, Context {
     /**
      * Should empty order greatest or least?
      */
-    private boolean orderEmptyGreatest = true;
+    private boolean orderEmptyGreatest = false;
 
     /**
      * XQuery 3.0 - declare context item :=

--- a/exist-core/src/test/xquery/order.xqm
+++ b/exist-core/src/test/xquery/order.xqm
@@ -1,0 +1,89 @@
+(:
+ : Copyright (C) 2014, Evolved Binary Ltd
+ :
+ : This file was originally ported from FusionDB to eXist-db by
+ : Evolved Binary, for the benefit of the eXist-db Open Source community.
+ : Only the ported code as it appears in this file, at the time that
+ : it was contributed to eXist-db, was re-licensed under The GNU
+ : Lesser General Public License v2.1 only for use in eXist-db.
+ :
+ : This license grant applies only to a snapshot of the code as it
+ : appeared when ported, it does not offer or infer any rights to either
+ : updates of this source code or access to the original source code.
+ :
+ : The GNU Lesser General Public License v2.1 only license follows.
+ :
+ : ---------------------------------------------------------------------
+ :
+ : Copyright (C) 2014, Evolved Binary Ltd
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "1.0";
+
+module namespace ord = "http://exist-db.org/test/order";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare variable $ord:items as element(item)+ := (
+        <item>
+         <ref>e1</ref>
+         <msDesc type="Ll"/>
+        </item>
+        ,
+        <item>
+         <ref>e2</ref>
+         <msDesc type="P"/>
+        </item>
+        ,
+        <item>
+         <ref>e3</ref>
+         <msDesc type="Ll"/>
+        </item>
+        ,
+        <item>
+         <ref>e4</ref>
+         <msDesc/>
+        </item>
+);
+
+declare
+    %test:assertEquals("e2", "e1", "e3", "e4")
+function ord:default-order-for-empty-sequence-is-empty-least() {
+    for $item in $ord:items
+    let $sort-condition as xs:boolean? := $item/msDesc/@type eq 'P'
+    order by $sort-condition descending
+    return
+        $item/ref/string()
+};
+
+declare
+    %test:assertEquals("e2", "e1", "e3", "e4")
+function ord:order-empty-sequence-as-empty-least() {
+    for $item in $ord:items
+    let $sort-condition as xs:boolean? := $item/msDesc/@type eq 'P'
+    order by $sort-condition descending empty least
+    return
+        $item/ref/string()
+};
+
+declare
+    %test:assertEquals("e4", "e2", "e1", "e3")
+function ord:order-empty-sequence-as-empty-greatest() {
+    for $item in $ord:items
+    let $sort-condition as xs:boolean? := $item/msDesc/@type eq 'P'
+    order by $sort-condition descending empty greatest
+    return
+        $item/ref/string()
+};


### PR DESCRIPTION
At the moment eXist-db implements `empty greatest` as the default ordering in XQuery.

The spec says it is `implementation defined`. However, Saxon and BaseX both implement `empty least` as the default. IMHO `empty least` is the most likely *expected* behaviour.

In the interest of improved interoperability for XQuery users. This PR switched eXist-db from `empty greatest` to `empty least` as the default behaviour.

This isn't technically an API change, rather it is an internal behaviour change. Therefore it is a Semver minor change. But... if anyone thinks it should be a major release feature (i.e. 6.0.0), then let's hear your arguments ;-)