### PR TITLE
Revert Merge pull request #3815

### DIFF
--- a/extensions/indexes/spatial/pom.xml
+++ b/extensions/indexes/spatial/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.6.0</version>
+            <version>2.5.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The updated library `org.hsqldb:hsqldb` version 2.6.0 does require a later than JDK 8