### PR TITLE
Add a caller attribute to the output of system:get-running-xqueries#0

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/system/GetRunningXQueries.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/GetRunningXQueries.java
@@ -118,6 +118,8 @@ public class GetRunningXQueries extends BasicFunction
 		builder.addAttribute( new QName( "sourceType", null, null ), context.getSource().type() );
                 builder.addAttribute( new QName( "started", null, null), new DateTimeValue(new Date(watchdog.getStartTime())).getStringValue());
 		builder.addAttribute( new QName( "terminating", null, null ), ( watchdog.isTerminating() ? "true" : "false" ) );
+
+		builder.addAttribute(new QName("caller", null, null), context == getContext() ? "true" : "false");
 		
 		builder.startElement( new QName( "sourceKey", NAMESPACE_URI, PREFIX ), null );
 		builder.characters( context.getSource().path() );

--- a/exist-core/src/test/java/org/exist/xquery/functions/system/GetRunningXQueriesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/system/GetRunningXQueriesTest.java
@@ -1,0 +1,50 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.system;
+
+import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+import org.xmldb.api.base.ResourceSet;
+import org.xmldb.api.base.XMLDBException;
+
+import java.io.IOException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
+import static org.junit.Assert.assertNotNull;
+
+public class GetRunningXQueriesTest {
+
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existXmldbEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
+
+    @Test
+    public void caller() throws XMLDBException, XpathException, IOException, SAXException {
+        final ResourceSet result = existXmldbEmbeddedServer.executeQuery("system:get-running-xqueries()");
+        assertNotNull(result);
+        final String resultDoc = (String) result.getResource(0).getContent();
+
+        assertXpathEvaluatesTo("1", "count(//@caller)", resultDoc);
+    }
+}


### PR DESCRIPTION
Allows the user to identify the query that asked for the list of running queries.