### PR TITLE
Fix NPE and Deadlock when Path Locks are used for Documents

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -2209,7 +2209,8 @@ public class NativeBroker extends DBBroker {
         //TODO : resolve URIs !
         final XmldbURI collUri = fileName.removeLastSegment();
         final XmldbURI docUri = fileName.lastSegment();
-        try(final Collection collection = openCollection(collUri, LockMode.READ_LOCK)) {
+        final LockMode collectionLockMode = lockManager.relativeCollectionLockMode(LockMode.READ_LOCK, lockMode);
+        try(final Collection collection = openCollection(collUri, collectionLockMode)) {
             if (collection == null) {
                 LOG.debug("Collection '{}' not found!", collUri);
                 return null;

--- a/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
@@ -576,7 +576,12 @@ public class LockManager {
      * @return true if a WRITE_LOCK is held
      */
     public boolean isDocumentLockedForWrite(final XmldbURI documentPath) {
-        final MultiLock existingLock = getDocumentLock(documentPath.toString());
+        final MultiLock existingLock;
+        if (!usePathLocksForDocuments) {
+            existingLock = getDocumentLock(documentPath.toString());
+        } else {
+            existingLock = getPathLock(documentPath.toString());
+        }
         return existingLock.getWriteLockCount() > 0;
     }
 
@@ -588,7 +593,12 @@ public class LockManager {
      * @return true if a READ_LOCK is held
      */
     public boolean isDocumentLockedForRead(final XmldbURI documentPath) {
-        final MultiLock existingLock = getDocumentLock(documentPath.toString());
+        final MultiLock existingLock;
+        if (!usePathLocksForDocuments) {
+            existingLock = getDocumentLock(documentPath.toString());
+        } else {
+            existingLock = getPathLock(documentPath.toString());
+        }
         return existingLock.getReadLockCount() > 0;
     }
 

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -275,9 +275,11 @@ public class RpcConnection implements RpcAPI {
         do {
             MutableDocumentSet docs = null;
             final LockedDocumentMap lockedDocuments = new LockedDocumentMap();
-            try(final Collection coll = broker.openCollection(XmldbURI.createInternal(protectColl), LockMode.READ_LOCK)) {
+            final LockMode documentLockMode = LockMode.WRITE_LOCK;
+            final LockMode collectionLockMode = broker.getBrokerPool().getLockManager().relativeCollectionLockMode(LockMode.READ_LOCK, documentLockMode);
+            try (final Collection coll = broker.openCollection(XmldbURI.createInternal(protectColl), collectionLockMode)) {
                 docs = new DefaultDocumentSet();
-                coll.allDocs(broker, docs, true, lockedDocuments, LockMode.WRITE_LOCK);
+                coll.allDocs(broker, docs, true, lockedDocuments, documentLockMode);
                 return lockedDocuments;
             } catch (final LockException e) {
                 LOG.warn("Deadlock detected. Starting over again. Docs: {}; locked: {}. Cause: {}", docs.getDocumentCount(), lockedDocuments.size(), e.getMessage());

--- a/exist-core/src/test/java/org/exist/collections/CollectionRemovalTest.java
+++ b/exist-core/src/test/java/org/exist/collections/CollectionRemovalTest.java
@@ -134,7 +134,7 @@ public class CollectionRemovalTest {
     private void retrieveDoc(final XmldbURI uri) throws EXistException, PermissionDeniedException, SAXException, LockException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
-                final Collection test = broker.openCollection(uri, LockMode.WRITE_LOCK)) {
+                final Collection test = broker.openCollection(uri, LockMode.READ_LOCK)) {
             assertNotNull(test);
 
             try(final LockedDocument lockedDoc = test.getDocumentWithLock(broker, XmldbURI.createInternal("document.xml"), LockMode.READ_LOCK)) {

--- a/exist-core/src/test/java/org/exist/collections/triggers/HistoryTriggerTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/HistoryTriggerTest.java
@@ -132,7 +132,7 @@ public class HistoryTriggerTest {
             storeInTestCollection(transaction, broker, testDoc2Name, testDoc2Content);
 
             // overwrite the first document by copying the second over it (and make sure we don't get a StackOverflow exception)
-            try(final Collection testCollection = broker.openCollection(TEST_COLLECTION_URI, Lock.LockMode.WRITE_LOCK);) {
+            try(final Collection testCollection = broker.openCollection(TEST_COLLECTION_URI, Lock.LockMode.WRITE_LOCK)) {
                 assertNotNull(testCollection);
 
                 try(final LockedDocument lockedDoc2 = testCollection.getDocumentWithLock(broker, testDoc2Name, Lock.LockMode.READ_LOCK)) {

--- a/exist-core/src/test/java/org/exist/config/TwoDatabasesTest.java
+++ b/exist-core/src/test/java/org/exist/config/TwoDatabasesTest.java
@@ -143,7 +143,7 @@ public class TwoDatabasesTest {
         return top;
     }
 
-    private boolean getBin(final DBBroker broker, final String suffix) throws PermissionDeniedException, IOException, LockException {
+    private boolean getBin(final DBBroker broker, final String suffix) throws PermissionDeniedException, IOException {
         BinaryDocument binDoc = null;
         try(final Collection top = broker.openCollection(XmldbURI.create("xmldb:exist:///db"), LockMode.READ_LOCK)) {
             binDoc = (BinaryDocument) top.getDocument(broker, XmldbURI.create("bin"));

--- a/exist-core/src/test/java/org/exist/util/XMLReaderSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/util/XMLReaderSecurityTest.java
@@ -159,7 +159,7 @@ public class XMLReaderSecurityTest {
 
             try (final Collection testCollection = broker.openCollection(TEST_COLLECTION, Lock.LockMode.READ_LOCK)) {
 
-                try (final LockedDocument testDoc = testCollection.getDocumentWithLock(broker, docName, Lock.LockMode.READ_LOCK);){
+                try (final LockedDocument testDoc = testCollection.getDocumentWithLock(broker, docName, Lock.LockMode.READ_LOCK)) {
 
                     // release the collection lock early inline with asymmetrical locking
                     testCollection.close();
@@ -192,7 +192,7 @@ public class XMLReaderSecurityTest {
         try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
              final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
 
-            try (final Collection testCollection = broker.openCollection(TEST_COLLECTION, Lock.LockMode.WRITE_LOCK);){
+            try (final Collection testCollection = broker.openCollection(TEST_COLLECTION, Lock.LockMode.WRITE_LOCK)) {
 
                 //debugReader("cannotExpandExternalEntitiesWhenDisabled", broker, testCollection);
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
@@ -1602,7 +1602,7 @@ public class PermissionsFunctionChownTest {
     private static void assertCollectionSetUidSetGid(final Subject execAsUser, final XmldbURI uri, final boolean isSet) throws EXistException, PermissionDeniedException {
         final BrokerPool pool = existWebServer.getBrokerPool();
         try (final DBBroker broker = pool.get(Optional.of(execAsUser))) {
-            try (final Collection col = broker.openCollection(uri, Lock.LockMode.READ_LOCK);) {
+            try (final Collection col = broker.openCollection(uri, Lock.LockMode.READ_LOCK)) {
 
                 if (isSet) {
                     assertTrue(col.getPermissions().isSetUid());

--- a/exist-core/src/test/resources-filtered/conf.xml
+++ b/exist-core/src/test/resources-filtered/conf.xml
@@ -35,9 +35,10 @@
                 startup
                     triggers
                 pool
+                query-pool
                 recovery
-                security
                 watchdog
+            lock-manager
             repository
             binary-manager
             indexer
@@ -74,9 +75,6 @@
     
         - http://exist-db.org/exist/apps/doc/configuration.xml
         - http://exist-db.org/exist/apps/doc/documentation.xml
-        - http://atomic.exist-db.org/
-        
-    Version: 3.3.0-SNAPSHOT
 
 -->
 <exist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/conf.xsd">
@@ -148,19 +146,6 @@
             with high load will never be shrinked. A negative value means that
             shrinkage will not be performed.
 
-         - doc-ids:
-            how document ids are managed by eXist. Takes the values
-            "default" or "incremental".
-            
-            eXist assigns a unique, 32bit integer document id to every 
-            document. When a document is deleted, its id will be freed 
-            and reused for the next document stored. The disadvantage 
-            of this approach is that document ids
-            are not stable, i.e. one cannot be sure that the same document
-            id will always identify the same document.
-
-            If you need stable, incremental ids, set the option doc-ids to
-            "incremental".
         - minDiskSpace:
             The amount of disk space (in megabytes) which should be available for
             the database to continue operations. If free disk space goes below
@@ -168,7 +153,48 @@
             switch to read-only mode in order to prevent potential data loss. 
             Set the limit large enough to allow all pending operations to 
             complete. Set to -1 to disable. The default is 1 gigabyte.
-    
+
+        - posix-chown-restricted:
+            As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
+
+            When posix-chown-restricted="true" (the default) then:
+                1. Only a superuser process can change the user ID of the file.
+                2. A non-superuser process can change the group ID of the file
+                   if the process owns the file (the effective user ID equals
+                   the user ID of the file), and group equals either the
+                   effective group ID of the process or one of the
+                   process’s supplementary group IDs.
+            This means that when posix-chown-restricted="true", you can’t change
+            the user ID of your files. You can change the group ID of files that
+            you own, but only to groups that you belong to.
+
+            When posix-chown-restricted="false" you can change the user ID of
+            any file that you own, effectively "giving away the file" to
+            another user. Such a setting has negative security implications,
+            further details can be seen in the "Rationale" section for the
+            chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
+            See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+
+        - preserve-on-copy
+            When copying Collections and Documents within the database, the
+            default (`false`), is not to preserve their attributes
+            (modification time, mode, user-id, group-id, and ACL).
+
+            NOTE: Not preserving attributes, is inline with both the GNU and
+            BSD `cp` commands, and therefore expected behaviour; The target
+            Collection or Document is created following the rules of the
+            target parent, and the effective user and their umask.
+
+            Setting preserve-on-copy="true" changes the default behaviour
+            so that the target Collection or Document of a copy, has the same
+            attributes as the source.
+
+            The preserve-on-copy setting can be overridden on a case-by-case
+            basis by setting the `preserve` flag to either `true` or `false`
+            when calling xmldb:copy(), or via any other API that supports copy.
+            Omitting the preserve flag when calling a copy operation, implies
+            the behaviour that is set in this configuration.
+
         =====================================================================
         
         The settings below are very conservative to avoid out-of-memory
@@ -180,7 +206,7 @@
     -->
     <db-connection cacheSize="256M" checkMaxCacheSize="true" collectionCache="64M" database="native"
         files="${basedir}/target/test-data" pageSize="4096" nodesBuffer="1000" cacheShrinkThreshold="10000"
-        doc-ids="default" minDiskSpace="1024M">
+        minDiskSpace="1024M" posix-chown-restricted="true" preserve-on-copy="false">
 
         <!--
             Startup Triggers are executed before the database becomes generally available
@@ -188,10 +214,11 @@
         -->
         <startup>
             <triggers>
-                <!--
-                    Trigger for registering the GNU Crypto JCE Provider with Java
-                -->
-                <trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
+
+		<!--
+		    Trigger for registering the GNU Crypto JCE Provider with Java
+		-->
+		<trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
 
                 <!--
                     Trigger for registering eXists XML:DB URL handler with Java
@@ -247,15 +274,9 @@
                     by threads, each thread needs a private copy of a query.             
                                                                                          
                 - timeout:                                                               
-                    amount of time that a query will be cached in the query-pool.        
-                                                                                         
-                - timeout-check-interval:                                                
-                    time between checking for timed out queries. For value "-1"          
-                    the time out is switched off, resulting cached queries to remain     
-                    in the cache forever.                                                
+                    amount of time that a query will be cached in the query-pool in milliseconds.
             -->
-        <query-pool max-stack-size="64" size="128" timeout="120000"                
-                    timeout-check-interval="30000"/>
+        <query-pool max-stack-size="64" size="128" timeout="120000"/>
 
         <!--
             Settings for the journaling and recovery of the database. With 
@@ -352,6 +373,92 @@
         <watchdog output-size-limit="1000000" query-timeout="-1"/>
 
     </db-connection>
+
+
+    <!--
+        Settings for the Database Lock Manager
+
+        - upgrade-check
+            Used by developers for diagnosing illegal lock upgrade issues. When enabled
+            checks for lock upgrading within the same thread, i.e. READ_LOCK -> WRITE_LOCK
+            are enabled. When an illegal upgrade is detected a LockException is thrown.
+            Such behaviour will likely corrupt any database writes, and should only be
+            used by developers when debugging database issues.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.upgrade-check`,
+                or (legacy) `exist.lockmanager.upgrade.check`.
+
+        - warn-wait-on-read-for-write
+            Used by developers for diagnosing lock performance issues. When enabled
+            checks for detecting when a thread wants to acquire the WRITE_LOCK
+            but another thread holds the READ_LOCK are enabled. When such operations
+            are detected a log message is written to locks.log at WARN level.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
+                or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
+    -->
+    <lock-manager
+            upgrade-check="false"
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
+
+        <!--
+            Settings for the Lock Table
+
+            - disabled
+                Disables the database lock table which tracks database locks. The Lock Table is enabled by default
+                and allows reporting on database locking via JMX.
+
+                NOTE: Tracking locks via the Lock Table imposes a small overhead per-Lock. Once users
+                have finished testing their system to ensure correct operation, they may wish to disable
+                this in production to ensure the absolute best performance.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.disabled`,
+                    or (legacy) `exist.locktable.disable`.
+
+            - trace-stack-depth
+                When set above 0, this captures n frames of each threads stack that performs a try/lock/release
+                operation. These frames are visible from JMX reporting.
+                In addition, when the logging level for the Lock Table is set in log4j2.xml to TRACE the lock
+                events are written to the locks.log file.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
+                    or (legacy) `exist.locktable.trace.stack.depth`.
+        -->
+        <lock-table disabled="false" trace-stack-depth="0"/>
+
+
+        <!-- Settings for Document Locking
+
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
+
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
+
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
+        -->
+        <document use-path-locks="false"/>
+
+    </lock-manager>
 
     <!--
         Settings for the package repository:
@@ -542,6 +649,18 @@
     <!--
         Default settings for parsing structured documents:
 
+        - xml (optional)
+
+            - features
+                Any default SAX2 feature flags to set on the parser
+
+                    - feature
+                        - name
+                            the name of the feature flag
+                        - value
+                            the value of the feature flag
+
+
         - html-to-xml (optional)
 
             - class
@@ -578,6 +697,22 @@
                             the value of the feature flag
     -->
     <parser>
+
+        <xml>
+
+            <features>
+
+                <!-- NOTE: the following feature flags should likely be set in production to ensure a secure environment -->
+
+                <!--
+                <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
+                <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
+                <feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
+                -->
+
+            </features>
+
+        </xml>
 
         <!-- html-to-xml class="org.ccil.cowan.tagsoup.Parser"/ -->
 
@@ -750,7 +885,7 @@
             enable-query-rewriting="yes" backwardCompatible="no" 
             enforce-index-use="always"
             raise-error-on-failed-retrieval="no">
-
+        
         <builtin-modules>
             <module uri="http://www.w3.org/2005/xpath-functions/map"  class="org.exist.xquery.functions.map.MapModule" />
             <module uri="http://www.w3.org/2005/xpath-functions/math" class="org.exist.xquery.functions.math.MathModule" />

--- a/exist-core/src/test/resources-filtered/org/exist/storage/statistics/conf.xml
+++ b/exist-core/src/test/resources-filtered/org/exist/storage/statistics/conf.xml
@@ -35,9 +35,10 @@
                 startup
                     triggers
                 pool
+                query-pool
                 recovery
-                security
                 watchdog
+            lock-manager
             repository
             binary-manager
             indexer
@@ -74,9 +75,6 @@
     
         - http://exist-db.org/exist/apps/doc/configuration.xml
         - http://exist-db.org/exist/apps/doc/documentation.xml
-        - http://atomic.exist-db.org/
-        
-    Version: 3.3.0-SNAPSHOT
 
 -->
 <exist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/conf.xsd">
@@ -148,19 +146,6 @@
             with high load will never be shrinked. A negative value means that
             shrinkage will not be performed.
 
-         - doc-ids:
-            how document ids are managed by eXist. Takes the values
-            "default" or "incremental".
-            
-            eXist assigns a unique, 32bit integer document id to every 
-            document. When a document is deleted, its id will be freed 
-            and reused for the next document stored. The disadvantage 
-            of this approach is that document ids
-            are not stable, i.e. one cannot be sure that the same document
-            id will always identify the same document.
-
-            If you need stable, incremental ids, set the option doc-ids to
-            "incremental".
         - minDiskSpace:
             The amount of disk space (in megabytes) which should be available for
             the database to continue operations. If free disk space goes below
@@ -168,7 +153,48 @@
             switch to read-only mode in order to prevent potential data loss. 
             Set the limit large enough to allow all pending operations to 
             complete. Set to -1 to disable. The default is 1 gigabyte.
-    
+
+        - posix-chown-restricted:
+            As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
+
+            When posix-chown-restricted="true" (the default) then:
+                1. Only a superuser process can change the user ID of the file.
+                2. A non-superuser process can change the group ID of the file
+                   if the process owns the file (the effective user ID equals
+                   the user ID of the file), and group equals either the
+                   effective group ID of the process or one of the
+                   process’s supplementary group IDs.
+            This means that when posix-chown-restricted="true", you can’t change
+            the user ID of your files. You can change the group ID of files that
+            you own, but only to groups that you belong to.
+
+            When posix-chown-restricted="false" you can change the user ID of
+            any file that you own, effectively "giving away the file" to
+            another user. Such a setting has negative security implications,
+            further details can be seen in the "Rationale" section for the
+            chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
+            See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+
+        - preserve-on-copy
+            When copying Collections and Documents within the database, the
+            default (`false`), is not to preserve their attributes
+            (modification time, mode, user-id, group-id, and ACL).
+
+            NOTE: Not preserving attributes, is inline with both the GNU and
+            BSD `cp` commands, and therefore expected behaviour; The target
+            Collection or Document is created following the rules of the
+            target parent, and the effective user and their umask.
+
+            Setting preserve-on-copy="true" changes the default behaviour
+            so that the target Collection or Document of a copy, has the same
+            attributes as the source.
+
+            The preserve-on-copy setting can be overridden on a case-by-case
+            basis by setting the `preserve` flag to either `true` or `false`
+            when calling xmldb:copy(), or via any other API that supports copy.
+            Omitting the preserve flag when calling a copy operation, implies
+            the behaviour that is set in this configuration.
+
         =====================================================================
         
         The settings below are very conservative to avoid out-of-memory
@@ -180,7 +206,7 @@
     -->
     <db-connection cacheSize="256M" checkMaxCacheSize="true" collectionCache="64M" database="native"
         files="${basedir}/target/test-data" pageSize="4096" nodesBuffer="1000" cacheShrinkThreshold="10000"
-        doc-ids="default" minDiskSpace="1024M">
+        minDiskSpace="1024M" posix-chown-restricted="true" preserve-on-copy="false">
 
         <!--
             Startup Triggers are executed before the database becomes generally available
@@ -188,10 +214,11 @@
         -->
         <startup>
             <triggers>
-                <!--
-                    Trigger for registering the GNU Crypto JCE Provider with Java
-                -->
-                <trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
+
+		<!--
+		    Trigger for registering the GNU Crypto JCE Provider with Java
+		-->
+		<trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
 
                 <!--
                     Trigger for registering eXists XML:DB URL handler with Java
@@ -246,15 +273,9 @@
                     by threads, each thread needs a private copy of a query.             
                                                                                          
                 - timeout:                                                               
-                    amount of time that a query will be cached in the query-pool.        
-                                                                                         
-                - timeout-check-interval:                                                
-                    time between checking for timed out queries. For value "-1"          
-                    the time out is switched off, resulting cached queries to remain     
-                    in the cache forever.                                                
+                    amount of time that a query will be cached in the query-pool in milliseconds.
             -->
-        <query-pool max-stack-size="64" size="128" timeout="120000"                
-                    timeout-check-interval="30000"/>
+        <query-pool max-stack-size="64" size="128" timeout="120000"/>
 
         <!--
             Settings for the journaling and recovery of the database. With 
@@ -351,6 +372,92 @@
         <watchdog output-size-limit="1000000" query-timeout="-1"/>
 
     </db-connection>
+
+
+    <!--
+        Settings for the Database Lock Manager
+
+        - upgrade-check
+            Used by developers for diagnosing illegal lock upgrade issues. When enabled
+            checks for lock upgrading within the same thread, i.e. READ_LOCK -> WRITE_LOCK
+            are enabled. When an illegal upgrade is detected a LockException is thrown.
+            Such behaviour will likely corrupt any database writes, and should only be
+            used by developers when debugging database issues.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.upgrade-check`,
+                or (legacy) `exist.lockmanager.upgrade.check`.
+
+        - warn-wait-on-read-for-write
+            Used by developers for diagnosing lock performance issues. When enabled
+            checks for detecting when a thread wants to acquire the WRITE_LOCK
+            but another thread holds the READ_LOCK are enabled. When such operations
+            are detected a log message is written to locks.log at WARN level.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
+                or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
+    -->
+    <lock-manager
+            upgrade-check="false"
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
+
+        <!--
+            Settings for the Lock Table
+
+            - disabled
+                Disables the database lock table which tracks database locks. The Lock Table is enabled by default
+                and allows reporting on database locking via JMX.
+
+                NOTE: Tracking locks via the Lock Table imposes a small overhead per-Lock. Once users
+                have finished testing their system to ensure correct operation, they may wish to disable
+                this in production to ensure the absolute best performance.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.disabled`,
+                    or (legacy) `exist.locktable.disable`.
+
+            - trace-stack-depth
+                When set above 0, this captures n frames of each threads stack that performs a try/lock/release
+                operation. These frames are visible from JMX reporting.
+                In addition, when the logging level for the Lock Table is set in log4j2.xml to TRACE the lock
+                events are written to the locks.log file.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
+                    or (legacy) `exist.locktable.trace.stack.depth`.
+        -->
+        <lock-table disabled="false" trace-stack-depth="0"/>
+
+
+        <!-- Settings for Document Locking
+
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
+
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
+
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
+        -->
+        <document use-path-locks="false"/>
+
+    </lock-manager>
 
     <!--
         Settings for the package repository:
@@ -541,6 +648,18 @@
     <!--
         Default settings for parsing structured documents:
 
+        - xml (optional)
+
+            - features
+                Any default SAX2 feature flags to set on the parser
+
+                    - feature
+                        - name
+                            the name of the feature flag
+                        - value
+                            the value of the feature flag
+
+
         - html-to-xml (optional)
 
             - class
@@ -577,6 +696,22 @@
                             the value of the feature flag
     -->
     <parser>
+
+        <xml>
+
+            <features>
+
+                <!-- NOTE: the following feature flags should likely be set in production to ensure a secure environment -->
+
+                <!--
+                <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
+                <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
+                <feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
+                -->
+
+            </features>
+
+        </xml>
 
         <!-- html-to-xml class="org.ccil.cowan.tagsoup.Parser"/ -->
 
@@ -749,7 +884,7 @@
             enable-query-rewriting="yes" backwardCompatible="no" 
             enforce-index-use="always"
             raise-error-on-failed-retrieval="no">
-
+        
         <builtin-modules>
             <module uri="http://www.w3.org/2005/xpath-functions/map"  class="org.exist.xquery.functions.map.MapModule" />
             <module uri="http://www.w3.org/2005/xpath-functions/math" class="org.exist.xquery.functions.math.MathModule" />

--- a/exist-core/src/test/resources-filtered/org/exist/xquery/functions/transform/conf.xml
+++ b/exist-core/src/test/resources-filtered/org/exist/xquery/functions/transform/conf.xml
@@ -35,9 +35,10 @@
                 startup
                     triggers
                 pool
+                query-pool
                 recovery
-                security
                 watchdog
+            lock-manager
             repository
             binary-manager
             indexer
@@ -74,9 +75,6 @@
     
         - http://exist-db.org/exist/apps/doc/configuration.xml
         - http://exist-db.org/exist/apps/doc/documentation.xml
-        - http://atomic.exist-db.org/
-        
-    Version: 3.3.0-SNAPSHOT
 
 -->
 <exist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/conf.xsd">
@@ -148,19 +146,6 @@
             with high load will never be shrinked. A negative value means that
             shrinkage will not be performed.
 
-         - doc-ids:
-            how document ids are managed by eXist. Takes the values
-            "default" or "incremental".
-            
-            eXist assigns a unique, 32bit integer document id to every 
-            document. When a document is deleted, its id will be freed 
-            and reused for the next document stored. The disadvantage 
-            of this approach is that document ids
-            are not stable, i.e. one cannot be sure that the same document
-            id will always identify the same document.
-
-            If you need stable, incremental ids, set the option doc-ids to
-            "incremental".
         - minDiskSpace:
             The amount of disk space (in megabytes) which should be available for
             the database to continue operations. If free disk space goes below
@@ -168,7 +153,48 @@
             switch to read-only mode in order to prevent potential data loss. 
             Set the limit large enough to allow all pending operations to 
             complete. Set to -1 to disable. The default is 1 gigabyte.
-    
+
+        - posix-chown-restricted:
+            As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
+
+            When posix-chown-restricted="true" (the default) then:
+                1. Only a superuser process can change the user ID of the file.
+                2. A non-superuser process can change the group ID of the file
+                   if the process owns the file (the effective user ID equals
+                   the user ID of the file), and group equals either the
+                   effective group ID of the process or one of the
+                   process’s supplementary group IDs.
+            This means that when posix-chown-restricted="true", you can’t change
+            the user ID of your files. You can change the group ID of files that
+            you own, but only to groups that you belong to.
+
+            When posix-chown-restricted="false" you can change the user ID of
+            any file that you own, effectively "giving away the file" to
+            another user. Such a setting has negative security implications,
+            further details can be seen in the "Rationale" section for the
+            chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
+            See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+
+        - preserve-on-copy
+            When copying Collections and Documents within the database, the
+            default (`false`), is not to preserve their attributes
+            (modification time, mode, user-id, group-id, and ACL).
+
+            NOTE: Not preserving attributes, is inline with both the GNU and
+            BSD `cp` commands, and therefore expected behaviour; The target
+            Collection or Document is created following the rules of the
+            target parent, and the effective user and their umask.
+
+            Setting preserve-on-copy="true" changes the default behaviour
+            so that the target Collection or Document of a copy, has the same
+            attributes as the source.
+
+            The preserve-on-copy setting can be overridden on a case-by-case
+            basis by setting the `preserve` flag to either `true` or `false`
+            when calling xmldb:copy(), or via any other API that supports copy.
+            Omitting the preserve flag when calling a copy operation, implies
+            the behaviour that is set in this configuration.
+
         =====================================================================
         
         The settings below are very conservative to avoid out-of-memory
@@ -180,7 +206,7 @@
     -->
     <db-connection cacheSize="256M" checkMaxCacheSize="true" collectionCache="64M" database="native"
         files="${basedir}/target/test-data" pageSize="4096" nodesBuffer="1000" cacheShrinkThreshold="10000"
-        doc-ids="default" minDiskSpace="1024M">
+        minDiskSpace="1024M" posix-chown-restricted="true" preserve-on-copy="false">
 
         <!--
             Startup Triggers are executed before the database becomes generally available
@@ -188,10 +214,11 @@
         -->
         <startup>
             <triggers>
-                <!--
-                    Trigger for registering the GNU Crypto JCE Provider with Java
-                -->
-                <trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
+
+		<!--
+		    Trigger for registering the GNU Crypto JCE Provider with Java
+		-->
+		<trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
 
                 <!--
                     Trigger for registering eXists XML:DB URL handler with Java
@@ -257,15 +284,9 @@
                     by threads, each thread needs a private copy of a query.             
                                                                                          
                 - timeout:                                                               
-                    amount of time that a query will be cached in the query-pool.        
-                                                                                         
-                - timeout-check-interval:                                                
-                    time between checking for timed out queries. For value "-1"          
-                    the time out is switched off, resulting cached queries to remain     
-                    in the cache forever.                                                
+                    amount of time that a query will be cached in the query-pool in milliseconds.
             -->
-        <query-pool max-stack-size="64" size="128" timeout="120000"                
-                    timeout-check-interval="30000"/>
+        <query-pool max-stack-size="64" size="128" timeout="120000"/>
 
         <!--
             Settings for the journaling and recovery of the database. With 
@@ -362,6 +383,92 @@
         <watchdog output-size-limit="1000000" query-timeout="-1"/>
 
     </db-connection>
+
+
+    <!--
+        Settings for the Database Lock Manager
+
+        - upgrade-check
+            Used by developers for diagnosing illegal lock upgrade issues. When enabled
+            checks for lock upgrading within the same thread, i.e. READ_LOCK -> WRITE_LOCK
+            are enabled. When an illegal upgrade is detected a LockException is thrown.
+            Such behaviour will likely corrupt any database writes, and should only be
+            used by developers when debugging database issues.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.upgrade-check`,
+                or (legacy) `exist.lockmanager.upgrade.check`.
+
+        - warn-wait-on-read-for-write
+            Used by developers for diagnosing lock performance issues. When enabled
+            checks for detecting when a thread wants to acquire the WRITE_LOCK
+            but another thread holds the READ_LOCK are enabled. When such operations
+            are detected a log message is written to locks.log at WARN level.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
+                or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
+    -->
+    <lock-manager
+            upgrade-check="false"
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
+
+        <!--
+            Settings for the Lock Table
+
+            - disabled
+                Disables the database lock table which tracks database locks. The Lock Table is enabled by default
+                and allows reporting on database locking via JMX.
+
+                NOTE: Tracking locks via the Lock Table imposes a small overhead per-Lock. Once users
+                have finished testing their system to ensure correct operation, they may wish to disable
+                this in production to ensure the absolute best performance.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.disabled`,
+                    or (legacy) `exist.locktable.disable`.
+
+            - trace-stack-depth
+                When set above 0, this captures n frames of each threads stack that performs a try/lock/release
+                operation. These frames are visible from JMX reporting.
+                In addition, when the logging level for the Lock Table is set in log4j2.xml to TRACE the lock
+                events are written to the locks.log file.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
+                    or (legacy) `exist.locktable.trace.stack.depth`.
+        -->
+        <lock-table disabled="false" trace-stack-depth="0"/>
+
+
+        <!-- Settings for Document Locking
+
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
+
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
+
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
+        -->
+        <document use-path-locks="false"/>
+
+    </lock-manager>
 
     <!--
         Settings for the package repository:
@@ -552,6 +659,18 @@
     <!--
         Default settings for parsing structured documents:
 
+        - xml (optional)
+
+            - features
+                Any default SAX2 feature flags to set on the parser
+
+                    - feature
+                        - name
+                            the name of the feature flag
+                        - value
+                            the value of the feature flag
+
+
         - html-to-xml (optional)
 
             - class
@@ -588,6 +707,22 @@
                             the value of the feature flag
     -->
     <parser>
+
+        <xml>
+
+            <features>
+
+                <!-- NOTE: the following feature flags should likely be set in production to ensure a secure environment -->
+
+                <!--
+                <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
+                <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
+                <feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
+                -->
+
+            </features>
+
+        </xml>
 
         <!-- html-to-xml class="org.ccil.cowan.tagsoup.Parser"/ -->
 
@@ -760,7 +895,7 @@
             enable-query-rewriting="yes" backwardCompatible="no" 
             enforce-index-use="always"
             raise-error-on-failed-retrieval="no">
-
+        
         <builtin-modules>
             <module uri="http://www.w3.org/2005/xpath-functions/map"  class="org.exist.xquery.functions.map.MapModule" />
             <module uri="http://www.w3.org/2005/xpath-functions/math" class="org.exist.xquery.functions.math.MathModule" />

--- a/extensions/indexes/lucene/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/lucene/src/test/resources-filtered/conf.xml
@@ -35,9 +35,10 @@
                 startup
                     triggers
                 pool
+                query-pool
                 recovery
-                security
                 watchdog
+            lock-manager
             repository
             binary-manager
             indexer
@@ -74,9 +75,6 @@
     
         - http://exist-db.org/exist/apps/doc/configuration.xml
         - http://exist-db.org/exist/apps/doc/documentation.xml
-        - http://atomic.exist-db.org/
-        
-    Version: 3.3.0-SNAPSHOT
 
 -->
 <exist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/conf.xsd">
@@ -148,19 +146,6 @@
             with high load will never be shrinked. A negative value means that
             shrinkage will not be performed.
 
-         - doc-ids:
-            how document ids are managed by eXist. Takes the values
-            "default" or "incremental".
-            
-            eXist assigns a unique, 32bit integer document id to every 
-            document. When a document is deleted, its id will be freed 
-            and reused for the next document stored. The disadvantage 
-            of this approach is that document ids
-            are not stable, i.e. one cannot be sure that the same document
-            id will always identify the same document.
-
-            If you need stable, incremental ids, set the option doc-ids to
-            "incremental".
         - minDiskSpace:
             The amount of disk space (in megabytes) which should be available for
             the database to continue operations. If free disk space goes below
@@ -168,7 +153,48 @@
             switch to read-only mode in order to prevent potential data loss. 
             Set the limit large enough to allow all pending operations to 
             complete. Set to -1 to disable. The default is 1 gigabyte.
-    
+
+        - posix-chown-restricted:
+            As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
+
+            When posix-chown-restricted="true" (the default) then:
+                1. Only a superuser process can change the user ID of the file.
+                2. A non-superuser process can change the group ID of the file
+                   if the process owns the file (the effective user ID equals
+                   the user ID of the file), and group equals either the
+                   effective group ID of the process or one of the
+                   process’s supplementary group IDs.
+            This means that when posix-chown-restricted="true", you can’t change
+            the user ID of your files. You can change the group ID of files that
+            you own, but only to groups that you belong to.
+
+            When posix-chown-restricted="false" you can change the user ID of
+            any file that you own, effectively "giving away the file" to
+            another user. Such a setting has negative security implications,
+            further details can be seen in the "Rationale" section for the
+            chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
+            See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+
+        - preserve-on-copy
+            When copying Collections and Documents within the database, the
+            default (`false`), is not to preserve their attributes
+            (modification time, mode, user-id, group-id, and ACL).
+
+            NOTE: Not preserving attributes, is inline with both the GNU and
+            BSD `cp` commands, and therefore expected behaviour; The target
+            Collection or Document is created following the rules of the
+            target parent, and the effective user and their umask.
+
+            Setting preserve-on-copy="true" changes the default behaviour
+            so that the target Collection or Document of a copy, has the same
+            attributes as the source.
+
+            The preserve-on-copy setting can be overridden on a case-by-case
+            basis by setting the `preserve` flag to either `true` or `false`
+            when calling xmldb:copy(), or via any other API that supports copy.
+            Omitting the preserve flag when calling a copy operation, implies
+            the behaviour that is set in this configuration.
+
         =====================================================================
         
         The settings below are very conservative to avoid out-of-memory
@@ -180,7 +206,7 @@
     -->
     <db-connection cacheSize="256M" checkMaxCacheSize="true" collectionCache="64M" database="native"
         files="${basedir}/target/test-data" pageSize="4096" nodesBuffer="1000" cacheShrinkThreshold="10000"
-        doc-ids="default" minDiskSpace="1024M">
+        minDiskSpace="1024M" posix-chown-restricted="true" preserve-on-copy="false">
 
         <!--
             Startup Triggers are executed before the database becomes generally available
@@ -188,10 +214,11 @@
         -->
         <startup>
             <triggers>
-                <!--
-                    Trigger for registering the GNU Crypto JCE Provider with Java
-                -->
-                <trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
+
+		<!--
+		    Trigger for registering the GNU Crypto JCE Provider with Java
+		-->
+		<trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
 
                 <!--
                     Trigger for registering eXists XML:DB URL handler with Java
@@ -246,15 +273,9 @@
                     by threads, each thread needs a private copy of a query.             
                                                                                          
                 - timeout:                                                               
-                    amount of time that a query will be cached in the query-pool.        
-                                                                                         
-                - timeout-check-interval:                                                
-                    time between checking for timed out queries. For value "-1"          
-                    the time out is switched off, resulting cached queries to remain     
-                    in the cache forever.                                                
+                    amount of time that a query will be cached in the query-pool in milliseconds.
             -->
-        <query-pool max-stack-size="64" size="128" timeout="120000"                
-                    timeout-check-interval="30000"/>
+        <query-pool max-stack-size="64" size="128" timeout="120000"/>
 
         <!--
             Settings for the journaling and recovery of the database. With 
@@ -351,6 +372,92 @@
         <watchdog output-size-limit="1000000" query-timeout="-1"/>
 
     </db-connection>
+
+
+    <!--
+        Settings for the Database Lock Manager
+
+        - upgrade-check
+            Used by developers for diagnosing illegal lock upgrade issues. When enabled
+            checks for lock upgrading within the same thread, i.e. READ_LOCK -> WRITE_LOCK
+            are enabled. When an illegal upgrade is detected a LockException is thrown.
+            Such behaviour will likely corrupt any database writes, and should only be
+            used by developers when debugging database issues.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.upgrade-check`,
+                or (legacy) `exist.lockmanager.upgrade.check`.
+
+        - warn-wait-on-read-for-write
+            Used by developers for diagnosing lock performance issues. When enabled
+            checks for detecting when a thread wants to acquire the WRITE_LOCK
+            but another thread holds the READ_LOCK are enabled. When such operations
+            are detected a log message is written to locks.log at WARN level.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
+                or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
+    -->
+    <lock-manager
+            upgrade-check="false"
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
+
+        <!--
+            Settings for the Lock Table
+
+            - disabled
+                Disables the database lock table which tracks database locks. The Lock Table is enabled by default
+                and allows reporting on database locking via JMX.
+
+                NOTE: Tracking locks via the Lock Table imposes a small overhead per-Lock. Once users
+                have finished testing their system to ensure correct operation, they may wish to disable
+                this in production to ensure the absolute best performance.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.disabled`,
+                    or (legacy) `exist.locktable.disable`.
+
+            - trace-stack-depth
+                When set above 0, this captures n frames of each threads stack that performs a try/lock/release
+                operation. These frames are visible from JMX reporting.
+                In addition, when the logging level for the Lock Table is set in log4j2.xml to TRACE the lock
+                events are written to the locks.log file.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
+                    or (legacy) `exist.locktable.trace.stack.depth`.
+        -->
+        <lock-table disabled="false" trace-stack-depth="0"/>
+
+
+        <!-- Settings for Document Locking
+
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
+
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
+
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
+        -->
+        <document use-path-locks="false"/>
+
+    </lock-manager>
 
     <!--
         Settings for the package repository:
@@ -544,6 +651,18 @@
     <!--
         Default settings for parsing structured documents:
 
+        - xml (optional)
+
+            - features
+                Any default SAX2 feature flags to set on the parser
+
+                    - feature
+                        - name
+                            the name of the feature flag
+                        - value
+                            the value of the feature flag
+
+
         - html-to-xml (optional)
 
             - class
@@ -580,6 +699,22 @@
                             the value of the feature flag
     -->
     <parser>
+
+        <xml>
+
+            <features>
+
+                <!-- NOTE: the following feature flags should likely be set in production to ensure a secure environment -->
+
+                <!--
+                <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
+                <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
+                <feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
+                -->
+
+            </features>
+
+        </xml>
 
         <!-- html-to-xml class="org.ccil.cowan.tagsoup.Parser"/ -->
 

--- a/extensions/indexes/ngram/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/ngram/src/test/resources-filtered/conf.xml
@@ -35,9 +35,10 @@
                 startup
                     triggers
                 pool
+                query-pool
                 recovery
-                security
                 watchdog
+            lock-manager
             repository
             binary-manager
             indexer
@@ -74,9 +75,6 @@
     
         - http://exist-db.org/exist/apps/doc/configuration.xml
         - http://exist-db.org/exist/apps/doc/documentation.xml
-        - http://atomic.exist-db.org/
-        
-    Version: 3.3.0-SNAPSHOT
 
 -->
 <exist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/conf.xsd">
@@ -148,19 +146,6 @@
             with high load will never be shrinked. A negative value means that
             shrinkage will not be performed.
 
-         - doc-ids:
-            how document ids are managed by eXist. Takes the values
-            "default" or "incremental".
-            
-            eXist assigns a unique, 32bit integer document id to every 
-            document. When a document is deleted, its id will be freed 
-            and reused for the next document stored. The disadvantage 
-            of this approach is that document ids
-            are not stable, i.e. one cannot be sure that the same document
-            id will always identify the same document.
-
-            If you need stable, incremental ids, set the option doc-ids to
-            "incremental".
         - minDiskSpace:
             The amount of disk space (in megabytes) which should be available for
             the database to continue operations. If free disk space goes below
@@ -168,7 +153,48 @@
             switch to read-only mode in order to prevent potential data loss. 
             Set the limit large enough to allow all pending operations to 
             complete. Set to -1 to disable. The default is 1 gigabyte.
-    
+
+        - posix-chown-restricted:
+            As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
+
+            When posix-chown-restricted="true" (the default) then:
+                1. Only a superuser process can change the user ID of the file.
+                2. A non-superuser process can change the group ID of the file
+                   if the process owns the file (the effective user ID equals
+                   the user ID of the file), and group equals either the
+                   effective group ID of the process or one of the
+                   process’s supplementary group IDs.
+            This means that when posix-chown-restricted="true", you can’t change
+            the user ID of your files. You can change the group ID of files that
+            you own, but only to groups that you belong to.
+
+            When posix-chown-restricted="false" you can change the user ID of
+            any file that you own, effectively "giving away the file" to
+            another user. Such a setting has negative security implications,
+            further details can be seen in the "Rationale" section for the
+            chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
+            See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+
+        - preserve-on-copy
+            When copying Collections and Documents within the database, the
+            default (`false`), is not to preserve their attributes
+            (modification time, mode, user-id, group-id, and ACL).
+
+            NOTE: Not preserving attributes, is inline with both the GNU and
+            BSD `cp` commands, and therefore expected behaviour; The target
+            Collection or Document is created following the rules of the
+            target parent, and the effective user and their umask.
+
+            Setting preserve-on-copy="true" changes the default behaviour
+            so that the target Collection or Document of a copy, has the same
+            attributes as the source.
+
+            The preserve-on-copy setting can be overridden on a case-by-case
+            basis by setting the `preserve` flag to either `true` or `false`
+            when calling xmldb:copy(), or via any other API that supports copy.
+            Omitting the preserve flag when calling a copy operation, implies
+            the behaviour that is set in this configuration.
+
         =====================================================================
         
         The settings below are very conservative to avoid out-of-memory
@@ -180,7 +206,7 @@
     -->
     <db-connection cacheSize="256M" checkMaxCacheSize="true" collectionCache="64M" database="native"
         files="${basedir}/target/test-data" pageSize="4096" nodesBuffer="1000" cacheShrinkThreshold="10000"
-        doc-ids="default" minDiskSpace="1024M">
+        minDiskSpace="1024M" posix-chown-restricted="true" preserve-on-copy="false">
 
         <!--
             Startup Triggers are executed before the database becomes generally available
@@ -188,10 +214,11 @@
         -->
         <startup>
             <triggers>
-                <!--
-                    Trigger for registering the GNU Crypto JCE Provider with Java
-                -->
-                <trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
+
+		<!--
+		    Trigger for registering the GNU Crypto JCE Provider with Java
+		-->
+		<trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
 
                 <!--
                     Trigger for registering eXists XML:DB URL handler with Java
@@ -246,15 +273,9 @@
                     by threads, each thread needs a private copy of a query.             
                                                                                          
                 - timeout:                                                               
-                    amount of time that a query will be cached in the query-pool.        
-                                                                                         
-                - timeout-check-interval:                                                
-                    time between checking for timed out queries. For value "-1"          
-                    the time out is switched off, resulting cached queries to remain     
-                    in the cache forever.                                                
+                    amount of time that a query will be cached in the query-pool in milliseconds.
             -->
-        <query-pool max-stack-size="64" size="128" timeout="120000"                
-                    timeout-check-interval="30000"/>
+        <query-pool max-stack-size="64" size="128" timeout="120000"/>
 
         <!--
             Settings for the journaling and recovery of the database. With 
@@ -351,6 +372,92 @@
         <watchdog output-size-limit="1000000" query-timeout="-1"/>
 
     </db-connection>
+
+
+    <!--
+        Settings for the Database Lock Manager
+
+        - upgrade-check
+            Used by developers for diagnosing illegal lock upgrade issues. When enabled
+            checks for lock upgrading within the same thread, i.e. READ_LOCK -> WRITE_LOCK
+            are enabled. When an illegal upgrade is detected a LockException is thrown.
+            Such behaviour will likely corrupt any database writes, and should only be
+            used by developers when debugging database issues.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.upgrade-check`,
+                or (legacy) `exist.lockmanager.upgrade.check`.
+
+        - warn-wait-on-read-for-write
+            Used by developers for diagnosing lock performance issues. When enabled
+            checks for detecting when a thread wants to acquire the WRITE_LOCK
+            but another thread holds the READ_LOCK are enabled. When such operations
+            are detected a log message is written to locks.log at WARN level.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
+                or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
+    -->
+    <lock-manager
+            upgrade-check="false"
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
+
+        <!--
+            Settings for the Lock Table
+
+            - disabled
+                Disables the database lock table which tracks database locks. The Lock Table is enabled by default
+                and allows reporting on database locking via JMX.
+
+                NOTE: Tracking locks via the Lock Table imposes a small overhead per-Lock. Once users
+                have finished testing their system to ensure correct operation, they may wish to disable
+                this in production to ensure the absolute best performance.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.disabled`,
+                    or (legacy) `exist.locktable.disable`.
+
+            - trace-stack-depth
+                When set above 0, this captures n frames of each threads stack that performs a try/lock/release
+                operation. These frames are visible from JMX reporting.
+                In addition, when the logging level for the Lock Table is set in log4j2.xml to TRACE the lock
+                events are written to the locks.log file.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
+                    or (legacy) `exist.locktable.trace.stack.depth`.
+        -->
+        <lock-table disabled="false" trace-stack-depth="0"/>
+
+
+        <!-- Settings for Document Locking
+
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
+
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
+
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
+        -->
+        <document use-path-locks="false"/>
+
+    </lock-manager>
 
     <!--
         Settings for the package repository:
@@ -544,6 +651,18 @@
     <!--
         Default settings for parsing structured documents:
 
+        - xml (optional)
+
+            - features
+                Any default SAX2 feature flags to set on the parser
+
+                    - feature
+                        - name
+                            the name of the feature flag
+                        - value
+                            the value of the feature flag
+
+
         - html-to-xml (optional)
 
             - class
@@ -580,6 +699,22 @@
                             the value of the feature flag
     -->
     <parser>
+
+        <xml>
+
+            <features>
+
+                <!-- NOTE: the following feature flags should likely be set in production to ensure a secure environment -->
+
+                <!--
+                <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
+                <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
+                <feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
+                -->
+
+            </features>
+
+        </xml>
 
         <!-- html-to-xml class="org.ccil.cowan.tagsoup.Parser"/ -->
 
@@ -752,7 +887,7 @@
             enable-query-rewriting="yes" backwardCompatible="no" 
             enforce-index-use="always"
             raise-error-on-failed-retrieval="no">
-
+        
         <builtin-modules>
 
             <!-- Module under test! -->

--- a/extensions/indexes/range/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/range/src/test/resources-filtered/conf.xml
@@ -35,9 +35,10 @@
                 startup
                     triggers
                 pool
+                query-pool
                 recovery
-                security
                 watchdog
+            lock-manager
             repository
             binary-manager
             indexer
@@ -74,9 +75,6 @@
     
         - http://exist-db.org/exist/apps/doc/configuration.xml
         - http://exist-db.org/exist/apps/doc/documentation.xml
-        - http://atomic.exist-db.org/
-        
-    Version: 3.3.0-SNAPSHOT
 
 -->
 <exist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/conf.xsd">
@@ -148,19 +146,6 @@
             with high load will never be shrinked. A negative value means that
             shrinkage will not be performed.
 
-         - doc-ids:
-            how document ids are managed by eXist. Takes the values
-            "default" or "incremental".
-            
-            eXist assigns a unique, 32bit integer document id to every 
-            document. When a document is deleted, its id will be freed 
-            and reused for the next document stored. The disadvantage 
-            of this approach is that document ids
-            are not stable, i.e. one cannot be sure that the same document
-            id will always identify the same document.
-
-            If you need stable, incremental ids, set the option doc-ids to
-            "incremental".
         - minDiskSpace:
             The amount of disk space (in megabytes) which should be available for
             the database to continue operations. If free disk space goes below
@@ -168,7 +153,48 @@
             switch to read-only mode in order to prevent potential data loss. 
             Set the limit large enough to allow all pending operations to 
             complete. Set to -1 to disable. The default is 1 gigabyte.
-    
+
+        - posix-chown-restricted:
+            As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
+
+            When posix-chown-restricted="true" (the default) then:
+                1. Only a superuser process can change the user ID of the file.
+                2. A non-superuser process can change the group ID of the file
+                   if the process owns the file (the effective user ID equals
+                   the user ID of the file), and group equals either the
+                   effective group ID of the process or one of the
+                   process’s supplementary group IDs.
+            This means that when posix-chown-restricted="true", you can’t change
+            the user ID of your files. You can change the group ID of files that
+            you own, but only to groups that you belong to.
+
+            When posix-chown-restricted="false" you can change the user ID of
+            any file that you own, effectively "giving away the file" to
+            another user. Such a setting has negative security implications,
+            further details can be seen in the "Rationale" section for the
+            chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
+            See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+
+        - preserve-on-copy
+            When copying Collections and Documents within the database, the
+            default (`false`), is not to preserve their attributes
+            (modification time, mode, user-id, group-id, and ACL).
+
+            NOTE: Not preserving attributes, is inline with both the GNU and
+            BSD `cp` commands, and therefore expected behaviour; The target
+            Collection or Document is created following the rules of the
+            target parent, and the effective user and their umask.
+
+            Setting preserve-on-copy="true" changes the default behaviour
+            so that the target Collection or Document of a copy, has the same
+            attributes as the source.
+
+            The preserve-on-copy setting can be overridden on a case-by-case
+            basis by setting the `preserve` flag to either `true` or `false`
+            when calling xmldb:copy(), or via any other API that supports copy.
+            Omitting the preserve flag when calling a copy operation, implies
+            the behaviour that is set in this configuration.
+
         =====================================================================
         
         The settings below are very conservative to avoid out-of-memory
@@ -180,7 +206,7 @@
     -->
     <db-connection cacheSize="256M" checkMaxCacheSize="true" collectionCache="64M" database="native"
         files="${basedir}/target/test-data" pageSize="4096" nodesBuffer="1000" cacheShrinkThreshold="10000"
-        doc-ids="default" minDiskSpace="1024M">
+        minDiskSpace="1024M" posix-chown-restricted="true" preserve-on-copy="false">
 
         <!--
             Startup Triggers are executed before the database becomes generally available
@@ -188,10 +214,11 @@
         -->
         <startup>
             <triggers>
-                <!--
-                    Trigger for registering the GNU Crypto JCE Provider with Java
-                -->
-                <trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
+
+		<!--
+		    Trigger for registering the GNU Crypto JCE Provider with Java
+		-->
+		<trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
 
                 <!--
                     Trigger for registering eXists XML:DB URL handler with Java
@@ -246,15 +273,9 @@
                     by threads, each thread needs a private copy of a query.             
                                                                                          
                 - timeout:                                                               
-                    amount of time that a query will be cached in the query-pool.        
-                                                                                         
-                - timeout-check-interval:                                                
-                    time between checking for timed out queries. For value "-1"          
-                    the time out is switched off, resulting cached queries to remain     
-                    in the cache forever.                                                
+                    amount of time that a query will be cached in the query-pool in milliseconds.
             -->
-        <query-pool max-stack-size="64" size="128" timeout="120000"                
-                    timeout-check-interval="30000"/>
+        <query-pool max-stack-size="64" size="128" timeout="120000"/>
 
         <!--
             Settings for the journaling and recovery of the database. With 
@@ -351,6 +372,92 @@
         <watchdog output-size-limit="1000000" query-timeout="-1"/>
 
     </db-connection>
+
+
+    <!--
+        Settings for the Database Lock Manager
+
+        - upgrade-check
+            Used by developers for diagnosing illegal lock upgrade issues. When enabled
+            checks for lock upgrading within the same thread, i.e. READ_LOCK -> WRITE_LOCK
+            are enabled. When an illegal upgrade is detected a LockException is thrown.
+            Such behaviour will likely corrupt any database writes, and should only be
+            used by developers when debugging database issues.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.upgrade-check`,
+                or (legacy) `exist.lockmanager.upgrade.check`.
+
+        - warn-wait-on-read-for-write
+            Used by developers for diagnosing lock performance issues. When enabled
+            checks for detecting when a thread wants to acquire the WRITE_LOCK
+            but another thread holds the READ_LOCK are enabled. When such operations
+            are detected a log message is written to locks.log at WARN level.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
+                or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
+    -->
+    <lock-manager
+            upgrade-check="false"
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
+
+        <!--
+            Settings for the Lock Table
+
+            - disabled
+                Disables the database lock table which tracks database locks. The Lock Table is enabled by default
+                and allows reporting on database locking via JMX.
+
+                NOTE: Tracking locks via the Lock Table imposes a small overhead per-Lock. Once users
+                have finished testing their system to ensure correct operation, they may wish to disable
+                this in production to ensure the absolute best performance.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.disabled`,
+                    or (legacy) `exist.locktable.disable`.
+
+            - trace-stack-depth
+                When set above 0, this captures n frames of each threads stack that performs a try/lock/release
+                operation. These frames are visible from JMX reporting.
+                In addition, when the logging level for the Lock Table is set in log4j2.xml to TRACE the lock
+                events are written to the locks.log file.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
+                    or (legacy) `exist.locktable.trace.stack.depth`.
+        -->
+        <lock-table disabled="false" trace-stack-depth="0"/>
+
+
+        <!-- Settings for Document Locking
+
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
+
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
+
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
+        -->
+        <document use-path-locks="false"/>
+
+    </lock-manager>
 
     <!--
         Settings for the package repository:
@@ -547,6 +654,18 @@
     <!--
         Default settings for parsing structured documents:
 
+        - xml (optional)
+
+            - features
+                Any default SAX2 feature flags to set on the parser
+
+                    - feature
+                        - name
+                            the name of the feature flag
+                        - value
+                            the value of the feature flag
+
+
         - html-to-xml (optional)
 
             - class
@@ -583,6 +702,22 @@
                             the value of the feature flag
     -->
     <parser>
+
+        <xml>
+
+            <features>
+
+                <!-- NOTE: the following feature flags should likely be set in production to ensure a secure environment -->
+
+                <!--
+                <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
+                <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
+                <feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
+                -->
+
+            </features>
+
+        </xml>
 
         <!-- html-to-xml class="org.ccil.cowan.tagsoup.Parser"/ -->
 
@@ -755,7 +890,7 @@
             enable-query-rewriting="yes" backwardCompatible="no" 
             enforce-index-use="always"
             raise-error-on-failed-retrieval="no">
-
+        
         <builtin-modules>
 
             <!-- Module under test! -->

--- a/extensions/indexes/sort/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/sort/src/test/resources-filtered/conf.xml
@@ -35,9 +35,10 @@
                 startup
                     triggers
                 pool
+                query-pool
                 recovery
-                security
                 watchdog
+            lock-manager
             repository
             binary-manager
             indexer
@@ -74,9 +75,6 @@
     
         - http://exist-db.org/exist/apps/doc/configuration.xml
         - http://exist-db.org/exist/apps/doc/documentation.xml
-        - http://atomic.exist-db.org/
-        
-    Version: 3.3.0-SNAPSHOT
 
 -->
 <exist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/conf.xsd">
@@ -148,19 +146,6 @@
             with high load will never be shrinked. A negative value means that
             shrinkage will not be performed.
 
-         - doc-ids:
-            how document ids are managed by eXist. Takes the values
-            "default" or "incremental".
-            
-            eXist assigns a unique, 32bit integer document id to every 
-            document. When a document is deleted, its id will be freed 
-            and reused for the next document stored. The disadvantage 
-            of this approach is that document ids
-            are not stable, i.e. one cannot be sure that the same document
-            id will always identify the same document.
-
-            If you need stable, incremental ids, set the option doc-ids to
-            "incremental".
         - minDiskSpace:
             The amount of disk space (in megabytes) which should be available for
             the database to continue operations. If free disk space goes below
@@ -168,7 +153,48 @@
             switch to read-only mode in order to prevent potential data loss. 
             Set the limit large enough to allow all pending operations to 
             complete. Set to -1 to disable. The default is 1 gigabyte.
-    
+
+        - posix-chown-restricted:
+            As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
+
+            When posix-chown-restricted="true" (the default) then:
+                1. Only a superuser process can change the user ID of the file.
+                2. A non-superuser process can change the group ID of the file
+                   if the process owns the file (the effective user ID equals
+                   the user ID of the file), and group equals either the
+                   effective group ID of the process or one of the
+                   process’s supplementary group IDs.
+            This means that when posix-chown-restricted="true", you can’t change
+            the user ID of your files. You can change the group ID of files that
+            you own, but only to groups that you belong to.
+
+            When posix-chown-restricted="false" you can change the user ID of
+            any file that you own, effectively "giving away the file" to
+            another user. Such a setting has negative security implications,
+            further details can be seen in the "Rationale" section for the
+            chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
+            See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+
+        - preserve-on-copy
+            When copying Collections and Documents within the database, the
+            default (`false`), is not to preserve their attributes
+            (modification time, mode, user-id, group-id, and ACL).
+
+            NOTE: Not preserving attributes, is inline with both the GNU and
+            BSD `cp` commands, and therefore expected behaviour; The target
+            Collection or Document is created following the rules of the
+            target parent, and the effective user and their umask.
+
+            Setting preserve-on-copy="true" changes the default behaviour
+            so that the target Collection or Document of a copy, has the same
+            attributes as the source.
+
+            The preserve-on-copy setting can be overridden on a case-by-case
+            basis by setting the `preserve` flag to either `true` or `false`
+            when calling xmldb:copy(), or via any other API that supports copy.
+            Omitting the preserve flag when calling a copy operation, implies
+            the behaviour that is set in this configuration.
+
         =====================================================================
         
         The settings below are very conservative to avoid out-of-memory
@@ -180,7 +206,7 @@
     -->
     <db-connection cacheSize="256M" checkMaxCacheSize="true" collectionCache="64M" database="native"
         files="${basedir}/target/test-data" pageSize="4096" nodesBuffer="1000" cacheShrinkThreshold="10000"
-        doc-ids="default" minDiskSpace="1024M">
+        minDiskSpace="1024M" posix-chown-restricted="true" preserve-on-copy="false">
 
         <!--
             Startup Triggers are executed before the database becomes generally available
@@ -188,10 +214,11 @@
         -->
         <startup>
             <triggers>
-                <!--
-                    Trigger for registering the GNU Crypto JCE Provider with Java
-                -->
-                <trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
+
+		<!--
+		    Trigger for registering the GNU Crypto JCE Provider with Java
+		-->
+		<trigger class="org.exist.security.BouncyCastleJceProviderStartupTrigger"/>
 
                 <!--
                     Trigger for registering eXists XML:DB URL handler with Java
@@ -246,15 +273,9 @@
                     by threads, each thread needs a private copy of a query.             
                                                                                          
                 - timeout:                                                               
-                    amount of time that a query will be cached in the query-pool.        
-                                                                                         
-                - timeout-check-interval:                                                
-                    time between checking for timed out queries. For value "-1"          
-                    the time out is switched off, resulting cached queries to remain     
-                    in the cache forever.                                                
+                    amount of time that a query will be cached in the query-pool in milliseconds.
             -->
-        <query-pool max-stack-size="64" size="128" timeout="120000"                
-                    timeout-check-interval="30000"/>
+        <query-pool max-stack-size="64" size="128" timeout="120000"/>
 
         <!--
             Settings for the journaling and recovery of the database. With 
@@ -351,6 +372,92 @@
         <watchdog output-size-limit="1000000" query-timeout="-1"/>
 
     </db-connection>
+
+
+    <!--
+        Settings for the Database Lock Manager
+
+        - upgrade-check
+            Used by developers for diagnosing illegal lock upgrade issues. When enabled
+            checks for lock upgrading within the same thread, i.e. READ_LOCK -> WRITE_LOCK
+            are enabled. When an illegal upgrade is detected a LockException is thrown.
+            Such behaviour will likely corrupt any database writes, and should only be
+            used by developers when debugging database issues.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.upgrade-check`,
+                or (legacy) `exist.lockmanager.upgrade.check`.
+
+        - warn-wait-on-read-for-write
+            Used by developers for diagnosing lock performance issues. When enabled
+            checks for detecting when a thread wants to acquire the WRITE_LOCK
+            but another thread holds the READ_LOCK are enabled. When such operations
+            are detected a log message is written to locks.log at WARN level.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
+                or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
+    -->
+    <lock-manager
+            upgrade-check="false"
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
+
+        <!--
+            Settings for the Lock Table
+
+            - disabled
+                Disables the database lock table which tracks database locks. The Lock Table is enabled by default
+                and allows reporting on database locking via JMX.
+
+                NOTE: Tracking locks via the Lock Table imposes a small overhead per-Lock. Once users
+                have finished testing their system to ensure correct operation, they may wish to disable
+                this in production to ensure the absolute best performance.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.disabled`,
+                    or (legacy) `exist.locktable.disable`.
+
+            - trace-stack-depth
+                When set above 0, this captures n frames of each threads stack that performs a try/lock/release
+                operation. These frames are visible from JMX reporting.
+                In addition, when the logging level for the Lock Table is set in log4j2.xml to TRACE the lock
+                events are written to the locks.log file.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
+                    or (legacy) `exist.locktable.trace.stack.depth`.
+        -->
+        <lock-table disabled="false" trace-stack-depth="0"/>
+
+
+        <!-- Settings for Document Locking
+
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
+
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
+
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
+        -->
+        <document use-path-locks="false"/>
+
+    </lock-manager>
 
     <!--
         Settings for the package repository:
@@ -544,6 +651,18 @@
     <!--
         Default settings for parsing structured documents:
 
+        - xml (optional)
+
+            - features
+                Any default SAX2 feature flags to set on the parser
+
+                    - feature
+                        - name
+                            the name of the feature flag
+                        - value
+                            the value of the feature flag
+
+
         - html-to-xml (optional)
 
             - class
@@ -580,6 +699,22 @@
                             the value of the feature flag
     -->
     <parser>
+
+        <xml>
+
+            <features>
+
+                <!-- NOTE: the following feature flags should likely be set in production to ensure a secure environment -->
+
+                <!--
+                <feature name="http://xml.org/sax/features/external-general-entities" value="false"/>
+                <feature name="http://xml.org/sax/features/external-parameter-entities" value="false"/>
+                <feature name="http://javax.xml.XMLConstants/feature/secure-processing" value="true"/>
+                -->
+
+            </features>
+
+        </xml>
 
         <!-- html-to-xml class="org.ccil.cowan.tagsoup.Parser"/ -->
 
@@ -752,7 +887,7 @@
             enable-query-rewriting="yes" backwardCompatible="no" 
             enforce-index-use="always"
             raise-error-on-failed-retrieval="no">
-
+        
         <builtin-modules>
 
             <!-- Module under test! -->

--- a/extensions/indexes/spatial/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/spatial/src/test/resources-filtered/conf.xml
@@ -35,9 +35,10 @@
                 startup
                     triggers
                 pool
+                query-pool
                 recovery
-                security
                 watchdog
+            lock-manager
             repository
             binary-manager
             indexer
@@ -74,9 +75,6 @@
     
         - http://exist-db.org/exist/apps/doc/configuration.xml
         - http://exist-db.org/exist/apps/doc/documentation.xml
-        - http://atomic.exist-db.org/
-        
-    Version: 5.0.0-SNAPSHOT
 
 -->
 <exist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="schema/conf.xsd">
@@ -148,20 +146,6 @@
             with high load will never be shrinked. A negative value means that
             shrinkage will not be performed.
 
-         - doc-ids:
-            how document ids are managed by eXist. Takes the values
-            "default" or "incremental".
-            
-            eXist assigns a unique, 32bit integer document id to every 
-            document. When a document is deleted, its id will be freed 
-            and reused for the next document stored. The disadvantage 
-            of this approach is that document ids
-            are not stable, i.e. one cannot be sure that the same document
-            id will always identify the same document.
-
-            If you need stable, incremental ids, set the option doc-ids to
-            "incremental".
-
         - minDiskSpace:
             The amount of disk space (in megabytes) which should be available for
             the database to continue operations. If free disk space goes below
@@ -171,25 +155,25 @@
             complete. Set to -1 to disable. The default is 1 gigabyte.
 
         - posix-chown-restricted:
-           As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
+            As defined by POSIX.1 for _POSIX_CHOWN_RESTRICTED.
 
-           When posix-chown-restricted="true" (the default) then:
-               1. Only a superuser process can change the user ID of the file.
-               2. A non-superuser process can change the group ID of the file
-                  if the process owns the file (the effective user ID equals
-                  the user ID of the file), and group equals either the
-                  effective group ID of the process or one of the
-                  process’s supplementary group IDs.
-           This means that when posix-chown-restricted="true", you can’t change
-           the user ID of your files. You can change the group ID of files that
-           you own, but only to groups that you belong to.
+            When posix-chown-restricted="true" (the default) then:
+                1. Only a superuser process can change the user ID of the file.
+                2. A non-superuser process can change the group ID of the file
+                   if the process owns the file (the effective user ID equals
+                   the user ID of the file), and group equals either the
+                   effective group ID of the process or one of the
+                   process’s supplementary group IDs.
+            This means that when posix-chown-restricted="true", you can’t change
+            the user ID of your files. You can change the group ID of files that
+            you own, but only to groups that you belong to.
 
-           When posix-chown-restricted="false" you can change the user ID of
-           any file that you own, effectively "giving away the file" to
-           another user. Such a setting has negative security implications,
-           further details can be seen in the "Rationale" section for the
-           chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
-           See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
+            When posix-chown-restricted="false" you can change the user ID of
+            any file that you own, effectively "giving away the file" to
+            another user. Such a setting has negative security implications,
+            further details can be seen in the "Rationale" section for the
+            chown function in the POSIX.1-2017 (Issue 7, 2018 edition) standard.
+            See: http://pubs.opengroup.org/onlinepubs/9699919799/functions/chown.html#tag_16_59_07
 
         - preserve-on-copy
             When copying Collections and Documents within the database, the
@@ -210,7 +194,7 @@
             when calling xmldb:copy(), or via any other API that supports copy.
             Omitting the preserve flag when calling a copy operation, implies
             the behaviour that is set in this configuration.
-    
+
         =====================================================================
         
         The settings below are very conservative to avoid out-of-memory
@@ -222,7 +206,7 @@
     -->
     <db-connection cacheSize="256M" checkMaxCacheSize="true" collectionCache="64M" database="native"
         files="${basedir}/target/test-data" pageSize="4096" nodesBuffer="1000" cacheShrinkThreshold="10000"
-        doc-ids="default" minDiskSpace="1024M" posix-chown-restricted="true" preserve-on-copy="false">
+        minDiskSpace="1024M" posix-chown-restricted="true" preserve-on-copy="false">
 
         <!--
             Startup Triggers are executed before the database becomes generally available
@@ -247,29 +231,6 @@
                     <parameter name="mode" value="memory"/>
                 </trigger>
 
-                <!-- 
-                    EXQuery RESTXQ trigger to load the RESTXQ Registry at startup time 
-                -->
-                <trigger class="org.exist.extensions.exquery.restxq.impl.RestXqStartupTrigger"/>
-                
-                <!-- 
-                    AutoDeploymentTrigger will install any .xar application package it finds
-                    in the autodeploy directory unless the application has already been installed
-                    in the db. 
-                -->   
-                <trigger class="org.exist.repo.AutoDeploymentTrigger"/>
-                
-                <!-- 
-                    XQueryStartupTrigger will execute all xquery scripts stored in the
-                    /db/system/autostart collection during startup of the database. 
-
-                    The collection must be owned by SYSTEM/DBA mode "rwxrwx___" (0770)
-					
-                    Each of the scripts must be owned by a DBA user, group DBA, 
-                    mode "rwxrwx___" (0770) with mime-type "application/xquery". 
-                    The names of the scripts must end with ".xq", ".xqy" or ".xquery".
-                -->
-                <!--<trigger class="org.exist.collections.triggers.XQueryStartupTrigger"/>-->
                     
             </triggers>
         </startup>
@@ -413,6 +374,92 @@
         <watchdog output-size-limit="1000000" query-timeout="-1"/>
 
     </db-connection>
+
+
+    <!--
+        Settings for the Database Lock Manager
+
+        - upgrade-check
+            Used by developers for diagnosing illegal lock upgrade issues. When enabled
+            checks for lock upgrading within the same thread, i.e. READ_LOCK -> WRITE_LOCK
+            are enabled. When an illegal upgrade is detected a LockException is thrown.
+            Such behaviour will likely corrupt any database writes, and should only be
+            used by developers when debugging database issues.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.upgrade-check`,
+                or (legacy) `exist.lockmanager.upgrade.check`.
+
+        - warn-wait-on-read-for-write
+            Used by developers for diagnosing lock performance issues. When enabled
+            checks for detecting when a thread wants to acquire the WRITE_LOCK
+            but another thread holds the READ_LOCK are enabled. When such operations
+            are detected a log message is written to locks.log at WARN level.
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.warn-wait-on-read-for-write`,
+                or (legacy) `exist.lockmanager.warn.waitonreadforwrite`.
+
+        - paths-multi-writer
+            Set to true to enable Multi-Writer/Multi-Reader semantics for
+            the database Collection/Document Hierarchy as opposed to the default (false)
+            for Single-Writer/Multi-Reader.
+
+            NOTE: Whilst enabling Multiple-Writers on the Collection and Document Hierarchy can improve concurrent
+            through-put for write-heavy workloads, it can also can lead to deadlocks unless the User's
+            Collection Hierarchy is carefully designed to isolate query/database writes between Collection combs.
+            It is highly recommended that users leave this as the default setting. For more information, see:
+            "Locking and Cache Improvements for eXist-db", 2018-02-05, Section "Attempt 6" Page 58 -
+            https://www.evolvedbinary.com/technical-reports/exist-db/locking-and-cache-improvements/
+
+            This can also be set via the Java System Properties `org.exist.lock-manager.paths-multiple-writers`,
+            or (legacy) `exist.lockmanager.paths-multiwriter`.
+    -->
+    <lock-manager
+            upgrade-check="false"
+            warn-wait-on-read-for-write="false"
+            paths-multi-writer="false">
+
+        <!--
+            Settings for the Lock Table
+
+            - disabled
+                Disables the database lock table which tracks database locks. The Lock Table is enabled by default
+                and allows reporting on database locking via JMX.
+
+                NOTE: Tracking locks via the Lock Table imposes a small overhead per-Lock. Once users
+                have finished testing their system to ensure correct operation, they may wish to disable
+                this in production to ensure the absolute best performance.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.disabled`,
+                    or (legacy) `exist.locktable.disable`.
+
+            - trace-stack-depth
+                When set above 0, this captures n frames of each threads stack that performs a try/lock/release
+                operation. These frames are visible from JMX reporting.
+                In addition, when the logging level for the Lock Table is set in log4j2.xml to TRACE the lock
+                events are written to the locks.log file.
+
+                This can also be set via the Java System Properties `org.exist.lock-manager.lock-table.trace-stack-depth`,
+                    or (legacy) `exist.locktable.trace.stack.depth`.
+        -->
+        <lock-table disabled="false" trace-stack-depth="0"/>
+
+
+        <!-- Settings for Document Locking
+
+            - use-path-locks
+                Set to true to have documents participate in the same hierarchical
+                path based locking strategy as Collections.
+
+                This has a performance and concurrency impact, but will ensure
+                that you cannot have deadlocks between Collections and Documents.
+
+                NOTE: in future this will likely be set to `true` by default.
+
+                This can also be set via the Java System Property `org.exist.lock-manager.document.use-path-locks`.
+        -->
+        <document use-path-locks="false"/>
+
+    </lock-manager>
 
     <!--
         Settings for the package repository:


### PR DESCRIPTION
The use of Path Locks for Documents has always been experimental. However, some issues have been reported when they are enabled by advanced users. This PR addresses those issues.

**NOTE:** I have tested this by running the full test-suite for eXist-db with `<document use-path-locks="false"/>` and then again with `<document use-path-locks="true"/>` set in `conf.xml`. All tests pass :-)