### PR TITLE
Offer further build profiles

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -960,16 +960,11 @@
                         <goals>
                             <goal>single</goal>
                         </goals>
-                        <configuration>
-                            <attach>false</attach>
-                            <tarLongFileMode>gnu</tarLongFileMode>
-                            <descriptors>
-                                <descriptor>src/assembly/dist-assembly-unix.xml</descriptor>
-                                <descriptor>src/assembly/dist-assembly-win.xml</descriptor>
-                            </descriptors>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <skipAssembly>true</skipAssembly>  <!-- Overridden by profile build-dist-archives -->
+                </configuration>
             </plugin>
 
             <plugin>
@@ -1060,6 +1055,30 @@
 
 
     <profiles>
+        <profile>
+            <id>build-dist-archives</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <skipAssembly>false</skipAssembly>  <!-- Override setting in default profile build/plugins for this module -->
+                            <attach>false</attach>
+                            <tarLongFileMode>gnu</tarLongFileMode>
+                            <descriptors>
+                                <descriptor>src/assembly/dist-assembly-unix.xml</descriptor>
+                                <descriptor>src/assembly/dist-assembly-win.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>codesign-mac-app</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,6 @@
         <module>exist-parent</module>
         <module>exist-ant</module>
         <module>exist-core</module>
-        <module>exist-core-jcstress</module>
-        <module>exist-core-jmh</module>
         <module>exist-distribution</module>
         <module>exist-jetty-config</module>
         <module>exist-samples</module>
@@ -59,6 +57,27 @@
                 <module>exist-docker</module>
             </modules>
         </profile>
+
+        <profile>
+            <id>concurrency-stress-tests</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>exist-core-jcstress</module>
+            </modules>
+        </profile>
+
+        <profile>
+            <id>micro-benchmarks</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>exist-core-jmh</module>
+            </modules>
+        </profile>
+
     </profiles>
 
 </project>


### PR DESCRIPTION
@line-o If you don't need the distribution archives, e.g. when testing/hacking locally. Then with this PR, setting `-P !build-dist-archives` can save ~40 seconds on each build (at least on my machine).