### PR TITLE
Reduces JDK pipeline to the LTS and last released versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,27 +14,12 @@ matrix:
       services:
         - docker
 
-    - jdk: openjdk9
-      env:
-        - BUILD_DOCKER=false
-        - MAVEN_OPTS="-Ddependency-check.skip=true"
-
-    - jdk: openjdk10
-      env:
-        - BUILD_DOCKER=false
-        - MAVEN_OPTS="-Ddependency-check.skip=true"
-
     - jdk: openjdk11
       env:
         - BUILD_DOCKER=false
         - MAVEN_OPTS="-Ddependency-check.skip=true"
 
-    - jdk: openjdk12
-      env:
-        - BUILD_DOCKER=false
-        - MAVEN_OPTS="-Ddependency-check.skip=true"
-
-    - jdk: openjdk13
+    - jdk: openjdk14
       env:
         - BUILD_DOCKER=false
         - MAVEN_OPTS="-Ddependency-check.skip=true"


### PR DESCRIPTION
### Description:
Removes the no longer supported JDKs as from _openjdk.java.net_ in order to speed up the build feedback.