### PR TITLE
fn:replace and fn:analyze-string are now implemented with Saxon

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -23,6 +23,7 @@ package org.exist.storage;
 
 import com.evolvedbinary.j8fu.fsm.AtomicFSM;
 import com.evolvedbinary.j8fu.fsm.FSM;
+import com.evolvedbinary.j8fu.lazy.AtomicLazyVal;
 import net.jcip.annotations.GuardedBy;
 import net.jcip.annotations.ThreadSafe;
 import org.apache.logging.log4j.LogManager;
@@ -86,6 +87,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -376,6 +378,13 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
     private Optional<ExistRepository> expathRepo = Optional.empty();
 
     private StartupTriggersManager startupTriggersManager;
+
+    /**
+     * Configuration for Saxon.
+     *
+     * One instance per-database, lazily initialised.
+     */
+    private AtomicLazyVal<net.sf.saxon.Configuration> saxonConfig = new AtomicLazyVal<>(net.sf.saxon.Configuration::newConfiguration);
 
     /**
      * Creates and configures the database instance.
@@ -1919,6 +1928,10 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
 
     public PluginsManager getPluginsManager() {
         return pluginManager;
+    }
+
+    public net.sf.saxon.Configuration getSaxonConfiguration() {
+        return saxonConfig.get();
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/RegexMatcher.java
+++ b/exist-core/src/main/java/org/exist/storage/RegexMatcher.java
@@ -26,26 +26,24 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.exist.EXistException;
+import org.exist.util.PatternFactory;
 
 /**
  * A {@link org.exist.storage.TermMatcher} that matches index entries against a
  * regular expression. Used by {@link org.exist.storage.NativeValueIndex}.
- * 
- * @author wolf
- *
  */
 class RegexMatcher implements TermMatcher {
 	
 	private Matcher matcher;
-    private boolean matchAll = false;
+    private boolean matchAll;
 
-    public RegexMatcher(String expr, int flags) throws EXistException {
+    public RegexMatcher(final String expr, final int flags) throws EXistException {
         this(expr, flags, false);
     }
-    
-    public RegexMatcher(String expr, int flags, boolean matchAll) throws EXistException {
+
+    public RegexMatcher(final String expr, final int flags, final boolean matchAll) throws EXistException {
         try {
-            final Pattern pattern = Pattern.compile(expr, flags);
+            final Pattern pattern = PatternFactory.getInstance().getPattern(expr, flags);
             matcher = pattern.matcher("");
         } catch(final PatternSyntaxException e) {
             throw new EXistException("Invalid regular expression: " + e.getMessage());
@@ -53,12 +51,8 @@ class RegexMatcher implements TermMatcher {
         this.matchAll = matchAll;        
     }
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.util.Comparator#equals(java.lang.Object)
-	 */
-	public boolean matches(CharSequence term) {
+	@Override
+	public boolean matches(final CharSequence term) {
         matcher.reset(term);
         return matchAll ? matcher.matches() : matcher.find();
 	}

--- a/exist-core/src/main/java/org/exist/util/PatternFactory.java
+++ b/exist-core/src/main/java/org/exist/util/PatternFactory.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  *
  * Patterns are Cached in a LRU like Cache
  *
- * @author <a href="mailto:adam.retter@googlemail.com">Adam Retter</a>
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class PatternFactory {
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
@@ -124,9 +124,7 @@ public class FunAnalyzeString extends BasicFunction {
     }
 
     private void analyzeString(final MemTreeBuilder builder, final String input, String pattern, final String flags) throws XPathException {
-
-        //TODO(AR) should be one Configuration instance per database
-        final Configuration config = Configuration.newConfiguration();
+        final Configuration config = context.getBroker().getBrokerPool().getSaxonConfiguration();
 
         final List<String> warnings = new ArrayList<>(1);
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
@@ -21,17 +21,16 @@
  */
 package org.exist.xquery.functions.fn;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.om.Item;
+import net.sf.saxon.regex.RegexIterator;
+import net.sf.saxon.regex.RegularExpression;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
-import org.exist.util.PatternFactory;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.Function;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.NodeValue;
@@ -42,18 +41,11 @@ import org.xml.sax.helpers.AttributesImpl;
 
 import javax.xml.XMLConstants;
 
-import static org.exist.xquery.regex.RegexUtil.*;
-
 /**
  * XPath and XQuery 3.0 F+O fn:analyze-string()
- * 
- * @author <a href="mailto:adam@exist-db.org">Adam Retter</a>
- * @serial 201211101626
- * 
- * Corrections were made by to the previous buggy version
- * by taking inspiration from the BaseX 7.3 version.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
-
 public class FunAnalyzeString extends BasicFunction {
 
     private final static QName fnAnalyzeString = new QName("analyze-string", Function.BUILTIN_FUNCTION_NS);
@@ -117,7 +109,7 @@ public class FunAnalyzeString extends BasicFunction {
             }
             if (!"" .equals(input)) {
                 final String pattern = args[1].itemAt(0).getStringValue();
-                String flags = null;
+                String flags = "";
                 if (args.length == 3) {
                     flags = args[2].itemAt(0).getStringValue();
                 }
@@ -133,80 +125,70 @@ public class FunAnalyzeString extends BasicFunction {
 
     private void analyzeString(final MemTreeBuilder builder, final String input, String pattern, final String flags) throws XPathException {
 
-        final int iFlags = parseFlags(this, flags);
+        //TODO(AR) should be one Configuration instance per database
+        final Configuration config = Configuration.newConfiguration();
 
-        if(!hasLiteral(iFlags)) {
-            pattern = translateRegexp(this, pattern, hasIgnoreWhitespace(iFlags), hasCaseInsensitive(iFlags));
-        }
+        final List<String> warnings = new ArrayList<>(1);
 
-        final Pattern ptn = PatternFactory.getInstance().getPattern(pattern, iFlags);
-        
-        final Matcher matcher = ptn.matcher(input);
-        
-        int offset = 0;
-        while(matcher.find()) {
-            if(matcher.start() != offset) {
-                nonMatch(builder, input.substring(offset, matcher.start()));
-            }
-            match(builder, matcher, input, 0);
-            
-            offset = matcher.end();
-        }
-        
-        if(offset != input.length()) {
-            nonMatch(builder, input.substring(offset));
-        }
-    }
-    
-    private static class GroupPosition {
-        public int groupNumber;
-        public int position;
+        try {
+            final RegularExpression regularExpression = config.compileRegularExpression(pattern, flags, "XP30", warnings);
 
-        public GroupPosition(final int groupNumber, final int position) {
-            this.groupNumber = groupNumber;
-            this.position = position;
-        }
-    }
-    
-    private GroupPosition match(final MemTreeBuilder builder, final Matcher matcher, final String input, final int group) {
-        if(group == 0) {
-            builder.startElement(QN_MATCH, null);
-        } else {
-            final AttributesImpl attributes = new AttributesImpl();
-            attributes.addAttribute("", QN_NR.getLocalPart(), QN_NR.getLocalPart(), "int", Integer.toString(group));
-            builder.startElement(QN_GROUP, attributes);
-        }
-        
-        final int groupStart = matcher.start(group);
-        final int groupEnd = matcher.end(group);
-        final int groupCount = matcher.groupCount();
-        
-        GroupPosition groupAndPosition = new GroupPosition(group + 1, groupStart);
-        while(groupAndPosition.groupNumber <= groupCount && matcher.end(groupAndPosition.groupNumber) <= groupEnd) {
-            final int start = matcher.start(groupAndPosition.groupNumber);
-            if(start >= 0) { //group matched
-                if(groupAndPosition.position < start) {
-                    builder.characters(input.substring(groupAndPosition.position, start));
+            //TODO(AR) cache the regular expression... might be possible through Saxon config
+
+            final RegexIterator regexIterator = regularExpression.analyze(input);
+            Item item;
+            while ((item = regexIterator.next()) != null) {
+                if (regexIterator.isMatching()) {
+                    match(builder, regexIterator);
+                } else {
+                    nonMatch(builder, item);
                 }
-                groupAndPosition = match(builder, matcher, input, groupAndPosition.groupNumber);
-            } else {
-                groupAndPosition.groupNumber++; //skip to next group
+            }
+
+            for (final String warning : warnings) {
+                LOG.warn(warning);
+            }
+        } catch (final net.sf.saxon.trans.XPathException e) {
+            switch (e.getErrorCodeLocalPart()) {
+                case "FORX0001":
+                    throw new XPathException(this, ErrorCodes.FORX0001, e.getMessage());
+                case "FORX0002":
+                    throw new XPathException(this, ErrorCodes.FORX0002, e.getMessage());
+                case "FORX0003":
+                    throw new XPathException(this, ErrorCodes.FORX0003, e.getMessage());
+                default:
+                    throw new XPathException(this, e.getMessage());
             }
         }
-        
-        if(groupAndPosition.position < groupEnd) {
-            builder.characters(input.substring(groupAndPosition.position, groupEnd));
-            groupAndPosition.position = groupEnd;
-        }
-        
+    }
+    
+    private void match(final MemTreeBuilder builder, final RegexIterator regexIterator) throws net.sf.saxon.trans.XPathException {
+        builder.startElement(QN_MATCH, null);
+        regexIterator.processMatchingSubstring(new RegexIterator.MatchHandler() {
+            @Override
+            public void characters(final CharSequence s) {
+                builder.characters(s);
+            }
+
+            @Override
+            public void onGroupStart(final int groupNumber) throws net.sf.saxon.trans.XPathException {
+                final AttributesImpl attributes = new AttributesImpl();
+                attributes.addAttribute("", QN_NR.getLocalPart(), QN_NR.getLocalPart(), "int", Integer.toString(groupNumber));
+
+                builder.startElement(QN_GROUP, attributes);
+            }
+
+            @Override
+            public void onGroupEnd(final int groupNumber) throws net.sf.saxon.trans.XPathException {
+                builder.endElement();
+            }
+        });
         builder.endElement();
-        
-        return groupAndPosition;
     }
 
-    private void nonMatch(final MemTreeBuilder builder, final String nonMatch) {
+    private void nonMatch(final MemTreeBuilder builder, final Item item) {
         builder.startElement(QN_NON_MATCH, null);
-        builder.characters(nonMatch);
+        builder.characters(item.getStringValueCS());
         builder.endElement();
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReplace.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReplace.java
@@ -21,11 +21,13 @@
  */
 package org.exist.xquery.functions.fn;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.PatternSyntaxException;
 
+import net.sf.saxon.Configuration;
+import net.sf.saxon.functions.Replace;
+import net.sf.saxon.regex.RegularExpression;
 import org.exist.dom.QName;
-import org.exist.util.PatternFactory;
 import org.exist.xquery.Atomize;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.Dependency;
@@ -49,6 +51,7 @@ import org.exist.xquery.value.Type;
 import static org.exist.xquery.regex.RegexUtil.*;
 
 /**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  */
 public class FunReplace extends FunMatches {
@@ -103,14 +106,12 @@ public class FunReplace extends FunMatches {
 		)
 	};
 
-	public FunReplace(XQueryContext context, FunctionSignature signature) {
+	public FunReplace(final XQueryContext context, final FunctionSignature signature) {
 		super(context, signature);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.Function#setArguments(java.util.List)
-	 */
-	public void setArguments(List<Expression> arguments) throws XPathException {
+	@Override
+	public void setArguments(List<Expression> arguments) {
 	    steps.clear();
         Expression arg = arguments.get(0);
         arg = new DynamicCardinalityCheck(context, Cardinality.ZERO_OR_ONE, arg,
@@ -143,10 +144,8 @@ public class FunReplace extends FunMatches {
         }
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.Expression#eval(org.exist.dom.persistent.DocumentSet, org.exist.xquery.value.Sequence, org.exist.xquery.value.Item)
-	 */
-	public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+	@Override
+	public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
 		if (context.getProfiler().isEnabled()) {
 			context.getProfiler().start(this);
 			context.getProfiler().message(this, Profiler.DEPENDENCIES, "DEPENDENCIES", Dependency.getDependenciesName(this.getDependencies()));
@@ -158,90 +157,66 @@ public class FunReplace extends FunMatches {
 			}
 		}
 
-		Sequence result;
+		final Sequence result;
 		final Sequence stringArg = getArgument(0).eval(contextSequence, contextItem);
 		if (stringArg.isEmpty()) {
 			result = StringValue.EMPTY_STRING;
 		} else {
-			final int flags;
+			final String flags;
 			if (getSignature().getArgumentCount() == 4) {
-				flags =	parseFlags(this, getArgument(3).eval(contextSequence, contextItem).getStringValue());
+				flags =	getArgument(3).eval(contextSequence, contextItem).getStringValue();
 			} else {
-				flags = 0;
+				flags = "";
 			}
 
     		final String string = stringArg.getStringValue();
     		final Sequence patternSeq = getArgument(1).eval(contextSequence, contextItem);
+    		final String pattern = patternSeq.getStringValue();
 
 			final Sequence replaceSeq = getArgument(2).eval(contextSequence, contextItem);
-			String replace = replaceSeq.getStringValue();
+			final String replace = replaceSeq.getStringValue();
 
-    		final String pattern;
-			if(hasLiteral(flags)) {
-				// no need to change anything in the pattern
-				pattern = patternSeq.getStringValue();
 
-				// however, $ and \ now have no special significance
-				replace = replace
-						.replace("\\", "\\\\")
-						.replace("$", "\\$");
-			} else {
-				pattern = translateRegexp(this, patternSeq.getStringValue(), hasIgnoreWhitespace(flags), hasCaseInsensitive(flags));
+			//TODO(AR) should be one Configuration instance per database
+			final Configuration config = Configuration.newConfiguration();
+
+			final List<String> warnings = new ArrayList<>(1);
+
+			try {
+				final RegularExpression regularExpression = config.compileRegularExpression(pattern, flags, "XP30", warnings);
+
+				//TODO(AR) cache the regular expression... might be possible through Saxon config
+
+				if (!hasLiteral(flags)) {
+					final String msg = Replace.checkReplacement(replace);
+					if (msg != null) {
+						throw new XPathException(this, ErrorCodes.FORX0004, msg);
+					}
+				}
+				final CharSequence res = regularExpression.replace(string, replace);
+				result = new StringValue(res.toString());
+
+			} catch (final net.sf.saxon.trans.XPathException e) {
+				switch (e.getErrorCodeLocalPart()) {
+					case "FORX0001":
+						throw new XPathException(this, ErrorCodes.FORX0001, e.getMessage());
+					case "FORX0002":
+						throw new XPathException(this, ErrorCodes.FORX0002, e.getMessage());
+					case "FORX0003":
+						throw new XPathException(this, ErrorCodes.FORX0003, e.getMessage());
+					case "FORX0004":
+						throw new XPathException(this, ErrorCodes.FORX0004, e.getMessage());
+					default:
+						throw new XPathException(this, e.getMessage());
+				}
 			}
-
-            //An error is raised [err:FORX0004] if the value of $replacement contains a "$" character that is not immediately followed by a digit 0-9 and not immediately preceded by a "\".
-            //An error is raised [err:FORX0004] if the value of $replacement contains a "\" character that is not part of a "\\" pair, unless it is immediately followed by a "$" character.
-            for (int i = 0 ; i < replace.length() ; i++) {
-            	//Commented out : this seems to be a total non sense
-            	/*
-            	if (replace.charAt(i) == '$') {
-            		try {
-            			if (!(replace.charAt(i - 1) == '\\' || Character.isDigit(replace.charAt(i + 1))))
-            				throw new XPathException(this, ErrorCodes.FORX0004, "The value of $replacement contains a '$' character that is not immediately followed by a digit 0-9 and not immediately preceded by a '\\'.");
-            		//Handle index exceptions
-            		} catch (Exception e){
-            			throw new XPathException(this, ErrorCodes.FORX0004, "The value of $replacement contains a '$' character that is not immediately followed by a digit 0-9 and not immediately preceded by a '\\'.");
-            		}
-            	}
-            	*/
-            	if (replace.charAt(i) == '\\') {
-            		try {
-            			if (!(replace.charAt(i + 1) == '\\' || replace.charAt(i + 1) == '$')) {
-            				throw new XPathException(this, ErrorCodes.FORX0004, "The value of $replacement contains a '\\' character that is not part of a '\\\\' pair, unless it is immediately followed by a '$' character.", replaceSeq);
-            			}
-            			i++;
-            		//Handle index exceptions
-            		} catch (final Exception e){
-            			throw new XPathException(this, ErrorCodes.FORX0004, "The value of $replacement contains a '\\' character that is not part of a '\\\\' pair, unless it is immediately followed by a '$' character.", replaceSeq);
-            		}
-            	}
-            	
-            }
-
-    		try {
-    			if (pat == null || (!pattern.equals(pat.pattern())) || flags != pat.flags()) {
-    				pat = PatternFactory.getInstance().getPattern(pattern, flags);
-                    matcher = pat.matcher(string);
-                } else {
-                    matcher.reset(string);
-                }
-                final String r = matcher.replaceAll(replace);
-    			result = new StringValue(r);
-    		} catch (final PatternSyntaxException e) {
-    			throw new XPathException(this, ErrorCodes.FORX0001, "Invalid regular expression: " + e.getMessage(), patternSeq, e);
-    		} catch (final IndexOutOfBoundsException e) {
-    		    throw new XPathException(this, ErrorCodes.FORX0001, e.getMessage(), patternSeq, e);
-       		//Some JVMs seem to raise this one
-    		} catch (final IllegalArgumentException e) {
-    			throw new XPathException(this, ErrorCodes.FORX0004, "Invalid replace expression: " + e.getMessage(), replaceSeq, e);
-            }
         }
         
-        if (context.getProfiler().isEnabled()) 
-            {context.getProfiler().end(this, "", result);} 
+        if (context.getProfiler().isEnabled()) {
+        	context.getProfiler().end(this, "", result);
+        }
         
         return result;   
         
 	}
-
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReplace.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReplace.java
@@ -176,9 +176,7 @@ public class FunReplace extends FunMatches {
 			final Sequence replaceSeq = getArgument(2).eval(contextSequence, contextItem);
 			final String replace = replaceSeq.getStringValue();
 
-
-			//TODO(AR) should be one Configuration instance per database
-			final Configuration config = Configuration.newConfiguration();
+			final Configuration config = context.getBroker().getBrokerPool().getSaxonConfiguration();
 
 			final List<String> warnings = new ArrayList<>(1);
 

--- a/exist-core/src/main/java/org/exist/xquery/regex/RegexUtil.java
+++ b/exist-core/src/main/java/org/exist/xquery/regex/RegexUtil.java
@@ -19,7 +19,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 package org.exist.xquery.regex;
 
 import org.exist.thirdparty.net.sf.saxon.functions.regex.JDK15RegexTranslator;
@@ -36,7 +35,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 /**
- * @author <a href="mailto:adam@exist-db.org">Adam Retter</a>
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class RegexUtil {
 
@@ -92,6 +91,17 @@ public class RegexUtil {
      */
     public static boolean hasLiteral(final int flags) {
         return (flags & Pattern.LITERAL) != 0;
+    }
+
+    /**
+     * Determines if the XQuery Expression flags have the literal flag set.
+     *
+     * @param flags The XQuery Expression flags
+     *
+     * @return true if the literal flag is set
+     */
+    public static boolean hasLiteral(final String flags) {
+        return flags.contains("q");
     }
 
     /**

--- a/exist-core/src/test/xquery/regex.xml
+++ b/exist-core/src/test/xquery/regex.xml
@@ -107,8 +107,13 @@
     </test>
     <test output="text">
         <task>fn:replace-non-capturing-1</task>
-        <code>fn:replace("hello", "hel(?:lo)", "$1")</code>
-        <error>FORX0001</error>
+        <code>let $x := fn:replace("hello", "hel(?:lo)", "$1") return count($x) || ':' || string-length($x[1])</code>
+        <expected>1:0</expected>
+    </test>
+    <test output="text">
+        <task>fn:matches-non-capturing-1</task>
+        <code>fn:matches("", "hel(?:lo)")</code>
+        <expected>false</expected>
     </test>
     <test output="text">
         <task>fn:replace-non-capturing-2</task>

--- a/exist-core/src/test/xquery/xquery3/forwhere.xml
+++ b/exist-core/src/test/xquery/xquery3/forwhere.xml
@@ -41,7 +41,7 @@
         <code><![CDATA[xquery version "3.1";
 
 let $f := function($x as xs:string) {true()}
-let $words := analyze-string('', '\w+')/fn:match/ text ()
+let $words := analyze-string('', '\w+')/fn:match/text()
 return for $w in $words where $f($w) return $w
 
 ]]></code>


### PR DESCRIPTION
In an attempt to fix some bugs with eXist-db's `fn:replace` and `fn:analyze-string`, these new versions just wrap the Saxon equivalents.

If people like this, we could also extend it to `fn:matches`.