### PR TITLE
allow function types in context item

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -283,7 +283,8 @@ versionDecl throws XPathException
         { #versionDecl = #(#[VERSION_DECL, v.getText()], enc); }
 	;
 
-setter:
+setter
+:
 	(
 		( "declare" "default" ) =>
 		"declare"! "default"!
@@ -321,12 +322,12 @@ setter:
 	;
 
 preserveMode
-	:
+:
 	( "preserve" | "no-preserve" )
 	;
 
 inheritMode
-	:
+:
 	( "inherit" | "no-inherit" )
 	;
 
@@ -406,7 +407,7 @@ schemaImport throws XPathException
 
 schemaPrefix
 { String prefix = null; }
-	:
+:
 	"namespace"! prefix=ncnameOrKeyword EQ!
 	{ #schemaPrefix = #[NCNAME, prefix]; }
 	|
@@ -416,15 +417,17 @@ schemaPrefix
 annotateDecl! throws XPathException
 :
 	decl:"declare"! ann:annotations!
-	(	("function")=> f:functionDecl[#ann] { #annotateDecl = #f; }
-	| 	("variable")=> v:varDecl[#decl, #ann] { #annotateDecl = #v; }
+	(
+	    ("function") => f:functionDecl[#ann] { #annotateDecl = #f; }
+	    |
+	    ("variable") => v:varDecl[#decl, #ann] { #annotateDecl = #v; }
 	)
-;
+    ;
 
 contextItemDeclUp! throws XPathException
 :
 	decl:"declare"! c:contextItemDecl[#decl] { #contextItemDeclUp = #c; }
-;
+    ;
 
 contextItemDecl [XQueryAST decl] throws XPathException
 :
@@ -442,8 +445,9 @@ contextItemDecl [XQueryAST decl] throws XPathException
 
 
 annotations
-:       (annotation)*
-;
+:
+    (annotation)*
+    ;
 
 annotation
 {
@@ -452,14 +456,13 @@ annotation
 :
 	MOD! name=eqName! (LPAREN! literal (COMMA! literal)* RPAREN!)?
         { #annotation= #(#[ANNOT_DECL, name], #annotation); }
-;
+    ;
 
 eqName returns [String name]
-{
-	name= null;
-}
-:	( name=qName | name=uriQualifiedName )
-;
+{ name= null; }
+:
+    ( name=qName | name=uriQualifiedName )
+    ;
 
 uriQualifiedName returns [String name]
 {
@@ -470,7 +473,7 @@ uriQualifiedName returns [String name]
     ( uri=bracedUriLiteral name=ncnameOrKeyword )
     // convert to Clark notation
     { name = "{" + uri + "}" + name; }
-;
+    ;
 
 bracedUriLiteral returns [String uri]
 {
@@ -479,12 +482,12 @@ bracedUriLiteral returns [String uri]
 :
     lit:BRACED_URI_LITERAL
     { uri = lit.getText(); }
-;
+    ;
 
 functionDeclUp! throws XPathException
 :
 	"declare"! f:functionDecl[null] { #functionDeclUp = #f; }
-;
+    ;
 
 functionDecl [XQueryAST ann] throws XPathException
 { String name= null; }
@@ -546,8 +549,10 @@ uri throws XPathException
 	STRING_LITERAL
 	;
 
-typeDeclaration throws XPathException:
-	"as"^ sequenceType ;
+typeDeclaration throws XPathException
+:
+	"as"^ sequenceType
+	;
 
 // === Types ===
 
@@ -560,7 +565,7 @@ sequenceType throws XPathException
 
 occurrenceIndicator
 :
-        ( QUESTION | STAR | PLUS )
+    ( QUESTION | STAR | PLUS )
 	;
 
 itemType throws XPathException
@@ -674,12 +679,12 @@ queryBody throws XPathException: expr ;
 expr throws XPathException
 { boolean isSequence = false; }
 :
-  exprSingle ( COMMA! exprSingle { isSequence = true; })*
-  {
-    if (isSequence)
-      #expr = #(#[SEQUENCE, "sequence"], #expr);
-  }
-	;
+    exprSingle ( COMMA! exprSingle { isSequence = true; })*
+    {
+        if (isSequence)
+          #expr = #(#[SEQUENCE, "sequence"], #expr);
+    }
+    ;
 
 exprSingle throws XPathException
 :
@@ -762,19 +767,22 @@ catchVars throws XPathException
 
 catchErrorCode
 { String varName; }
-:	DOLLAR! varName=qName
+:
+    DOLLAR! varName=qName
 	{ #catchErrorCode= #[CATCH_ERROR_CODE, varName]; }
 	;
 
 catchErrorDesc
 { String varName; }
-:	DOLLAR! varName=qName
+:
+    DOLLAR! varName=qName
 	{ #catchErrorDesc= #[CATCH_ERROR_DESC, varName]; }
 	;
 
 catchErrorVal
 { String varName; }
-:	DOLLAR! varName=qName
+:
+    DOLLAR! varName=qName
 	{ #catchErrorVal= #[CATCH_ERROR_VAL, varName]; }
 	;
 
@@ -876,8 +884,8 @@ groupingSpecList throws XPathException
     ;
 
 groupingSpec throws XPathException
-	{ String groupKeyVarName; }
-	:
+{ String groupKeyVarName; }
+:
 	DOLLAR! groupKeyVarName=varName! ( COLON! EQ! exprSingle )? ( "collation" STRING_LITERAL )?
     { #groupingSpec = #(#[VARIABLE_BINDING, groupKeyVarName], #groupingSpec); }
     ;
@@ -890,13 +898,15 @@ groupingSpec throws XPathException
     ;
 */
 
-quantifiedExpr throws XPathException:
+quantifiedExpr throws XPathException
+:
 	( "some"^ | "every"^ ) quantifiedInVarBinding ( COMMA! quantifiedInVarBinding )*
 	"satisfies"! exprSingle
 	;
 
 quantifiedInVarBinding throws XPathException
-{ String varName; }:
+{ String varName; }
+:
 	DOLLAR! varName=varName! ( typeDeclaration )? "in"! exprSingle
 	{ #quantifiedInVarBinding = #(#[VARIABLE_BINDING, varName], #quantifiedInVarBinding); }
 	;
@@ -917,14 +927,16 @@ switchCaseClause throws XPathException
 	;
 
 typeswitchExpr throws XPathException
-{ String varName; }:
+{ String varName; }
+:
 	"typeswitch"^ LPAREN! expr RPAREN!
 	( caseClause )+
 	"default" ( defaultVar )? "return"! exprSingle
 	;
 
 caseClause throws XPathException
-{ String varName; }:
+{ String varName; }
+:
 	"case"^ ( caseVar )?
 	sequenceTypeUnion caseReturn
 	;
@@ -940,23 +952,26 @@ caseReturn throws XPathException
     ;
 
 caseVar throws XPathException
-{ String varName; }:
+{ String varName; }
+:
 	DOLLAR! varName=varName! "as"
 	{ #caseVar = #[VARIABLE_BINDING, varName]; }
 	;
 
 defaultVar throws XPathException
-{ String varName; }:
+{ String varName; }
+:
 	DOLLAR! varName=varName!
 	{ #defaultVar = #[VARIABLE_BINDING, varName]; }
 	;
 
-ifExpr throws XPathException:
-        "if"^ LPAREN! expr RPAREN! t:"then"! thenExpr:exprSingle e:"else"! elseExpr:exprSingle
-        {
-            #thenExpr.copyLexInfo(#t);
-            #elseExpr.copyLexInfo(#e);
-        }
+ifExpr throws XPathException
+:
+    "if"^ LPAREN! expr RPAREN! t:"then"! thenExpr:exprSingle e:"else"! elseExpr:exprSingle
+    {
+        #thenExpr.copyLexInfo(#t);
+        #elseExpr.copyLexInfo(#e);
+    }
     ;
 
 // === Logical ===
@@ -1063,11 +1078,11 @@ pragma throws XPathException
         lexer.wsExplicit = false;
 		#pragma = #(#[PRAGMA, name], #pragma);
 	}
-exception catch [RecognitionException e]
-        {
-            lexer.wsExplicit = false;
-            throw new XPathException(ErrorCodes.XPST0003, "Parse error: " + e.getMessage() + " at line: " + e.getLine() + " column: " + e.getColumn());
-        }
+    exception catch [RecognitionException e]
+    {
+        lexer.wsExplicit = false;
+        throw new XPathException(ErrorCodes.XPST0003, "Parse error: " + e.getMessage() + " at line: " + e.getLine() + " column: " + e.getColumn());
+    }
 	;
 
 unionExpr throws XPathException
@@ -1216,7 +1231,8 @@ wildcard
 	}
 	;
 
-postfixExpr throws XPathException:
+postfixExpr throws XPathException
+:
 	primaryExpr (
 		(LPPAREN) => predicate
 		|
@@ -1226,12 +1242,14 @@ postfixExpr throws XPathException:
 	)*
 	;
 
-arrowExpr throws XPathException:
+arrowExpr throws XPathException
+:
     unaryExpr ( ARROW_OP^ arrowFunctionSpecifier argumentList )*
     ;
 
 arrowFunctionSpecifier throws XPathException
-{ String name= null; }:
+{ String name= null; }
+:
     name=n:eqName
     {
         #arrowFunctionSpecifier= #[EQNAME, name];
@@ -1244,8 +1262,10 @@ arrowFunctionSpecifier throws XPathException
     ;
 
 lookup throws XPathException
-{ String name= null; }:
-    q:QUESTION! (
+{ String name= null; }
+:
+    q:QUESTION!
+    (
         name=ncnameOrKeyword
         {
         	#lookup = #(#[LOOKUP, name]);
@@ -1272,7 +1292,8 @@ lookup throws XPathException
     )
     ;
 
-dynamicFunCall throws XPathException:
+dynamicFunCall throws XPathException
+:
 	args:argumentList
 	{
 		#dynamicFunCall = #(#[DYNAMIC_FCALL, "DynamicFunction"], #args);
@@ -1283,11 +1304,22 @@ dynamicFunCall throws XPathException:
 primaryExpr throws XPathException
 { String varName= null; }
 :
-	( ( "element" | "attribute" | "text" | "document" | "processing-instruction" |
-	"comment" | "namespace" ) LCURLY ) =>
-	computedConstructor
+	(
+	    (
+	        "element" | "attribute" | "text" | "document" |
+	        "processing-instruction" | "comment" | "namespace"
+	    )
+	    LCURLY
+	)
+	=> computedConstructor
 	|
-	( ( "element" | "attribute" | "processing-instruction" | "namespace" ) qName LCURLY ) => computedConstructor
+	(
+	    (
+	        "element" | "attribute" | "processing-instruction" | "namespace"
+        )
+        qName LCURLY
+    )
+	=> computedConstructor
 	|
 	( "ordered" LCURLY ) => orderedExpr
 	|
@@ -1301,7 +1333,7 @@ primaryExpr throws XPathException
 	|
 	( MOD | "function" LPAREN | eqName HASH ) => functionItemExpr
 	|
-	(eqName LPAREN ) => functionCall
+	( eqName LPAREN ) => functionCall
 	|
 	( QUESTION ) => lookup
 	|
@@ -1317,7 +1349,7 @@ primaryExpr throws XPathException
 	;
 
 stringConstructor throws XPathException
-	:
+:
 	STRING_CONSTRUCTOR_START^
 	{ lexer.inStringConstructor = true; }
 	stringConstructorContent
@@ -1326,12 +1358,12 @@ stringConstructor throws XPathException
 	;
 
 stringConstructorContent throws XPathException
-	:
+:
 	( STRING_CONSTRUCTOR_CONTENT | stringConstructorInterpolation )*
 	;
 
 stringConstructorInterpolation throws XPathException
-	:
+:
 	STRING_CONSTRUCTOR_INTERPOLATION_START^
 	{ lexer.inStringConstructor = false; }
 	( expr )?
@@ -1340,7 +1372,7 @@ stringConstructorInterpolation throws XPathException
 	;
 
 mapConstructor throws XPathException
-    :
+:
     a:"map"! LCURLY! ( mapAssignment ( COMMA! mapAssignment )* )? RCURLY!
     {
         #mapConstructor = #(#[MAP, "map"], #mapConstructor);
@@ -1349,7 +1381,7 @@ mapConstructor throws XPathException
     ;
 
 mapAssignment throws XPathException
-	:
+:
     (exprSingle COLON! EQ!) => exprSingle COLON^ eq:EQ^ exprSingle
     {
         throw new XPathException(#eq.getLine(), #eq.getColumn(), ErrorCodes.XPST0003,
@@ -1360,7 +1392,7 @@ mapAssignment throws XPathException
 	;
 
 arrayConstructor throws XPathException
-    :
+:
     lp:LPPAREN! (exprSingle ( COMMA! exprSingle )* )? RPPAREN!
     {
         #arrayConstructor = #(#[ARRAY, "["], #arrayConstructor);
@@ -1375,12 +1407,12 @@ arrayConstructor throws XPathException
     ;
 
 orderedExpr throws XPathException
-	:
+:
 	"ordered"! LCURLY! expr RCURLY!
 	;
 
 unorderedExpr throws XPathException
-	:
+:
 	"unordered"! LCURLY! expr RCURLY!
 	;
 
@@ -1419,9 +1451,7 @@ functionItemExpr throws XPathException
 	;
 
 namedFunctionRef throws XPathException
-{
-	String name = null;
-}
+{ String name = null; }
 :
 	name=eqName! h:HASH! INTEGER_LITERAL
 	{
@@ -1474,43 +1504,65 @@ argument throws XPathException
 	argumentPlaceholder | exprSingle
 	;
 
-argumentPlaceholder throws XPathException
-:
-	QUESTION
-	;
+argumentPlaceholder throws XPathException : QUESTION ;
 
-contextItemExpr : SELF^ ;
+contextItemExpr : SELF ;
 
 kindTest
 :
-	textTest | anyKindTest | elementTest | attributeTest | commentTest | namespaceNodeTest | piTest | documentTest
+	textTest | anyKindTest | elementTest | attributeTest |
+	commentTest | namespaceNodeTest | piTest | documentTest
 	;
 
-textTest : "text"^ LPAREN! RPAREN! ;
+textTest
+:
+    "text"^ LPAREN! RPAREN!
+    ;
 
-anyKindTest : "node"^ LPAREN! RPAREN! ;
+anyKindTest
+:
+    "node"^ LPAREN! RPAREN!
+    ;
 
-elementTest : "element"^ LPAREN! ( elementNameOrWildcard ( COMMA! typeName ( QUESTION )? )?  )? RPAREN! ;
+elementTest
+:
+    "element"^ LPAREN!
+    (
+        elementNameOrWildcard
+        ( COMMA! typeName ( QUESTION )? )?
+    )?
+    RPAREN!
+    ;
 
 typeName
-{ String eq = null; }:
+{ String eq = null; }
+:
 	eq=eqName
 	{ #typeName = #[EQNAME, eq]; }
 	;
 
 elementNameOrWildcard
-{ String eq = null; }:
+{ String eq = null; }
+:
 	STAR { #elementNameOrWildcard = #[WILDCARD, "*"]; }
 	|
 	eq=eqName { #elementNameOrWildcard = #[EQNAME, eq]; }
 	;
 
-attributeTest : "attribute"! LPAREN! ( attributeNameOrWildcard ( COMMA! typeName ( QUESTION )? )? ) ? RPAREN!
+attributeTest
+:
+    "attribute"! LPAREN!
+    (
+        attributeNameOrWildcard
+        ( COMMA! typeName ( QUESTION )? )?
+    )?
+    RPAREN!
 	{ #attributeTest= #(#[ATTRIBUTE_TEST, "attribute()"], #attributeTest); }
 	;
 
 attributeNameOrWildcard
-{ String eq = null; }:
+{ String eq = null; }
+:
 	STAR { #attributeNameOrWildcard = #[WILDCARD, "*"]; }
 	|
 	eq=eqName { #attributeNameOrWildcard = #[EQNAME, eq]; }
@@ -1520,9 +1572,19 @@ commentTest : "comment"^ LPAREN! RPAREN! ;
 
 namespaceNodeTest : "namespace-node"^ LPAREN! RPAREN! ;
 
-piTest : "processing-instruction"^ LPAREN! ( NCNAME | STRING_LITERAL )? RPAREN! ;
+piTest
+:
+    "processing-instruction"^ LPAREN!
+    ( NCNAME | STRING_LITERAL )?
+    RPAREN!
+    ;
 
-documentTest : "document-node"^ LPAREN! ( elementTest | schemaElementTest )? RPAREN! ;
+documentTest
+:
+    "document-node"^ LPAREN!
+    ( elementTest | schemaElementTest )?
+    RPAREN!
+    ;
 
 schemaElementTest : "schema-element"^ LPAREN! eqName RPAREN! ;
 
@@ -1532,9 +1594,7 @@ qName returns [String name]
 	String name2;
 }
 :
-	n:QNAME {
-	    name = n.getText();
-    }
+	n:QNAME { name = n.getText(); }
     |
     name=ncnameOrKeyword
 	;
@@ -1566,9 +1626,7 @@ computedConstructor throws XPathException
 	;
 
 compElemConstructor throws XPathException
-{
-	String eq;
-}
+{ String eq; }
 :
 	( "element" LCURLY ) =>
 	"element"! LCURLY! expr RCURLY! LCURLY! (expr)? RCURLY!
@@ -1579,9 +1637,7 @@ compElemConstructor throws XPathException
 	;
 
 compAttrConstructor throws XPathException
-{
-	String eq;
-}
+{ String eq; }
 :
 	( "attribute" LCURLY ) =>
 	"attribute"! LCURLY! e1:expr RCURLY! e2:compConstructorValue
@@ -1592,8 +1648,8 @@ compAttrConstructor throws XPathException
 	;
 
 compConstructorValue throws XPathException
-    :
-        LCURLY^ ( e2:expr )?  RCURLY!
+:
+    LCURLY^ ( e2:expr )?  RCURLY!
     ;
 
 compTextConstructor throws XPathException
@@ -1609,9 +1665,7 @@ compDocumentConstructor throws XPathException
 	;
 
 compXmlPI throws XPathException
-{
-	String qn;
-}
+{ String qn; }
 :
 	( "processing-instruction" LCURLY ) =>
 	"processing-instruction"! LCURLY! e1:expr RCURLY! e2:compConstructorValue
@@ -1628,9 +1682,7 @@ compXmlComment throws XPathException
 	;
 
 compNamespaceConstructor throws XPathException
-{
-	String qn;
-}
+{ String qn; }
 :
 	( "namespace" LCURLY ) =>
 	"namespace"! LCURLY! expr RCURLY! LCURLY! (expr)? RCURLY!
@@ -1641,12 +1693,10 @@ compNamespaceConstructor throws XPathException
 	;
 
 elementConstructor throws XPathException
-{
-	String name= null;
-    //lexer.wsExplicit = true;
-}
+{ String name= null; }
 :
-	( LT qName ~( GT | SLASH ) ) => elementWithAttributes | elementWithoutAttributes
+	( LT qName ~( GT | SLASH ) )
+	=> elementWithAttributes | elementWithoutAttributes
 	;
 
 elementWithoutAttributes throws XPathException
@@ -1686,18 +1736,18 @@ elementWithoutAttributes throws XPathException
 		)
 	)
     { #elementWithoutAttributes.copyLexInfo(#q); }
-     exception catch [RecognitionException e]
-        {
-        	if (e.getMessage().contains("expecting XML end tag") || e.getMessage().contains("<")) {
-            	lexer.wsExplicit = false;
-            	throw new XPathException(#q, ErrorCodes.XPST0003, "No closing end tag found for element constructor: " + name);
-            } else if (e.getMessage().contains("unexpected token")) {
-	        	throw new XPathException(e.getLine(), e.getColumn(), ErrorCodes.XPST0003, e.getMessage() +
-	        		" (while expecting closing tag for element constructor: " + name + ")");
-            } else {
-            	throw e;
-            }
+    exception catch [RecognitionException e]
+    {
+        if (e.getMessage().contains("expecting XML end tag") || e.getMessage().contains("<")) {
+            lexer.wsExplicit = false;
+            throw new XPathException(#q, ErrorCodes.XPST0003, "No closing end tag found for element constructor: " + name);
+        } else if (e.getMessage().contains("unexpected token")) {
+            throw new XPathException(e.getLine(), e.getColumn(), ErrorCodes.XPST0003, e.getMessage() +
+                " (while expecting closing tag for element constructor: " + name + ")");
+        } else {
+            throw e;
         }
+    }
 	;
 
 // === XML ===
@@ -1738,17 +1788,20 @@ elementWithAttributes throws XPathException
 	)
     { #elementWithAttributes.copyLexInfo(#q); }
     exception catch [RecognitionException e]
-        {
-        	if (e.getMessage().contains("expecting XML end tag") || e.getMessage().contains("<")) {
-	            lexer.wsExplicit = false;
-	            throw new XPathException(#q, ErrorCodes.XPST0003, "Static error: no closing end tag found for element constructor: " + name);
-	        } else if (e.getMessage().contains("unexpected token")) {
-	        	throw new XPathException(e.getLine(), e.getColumn(), ErrorCodes.XPST0003, e.getMessage() +
-	        		" (while expecting closing tag for element constructor: " + name + ")");
-	        } else {
-	        	throw e;
-	        }
+    {
+        if (
+            e.getMessage().contains("expecting XML end tag") ||
+            e.getMessage().contains("<")
+        ) {
+            lexer.wsExplicit = false;
+            throw new XPathException(#q, ErrorCodes.XPST0003, "Static error: no closing end tag found for element constructor: " + name);
+        } else if (e.getMessage().contains("unexpected token")) {
+            throw new XPathException(e.getLine(), e.getColumn(), ErrorCodes.XPST0003, e.getMessage() +
+                " (while expecting closing tag for element constructor: " + name + ")");
+        } else {
+            throw e;
         }
+    }
 	;
 
 attributeList throws XPathException
@@ -1905,9 +1958,7 @@ attributeEnclosedExpr throws XPathException
 ncnameOrKeyword returns [String name]
 { name= null; }
 :
-	n1:NCNAME {
-	    name= n1.getText();
-    }
+	n1:NCNAME { name= n1.getText(); }
 	|
 	name=reservedKeywords
 	;
@@ -2241,7 +2292,7 @@ options {
 }
 :
     NAME_START_CHAR ( NAME_CHAR)* COLON NAME_START_CHAR ( NAME_CHAR)*
-;
+    ;
 
 protected WS
 :
@@ -2275,8 +2326,10 @@ options {
 	"(:" ( options { greedy=false; }: ( EXPR_COMMENT | . ) )* ":)"
 	;
 
-protected INTEGER_LITERAL :
-	{ !(inElementContent || inAttributeContent) }? DIGITS ;
+protected INTEGER_LITERAL
+:
+	{ !(inElementContent || inAttributeContent) }? DIGITS
+	;
 
 protected DOUBLE_LITERAL
 :
@@ -2342,7 +2395,7 @@ options {
 }
 :
     'Q'! LCURLY! ( PREDEFINED_ENTITY_REF | CHAR_REF |  ~( '&' | '{' | '}' ) )* RCURLY!
-;
+    ;
 
 protected QUOT_ATTRIBUTE_CONTENT
 options {
@@ -2415,22 +2468,27 @@ options {
 	XML_CDATA_END!
 	;
 
-protected S: ( options { greedy=true; }: ( ' ' | '\n' | '\r' | '\t' ) )+
+protected S
+:
+    ( options { greedy=true; }: ( ' ' | '\n' | '\r' | '\t' ) )+
 	;
 
-protected PRAGMA_START :
+protected PRAGMA_START
+:
 	"(#" ( WS )?
-	{ inPragma = true; };
+	{ inPragma = true; }
+	;
 
 protected PRAGMA_END
 options {
 	paraphrase="pragma expression";
 	testLiterals=false;
-}:
-		(
-			WS!
-			( options { greedy=false; }: . )*
-		)?
+}
+:
+    (
+        WS!
+        ( options { greedy=false; }: . )*
+    )?
 	"#)"!
 	;
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2091,6 +2091,14 @@ throws PermissionDeniedException, EXistException, XPathException
 	step=postfixExpr [step]
 	{ path.add(step); }
 	|
+    s:SELF
+	{
+	    step= new ContextItemExpression(context);
+        step.setASTNode(s);
+    }
+    step=postfixExpr [step]
+    { path.add(step); }
+	|
 	#(
 		PARENTHESIZED
 		{ PathExpr pathExpr= new PathExpr(context); }
@@ -2560,7 +2568,7 @@ throws PermissionDeniedException, EXistException, XPathException
 	|
 	SELF
 	{
-		step= new LocationStep(context, Constants.SELF_AXIS, new TypeTest(Type.NODE));
+		step = new ContextItemExpression(context);
 		path.add(step);
 	}
 	( predicate [(LocationStep) step] )*

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2074,18 +2074,15 @@ throws PermissionDeniedException, EXistException, XPathException
 primaryExpr [PathExpr path]
 returns [Expression step]
 throws PermissionDeniedException, EXistException, XPathException
-{
-	step = null;
-}:
+{ step = null; }
+:
 	step=constructor [path]
 	step=postfixExpr [step]
-	{
-		path.add(step);
-	}
+	{ path.add(step); }
 	|
 	step=mapConstr [path]
-  step=postfixExpr [step]
-  { path.add(step); }
+    step=postfixExpr [step]
+    { path.add(step); }
 	|
 	step=arrayConstr [path]
 	step=postfixExpr [step]

--- a/exist-core/src/main/java/org/exist/xquery/ContextItemExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/ContextItemExpression.java
@@ -1,0 +1,80 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.Type;
+import static org.exist.xquery.ErrorCodes.XPDY0002;
+
+public class ContextItemExpression extends LocationStep {
+
+    private int returnType = Type.ITEM;
+
+    public ContextItemExpression(final XQueryContext context) {
+        // TODO: create class AnyItemTest (one private implementation found in saxon)
+        super(context, Constants.SELF_AXIS, new AnyNodeTest());
+    }
+
+    @Override
+    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+        contextInfo.addFlag(DOT_TEST);
+        // set return type to static type to allow for index use in optimization step
+        returnType = contextInfo.getStaticType();
+
+        super.analyze(contextInfo);
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        if (contextSequence == null && contextItem == null) {
+            throw new XPathException(this, XPDY0002, "Nothing to select");
+        }
+
+        // function types in context item are returned unchanged
+        if (contextItem != null &&
+                Type.subTypeOf(contextItem.getType(), Type.FUNCTION_REFERENCE)) {
+            return contextItem.toSequence();
+        }
+
+        // function types in context sequence are returned unchanged
+        if (contextSequence != null &&
+                Type.subTypeOf(contextSequence.getItemType(), Type.FUNCTION_REFERENCE)) {
+            return contextSequence;
+        }
+
+        // handle everything else in super class
+        return super.eval(contextSequence, contextItem);
+    }
+
+    @Override
+    public int returnsType() {
+        return returnType;
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display(".");
+    }
+
+}

--- a/exist-core/src/main/java/org/exist/xquery/ValueComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/ValueComparison.java
@@ -77,7 +77,7 @@ public class ValueComparison extends GeneralComparison {
             final Collator collator = getCollator(contextSequence);
 			return BooleanValue.valueOf(compareAtomic(collator, lv, rv, StringTruncationOperator.NONE, relation));
 		} 
-        throw new XPathException(this, "Type error: sequence with more than one item is not allowed here");
+        throw new XPathException(this, ErrorCodes.XPTY0004, "Type error: sequence with more than one item is not allowed here");
 	}
 
 	protected Sequence nodeSetCompare(NodeSet nodes, Sequence contextSequence) throws XPathException {		
@@ -89,14 +89,14 @@ public class ValueComparison extends GeneralComparison {
             for (final NodeProxy current : nodes) {
                 ContextItem context = current.getContext();
                 if (context == null) {
-                    throw new XPathException(this, "Context is missing for node set comparison");
+                    throw new XPathException(this, ErrorCodes.XPDY0002, "Context is missing for node set comparison");
                 }
                 do {
                     final AtomicValue lv = current.atomize();
                     final Sequence rs = getRight().eval(context.getNode().toSequence());
                     if (!rs.hasOne()) {
-                        throw new XPathException(this,
-                                "Type error: sequence with less or more than one item is not allowed here");
+                        throw new XPathException(this, ErrorCodes.XPTY0004,
+								"Type error: sequence with less or more than one item is not allowed here");
                     }
                     if (compareAtomic(collator, lv, rs.itemAt(0).atomize(), StringTruncationOperator.NONE, relation)) {
                         result.add(current);
@@ -106,8 +106,8 @@ public class ValueComparison extends GeneralComparison {
         } else {
             final Sequence rs = getRight().eval(null);
             if (!rs.hasOne())
-                {throw new XPathException(this,
-                        "Type error: sequence with less or more than one item is not allowed here");}
+                {throw new XPathException(this, ErrorCodes.XPTY0004,
+						"Type error: sequence with less or more than one item is not allowed here");}
             final AtomicValue rv = rs.itemAt(0).atomize();
             for (final NodeProxy current : nodes) {
                 final AtomicValue lv = current.atomize();

--- a/exist-core/src/test/xquery/xquery3/bang.xql
+++ b/exist-core/src/test/xquery/xquery3/bang.xql
@@ -19,7 +19,7 @@
  : License along with this library; if not, write to the Free Software
  : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  :)
-xquery version "3.0";
+xquery version "3.1";
 
 module namespace bang="http://exist-db.org/xquery/test/bang";
 
@@ -202,3 +202,90 @@ declare
 function bang:element-left-number-attribute-right() {
     <emp id='1'/> ! number(@id)
 };
+
+declare
+    %test:assertEquals(1,2,3)
+function bang:map-get () {
+    (map {'a':1}, map {'a':2}, map {'a':3}) ! map:get(., 'a')
+};
+
+declare
+    %test:assertEquals(1,2,3)
+function bang:array-get () {
+    ([1], [2], [3]) ! array:get(., 1)
+};
+
+declare
+     %test:assertEquals(1,2,3)
+function bang:map-lookup-context-item () {
+    (map {'a':1}, map {'a':2}, map {'a':3}) ! .?a
+};
+
+declare
+     %test:assertEquals(1,2,3)
+function bang:map-lookup-parenthesized () {
+    (map {'a':1}, map {'a':2}, map {'a':3}) ! (.?a)
+};
+
+declare
+     %test:assertEquals(1,2,3)
+function bang:map-lookup-parenthesized-context-item () {
+    (map {'a':1}, map {'a':2}, map {'a':3}) ! (.)?a
+};
+
+declare
+    %test:assertEquals(1,2,3)
+function bang:array-lookup-standard () {
+    ([1], [2], [3]) ! .?1
+};
+
+declare
+    %test:assertEquals(1,2,3)
+function bang:array-lookup-parenthesized () {
+    ([1], [2], [3]) ! (.?1)
+};
+
+declare
+    %test:assertEquals(1,2,3)
+function bang:array-lookup-parenthesized-context-item () {
+    ([1], [2], [3]) ! (.)?1
+};
+
+declare
+    %test:assertEquals(1,1,1,1,1)
+function bang:mixed-function-types-call () {
+    let $id := function ($a) { $a }
+    return (function ($a) {1}, $id, sum#1, [1], map{1:1}) ! .(1)
+};
+
+declare
+    %test:assertEquals(1,1,1,1,1)
+function bang:mixed-function-types-call-parenthesized () {
+    let $id := function ($a) { $a }
+    return (function ($a) {1}, $id, sum#1, [1], map{1:1}) ! (.(1))
+};
+
+declare
+    %test:assertEquals(1,1,1,1,1)
+function bang:mixed-function-types-call-parenthesized-context-item () {
+    let $id := function ($a) { $a }
+    return (function ($a) {1}, $id, sum#1, [1], map{1:1}) ! (.)(1)
+};
+
+(:~
+ : parse error needs to be fixed first
+ : https://github.com/eXist-db/exist/issues/1655
+
+declare
+    %test:assertEquals(1,2,3)
+function bang:array-lookup-implicit-context () {
+    ([1], [2], [3]) ! ?1
+};
+
+declare
+    %test:assertEquals(1,2,3)
+function bang:map-lookup-implicit-context () {
+    (map {'a':1}, map {'a':2}, map {'a':3}) ! ?a
+};
+
+ :)

--- a/exist-core/src/test/xquery/xquery3/filter-function-items-in-context.xql
+++ b/exist-core/src/test/xquery/xquery3/filter-function-items-in-context.xql
@@ -1,0 +1,109 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : tests focussing on filtering function items in context
+ :)
+module namespace filter-function-items-in-context="http://exist-db.org/xquery/test/filter-function-items-in-context";
+
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+
+declare variable $filter-function-items-in-context:maps := ( map { "id": 1 }, map { "id": 2, "foo": 3 } );
+declare variable $filter-function-items-in-context:arrays := ( [1, 2], ["a", "b", "c"] );
+
+declare
+    %test:assertEquals(1)
+function filter-function-items-in-context:map-function() {
+    $filter-function-items-in-context:maps[map:size(.) eq 1]?id
+};
+
+declare
+    %test:assertEquals(2)
+function filter-function-items-in-context:map-get() {
+    $filter-function-items-in-context:maps[map:get(., "id") eq 2]?id
+};
+
+declare
+    %test:assertEquals(2)
+function filter-function-items-in-context:map-key() {
+    $filter-function-items-in-context:maps[(.)("id") eq 2]?id
+};
+
+declare
+    %test:assertEquals(2)
+function filter-function-items-in-context:map-lookup() {
+    $filter-function-items-in-context:maps[(.)?id eq 2]?id
+};
+
+declare
+    %test:assertEquals("a", "b", "c")
+function filter-function-items-in-context:array-get() {
+    $filter-function-items-in-context:arrays[array:get(.,2) instance of xs:string]?*
+};
+
+declare
+    %test:assertEquals("a", "b", "c")
+function filter-function-items-in-context:array-lookup() {
+    $filter-function-items-in-context:arrays[(.)?2 instance of xs:string]?*
+};
+
+declare
+    %test:assertEquals(1)
+function filter-function-items-in-context:array-function() {
+    $filter-function-items-in-context:arrays[array:size(.) eq 2]?1
+};
+
+declare
+    %test:assertEquals(1)
+function filter-function-items-in-context:named-function-arity () {
+    (
+        current-date#0,
+        string-join#1
+    )
+    [function-arity(.) eq 1] => count()
+};
+
+declare
+    %test:assertEquals(1)
+function filter-function-items-in-context:anonymous-function-arity () {
+    (
+        function() { "foo" },
+        function($x) { "bar" }
+    )
+    [function-arity(.) eq 1] => count()
+};
+
+declare
+    %test:assertEquals(7)
+function filter-function-items-in-context:mixed-sequence () {
+    (
+        $filter-function-items-in-context:arrays,
+        $filter-function-items-in-context:maps,
+        string-join#1,
+        function($x) { $x },
+        sum#1
+    )
+    [. instance of function(*)] => count()
+};


### PR DESCRIPTION
## Description:

Enable function items (functions, arrays, maps) to be used as values of the context item `.`

#### in predicates: 

- [x] `([1, 2], [2, 4])[array:get(., 1) > 1]` returns `[2, 4]` 
- [x] `([1, 2], [2, 4])[(.)?1 > 1]` returns `[2, 4]` 
- [x] `([1, 2], [2, 4])[(.)(1) > 1]` returns `[2, 4]` 
- [x]  `([1, 2], [2, 4])[.?1 > 1]` returns `[2, 4]` 
- [x]  `([1, 2], [2, 4])[.(1) > 1]` returns `[2, 4]` 
- [x] `(map{"a":2}, map{"a":1})[map:get(., "a") > 1]` returns `map{"a":2}` 
- [x] `(map{"a":2}, map{"a":1})[(.)?a > 1]` returns `map{"a":2}` 
- [x] `(map{"a":2}, map{"a":1})[(.)("a") > 1]` returns `map{"a":2}` 
- [x]  `(map{"a":2}, map{"a":1})[.?a > 1]` returns `map{"a":2}` 
- [x] `(map{"a":2}, map{"a":1})[.("a") > 1]` returns `map{"a":2}` 
- [x] `(sum#2, function(){})[function-arity(.) > 1]` returns `sum#2` 
- [x] `(function(){2}, function(){1})[(.)() > 1]` returns `2` 
- [x] `(function(){2}, function(){1})[.() > 1]` returns `2` 

#### after the simple map operator

The map expression status applies to arrays as well

- [x] `(map { 'key': 'value' }, map { 'key': 'other' }) ! map:get(., 'key')` returns `('value', 'other')`
- [x] `(map { 'key': 'value' }, map { 'key': 'other' }) ! (.)?key` returns `('value', 'other')`
- [x] `(map { 'key': 'value' }, map { 'key': 'other' }) ! (.)("key")` returns `('value', 'other')`
- [x] `(map { 'key': 'value' }, map { 'key': 'other' }) ! .("key")` returns `('value', 'other')`
- [x] `(map { 'key': 'value' }, map { 'key': 'other' }) ! (.?key)` returns `('value', 'other')`
- [x] `(map { 'key': 'value' }, map { 'key': 'other' }) ! .?key` returns `('value', 'other')`
- [x] `(function(){2}, function(){1}) ! (.)()` returns `(2,1)` 
- [x] `(function(){2}, function(){1}) ! .()` returns `(2,1)` 
- [x] `(function(){2}, function(){1}) ! (.())` returns `(2,1)` 

Unary lookup statements are not part of this PR but tracked in #1655

- `(map{"a":2}, map{"a":1})[?a > 1]` returns `map{"a":2}`
- `([1, 2], [2, 4])[?1 > 1]` returns `[2, 4]`
- `(map { 'key': 'value' }, map { 'key': 'other' }) ! ?key` returns `('value', 'other')`

### Reference:

fixes #3240 

### Type of tests:

XQsuite tests added