### PR TITLE
Collection must be persisted when renaming/moving

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -626,6 +626,7 @@
                                     Already under LGPL 2.1, but with a different Copyright
                                 -->
                                 <exclude>src/main/java/org/exist/util/UTF8.java</exclude>
+                                <exclude>src/test/java/org/exist/storage/MoveCollectionTest.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/blob/**</exclude>
                                 <exclude>src/test/java/org/exist/storage/blob/**</exclude>
                                 <exclude>src/main/java/org/exist/storage/journal/JournalManager.java</exclude>
@@ -751,6 +752,7 @@ The original license statement is also included below.]]></preamble>
                             -->
                             <header>FDB-backport-LGPL-21-ONLY-license.template.txt</header>
                             <includes>
+                                <include>src/test/java/org/exist/storage/MoveCollectionTest.java</include>
                                 <include>src/main/java/org/exist/storage/blob/**</include>
                                 <include>src/test/java/org/exist/storage/blob/**</include>
                                 <include>src/main/java/org/exist/storage/journal/JournalManager.java</include>

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -1528,7 +1528,11 @@ public class NativeBroker extends DBBroker {
         if (sourceCollectionParent != null) {
             final XmldbURI sourceCollectionName = sourceCollectionUri.lastSegment();
             sourceCollectionParent.removeCollection(this, sourceCollectionName);
-            saveCollection(transaction, sourceCollectionParent);
+
+            // if this is a rename, the save will happen after we "add the destination to the target" below...
+            if (!sourceCollectionParent.getURI().equals(targetCollection)) {
+                saveCollection(transaction, sourceCollectionParent);
+            }
         }
 
         // remove source from cache
@@ -1547,9 +1551,7 @@ public class NativeBroker extends DBBroker {
 
         // add destination to target
         targetCollection.addCollection(this, sourceCollection);
-        if (sourceCollectionParent != targetCollection) {
-            saveCollection(transaction, targetCollection);
-        }
+        saveCollection(transaction, targetCollection);
 
         if(fireTrigger) {
             trigger.afterMoveCollection(this, transaction, sourceCollection, sourceCollectionUri);

--- a/exist-core/src/test/java/org/exist/storage/MoveCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveCollectionTest.java
@@ -1,14 +1,25 @@
 /*
- * eXist-db Open Source Native XML Database
- * Copyright (C) 2001 The eXist-db Authors
+ * Copyright (C) 2014, Evolved Binary Ltd
  *
- * info@exist-db.org
- * http://www.exist-db.org
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; version 2.1.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -28,37 +39,81 @@ import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
+import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class MoveCollectionTest {
 
-    @ClassRule
-    public static ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+    @Rule
+    public ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
     @Test
     public void moveDeep() throws EXistException, IOException, PermissionDeniedException, TriggerException, LockException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
-        try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
-            final Txn transaction = transact.beginTransaction()) {
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = transact.beginTransaction()) {
 
-            final Collection src = broker.getOrCreateCollection(transaction, XmldbURI.create("/db/a/b/c/d/e/f/g/h/i/j/k"));
-            assertNotNull(src);
-            broker.saveCollection(transaction, src);
+            final XmldbURI srcUri = XmldbURI.create("/db/a/b/c/d/e/f/g/h/i/j/k");
+            final XmldbURI destUri = XmldbURI.create("/db/z/y/x/w/v/u");
 
-            final Collection dst = broker.getOrCreateCollection(transaction, XmldbURI.create("/db/z/y/x/w/v/u"));
-            assertNotNull(dst);
-            broker.saveCollection(transaction, dst);
+            try (final Collection src = broker.getOrCreateCollection(transaction, srcUri)) {
+                assertNotNull(src);
+                broker.saveCollection(transaction, src);
+            }
 
-            broker.moveCollection(transaction, src, dst, src.getURI().lastSegment());
+            try (final Collection dst = broker.getOrCreateCollection(transaction, destUri)) {
+                assertNotNull(dst);
+                broker.saveCollection(transaction, dst);
+            }
+
+            try (final Collection src = broker.openCollection(srcUri, Lock.LockMode.WRITE_LOCK);
+                 final Collection dst = broker.openCollection(destUri, Lock.LockMode.WRITE_LOCK)) {
+
+                broker.moveCollection(transaction, src, dst, src.getURI().lastSegment());
+            }
+
+            transact.commit(transaction);
+        }
+    }
+
+    @Test
+    public void rename() throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = transact.beginTransaction()) {
+
+            final XmldbURI testColUri = XmldbURI.create("/db/move-collection-test-rename");
+            final XmldbURI srcColUri = testColUri.append("before");
+            final XmldbURI newName = XmldbURI.create("after");
+
+            try (final Collection testCol = broker.getOrCreateCollection(transaction, testColUri)) {
+                assertNotNull(testCol);
+                broker.saveCollection(transaction, testCol);
+            }
+
+            try (final Collection srcCol = broker.getOrCreateCollection(transaction, srcColUri)) {
+                assertNotNull(srcCol);
+                broker.saveCollection(transaction, srcCol);
+            }
+
+            try (final Collection src = broker.openCollection(srcColUri, Lock.LockMode.WRITE_LOCK);
+                 final Collection testCol = broker.openCollection(testColUri, Lock.LockMode.WRITE_LOCK)) {
+
+                broker.moveCollection(transaction, src, testCol, newName);
+
+                assertFalse(testCol.hasChildCollection(broker, srcColUri.lastSegment()));
+                assertTrue(testCol.hasChildCollection(broker, newName));
+            }
 
             transact.commit(transaction);
         }


### PR DESCRIPTION
Back-ported a fix from FusionDB. Previously Collections were not correctly persisted under certain move/rename conditions.