### PR TITLE
[Bugfix] Array: extend remove() function to allow multiple deletes in one go. (XQTS)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayFunction.java
@@ -344,22 +344,25 @@ public class ArrayFunction extends BasicFunction {
                             return array;
                         }
 
-                        // Get and reverse sort parameters
-                        List<Integer> positions = new ArrayList<>();
-                        for (int i = 0; i < args[1].getItemCount(); i++) {
+                        final int arraySize = args[1].getItemCount();
+
+                        // Fetch and reverse sort parameters
+                        int[] positions = new int[arraySize];
+                        for (int i = 0; i < arraySize; i++) {
                             final int position = ((IntegerValue) args[1].itemAt(i)).getInt();
                             if (position < 1 || position > array.getSize()) {
                                 throw new XPathException(this, ErrorCodes.FOAY0001, "Index of item to remove (" + position + ") is out of bounds");
                             }
-                            positions.add(position - 1);
+                            positions[i] = position - 1;
                         }
-                        positions.sort(Comparator.reverseOrder());
+                        Arrays.sort(positions);
 
-                        // Effectively iterate reverse over array, delete items
+                        // Iterate reverse over array, delete items
                         ArrayType resultArray = array;
-                        for (int pos : positions) {
-                            resultArray = resultArray.remove(pos);
+                        for (int pos = arraySize - 1; pos >= 0; pos--) {
+                            resultArray = resultArray.remove(positions[pos]);
                         }
+
                         return resultArray;
 
                     case INSERT_BEFORE:

--- a/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayFunction.java
@@ -356,7 +356,7 @@ public class ArrayFunction extends BasicFunction {
                         ArrayType resultArray = array;
                         for (int pos : positions) {
                             if (pos < 1 || pos > array.getSize()) {
-                                throw new XPathException(this, ErrorCodes.FOAY0001, "Index of item to remove (" + rpos + ") is out of bounds");
+                                throw new XPathException(this, ErrorCodes.FOAY0001, "Index of item to remove (" + pos + ") is out of bounds");
                             }
                             resultArray = resultArray.remove(pos);
                         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayFunction.java
@@ -348,6 +348,9 @@ public class ArrayFunction extends BasicFunction {
                         List<Integer> positions = new ArrayList<>();
                         for (int i = 0; i < args[1].getItemCount(); i++) {
                             final int position = ((IntegerValue) args[1].itemAt(i)).getInt();
+                            if (position < 1 || position > array.getSize()) {
+                                throw new XPathException(this, ErrorCodes.FOAY0001, "Index of item to remove (" + position + ") is out of bounds");
+                            }
                             positions.add(position - 1);
                         }
                         positions.sort(Comparator.reverseOrder());
@@ -355,9 +358,6 @@ public class ArrayFunction extends BasicFunction {
                         // Effectively iterate reverse over array, delete items
                         ArrayType resultArray = array;
                         for (int pos : positions) {
-                            if (pos < 1 || pos > array.getSize()) {
-                                throw new XPathException(this, ErrorCodes.FOAY0001, "Index of item to remove (" + pos + ") is out of bounds");
-                            }
                             resultArray = resultArray.remove(pos);
                         }
                         return resultArray;

--- a/exist-core/src/test/xquery/arrays/arrays.xql
+++ b/exist-core/src/test/xquery/arrays/arrays.xql
@@ -405,6 +405,19 @@ function arr:remove2() {
 };
 
 declare
+    %test:assertEmpty
+    %test:assertEquals("a", "b", "c", "d")
+function arr:remove3() {
+    array:remove(["a", "b", "c", "d"], ())
+};
+
+declare
+    %test:assertEquals("b", "d")
+function arr:remove4() {
+    array:remove(["a", "b", "c", "d", "e"], (1,3,5))
+};
+
+declare
     %test:assertEquals("d", "c", "b", "a")
 function arr:reverse1() {
     array:reverse(["a", "b", "c", "d"])?*

--- a/exist-core/src/test/xquery/arrays/arrays.xql
+++ b/exist-core/src/test/xquery/arrays/arrays.xql
@@ -405,16 +405,15 @@ function arr:remove2() {
 };
 
 declare
-    %test:assertEmpty
     %test:assertEquals("a", "b", "c", "d")
 function arr:remove3() {
-    array:remove(["a", "b", "c", "d"], ())
+    array:remove(["a", "b", "c", "d"], ())?*
 };
 
 declare
     %test:assertEquals("b", "d")
 function arr:remove4() {
-    array:remove(["a", "b", "c", "d", "e"], (1,3,5))
+    array:remove(["a", "b", "c", "d", "e"], (3,1,5))?*
 };
 
 declare


### PR DESCRIPTION
 reimplement two missing Remove usecases; Found in XQTS. Added tests:


```xquery
declare
    %test:assertEmpty
    %test:assertEquals("a", "b", "c", "d")
function arr:remove3() {
    array:remove(["a", "b", "c", "d"], ())?*
};

declare
    %test:assertEquals("b", "d")
function arr:remove4() {
    array:remove(["a", "b", "c", "d", "e"], (3,1,5))?*
};
```