### PR TITLE
Docker ci

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,9 @@ To help the community judge your pull request (PR), please include the following
 - A context reference to a [Github Issue](https://github.com/eXist-db/exist/issues), a message in the [eXist-open mailinglist](http://exist-open.markmail.org), or a [specification](https://www.w3.org/TR/xquery-31/).
 - Tests. The [XQSuite - Annotation-based Test Framework for XQuery](http://exist-db.org/exist/apps/doc/xqsuite.xml) makes it very easy for you to create tests. These tests can be executed from the [eXide editor](http://exist-db.org/exist/apps/eXide/index.html) via XQuery > Run as Test.
 
-Your PR will be tested using [Travis CI](https://travis-ci.com/eXist-db/exist) and [AppVeyor](https://ci.appveyor.com/project/AdamRetter/exist) against a number of operating systems and environments. The build status is visible in the PR. 
+Your PR will be tested using [GitHub Actions](https://github.com/eXist-db/exist/actions) against a number of operating systems and environments. The build status is visible in the PR. 
 
-To detect errors in your PR before submitting it, please run eXist's full test suite on your own system via `build.sh test`.
+To detect errors in your PR before submitting it, please run eXist's full test suite on your own system via `mvn -V clean verify`.
 
 ------
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     name: (JDK ${{ matrix.jdk }} / ${{ matrix.os }}) Build and Test 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         jdk: ['8', '11']
@@ -32,3 +32,39 @@ jobs:
       - name: Maven Javadoc
         if: ${{ matrix.jdk == '8' }}
         run: mvn -V -B -q -T 2C javadoc:javadoc
+  deploy:
+        name: Publishing docker images
+        runs-on: ubuntu-latest
+        needs: build
+        if: ${{ github.ref == ('refs/heads/develop' || 'refs/heads/master') }}
+        steps:
+          - uses: actions/checkout@v2
+            with:
+              fetch-depth: 0
+          - name: Set up JDK 8
+            uses: actions/setup-java@v1
+            with:
+              java-version: '8'
+          # TODO(DP): reuse artefacts from Build step
+          - name: Maven Build
+            run: mvn -V -B -q -T 2C -P \!mac-dmg-on-mac,\!codesign-mac-dmg,\!mac-dmg-on-unix,\!installer clean package -DskipTests -Ddependency-check.skip=true -Ddocker=true
+          - name: Build and push latest images
+            if: ${{ github.ref == 'refs/heads/develop' }}
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+              DOCKER_PASSWORD: $ {{ secrets.DOCKER_PASSWORD }}
+            run: |
+              cd exist-docker
+              mvn -DskipTests -Ddocker.tag=latest -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
+              cd ..
+          - name: Build and push release images
+            if: ${{ github.ref == 'refs/heads/master' }}
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+              DOCKER_PASSWORD: $ {{ secrets.DOCKER_PASSWORD }}
+            run: |
+              cd exist-docker
+              mvn -DskipTests -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
+              cd ..       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,16 @@
 name: CI
-on:
-  push:
-    branches:
-      - develop
-      - master
-  pull_request:
-    types: [opened, synchronize, reopened]
+on: [push, pull_request]
 jobs:
   build:
-    name: Build and Test (${{ matrix.os }} / OpenJDK ${{ matrix.jdk }})
+    name: (JDK ${{ matrix.jdk }} / ${{ matrix.os }}) Build and Test 
     strategy:
       fail-fast: true
       matrix:
-        jdk: ['8', '11', '15']
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        jdk: ['8', '11']
+        include:
+          - os: ubuntu-latest
+            jdk: '15'        
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -29,13 +26,9 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 # NOTE(AR) The `-T 2C` enables multi-threaded builds below, faster, but may need to be disabled when diagnosing problems 
       - name: Maven Build
-        run: mvn -V -B -T 2C -DskipTests=true "-Dmaven.javadoc.skip=true" install
+        run: mvn -V -B -q -T 2C -DskipTests=true "-Dmaven.javadoc.skip=true" install
       - name: Maven Test
-        run: mvn -V -B "-Dsurefire.useFile=false" -DtrimStackTrace=false test
-      - name: Maven License Check
-        run: mvn -V -B license:check
-# TODO(AR) test and license:check should be replaced by verify, but seems to cause an error on GitHub Actions
-#      - name: Maven Verify
-#        run: mvn -V -B verify
+        run: mvn -V -B clean verify
       - name: Maven Javadoc
-        run: mvn -V -B javadoc:javadoc
+        if: ${{ matrix.jdk == '8' }}
+        run: mvn -V -B -q -T 2C javadoc:javadoc


### PR DESCRIPTION
`fail-fast` causes too many headaches, its disabled again. 

docker image deploymen needs to run on `develop`

performance tweaks to CI in general. 