### PR TITLE
Broker pool service api

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -641,6 +641,7 @@
                                 <exclude>src/test/java/org/exist/storage/journal/JournalXmlTest.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/journal/LsnTest.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/BrokerPoolService.java</exclude>
+                                <exclude>src/test/java/org/exist/storage/BrokerPoolServiceTest.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/BrokerPoolServiceException.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/BrokerPoolServicesManager.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/BrokerPoolServicesManagerException.java</exclude>
@@ -779,6 +780,7 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/test/java/org/exist/storage/journal/JournalXmlTest.java</include>
                                 <include>src/test/java/org/exist/storage/journal/LsnTest.java</include>
                                 <include>src/main/java/org/exist/storage/BrokerPoolService.java</include>
+                                <include>src/test/java/org/exist/storage/BrokerPoolServiceTest.java</include>
                                 <include>src/main/java/org/exist/storage/BrokerPoolServiceException.java</include>
                                 <include>src/main/java/org/exist/storage/BrokerPoolServicesManager.java</include>
                                 <include>src/main/java/org/exist/storage/BrokerPoolServicesManagerException.java</include>

--- a/exist-core/src/main/java/org/exist/LifeCycle.java
+++ b/exist-core/src/main/java/org/exist/LifeCycle.java
@@ -27,7 +27,10 @@ import org.exist.storage.txn.Txn;
 /**
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
  *
+ * @deprecated Use {@link org.exist.storage.BrokerPoolService} instead which
+ * offers more fine grained events.
  */
