### PR TITLE
Fix typo in error message for system:get-running-jobs

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/system/GetRunningJobs.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/GetRunningJobs.java
@@ -61,7 +61,7 @@ public class GetRunningJobs extends BasicFunction {
 
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
         if( !context.getSubject().hasDbaRole() ) {
-            throw( new XPathException( this, "Permission denied, calling user '" + context.getSubject().getName() + "' must be a DBA to get the list of running xqueries" ) );
+            throw( new XPathException( this, "Permission denied, calling user '" + context.getSubject().getName() + "' must be a DBA to get the list of running jobs" ) );
         }
 
         context.pushDocumentContext();


### PR DESCRIPTION
### Description:

Fixes a simple typo in the error message of `system:get-running-jobs()`. 

(The original error message appears to have been copied and pasted from https://github.com/eXist-db/exist/blob/develop/exist-core/src/main/java/org/exist/xquery/functions/system/GetRunningXQueries.java#L74.)

### Reference:

n/a

### Type of tests:

n/a