### PR TITLE
[hotfix] add location info to element content errors

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -1663,12 +1663,19 @@ compElemConstructor throws XPathException
 { String eq; }
 :
 	( "element" LCURLY ) =>
-	"element"! LCURLY! expr RCURLY! compConstructorValue
+	"element"! LCURLY! expr RCURLY! compElemConstructorContent
 	{ #compElemConstructor = #(#[COMP_ELEM_CONSTRUCTOR], #compElemConstructor); }
 	|
-	"element"! eq=eqName e3:compConstructorValue
-	{ #compElemConstructor = #(#[COMP_ELEM_CONSTRUCTOR, eq], #[STRING_LITERAL, eq], #e3); }
+	"element"! eq=eqName v:compElemConstructorContent
+	{ #compElemConstructor = #(#[COMP_ELEM_CONSTRUCTOR, eq], #[STRING_LITERAL, eq], #v); }
 	;
+
+compElemConstructorContent throws XPathException
+:
+    ( LCURLY RCURLY ) => LCURLY! RCURLY!
+    | LCURLY^ (expr)?  RCURLY!
+    ;
+
 
 compAttrConstructor throws XPathException
 { String eq; }

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -1663,10 +1663,10 @@ compElemConstructor throws XPathException
 { String eq; }
 :
 	( "element" LCURLY ) =>
-	"element"! LCURLY! expr RCURLY! LCURLY! (expr)? RCURLY!
+	"element"! LCURLY! expr RCURLY! compConstructorValue
 	{ #compElemConstructor = #(#[COMP_ELEM_CONSTRUCTOR], #compElemConstructor); }
 	|
-	"element"! eq=eqName LCURLY! (e3:expr)? RCURLY!
+	"element"! eq=eqName e3:compConstructorValue
 	{ #compElemConstructor = #(#[COMP_ELEM_CONSTRUCTOR, eq], #[STRING_LITERAL, eq], #e3); }
 	;
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -1673,7 +1673,9 @@ compElemConstructor throws XPathException
 compElemConstructorContent throws XPathException
 :
     ( LCURLY RCURLY ) => LCURLY! RCURLY!
-    | LCURLY^ (expr)?  RCURLY!
+    { #compElemConstructorContent= #(#[PARENTHESIZED, "Parenthesized"], null); }
+    | LCURLY! e:expr RCURLY!
+    { #compElemConstructorContent.copyLexInfo(#e); }
     ;
 
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -3157,8 +3157,11 @@ throws PermissionDeniedException, EXistException, XPathException
 		qnameExpr=expr [qnamePathExpr]
 		(
 			{ elementContent = new PathExpr(context); }
-			contentExpr=expr[elementContent]
-			{ construct.addPathIfNotFunction(elementContent); }
+			contentExpr=ec:expr[elementContent]
+			{
+			  elementContent.setASTNode(ec);
+			  construct.addPathIfNotFunction(elementContent);
+			}
 		)*
 	)
 	|

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -3158,7 +3158,7 @@ throws PermissionDeniedException, EXistException, XPathException
 		(
 			{ elementContent = new PathExpr(context); }
 			contentExpr=expr[elementContent]
-			{ construct.addPath(elementContent); }
+			{ construct.addPathIfNotFunction(elementContent); }
 		)*
 	)
 	|

--- a/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
@@ -98,7 +98,7 @@ public class EnclosedExpr extends PathExpr {
                 while (next != null) {
                     context.proceed(this, builder);
                     if (Type.subTypeOf(next.getType(), Type.FUNCTION_REFERENCE)) {
-                        throw new XPathException(ErrorCodes.XQTY0105, "Enclosed expression contains function item");
+                        throw new XPathException(this, ErrorCodes.XQTY0105, "Enclosed expression contains function item");
 
                         // if item is an atomic value, collect the string values of all
                         // following atomic values and separate them by a space.

--- a/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
@@ -35,11 +35,12 @@ import org.exist.xquery.value.ValueSequence;
  */
 public class SequenceConstructor extends PathExpr {
 
-    public SequenceConstructor(XQueryContext context) {
+    public SequenceConstructor(final XQueryContext context) {
         super(context);
     }
 
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         contextInfo.setParent(this);
         inPredicate = (contextInfo.getFlags() & IN_PREDICATE) > 0;
         unordered = (contextInfo.getFlags() & UNORDERED) > 0;
@@ -58,20 +59,20 @@ public class SequenceConstructor extends PathExpr {
         contextInfo.setStaticReturnType(staticType);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#eval(org.exist.dom.persistent.DocumentSet, org.exist.xquery.value.Sequence, org.exist.xquery.value.Item)
-     */
-    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
         if (context.getProfiler().isEnabled()) {
             context.getProfiler().start(this);
             context.getProfiler().message(this, Profiler.DEPENDENCIES,
                 "DEPENDENCIES", Dependency.getDependenciesName(this.getDependencies()));
-            if (contextSequence != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES,
-                    "CONTEXT SEQUENCE", contextSequence);}
-            if (contextItem != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES,
-                    "CONTEXT ITEM", contextItem.toSequence());}
+            if (contextSequence != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES,
+                    "CONTEXT SEQUENCE", contextSequence);
+            }
+            if (contextItem != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES,
+                    "CONTEXT ITEM", contextItem.toSequence());
+            }
         }
         final ValueSequence result = new ValueSequence();
         result.keepUnOrdered(unordered);
@@ -86,21 +87,21 @@ public class SequenceConstructor extends PathExpr {
                 context.popDocumentContext();
             }
         }
-        if (context.getProfiler().isEnabled()) 
-            {context.getProfiler().end(this, "", result);}
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", result);
+        }
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.PathExpr#dump(org.exist.xquery.util.ExpressionDumper)
-     */
-    public void dump(ExpressionDumper dumper) {
+    @Override
+    public void dump(final ExpressionDumper dumper) {
         dumper.display("(");
         dumper.startIndent();
         boolean moreThanOne = false;
         for(final Expression step : steps) {
-            if (moreThanOne)
-                {dumper.display(", ");}
+            if (moreThanOne) {
+                dumper.display(", ");
+            }
             moreThanOne = true;
             step.dump(dumper);
         }
@@ -108,13 +109,15 @@ public class SequenceConstructor extends PathExpr {
         dumper.nl().display(")");
     }
 
+    @Override
     public String toString() {
         final StringBuilder result = new StringBuilder();
         result.append("( ");
         boolean moreThanOne = false;
         for (final Expression step : steps) {
-            if (moreThanOne)
-                {result.append(", ");}
+            if (moreThanOne) {
+                result.append(", ");
+            }
             moreThanOne = true;
             result.append(step.toString());
         }
@@ -138,9 +141,7 @@ public class SequenceConstructor extends PathExpr {
         super.addPath(path);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#returnsType()
-     */
+    @Override
     public int returnsType() {
         return Type.ITEM;
     }
@@ -155,10 +156,8 @@ public class SequenceConstructor extends PathExpr {
         return true;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#resetState()
-     */
-    public void resetState(boolean postOptimization) {
+    @Override
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
@@ -124,14 +124,15 @@ public class SequenceConstructor extends PathExpr {
 
     /**
      * Add another PathExpr to this object's expression list.
-     * Performs a static check, if return type is a function type.
+     * Performs a static check, if return type is a function type other than array.
+     * see #id-content setion 1.e.i and 1.e.ii
      *
      * @throws XPathException when Path returns a function type
      * @param path A path to add to this path
      */
     public void addPathIfNotFunction(final PathExpr path) throws XPathException {
         int retType = path.returnsType();
-        if (Type.subTypeOf(retType, Type.FUNCTION_REFERENCE)) {
+        if (Type.subTypeOf(retType, Type.FUNCTION_REFERENCE) && retType != Type.ARRAY) {
             throw new XPathException(path, ErrorCodes.XQTY0105, "Function types are not allowed in element content. Got " + Type.getTypeName(retType));
         }
         super.addPath(path);

--- a/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
@@ -122,6 +122,21 @@ public class SequenceConstructor extends PathExpr {
         return result.toString();
     }
 
+    /**
+     * Add another PathExpr to this object's expression list.
+     * Performs a static check, if return type is a function type.
+     *
+     * @throws XPathException when Path returns a function type
+     * @param path A path to add to this path
+     */
+    public void addPathIfNotFunction(final PathExpr path) throws XPathException {
+        int retType = path.returnsType();
+        if (Type.subTypeOf(retType, Type.FUNCTION_REFERENCE)) {
+            throw new XPathException(path, ErrorCodes.XQTY0105, "Function types are not allowed in element content. Got " + Type.getTypeName(retType));
+        }
+        super.addPath(path);
+    }
+
     /* (non-Javadoc)
      * @see org.exist.xquery.Expression#returnsType()
      */

--- a/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/SequenceConstructor.java
@@ -125,13 +125,13 @@ public class SequenceConstructor extends PathExpr {
     /**
      * Add another PathExpr to this object's expression list.
      * Performs a static check, if return type is a function type other than array.
-     * see #id-content setion 1.e.i and 1.e.ii
+     * see #id-content section 1.e.i and 1.e.ii
      *
      * @throws XPathException when Path returns a function type
      * @param path A path to add to this path
      */
     public void addPathIfNotFunction(final PathExpr path) throws XPathException {
-        int retType = path.returnsType();
+        final int retType = path.returnsType();
         if (Type.subTypeOf(retType, Type.FUNCTION_REFERENCE) && retType != Type.ARRAY) {
             throw new XPathException(path, ErrorCodes.XQTY0105, "Function types are not allowed in element content. Got " + Type.getTypeName(retType));
         }

--- a/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContent.java
+++ b/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContent.java
@@ -42,35 +42,35 @@ public class FunctionTypeInElementContent {
     @Test
     public void arrayLiteral() throws XMLDBException {
         final String query = "element test { [] }";
-        final String error = "err:XQTY0105 Function types are not allowed in element content. Got array(*) [at line 1, column 14, source: element test { [] }]";
-        assertCompilationError(query, error);
+        assertCompilationSuccess(query);
     }
+
+    @Test
+    public void arrayConstructor() throws XMLDBException {
+        final String query = "element test { array { () } }";
+        assertCompilationSuccess(query);
+    }
+
 
     @Test
     public void partialBuiltIn() throws XMLDBException {
         final String query = "element test { sum(?) }";
-        final String error = "err:XQTY0105 Function types are not allowed in element content. Got function(*) [at line 1, column 14, source: element test { sum(?) }]";
+        final String error = "err:XQTY0105 Function types are not allowed in element content. Got function(*) [at line 1, column 16, source: element test { sum(?) }]";
         assertCompilationError(query, error);
     }
 
     @Test
     public void userDefinedFunction() throws XMLDBException {
         final String query = "element test { function () { () } }";
-        final String error = "err:XQTY0105 Function types are not allowed in element content. Got function(*) [at line 1, column 14, source: element test { function () { () } }]";
-        assertCompilationError(query, error);
-    }
-
-    @Test
-    public void arrayConstructor() throws XMLDBException {
-        final String query = "element test { array { () } }";
-        final String error = "err:XQTY0105 Function types are not allowed in element content. Got array(*) [at line 1, column 14, source: element test { array { () } }]";
+        // TODO: user defined function has its location offset to a weird location
+        final String error = "err:XQTY0105 Function types are not allowed in element content. Got function(*) [at line 1, column 25, source: element test { function () { () } }]";
         assertCompilationError(query, error);
     }
 
     @Test
     public void mapConstructor() throws XMLDBException {
         final String query = "element test { map {} }";
-        final String error = "err:XQTY0105 Function types are not allowed in element content. Got map(*) [at line 1, column 14, source: element test { map {} }]";
+        final String error = "err:XQTY0105 Function types are not allowed in element content. Got map(*) [at line 1, column 16, source: element test { map {} }]";
         assertCompilationError(query, error);
     }
 
@@ -106,5 +106,11 @@ public class FunctionTypeInElementContent {
         } catch (XMLDBException ex) {
             assertEquals( error, ex.getMessage() );
         }
+    }
+    private void assertCompilationSuccess(final String query) throws XMLDBException {
+        final XQueryService service = (XQueryService)existEmbeddedServer.getRoot().getService("XQueryService", "1.0");
+
+        service.compile(query);
+        assertTrue( true );
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContent.java
+++ b/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContent.java
@@ -1,0 +1,110 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.test.ExistXmldbEmbeddedServer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.XQueryService;
+
+import static org.junit.Assert.*;
+
+/**
+ * Ensure function types returned in element content throws at compile time and has location information
+ * https://github.com/eXist-db/exist/issues/3474
+ *
+ * @author <a href="mailto:juri@existsolutions.com">Juri Leino</a>
+ */
+public class FunctionTypeInElementContent {
+    @ClassRule
+    public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(true, true, true);
+
+    @Test
+    public void arrayLiteral() throws XMLDBException {
+        final String query = "element test { [] }";
+        final String error = "err:XQTY0105 Function types are not allowed in element content. Got array(*) [at line 1, column 14, source: element test { [] }]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void partialBuiltIn() throws XMLDBException {
+        final String query = "element test { sum(?) }";
+        final String error = "err:XQTY0105 Function types are not allowed in element content. Got function(*) [at line 1, column 14, source: element test { sum(?) }]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void userDefinedFunction() throws XMLDBException {
+        final String query = "element test { function () { () } }";
+        final String error = "err:XQTY0105 Function types are not allowed in element content. Got function(*) [at line 1, column 14, source: element test { function () { () } }]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void arrayConstructor() throws XMLDBException {
+        final String query = "element test { array { () } }";
+        final String error = "err:XQTY0105 Function types are not allowed in element content. Got array(*) [at line 1, column 14, source: element test { array { () } }]";
+        assertCompilationError(query, error);
+    }
+
+    @Test
+    public void mapConstructor() throws XMLDBException {
+        final String query = "element test { map {} }";
+        final String error = "err:XQTY0105 Function types are not allowed in element content. Got map(*) [at line 1, column 14, source: element test { map {} }]";
+        assertCompilationError(query, error);
+    }
+
+//  -- no error is thrown at compile time
+//    @Test
+//    public void mapConstructorInSequence() throws XMLDBException {
+//        final String query = "element test {\n" +
+//                "    \"a\",\n" +
+//                "    map {}\n" +
+//                "}";
+//        final String error = "err:XQTY0105 Function types are not allowed in element content. Got map(*) [at line 1, column 14, source: element test { map {} }]";
+//        assertCompilationError(query, error);
+//    }
+
+
+//  -- no error is thrown at compile time nor run time
+//    @Test
+//    public void arrayInSequence() throws XMLDBException {
+//        final String query = "element test {\n" +
+//                "    \"a\",\n" +
+//                "    []\n" +
+//                "}";
+//        final String error = "err:XQTY0105 Function types are not allowed in element content. Got map(*) [at line 1, column 14, source: element test { map {} }]";
+//        assertCompilationError(query, error);
+//    }
+
+    private void assertCompilationError(final String query, final String error) throws XMLDBException {
+        final XQueryService service = (XQueryService)existEmbeddedServer.getRoot().getService("XQueryService", "1.0");
+
+        try {
+            service.compile(query);
+            fail("no XMLDBException was thrown during compilation.");
+        } catch (XMLDBException ex) {
+            assertEquals( error, ex.getMessage() );
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
@@ -30,8 +30,9 @@ import static org.exist.test.DiffMatcher.elemSource;
 import static org.exist.test.XQueryAssertions.*;
 
 /**
- * Ensure function types returned in element content throws at compile time and has location information
- * https://github.com/eXist-db/exist/issues/3474
+ * Ensure function types returned in element content throws at compile time and
+ * has location information.
+ * See issue :<a href="https://github.com/eXist-db/exist/issues/3474">#3474</a>.
  *
  * @author <a href="mailto:juri@existsolutions.com">Juri Leino</a>
  */
@@ -43,7 +44,7 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
         assertXQResultSimilar(elemSource("<test/>"), executeQuery(query));
     }
 
-    // TODO: array content could be removed after https://github.com/eXist-db/exist/issues/3472 is fixed
+    // TODO(JL): array content could be removed after https://github.com/eXist-db/exist/issues/3472 is fixed
     @Test
     public void arrayConstructor() throws EXistException, PermissionDeniedException {
         final String query = "element test { array { () } }";
@@ -63,7 +64,7 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
         assertXQStaticError(ErrorCodes.XQTY0105, 1, 16, error, compileQuery(query));
     }
 
-    // TODO: Does still throw without location info
+    // TODO(JL): Does still throw without location info
     @Test
     public void functionReference() throws EXistException, PermissionDeniedException {
         final String query = "element test { sum#0 }";
@@ -71,7 +72,7 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
         assertXQStaticError(ErrorCodes.XQTY0105, 0, 0, error, compileQuery(query));
     }
 
-    // TODO: Does not throw at compile time
+    // TODO(JL): Does not throw at compile time
     @Test
     public void functionVariable() throws EXistException, PermissionDeniedException {
         final String query = "let $f := function () {} return element test { $f }";
@@ -79,7 +80,7 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
         assertXQDynamicError(ErrorCodes.XQTY0105, 1, 49, error, executeQuery(query));
     }
 
-    // TODO: user defined function has its location offset to a weird location
+    // TODO(JL): user defined function has its location offset to a weird location
     @Test
     public void userDefinedFunction() throws EXistException, PermissionDeniedException {
         final String query = "element test { function () {} }";
@@ -110,11 +111,11 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
         assertXQDynamicError(ErrorCodes.XQTY0105, 0, 0, error, executeQuery(query));
     }
 
+    // TODO(JL): add (sub-expression) location
     /**
      * This is an edge case, which would evaluate to empty sequence
      * but should arguably still throw.
      */
-    // TODO: add (sub-expression) location
     @Test
     public void sequenceOfMapsEdgeCase() throws EXistException, PermissionDeniedException {
         final String query = "element test { (map {})[2] }";
@@ -122,8 +123,8 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
         assertXQStaticError(ErrorCodes.XQTY0105, 0, 0, error, compileQuery(query));
     }
 
-    // TODO: add (sub-expression) location
-    // TODO: this could throw at compile time
+    // TODO(JL): add (sub-expression) location
+    // TODO(JL): this could throw at compile time
     @Test
     public void arrayOfMaps() throws EXistException, PermissionDeniedException {
         final String query = "element test { [map {}] }";
@@ -131,8 +132,8 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
         assertXQDynamicError(ErrorCodes.XQTY0105, 1, 16, error, executeQuery(query));
     };
 
-    // TODO: add (sub-expression) location
-    // TODO: This should throw at compile time, but does not
+    // TODO(JL): add (sub-expression) location
+    // TODO(JL): This should throw at compile time, but does not
     @Test
     public void mapConstructorInSubExpression() throws EXistException, PermissionDeniedException {
         final String query = "element test { \"a\", map {} }";

--- a/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
@@ -99,6 +99,12 @@ public class FunctionTypeInElementContentTest {
         assertCompilationError(query, error);
     }
 
+    @Test
+    public void mapConstructorLookup() throws XMLDBException {
+        final String query = "element test { map {1:1}?1 }";
+        assertCompilationSuccess(query);
+    }
+
     /**
      * sequence in enclosed expression with only a function type
      */

--- a/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
@@ -79,14 +79,14 @@ public class FunctionTypeInElementContentTest {
     @Ignore
     @Test
     public void functionVariable() throws XMLDBException {
-        final String query = "let $f := function () { () } return element test { $f }";
+        final String query = "let $f := function () {} return element test { $f }";
         final String error = "err:XQTY0105 Function types are not allowed in element content. Got function(*) [at line 1, column 16, source: element test { sum(?) }]";
         assertCompilationError(query, error);
     }
 
     @Test
     public void userDefinedFunction() throws XMLDBException {
-        final String query = "element test { function () { () } }";
+        final String query = "element test { function () {} }";
         // TODO: user defined function has its location offset to a weird location
         final String error = "err:XQTY0105 Function types are not allowed in element content. Got function(*) [at line 1, column 25, source: element test { function () { () } }]";
         assertCompilationError(query, error);

--- a/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
@@ -46,9 +46,7 @@ public class FunctionTypeInElementContentTest {
         assertCompilationSuccess(query);
     }
 
-    /**
-     * TODO: remove empty sequence after https://github.com/eXist-db/exist/issues/3472 is fixed
-     */
+    // TODO: array content could be removed after https://github.com/eXist-db/exist/issues/3472 is fixed
     @Test
     public void arrayConstructor() throws XMLDBException {
         final String query = "element test { array { () } }";
@@ -68,9 +66,7 @@ public class FunctionTypeInElementContentTest {
         assertCompilationError(query, error);
     }
 
-    /**
-     * TODO: Investigate does still throw without location info
-     */
+    // TODO: Investigate does still throw without location info
     @Ignore
     @Test
     public void functionReference() throws XMLDBException {
@@ -79,9 +75,7 @@ public class FunctionTypeInElementContentTest {
         assertCompilationError(query, error);
     }
 
-    /**
-     * Does not throw at compile time
-     */
+    // Does not throw at compile time
     @Ignore
     @Test
     public void functionVariable() throws XMLDBException {
@@ -90,9 +84,6 @@ public class FunctionTypeInElementContentTest {
         assertCompilationError(query, error);
     }
 
-    /**
-     * TODO: remove empty sequence after https://github.com/eXist-db/exist/issues/3551 is fixed
-     */
     @Test
     public void userDefinedFunction() throws XMLDBException {
         final String query = "element test { function () { () } }";
@@ -120,11 +111,10 @@ public class FunctionTypeInElementContentTest {
     }
 
     /**
-     * there is an edge case which would evaluate to empty sequence
-     * but should arguably still throw
-     * Does still throw without location info
-     * TODO: add (sub-expression) location
+     * This is an edge case, which would evaluate to empty sequence
+     * but should arguably still throw.
      */
+    // TODO: add (sub-expression) location
     @Test
     public void sequenceOfMapsEdgeCase() throws XMLDBException {
         final String query = "element test { (map {})[2] }";
@@ -132,10 +122,8 @@ public class FunctionTypeInElementContentTest {
         assertCompilationError(query, error);
     }
 
-    /**
-     * -- no error is thrown at compile time
-     * TODO: add (sub-expression) location
-     */
+    // TODO: add (sub-expression) location
+    // TODO: this could throw at compile time
     @Test
     public void ArrayOfMaps() throws XMLDBException {
         final String query = "element test { [map {}] }";
@@ -143,10 +131,8 @@ public class FunctionTypeInElementContentTest {
         assertCompilationError(query, error);
     };
 
-    /**
-     * This could throw at compile time, but does not
-     * TODO: add (sub-expression) location
-     */
+    // TODO: add (sub-expression) location
+    // TODO: This should throw at compile time, but does not
     @Ignore
     @Test
     public void mapConstructorInSubExpression() throws XMLDBException {

--- a/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.*;
  *
  * @author <a href="mailto:juri@existsolutions.com">Juri Leino</a>
  */
-public class FunctionTypeInElementContent {
+public class FunctionTypeInElementContentTest {
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(true, true, true);
 

--- a/exist-core/src/test/xquery/errors.xql
+++ b/exist-core/src/test/xquery/errors.xql
@@ -330,38 +330,45 @@ function et:issue3473c() {
  : related to https://github.com/eXist-db/exist/issues/3474
  :)
 declare
-    %test:assertEquals(339)
-    %test:pending("expression seems to swallow subexpression location")
-function et:enclosed-expression-evaluates-to-map() {
+    %test:assertTrue
+    %test:pending("location info still missing")
+function et:subexpression-in-enclosed-expression-evaluates-to-map() {
     try {
-        element foo {
-            (
-                "a",
-                map {}
-            )[2]
-        }
+        element test { 1, map {} }
     }
     catch err:XQTY0105 {
-        $err:line-number
+        exists($err:line-number) and
+        $err:line-number > 0 and
+        exists($err:column-number) and
+        $err:column-number > 0
     }
 };
 
-(:~
- : sequnce in enclosed expression with only a function type
- : weird edge case which should evaluate to empty sequence
- : but should arguably still throw
- : related to https://github.com/eXist-db/exist/issues/3474
- :)
 declare
-    %test:assertEquals(361)
-    %test:pending("expression seems to swallow subexpression location")
-function et:enclosed-expression-edge-case() {
+    %test:assertTrue
+    %test:pending("location info still missing")
+function et:enclosed-expression-evaluates-to-map() {
     try {
-        element foo {
-            (map {})[2]
-        }
+        element test { ( "a", map {} )[2] }
     }
     catch err:XQTY0105 {
-        $err:line-number
+        exists($err:line-number) and
+        $err:line-number > 0 and
+        exists($err:column-number) and
+        $err:column-number > 0
+    }
+};
+
+declare
+    %test:assertTrue
+function et:array-in-enclosed-expression-evaluates-to-map() {
+    try {
+        element test { [map {}] }
+    }
+    catch err:XQTY0105 {
+        exists($err:line-number) and
+        $err:line-number > 0 and
+        exists($err:column-number) and
+        $err:column-number > 0
     }
 };

--- a/exist-core/src/test/xquery/errors.xql
+++ b/exist-core/src/test/xquery/errors.xql
@@ -326,19 +326,42 @@ function et:issue3473c() {
 };
 
 (:~
- : function type item in element content in sequence
- : throws at runtime not compile time
- : https://github.com/eXist-db/exist/issues/3474
+ : function type item returned in element content in sequence at runtime
+ : related to https://github.com/eXist-db/exist/issues/3474
  :)
 declare
-    %test:assertEquals(337)
-function et:issue3474() {
+    %test:assertEquals(339)
+    %test:pending("expression seems to swallow subexpression location")
+function et:enclosed-expression-evaluates-to-map() {
     try {
         element foo {
-            "a",
-            map { "x": "y" }
+            (
+                "a",
+                map {}
+            )[2]
         }
-    } catch * {
+    }
+    catch err:XQTY0105 {
+        $err:line-number
+    }
+};
+
+(:~
+ : sequnce in enclosed expression with only a function type
+ : weird edge case which should evaluate to empty sequence
+ : but should arguably still throw
+ : related to https://github.com/eXist-db/exist/issues/3474
+ :)
+declare
+    %test:assertEquals(361)
+    %test:pending("expression seems to swallow subexpression location")
+function et:enclosed-expression-edge-case() {
+    try {
+        element foo {
+            (map {})[2]
+        }
+    }
+    catch err:XQTY0105 {
         $err:line-number
     }
 };

--- a/exist-core/src/test/xquery/errors.xql
+++ b/exist-core/src/test/xquery/errors.xql
@@ -325,13 +325,19 @@ function et:issue3473c() {
     }
 };
 
-(: https://github.com/eXist-db/exist/issues/3474 :)
+(:~
+ : function type item in element content in sequence
+ : throws at runtime not compile time
+ : https://github.com/eXist-db/exist/issues/3474
+ :)
 declare
-    %test:pending("to be addressed in another PR")
-    %test:assertEquals(333)
+    %test:assertEquals(337)
 function et:issue3474() {
     try {
-        element foo { map { "x": "y" } }
+        element foo {
+            "a",
+            map { "x": "y" }
+        }
     } catch * {
         $err:line-number
     }


### PR DESCRIPTION
### Description:

The queries below are all invalid because the element content contains expressions which will evaluate to function types. The error is thrown a) at run-time and b) without location information (line and column number).

```xquery
element foo { sum(?) },
element foo { map{} },
```

This PR fixes the XQuery parser so that location information is given when an error is raised and also checks each expression if the return type is known to be a function type at compilation time.

- Add `path` to XPathException thrown in EnclosedExpr (for dynamic errors, works only if location is preserved during compilation)
- Add method `addPathIfNotFunction` to SequenceConstructor to add a static type check for each path before it is added. Throws if a function type (map, array, function, partial ...) is found.
- fix `compElemConstructor` rule in XQuery.g by using existing rule `compConstructorValue`. This adds location info to element content sub-expressions
- use new SequenceConstructor method in XQueryTree.g to add paths to EnclosedExpr content and thus statically check return types of subexpressions

There is an exception when it comes to function types: Arrays are serialised when they appear in element content:

```xquery
element foo { [1] }
(: this must evaluate to <test>1</test> :)
```

### Reference:

Fixes #3474 

[Element Content Rules](https://www.w3.org/TR/xquery-31/#id-content)
As @adamretter pointed out 1.e(i) and 1.e(ii) define the behaviour: arrays are flattened but any other function type throws. 

When the function is returned at runtime Saxon10-HE throws a different error code [XTDE0450](https://www.w3.org/TR/xslt-30/#err-XTDE0450).
We should think about mimicking this behaviour or if we stick to XQTY0105 for static and dynamic errors.

### Type of tests:

adds jUnit testsuite and modifies one XQsuite test