### PR TITLE
[feature] Add a  parameter to util:eval to preserve the original erro…

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -671,6 +671,7 @@
                                 <exclude>src/main/java/org/exist/xquery/Cardinality.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportModuleTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/map/MapType.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/functions/util/Eval.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/ItemComparator.java</exclude>
@@ -803,6 +804,7 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/main/java/org/exist/xquery/Cardinality.java</include>
                                 <include>src/test/java/org/exist/xquery/ImportModuleTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/map/MapType.java</include>
+                                <include>src/main/java/org/exist/xquery/functions/util/Eval.java</include>
                                 <include>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</include>
                                 <include>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</include>
                                 <include>src/main/java/org/exist/xquery/value/ItemComparator.java</include>

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/UtilModule.java
@@ -73,14 +73,17 @@ public class UtilModule extends AbstractInternalModule {
             new FunctionDef(Eval.FS_EVAL[0], Eval.class),
             new FunctionDef(Eval.FS_EVAL[1], Eval.class),
             new FunctionDef(Eval.FS_EVAL[2], Eval.class),
+            new FunctionDef(Eval.FS_EVAL[3], Eval.class),
             new FunctionDef(Eval.FS_EVAL_WITH_CONTEXT[0], Eval.class),
             new FunctionDef(Eval.FS_EVAL_WITH_CONTEXT[1], Eval.class),
+            new FunctionDef(Eval.FS_EVAL_WITH_CONTEXT[2], Eval.class),
             new FunctionDef(Eval.FS_EVAL_INLINE[0], Eval.class),
             new FunctionDef(Eval.FS_EVAL_INLINE[1], Eval.class),
-
+            new FunctionDef(Eval.FS_EVAL_INLINE[2], Eval.class),
             new FunctionDef(Eval.FS_EVAL_AND_SERIALIZE[0], Eval.class),
             new FunctionDef(Eval.FS_EVAL_AND_SERIALIZE[1], Eval.class),
             new FunctionDef(Eval.FS_EVAL_AND_SERIALIZE[2], Eval.class),
+            new FunctionDef(Eval.FS_EVAL_AND_SERIALIZE[3], Eval.class),
             new FunctionDef(Compile.signatures[0], Compile.class),
             new FunctionDef(Compile.signatures[1], Compile.class),
             new FunctionDef(Compile.signatures[2], Compile.class),
@@ -163,7 +166,7 @@ public class UtilModule extends AbstractInternalModule {
 
     public final static QName ERROR_CODE_QNAME = new QName("error-code", UtilModule.NAMESPACE_URI, UtilModule.PREFIX);
 
-    public UtilModule(final Map<String, List<?>> parameters) throws XPathException {
+    public UtilModule(final Map<String, List<? extends Object>> parameters) throws XPathException {
         super(functions, parameters, true);
 
         final List<String> evalDisabledParamList = (List<String>) getParameter("evalDisabled");

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
@@ -95,6 +95,7 @@ public class DocTest {
 
         storeResource(test, "test.xq", "BinaryResource", "application/xquery", "doc('test.xml')");
         storeResource(test, "test1.xq", "BinaryResource", "application/xquery", "doc('/test.xml')");
+        storeResource(test, "test2.xq", "BinaryResource", "application/xquery", "doc('/db/test.xml')");
 
         storeResource(existEmbeddedServer.getRoot(), "test.xml", "XMLResource", null, "<x/>");
         storeResource(test, "test.xml", "XMLResource", null, "<y/>");
@@ -124,7 +125,7 @@ public class DocTest {
     }
 
     @Test
-    public void testURIResolveWithEval() throws XPathException, XMLDBException {
+    public void testURIResolveWithEval() throws XMLDBException {
         String query = "util:eval(xs:anyURI('/db/test/test.xq'), false(), ())";
         ResourceSet result = existEmbeddedServer.executeQuery(query);
 
@@ -134,6 +135,14 @@ public class DocTest {
         assertEquals("y", n.getLocalName());
 
         query = "util:eval(xs:anyURI('/db/test/test1.xq'), false(), ())";
+        result = existEmbeddedServer.executeQuery(query);
+
+        res = (LocalXMLResource)result.getResource(0);
+        assertNotNull(res);
+        n = res.getContentAsDOM();
+        assertEquals("x", n.getLocalName());
+
+        query = "util:eval(xs:anyURI('/db/test/test2.xq'), false(), ())";
         result = existEmbeddedServer.executeQuery(query);
 
         res = (LocalXMLResource)result.getResource(0);

--- a/exist-core/src/test/java/org/exist/xquery/functions/util/EvalTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/util/EvalTest.java
@@ -342,6 +342,44 @@ public class EvalTest {
         final Resource r = result.getResource(0);
         assertEquals("<i>1</i><i>2</i><i>3</i><i>4</i>", r.getContent());
     }
+
+    @Test
+    public void evalErrorInfo() {
+        final String query = "let $query := \"let $msg := 'some error message'\n" +
+                "let $code := xs:QName('some-error')\n" +
+                "return\n" +
+                "    fn:error($code, $msg)\"\n" +
+                "return\n" +
+                "    util:eval($query, false(), (), false())";
+        try {
+            existEmbeddedServer.executeQuery(query);
+
+            fail("Expected XPathException");
+
+        } catch (final XMLDBException e) {
+            assertTrue(e.getMessage().contains("line 6"));
+            assertTrue(e.getMessage().contains("column 5"));
+        }
+    }
+
+    @Test
+    public void evalPassErrorInfo() {
+        final String query = "let $query := \"let $msg := 'some error message'\n" +
+                "let $code := xs:QName('some-error')\n" +
+                "return\n" +
+                "    fn:error($code, $msg)\"\n" +
+                "return\n" +
+                "    util:eval($query, false(), (), true())";
+        try {
+            existEmbeddedServer.executeQuery(query);
+
+            fail("Expected XPathException");
+
+        } catch (final XMLDBException e) {
+            assertTrue(e.getMessage().contains("line 4"));
+            assertTrue(e.getMessage().contains("column 5"));
+        }
+    }
     
     private void writeModule(Collection collection, String modulename, String module) throws XMLDBException {
         BinaryResource res = (BinaryResource) collection.createResource(modulename, "BinaryResource");


### PR DESCRIPTION
This back-ports a feature to eXist-db from FusionDB. The feature adds a `$pass` parameter to `util:eval`. This is similar to the BaseX option, it preserves the line and column number of any error within the evaluated string, rather than setting it to that of the `util:eval` expression.

Closes https://github.com/eXist-db/exist/issues/3513