### PR TITLE
Speed up CI when Docker Images are built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,25 @@ name: CI
 on: [push, pull_request]
 jobs:
   build:
-    name: (${{ matrix.os }} / JDK ${{ matrix.jdk }}) Build and Test
+    name: (${{ matrix.os }} / JDK ${{ matrix.jdk }} / Docker Image ${{ matrix.build-docker-image }}) Build and Test
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         jdk: ['8', '11']
+        build-docker-image: [false]
         include:
+          # Also build on JDK 15 on Ubuntu (experimental)
           - os: ubuntu-latest
             jdk: 15
+          # Only build our Docker Image on Ubuntu / JDK 8
+          - os: ubuntu-latest
+            jdk: 8
+            build-docker-image: true
+        exclude:
+          - os: ubuntu-latest
+            jdk: 8
+            build-docker-image: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -24,9 +34,9 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-# NOTE(AR) The `-T 2C` enables multi-threaded builds below, faster, but may need to be disabled when diagnosing problems 
+# NOTE(AR) The `-T 2C` enables multi-threaded builds below, faster, but may need to be disabled when diagnosing problems
       - name: Maven Build
-        run: mvn -V -B -q -T 2C -DskipTests=true "-Dmaven.javadoc.skip=true" install
+        run: mvn -V -B -q -T 2C -DskipTests=true "-Dmaven.javadoc.skip=true" -Ddocker=${{ matrix.build-docker-image }} install
       - name: Maven Test
         run: mvn -V -B "-Dsurefire.useFile=false" -DtrimStackTrace=false test
       - name: Maven License Check
@@ -36,39 +46,19 @@ jobs:
 #        run: mvn -V -B verify
       - name: Maven Javadoc
         run: mvn -V -B -q -T 2C javadoc:javadoc
-  deploy:
-    name: Publish Docker Images
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == ('refs/heads/develop' || 'refs/heads/master')
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up JDK 8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      # TODO: reuse artifacts from Build step
-      - name: Maven Build
-        run: mvn -V -B -q -T 2C -DskipTests -Ddependency-check.skip=true -Ddocker=true -P \!mac-dmg-on-mac,\!codesign-mac-dmg,\!mac-dmg-on-unix,\!installer clean package
-      - name: Build and push latest images
-        if: github.ref == 'refs/heads/develop'
+      - name: Publish Latest Docker Images
+        if: matrix.build-docker-image == true && github.ref == 'refs/heads/develop'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: $ {{ secrets.DOCKER_PASSWORD }}
-        run: |
-          cd exist-docker
-          mvn -DskipTests -Ddocker.tag=latest -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
-          cd ..
-      - name: Build and push release images
-        if: github.ref == 'refs/heads/master'
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        working-directory: exist-docker
+        run: mvn -Ddocker.tag=latest -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:push
+      - name: Publish Release Docker Images
+        if: matrix.build-docker-image == true && github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: $ {{ secrets.DOCKER_PASSWORD }}
-        run: |
-          cd exist-docker
-          mvn -DskipTests -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
-          cd ..
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        working-directory: exist-docker
+        run: mvn -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:push


### PR DESCRIPTION
Previously when a Docker Image was needed (i.e. a commit to `develop` or `merge`) eXist-db would be built twice during the workflow. This should remove that duplication, which means both less chance of failures, and less build minutes consumed.