### PR TITLE
add util:base64-encode-url-safe

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
@@ -42,82 +42,80 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 /**
  * Base64 String conversion functions.
  *
- * @author  Andrzej Taramina (andrzej@chaeron.com)
+ * @author Andrzej Taramina (andrzej@chaeron.com)
  */
 
-public class Base64Functions extends BasicFunction
-{
-    protected static final Logger           logger       = LogManager.getLogger( Base64Functions.class );
+public class Base64Functions extends BasicFunction {
+    protected static final Logger logger = LogManager.getLogger(Base64Functions.class);
 
-   public final static FunctionSignature[] signatures = {
-        new FunctionSignature(
-            new QName( "base64-encode", UtilModule.NAMESPACE_URI, UtilModule.PREFIX ),
-            "Encodes the given string as Base64",
-            new SequenceType[] {
-                new FunctionParameterSequenceType( "string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded" )
-            },
-            new FunctionReturnSequenceType( Type.STRING, Cardinality.ZERO_OR_ONE, "the Base64 encoded output, with trailing newlines trimmed" )
-        ),
-		
-		 new FunctionSignature(
-            new QName( "base64-encode", UtilModule.NAMESPACE_URI, UtilModule.PREFIX ),
-            "Encodes the given string as Base64",
-            new SequenceType[] {
-                new FunctionParameterSequenceType( "string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded" ),
-				new FunctionParameterSequenceType( "trim", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "Trim trailing newlines?" )
-            },
-            new FunctionReturnSequenceType( Type.STRING, Cardinality.ZERO_OR_ONE, "the Base64 encoded output" ),
-			"This function is deprecated. The output does not need to be trimmed, please use util:base64-encode#1 instead."
-        ),
-		
-         new FunctionSignature(
-            new QName( "base64-decode", UtilModule.NAMESPACE_URI, UtilModule.PREFIX ),
-            "Decode the given Base64 encoded string back to clear text",
-            new SequenceType[] {
-                new FunctionParameterSequenceType( "string", Type.STRING, Cardinality.ZERO_OR_ONE, "The Base64 string to be decoded" )
-            },
-            new FunctionReturnSequenceType( Type.STRING, Cardinality.ZERO_OR_ONE, "the decoded output" )
-        ),
+    public final static FunctionSignature[] signatures = {
+            new FunctionSignature(
+                    new QName("base64-encode", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Encodes the given string as Base64",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded")
+                    },
+                    new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the Base64 encoded output, with trailing newlines trimmed")
+            ),
 
-		new FunctionSignature(
-			new QName( "base64-encode-url-safe", UtilModule.NAMESPACE_URI, UtilModule.PREFIX ),
-			"Encodes the given string as Base64 (url-safe)",
-			new SequenceType[] {
-					new FunctionParameterSequenceType( "string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded (url-safe)" )
-			},
-			new FunctionReturnSequenceType( Type.STRING, Cardinality.ZERO_OR_ONE, "the Base64, url-safe encoded output without padding" )
-		)
+            new FunctionSignature(
+                    new QName("base64-encode", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Encodes the given string as Base64",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded"),
+                            new FunctionParameterSequenceType("trim", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "Trim trailing newlines?")
+                    },
+                    new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the Base64 encoded output"),
+                    "This function is deprecated. The output does not need to be trimmed, please use util:base64-encode#1 instead."
+            ),
 
-	};
-	
+            new FunctionSignature(
+                    new QName("base64-decode", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Decode the given Base64 encoded string back to clear text",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("string", Type.STRING, Cardinality.ZERO_OR_ONE, "The Base64 string to be decoded")
+                    },
+                    new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the decoded output")
+            ),
 
-    public Base64Functions( XQueryContext context, FunctionSignature signature )
-    {
-        super( context, signature );
+            new FunctionSignature(
+                    new QName("base64-encode-url-safe", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
+                    "Encodes the given string as Base64 (url-safe)",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded (url-safe)")
+                    },
+                    new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_ONE, "the Base64, url-safe encoded output without padding")
+            )
+
+    };
+
+
+    public Base64Functions(XQueryContext context, FunctionSignature signature) {
+        super(context, signature);
     }
-	
 
