### PR TITLE
[bugfix] NPE on predicates with an empty sequence

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -194,7 +194,11 @@ public class Predicate extends PathExpr {
                         innerSeq = inner.eval(Dependency.dependsOn(inner.getDependencies(), Dependency.CONTEXT_ITEM)
                                 ? contextSequence : null);
                     }
-                    if (innerSeq.getCardinality().isSubCardinalityOrEqualOf(Cardinality.EXACTLY_ONE)) {
+
+                    // We must check for empty sequences here to avoid an NPE
+                    if (innerSeq.isEmpty()) {
+                        result = Sequence.EMPTY_SEQUENCE;
+                    } else if (innerSeq.getCardinality().isSubCardinalityOrEqualOf(Cardinality.EXACTLY_ONE)) {
                         result = selectByPosition(outerSequence, contextSequence, mode, innerSeq);
                     } else {
                         throw new XPathException(this, ErrorCodes.FORG0006, "Effective boolean value is not defined for a sequence of two or more items starting with a " + Type.getTypeName(innerSeq.itemAt(0).getType()) + " value");

--- a/exist-core/src/test/xquery/positional.xql
+++ b/exist-core/src/test/xquery/positional.xql
@@ -105,3 +105,29 @@ declare
 function pf:multiple-positions() {
     (3,4)[1,2]
 };
+
+declare
+    %test:assertError("err:FORG0006")
+function pf:implicit-position-sequence() {
+    (3,4)[(1,2)]
+};
+
+declare
+    %test:assertError("err:FORG0006")
+function pf:implicit-position-range() {
+    (3,4)[2 to 4]
+};
+
+(: https://github.com/eXist-db/exist/issues/3797 :)
+declare
+    %test:assertEmpty
+function pf:empty-sequence-in-predicate() {
+    (1)[()]
+};
+
+(: https://github.com/eXist-db/exist/issues/3797 :)
+declare
+    %test:assertEmpty
+function pf:predicate-evaluates-to-empty-sequence() {
+    (1)[()+1]
+};


### PR DESCRIPTION
### Description:

If the inner sequence in a predicate evaluates to an empty sequence, an empty sequence is returned.

### Reference:

fixes #3797

Saxon 10 HE and BaseX 9.5 as well as eXist-db versions > 5.3.0-SNAPSHOT all have this behaviour.

@dizzzz showed in #3800 a nicer condition with `Sequence#isEmpty` so I incorporated that.

### Type of tests:

Several tests added to positional.xql XQSuite