### PR TITLE
Enable conf.xml option document/@use-path-locks

### DIFF
--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -321,7 +321,7 @@ public class Configuration implements ErrorHandler
             final Element document = (Element)nlDocument.item(0);
             final boolean documentUsePathLocks = parseBoolean(getConfigAttributeValue(document, "use-path-locks"), false);
 
-            config.put(LockManager.CONFIGURATION_PATHS_MULTI_WRITER, documentUsePathLocks);
+            config.put(LockManager.CONFIGURATION_PATH_LOCKS_FOR_DOCUMENTS, documentUsePathLocks);
         }
     }
 


### PR DESCRIPTION
The option in `conf.xml` <document use-path-locks="false"/> was previously ignored.
