### PR TITLE
Log a warning if a collection.xconf is binary

### DIFF
--- a/exist-core/src/main/java/org/exist/client/CollectionXConf.java
+++ b/exist-core/src/main/java/org/exist/client/CollectionXConf.java
@@ -38,6 +38,7 @@ import org.xml.sax.SAXException;
 import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.BinaryResource;
 
 /**
  * Class to represent a collection.xconf which holds the configuration data for a collection
@@ -87,6 +88,10 @@ public class CollectionXConf
 		for (String resource : resources) {
 			if (resource.endsWith(CollectionConfiguration.COLLECTION_CONFIG_SUFFIX)) {
 				resConfig = collection.getResource(resource);
+				if (resConfig.getResourceType().equals(BinaryResource.RESOURCE_TYPE)) {
+					System.err.println("Found a possible Collection configuration document: " + resConfig.getId() + ", however it is a Binary document! A user may have stored the document as a Binary document by mistake. Skipping...");
+					continue;
+				}
 				break;
 			}
 		}
@@ -538,7 +543,7 @@ public class CollectionXConf
 					collection = client.getCollection(path);
 				}
 				
-				resConfig = collection.createResource(CollectionConfigurationManager.COLLECTION_CONFIG_FILENAME, "XMLResource");
+				resConfig = collection.createResource(CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE, "XMLResource");
 			}
 			
 			//set the content of the collection.xconf

--- a/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/DocumentImpl.java
@@ -444,11 +444,6 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Resource, Do
         isReferenced = referenced;
     }
 
-    @EnsureContainerLocked(mode=READ_LOCK)
-    public boolean isCollectionConfig() {
-        return fileURI.endsWith(CollectionConfiguration.COLLECTION_CONFIG_SUFFIX_URI);
-    }
-
     @Override
     @EnsureContainerLocked(mode=READ_LOCK)
     public Permission getPermissions() {

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -146,7 +146,7 @@ public class NativeBroker extends DBBroker {
 
     public static final int OFFSET_COLLECTION_ID = 0;
 
-    public final static String INIT_COLLECTION_CONFIG = "collection.xconf.init";
+    public final static String INIT_COLLECTION_CONFIG = CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE + ".init";
 
     /** in-memory buffer size to use when copying binary resources */
     private final static int BINARY_RESOURCE_BUF_SIZE = 65536;

