### PR TITLE
fix(ci): reenable docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - master # needed for docker release builds
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -38,3 +39,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B verify
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build    
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Build and push latest images
+        if: github.ref == 'refs/heads/develop'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: $ {{ secrets.DOCKER_PASSWORD }}
+        run: >-
+          cd exist-docker &&
+          mvn -DskipTests -Ddocker.tag=latest -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push &&
+          cd ..
+      - name: Build and push release images
+        if: github.ref == 'refs/heads/master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: $ {{ secrets.DOCKER_PASSWORD }}
+        run: >-
+          cd exist-docker &&
+          mvn -DskipTests -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push &&
+          cd ..


### PR DESCRIPTION
add deployment to docker, mirroring what we did on travis. 

secrets: DOCKER_USERNAME & DOCKER_PASSWORD must be configured in repo

close #3696
