### PR TITLE
[bugfix] Fix formatting of am/pm for 12 pm

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/util/NumberFormatter.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/NumberFormatter.java
@@ -64,7 +64,7 @@ public abstract class NumberFormatter {
     public String getAmPm(int hour) {
         final DateFormatSymbols symbols = DateFormatSymbols.getInstance(locale);
         final String[] amPm = symbols.getAmPmStrings();
-        if (hour > 12) {
+        if (hour >= 12) {
             return amPm[1];
         }
         return amPm[0];

--- a/exist-core/src/test/xquery/dates/format-dates.xql
+++ b/exist-core/src/test/xquery/dates/format-dates.xql
@@ -90,6 +90,8 @@ function fd:format-square-brackets($date as xs:date) {
 declare
     %test:args("2012-06-26T23:14:22.566+02:00")
     %test:assertEquals("11:14 pm on Tuesday, June 26th, 2012")
+    %test:args("2020-06-21T12:34:56.566-04:00")
+    %test:assertEquals("12:34 pm on Sunday, June 21st, 2020")
 function fd:format-dateTime($date as xs:dateTime) {
     format-dateTime($date, "[h00]:[m00] [P] on [FNn], [MNn] [D1o], [Y]", "en", (), ())
 };
@@ -510,6 +512,8 @@ declare
     %test:assertEquals("05:45 pm")
     %test:args("09:45:50")
     %test:assertEquals("09:45 am")
+    %test:args("12:45:50")
+    %test:assertEquals("12:45 pm")
 function fd:time-am-pm($time as xs:time) {
     format-time($time, "[h00]:[m00] [P]")
 };


### PR DESCRIPTION
# Description:

When formatting a dateTime or time using the `[P]` specifier in the picture string (for am/pm), times from 12:00-12:59 were rendered with “am” instead of “pm”. 

### Reference:

See https://www.w3.org/TR/xpath-functions-31/#rules-for-datetime-formatting.

### Type of tests:

Updated existing xqsuite tests for `[P]` specifier