### PR TITLE
fn:base-uri should not raise XPDY0002 when the context item is empty

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunBaseURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunBaseURI.java
@@ -115,9 +115,12 @@ public class FunBaseURI extends BasicFunction {
             }
         } else {
             if (args.length == 0) {
-                if (contextSequence == null || contextSequence.isEmpty()) {
+                if (contextSequence == null) {
                     throw new XPathException(this, ErrorCodes.XPDY0002,
-                        "Context sequence is empty and no argument specified");
+                        "The context item is absent");
+                }
+                if (contextSequence.isEmpty()) {
+                    return Sequence.EMPTY_SEQUENCE;
                 }
                 final Item item = contextSequence.itemAt(0);
                 if (!Type.subTypeOf(item.getType(), Type.NODE)) {

--- a/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
@@ -2551,6 +2551,35 @@ public class XQueryTest {
         assertEquals("/db/test/baseuri.xml", result.getResource(0).getContent().toString());
     }
 
+    /**
+     * @see <a href="https://github.com/eXist-db/exist/issues/3497">[BUG] ()/fn:base-uri() incorrectly raises XPDY0002</a>
+     */
+    @Test
+    public void resolveBaseURIErrorCases() throws XMLDBException {
+        final XPathQueryService service = (XPathQueryService) existEmbeddedServer.getRoot().getService("XPathQueryService", "1.0");
+
+        String query = "()/fn:base-uri()";
+        ResourceSet result = service.query(query);
+        assertEquals(0, result.getSize());
+
+        query = "()/base-uri(.)";
+        result = service.query(query);
+        assertEquals(0, result.getSize());
+
+        query = "base-uri(.)";
+        try {
+            result = service.query(query);
+            assertEquals(0, result.getSize());
+
+            fail("Should have raised error: XPDY0002");
+
+        } catch (final XMLDBException e) {
+            assertEquals(org.xmldb.api.base.ErrorCodes.VENDOR_ERROR, e.errorCode);
+            final Throwable cause = e.getCause();
+            assertEquals(XPathException.class, cause.getClass());
+            assertEquals(ErrorCodes.XPDY0002, ((XPathException) cause).getErrorCode());
+        }
+    }
 
     /**
      * @see http://sourceforge.net/support/tracker.php?aid=2429093


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/3497