### PR TITLE
Fix incomplete type error reporting

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/LetExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/LetExpr.java
@@ -153,12 +153,15 @@ public class LetExpr extends BindingExpression {
                                 }
                             }
 
+                            if ((!value.isEmpty()) && sequenceType.getPrimaryType() == Type.ELEMENT && value.getItemType() == Type.ELEMENT) {
+                                final NodeValue nvItem = (NodeValue) value.itemAt(0);
+                                valueType.setNodeName(nvItem.getQName());
+                            }
+
                             throw new XPathException(
                                     this,
                                     ErrorCodes.XPTY0004,
-                                    "Invalid type for variable $" + varName + ". Expected " +
-                                    sequenceType.toString() + ", got " +
-                                    valueType.toString(), in);
+                                    String.format("Invalid type for variable $%s. Expected %s, got %s", varName, sequenceType.toString(), valueType.toString()), in);
                         }
                     }
                 }

--- a/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
@@ -237,7 +237,9 @@ public class SequenceType {
 
         final String str;
         if (primaryType == Type.DOCUMENT && nodeName != null) {
-            str = "document-node(" + nodeName.getStringValue()  + ")";
+            str = "document-node(" + nodeName.getStringValue() + ")";
+        } else if (primaryType == Type.ELEMENT && nodeName != null) {
+            str = "element(" + nodeName.getStringValue() + ")";
         } else {
             str = Type.getTypeName(primaryType);
         }

--- a/exist-core/src/test/xquery/errors.xql
+++ b/exist-core/src/test/xquery/errors.xql
@@ -372,3 +372,15 @@ function et:array-in-enclosed-expression-evaluates-to-map() {
         $err:column-number > 0
     }
 };
+
+declare
+    %test:assertTrue
+function et:element-type-error-reporting() {
+
+    try {
+        let $test as element(b)? := <a c="2"><d/></a> return $test
+    } catch * {
+            fn:ends-with($err:description, "Invalid type for variable $test. Expected element(b)?, got element(a)")
+    }
+
+};


### PR DESCRIPTION
Fixed #3628 

the query

```xquery
let $test as element(b)? := <a c="2"><d/></a> return $test
```

returns now

```
err:XPTY0004 Invalid type for variable $test. Expected element(b)?, got element(a)
```


