### PR TITLE
Avoid IllegalStateException in Http Session functions

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -671,6 +671,8 @@
                                 <exclude>src/main/java/org/exist/xquery/Cardinality.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportModuleTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/map/MapType.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/session/AbstractSessionTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/session/AttributeTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/util/Eval.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</exclude>
@@ -804,6 +806,8 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/main/java/org/exist/xquery/Cardinality.java</include>
                                 <include>src/test/java/org/exist/xquery/ImportModuleTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/map/MapType.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/session/AbstractSessionTest.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/session/AttributeTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/util/Eval.java</include>
                                 <include>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</include>
                                 <include>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</include>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -672,7 +672,9 @@
                                 <exclude>src/test/java/org/exist/xquery/ImportModuleTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/map/MapType.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/session/AbstractSessionTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/xmldb/AbstractXMLDBTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/session/AttributeTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticateTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/util/Eval.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</exclude>
@@ -807,7 +809,9 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/test/java/org/exist/xquery/ImportModuleTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/map/MapType.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/session/AbstractSessionTest.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/xmldb/AbstractXMLDBTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/session/AttributeTest.java</include>
+                                <include>src/test/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticateTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/util/Eval.java</include>
                                 <include>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</include>
                                 <include>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</include>

--- a/exist-core/src/main/java/org/exist/http/servlets/HttpSessionWrapper.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/HttpSessionWrapper.java
@@ -28,10 +28,18 @@ import javax.servlet.http.HttpSession;
 
 /**
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class HttpSessionWrapper implements SessionWrapper {
 
-	private HttpSession session;
+	private final HttpSession session;
+
+	/**
+	 * @param session The HTTP Session
+	 */
+	public HttpSessionWrapper(final HttpSession session) {
+		this.session = session;
+	}
 
 	/**
 	 * Get the Servlet Context
@@ -42,90 +50,69 @@ public class HttpSessionWrapper implements SessionWrapper {
 		return session.getServletContext();
 	}
 
-	/**
-	 * @param session The HTTP Session
-	 */
-	public HttpSessionWrapper(HttpSession session) {
-		this.session = session;
-	}
-
-	/**
-	 * @param name the name of the attribute
-	 * @return Returns the session attribute object or null
-	 */
-	public Object getAttribute(String name) {
+	@Override
+	public Object getAttribute(final String name) {
 		return session.getAttribute(name);
 	}
 
-	/**
-	 * @return An enumeration of all the attribute names
-	 */
-	public Enumeration getAttributeNames() {
+	@Override
+	public Enumeration<String> getAttributeNames() {
 		return session.getAttributeNames();
 	}
 
-	/**
-	 * @return The creation time of the session
-	 */
+	@Override
 	public long getCreationTime() {
 		return session.getCreationTime();
 	}
 
-	/**
-	 * @return The id of the session
-	 */
+	@Override
 	public String getId() {
 		return session.getId();
 	}
 
-	/**
-	 * @return The last time the session was accessed
-	 */
+	@Override
 	public long getLastAccessedTime() {
 		return session.getLastAccessedTime();
 	}
 
-	/**
-	 * @return The maximum inactive interval.
-	 */
+	@Override
 	public int getMaxInactiveInterval() {
 		return session.getMaxInactiveInterval();
 	}
 
-	/**
-	 * Invalidate the session.
-	 */
+	@Override
 	public void invalidate() {
 		session.invalidate();
 	}
 
-	/**
-	 * @return A boolean indicating if the session was just created
-	 */
+	@Override
 	public boolean isNew() {
         return session.isNew();
     }
 
-	/**
-	 * @param name the name of the attribute
-	 */
-	public void removeAttribute(String name) {
+	@Override
+	public void removeAttribute(final String name) {
 		session.removeAttribute(name);
 	}
 
-	/**
-	 * @param name the name of the attribute
-	 * @param value the value of the attribute
-	 */
-	public void setAttribute(String name, Object value) {
+	@Override
+	public void setAttribute(final String name, final Object value) {
 		session.setAttribute(name, value);
 	}
 
-	/**
-	 * @param interval the maximum inactive interval
-	 */
-	public void setMaxInactiveInterval(int interval) {
+	@Override
+	public void setMaxInactiveInterval(final int interval) {
 		session.setMaxInactiveInterval(interval);
 	}
 
+	@Override
+	public boolean isInvalid() {
+		try {
+			session.getLastAccessedTime();  // will throw IllegalStateException if session is Invalidated
+			return false;
+		} catch (final IllegalStateException e) {
+			// thrown by HttpSession#getLastAccessedTime() if the session was invalidated!
+			return true;
+		}
+	}
 }

--- a/exist-core/src/main/java/org/exist/http/servlets/RequestWrapper.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/RequestWrapper.java
@@ -32,98 +32,226 @@ import java.util.List;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.http.Cookie;
 
-/**
- * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
- */
- public interface RequestWrapper {
+public interface RequestWrapper {
 
-     Object getAttribute(String name);
+    /**
+     * @see javax.servlet.ServletRequest#getAttributeNames()
+     */
+    Enumeration<String> getAttributeNames();
 
-     Enumeration<String> getAttributeNames();
-    
-     String getCharacterEncoding();
-	
-	 long getContentLength();
-	
-	 InputStream getInputStream() throws IOException;
-	
-	 Cookie[] getCookies();
-	
-	 String getContentType();
-	
-	 String getContextPath();
-	
-	 String getHeader(String arg0);
-	
-	 Enumeration getHeaderNames();
-	
-	 Enumeration getHeaders(String arg0);
-	
-	 String getMethod();
-	
-	 String getParameter(String arg0);
-	
-	 Enumeration<String> getParameterNames();
-	
-	 String[] getParameterValues(String arg0);
-	
-	 List<Path> getFileUploadParam(String parameter);
-	
-	 List<String> getUploadedFileName(String parameter);
-	
-	 String getPathInfo();
-	
-	 String getPathTranslated();
-	
-	 String getProtocol();
-	
-	 String getQueryString();
-	
-	 String getRemoteAddr();
-	
-	 String getRemoteHost();
-	
-	 int getRemotePort();
-	
-	 String getRemoteUser();
-	
-	 String getRequestedSessionId();
-	
-	 String getRequestURI();
-	
-	 StringBuffer getRequestURL();
-	
-	 String getScheme();
-	
-	 String getServerName();
-	
-	 int getServerPort();
-	
-	 String getServletPath();
-	
-	 SessionWrapper getSession();
-	
-	 SessionWrapper getSession(boolean arg0);
-	
-	 Principal getUserPrincipal();
-	
-	 boolean isRequestedSessionIdFromCookie();
-	
-	 boolean isRequestedSessionIdFromURL();
-	
-	 boolean isRequestedSessionIdValid();
-	
-	 boolean isSecure();
-	
-	 boolean isUserInRole(String arg0);
-	
-	 void removeAttribute(String arg0);
-	
-	 void setAttribute(String arg0, Object arg1);
-	
-	 void setCharacterEncoding(String arg0) throws UnsupportedEncodingException;
+    /**
+     * @see javax.servlet.ServletRequest#getAttribute(String)
+     */
+    Object getAttribute(String name);
 
-	 boolean isMultipartContent();
+    /**
+     * @see javax.servlet.ServletRequest#setAttribute(String, Object)
+     */
+    void setAttribute(String name, Object o);
 
-	 RequestDispatcher getRequestDispatcher(final String path);
+    /**
+     * @see javax.servlet.ServletRequest#removeAttribute(String)
+     */
+    void removeAttribute(String name);
+
+    /**
+     * @see javax.servlet.ServletRequest#getCharacterEncoding()
+     */
+    String getCharacterEncoding();
+
+    /**
+     * @see javax.servlet.ServletRequest#setCharacterEncoding(String)
+     */
+    void setCharacterEncoding(String env) throws UnsupportedEncodingException;
+
+    /**
+     * @see javax.servlet.ServletRequest#getContentLength()
+     */
+    long getContentLength();
+
+    /**
+     * @see javax.servlet.ServletRequest#getContentLengthLong()
+     */
+    long getContentLengthLong();
+
+    /**
+     * @see javax.servlet.ServletRequest#getInputStream()
+     */
+    InputStream getInputStream() throws IOException;
+
+    /**
+     * @see javax.servlet.ServletRequest#getContentType()
+     */
+    String getContentType();
+
+    /**
+     * @see javax.servlet.ServletRequest#getParameterNames()
+     */
+    Enumeration<String> getParameterNames();
+
+    /**
+     * @see javax.servlet.ServletRequest#getParameter(String)
+     */
+    String getParameter(String name);
+
+    /**
+     * @see javax.servlet.ServletRequest#getParameterValues(String)
+     */
+    String[] getParameterValues(String name);
+
+    /**
+     * @see javax.servlet.ServletRequest#getProtocol()
+     */
+    String getProtocol();
+
+    /**
+     * @see javax.servlet.ServletRequest#getScheme()
+     */
+    String getScheme();
+
+    /**
+     * @see javax.servlet.ServletRequest#getServerName()
+     */
+    String getServerName();
+
+    /**
+     * @see javax.servlet.ServletRequest#getServerPort()
+     */
+    int getServerPort();
+
+    /**
+     * @see javax.servlet.ServletRequest#getRemoteAddr()
+     */
+    String getRemoteAddr();
+
+    /**
+     * @see javax.servlet.ServletRequest#getRemoteHost()
+     */
+    String getRemoteHost();
+
+    /**
+     * @see javax.servlet.ServletRequest#getRemotePort()
+     */
+    int getRemotePort();
+
+    /**
+     * @see javax.servlet.ServletRequest#isSecure()
+     */
+    boolean isSecure();
+
+    /**
+     * @see javax.servlet.ServletRequest#getRequestDispatcher(String)
+     */
+    RequestDispatcher getRequestDispatcher(final String path);
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getCookies()
+     */
+    Cookie[] getCookies();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getContextPath()
+     */
+    String getContextPath();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getHeaderNames()
+     */
+    Enumeration<String> getHeaderNames();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getHeader(String)
+     */
+    String getHeader(String name);
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getHeaders(String)
+     */
+    Enumeration<String> getHeaders(String name);
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getMethod()
+     */
+    String getMethod();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getPathInfo()
+     */
+    String getPathInfo();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getPathTranslated()
+     */
+    String getPathTranslated();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getQueryString()
+     */
+    String getQueryString();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getRemoteUser()
+     */
+    String getRemoteUser();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getRequestedSessionId()
+     */
+    String getRequestedSessionId();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#isRequestedSessionIdFromCookie()
+     */
+    boolean isRequestedSessionIdFromCookie();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#isRequestedSessionIdFromURL()
+     */
+    boolean isRequestedSessionIdFromURL();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#isRequestedSessionIdValid()
+     */
+    boolean isRequestedSessionIdValid();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getRequestURI()
+     */
+    String getRequestURI();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getRequestURL()
+     */
+    StringBuffer getRequestURL();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getServletPath()
+     */
+    String getServletPath();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getSession()
+     */
+    SessionWrapper getSession();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getSession()
+     */
+    SessionWrapper getSession(boolean create);
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#getUserPrincipal()
+     */
+    Principal getUserPrincipal();
+
+    /**
+     * @see javax.servlet.http.HttpServletRequest#isUserInRole(String)
+     */
+    boolean isUserInRole(String role);
+
+    boolean isMultipartContent();
+
+    List<Path> getFileUploadParam(String parameter);
+
+    List<String> getUploadedFileName(String parameter);
 }

--- a/exist-core/src/main/java/org/exist/http/servlets/ResponseWrapper.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/ResponseWrapper.java
@@ -26,167 +26,149 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Locale;
 
-/**
- * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
- */
 public interface ResponseWrapper {
+
+    /**
+     * @see javax.servlet.ServletResponse#flushBuffer()
+     */
+    void flushBuffer() throws IOException;
+
+    /**
+     * @see javax.servlet.ServletResponse#getCharacterEncoding()
+     */
+    String getCharacterEncoding();
+
+    /**
+     * @see javax.servlet.ServletResponse#getLocale()
+     */
+    Locale getLocale();
+
+    /**
+     * @see javax.servlet.ServletResponse#setLocale(Locale)
+     */
+    void setLocale(Locale loc);
+
+    /**
+     * @see javax.servlet.ServletResponse#setContentType(String)
+     */
+    void setContentType(String type);
+
+    /**
+     * @see javax.servlet.ServletResponse#getOutputStream()
+     */
+    OutputStream getOutputStream() throws IOException;
+
+    /**
+     * @see javax.servlet.ServletResponse#isCommitted()
+     */
+    boolean isCommitted();
 	
-	/**
-	 * Add a cookie.
-	 *
-	 * @param name	Name of the Cookie
-	 * @param value	Value of the Cookie
-	 */
-	public void addCookie(String name, String value);
+    /**
+     * Add a cookie.
+     *
+     * @param name  Name of the Cookie
+     * @param value Value of the Cookie
+     */
+    void addCookie(String name, String value);
 
-	/**
-	 * Add a cookie.
-	 *
-	 * @param name	Name of the Cookie
-	 * @param value	Value of the Cookie
-	 * @param maxAge maxAge of the Cookie
-	 */
-	public void addCookie(String name, String value, int maxAge);
-	
-	/**
-	 * Add a cookie.
-	 *
-	 * @param name	Name of the Cookie
-	 * @param value	Value of the Cookie
-	 * @param maxAge maxAge of the Cookie
-	 * @param secure security of the Cookie
-	 */
-	public void addCookie(String name, String value, int maxAge, boolean secure);
-	
-	/**
-	 * Add a cookie.
-	 *
-	 * @param name Name of the Cookie
-	 * @param value Value of the Cookie
-	 * @param maxAge an <code>int</code> value
-	 * @param secure security of the Cookie
-	 * @param domain domain of the cookie
-	 * @param path path scope of the cookie
-	 */
-	public void addCookie(String name, String value, int maxAge, boolean secure, String domain, String path);
+    /**
+     * Add a cookie.
+     *
+     * @param name   Name of the Cookie
+     * @param value  Value of the Cookie
+     * @param maxAge maxAge of the Cookie
+     */
+    void addCookie(String name, String value, int maxAge);
 
-	/**
-	 * Add a date header.
-	 *
-	 * @param name the header name
-	 * @param value the value of the header
-	 */
-	public void addDateHeader(String name, long value);
+    /**
+     * Add a cookie.
+     *
+     * @param name   Name of the Cookie
+     * @param value  Value of the Cookie
+     * @param maxAge maxAge of the Cookie
+     * @param secure security of the Cookie
+     */
+    void addCookie(String name, String value, int maxAge, boolean secure);
 
-	/**
-	 * Add a header.
-	 *
-	 * @param name the header name
-	 * @param value the value of the header
-	 */
-	public void addHeader(String name, String value);
+    /**
+     * Add a cookie.
+     *
+     * @param name   Name of the Cookie
+     * @param value  Value of the Cookie
+     * @param maxAge an <code>int</code> value
+     * @param secure security of the Cookie
+     * @param domain domain of the cookie
+     * @param path   path scope of the cookie
+     */
+    void addCookie(String name, String value, int maxAge, boolean secure, String domain, String path);
 
-	/**
-	 * Add a int header.
-	 *
-	 * @param name the header name
-	 * @param value the value of the header
-	 */
-	public void addIntHeader(String name, int value);
+    /**
+     * @see javax.servlet.http.HttpServletResponse#setDateHeader(String, long)
+     */
+    void setDateHeader(String name, long date);
 
-	/**
-	 * Returns true of the response contains the header.
-	 *
-	 * @param name the header name
-	 * @return a boolean indicating whether the header is present
-	 */
-	public boolean containsHeader(String name);
+    /**
+     * @see javax.servlet.http.HttpServletResponse#addDateHeader(String, long)
+     */
+    void addDateHeader(String name, long date);
 
-	/**
-	 * Encode a String as a URL.
-	 *
-	 * @param s the string to encode
-	 * @return the encoded value
-	 */
-	public String encodeURL(String s);
+    /**
+     * @see javax.servlet.http.HttpServletResponse#setIntHeader(String, int)
+     */
+    void setIntHeader(String name, int value);
 
+    /**
+     * @see javax.servlet.http.HttpServletResponse#addIntHeader(String, int)
+     */
+    void addIntHeader(String name, int value);
 
-	public void flushBuffer() throws IOException;
+    /**
+     * @see javax.servlet.http.HttpServletResponse#addDateHeader(String, long)
+     */
+    void addHeader(String name, String value);
 
-	/**
-	 * Get the character encoding.
-	 *
-	 * @return returns the default character encoding
-	 */
-	public String getCharacterEncoding();
+    /**
+     * @see javax.servlet.http.HttpServletResponse#containsHeader(String)
+     */
+    boolean containsHeader(String name);
 
-	/**
-	 * @return returns the default locale
-	 */
-	public Locale getLocale();
-	
-	/**
-	 * @return returns isCommitted
-	 */
-	public boolean isCommitted();
-	
-	/**
-	 * @param contentType Content Type of the response
-	 */
-	public void setContentType(String contentType);
+    /**
+     * @see javax.servlet.http.HttpServletResponse#setHeader(String, String)
+     */
+    void setHeader(String name, String value);
 
-	/**
-	 * Set a date header.
-	 *
-	 * @param name the header name
-	 * @param value the header value
-	 */
-	public void setDateHeader(String name, long value);
+    /**
+     * @see javax.servlet.http.HttpServletResponse#encodeURL(String)
+     */
+    String encodeURL(String s);
 
-	/**
-	 * Set a header.
-	 *
-	 * @param name the header name
-	 * @param value the header value
-	 */
-	public void setHeader(String name, String value);
+    /**
+     * @see javax.servlet.http.HttpServletResponse#sendRedirect(String)
+     */
+    void sendRedirect(String location) throws IOException;
 
-	/**
-	 * Set an int header.
-	 *
-	 * @param name the header name
-	 * @param value the header value
-	 */
-	public void setIntHeader(String name, int value);
+    /**
+     * @see javax.servlet.http.HttpServletResponse#sendError(int)
+     */
+    void sendError(final int sc) throws IOException;
 
-	void sendError(final int code) throws IOException;
+    /**
+     * @see javax.servlet.http.HttpServletResponse#sendError(int, String)
+     */
+    void sendError(final int sc, final String msg) throws IOException;
 
-	void sendError(final int code, final String msg) throws IOException;
+    /**
+     * Get a date header.
+     *
+     * @param name the header name
+     * @return the value of Date Header corresponding to given name,0 if none has been set.
+     */
+    long getDateHeader(String name);
 
-	/**
-	 * Set the HTP Status Code
-	 *
-	 * @param statusCode the status code.
-	 */
-    public void setStatusCode(int statusCode);
-
-	/**
-	 * Set the locale.
-	 *
-	 * @param locale the locale.
-	 */
-	public void setLocale(Locale locale);
-	
-	public void sendRedirect(String url) throws IOException;
-	
-	/**
-	 * Get a date header.
-	 *
-	 * @param name the header name
-	 *
-	 * @return the value of Date Header corresponding to given name,0 if none has been set.
-	 */
-	public long getDateHeader(String name);
-    
-    public OutputStream getOutputStream() throws IOException;
+    /**
+     * Set the HTP Status Code
+     *
+     * @param statusCode the status code.
+     */
+    void setStatusCode(int statusCode);
 }

--- a/exist-core/src/main/java/org/exist/http/servlets/SessionWrapper.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/SessionWrapper.java
@@ -21,32 +21,70 @@
  */
 package org.exist.http.servlets;
 
+import javax.servlet.http.HttpSession;
 import java.util.Enumeration;
 
-/**
- * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
- */
 public interface SessionWrapper {
-	
-	public Object getAttribute(String arg0);
-	
-	public Enumeration<String> getAttributeNames();
-	
-	public long getCreationTime();
-	
-	public String getId();
-	
-	public long getLastAccessedTime();
-	
-	public int getMaxInactiveInterval();
-	
-	public void invalidate();
-	
-	public boolean isNew();
-	
-	public void removeAttribute(String arg0);
-	
-	public void setAttribute(String arg0, Object arg1);
-	
-	public void setMaxInactiveInterval(int arg0);
+
+	/**
+	 * @see HttpSession#getAttributeNames()
+	 */
+	Enumeration<String> getAttributeNames();
+
+	/**
+	 * @see HttpSession#getAttribute(String)
+	 */
+	Object getAttribute(String name);
+
+	/**
+	 * @see HttpSession#setAttribute(String, Object)
+	 */
+	void setAttribute(String name, Object value);
+
+	/**
+	 * @see HttpSession#removeAttribute(String)
+	 */
+	void removeAttribute(String name);
+
+	/**
+	 * @see HttpSession#getCreationTime()
+	 */
+	long getCreationTime();
+
+	/**
+	 * @see HttpSession#getId()
+	 */
+	String getId();
+
+	/**
+	 * @see HttpSession#getLastAccessedTime()
+	 */
+	long getLastAccessedTime();
+
+	/**
+	 * @see HttpSession#getMaxInactiveInterval()
+	 */
+	int getMaxInactiveInterval();
+
+	/**
+	 * @see HttpSession#setMaxInactiveInterval(int)
+	 */
+	void setMaxInactiveInterval(int interval);
+
+	/**
+	 * @see HttpSession#invalidate()
+	 */
+	void invalidate();
+
+	/**
+	 * @see HttpSession#isNew()
+	 */
+	boolean isNew();
+
+	/**
+	 * Returns true of the session is invalid.
+	 *
+	 * @return true if the session is invalid, false otherwise.
+	 */
+	boolean isInvalid();
 }

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -2031,7 +2031,12 @@ public class XQueryContext implements BinaryValueManager, Context {
                 final Optional<SessionWrapper> maybeSession = Optional.ofNullable(getHttpContext())
                         .map(HttpContext::getSession);
                 if (maybeSession.isPresent()) {
-                    return (Subject) maybeSession.get().getAttribute(HTTP_SESSIONVAR_XMLDB_USER);
+                    try {
+                        return (Subject) maybeSession.get().getAttribute(HTTP_SESSIONVAR_XMLDB_USER);
+                    } catch (final IllegalStateException e) {
+                        // this is thrown if HttpSession#getAttribute is called on an invalid session
+                        return null;
+                    }
                 }
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/Clear.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/Clear.java
@@ -22,6 +22,7 @@
 package org.exist.xquery.functions.session;
 
 import java.util.Enumeration;
+import java.util.Optional;
 
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
@@ -33,7 +34,7 @@ import org.exist.xquery.value.Type;
 import javax.annotation.Nonnull;
 
 /**
- * @author Adam Retter (adam.retter@devon.gov.uk)
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  * @author Loren Cahlander
  */
 public class Clear extends StrictSessionFunction {
@@ -51,14 +52,14 @@ public class Clear extends StrictSessionFunction {
 
     @Override
     protected Sequence eval(final Sequence[] args, @Nonnull final SessionWrapper session) throws XPathException {
-        final Enumeration<String> attributeNames = session.getAttributeNames();
-        if (!attributeNames.hasMoreElements()) {
-            return Sequence.EMPTY_SEQUENCE;
-        }
 
-        while (attributeNames.hasMoreElements()) {
-            final String attributeName = attributeNames.nextElement();
-            session.removeAttribute(attributeName);
+        final Optional<Enumeration<String>> maybeAttributeNames = withValidSession(session, SessionWrapper::getAttributeNames);
+        if (maybeAttributeNames.isPresent()) {
+            final Enumeration<String> attributeNames = maybeAttributeNames.get();
+            while (attributeNames.hasMoreElements()) {
+                final String attributeName = attributeNames.nextElement();
+                session.removeAttribute(attributeName);
+            }
         }
 
         return Sequence.EMPTY_SEQUENCE;

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/Create.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/Create.java
@@ -41,7 +41,7 @@ public class Create extends SessionFunction {
     public final static FunctionSignature signature =
             new FunctionSignature(
                     new QName("create", SessionModule.NAMESPACE_URI, SessionModule.PREFIX),
-                    "Initialize an HTTP session if not already present",
+                    "Initialize an HTTP session if not already present (and valid)",
                     null,
                     new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
@@ -51,7 +51,7 @@ public class Create extends SessionFunction {
 
     @Override
     public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> session) throws XPathException {
-        getOrCreateSession(session);
+        getValidOrCreateSession(session);
         return Sequence.EMPTY_SEQUENCE;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/GetAttribute.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/GetAttribute.java
@@ -70,16 +70,20 @@ public class GetAttribute extends SessionFunction {
             }
             return XPathUtil.javaObjectToXPath(o, context);
         } catch (final IllegalStateException ise) {
-            //TODO: if we throw an exception here it means that getAttribute()
-            //cannot be called after invalidate() on the session object. This is the
-            //way that it works in Java, however this isnt the way it works in xquery currently
-            //we can change this but we need to be aware of the consequences, the eXist admin webapp is a
-            //good example of what happens if you change this - try logging out of the webapp ;-)
-            // - deliriumsky
+            /*
+            This occurs when SessionWrapper#getAttribute(String) is called
+            on an invalidated HttpSession.
 
-            //log.error(ise.getStackTrace());
-            //throw new XPathException(this, "Session has an IllegalStateException for getAttribute() - " + ise.getStackTrace() + System.getProperty("line.separator") + System.getProperty("line.separator") + "Did you perhaps call session:invalidate() previously?");
+            The description of the XQuery function session:get-attribute#1 is such
+            that we cannot raise an error, so the only option is to return an empty
+            sequence.
+            */
 
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Called session:get-attribute('" + attributeName + "') on an invalidated session!");
+            }
+
+            // TODO(AR) consider revising this in future so that session:get-attribute#1 can raise an error if the session is invalid
             return Sequence.EMPTY_SEQUENCE;
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/GetAttributeNames.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/GetAttributeNames.java
@@ -22,6 +22,7 @@
 package org.exist.xquery.functions.session;
 
 import java.util.Enumeration;
+import java.util.Optional;
 
 import org.exist.dom.QName;
 import org.exist.http.servlets.SessionWrapper;
@@ -37,6 +38,7 @@ import javax.annotation.Nonnull;
 /**
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  * @author Loren Cahlander
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class GetAttributeNames extends StrictSessionFunction {
     public final static FunctionSignature signature =
@@ -52,9 +54,14 @@ public class GetAttributeNames extends StrictSessionFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, @Nonnull final SessionWrapper session)
-            throws XPathException {
-        final Enumeration<String> attributeNames = session.getAttributeNames();
+    public Sequence eval(final Sequence[] args, @Nonnull final SessionWrapper session) throws XPathException {
+
+        final Optional<Enumeration<String>> maybeAttributeNames = withValidSession(session, SessionWrapper::getAttributeNames);
+        if (!maybeAttributeNames.isPresent()) {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+
+        final Enumeration<String> attributeNames = maybeAttributeNames.get();
         if (!attributeNames.hasMoreElements()) {
             return Sequence.EMPTY_SEQUENCE;
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/GetCreationTime.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/GetCreationTime.java
@@ -36,7 +36,7 @@ import org.exist.xquery.value.Type;
  * Returns the time when this session was created, or
  * January 1, 1970 GMT if it is an invalidated session
  *
- * @author José María Fernández (jmfg@users.sourceforge.net)
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class GetCreationTime extends SessionFunction {
 
@@ -59,11 +59,8 @@ public class GetCreationTime extends SessionFunction {
             return XPathUtil.javaObjectToXPath(-1, context);
         }
 
-        try {
-            final long creationTime = session.get().getCreationTime();
-            return new DateTimeValue(new Date(creationTime));
-        } catch (final IllegalStateException ise) {
-            return new DateTimeValue(new Date(0));
-        }
+        final Date creationTime = withValidSession(session.get(), SessionWrapper::getCreationTime).map(Date::new)
+                .orElseGet(() -> new Date(0));
+        return new DateTimeValue(creationTime);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/GetID.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/GetID.java
@@ -35,7 +35,7 @@ import javax.annotation.Nonnull;
  * Returns the ID of the current session or an empty sequence
  * if there is no session.
  *
- * @author <a href="mailto:adam.retter@devon.gov.uk">Adam Retter</a>
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  * @author Loren Cahlander
  */
 public class GetID extends StrictSessionFunction {
@@ -51,12 +51,11 @@ public class GetID extends StrictSessionFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, @Nonnull final SessionWrapper session)
-            throws XPathException {
-        final String id = session.getId();
-        if (id == null) {
-            return Sequence.EMPTY_SEQUENCE;
-        }
-        return (new StringValue(id));
+    public Sequence eval(final Sequence[] args, @Nonnull final SessionWrapper session) throws XPathException {
+
+        return withValidSession(session, SessionWrapper::getId)
+                .filter(id -> id != null)
+                .map(id -> (Sequence)new StringValue(id))
+                .orElse(Sequence.EMPTY_SEQUENCE);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/GetLastAccessedTime.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/GetLastAccessedTime.java
@@ -38,6 +38,7 @@ import org.exist.xquery.value.Type;
  * session
  *
  * @author José María Fernández (jmfg@users.sourceforge.net)
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class GetLastAccessedTime extends SessionFunction {
 
@@ -57,17 +58,13 @@ public class GetLastAccessedTime extends SessionFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> session)
-            throws XPathException {
+    public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> session) throws XPathException {
         if (!session.isPresent()) {
             return XPathUtil.javaObjectToXPath(-1, context);
         }
 
-        try {
-            final long lastAccessedTime = session.get().getLastAccessedTime();
-            return new DateTimeValue(new Date(lastAccessedTime));
-        } catch (final IllegalStateException ise) {
-            return new DateTimeValue(new Date(0));
-        }
+        final Date lastAccessedTime = withValidSession(session.get(), SessionWrapper::getLastAccessedTime).map(Date::new)
+                .orElseGet(() -> new Date(0));
+        return new DateTimeValue(lastAccessedTime);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/GetMaxInactiveInterval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/GetMaxInactiveInterval.java
@@ -35,6 +35,7 @@ import java.util.Optional;
  * if the attribute does not exist.
  *
  * @author Loren Cahlander
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class GetMaxInactiveInterval extends SessionFunction {
 
@@ -54,17 +55,12 @@ public class GetMaxInactiveInterval extends SessionFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> session)
-            throws XPathException {
+    public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> session) throws XPathException {
         if (!session.isPresent()) {
             return XPathUtil.javaObjectToXPath(-1, context);
         }
 
-        try {
-            final int interval = session.get().getMaxInactiveInterval();
-            return XPathUtil.javaObjectToXPath(interval, context);
-        } catch (final IllegalStateException ise) {
-            return XPathUtil.javaObjectToXPath(-1, context);
-        }
+        final int interval = withValidSession(session.get(), SessionWrapper::getMaxInactiveInterval).orElse(-1);
+        return XPathUtil.javaObjectToXPath(interval, context);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/Invalidate.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/Invalidate.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 
 /**
  * @author wolf
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class Invalidate extends SessionFunction {
 
@@ -48,13 +49,14 @@ public class Invalidate extends SessionFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> session)
-            throws XPathException {
+    public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> session) throws XPathException {
         if (!session.isPresent()) {
             return Sequence.EMPTY_SEQUENCE;
         }
 
-        session.get().invalidate();
-        return Sequence.EMPTY_SEQUENCE;
+        return withValidSession(session.get(), s -> {
+            s.invalidate();
+            return Sequence.EMPTY_SEQUENCE;
+        }).orElse(Sequence.EMPTY_SEQUENCE);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/RemoveAttribute.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/RemoveAttribute.java
@@ -32,7 +32,7 @@ import org.exist.xquery.value.Type;
 import javax.annotation.Nonnull;
 
 /**
- * @author Adam Retter (adam.retter@devon.gov.uk)
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  * @author Loren Cahlander
  */
 public class RemoveAttribute extends StrictSessionFunction {
@@ -51,10 +51,13 @@ public class RemoveAttribute extends StrictSessionFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, @Nonnull final SessionWrapper session)
-            throws XPathException {
-        final String attrib = args[0].getStringValue();
-        session.removeAttribute(attrib);
-        return Sequence.EMPTY_SEQUENCE;
+    public Sequence eval(final Sequence[] args, @Nonnull final SessionWrapper session) throws XPathException {
+
+        final String name = args[0].getStringValue();
+
+        return withValidSession(session, s -> {
+            s.removeAttribute(name);
+            return Sequence.EMPTY_SEQUENCE;
+        }).orElse(Sequence.EMPTY_SEQUENCE);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/SessionFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/SessionFunction.java
@@ -41,9 +41,9 @@ public abstract class SessionFunction extends BasicFunction {
     }
 
     @Override
-    public final Sequence eval(final Sequence[] args, final Sequence contextSequence)
-            throws XPathException {
-        return eval(args,
+    public final Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        return eval(
+                args,
                 Optional.ofNullable(context.getHttpContext())
                     .map(XQueryContext.HttpContext::getSession)
         );
@@ -59,10 +59,15 @@ public abstract class SessionFunction extends BasicFunction {
      *
      * @throws XPathException an XPath Exception
      */
-    protected abstract Sequence eval(final Sequence[] args, final Optional<SessionWrapper> session) throws XPathException;
+    protected abstract Sequence eval(final Sequence[] args,
+            final Optional<SessionWrapper> session) throws XPathException;
 
     /**
      * Gets an existing Session, or creates a new Session.
+     *
+     * NOTE that if the returned session is an existing
+     * then it may have been invalidated;
+     * See {@link #getValidOrCreateSession(Optional)}.
      *
      * @param session a possible existing session.
      *
@@ -71,11 +76,15 @@ public abstract class SessionFunction extends BasicFunction {
      * @throws XPathException if a session could not be created.
      */
     protected SessionWrapper getOrCreateSession(final Optional<SessionWrapper> session) throws XPathException {
-        return getOrCreateSession(this, context, session);
+        return getOrCreateSession(this, context, session, false);
     }
 
     /**
      * Gets an existing Session, or creates a new Session.
+     *
+     * NOTE that if the returned session is an existing
+     * then it may have been invalidated;
+     * See {@link #getValidOrCreateSession(Expression, XQueryContext, Optional)}.
      *
      * @param expr the calling expression.
      * @param context the XQuery context.
@@ -86,8 +95,54 @@ public abstract class SessionFunction extends BasicFunction {
      * @throws XPathException if a session could not be created.
      */
     static SessionWrapper getOrCreateSession(final Expression expr, final XQueryContext context, final Optional<SessionWrapper> session) throws XPathException {
+        return getOrCreateSession(expr, context, session, false);
+    }
+
+    /**
+     * Gets an existing Session, if there is no existing session
+     * or the existing session has been invalidate,
+     * then a new Session is created and returned.
+     *
+     * @param session a possible existing session.
+     *
+     * @return a session.
+     *
+     * @throws XPathException if a session could not be created.
+     */
+    protected SessionWrapper getValidOrCreateSession(final Optional<SessionWrapper> session) throws XPathException {
+        return getOrCreateSession(this, context, session, true);
+    }
+
+    /**
+     * Gets an existing Session, if there is no existing session
+     * or the existing session has been invalidate,
+     * then a new Session is created and returned.
+     *
+     * @param expr the calling expression.
+     * @param context the XQuery context.
+     * @param session a possible existing session.
+     *
+     * @return a session.
+     *
+     * @throws XPathException if a session could not be created.
+     */
+    static SessionWrapper getValidOrCreateSession(final Expression expr, final XQueryContext context, final Optional<SessionWrapper> session) throws XPathException {
+        return getOrCreateSession(expr, context, session, true);
+    }
+
+    private static SessionWrapper getOrCreateSession(final Expression expr, final XQueryContext context, final Optional<SessionWrapper> session, final boolean sessionMustBeValid) throws XPathException {
         if (session.isPresent()) {
-            return session.get();
+            final SessionWrapper existingSession = session.get();
+
+            if (sessionMustBeValid) {
+                if (existingSession.isInvalid()) {
+                    LOG.warn("Existing HTTP Session was invalid, creating a new HTTP Session");
+                } else {
+                    return existingSession;
+                }
+            } else {
+                return existingSession;
+            }
         }
 
         final RequestWrapper request = Optional.ofNullable(context.getHttpContext())
@@ -97,5 +152,22 @@ public abstract class SessionFunction extends BasicFunction {
         final SessionWrapper newSession = request.getSession(true);
         context.setHttpContext(context.getHttpContext().setSession(newSession));
         return newSession;
+    }
+
+    protected static <T> Optional<T> withValidSession(final SessionWrapper session, final java.util.function.Function<SessionWrapper, T> op) {
+        try {
+            return Optional.of(op.apply(session));
+        } catch (final IllegalStateException ise) {
+                /*
+                This occurs when a function is called
+                on an invalidated HttpSession.
+                */
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Called session operation on an invalidated session!");
+            }
+
+            return Optional.empty();
+        }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/SessionFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/SessionFunction.java
@@ -92,7 +92,7 @@ public abstract class SessionFunction extends BasicFunction {
 
         final RequestWrapper request = Optional.ofNullable(context.getHttpContext())
                 .map(XQueryContext.HttpContext::getRequest)
-                .orElseThrow(() -> new XPathException(expr, ErrorCodes.XPDY0002, "No response object found in the current XQuery context."));
+                .orElseThrow(() -> new XPathException(expr, ErrorCodes.XPDY0002, "No request object found in the current XQuery context."));
 
         final SessionWrapper newSession = request.getSession(true);
         context.setHttpContext(context.getHttpContext().setSession(newSession));

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/SetAttribute.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/SetAttribute.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 /**
  * @author Wolfgang Meier
  * @author Loren Cahlander
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class SetAttribute extends SessionFunction {
 
@@ -54,7 +55,7 @@ public class SetAttribute extends SessionFunction {
 
     @Override
     public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> maybeSession) throws XPathException {
-        final SessionWrapper session = getOrCreateSession(maybeSession);
+        final SessionWrapper session = getValidOrCreateSession(maybeSession);
 
         final String attributeName = args[0].getStringValue();
         final Sequence attributeValue = args[1];

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/SetCurrentUser.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/SetCurrentUser.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 /**
  * @author Wolfgang Meier
  * @author Loren Cahlander
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class SetCurrentUser extends UserSwitchingBasicFunction {
 
@@ -82,7 +83,7 @@ public class SetCurrentUser extends UserSwitchingBasicFunction {
         switchUser(user);
 
         //validated user, store in session
-        final SessionWrapper session = SessionFunction.getOrCreateSession(this, context,
+        final SessionWrapper session = SessionFunction.getValidOrCreateSession(this, context,
                 Optional.ofNullable(context.getHttpContext())
                         .map(XQueryContext.HttpContext::getSession)
         );

--- a/exist-core/src/main/java/org/exist/xquery/functions/session/SetMaxInactiveInterval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/session/SetMaxInactiveInterval.java
@@ -36,6 +36,7 @@ import java.util.Optional;
  * Set the max inactive interval for the current session
  *
  * @author José María Fernández (jmfg@users.sourceforge.net)
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class SetMaxInactiveInterval extends SessionFunction {
 
@@ -56,9 +57,8 @@ public class SetMaxInactiveInterval extends SessionFunction {
     }
 
     @Override
-    public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> maybeSession)
-            throws XPathException {
-        final SessionWrapper session = getOrCreateSession(maybeSession);
+    public Sequence eval(final Sequence[] args, final Optional<SessionWrapper> maybeSession) throws XPathException {
+        final SessionWrapper session = getValidOrCreateSession(maybeSession);
 
         final int interval = ((IntegerValue) args[0].convertTo(Type.INT)).getInt();
         session.setMaxInactiveInterval(interval);

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticate.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticate.java
@@ -200,7 +200,7 @@ public class XMLDBAuthenticate extends UserSwitchingBasicFunction {
 
         final RequestWrapper request = Optional.ofNullable(context.getHttpContext())
                 .map(XQueryContext.HttpContext::getRequest)
-                .orElseThrow(() -> new XPathException(this, ErrorCodes.XPDY0002, "No response object found in the current XQuery context."));
+                .orElseThrow(() -> new XPathException(this, ErrorCodes.XPDY0002, "No request object found in the current XQuery context."));
 
         final Optional<SessionWrapper> newSession = Optional.ofNullable(request.getSession(true));
         newSession.ifPresent(session -> context.setHttpContext(context.getHttpContext().setSession(session)));

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticate.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticate.java
@@ -47,8 +47,8 @@ import org.xmldb.api.base.XMLDBException;
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  * @author Andrzej Taramina (andrzej@chaeron.com)
  * @author ljo
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
-
 public class XMLDBAuthenticate extends UserSwitchingBasicFunction {
     private static final Logger logger = LogManager.getLogger(XMLDBAuthenticate.class);
 
@@ -178,7 +178,20 @@ public class XMLDBAuthenticate extends UserSwitchingBasicFunction {
      */
     private void cacheUserInHttpSession(final Subject user, final boolean createSession) throws XPathException {
         final Optional<SessionWrapper> session = getSession(createSession);
-        session.ifPresent(sess -> sess.setAttribute(XQueryContext.HTTP_SESSIONVAR_XMLDB_USER, user));
+        session.ifPresent(sess -> {
+            try {
+                sess.setAttribute(XQueryContext.HTTP_SESSIONVAR_XMLDB_USER, user);
+            } catch (final IllegalStateException ise) {
+                /*
+                This occurs when setAttribute is called
+                on an invalidated HttpSession.
+                */
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Attempted to cache a user in an invalidated HttpSession");
+                }
+            }
+        });
     }
 
     /**
@@ -190,12 +203,18 @@ public class XMLDBAuthenticate extends UserSwitchingBasicFunction {
      */
     private Optional<SessionWrapper> getSession(final boolean createSession)
             throws XPathException {
-        final Optional<SessionWrapper> existingSession =
+        final Optional<SessionWrapper> maybeExistingSession =
                 Optional.ofNullable(context.getHttpContext())
                         .map(XQueryContext.HttpContext::getSession);
 
-        if (existingSession.isPresent() || !createSession) {
-            return existingSession;
+        if (maybeExistingSession.isPresent() || !createSession) {
+            if (!createSession) {
+                return maybeExistingSession;
+            }
+
+            if (!maybeExistingSession.get().isInvalid()) {
+                return maybeExistingSession;
+            }
         }
 
         final RequestWrapper request = Optional.ofNullable(context.getHttpContext())

--- a/exist-core/src/test/java/org/exist/xquery/functions/session/AbstractSessionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/session/AbstractSessionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.session;
+
+import org.exist.test.ExistWebServer;
+import org.exist.xmldb.XmldbURI;
+import org.junit.Rule;
+
+public abstract class AbstractSessionTest {
+
+    /**
+     * To avoid pollution between tests
+     * we restart the server for each test
+     * which ensures a clean http session.
+     */
+    @Rule
+    public final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+
+    protected String getRestUrl() {
+        return "http://localhost:" + existWebServer.getPort();
+    }
+
+    protected String getCollectionRootUri() {
+        return getRestUrl() + XmldbURI.ROOT_COLLECTION;
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/session/AttributeTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/session/AttributeTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.session;
+
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.fluent.Request;
+import org.exist.util.UUIDGenerator;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+public class AttributeTest extends AbstractSessionTest {
+
+    @Test
+    public void getSetAttributeExplicitSessionCreation() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // get the value of the attribute named "attr1", and check its value is the empty sequence
+        final Request requestGetAttr = xqueryRequest("session:get-attribute('attr1')");
+        final HttpResponse getResponse1 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse1.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(getResponse1.getEntity()));
+
+        // set the value of the attribute named "attr1" to a random UUID
+        final String attr1Value = UUIDGenerator.getUUIDversion4();
+        final Request requestSetAttr1 = xqueryRequest("session:set-attribute('attr1', '" + attr1Value + "')");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(setResponse1.getEntity()));
+
+        // get the value of the attribute named "attr1", and check its value is the UUID
+        final HttpResponse getResponse2 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse2.getStatusLine().getStatusCode());
+        assertEquals(attr1Value, readEntityAsString(getResponse2.getEntity()));
+    }
+
+    @Test
+    public void getSetAttributeImplicitSessionCreation() throws IOException {
+        // get the value of the attribute named "attr1", and check its value is the empty sequence
+        final Request requestGetAttr = xqueryRequest("session:get-attribute('attr1')");
+        final HttpResponse getResponse1 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse1.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(getResponse1.getEntity()));
+
+        // set the value of the attribute named "attr1" to a random UUID
+        final String attr1Value = UUIDGenerator.getUUIDversion4();
+        final Request requestSetAttr1 = xqueryRequest("session:set-attribute('attr1', '" + attr1Value + "')");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(setResponse1.getEntity()));
+
+        // get the value of the attribute named "attr1", and check its value is the UUID
+        final HttpResponse getResponse2 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse2.getStatusLine().getStatusCode());
+        assertEquals(attr1Value, readEntityAsString(getResponse2.getEntity()));
+    }
+
+    @Test
+    public void getAttributeOnInvalidatedSessionSeparateHttpCalls() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // invalidate the session
+        final Request requestInvalidateSession = xqueryRequest("session:invalidate()");
+        final HttpResponse invalidateSessionResponse = requestInvalidateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, invalidateSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(invalidateSessionResponse.getEntity()));
+
+        // get the value of the attribute named "attr1", and check its value is the empty sequence
+        final Request requestGetAttr1 = xqueryRequest("session:get-attribute('attr1')");
+        final HttpResponse getResponse1 = requestGetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse1.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(getResponse1.getEntity()));
+    }
+
+    @Test
+    public void getAttributeOnInvalidatedSessionSameHttpCall() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // invalidate the session and call get-attribute
+        final Request requestInvalidateSession = xqueryRequest("session:invalidate(), session:get-attribute('attr1')");
+        final HttpResponse invalidateSessionResponse = requestInvalidateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, invalidateSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(invalidateSessionResponse.getEntity()));
+    }
+
+    @Test
+    public void setAttributeOnInvalidatedSessionSeparateHttpCalls() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // invalidate the session
+        final Request requestInvalidateSession = xqueryRequest("session:invalidate()");
+        final HttpResponse invalidateSessionResponse = requestInvalidateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, invalidateSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(invalidateSessionResponse.getEntity()));
+
+        // set the value of the attribute named "attr1" to a random UUID
+        final String attr1Value = UUIDGenerator.getUUIDversion4();
+        final Request requestSetAttr1 = xqueryRequest("session:set-attribute('attr1', '" + attr1Value + "')");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        final String responseBody = readEntityAsString(setResponse1.getEntity());
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+        assertEquals("", responseBody);
+
+        // get the value of the attribute named "attr1", and check its value is the UUID
+        final Request requestGetAttr = xqueryRequest("session:get-attribute('attr1')");
+        final HttpResponse getResponse2 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse2.getStatusLine().getStatusCode());
+        assertEquals(attr1Value, readEntityAsString(getResponse2.getEntity()));
+    }
+
+    @Test
+    public void setAttributeOnInvalidatedSessionSameHttpCall() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // invalidate the session and call set-attribute
+        final String attr1Value = UUIDGenerator.getUUIDversion4();
+        final Request requestInvalidateSession = xqueryRequest("session:invalidate(), session:set-attribute('attr1', '" + attr1Value + "')");
+        final HttpResponse invalidateSessionResponse = requestInvalidateSession
+                .execute()
+                .returnResponse();
+        final String responseBody = readEntityAsString(invalidateSessionResponse.getEntity());
+        assertEquals(HttpStatus.SC_OK, invalidateSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", responseBody);
+
+        // get the value of the attribute named "attr1", and check its value is the UUID
+        final Request requestGetAttr = xqueryRequest("session:get-attribute('attr1')");
+        final HttpResponse getResponse2 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse2.getStatusLine().getStatusCode());
+        assertEquals(attr1Value, readEntityAsString(getResponse2.getEntity()));
+    }
+
+    public Request xqueryRequest(final String xquery) throws UnsupportedEncodingException {
+        return Request.Get(getCollectionRootUri() + "/?_query=" + URLEncoder.encode(xquery, UTF_8.name()) + "&_wrap=no");
+    }
+
+    private static String readEntityAsString(final HttpEntity entity) throws IOException {
+        return new String(readEntity(entity), UTF_8);
+    }
+
+    private static byte[] readEntity(final HttpEntity entity) throws IOException {
+        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
+            entity.writeTo(os);
+            return os.toByteArray();
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/xmldb/AbstractXMLDBTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/xmldb/AbstractXMLDBTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.xmldb;
+
+import org.exist.test.ExistWebServer;
+import org.exist.xmldb.XmldbURI;
+import org.junit.Rule;
+
+public abstract class AbstractXMLDBTest {
+
+    /**
+     * To avoid pollution between tests
+     * we restart the server for each test
+     * which ensures a clean http session.
+     */
+    @Rule
+    public final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+
+    protected String getRestUrl() {
+        return "http://localhost:" + existWebServer.getPort();
+    }
+
+    protected String getCollectionRootUri() {
+        return getRestUrl() + XmldbURI.ROOT_COLLECTION;
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticateTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticateTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.xmldb;
+
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.fluent.Request;
+import org.exist.TestUtils;
+import org.exist.security.internal.aider.GroupAider;
+import org.exist.security.internal.aider.UserAider;
+import org.exist.xmldb.UserManagementService;
+import org.junit.Before;
+import org.junit.Test;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.XMLDBException;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
+
+import javax.xml.transform.Source;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class XMLDBAuthenticateTest extends AbstractXMLDBTest{
+
+    private static final String USER1_UID = "user1";
+    private static final String USER1_PWD = "user1";
+
+    @Before
+    public void beforeClass() throws XMLDBException {
+        final Collection root = DatabaseManager.getCollection("xmldb:exist://localhost:" + existWebServer.getPort() + "/xmlrpc/db", TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        final UserManagementService ums = (UserManagementService)root.getService("UserManagementService", "1.0");
+
+        final GroupAider group1 = new GroupAider(USER1_UID);
+        ums.addGroup(group1);
+
+        final UserAider user1 = new UserAider(USER1_UID, group1);
+        user1.setPassword(USER1_PWD);
+        ums.addAccount(user1);
+    }
+
+    @Test
+    public void loginExplicitSessionCreation() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // login to the database
+        final Request requestGetAttr = xqueryRequest("xmldb:login('/db', '" + USER1_UID + "', '" + USER1_PWD + "')");
+        final HttpResponse getResponse1 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse1.getStatusLine().getStatusCode());
+        assertEquals("true", readEntityAsString(getResponse1.getEntity()));
+
+        // get the identity of the current user
+        final Request requestSetAttr1 = xqueryRequest("sm:id()");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+
+        final Source expected = Input.fromString(
+                "<sm:id xmlns:sm=\"http://exist-db.org/xquery/securitymanager\">\n" +
+                "    <sm:real>\n" +
+                "        <sm:username>user1</sm:username>\n" +
+                "        <sm:groups>\n" +
+                "            <sm:group>user1</sm:group>\n" +
+                "        </sm:groups>\n" +
+                "    </sm:real>\n" +
+                "</sm:id>").build();
+        final Source actual = Input.fromString(readEntityAsString(setResponse1.getEntity())).build();
+        final Diff diff = DiffBuilder.compare(expected)
+                .withTest(actual)
+                .checkForSimilar()
+                .build();
+        assertFalse(diff.toString(), diff.hasDifferences());
+    }
+
+    @Test
+    public void loginImplicitSessionCreateSessionFalse() throws IOException {
+        // login to the database
+        final Request requestGetAttr = xqueryRequest("xmldb:login('/db', '" + USER1_UID + "', '" + USER1_PWD + "', false())");
+        final HttpResponse getResponse1 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse1.getStatusLine().getStatusCode());
+        assertEquals("true", readEntityAsString(getResponse1.getEntity()));
+
+        // get the identity of the current user
+        final Request requestSetAttr1 = xqueryRequest("sm:id()");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+
+        final Source expected = Input.fromString(
+                "<sm:id xmlns:sm=\"http://exist-db.org/xquery/securitymanager\">\n" +
+                        "    <sm:real>\n" +
+                        "        <sm:username>guest</sm:username>\n" +
+                        "        <sm:groups>\n" +
+                        "            <sm:group>guest</sm:group>\n" +
+                        "        </sm:groups>\n" +
+                        "    </sm:real>\n" +
+                        "</sm:id>").build();
+        final Source actual = Input.fromString(readEntityAsString(setResponse1.getEntity())).build();
+        final Diff diff = DiffBuilder.compare(expected)
+                .withTest(actual)
+                .checkForSimilar()
+                .build();
+        assertFalse(diff.toString(), diff.hasDifferences());
+    }
+
+    @Test
+    public void loginImplicitSessionCreateSessionTrue() throws IOException {
+        // login to the database
+        final Request requestGetAttr = xqueryRequest("xmldb:login('/db', '" + USER1_UID + "', '" + USER1_PWD + "', true())");
+        final HttpResponse getResponse1 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse1.getStatusLine().getStatusCode());
+        assertEquals("true", readEntityAsString(getResponse1.getEntity()));
+
+        // get the identity of the current user
+        final Request requestSetAttr1 = xqueryRequest("sm:id()");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+
+        final Source expected = Input.fromString(
+                "<sm:id xmlns:sm=\"http://exist-db.org/xquery/securitymanager\">\n" +
+                        "    <sm:real>\n" +
+                        "        <sm:username>user1</sm:username>\n" +
+                        "        <sm:groups>\n" +
+                        "            <sm:group>user1</sm:group>\n" +
+                        "        </sm:groups>\n" +
+                        "    </sm:real>\n" +
+                        "</sm:id>").build();
+        final Source actual = Input.fromString(readEntityAsString(setResponse1.getEntity())).build();
+        final Diff diff = DiffBuilder.compare(expected)
+                .withTest(actual)
+                .checkForSimilar()
+                .build();
+        assertFalse(diff.toString(), diff.hasDifferences());
+    }
+
+    @Test
+    public void loginOnInvalidatedSessionCreateSessionFalseSeparateHttpCalls() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // invalidate the session
+        final Request requestInvalidateSession = xqueryRequest("session:invalidate()");
+        final HttpResponse invalidateSessionResponse = requestInvalidateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, invalidateSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(invalidateSessionResponse.getEntity()));
+
+        // login to the database
+        final Request requestGetAttr = xqueryRequest("xmldb:login('/db', '" + USER1_UID + "', '" + USER1_PWD + "', false())");
+        final HttpResponse getResponse1 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse1.getStatusLine().getStatusCode());
+        assertEquals("true", readEntityAsString(getResponse1.getEntity()));
+
+        // get the identity of the current user
+        final Request requestSetAttr1 = xqueryRequest("sm:id()");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+
+        final Source expected = Input.fromString(
+                "<sm:id xmlns:sm=\"http://exist-db.org/xquery/securitymanager\">\n" +
+                        "    <sm:real>\n" +
+                        "        <sm:username>guest</sm:username>\n" +
+                        "        <sm:groups>\n" +
+                        "            <sm:group>guest</sm:group>\n" +
+                        "        </sm:groups>\n" +
+                        "    </sm:real>\n" +
+                        "</sm:id>").build();
+        final Source actual = Input.fromString(readEntityAsString(setResponse1.getEntity())).build();
+        final Diff diff = DiffBuilder.compare(expected)
+                .withTest(actual)
+                .checkForSimilar()
+                .build();
+        assertFalse(diff.toString(), diff.hasDifferences());
+    }
+
+    @Test
+    public void loginOnInvalidatedSessionCreateSessionTrueSeparateHttpCalls() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // invalidate the session
+        final Request requestInvalidateSession = xqueryRequest("session:invalidate()");
+        final HttpResponse invalidateSessionResponse = requestInvalidateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, invalidateSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(invalidateSessionResponse.getEntity()));
+
+        // login to the database
+        final Request requestGetAttr = xqueryRequest("xmldb:login('/db', '" + USER1_UID + "', '" + USER1_PWD + "', true())");
+        final HttpResponse getResponse1 = requestGetAttr
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, getResponse1.getStatusLine().getStatusCode());
+        assertEquals("true", readEntityAsString(getResponse1.getEntity()));
+
+        // get the identity of the current user
+        final Request requestSetAttr1 = xqueryRequest("sm:id()");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+
+        final Source expected = Input.fromString(
+                "<sm:id xmlns:sm=\"http://exist-db.org/xquery/securitymanager\">\n" +
+                        "    <sm:real>\n" +
+                        "        <sm:username>user1</sm:username>\n" +
+                        "        <sm:groups>\n" +
+                        "            <sm:group>user1</sm:group>\n" +
+                        "        </sm:groups>\n" +
+                        "    </sm:real>\n" +
+                        "</sm:id>").build();
+        final Source actual = Input.fromString(readEntityAsString(setResponse1.getEntity())).build();
+        final Diff diff = DiffBuilder.compare(expected)
+                .withTest(actual)
+                .checkForSimilar()
+                .build();
+        assertFalse(diff.toString(), diff.hasDifferences());
+    }
+
+    @Test
+    public void loginOnInvalidatedSessionCreateSessionFalseSameHttpCall() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // invalidate the session and login to the database
+        final Request requestInvalidateSession = xqueryRequest("session:invalidate(), xmldb:login('/db', '" + USER1_UID + "', '" + USER1_PWD + "', false())");
+        final HttpResponse invalidateSessionResponse = requestInvalidateSession
+                .execute()
+                .returnResponse();
+        final String responseBody = readEntityAsString(invalidateSessionResponse.getEntity());
+        assertEquals(responseBody, HttpStatus.SC_OK, invalidateSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("true", responseBody);
+
+        // get the identity of the current user
+        final Request requestSetAttr1 = xqueryRequest("sm:id()");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+
+        final Source expected = Input.fromString(
+                "<sm:id xmlns:sm=\"http://exist-db.org/xquery/securitymanager\">\n" +
+                        "    <sm:real>\n" +
+                        "        <sm:username>guest</sm:username>\n" +
+                        "        <sm:groups>\n" +
+                        "            <sm:group>guest</sm:group>\n" +
+                        "        </sm:groups>\n" +
+                        "    </sm:real>\n" +
+                        "</sm:id>").build();
+        final Source actual = Input.fromString(readEntityAsString(setResponse1.getEntity())).build();
+        final Diff diff = DiffBuilder.compare(expected)
+                .withTest(actual)
+                .checkForSimilar()
+                .build();
+        assertFalse(diff.toString(), diff.hasDifferences());
+    }
+
+    @Test
+    public void loginOnInvalidatedSessionCreateSessionTrueSameHttpCall() throws IOException {
+        // explicitly create a new session
+        final Request requestCreateSession = xqueryRequest("session:create()");
+        final HttpResponse createSessionResponse = requestCreateSession
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, createSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("", readEntityAsString(createSessionResponse.getEntity()));
+
+        // invalidate the session and login to the database
+        final Request requestInvalidateSession = xqueryRequest("session:invalidate(), xmldb:login('/db', '" + USER1_UID + "', '" + USER1_PWD + "', true())");
+        final HttpResponse invalidateSessionResponse = requestInvalidateSession
+                .execute()
+                .returnResponse();
+        final String responseBody = readEntityAsString(invalidateSessionResponse.getEntity());
+        assertEquals(responseBody, HttpStatus.SC_OK, invalidateSessionResponse.getStatusLine().getStatusCode());
+        assertEquals("true", responseBody);
+
+        // get the identity of the current user
+        final Request requestSetAttr1 = xqueryRequest("sm:id()");
+        final HttpResponse setResponse1 = requestSetAttr1
+                .execute()
+                .returnResponse();
+        assertEquals(HttpStatus.SC_OK, setResponse1.getStatusLine().getStatusCode());
+
+        final Source expected = Input.fromString(
+                "<sm:id xmlns:sm=\"http://exist-db.org/xquery/securitymanager\">\n" +
+                        "    <sm:real>\n" +
+                        "        <sm:username>user1</sm:username>\n" +
+                        "        <sm:groups>\n" +
+                        "            <sm:group>user1</sm:group>\n" +
+                        "        </sm:groups>\n" +
+                        "    </sm:real>\n" +
+                        "</sm:id>").build();
+        final Source actual = Input.fromString(readEntityAsString(setResponse1.getEntity())).build();
+        final Diff diff = DiffBuilder.compare(expected)
+                .withTest(actual)
+                .checkForSimilar()
+                .build();
+        assertFalse(diff.toString(), diff.hasDifferences());
+    }
+
+    public Request xqueryRequest(final String xquery) throws UnsupportedEncodingException {
+        return Request.Get(getCollectionRootUri() + "/?_query=" + URLEncoder.encode(xquery, UTF_8.name()) + "&_wrap=no");
+    }
+
+    private static String readEntityAsString(final HttpEntity entity) throws IOException {
+        return new String(readEntity(entity), UTF_8);
+    }
+
+    private static byte[] readEntity(final HttpEntity entity) throws IOException {
+        try (final UnsynchronizedByteArrayOutputStream os = new UnsynchronizedByteArrayOutputStream()) {
+            entity.writeTo(os);
+            return os.toByteArray();
+        }
+    }
+}


### PR DESCRIPTION
Fixes an `IllegalStateException` which could occur when eXist-db tries to perform Http Session functions but the session has been invalidated (but not yet cleaned up by Jetty).

I back-ported these tests and fixes from FusionDB.

Closes https://github.com/eXist-db/exist/issues/3610