### PR TITLE
Fix storage of repo.xml during package installation

### DIFF
--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -362,7 +362,7 @@ public class Deployment {
                 runQuery(broker, null, packageDir, setupPath.get(), pkgName, QueryPurpose.SETUP);
                 return Optional.empty();
             } else {
-                // otherwise copy all child directories to the target collection
+                // otherwise create the target collection
                 XmldbURI targetCollection = null;
                 if (userTarget != null) {
                     try {
@@ -431,18 +431,22 @@ public class Deployment {
                     runQuery(broker, targetCollection, packageDir, preSetupPath.get(), pkgName, QueryPurpose.PREINSTALL);
                 }
 
-                // any required users and group should have been created by the pre-setup query.
-                // check for invalid users now.
+                // create the group specified in the permissions element if needed
+                // create the user specified in the permissions element if needed; assign it to the specified group
+                // TODO: if the user already exists, check and ensure the user is assigned to the specified group
                 if(requestedPerms.isPresent()) {
                     checkUserSettings(broker, requestedPerms.get());
                 }
 
                 final InMemoryNodeSet resources = findElements(repoXML,RESOURCES_ELEMENT);
 
-                // install
+                // store all package contents into database, using the user/group/mode in the permissions element. however:
+                // 1. repo.xml is excluded for now, since it may contain the default user's password in the clear
+                // 2. contents of directories identified in the path attribute of any <resource path=""/> element are stored as binary
                 final List<String> errors = scanDirectory(broker, transaction, packageDir, targetCollection, resources, true, false,
                         requestedPerms);
                 
+                // store repo.xml, filtering out the default user's password
                 storeRepoXML(broker, transaction, repoXML, targetCollection, requestedPerms);
 
                 // run the post-setup query if present


### PR DESCRIPTION
### Description:

Closes #3734. 

This PR simply makes sure repo.xml is stored before post-install.xql is run, as documentation indicates it should be—instead of waiting to store repo.xml after post-install.xql, which makes it impossible to read from repo.xml to determine default permissions, etc. 

Also, this PR adds to and, in some cases, corrects comments explaining the sequence of deployment—incrementally adding to our understanding of how deployment works and where it could be improved.

### Reference:

- https://github.com/eXist-db/exist/issues/3734#issuecomment-795106259
- https://github.com/eXist-db/public-repo/issues/55
- https://github.com/eXist-db/exist/commit/877a6b71c6a55ab2466fe51a8ab996ea9bd62330

### Type of tests:

I tested this PR on my fix to the issue above, and confirmed that when applying this PR, a corresponding PR for the public-repo, https://github.com/eXist-db/public-repo/pull/67, works perfectly. 