-    public Sequence eval( Sequence[] args, Sequence contextSequence ) throws XPathException
-    {
-		Sequence value	= Sequence.EMPTY_SEQUENCE;
 
-        if( !args[0].isEmpty() ) {       
-			final String str = args[0].getStringValue();
+    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
+        if (args[0].isEmpty()) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
 
-	        if (isCalledAs("base64-encode")) {
-				String b64Str = Base64.encodeBase64String(str.getBytes(UTF_8));
-				value = new StringValue(b64Str);
-			} else if (isCalledAs("base64-encode-url-safe")) {
-				String b64Str = Base64.encodeBase64URLSafeString(str.getBytes(UTF_8));
-				value = new StringValue(b64Str);
-	        } else {
-				// Base64.decodeBase64 can handle url-safe encoded data as well
-	        	final byte[] data = Base64.decodeBase64(str);
-				value = new StringValue(new String(data, UTF_8));
-	        }
-		}
-		
-		return( value );
+        final String str = args[0].getStringValue();
+
+        if (isCalledAs("base64-encode")) {
+            String b64Str = Base64.encodeBase64String(str.getBytes(UTF_8));
+            return new StringValue(b64Str);
+        }
+
+        if (isCalledAs("base64-encode-url-safe")) {
+            String b64Str = Base64.encodeBase64URLSafeString(str.getBytes(UTF_8));
+            return new StringValue(b64Str);
+        }
+
+        // isCalledAs("base64-decode")
+        // Base64.decodeBase64 can handle standard and url-safe base64 encoded data
+        final byte[] data = Base64.decodeBase64(str);
+        return new StringValue(new String(data, UTF_8));
     }
 
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
@@ -66,7 +66,8 @@ public class Base64Functions extends BasicFunction
                 new FunctionParameterSequenceType( "string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded" ),
 				new FunctionParameterSequenceType( "trim", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "Trim trailing newlines?" )
             },
