### PR TITLE
added missing directoryScanner.scan(); to fix repo:install-from-db

### DIFF
--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
@@ -130,6 +130,7 @@ public class DirectoryList extends BasicFunction {
             directoryScanner.setIncludes(includes);
             directoryScanner.setBasedir(baseDir.toFile());
             directoryScanner.setCaseSensitive(true);
+            directoryScanner.scan();
 
             for (final String includedFile : directoryScanner.getIncludedFiles()) {
                 final Path file = baseDir.resolve(includedFile);


### PR DESCRIPTION
Added missing directoryScanner.scan() to fix repo:install-from-db. The bug can be reproduced by executing `ant deploy-one -Drepo-name=hsg-shell -Dxar=hsg-shell-0.2.xar` in https://github.com/HistoryAtState/hsg-project. The ant target calls `https://github.com/HistoryAtState/hsg-project/blob/master/build/deploy.xql` which triggers the exception ` java.lang.IllegalStateException: Must call scan() first`.