### PR TITLE
Fix GitHub Actions for SonarCloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,37 @@
+name: SonarCloud
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -V -B -Dsurefire.useFile=false -DtrimStackTrace=false -Ddependency-check.skip=true -Ddocker=false -P \!mac-dmg-on-mac,\!codesign-mac-dmg,\!mac-dmg-on-unix,\!installer,\!concurrency-stress-tests,\!micro-benchmarks,\!build-dist-archives verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: Cache SonarCloud packages
         uses: actions/cache@v2
         with:

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectFunction.java
@@ -25,7 +25,8 @@ import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 
-import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.FunctionDSL.param;
+import static org.exist.xquery.FunctionDSL.returns;
 import static org.exist.xquery.functions.inspect.InspectionModule.functionSignature;
 
 public class InspectFunction extends BasicFunction {

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
@@ -32,7 +32,8 @@ import org.xml.sax.helpers.AttributesImpl;
 import javax.xml.XMLConstants;
 import java.util.Map;
 
-import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.FunctionDSL.param;
+import static org.exist.xquery.FunctionDSL.returnsOpt;
 import static org.exist.xquery.functions.inspect.InspectionModule.functionSignature;
 
 public class InspectModule extends BasicFunction {

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/ModuleFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/ModuleFunctions.java
@@ -34,8 +34,12 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Iterator;
 
-import static org.exist.xquery.FunctionDSL.*;
-import static org.exist.xquery.functions.inspect.InspectionModule.*;
+import static org.exist.xquery.FunctionDSL.arities;
+import static org.exist.xquery.FunctionDSL.arity;
+import static org.exist.xquery.FunctionDSL.param;
+import static org.exist.xquery.FunctionDSL.returnsOptMany;
+import static org.exist.xquery.functions.inspect.InspectionModule.functionSignature;
+import static org.exist.xquery.functions.inspect.InspectionModule.functionSignatures;
 
 public class ModuleFunctions extends BasicFunction {
 

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -124,6 +124,7 @@
         <sonar.projectKey>eXist-db_exist</sonar.projectKey>
         <sonar.organization>exist-db</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Fixes the SonarCloud integration with GitHub Actions.

**NOTE**: Previously SonarCloud Automated Analysis, and Manual Analysis (i.e. via CI) were enabled. You can only use one. Automated Analysis is not supported for Java projects, and so I disabled that in the SonarCloud dashboard. I believe it was the automated analysis that was previously (incorrectly) reporting 100% green for everything.