### PR TITLE
Revert PR #3455 maven-surefire-plugin-3.0.0-M5

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -601,7 +601,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>3.0.0-M4</version>
                     <configuration>
                         <forkCount>2C</forkCount>
 


### PR DESCRIPTION
There seems to be an issue with Maven Surefire Plugin 3.0.0-M5 when running parallel builds.