### PR TITLE
Bugfix: make sure 0 byte sized binary resources can be included in ZiPfile

### DIFF
--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/AbstractCompressFunction.java
@@ -394,23 +394,23 @@ public abstract class AbstractCompressFunction extends BasicFunction
 		}
 
         final byte[] value;
-		if (doc.getResourceType() == DocumentImpl.XML_FILE) {
-			// xml file
-			Serializer serializer = context.getBroker().getSerializer();
-			serializer.setUser(context.getSubject());
-			serializer.setProperty("omit-xml-declaration", "no");
+        if (doc.getResourceType() == DocumentImpl.XML_FILE) {
+            // xml file
+            Serializer serializer = context.getBroker().getSerializer();
+            serializer.setUser(context.getSubject());
+            serializer.setProperty("omit-xml-declaration", "no");
             getDynamicSerializerOptions(serializer);
             String strDoc = serializer.serialize(doc);
-            value = strDoc.getBytes();            
-		} else if (doc.getResourceType() == DocumentImpl.BINARY_FILE) {
-			// binary file
-            try (final InputStream is = context.getBroker().getBinaryResource((BinaryDocument)doc);
-                 final UnsynchronizedByteArrayOutputStream baos = new UnsynchronizedByteArrayOutputStream(doc.getContentLength() == -1 ? 1024 : (int)doc.getContentLength())) {
+            value = strDoc.getBytes();
+        } else if (doc.getResourceType() == DocumentImpl.BINARY_FILE && doc.getContentLength() > 0) {
+            // binary file
+            try (final InputStream is = context.getBroker().getBinaryResource((BinaryDocument) doc);
+                 final UnsynchronizedByteArrayOutputStream baos = new UnsynchronizedByteArrayOutputStream(doc.getContentLength() == -1 ? 1024 : (int) doc.getContentLength())) {
                 baos.write(is);
                 value = baos.toByteArray();
             }
-		} else {
-		    value = new byte[0];
+        } else {
+            value = new byte[0];
         }
 
 		// close the entry

--- a/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
+++ b/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
@@ -50,3 +50,19 @@ function z:fnZipUtf8Content() {
   return
     ($z:myZipContentUTF8Base64 eq  $z:myStaticUTF8ContentBase64)
 };
+
+(: Verify zero byte sized resource :)
+declare
+	%test:assertEquals("")
+function z:zeroByteBinResource() {
+    let $collection-uri :="/db/"
+    let $resource-name :="empty.txt"
+    let $contents :=""
+
+    let $empty-file := xmldb:store-as-binary($collection-uri, $resource-name, $contents)
+
+    let $zip := compression:zip(<entry type="uri" name="{$collection-uri}">{$collection-uri||$resource-name}</entry>, true())
+
+    return util:binary-to-string(util:binary-doc($collection-uri||$resource-name))
+};
+


### PR DESCRIPTION
Bugfix: make sure 0 byte sized binary resources can be included in ZIP file. Fixes 3565


