### PR TITLE
Reinstate fix for output directory

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -726,6 +726,7 @@
                             <goal>copy</goal>
                         </goals>
                         <configuration>
+                            <outputDirectory></outputDirectory>  <!-- NOTE: this must be empty -->
                             <resources>
                                 <resource>
                                     <workOnFullPath>true</workOnFullPath>


### PR DESCRIPTION
This was removed by accident in https://github.com/eXist-db/exist/commit/0cb91e913467fb240d2d92901d26787ec4cc4778#diff-cdb817f2816641803dc3213d102cb5e244562e20f39fe7b0d939270306860172L729