-            new FunctionReturnSequenceType( Type.STRING, Cardinality.ZERO_OR_ONE, "the Base64 encoded output" )
+            new FunctionReturnSequenceType( Type.STRING, Cardinality.ZERO_OR_ONE, "the Base64 encoded output" ),
+			"This function is deprecated. The output does not need to be trimmed, please use util:base64-encode#1 instead."
         ),
 		
          new FunctionSignature(
@@ -99,20 +100,12 @@ public class Base64Functions extends BasicFunction
     public Sequence eval( Sequence[] args, Sequence contextSequence ) throws XPathException
     {
 		Sequence value	= Sequence.EMPTY_SEQUENCE;
-		boolean  trim	= true;
-		
+
         if( !args[0].isEmpty() ) {       
 			final String str = args[0].getStringValue();
-			
-			if( args.length == 2 ) {
-				trim = args[1].effectiveBooleanValue();
-			}
-	
+
 	        if (isCalledAs("base64-encode")) {
 				String b64Str = Base64.encodeBase64String(str.getBytes(UTF_8));
-				if (trim) {
-					b64Str = b64Str.trim();
-				}
 				value = new StringValue(b64Str);
 			} else if (isCalledAs("base64-encode-url-safe")) {
 				String b64Str = Base64.encodeBase64URLSafeString(str.getBytes(UTF_8));

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
@@ -90,12 +90,12 @@ public class Base64Functions extends BasicFunction {
     };
 
 
-    public Base64Functions(XQueryContext context, FunctionSignature signature) {
+    public Base64Functions(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
 
-    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
         if (args[0].isEmpty()) {
             return Sequence.EMPTY_SEQUENCE;
         }
@@ -103,12 +103,12 @@ public class Base64Functions extends BasicFunction {
         final String str = args[0].getStringValue();
 
         if (isCalledAs("base64-encode")) {
-            String b64Str = Base64.encodeBase64String(str.getBytes(UTF_8));
+            final String b64Str = Base64.encodeBase64String(str.getBytes(UTF_8));
             return new StringValue(b64Str);
         }
 
         if (isCalledAs("base64-encode-url-safe")) {
-            String b64Str = Base64.encodeBase64URLSafeString(str.getBytes(UTF_8));
+            final String b64Str = Base64.encodeBase64URLSafeString(str.getBytes(UTF_8));
             return new StringValue(b64Str);
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
@@ -51,7 +51,7 @@ public class Base64Functions extends BasicFunction {
     public final static FunctionSignature[] signatures = {
             new FunctionSignature(
                     new QName("base64-encode", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
-                    "Encodes the given string as Base64",
+                    "Encodes the given string as Base64 (see RFC 2045 §6.8)",
                     new SequenceType[]{
                             new FunctionParameterSequenceType("string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded")
                     },
@@ -80,7 +80,7 @@ public class Base64Functions extends BasicFunction {
 
             new FunctionSignature(
                     new QName("base64-encode-url-safe", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
-                    "Encodes the given string as Base64, url-safe. No padding and use - and _ instead of + and /.",
+                    "Encodes the given string as Base64, url-safe. No padding and use - and _ instead of + and / (see RFC 4648 §5).",
                     new SequenceType[]{
                             new FunctionParameterSequenceType("string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded (url-safe)")
                     },

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
@@ -80,7 +80,7 @@ public class Base64Functions extends BasicFunction {
 
             new FunctionSignature(
                     new QName("base64-encode-url-safe", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
-                    "Encodes the given string as Base64 (url-safe)",
+                    "Encodes the given string as Base64, url-safe. No padding and use - and _ instead of + and /.",
                     new SequenceType[]{
                             new FunctionParameterSequenceType("string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded (url-safe)")
                     },

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Base64Functions.java
@@ -76,8 +76,18 @@ public class Base64Functions extends BasicFunction
                 new FunctionParameterSequenceType( "string", Type.STRING, Cardinality.ZERO_OR_ONE, "The Base64 string to be decoded" )
             },
             new FunctionReturnSequenceType( Type.STRING, Cardinality.ZERO_OR_ONE, "the decoded output" )
-        )
-    };
+        ),
+
+		new FunctionSignature(
+			new QName( "base64-encode-url-safe", UtilModule.NAMESPACE_URI, UtilModule.PREFIX ),
+			"Encodes the given string as Base64 (url-safe)",
+			new SequenceType[] {
+					new FunctionParameterSequenceType( "string", Type.STRING, Cardinality.ZERO_OR_ONE, "The string to be Base64 encoded (url-safe)" )
+			},
+			new FunctionReturnSequenceType( Type.STRING, Cardinality.ZERO_OR_ONE, "the Base64, url-safe encoded output without padding" )
+		)
+
+	};
 	
 
     public Base64Functions( XQueryContext context, FunctionSignature signature )
@@ -104,8 +114,11 @@ public class Base64Functions extends BasicFunction
 					b64Str = b64Str.trim();
 				}
 				value = new StringValue(b64Str);
+			} else if (isCalledAs("base64-encode-url-safe")) {
+				String b64Str = Base64.encodeBase64URLSafeString(str.getBytes(UTF_8));
+				value = new StringValue(b64Str);
 	        } else {
-
+				// Base64.decodeBase64 can handle url-safe encoded data as well
 	        	final byte[] data = Base64.decodeBase64(str);
 				value = new StringValue(new String(data, UTF_8));
 	        }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
@@ -147,6 +147,7 @@ public class UtilModule extends AbstractInternalModule {
             new FunctionDef(Base64Functions.signatures[0], Base64Functions.class),
             new FunctionDef(Base64Functions.signatures[1], Base64Functions.class),
             new FunctionDef(Base64Functions.signatures[2], Base64Functions.class),
+            new FunctionDef(Base64Functions.signatures[3], Base64Functions.class),
             new FunctionDef(BaseConversionFunctions.FNS_INT_TO_OCTAL, BaseConversionFunctions.class),
             new FunctionDef(BaseConversionFunctions.FNS_OCTAL_TO_INT, BaseConversionFunctions.class),
             new FunctionDef(LineNumber.signature, LineNumber.class)

--- a/exist-core/src/test/java/org/exist/xquery/functions/util/Base64FunctionsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/util/Base64FunctionsTest.java
@@ -51,6 +51,22 @@ public class Base64FunctionsTest {
     }
 
     @Test
+    public void testBase64EncodeWithTrim() throws XMLDBException {
+        final String query = "util:base64-encode( 'This is a longer test to enforce an encoded string longer than the chunking limit!', true() )";
+        final ResourceSet result = existXmldbEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertEquals("VGhpcyBpcyBhIGxvbmdlciB0ZXN0IHRvIGVuZm9yY2UgYW4gZW5jb2RlZCBzdHJpbmcgbG9uZ2VyIHRoYW4gdGhlIGNodW5raW5nIGxpbWl0IQ==", r);
+    }
+
+    @Test
+    public void testBase64EncodeWithTrimFalse() throws XMLDBException {
+        final String query = "util:base64-encode( 'This is a longer test to enforce an encoded string longer than the chunking limit!', false() )";
+        final ResourceSet result = existXmldbEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertEquals("VGhpcyBpcyBhIGxvbmdlciB0ZXN0IHRvIGVuZm9yY2UgYW4gZW5jb2RlZCBzdHJpbmcgbG9uZ2VyIHRoYW4gdGhlIGNodW5raW5nIGxpbWl0IQ==", r);
+    }
+
+    @Test
     public void testBase64Decode() throws XMLDBException {
         final String query = "util:base64-decode( 'VGhpcyBpcyBhIHRlc3Qh' )";
         final ResourceSet result = existXmldbEmbeddedServer.executeQuery(query);

--- a/exist-core/src/test/java/org/exist/xquery/functions/util/Base64FunctionsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/util/Base64FunctionsTest.java
@@ -66,5 +66,28 @@ public class Base64FunctionsTest {
         assertEquals("This is a test!", r);
     }
 
+    @Test
+    public void testBase64EncodeUrlSafeNoSpecial() throws XMLDBException {
+        final String query = "util:base64-decode-url-safe( 'This is a test!' )";
+        final ResourceSet result = existXmldbEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertEquals("VGhpcyBpcyBhIHRlc3Qh", r);
+    }
+
+    @Test
+    public void testBase64EncodeUrlSafeSpecial() throws XMLDBException {
+        final String query = "util:base64-decode-url-safe( '.ÿd' )";
+        final ResourceSet result = existXmldbEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertEquals("LsO_ZA", r);
+    }
+
+    @Test
+    public void testBase64DecodeUrlSafe() throws XMLDBException {
+        final String query = "util:base64-decode( 'LsO_ZA' )";
+        final ResourceSet result = existXmldbEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertEquals(".ÿd", r);
+    }
 
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/util/Base64FunctionsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/util/Base64FunctionsTest.java
@@ -68,7 +68,7 @@ public class Base64FunctionsTest {
 
     @Test
     public void testBase64EncodeUrlSafeNoSpecial() throws XMLDBException {
-        final String query = "util:base64-decode-url-safe( 'This is a test!' )";
+        final String query = "util:base64-encode-url-safe( 'This is a test!' )";
         final ResourceSet result = existXmldbEmbeddedServer.executeQuery(query);
         final String r = (String) result.getResource(0).getContent();
         assertEquals("VGhpcyBpcyBhIHRlc3Qh", r);
@@ -76,7 +76,7 @@ public class Base64FunctionsTest {
 
     @Test
     public void testBase64EncodeUrlSafeSpecial() throws XMLDBException {
-        final String query = "util:base64-decode-url-safe( '.ÿd' )";
+        final String query = "util:base64-encode-url-safe( '.ÿd' )";
         final ResourceSet result = existXmldbEmbeddedServer.executeQuery(query);
         final String r = (String) result.getResource(0).getContent();
         assertEquals("LsO_ZA", r);


### PR DESCRIPTION
### Description:

There is a number of use cases (data-url, JWT) where the data must be encoded as base64 url-safe.
This PR adds a new utility function adding this functionality.

Compare the output of 

```
util:base64-encode(".ÿd"),
util:base64-encode-url-safe(".ÿd")
```

Additionally, this PR deprecates `util:base64-encode#2`. The trim-parameter serves no purpose since the output cannot be chunked because of the encoder that is used internally.

The class is refactored for readability and the formatting is fixed.

### Reference:

[RFC4648](https://tools.ietf.org/html/rfc4648)

### Type of tests:

Java tests were added to the tests that were already existing, ensuring that the functionality will persist even when implementation changes in the future.