### PR TITLE
line and column numbers in unknown-atomic-type errors

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -586,8 +586,11 @@ singleType throws XPathException
 atomicType throws XPathException
 { String name= null; }
 :
-	name=qName
-	{ #atomicType= #[ATOMIC_TYPE, name]; }
+	name=q:qName
+	{
+	  #atomicType= #[ATOMIC_TYPE, name];
+	  #atomicType.copyLexInfo(#q);
+	}
 	;
 
 functionTest throws XPathException

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -970,9 +970,11 @@ throws XPathException
 			    try {
                     QName qn= QName.parse(staticContext, t.getText());
                     int code= Type.getType(qn);
-                    if(!Type.subTypeOf(code, Type.ATOMIC))
-                        throw new XPathException(t, "Type " + qn.toString() + " is not an atomic type");
+                    if (!Type.subTypeOf(code, Type.ATOMIC))
+                        throw new XPathException(t.getLine(), t.getColumn(), ErrorCodes.XPST0051, qn.toString() + " is not atomic");
                     type.setPrimaryType(code);
+                } catch (final XPathException e) {
+                    throw new XPathException(t.getLine(), t.getColumn(), ErrorCodes.XPST0051, "Unknown simple type " + t.getText());
                 } catch (final IllegalQNameException e) {
                     throw new XPathException(t.getLine(), t.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + t.getText());
                 }
@@ -3378,6 +3380,8 @@ throws PermissionDeniedException, EXistException, XPathException
                 castExpr.setASTNode(castAST);
                 path.add(castExpr);
                 step = castExpr;
+            } catch (final XPathException e) {
+                throw new XPathException(t.getLine(), t.getColumn(), ErrorCodes.XPST0051, "Unknown simple type " + t.getText());
             } catch (final IllegalQNameException e) {
                 throw new XPathException(t.getLine(), t.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + t.getText());
             }
@@ -3404,6 +3408,8 @@ throws PermissionDeniedException, EXistException, XPathException
                 castExpr.setASTNode(castAST);
                 path.add(castExpr);
                 step = castExpr;
+            } catch (final XPathException e) {
+                throw new XPathException(t2.getLine(), t2.getColumn(), ErrorCodes.XPST0051, "Unknown simple type " + t2.getText());
             } catch (final IllegalQNameException e) {
                 throw new XPathException(t2.getLine(), t2.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + t2.getText());
             }

--- a/exist-core/src/test/java/org/exist/xquery/UnknownAtomicTypeTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/UnknownAtomicTypeTest.java
@@ -1,0 +1,75 @@
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.assertEquals;
+
+public class UnknownAtomicTypeTest {
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(true, true, true);
+
+    @Test
+    public void letVariable() throws XMLDBException {
+        final String query = "let $x as y := 0 return $x";
+        final String error = "err:XPST0051 Unknown simple type y [at line 1, column 11]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void functionReturnType() throws XMLDBException {
+        final String query = "function () as y { () }";
+        final String error = "err:XPST0051 Unknown simple type y [at line 1, column 16]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void functionParameterType() throws XMLDBException {
+        final String query = "function ($x as y) { $x }";
+        final String error = "err:XPST0051 Unknown simple type y [at line 1, column 17]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void instanceOf() throws XMLDBException {
+        final String query = "1 instance of y";
+        final String error = "err:XPST0051 Unknown simple type y [at line 1, column 15]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void treatAs() throws XMLDBException {
+        final String query = "1 treat as y";
+        final String error = "err:XPST0051 Unknown simple type y [at line 1, column 12]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void castAs() throws XMLDBException {
+        final String query = "1 cast as y";
+        final String error = "err:XPST0051 Unknown simple type y [at line 1, column 11]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void castableAs() throws XMLDBException {
+        final String query = "1 castable as y";
+        final String error = "err:XPST0051 Unknown simple type y [at line 1, column 15]";
+        assertCompilationError(query, error);
+    }
+
+    private void assertCompilationError(final String query, final String error) throws XMLDBException {
+        final XQueryService service = (XQueryService)existEmbeddedServer.getRoot().getService("XQueryService", "1.0");
+
+        try {
+            service.compile(query);
+            fail("no XMLDBException was thrown during compilation.");
+        } catch (XMLDBException ex) {
+            assertEquals( error, ex.getMessage() );
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/UnknownAtomicTypeTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/UnknownAtomicTypeTest.java
@@ -1,14 +1,40 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package org.exist.xquery;
 
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.ClassRule;
 import org.junit.Test;
-import static org.junit.Assert.*;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.XQueryService;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
+/**
+ * Ensure tests for unknown atomic types are reported with location information
+ * https://github.com/eXist-db/exist/issues/3518
+ *
+ * @author <a href="mailto:juri@existsolutions.com">Juri Leino</a>
+ */
 public class UnknownAtomicTypeTest {
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(true, true, true);


### PR DESCRIPTION
### Description:

Type errors for types after `instance of`, `cast as`, `castable as` and similar expressions do not show line and column numbers.

add line and column for type errors after

- [x]  `cast as` 
- [x] `castable as` 
- [x] `treat as` 
- [x] `instance of` 
- [x] tests (static compilation errors need to be tested in java)
### Reference:

fixes #3518 

### Type of tests:

jUnit tests were added 

You can also evaluate any of the following expressions in eXide to see the change

```
let $x as y := 0 return $x
```

```
function ($x as y) { $x }
```

```
<x /> instance of y
```

```
<x /> cast as
y
```

```
<x /> castable as y
```

```
<x />
treat as
y
```