### PR TITLE
Small change to util:node-by-id to avoid unexpected NPE

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/util/GetNodeById.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/GetNodeById.java
@@ -55,14 +55,13 @@ public class GetNodeById extends BasicFunction {
 			"Retrieves a node by its internal node-id. The document is specified via the first " +
 			"argument. It may either be a document node or another node from the same document " +
 			"from which the target node will be retrieved by its id. The second argument is " +
-			"the internal node-id, specified as a string. Please note: the function does " +
-			"not check if the passed id does really point to an existing node. It just returns " +
-			"a pointer, which may thus be invalid.",
+			"the internal node-id, specified as a string. If a node with the matching node-id is found, it is returned. " +
+			"Otherwise returns the empty sequence.",
 			new SequenceType[] {
 				new FunctionParameterSequenceType("document", Type.NODE, Cardinality.EXACTLY_ONE, "The document whose node is to be retrieved by its id"),
 				new FunctionParameterSequenceType("node-id", Type.STRING, Cardinality.EXACTLY_ONE, "The internal node id")
 			},
-			new FunctionReturnSequenceType(Type.NODE, Cardinality.EXACTLY_ONE, "the node"));
+			new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_ONE, "the node or an empty sequence if a matching node does not exist"));
 
 	public GetNodeById(XQueryContext context) {
 		super(context, signature);
@@ -81,7 +80,11 @@ public class GetNodeById extends BasicFunction {
             return ((NodeImpl) docNode).getOwnerDocument().getNodeById(nodeId);
         } else {
             final DocumentImpl doc = ((NodeProxy)docNode).getOwnerDocument();
-            return new NodeProxy(doc, nodeId);
+            final NodeProxy proxy = new NodeProxy(doc, nodeId);
+            if (proxy.getNode() == null) {
+            	return Sequence.EMPTY_SEQUENCE;
+			}
+            return proxy;
         }
 	}
 }

--- a/exist-core/src/test/xquery/util/document-id.xqm
+++ b/exist-core/src/test/xquery/util/document-id.xqm
@@ -38,3 +38,14 @@ function docid:by-id() {
     return
     	util:get-resource-by-absolute-id($id)
 };
+
+declare
+    %test:args("1")
+    %test:assertEquals('<doc>/db</doc>')
+    %test:args("1.1")
+    %test:assertEquals('/db')
+    %test:args("1.15")
+    %test:assertEmpty
+function docid:node-by-id($id as xs:string) {
+    util:node-by-id(doc("/db/docid.xml"), $id)
+};


### PR DESCRIPTION
`util:node-by-id` should be changed to always check if the node identified by its nodeId does actually exist within the document or return an empty sequence instead. Not checking may lead to an undesirable and confusing NPE as a follow up. Instead we want to be able to determine that the node was not found.

Fixes the NPE reported here: https://github.com/eXist-db/exist/pull/3363#issuecomment-616183051

### Type of tests:

Test included.