### PR TITLE
[test] extend tests for immutability of maps 

### DIFF
--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -644,93 +644,92 @@ declare
     %test:assertTrue
 function mt:immutable-put-then-put() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
-    let $expected := $extended?($mt:test-key-one)
+    let $expected := $extended($mt:test-key-one)
     let $result := map:put($extended, $mt:test-key-one, false())
-
-    return $expected eq $extended?($mt:test-key-one)
+    return $expected eq $extended($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-put-then-remove() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
-    let $expected := $extended?($mt:test-key-one)
+    let $expected := $extended($mt:test-key-one)
     let $result := map:remove($extended, $mt:test-key-one)
 
-    return $expected eq $extended?($mt:test-key-one)
+    return $expected eq $extended($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-put-then-merge() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
-    let $expected := $extended?($mt:test-key-one)
+    let $expected := $extended($mt:test-key-one)
     let $result := map:merge(($extended, map { $mt:test-key-one : false() }))
 
-    return $expected eq $extended?($mt:test-key-one)
+    return $expected eq $extended($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-remove-then-put() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
-    let $expected := $removed?($mt:test-key-one)
+    let $expected := $removed($mt:test-key-one)
 
     let $result := map:put($removed, $mt:test-key-one, false())
 
-    return $expected eq $removed?($mt:test-key-one)
+    return $expected eq $removed($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-remove-then-remove() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
-    let $expected := $removed?($mt:test-key-one)
+    let $expected := $removed($mt:test-key-one)
 
     let $result := map:put($removed, $mt:test-key-one, false())
 
-    return $expected eq $removed?($mt:test-key-one)
+    return $expected eq $removed($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-remove-then-merge() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
-    let $expected := $removed?($mt:test-key-one)
+    let $expected := $removed($mt:test-key-one)
     let $result := map:merge(($removed, map { $mt:test-key-one : false() }))
 
-    return $expected eq $removed?($mt:test-key-one)
+    return $expected eq $removed($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-merge-then-put() {
     let $merged := map:merge(mt:create-test-map())
-    let $expected := $merged?($mt:test-key-one)
+    let $expected := $merged($mt:test-key-one)
 
     let $result := map:put($merged, $mt:test-key-one, false())
 
-    return $expected eq $merged?($mt:test-key-one)
+    return $expected eq $merged($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-merge-then-remove() {
     let $merged := map:merge(mt:create-test-map())
-    let $expected := $merged?($mt:test-key-one)
+    let $expected := $merged($mt:test-key-one)
 
     let $result := map:remove($merged, $mt:test-key-one)
 
-    return $expected eq $merged?($mt:test-key-one)
+    return $expected eq $merged($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-merge-then-merge() {
     let $merged := map:merge(mt:create-test-map())
-    let $expected := $merged?($mt:test-key-one)
+    let $expected := $merged($mt:test-key-one)
 
     let $result := map:merge(($merged, map { $mt:test-key-one : false() }))
 
-    return $expected eq $merged?($mt:test-key-one)
+    return $expected eq $merged($mt:test-key-one)
 };

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -695,10 +695,9 @@ declare
 function mt:immutable-remove-then-remove() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed($mt:test-key-one)
-
-    let $result := map:put($removed, $mt:test-key-one, false())
-
-    return $expected eq $removed($mt:test-key-one)
+    let $result := map:remove($removed, $mt:test-key-one)
+    return
+        $expected eq $removed($mt:test-key-one),
 };
 
 declare

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -641,32 +641,42 @@ declare function mt:create-test-map() {
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-put-then-put() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended($mt:test-key-one)
     let $result := map:put($extended, $mt:test-key-one, false())
-    return $expected eq $extended($mt:test-key-one)
+    return
+        (
+            $expected eq $extended($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-put-then-remove() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended($mt:test-key-one)
     let $result := map:remove($extended, $mt:test-key-one)
-
-    return $expected eq $extended($mt:test-key-one)
+    return
+        (
+            $expected eq $extended($mt:test-key-one),
+            empty($result($mt:test-key-one))
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-put-then-merge() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended($mt:test-key-one)
     let $result := map:merge(($extended, map { $mt:test-key-one : false() }))
-
-    return $expected eq $extended($mt:test-key-one)
+    return
+        (
+            $expected eq $extended($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -627,3 +627,110 @@ function mt:multi-merge() {
   	    map { "wolfgang": "de" }
   	))?*
 };
+
+(:
+  immutability tests for https://github.com/eXist-db/exist/issues/3724
+:)
+declare variable $mt:test-key-one := 1;
+declare variable $mt:test-key-two := 2;
+declare function mt:get-test-map () {
+    map {
+        $mt:test-key-one : true(),
+        $mt:test-key-two : true()
+    }
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-put-after-put () {
+    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+    let $expected := $extended?($mt:test-key-one)
+    let $result := map:put($extended, $mt:test-key-one, false())
+
+    return $expected eq $extended?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-remove-after-put () {
+    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+    let $expected := $extended?($mt:test-key-one)
+    let $result := map:remove($extended, $mt:test-key-one)
+
+    return $expected eq $extended?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-merge-after-put () {
+    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+    let $expected := $extended?($mt:test-key-one)
+    let $result := map:merge(($extended, map { $mt:test-key-one : false() }))
+
+    return $expected eq $extended?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-put-after-remove () {
+    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+    let $expected := $removed?($mt:test-key-one)
+
+    let $result := map:put($removed, $mt:test-key-one, false())
+
+    return $expected eq $removed?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-remove-after-remove () {
+    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+    let $expected := $removed?($mt:test-key-one)
+
+    let $result := map:put($removed, $mt:test-key-one, false())
+
+    return $expected eq $removed?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-merge-after-remove () {
+    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+    let $expected := $removed?($mt:test-key-one)
+    let $result := map:merge(($removed, map { $mt:test-key-one : false() }))
+
+    return $expected eq $removed?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-put-after-merge () {
+    let $merged := map:merge(mt:get-test-map())
+    let $expected := $merged?($mt:test-key-one)
+
+    let $result := map:put($merged, $mt:test-key-one, false())
+
+    return $expected eq $merged?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-remove-after-merge () {
+    let $merged := map:merge(mt:get-test-map())
+    let $expected := $merged?($mt:test-key-one)
+
+    let $result := map:remove($merged, $mt:test-key-one)
+
+    return $expected eq $merged?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-merge-after-merge () {
+    let $merged := map:merge(mt:get-test-map())
+    let $expected := $merged?($mt:test-key-one)
+
+    let $result := map:merge(($merged, map { $mt:test-key-one : false() }))
+
+    return $expected eq $merged?($mt:test-key-one)
+};

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -680,65 +680,79 @@ function mt:immutable-put-then-merge() {
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-remove-then-put() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed($mt:test-key-one)
-
     let $result := map:put($removed, $mt:test-key-one, false())
-
-    return $expected eq $removed($mt:test-key-one)
+    return
+        (
+            $expected eq $removed($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-remove-then-remove() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed($mt:test-key-one)
     let $result := map:remove($removed, $mt:test-key-one)
     return
-        $expected eq $removed($mt:test-key-one),
+        (
+            $expected eq $removed($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-remove-then-merge() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed($mt:test-key-one)
     let $result := map:merge(($removed, map { $mt:test-key-one : false() }))
-
-    return $expected eq $removed($mt:test-key-one)
+    return
+        (
+            $expected eq $removed($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-merge-then-put() {
     let $merged := map:merge(mt:create-test-map())
     let $expected := $merged($mt:test-key-one)
-
     let $result := map:put($merged, $mt:test-key-one, false())
-
-    return $expected eq $merged($mt:test-key-one)
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-merge-then-remove() {
     let $merged := map:merge(mt:create-test-map())
     let $expected := $merged($mt:test-key-one)
-
     let $result := map:remove($merged, $mt:test-key-one)
-
-    return $expected eq $merged($mt:test-key-one)
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-merge-then-merge() {
     let $merged := map:merge(mt:create-test-map())
     let $expected := $merged($mt:test-key-one)
-
     let $result := map:merge(($merged, map { $mt:test-key-one : false() }))
-
-    return $expected eq $merged($mt:test-key-one)
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -633,7 +633,7 @@ function mt:multi-merge() {
 :)
 declare variable $mt:test-key-one := 1;
 declare variable $mt:test-key-two := 2;
-declare function mt:get-test-map () {
+declare function mt:create-test-map() {
     map {
         $mt:test-key-one : true(),
         $mt:test-key-two : true()
@@ -642,8 +642,8 @@ declare function mt:get-test-map () {
 
 declare
     %test:assertTrue
-function mt:immutable-put-after-put () {
-    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+function mt:immutable-put-then-put() {
+    let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended?($mt:test-key-one)
     let $result := map:put($extended, $mt:test-key-one, false())
 
@@ -652,8 +652,8 @@ function mt:immutable-put-after-put () {
 
 declare
     %test:assertTrue
-function mt:immutable-remove-after-put () {
-    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+function mt:immutable-put-then-remove() {
+    let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended?($mt:test-key-one)
     let $result := map:remove($extended, $mt:test-key-one)
 
@@ -662,8 +662,8 @@ function mt:immutable-remove-after-put () {
 
 declare
     %test:assertTrue
-function mt:immutable-merge-after-put () {
-    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+function mt:immutable-put-then-merge() {
+    let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended?($mt:test-key-one)
     let $result := map:merge(($extended, map { $mt:test-key-one : false() }))
 
@@ -672,8 +672,8 @@ function mt:immutable-merge-after-put () {
 
 declare
     %test:assertTrue
-function mt:immutable-put-after-remove () {
-    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+function mt:immutable-remove-then-put() {
+    let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed?($mt:test-key-one)
 
     let $result := map:put($removed, $mt:test-key-one, false())
@@ -683,8 +683,8 @@ function mt:immutable-put-after-remove () {
 
 declare
     %test:assertTrue
-function mt:immutable-remove-after-remove () {
-    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+function mt:immutable-remove-then-remove() {
+    let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed?($mt:test-key-one)
 
     let $result := map:put($removed, $mt:test-key-one, false())
@@ -694,8 +694,8 @@ function mt:immutable-remove-after-remove () {
 
 declare
     %test:assertTrue
-function mt:immutable-merge-after-remove () {
-    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+function mt:immutable-remove-then-merge() {
+    let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed?($mt:test-key-one)
     let $result := map:merge(($removed, map { $mt:test-key-one : false() }))
 
@@ -704,8 +704,8 @@ function mt:immutable-merge-after-remove () {
 
 declare
     %test:assertTrue
-function mt:immutable-put-after-merge () {
-    let $merged := map:merge(mt:get-test-map())
+function mt:immutable-merge-then-put() {
+    let $merged := map:merge(mt:create-test-map())
     let $expected := $merged?($mt:test-key-one)
 
     let $result := map:put($merged, $mt:test-key-one, false())
@@ -715,8 +715,8 @@ function mt:immutable-put-after-merge () {
 
 declare
     %test:assertTrue
-function mt:immutable-remove-after-merge () {
-    let $merged := map:merge(mt:get-test-map())
+function mt:immutable-merge-then-remove() {
+    let $merged := map:merge(mt:create-test-map())
     let $expected := $merged?($mt:test-key-one)
 
     let $result := map:remove($merged, $mt:test-key-one)
@@ -726,8 +726,8 @@ function mt:immutable-remove-after-merge () {
 
 declare
     %test:assertTrue
-function mt:immutable-merge-after-merge () {
-    let $merged := map:merge(mt:get-test-map())
+function mt:immutable-merge-then-merge() {
+    let $merged := map:merge(mt:create-test-map())
     let $expected := $merged?($mt:test-key-one)
 
     let $result := map:merge(($merged, map { $mt:test-key-one : false() }))

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -701,7 +701,7 @@ function mt:immutable-remove-then-remove() {
     return
         (
             $expected eq $removed($mt:test-key-one),
-            $expected ne $result($mt:test-key-one)
+            not(exists($result($mt:test-key-one)))
         )
 };
 
@@ -740,7 +740,7 @@ function mt:immutable-merge-then-remove() {
     return
         (
             $expected eq $merged($mt:test-key-one),
-            $expected ne $result($mt:test-key-one)
+            not(exists($result($mt:test-key-one)))
         )
 };
 
@@ -753,6 +753,6 @@ function mt:immutable-merge-then-merge() {
     return
         (
             $expected eq $merged($mt:test-key-one),
-            $expected ne $result($mt:test-key-one)
+            $result($mt:test-key-one) eq false()
         )
 };


### PR DESCRIPTION
### Description:

This PR now only adds tests that extend the previous test for the immutability of maps

~~fork maps before mutating them~~

### Reference:

refs #3724

Map implementation (bifurcan) documentation of the `forked()` method
https://lacuna.io/docs/bifurcan/io/lacuna/bifurcan/IMap.html#forked--

### Type of tests:

Extended XQsuite tests in exist-core/src/test/xquery/maps/maps.xql