### PR TITLE
[ignore] add os and build files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,15 @@
+# builds
+target/
+.settings/
+.factorypath
+.classpath
+.project
+
+# IDE specific files
 .idea/*
 !/.idea/runConfigurations
 *.iml
-target/
+.vscode
+
+# OS specific files
+.DS_Store


### PR DESCRIPTION
- ignore `.DS_Store` (OSX)
- ignore `.settings/`, `.factorypath`, `.classpath` and `.project`
    these are created when building on the command line and
    gobble up `git status` output

- group patterns by type
