### PR TITLE
Catch exception and enrich exception with location information. 

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -19,22 +19,18 @@
  */
 package org.exist.xquery;
 
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.VirtualNodeSet;
 import org.exist.xquery.util.ExpressionDumper;
-import org.exist.xquery.value.Item;
-import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceIterator;
-import org.exist.xquery.value.Type;
-import org.exist.xquery.value.ValueSequence;
+import org.exist.xquery.value.*;
 import org.xmldb.api.base.CompiledExpression;
+
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * PathExpr is just a sequence of XQuery/XPath expressions, which will be called
@@ -281,8 +277,8 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                         result = expr.eval(currentContext);
                     } catch (XPathException ex){
                         // enrich exception when information is available
-                        if(getLine()!=-1 || getColumn()!=-1 ) {
-                            ex.setLocation(getLine(), getColumn());
+                        if (ex.getLine() < 1 || ex.getColumn() < 1) {
+                            ex.setLocation(expr.getLine(), expr.getColumn());
                         }
                         throw ex;
                     }

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -277,7 +277,15 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                     }
                     result = exprResult;
                 } else {
-                    result = expr.eval(currentContext);
+                    try {
+                        result = expr.eval(currentContext);
+                    } catch (XPathException ex){
+                        // enrich exception when information is available
+                        if(getLine()!=-1 || getColumn()!=-1 ) {
+                            ex.setLocation(getLine(), getColumn());
+                        }
+                        throw ex;
+                    }
                 }
                 //TOUNDERSTAND : why did I have to write this test :-) ? -pb
                 //it looks like an empty sequence could be considered as a sub-type of Type.NODE

--- a/exist-core/src/test/xquery/errors.xql
+++ b/exist-core/src/test/xquery/errors.xql
@@ -196,3 +196,122 @@ function et:compile-query-func-decl() {
     return
         util:compile-query($query, "xmldb:exist://")
 };
+
+(: https://github.com/eXist-db/exist/issues/3450 :)
+declare
+    %test:assertEquals(208)
+function et:issue3450a() {
+    try {
+    (:
+    empty
+    :)
+        if (map { "foo": "bar" } eq 1) then "yay" else "boo"
+    } catch * {
+        $err:line-number
+    }
+};
+
+
+(: https://github.com/eXist-db/exist/issues/3450 :)
+declare
+    %test:assertEquals(220)
+function et:issue3450b() {
+    try {
+        if ("a" eq 1) then "yay" else "boo"
+    } catch * {
+        $err:line-number
+    }
+};
+
+(: https://github.com/eXist-db/exist/issues/3462 :)
+declare
+    %test:assertEquals(233)
+function et:issue3462a() {
+    try {
+        map {
+            "foo": ["bar", "baz"]
+        }[?foo eq "bar"]
+    } catch * {
+        $err:line-number
+    }
+};
+
+declare
+    %test:assertEquals(248)
+function et:issue3462b() {
+    try {
+            map {
+                "foo":
+                    map {
+                        "bar": "baz"
+                    }
+            }[?foo eq "bar"]
+    } catch * {
+        $err:line-number
+    }
+};
+
+(: https://github.com/eXist-db/exist/issues/3473 :)
+declare
+    %test:assertEquals(259)
+function et:issue3473a() {
+    try {
+        1 eq "2"
+    } catch * {
+        $err:line-number
+    }
+};
+
+(: https://github.com/eXist-db/exist/issues/3473 :)
+declare
+    %test:assertEquals(270)
+function et:issue3473b() {
+    try {
+        1 = "2"
+    } catch * {
+        $err:line-number
+    }
+};
+
+(: https://github.com/eXist-db/exist/issues/3473 :)
+declare
+    %test:assertEquals(301)
+function et:issue3473c() {
+    try {
+        let $colors :=
+                 map {
+                     "blue": "#2d7ff9",
+                     "cyan": "#18bfff",
+                     "gray": "#666",
+                     "grayDark": "666",
+                     "green": "#20c933",
+                     "greenDark": "20c933",
+                     "orange": "#ff6f2c",
+                     "pink": "#ff08c2",
+                     "pinkDark": "ff08c2",
+                     "purple": "#8b46ff",
+                     "red": "#f82b60",
+                     "redDarker": "f82b60",
+                     "teal": "#20d9d2",
+                     "yellow": "#fcb400",
+                     "yellowDark": "fcb400"
+                 }
+
+             return
+                error()
+    } catch * {
+        $err:line-number
+    }
+};
+
+(: https://github.com/eXist-db/exist/issues/3474 :)
+declare
+    %test:pending("to be addressed in another PR")
+    %test:assertEquals(312)
+function et:issue3474() {
+    try {
+        element foo { map { "x": "y" } }
+    } catch * {
+        $err:line-number
+    }
+};


### PR DESCRIPTION
Closes #3473

An exception occurred during query execution: err:XPTY0004 Type error: cannot compare operands: xs:integer and xs:string [at line 1, column 3]