### PR TITLE
[feature] support match highlighting on ft:field hits. Closes #3210

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -565,6 +565,23 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         }
     }
 
+    /**
+     * Calls {@link LuceneUtil#extractTerms(Query, Map, IndexReader, boolean)}  to extract
+     * the terms which would be matched by the given query.
+     *
+     * @param query to extract terms for
+     * @return the map returned by {@link LuceneUtil#extractTerms(Query, Map, IndexReader, boolean)}
+     * @throws IOException in case of Lucene IO error
+     */
+    public Map<Object, Query> getTerms(final Query query) throws IOException {
+        final Map<Object, Query> termMap = new TreeMap<>();
+        index.withReader(reader -> {
+            LuceneUtil.extractTerms(query, termMap, reader, false);
+            return termMap;
+        });
+        return termMap;
+    }
+
     public NodeSet queryField(XQueryContext context, int contextId, DocumentSet docs, NodeSet contextSet,
             String field, String queryString, int axis, QueryOptions options)
             throws IOException, XPathException {
@@ -1091,7 +1108,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
      *
      * @return the lucene config or null
      */
-    @Nullable protected LuceneConfig getLuceneConfig(DBBroker broker, DocumentSet docs) {
+    public LuceneConfig getLuceneConfig(DBBroker broker, DocumentSet docs) {
         for (Iterator<Collection> i = docs.getCollectionIterator(); i.hasNext(); ) {
             Collection collection = i.next();
             IndexSpec idxConf = collection.getIndexConfiguration(broker);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatchListener.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatchListener.java
@@ -315,14 +315,14 @@ public class LuceneMatchListener extends AbstractMatchListener {
         }
     }
 
-    private NodePath getPath(final NodeProxy proxy) {
+    public static NodePath getPath(final NodeProxy proxy) {
         final NodePath2 path = new NodePath2();
         final IStoredNode<?> node = (IStoredNode<?>) proxy.getNode();
         walkAncestor(node, path);
         return path;
     }
 
-    private void walkAncestor(final IStoredNode node, final NodePath2 path) {
+    private static void walkAncestor(final IStoredNode node, final NodePath2 path) {
         if (node == null) {
             return;
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -20,13 +20,29 @@
 
 package org.exist.xquery.modules.lucene;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.PhraseQuery;
+import org.apache.lucene.search.Query;
+import org.exist.Namespaces;
 import org.exist.dom.QName;
+import org.exist.dom.memtree.InMemoryNodeSet;
+import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.persistent.Match;
 import org.exist.dom.persistent.NodeProxy;
-import org.exist.indexing.lucene.LuceneIndex;
-import org.exist.indexing.lucene.LuceneMatch;
+import org.exist.indexing.lucene.*;
+import org.exist.storage.NodePath;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Map;
 
 public class Field extends BasicFunction {
 
@@ -61,6 +77,21 @@ public class Field extends BasicFunction {
                     },
                     new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
                             "Sequence corresponding to the values of the field attached, cast to the desired target type")
+            ),
+            new FunctionSignature(
+                    new QName("highlight-field-matches", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+                    "Highlights matches for the last executed lucene query within the value of a field " +
+                    "attached to a particular node obtained via a full text search. Only fields listed in the 'fields' option of ft:query will be " +
+                    "available to highlighting.",
+                    new SequenceType[] {
+                            new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
+                                    "the context node to check for attached fields which should be highlighted"),
+                            new FunctionParameterSequenceType("field", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "name of the field to highlight")
+                    },
+                    new FunctionReturnSequenceType(Type.ELEMENT, Cardinality.ZERO_OR_ONE,
+                            "An exist:field containing the content of the requested field with all query " +
+                                    "matches enclosed in an exist:match")
             )
     };
 
@@ -84,13 +115,134 @@ public class Field extends BasicFunction {
         }
 
         final NodeProxy proxy = (NodeProxy) nodeValue;
+        final LuceneMatch match = getMatch(proxy);
+        if (match == null) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+        final Sequence text = match.getField(fieldName, type);
+        if (isCalledAs("highlight-field-matches")) {
+            try {
+                return highlightMatches(fieldName, proxy, match, text);
+            } catch (IOException e) {
+                throw new XPathException(this, LuceneModule.EXXQDYFT0002, "Error highlighting matches in field: " + e.getMessage());
+            }
+        }
+        return text;
+    }
+
+    /**
+     * Highlight matches in field content using the analyzer defined for the field.
+     *
+     * @param fieldName the name of the field
+     * @param proxy node on which the field is defined
+     * @param match the lucene match attached to the node
+     * @param text the content of the field
+     * @return a sequence of exist:field elements containing the field content with matches enclosed in exist:match
+     * @throws XPathException in case of error
+     * @throws IOException in case of a lucene error
+     */
+    private Sequence highlightMatches(final String fieldName, final NodeProxy proxy, final LuceneMatch match, final Sequence text) throws XPathException, IOException {
+        final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+        final Map<Object, Query> terms = index.getTerms(match.getQuery());
+        final NodePath path = LuceneMatchListener.getPath(proxy);
+        final LuceneConfig config = index.getLuceneConfig(context.getBroker(), proxy.getDocumentSet());
+        LuceneIndexConfig idxConf = config.getConfig(path).next();
+        if (idxConf == null) {
+            // no lucene index: no fields to highlight
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        final Analyzer analyzer = idxConf.getAnalyzer();
+
+        context.pushDocumentContext();
+        try {
+            final MemTreeBuilder builder = context.getDocumentBuilder();
+            builder.startDocument();
+
+            final InMemoryNodeSet result =  new InMemoryNodeSet(text.getItemCount());
+            for (final SequenceIterator si = text.iterate(); si.hasNext(); ) {
+                final int nodeNr = builder.startElement(Namespaces.EXIST_NS, "field", "exist:field", null);
+                final String content = si.nextItem().getStringValue();
+                int currentPos = 0;
+                try (final Reader reader = new StringReader(content);
+                     final TokenStream tokenStream = analyzer.tokenStream(fieldName, reader)) {
+                    tokenStream.reset();
+                    final MarkableTokenFilter stream = new MarkableTokenFilter(tokenStream);
+                    while (stream.incrementToken()) {
+                        String token = stream.getAttribute(CharTermAttribute.class).toString();
+                        final Query query = terms.get(token);
+                        if (query != null) {
+                            if (match.getQuery() instanceof PhraseQuery) {
+                                final Term phraseTerms[] = ((PhraseQuery) match.getQuery()).getTerms();
+                                if (token.equals(phraseTerms[0].text())) {
+                                    // Scan the following text and collect tokens to see
+                                    // if they are part of the phrase.
+                                    stream.mark();
+                                    int t = 1;
+                                    OffsetAttribute offset = stream.getAttribute(OffsetAttribute.class);
+                                    final int startOffset = offset.startOffset();
+                                    int endOffset = offset.endOffset();
+                                    while (stream.incrementToken() && t < phraseTerms.length) {
+                                        token = stream.getAttribute(CharTermAttribute.class).toString();
+                                        if (token.equals(phraseTerms[t].text())) {
+                                            offset = stream.getAttribute(OffsetAttribute.class);
+                                            endOffset = offset.endOffset();
+                                            if (++t == phraseTerms.length) {
+                                                break;
+                                            }
+                                        } else {
+                                            break;
+                                        }
+                                    }
+                                    if (t == phraseTerms.length) {
+                                        if (currentPos < startOffset) {
+                                            builder.characters(content.substring(currentPos, startOffset));
+                                        }
+                                        builder.startElement(Namespaces.EXIST_NS, "match", "exist:match", null);
+                                        builder.characters(content.substring(startOffset, endOffset));
+                                        builder.endElement();
+                                        currentPos = endOffset;
+                                    }
+                                } // End of phrase handling
+                            } else {
+                                final OffsetAttribute offset = stream.getAttribute(OffsetAttribute.class);
+                                if (currentPos < offset.startOffset()) {
+                                    builder.characters(content.substring(currentPos, offset.startOffset()));
+                                }
+                                builder.startElement(Namespaces.EXIST_NS, "match", "exist:match", null);
+                                builder.characters(content.substring(offset.startOffset(), offset.endOffset()));
+                                builder.endElement();
+                                currentPos = offset.endOffset();
+                            }
+                        }
+                    }
+                }
+                if (currentPos < content.length() - 1)  {
+                    builder.characters(content.substring(currentPos));
+                }
+                builder.endElement();
+                result.add(builder.getDocument().getNode(nodeNr));
+            }
+            return result;
+        } finally {
+            context.popDocumentContext();
+        }
+    }
+
+    /**
+     * Get the lucene match object attached to the given node
+     *
+     * @param proxy node to check for matches
+     * @return the LuceneMatch object attached to the node or null
+     */
+    static @Nullable LuceneMatch getMatch(NodeProxy proxy) {
         Match match = proxy.getMatches();
         while (match != null) {
             if (match.getIndexId().equals(LuceneIndex.ID)) {
-                return ((LuceneMatch)match).getField(fieldName, type);
+                return (LuceneMatch) match;
             }
             match = match.getNextMatch();
         }
-        return Sequence.EMPTY_SEQUENCE;
+        return null;
     }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
@@ -68,6 +68,7 @@ public class LuceneModule extends AbstractInternalModule {
         new FunctionDef(Facets.signatures[2], Facets.class),
         new FunctionDef(Field.signatures[0], Field.class),
         new FunctionDef(Field.signatures[1], Field.class),
+        new FunctionDef(Field.signatures[2], Field.class),
         new FunctionDef(LuceneIndexKeys.signatures[0], LuceneIndexKeys.class)
     };
 

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -765,3 +765,22 @@ function facet:avoid-range-index-conflict-city() {
         else
             ()
 };
+
+declare
+    %test:args("abstract:vogel", "abstract")
+    %test:assertEquals("<exist:field xmlns:exist='http://exist.sourceforge.net/NS/exist'>Es zwitschern die <exist:match>Vögel</exist:match> im Walde</exist:field>")
+    %test:args("abstract:(weht AND wind)", "abstract")
+    %test:assertEquals("<exist:field xmlns:exist='http://exist.sourceforge.net/NS/exist'>Über dem Walde <exist:match>weht</exist:match> ein <exist:match>Wind</exist:match></exist:field>")
+    %test:args('abstract:"Walde weht ein Wind"', "abstract")
+    %test:assertEquals("<exist:field xmlns:exist='http://exist.sourceforge.net/NS/exist'>Über dem <exist:match>Walde weht ein Wind</exist:match></exist:field>")
+    %test:args('abstract:"Götter sich streiten"', "abstract")
+    %test:assertEquals("<exist:field xmlns:exist='http://exist.sourceforge.net/NS/exist'>Da nun einmal der Himmel zerrissen und die <exist:match>Götter sich streiten</exist:match></exist:field>")
+    %test:args('title:streiten', "title")
+    %test:assertEquals("<exist:field xmlns:exist='http://exist.sourceforge.net/NS/exist'><exist:match>Streiten</exist:match> und Hoffen</exist:field>")
+    %test:args('title:"Streiten und Hoffen"', "title")
+    %test:assertEquals("<exist:field xmlns:exist='http://exist.sourceforge.net/NS/exist'><exist:match>Streiten und Hoffen</exist:match></exist:field>")
+function facet:query-field-expand-matches($query as xs:string, $field as xs:string) {
+    let $result := doc("/db/lucenetest/documents.xml")//document[ft:query(., $query, map { "fields": $field })]
+    return
+        ft:highlight-field-matches($result, $field)[.//exist:match]
+};


### PR DESCRIPTION
# Description:

Implements match highlighting in query results obtained from lucene fields as proposed by @joewiz in #3210. Because fields are constructed at indexing time, the usual approach for match highlighting with `util:expand` cannot be applied. We also need to make sure that the same analyzer is applied as when the field was constructed. The PR adds one dedicated function.

### Reference:

#3210

### Type of tests:

Test case using German language analyzer included.