### PR TITLE
[fix] basic authentication

### DIFF
--- a/exist-core/src/main/java/org/exist/http/servlets/BasicAuthenticator.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/BasicAuthenticator.java
@@ -59,19 +59,20 @@ public class BasicAuthenticator implements Authenticator {
 		String credentials = request.getHeader("Authorization");
 		String username = null;
 		String password = null;
-                try {
-                    if (credentials != null) {
-							final byte[] c = Base64.decodeBase64(credentials.substring("Basic ".length()));
-                            final String s = new String(c, UTF_8);
-                            // LOG.debug("BASIC auth credentials: "+s);
-                            final int p = s.indexOf(':');
-                            username = p < 0 ? s : s.substring(0, p);
-                            password = p < 0 ? null : s.substring(p + 1);
-                    }
-                } catch(final IllegalArgumentException iae) {
-                    LOG.warn("Invalid BASIC authentication header received: " + iae.getMessage(), iae);
-                    credentials = null;
-                }
+
+		try {
+			if (credentials != null && credentials.startsWith("Basic")) {
+				final byte[] c = Base64.decodeBase64(credentials.substring("Basic ".length()));
+				final String s = new String(c, UTF_8);
+				// LOG.debug("BASIC auth credentials: "+s);
+				final int p = s.indexOf(':');
+				username = p < 0 ? s : s.substring(0, p);
+				password = p < 0 ? null : s.substring(p + 1);
+			}
+		} catch(final IllegalArgumentException iae) {
+			LOG.warn("Invalid BASIC authentication header received: " + iae.getMessage(), iae);
+			credentials = null;
+		}
 
 		// get the user from the session if possible
 		final HttpSession session = request.getSession(false);


### PR DESCRIPTION
A common authentication strategy is the bearer token authentication.

- The client sends `Authorization: Bearer [bearer-token]` to the server
- The server processes the Authorization header contents

At the moment, exist-db throws an error with that header. 
The BasicAuthenticator class treats any Authorization header as a basic authentication attempt, regardless of the scheme (`Basic`, `Bearer`, ...).

This PR changes BasicAuthenticator to also check if the header value starts with `Basic` before attempting to authenticate using the Basic Authentication strategy.