+@Deprecated
 public interface LifeCycle {
 
 	public void start(DBBroker broker, final Txn transaction) throws EXistException;

--- a/exist-core/src/main/java/org/exist/dom/persistent/SymbolTable.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/SymbolTable.java
@@ -134,7 +134,7 @@ public class SymbolTable implements BrokerPoolService, Closeable {
     }
 
     @Override
-    public void stop(final DBBroker systemBroker) throws BrokerPoolServiceException {
+    public void stopSystem(final DBBroker systemBroker) throws BrokerPoolServiceException {
         try {
             close();
         } catch (final IOException e) {

--- a/exist-core/src/main/java/org/exist/indexing/IndexManager.java
+++ b/exist-core/src/main/java/org/exist/indexing/IndexManager.java
@@ -244,7 +244,7 @@ public class IndexManager implements BrokerPoolService {
      * @throws BrokerPoolServiceException in case of an error in the BrookerPoolService
      */
     @Override
-    public void stop(final DBBroker systemBroker) throws BrokerPoolServiceException {
+    public void stopSystem(final DBBroker systemBroker) throws BrokerPoolServiceException {
         for (final Iterator<Index> i = iterator(); i.hasNext(); ) {
             final Index index = i.next();
             try {

--- a/exist-core/src/main/java/org/exist/plugin/Plug.java
+++ b/exist-core/src/main/java/org/exist/plugin/Plug.java
@@ -32,7 +32,10 @@ import org.exist.config.Configurable;
  * 
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
  *
+ * @deprecated Use {@link org.exist.storage.BrokerPoolService} instead which
+ * offers more fine grained events.
  */
+@Deprecated
 public interface Plug extends Configurable, LifeCycle {
 
 }

--- a/exist-core/src/main/java/org/exist/plugin/PluginsManagerImpl.java
+++ b/exist-core/src/main/java/org/exist/plugin/PluginsManagerImpl.java
@@ -65,8 +65,11 @@ import static java.lang.invoke.MethodType.methodType;
  * It control search procedure, activation and de-actication (including runtime).
  *
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
+ *
+ * @deprecated Should no longer be used.
  */
 @ConfigurationClass("plugin-manager")
+@Deprecated
 public class PluginsManagerImpl implements Configurable, BrokerPoolService, PluginsManager, LifeCycle {
 
     private static final Logger LOG = LogManager.getLogger(PluginsManagerImpl.class);

--- a/exist-core/src/main/java/org/exist/plugin/PluginsManagerImpl.java
+++ b/exist-core/src/main/java/org/exist/plugin/PluginsManagerImpl.java
@@ -187,8 +187,14 @@ public class PluginsManagerImpl implements Configurable, BrokerPoolService, Plug
         }
     }
 
+    @Override
+    @Deprecated
+    public void stop(final DBBroker broker) {
+	    stopSystem(broker);
+    }
+
 	@Override
-	public void stop(final DBBroker broker) {
+	public void stopSystem(final DBBroker broker) {
 		for (final Plug plugin : jacks.values()) {
 			try {
 				plugin.stop(broker);

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -521,6 +521,12 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
 
         this.startupTriggersManager = servicesManager.register(new StartupTriggersManager());
 
+        // this is just used for unit tests
+        final BrokerPoolService testBrokerPoolService = (BrokerPoolService) conf.getProperty("exist.testBrokerPoolService");
+        if (testBrokerPoolService != null) {
+            servicesManager.register(testBrokerPoolService);
+        }
+
         //configure the registered services
         try {
             servicesManager.configureServices(conf);

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -87,7 +87,6 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -569,6 +569,13 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
                             journalManager.ifPresent(JournalManager::disableJournalling);
                         }
 
+                        try(final Txn transaction = transactionManager.beginTransaction()) {
+                            servicesManager.startPreSystemServices(systemBroker, transaction);
+                            transaction.commit();
+                        } catch(final BrokerPoolServiceException e) {
+                            throw new EXistException(e);
+                        }
+
                         //Run the recovery process
                         boolean recovered = false;
                         if(isRecoveryEnabled()) {

--- a/exist-core/src/main/java/org/exist/storage/BrokerPoolService.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPoolService.java
@@ -125,7 +125,7 @@ public interface BrokerPoolService {
 
     /**
      * Start any part of this service that should happen at the
-     * start of multi-user mode
+     * start of multi-user mode.
      *
      * As this point the database is generally available,
      * {@link #startPreMultiUserSystem(DBBroker, Txn)} has already been called
@@ -141,7 +141,45 @@ public interface BrokerPoolService {
     }
 
     /**
-     * Stop this service.
+     * Stop any part of this service that should happen at the
+     * end of multi-user mode.
+     *
+     * As this point the database is about to shutdown but has not yet
+     * transitioned to single-user mode.
+     * You may still be competing with other services and/or
+     * users for database access.
+     *
+     * @param brokerPool The multi-user available broker pool instance
+     *
+     * @throws BrokerPoolServiceException if an error occurs when stopping the multi-user service
+     */
+    default void stopMultiUser(final BrokerPool brokerPool) throws BrokerPoolServiceException {
+        //nothing to stop
+    }
+
+    /**
+     * Stop any part of this service that should happen during
+     * system (single-user) mode.
+     *
+     * By default there is nothing to stop
+     *
+     * As this point the database is not generally available
+     * and the only system broker is passed to this function
+     *
+     * @param systemBroker The system mode broker
+     *
+     * @throws BrokerPoolServiceException if an error occurs when stopping the service
+     *
+     * @deprecated Use {@link #stopSystem(DBBroker)} instead.
+     */
+    @Deprecated
+    default void stop(final DBBroker systemBroker) throws BrokerPoolServiceException {
+        stopSystem(systemBroker);
+    }
+
+    /**
+     * Stop any part of this service that should happen during
+     * system (single-user) mode.
      *
      * By default there is nothing to stop
      *
@@ -152,7 +190,7 @@ public interface BrokerPoolService {
      *
      * @throws BrokerPoolServiceException if an error occurs when stopping the service
      */
-    default void stop(final DBBroker systemBroker) throws BrokerPoolServiceException {
+    default void stopSystem(final DBBroker systemBroker) throws BrokerPoolServiceException {
         //nothing to actually stop
     }
 

--- a/exist-core/src/main/java/org/exist/storage/BrokerPoolService.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPoolService.java
@@ -39,7 +39,7 @@ import org.exist.util.Configuration;
  * Interface for a class which provides
  * services to a BrokerPool instance
  *
- * @author <a href="mailto:adam.retter@googlemail.com">Adam Retter</a>
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public interface BrokerPoolService {
 
@@ -69,6 +69,22 @@ public interface BrokerPoolService {
      */
     default void prepare(final BrokerPool brokerPool) throws BrokerPoolServiceException {
         //nothing to prepare
+    }
+
+    /**
+     * Start any part of this service that should happen before
+     * system (single-user) mode.
+     *
+     * As this point the database is not generally available
+     * and the only system broker is passed to this function
+     *
+     * @param systemBroker The system mode broker
+     * @param transaction The transaction for the system service
+     *
+     * @throws BrokerPoolServiceException if an error occurs when starting the pre-system service
+     */
+    default void startPreSystem(final DBBroker systemBroker, final Txn transaction) throws BrokerPoolServiceException {
+        // nothing to start
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/BrokerPoolServicesManager.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPoolServicesManager.java
@@ -52,12 +52,12 @@ import java.util.List;
  *
  * This class should only be accessed from {@link BrokerPool}
  * and the order of method invocation (service state change)
- * is significant and must follow the order:
+ * is significant and must follow the startup order:
  *
  *      register -> configure -> prepare ->
- *          system -> pre-multi-user -> multi-user
+ *          pre-system -> system -> pre-multi-user -> multi-user
  *
- * @author <a href="mailto:adam.retter@googlemail.com">Adam Retter</a>
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 @NotThreadSafe
 class BrokerPoolServicesManager {
@@ -66,6 +66,7 @@ class BrokerPoolServicesManager {
         REGISTRATION,
         CONFIGURATION,
         PREPARATION,
+        PRE_SYSTEM,
         SYSTEM,
         PRE_MULTI_USER,
         MULTI_USER,
@@ -76,6 +77,7 @@ class BrokerPoolServicesManager {
     private enum ManagerEvent {
         CONFIGURE,
         PREPARE,
+        PREPARE_ENTER_SYSTEM_MODE,
         ENTER_SYSTEM_MODE,
         PREPARE_ENTER_MULTI_USER_MODE,
         ENTER_MULTI_USER_MODE,
@@ -86,13 +88,14 @@ class BrokerPoolServicesManager {
     @SuppressWarnings("unchecked")
     private FSM<ManagerState, ManagerEvent> states = new AtomicFSM<>(ManagerState.REGISTRATION, transitionTable(ManagerState.class, ManagerEvent.class)
             .when(ManagerState.REGISTRATION)
-                .on(ManagerEvent.CONFIGURE).switchTo(ManagerState.CONFIGURATION)
-                .on(ManagerEvent.PREPARE).switchTo(ManagerState.PREPARATION)
-                .on(ManagerEvent.ENTER_SYSTEM_MODE).switchTo(ManagerState.SYSTEM)
-                .on(ManagerEvent.PREPARE_ENTER_MULTI_USER_MODE).switchTo(ManagerState.PRE_MULTI_USER)
-                .on(ManagerEvent.ENTER_MULTI_USER_MODE).switchTo(ManagerState.MULTI_USER)
-                .on(ManagerEvent.STOP).switchTo(ManagerState.STOPPING)
-                .on(ManagerEvent.SHUTDOWN).switchTo(ManagerState.SHUTTING_DOWN)
+            .on(ManagerEvent.CONFIGURE).switchTo(ManagerState.CONFIGURATION)
+            .on(ManagerEvent.PREPARE).switchTo(ManagerState.PREPARATION)
+            .on(ManagerEvent.PREPARE_ENTER_SYSTEM_MODE).switchTo(ManagerState.PRE_SYSTEM)
+            .on(ManagerEvent.ENTER_SYSTEM_MODE).switchTo(ManagerState.SYSTEM)
+            .on(ManagerEvent.PREPARE_ENTER_MULTI_USER_MODE).switchTo(ManagerState.PRE_MULTI_USER)
+            .on(ManagerEvent.ENTER_MULTI_USER_MODE).switchTo(ManagerState.MULTI_USER)
+            .on(ManagerEvent.STOP).switchTo(ManagerState.STOPPING)
+            .on(ManagerEvent.SHUTDOWN).switchTo(ManagerState.SHUTTING_DOWN)
             .build()
     );
 
@@ -168,6 +171,31 @@ class BrokerPoolServicesManager {
                 LOG.trace("Preparing service: " + brokerPoolService.getClass().getSimpleName() + "...");
             }
             brokerPoolService.prepare(brokerPool);
+        }
+    }
+
+    /**
+     * Starts any services which should be started directly before
+     * the database enters system mode, but before any general system
+     * mode operations are performed.
+     *
+     * At this point the broker pool is in system (single user) mode
+     * and not generally available for access, only a single
+     * system broker is available, no system services have been started
+     *
+     * @param systemBroker The System Broker which is available for
+     *   services to use to access the database
+     * @param transaction The transaction for the system services
+     *
+     * @throws BrokerPoolServiceException if any service causes an error during starting the pre system mode
+     *
+     * @throws IllegalStateException Thrown if there is an attempt to start a service
+     * after any other service has entered the start pre-system mode.
+     */
+    void startPreSystemServices(final DBBroker systemBroker, final Txn transaction) throws BrokerPoolServiceException {
+        states.process(ManagerEvent.PREPARE_ENTER_SYSTEM_MODE);
+        for(final BrokerPoolService brokerPoolService : brokerPoolServices) {
+            brokerPoolService.startPreSystem(systemBroker, transaction);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/storage/SystemTaskManager.java
+++ b/exist-core/src/main/java/org/exist/storage/SystemTaskManager.java
@@ -61,7 +61,7 @@ public class SystemTaskManager implements BrokerPoolService {
      */
     public void processTasks(final DBBroker systemBroker, final Txn transaction) {
         //dont run the task if we are shutting down
-        if (pool.isShuttingDown() || pool.isShutDown()) {
+        if (pool.isShuttingDownOrDown()) {
             return;
         }
 

--- a/exist-core/src/main/java/org/exist/storage/journal/Journal.java
+++ b/exist-core/src/main/java/org/exist/storage/journal/Journal.java
@@ -343,7 +343,11 @@ public final class Journal implements Closeable {
             if (currentFile > Short.MAX_VALUE) {
                 throw new JournalException("Journal can only support " + Short.MAX_VALUE + " log files");
             }
-            currentLsn = new Lsn((short)currentFile, channel.position() + currentBuffer.position() + 1);
+
+            // TODO(AR) this is needed as the journal is initialised by starting a transaction for loading the SymbolTable... before recovery! which is likely wrong!!! as Recovery Cannot run if the Journal file has been switched!
+            final long pos = channel != null ? channel.position() : 0;
+
+            currentLsn = new Lsn((short)currentFile, pos + currentBuffer.position() + 1);
         } catch (final IOException e) {
             throw new JournalException("Unable to create LSN for: " + entry.dump());
         }

--- a/exist-core/src/test/java/org/exist/storage/BrokerPoolServiceTest.java
+++ b/exist-core/src/test/java/org/exist/storage/BrokerPoolServiceTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.EXistException;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.DatabaseConfigurationException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for exercising the BrokerPoolService
+ * infrastructure.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class BrokerPoolServiceTest {
+
+    // NOTE: this is a concurrent list because it is shared between the test and the BackgroundJobsBrokerPoolService
+    private final List<Future<List<BackgroundJobsBrokerPoolService.TimestampAndId>>> futures = new CopyOnWriteArrayList<>();
+
+    /**
+     * This test registers a custom BrokerPoolService
+     * and then runs the database.
+     *
+     * The custom BrokerPoolService launches a bunch of
+     * background jobs when the database starts, and then
+     * attempts to stop them cleanly when the database
+     * stops.
+     */
+    @Test
+    public void backgroundJobsShutdownCleanly() throws EXistException, IOException, DatabaseConfigurationException, InterruptedException, ExecutionException {
+        // Create and add our BackgroundJobsBrokerPoolService to the BrokerPool
+        final BrokerPoolService testBrokerPoolService = new BackgroundJobsBrokerPoolService(futures);
+        final Properties configProps = new Properties();
+        configProps.put("exist.testBrokerPoolService", testBrokerPoolService);
+
+        // run the database
+        final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(configProps, true, true);
+        existEmbeddedServer.startDb();
+        try {
+
+            // do nothing for a while (background jobs will be running)
+            Thread.sleep(3000);
+
+        } finally {
+            existEmbeddedServer.stopDb();
+        }
+
+        // check results
+        int totalBackgroundJobResults = 0;
+        for (final Future<List<BackgroundJobsBrokerPoolService.TimestampAndId>> future : futures) {
+            try {
+                final List<BackgroundJobsBrokerPoolService.TimestampAndId> backgroundJobResult = future.get();
+
+                // should contain at least 1 result
+                assertTrue(backgroundJobResult.size() >= 1);
+
+                totalBackgroundJobResults += backgroundJobResult.size();
+
+            } catch (final CancellationException e) {
+                // ignore as the background job was cancelled OK
+            } catch (final ExecutionException e) {
+                // a background task threw an exception... shouldn't happen, so throw it!
+                throw e;
+            } catch (final InterruptedException e) {
+                // interrupted while waiting on the future, can't recover...
+
+                // restore interrupt flag status
+                Thread.currentThread().interrupt();
+
+                throw e;
+            }
+        }
+
+        assertTrue(totalBackgroundJobResults > 0);
+    }
+
+    public static class BackgroundJobsBrokerPoolService implements BrokerPoolService {
+        private static final Logger LOG = LogManager.getLogger(BackgroundJobsBrokerPoolService.class);
+
+        private static final int NUM_THREADS = 10;
+        private static final int NUM_JOBS = 30;  // It is intentional that there are more jobs than threads
+        private static final long JOB_LOOP_DELAY = 1000;
+
+        private final AtomicReference<BrokerPool> brokerPoolRef = new AtomicReference<>();
+        private final ExecutorService executorService = Executors.newFixedThreadPool(NUM_THREADS);
+        private final List<Future<List<BackgroundJobsBrokerPoolService.TimestampAndId>>> futures;
+        private volatile boolean stopBackgroundJobs = false;
+
+        public BackgroundJobsBrokerPoolService(final List<Future<List<BackgroundJobsBrokerPoolService.TimestampAndId>>> futures) {
+            this.futures = futures;
+        }
+
+        @Override
+        public void startMultiUser(final BrokerPool brokerPool) throws BrokerPoolServiceException {
+            if (!brokerPoolRef.compareAndSet(null, brokerPool)) {
+                throw new BrokerPoolServiceException("BrokerPool reference is already set");
+            }
+
+            startBackgroundJobs();
+        }
+
+        @Override
+        public void stopMultiUser(final BrokerPool brokerPool) throws BrokerPoolServiceException {
+            if (brokerPoolRef.get() != brokerPool) {
+                throw new BrokerPoolServiceException("BrokerPool does not match BrokerPoolRef");
+            }
+
+            stopBackgroundJobs();
+
+            if (!brokerPoolRef.compareAndSet(brokerPool, null)) {
+                throw new BrokerPoolServiceException("Could not clear BrokerPool reference");
+            }
+        }
+
+        private void startBackgroundJobs() {
+            for (int i = 0; i < NUM_JOBS; i++) {
+                final Future<List<TimestampAndId>> future = executorService.submit(new BackgroundJob(i));
+                futures.add(future);
+            }
+        }
+
+        private void stopBackgroundJobs() {
+            // let the executor service know we will be shutting down
+            executorService.shutdown();
+
+            // signal the background jobs that they should stop
+            stopBackgroundJobs = true;
+
+            // wait for all jobs to finish... or timeout!
+            final long timeout = NUM_JOBS * JOB_LOOP_DELAY * 2;
+            try {
+                final boolean cleanFinish = executorService.awaitTermination(timeout, TimeUnit.MILLISECONDS);
+                if (!cleanFinish) {
+                    LOG.warn("Clean shutdown of background tasks failed... calling shutdownNow");
+                    // do the best we can
+                    executorService.shutdownNow();
+                }
+
+            } catch (final InterruptedException e) {
+                // restore interrupt flag status
+                Thread.currentThread().interrupt();
+
+                LOG.error(e.getMessage(), e);
+
+                // ... nothing else that we can do!
+                executorService.shutdownNow();
+            }
+        }
+
+        private class BackgroundJob implements Callable<List<TimestampAndId>> {
+            private final List<TimestampAndId> list = new ArrayList<>();
+            private final int jobId;
+
+            public BackgroundJob(final int jobId) {
+                this.jobId = jobId;
+            }
+
+            @Override
+            public List<TimestampAndId> call() throws Exception {
+                do {
+                    final BrokerPool brokerPool = brokerPoolRef.get();
+                    if (brokerPool == null) {
+                        throw new Exception("Unable to get BrokerPoolRef");
+                    }
+
+                    try (final DBBroker broker = brokerPool.getBroker()) {
+                        final long timestamp = System.nanoTime();
+                        final String id = "job_" + jobId + "_" + broker.getId();
+
+                        list.add(new TimestampAndId(timestamp, id));
+                    }
+
+                    // just to slow things down a little
+                    Thread.sleep(JOB_LOOP_DELAY);
+
+                } while (!stopBackgroundJobs);
+
+                return list;
+            }
+        }
+
+        private static class TimestampAndId {
+            public final long timestamp;
+            public final String id;
+
+            private TimestampAndId(final long timestamp, final String id) {
+                this.timestamp = timestamp;
+                this.id = id;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Improves the API of BrokerPool Service to add additional life-cycle functions for starting and stopping Broker Pool services.

1. `BrokerPoolService#startPreSystem`
Permits activities that need to happen before the database enters system (single-user) mode during startup.

2. `BrokerPoolService#stopMultiUser`
Permits activities that need to happen before the database exits multi-user mode during shutdown.


NOTE: Even though this is an internal API, I have taken care to ensure that it is backwards compatible.