### PR TITLE
Preserve original error message when using util:eval

### DIFF
--- a/exist-core/src/main/resources/org/exist/xquery/lib/test.xq
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/test.xq
@@ -302,9 +302,9 @@ declare function t:xpath($output as item()*, $xpath as element()) {
     let $expr := $xpath/string()
     return
         if (matches($expr, "^\s*/")) then
-            util:eval(concat("$output", $expr))
+            util:eval(concat("$output", $expr), false(), (), true())
         else
-            util:eval($expr)
+            util:eval($expr, false(), (), true())
 };
 
 declare function t:run-testSet($set as element(TestSet), $id as xs:string?) {

--- a/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -880,7 +880,7 @@ declare %private function test:assertXPath($annotation as element(annotation), $
             $prolog || "$result" || $expr
         else
             $prolog || $expr
-    let $eval-result := util:eval($eval-query)
+    let $eval-result := util:eval($eval-query, false(), (), true())
     let $xr := test:checkXPathResult($eval-result)
     return
         if ($xr) then


### PR DESCRIPTION
Pass on the original location and error when evaluating user-specified XPaths within the XQSuite.