--- a/exist-core/src/test/java/org/exist/collections/triggers/TriggerConfigTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/TriggerConfigTest.java
@@ -34,6 +34,7 @@ import org.exist.util.LockException;
 import org.exist.xmldb.IndexQueryService;
 import org.junit.*;
 
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -164,7 +165,7 @@ public class TriggerConfigTest {
             iqs.configureCollection(EMPTY_COLLECTION_CONFIG);
 
             Collection configCol =  DatabaseManager.getCollection(BASE_URI + "/db/system/config" + testCollection, "admin", "");
-            Resource resource = configCol.createResource("collection.xconf", "XMLResource");
+            Resource resource = configCol.createResource(DEFAULT_COLLECTION_CONFIG_FILE, "XMLResource");
             resource.setContent(COLLECTION_CONFIG);
             configCol.storeResource(resource);
 

--- a/exist-core/src/test/java/org/exist/validation/CollectionConfigurationTest.java
+++ b/exist-core/src/test/java/org/exist/validation/CollectionConfigurationTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.modules.CollectionManagementService;
 
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.*;
 
 /**
@@ -54,9 +55,9 @@ public class CollectionConfigurationTest {
     }
 
     private void storeCollectionXconf(String collection, String document) throws XMLDBException {
-        final ResourceSet result = existEmbeddedServer.executeQuery("xmldb:store(\"" + collection + "\", \"collection.xconf\", " + document + ")");
+        final ResourceSet result = existEmbeddedServer.executeQuery("xmldb:store(\"" + collection + "\", \"" + DEFAULT_COLLECTION_CONFIG_FILE + "\", " + document + ")");
         String r = (String) result.getResource(0).getContent();
-        assertEquals("Store xconf", collection + "/collection.xconf", r);
+        assertEquals("Store xconf", collection + "/" + DEFAULT_COLLECTION_CONFIG_FILE, r);
     }
 
 

--- a/exist-core/src/test/java/org/exist/validation/CollectionConfigurationValidationModeTest.java
+++ b/exist-core/src/test/java/org/exist/validation/CollectionConfigurationValidationModeTest.java
@@ -32,6 +32,7 @@ import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.modules.CollectionManagementService;
 
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.*;
 
 /**
@@ -72,9 +73,9 @@ public class CollectionConfigurationValidationModeTest {
     }
 
     private void storeCollectionXconf(final String collection, final String document) throws XMLDBException {
-        final ResourceSet result = existEmbeddedServer.executeQuery("xmldb:store(\"" + collection + "\", \"collection.xconf\", " + document + ")");
+        final ResourceSet result = existEmbeddedServer.executeQuery("xmldb:store(\"" + collection + "\", \"" + DEFAULT_COLLECTION_CONFIG_FILE + "\", " + document + ")");
         final String r = (String) result.getResource(0).getContent();
-        assertEquals("Store xconf", collection + "/collection.xconf", r);
+        assertEquals("Store xconf", collection + "/" + DEFAULT_COLLECTION_CONFIG_FILE, r);
     }
 
     private void storeDocument(final String collection, final String name, final String document) throws XMLDBException {

--- a/exist-core/src/test/java/org/exist/xmldb/CollectionConfigurationTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/CollectionConfigurationTest.java
@@ -26,6 +26,7 @@ import org.junit.*;
 import org.exist.security.Account;
 
 import static org.exist.TestUtils.*;
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -636,7 +637,7 @@ public class CollectionConfigurationTest {
 
         // remove config document thus dropping the configuration
         Collection confCol = DatabaseManager.getCollection("xmldb:exist://" + CONF_COLL_URI.toString(), ADMIN_DB_USER, ADMIN_DB_PWD);
-        Resource confDoc = confCol.getResource("collection.xconf");
+        Resource confDoc = confCol.getResource(DEFAULT_COLLECTION_CONFIG_FILE);
         assertNotNull(confDoc);
         confCol.removeResource(confDoc);
 //            cms = (CollectionManagementService) confCol.getService("CollectionManagementService", "1.0");
@@ -693,7 +694,7 @@ public class CollectionConfigurationTest {
 
         // remove config document thus dropping the configuration
         Collection confCol = DatabaseManager.getCollection("xmldb:exist://" + CONF_COLL_URI.toString(), ADMIN_DB_USER, ADMIN_DB_PWD);
-        Resource confDoc = confCol.getResource("collection.xconf");
+        Resource confDoc = confCol.getResource(DEFAULT_COLLECTION_CONFIG_FILE);
         assertNotNull(confDoc);
         confCol.removeResource(confDoc);
 

--- a/exist-core/src/test/java/org/exist/xquery/UnionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/UnionTest.java
@@ -24,6 +24,7 @@ package org.exist.xquery;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.*;
 
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -117,7 +118,7 @@ public class UnionTest {
     private void storeCollectionConfig() throws XMLDBException {
         
         final Collection colConfig = getOrCreateCollection("/db/system/config/db/" + TEST_COLLECTION_NAME);
-        final XMLResource docConfig = (XMLResource) colConfig.createResource("collection.xconf", "XMLResource");
+        final XMLResource docConfig = (XMLResource) colConfig.createResource(DEFAULT_COLLECTION_CONFIG_FILE, "XMLResource");
         docConfig.setContent(INDEX_CONFIG);
         colConfig.storeResource(docConfig);
     }

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpDtdCatalogTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpDtdCatalogTest.java
@@ -25,6 +25,8 @@ import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.*;
+
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.*;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.exist.samples.Samples.SAMPLES;
@@ -59,7 +61,7 @@ public class JaxpDtdCatalogTest {
         Collection conf = null;
         try {
             conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/parse");
-            ExistXmldbEmbeddedServer.storeResource(conf, "collection.xconf", noValidation.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
         } finally {
             if(conf != null) {
                 conf.close();

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpParseTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpParseTest.java
@@ -24,6 +24,8 @@ package org.exist.xquery.functions.validate;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.*;
+
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.*;
 import static org.exist.samples.Samples.SAMPLES;
 
@@ -61,7 +63,7 @@ public class JaxpParseTest {
         Collection conf = null;
         try {
             conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/parse_validate");
-            ExistXmldbEmbeddedServer.storeResource(conf, "collection.xconf", noValidation.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
         } finally {
             if(conf != null) {
                 conf.close();

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
@@ -26,6 +26,7 @@ import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.*;
 
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.*;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.exist.samples.Samples.SAMPLES;
@@ -61,7 +62,7 @@ public class JaxpXsdCatalogTest {
         Collection conf = null;
         try {
             conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/parse");
-            ExistXmldbEmbeddedServer.storeResource(conf, "collection.xconf", noValidation.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
         } finally {
             if(conf != null) {
                 conf.close();

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxvTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxvTest.java
@@ -28,6 +28,8 @@ import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.*;
+
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.*;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
@@ -61,7 +63,7 @@ public class JaxvTest {
         Collection conf = null;
         try {
             conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/personal");
-            ExistXmldbEmbeddedServer.storeResource(conf, "collection.xconf", noValidation.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
         } finally {
             if(conf != null) {
                 conf.close();

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JingRelaxNgTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JingRelaxNgTest.java
@@ -25,6 +25,8 @@ import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.*;
+
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.*;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.exist.samples.Samples.SAMPLES;
@@ -60,7 +62,7 @@ public class JingRelaxNgTest {
         Collection conf = null;
         try {
             conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/personal");
-            ExistXmldbEmbeddedServer.storeResource(conf, "collection.xconf", noValidation.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
         } finally {
             if(conf != null) {
                 conf.close();

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JingSchematronTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JingSchematronTest.java
@@ -26,6 +26,7 @@ import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.*;
 
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.exist.samples.Samples.SAMPLES;
 import static org.junit.Assert.*;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
@@ -62,7 +63,7 @@ public class JingSchematronTest {
         Collection conf = null;
         try {
             conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/tournament");
-            ExistXmldbEmbeddedServer.storeResource(conf, "collection.xconf", noValidation.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
         } finally {
             if(conf != null) {
                 conf.close();

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JingXsdTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JingXsdTest.java
@@ -26,6 +26,7 @@ import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.*;
 
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.exist.samples.Samples.SAMPLES;
 import static org.junit.Assert.*;
 
@@ -62,7 +63,7 @@ public class JingXsdTest {
         Collection conf = null;
         try {
             conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/personal");
-            ExistXmldbEmbeddedServer.storeResource(conf, "collection.xconf", noValidation.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
         } finally {
             if(conf != null) {
                 conf.close();

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseDtdTestNOK.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseDtdTestNOK.java
@@ -25,6 +25,8 @@ import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.*;
+
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.*;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.exist.samples.Samples.SAMPLES;
@@ -59,7 +61,7 @@ public class ParseDtdTestNOK {
         Collection conf = null;
         try {
             conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/hamlet");
-            ExistXmldbEmbeddedServer.storeResource(conf, "collection.xconf", noValidation.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
         } finally {
             if(conf != null) {
                 conf.close();

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseXsdTestNOK.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseXsdTestNOK.java
@@ -25,6 +25,8 @@ import org.custommonkey.xmlunit.exceptions.XpathException;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.*;
+
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.junit.Assert.*;
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathEvaluatesTo;
 import static org.exist.samples.Samples.SAMPLES;
@@ -59,7 +61,7 @@ public class ParseXsdTestNOK {
         Collection conf = null;
         try {
             conf = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "system/config/db/addressbook");
-            ExistXmldbEmbeddedServer.storeResource(conf, "collection.xconf", noValidation.getBytes());
+            ExistXmldbEmbeddedServer.storeResource(conf, DEFAULT_COLLECTION_CONFIG_FILE, noValidation.getBytes());
         } finally {
             if(conf != null) {
                 conf.close();

--- a/extensions/indexes/range/src/test/java/org/exist/indexing/range/RangeIndexConfigTest.java
+++ b/extensions/indexes/range/src/test/java/org/exist/indexing/range/RangeIndexConfigTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.easymock.EasyMock.*;
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
 import static org.exist.indexing.lucene.LuceneIndexConfig.MATCH_ATTR;
 import static org.exist.indexing.lucene.LuceneIndexConfig.QNAME_ATTR;
 
@@ -48,7 +49,7 @@ public class RangeIndexConfigTest {
     @Test
     public void errorsHaveSourceContext() throws NoSuchFieldException, IllegalAccessException {
         final String badCreateQName = "tei:persName "; // Note the trailing
-        final String mockCollectionXConfUri = "/db/system/conf/db/mock/collection.xconf";
+        final String mockCollectionXConfUri = "/db/system/conf/db/mock/" + DEFAULT_COLLECTION_CONFIG_FILE;
 
         final NodeList mockConfigNodes = createMock(NodeList.class);
         final Element mockConfigNode = createMock(Element.class);

--- a/extensions/modules/expathrepo/src/test/java/org/exist/repo/PackageTriggerTest.java
+++ b/extensions/modules/expathrepo/src/test/java/org/exist/repo/PackageTriggerTest.java
@@ -46,6 +46,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
+
 public class PackageTriggerTest {
 
     static final String xarFile = "triggertest-1.1.0.xar";
@@ -103,7 +105,7 @@ public class PackageTriggerTest {
         try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()))) {
             final XQuery xquery = brokerPool.getXQueryService();
             final Sequence result = xquery.execute(broker, "xmldb:create-collection('/db/system/config/db','trigger-test'), " +
-                    "xmldb:store('/db/system/config/db/trigger-test', 'collection.xconf', " +
+                    "xmldb:store('/db/system/config/db/trigger-test', '" + DEFAULT_COLLECTION_CONFIG_FILE + "', " +
                     "<collection xmlns=\"http://exist-db.org/collection-config/1.0\"><triggers><trigger class=\"org.exist.repo.ExampleTrigger\"/></triggers></collection>)", null);
             Assert.assertEquals(2, result.getItemCount());
         }


### PR DESCRIPTION
Log's a warning if an encountered Collection Configuration document (e.g. collection.xconf) is a Binary document instead of an XML Document.