### PR TITLE
Group membership is not correct immediately after restoring a backup

### DIFF
--- a/exist-core/src/main/java/org/exist/backup/BackupDescriptor.java
+++ b/exist-core/src/main/java/org/exist/backup/BackupDescriptor.java
@@ -29,6 +29,7 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
 
 
@@ -51,6 +52,8 @@ public interface BackupDescriptor {
     BackupDescriptor getChildBackupDescriptor(String describedItem);
 
     BackupDescriptor getBackupDescriptor(String describedItem);
+
+    List<BackupDescriptor> getChildBackupDescriptors();
 
     String getName();
 

--- a/exist-core/src/main/java/org/exist/backup/BackupDirectory.java
+++ b/exist-core/src/main/java/org/exist/backup/BackupDirectory.java
@@ -68,9 +68,7 @@ public class BackupDirectory {
 
     public Path createBackup(final boolean incremental, final boolean zip) {
         int counter = 0;
-        Path file;
-
-        do {
+        while (true) {
             final StringBuilder buf = new StringBuilder();
             buf.append(incremental ? PREFIX_INC_BACKUP_FILE : PREFIX_FULL_BACKUP_FILE);
             buf.append(dateFormat.format(new Date()));
@@ -79,12 +77,25 @@ public class BackupDirectory {
                 buf.append('_').append(counter);
             }
 
-            if (zip) {
-                buf.append(".zip");
+            // make sure a file/dir of the same basic name (i.e. without extension) does not exist
+            Path file = dir.resolve(buf.toString());
+            if (!Files.exists(file)) {
+
+                // is this a zip backup file?
+                if (!zip) {
+                    // no
+                    return file;
+
+                } else {
+                    // yes, so check that a file/dir of the same name as the desired zip file does not exist
+                    buf.append(".zip");
+                    file = dir.resolve(buf.toString());
+                    if (!Files.exists(file)) {
+                        return file;
+                    }
+                }
             }
-            file = dir.resolve(buf.toString());
-        } while (Files.exists(file));
-        return (file);
+        }
     }
 
 

--- a/exist-core/src/main/java/org/exist/backup/ExportMain.java
+++ b/exist-core/src/main/java/org/exist/backup/ExportMain.java
@@ -74,12 +74,20 @@ public class ExportMain {
             .description("export database contents while preserving as much data as possible")
             .defaultValue(false)
             .build();
+    private static final Argument<Boolean> noExportArg = optionArgument("--no-export")
+            .description("do not export the database contents, overrides argument --export")
+            .defaultValue(false)
+            .build();
     private static final Argument<Boolean> incrementalArg = optionArgument("-i", "--incremental")
             .description("create incremental backup (use with --export|-x)")
             .defaultValue(false)
             .build();
     private static final Argument<Boolean> zipArg = optionArgument("-z", "--zip")
             .description("write output to a ZIP instead of a file system directory")
+            .defaultValue(false)
+            .build();
+    private static final Argument<Boolean> noZipArg = optionArgument("--no-zip")
+            .description("do not zip the output, overrides argument --zip")
             .defaultValue(false)
             .build();
 
@@ -115,7 +123,7 @@ public class ExportMain {
     public static void main(final String[] args) {
         try {
             final ParsedArguments arguments = CommandLineParser
-                    .withArguments(noCheckArg, checkDocsArg, directAccessArg, exportArg, incrementalArg, zipArg)
+                    .withArguments(noCheckArg, checkDocsArg, directAccessArg, exportArg, noExportArg, incrementalArg, zipArg, noZipArg)
                     .andArguments(configArg, outputDirArg)
                     .andArguments(helpArg, verboseArg)
                     .parse(args);
@@ -134,9 +142,17 @@ public class ExportMain {
         final boolean noCheck = getBool(arguments, noCheckArg);
         final boolean checkDocs = getBool(arguments, checkDocsArg);
         final boolean direct = getBool(arguments, directAccessArg);
-        final boolean export = getBool(arguments, exportArg);
+        boolean export = getBool(arguments, exportArg);
+        final boolean noExport = getBool(arguments, noExportArg);
+        if (noExport) {
+            export = false;
+        }
         final boolean incremental = getBool(arguments, incrementalArg);
-        final boolean zip = getBool(arguments, zipArg);
+        boolean zip = getBool(arguments, zipArg);
+        final boolean noZip = getBool(arguments, noZipArg);
+        if (noZip) {
+            zip = false;
+        }
 
         final Optional<Path> dbConfig = getOpt(arguments, configArg).map(File::toPath);
         final Path exportTarget = arguments.get(outputDirArg).toPath();

--- a/exist-core/src/main/java/org/exist/backup/FileSystemBackupDescriptor.java
+++ b/exist-core/src/main/java/org/exist/backup/FileSystemBackupDescriptor.java
@@ -37,6 +37,9 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -71,6 +74,29 @@ public class FileSystemBackupDescriptor extends AbstractBackupDescriptor {
             // DoNothing(R)
         }
         return bd;
+    }
+
+    @Override
+    public List<BackupDescriptor> getChildBackupDescriptors() {
+        try {
+            try (final Stream<BackupDescriptor> entries = Files.list(descriptor.getParent())
+                    .filter(p -> Files.isDirectory(p) && Files.exists(p.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR)))
+                    .map(p -> p.resolve(BackupDescriptor.COLLECTION_DESCRIPTOR))
+                    .map(p -> {
+                        try {
+                            return Optional.<BackupDescriptor>of(new FileSystemBackupDescriptor(root, p));
+                        } catch (final FileNotFoundException e) {
+                            // Do nothing
+                            return Optional.<BackupDescriptor>empty();
+                        }
+                    })
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)) {
+                return entries.collect(Collectors.toList());
+            }
+        } catch (final IOException e) {
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/backup/FileSystemBackupDescriptor.java
+++ b/exist-core/src/main/java/org/exist/backup/FileSystemBackupDescriptor.java
@@ -87,6 +87,7 @@ public class FileSystemBackupDescriptor extends AbstractBackupDescriptor {
                             return Optional.<BackupDescriptor>of(new FileSystemBackupDescriptor(root, p));
                         } catch (final FileNotFoundException e) {
                             // Do nothing
+                            LOG.warn(e.getMessage(), e);
                             return Optional.<BackupDescriptor>empty();
                         }
                     })

--- a/exist-core/src/main/java/org/exist/backup/Restore.java
+++ b/exist-core/src/main/java/org/exist/backup/Restore.java
@@ -115,17 +115,23 @@ public class Restore {
             final BackupDescriptor bd = getBackupDescriptor(contents);
             descriptors.push(bd);
 
-            // check if the system collection is in the backup. This should be processed first
-            //TODO : find a way to make a corespondance with DBRoker's named constants
+            // check if the /db/system collection is in the backup. This must be processed before other /db collections
+            //TODO : find a way to make a correspondence with DBRoker's named constants
             final BackupDescriptor sysDescriptor = bd.getChildBackupDescriptor("system");
 
-            // check if the system/security collection is in the backup, this must be the first system collection processed
+            // check if the /db/system/security collection is in the backup, this must be processed before other /db/system collections
             if(sysDescriptor != null) {
                 descriptors.push(sysDescriptor);
                 
                 final BackupDescriptor secDescriptor = sysDescriptor.getChildBackupDescriptor("security");
-                if(secDescriptor != null) {
+                if (secDescriptor != null) {
                     descriptors.push(secDescriptor);
+
+                    // check if the /db/system/security/exist/groups collection is in the backup, this must be processed before other /db/system/security/** collections
+                    final BackupDescriptor existGroupsDescriptor = secDescriptor.getChildBackupDescriptor("exist/groups");
+                    if (existGroupsDescriptor != null) {
+                        descriptors.push(existGroupsDescriptor);
+                    }
                 }
             }
 

--- a/exist-core/src/main/java/org/exist/backup/ZipArchiveBackupDescriptor.java
+++ b/exist-core/src/main/java/org/exist/backup/ZipArchiveBackupDescriptor.java
@@ -166,6 +166,7 @@ public class ZipArchiveBackupDescriptor extends AbstractBackupDescriptor {
                         try {
                             return Optional.<ZipArchiveBackupDescriptor>of(new ZipArchiveBackupDescriptor(archive, mtcDescriptor.group(1)));
                         } catch (final FileNotFoundException e) {
+                            LOG.warn(e.getMessage(), e);
                             return Optional.<ZipArchiveBackupDescriptor>empty();
                         }
                     } else {

--- a/exist-core/src/main/java/org/exist/backup/ZipArchiveBackupDescriptor.java
+++ b/exist-core/src/main/java/org/exist/backup/ZipArchiveBackupDescriptor.java
@@ -37,7 +37,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Enumeration;
+import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -147,6 +153,30 @@ public class ZipArchiveBackupDescriptor extends AbstractBackupDescriptor {
         }
 
         return bd;
+    }
+
+    @Override
+    public List<BackupDescriptor> getChildBackupDescriptors() {
+        final Pattern ptnDescriptor = Pattern.compile("(" + base + "/[^/]+/" + ")" + BackupDescriptor.COLLECTION_DESCRIPTOR);
+        final Matcher mtcDescriptor = ptnDescriptor.matcher("");
+        try (final Stream<BackupDescriptor> entries = archive.stream()
+                .map(zipEntry -> {
+                    mtcDescriptor.reset(zipEntry.getName());
+                    if (mtcDescriptor.matches()) {
+                        try {
+                            return Optional.<ZipArchiveBackupDescriptor>of(new ZipArchiveBackupDescriptor(archive, mtcDescriptor.group(1)));
+                        } catch (final FileNotFoundException e) {
+                            return Optional.<ZipArchiveBackupDescriptor>empty();
+                        }
+                    } else {
+                        return Optional.<ZipArchiveBackupDescriptor>empty();
+                    }
+                })
+                .filter(Optional::isPresent)
+                .map(Optional::get)) {
+
+            return entries.collect(Collectors.toList());
+        }
     }
 
 

--- a/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
@@ -402,7 +402,7 @@ public class RestoreHandler extends DefaultHandler {
             name = atts.getValue("name");
         }
 
-        // exclude /db/system collection and sub-collections, as these have already been restored
+        // exclude the /db/system and /db/system/security collections and their sub-collections, as these have already been restored
         if ((XmldbURI.DB.equals(currentCollectionUri) && "system".equals(name))
                 || (XmldbURI.SYSTEM.equals(currentCollectionUri) && "security".equals(name))) {
             return;

--- a/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
@@ -35,6 +35,7 @@ import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.ACLPermission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.security.SecurityManager;
+import org.exist.security.internal.RealmImpl;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.lock.LockManager;
@@ -402,9 +403,10 @@ public class RestoreHandler extends DefaultHandler {
             name = atts.getValue("name");
         }
 
-        // exclude the /db/system and /db/system/security collections and their sub-collections, as these have already been restored
+        // exclude the /db/system, /db/system/security, /db/system/security/exist/groups collections and their sub-collections, as these have already been restored
         if ((XmldbURI.DB.equals(currentCollectionUri) && "system".equals(name))
-                || (XmldbURI.SYSTEM.equals(currentCollectionUri) && "security".equals(name))) {
+                || (XmldbURI.SYSTEM.equals(currentCollectionUri) && "security".equals(name))
+                || (XmldbURI.SYSTEM.append("security").append(RealmImpl.ID).equals(currentCollectionUri) && "groups".equals(name))) {
             return;
         }
 

--- a/exist-core/src/main/java/org/exist/security/AbstractRealm.java
+++ b/exist-core/src/main/java/org/exist/security/AbstractRealm.java
@@ -170,6 +170,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
                             if (account.getGroups().length == 0) {
                                 try {
                                     account.setPrimaryGroup(getGroup(SecurityManager.UNKNOWN_GROUP));
+                                    LOG.warn("Account '" + account.getName() + "' has no groups, but every account must have at least 1 group. Assigned group: " + SecurityManager.UNKNOWN_GROUP);
                                 } catch (final PermissionDeniedException e) {
                                     throw new ConfigurationException("Account has no group, unable to default to " + SecurityManager.UNKNOWN_GROUP + ": " + e.getMessage(), e);
                                 }
@@ -190,6 +191,7 @@ public abstract class AbstractRealm implements Realm, Configurable {
                             if (account.getGroups().length == 0) {
                                 try {
                                     account.setPrimaryGroup(getGroup(SecurityManager.UNKNOWN_GROUP));
+                                    LOG.warn("Account '" + account.getName() + "' has no groups, but every account must have at least 1 group. Assigned group: " + SecurityManager.UNKNOWN_GROUP);
                                 } catch (final PermissionDeniedException e) {
                                     throw new ConfigurationException("Account has no group, unable to default to " + SecurityManager.UNKNOWN_GROUP + ": " + e.getMessage(), e);
                                 }

--- a/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
+++ b/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
@@ -851,7 +851,7 @@ public class SecurityManagerImpl implements SecurityManager, BrokerPoolService {
 	            	        }
             			}
                 	} else {
-                		final Account account = new AccountImpl( realm, conf );
+                		final Account account = new AccountImpl(realm, conf);
                 		if (account.getGroups().length == 0) {
                 		    try {
                                 account.setPrimaryGroup(realm.getGroup(SecurityManager.UNKNOWN_GROUP));

--- a/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
+++ b/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
@@ -81,10 +81,9 @@ import org.quartz.SimpleTrigger;
  * There's only one SecurityManager for each database instance, which
  * may be obtained by {@link BrokerPool#getSecurityManager()}.
  * 
- * Users and groups are stored in the system collection, in document
- * users.xml. While it is possible to edit this file by hand, it
- * may lead to unexpected results, since SecurityManager reads 
- * users.xml only during database startup and shutdown.
+ * Users and groups are stored per-realm within the
+ * system collection: /db/system/security. Each realm
+ * has its own sub-collection.
  */
 //<!-- Central user configuration. Editing this document will cause the security to reload and update its internal database. Please handle with care! -->
 @ConfigurationClass("security-manager")

--- a/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
+++ b/exist-core/src/main/java/org/exist/security/internal/SecurityManagerImpl.java
@@ -855,6 +855,7 @@ public class SecurityManagerImpl implements SecurityManager, BrokerPoolService {
                 		if (account.getGroups().length == 0) {
                 		    try {
                                 account.setPrimaryGroup(realm.getGroup(SecurityManager.UNKNOWN_GROUP));
+                                LOG.warn("Account '" + account.getName() + "' has no groups, but every account must have at least 1 group. Assigned group: " + SecurityManager.UNKNOWN_GROUP);
                             } catch (final PermissionDeniedException e) {
                 		        throw new ConfigurationException("Account has no group, unable to default to " + SecurityManager.UNKNOWN_GROUP + ": " + e.getMessage(), e);
                             }

--- a/exist-core/src/test/java/org/exist/backup/XMLDBRestoreTest.java
+++ b/exist-core/src/test/java/org/exist/backup/XMLDBRestoreTest.java
@@ -349,7 +349,7 @@ public class XMLDBRestoreTest {
                         "    </resource>\n" +
                         "</collection>";
 
-        // account with no primary group!
+        // account with no such group!
         final String backupPasswordHash = Base64.encodeBase64String(ripemd160(username));
         final String backupPasswordDigest = MessageDigester.byteArrayToHex(ripemd160(username + ":exist:" + username));
         final String invalidUserDoc =

--- a/exist-core/src/test/java/org/exist/backup/XMLDBRestoreTest.java
+++ b/exist-core/src/test/java/org/exist/backup/XMLDBRestoreTest.java
@@ -30,6 +30,7 @@ import org.exist.security.SecurityManager;
 import org.exist.test.ExistWebServer;
 import org.exist.xmldb.*;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -181,6 +182,7 @@ public class XMLDBRestoreTest {
     /**
      * Restores users with groups from /db/system/security/exist
      */
+    @Ignore("Not yet supported")
     @Test
     public void restoreUserWithGroupsFromExistRealm() throws IOException, XMLDBException {
         final Path backupPath = tempFolder.newFolder().toPath();
@@ -191,6 +193,7 @@ public class XMLDBRestoreTest {
     /**
      * Restores users with groups from /db/system/security
      */
+    @Ignore("Not yet supported")
     @Test
     public void restoreUserWithGroupsFromSecurityCollection() throws IOException, XMLDBException {
         final Path backupPath = tempFolder.newFolder().toPath();
@@ -201,6 +204,7 @@ public class XMLDBRestoreTest {
     /**
      * Restores users with groups from /db/system
      */
+    @Ignore("Not yet supported")
     @Test
     public void restoreUserWithGroupsFromSystemCollection() throws IOException, XMLDBException {
         final Path backupPath = tempFolder.newFolder().toPath();

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -858,8 +858,8 @@
                                     <mainClass>org.exist.start.Main</mainClass>
                                     <commandLineArguments>
                                         <commandLineArgument>org.exist.backup.ExportMain</commandLineArgument>
-                                        <commandLineArgument>-x</commandLineArgument>
-                                        <commandLineArgument>-z</commandLineArgument>
+                                        <commandLineArgument>--export</commandLineArgument>
+                                        <commandLineArgument>--zip</commandLineArgument>
                                     </commandLineArguments>
                                     <platforms>
                                         <platform>booter-unix</platform>
@@ -959,8 +959,8 @@
                                     <mainClass>org.exist.start.Main</mainClass>
                                     <commandLineArguments>
                                         <commandLineArgument>org.exist.backup.ExportMain</commandLineArgument>
-                                        <commandLineArgument>-x</commandLineArgument>
-                                        <commandLineArgument>-z</commandLineArgument>
+                                        <commandLineArgument>--export</commandLineArgument>
+                                        <commandLineArgument>--zip</commandLineArgument>
                                     </commandLineArguments>
                                     <platforms>
                                         <platform>booter-unix</platform>


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/3650

It absolutely blows my mind that until today only 2 people have recently reported this but yet the problem has been around for quite some time (at least 5.1.1 if not before). I wonder if anyone else is doing backups/restores of their databases?!?

---

This PR provides a fix that **only** addresses the problem for those users that restore full or incremental backups of the entire database, i.e. starting from `/db`.

Any partial restore that starts from `/db/system` or below and includes the users and groups will still not correctly load the groups before the users. Unfortunately solving such a thing with the current approach of the restore code is impossible, and the restore system itself needs rewriting to take a different approach. As most users backup and restore full-databases this should solve it for the majority.

We may contribute a rewrite of the backup/restore system in future to fix a number of additional issues.