### PR TITLE
[fix] concatenation dependend on mode

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -2570,6 +2570,7 @@ options {
 	|
 	BRACED_URI_LITERAL { $setType(BRACED_URI_LITERAL); }
 	|
+	{ !inAttributeContent && !inElementContent && !inStringConstructor }?
 	( '|' '|' ) =>
 	CONCAT { $setType(CONCAT); }
 	|

--- a/exist-core/src/test/xquery/xquery3/concat.xql
+++ b/exist-core/src/test/xquery/xquery3/concat.xql
@@ -1,4 +1,4 @@
-xquery version "3.0";
+xquery version "3.1";
 
 module namespace concat="http://exist-db.org/xquery/test/string-concatenation";
 
@@ -39,19 +39,19 @@ function concat:empty-sequence1() {
 declare
     %test:assertTrue
 function concat:empty-sequence2() {
-    (() ||  ()) instance of xs:string
+    (() || ()) instance of xs:string
 };
 
 declare
     %test:assertTrue
 function concat:empty-sequence3() {
-    (() ||  ()) eq ""
+    (() || ()) eq ""
 };
 
 declare
     %test:assertEquals(1)
 function concat:empty-strings() {
-    count("" ||  "")
+    count("" || "")
 };
 
 declare
@@ -63,7 +63,7 @@ function concat:nested() {
 declare
     %test:assertEquals("ungrateful death")
 function concat:multiple() {
-    ('un' ||  () || 'grateful' || ' ' || "death")
+    ('un' || () || 'grateful' || ' ' || "death")
 };
 
 declare
@@ -79,6 +79,13 @@ function concat:precedence2() {
 };
 
 declare
+    %test:assertEquals("1234")
+function concat:precedence3() {
+    if (true()) then ("1234") else (12)
+    || "I belong to someone else"
+};
+
+declare
     %test:assertTrue
 function concat:nodes() {
     $concat:XML/b/c[1] || 2 eq "CC12"
@@ -87,11 +94,66 @@ function concat:nodes() {
 declare
     %test:assertError("FOTY0013")
 function concat:bad-argument() {
-    ("abc" || "abc" ||  fn:concat#3)
+    ("abc" || "abc" || fn:concat#3)
 };
 
-(: declare
+(: test for #1828 :)
+declare
+    %test:assertEquals("||||")
+function concat:mode-safe-element-content() {
+    <a>||</a> || '||'
+};
+
+declare
+    %test:assertEquals("||||")
+function concat:mode-safe-attribute-value() {
+    <a b="||" />/@b || '||'
+};
+
+declare
+    %test:assertEquals("<a>bc</a>")
+function concat:enclosed-in-element-content() {
+    <a>{ "b" || "c" }</a>
+};
+
+declare
+    %test:assertEquals("<a b='12'/>")
+function concat:decimal-in-attribute-value() {
+    <a b="{ 1 || 2 }"/>
+};
+
+declare
+    %test:assertEquals("<a b='cd'/>")
+function concat:variables-in-attribute-value() {
+    let $c := "c"
+    let $d := "d"
+    return <a b="{ $c || $d }"/>
+};
+
+(:~
+ : The two tests below cannot be commented in.
+ : They cause a parsing error and therefore must
+ : stay like this, until the underlying issue has
+ : been fixed
+ :)
+(:
+declare
+    %test:pending
     %test:assertEquals("<a b='ccdd'/>") 
-function concat:attributes1() {
-    <a b="{ 'cc' || 'dd'}"/>
-}; :)
+function concat:sq-strings-in-attribute-value() {
+    <a b="{ 'cc' || 'dd' }"/>
+};
+
+declare
+    %test:pending
+    %test:assertEquals("<a b='ccdd'/>")
+function concat:dq-strings-in-attribute-value() {
+    <a b="{ "cc" || "dd" }"/>
+};
+:)
+
+declare
+    %test:assertEquals("|| ||||")
+function concat:string-constructor() {
+    ``[|| `{ "||" || '||' }`]``
+};

--- a/exist-core/src/test/xquery/xquery3/concat.xql
+++ b/exist-core/src/test/xquery/xquery3/concat.xql
@@ -135,6 +135,7 @@ function concat:variables-in-attribute-value() {
  : They cause a parsing error and therefore must
  : stay like this, until the underlying issue has
  : been fixed
+ : https://github.com/eXist-db/exist/issues/291
  :)
 (:
 declare


### PR DESCRIPTION
## Description:

Modify the XQuery grammar to recognize `||` as concatenation operator
only when outside of attribute or element content and string constructors.

Add and extend the test suite for concatenation operator tests.
Testing for concatenation and literal `||` in different mixed modes.

Fix some minor whitespace issues.

### Reference: 

fixes #1828

### Type of tests:

xqsuite