### PR TITLE
Connection Pooling for SQL Module

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -428,6 +428,10 @@
                     <groupId>com.zaxxer</groupId>
                     <artifactId>HikariCP-java6</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.zaxxer</groupId>
+                    <artifactId>HikariCP-java7</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/exist-core/src/main/java/org/exist/xquery/modules/ModuleUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/modules/ModuleUtils.java
@@ -397,21 +397,21 @@ public class ModuleUtils {
      * @param <T> the class of the object being stored
      * @return  A unique ID representing the Object
      */
-    public static <T> long storeObjectInContextMap(XQueryContext context, String contextMapName, T o) {
+    public static <T> long storeObjectInContextMap(final XQueryContext context, final String contextMapName, final T o) {
 
         try(final ManagedLock<ReadWriteLock> writeLock = ManagedLock.acquire(contextMapLocks.getLock(contextMapName), LockMode.WRITE_LOCK)) {
 
             // get the existing map from the context
             Map<Long, T> map = (Map<Long, T>)context.getAttribute(contextMapName);
 
-            if(map == null) {
+            if (map == null) {
                 // if there is no map, create a new one
                 map = new HashMap<>();
             }
 
             // get an id for the map
             long uid = 0;
-            while(uid == 0 || map.keySet().contains(uid)) {
+            while (uid == 0 || map.keySet().contains(uid)) {
                 uid = getUID();
             }
 
@@ -421,7 +421,7 @@ public class ModuleUtils {
             // store the map back in the context
             context.setAttribute(contextMapName, map);
 
-            return (uid);
+            return uid;
         }
     }
     

--- a/exist-distribution/src/main/config/conf.xml
+++ b/exist-distribution/src/main/config/conf.xml
@@ -1004,7 +1004,38 @@
             <module uri="http://exist-db.org/xquery/process" class="org.exist.xquery.modules.process.ProcessModule"/>
             <module uri="http://exist-db.org/xquery/scheduler" class="org.exist.xquery.modules.scheduler.SchedulerModule"/>
             <module uri="http://exist-db.org/xquery/simple-ql" class="org.exist.xquery.modules.simpleql.SimpleQLModule"/>
-            <module uri="http://exist-db.org/xquery/sql" class="org.exist.xquery.modules.sql.SQLModule"/>
+            <module uri="http://exist-db.org/xquery/sql" class="org.exist.xquery.modules.sql.SQLModule">
+
+                <!--
+                Connection Pools can be setup for SQL connections, for use with sql:get-connection-from-pool($pool-name)
+                Each pool has a name and a number of configuration properties.
+                The HikariCP Connection Pool is used, you can find its configuration options
+                here: https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby
+
+                You can specify the username and password for a connection here, or you may specify it
+                when you call sql:get-connection-from-pool($pool-name, $username, $password).
+                -->
+
+                <!--
+                <parameter name="pool.1.name" value="pool-1"/>
+                <parameter name="pool.1.properties.dataSourceClassName" value="org.postgresql.ds.PGSimpleDataSource"/>
+                <parameter name="pool.1.properties.dataSource.user" value="my-username"/>
+                <parameter name="pool.1.properties.dataSource.password" value="my-password"/>
+                <parameter name="pool.1.properties.dataSource.databaseName" value="my-db"/>
+                <parameter name="pool.1.properties.maximumPoolSize" value="10"/>
+                <parameter name="pool.1.properties.registerMbeans" value="false"/>
+                -->
+
+                <!--
+                <parameter name="pool.2.name" value="pool-2"/>
+                <parameter name="pool.2.properties.dataSourceClassName" value="org.mariadb.jdbc.MariaDbDataSource"/>
+                <parameter name="pool.2.properties.dataSource.user" value="my-other-username"/>
+                <parameter name="pool.2.properties.dataSource.password" value="my-other-password"/>
+                <parameter name="pool.2.properties.dataSource.databaseName" value="other-db"/>
+                <parameter name="pool.2.properties.maximumPoolSize" value="10"/>
+                <parameter name="pool.2.properties.registerMbeans" value="false"/>
+                -->
+            </module>
             <module uri="http://exist-db.org/xquery/xmldiff" class="org.exist.xquery.modules.xmldiff.XmlDiffModule"/>
             <!--
                 XSL:FO Transformation Module

--- a/extensions/modules/sql/pom.xml
+++ b/extensions/modules/sql/pom.xml
@@ -73,6 +73,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>4.0.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -131,6 +137,8 @@
                             -->
                             <header>${project.parent.relativePath}/LGPL-21-license.template.txt</header>
                             <excludes>
+                                <exclude>src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/sql/SQLModule.java</exclude>
                                 <exclude>src/test/resources/jndi.properties</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/H2DatabaseResource.java</exclude>
@@ -144,6 +152,8 @@
                             -->
                             <header>${project.parent.relativePath}/FDB-backport-LGPL-21-ONLY-license.template.txt</header>
                             <includes>
+                                <include>src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/sql/SQLModule.java</include>
                                 <include>src/test/resources/jndi.properties</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/H2DatabaseResource.java</include>

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
@@ -1,14 +1,25 @@
 /*
- * eXist-db Open Source Native XML Database
- * Copyright (C) 2001 The eXist-db Authors
+ * Copyright (C) 2014, Evolved Binary Ltd
  *
- * info@exist-db.org
- * http://www.exist-db.org
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; version 2.1.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -21,13 +32,12 @@
  */
 package org.exist.xquery.modules.sql;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.exist.dom.QName;
 import org.exist.util.ParametersExtractor;
 import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
@@ -36,7 +46,6 @@ import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
 
 import java.sql.Connection;
@@ -45,120 +54,138 @@ import java.sql.SQLException;
 
 import java.util.Properties;
 
+import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.modules.sql.SQLModule.functionSignatures;
+
 
 /**
- * eXist SQL Module Extension GetConnectionFunction.
- * <p>
- * Get a connection to a SQL Database
+ * SQL Module Extension function for XQuery to retrieve a connection.
  *
- * @author <a href="mailto:adam@exist-db.org">Adam Retter</a>
- * @author Loren Cahlander
- * @version 1.21
- * @serial 2008-05-29
- * @see org.exist.xquery.BasicFunction#BasicFunction(org.exist.xquery.XQueryContext, org.exist.xquery.FunctionSignature)
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class GetConnectionFunction extends BasicFunction {
-    protected static final FunctionReturnSequenceType RETURN_TYPE = new FunctionReturnSequenceType(Type.LONG, Cardinality.ZERO_OR_ONE, "an xs:long representing the connection handle");
+    private static final FunctionReturnSequenceType RETURN_TYPE = returnsOpt(Type.LONG, "an xs:long representing the connection handle");
+    private static final FunctionParameterSequenceType JDBC_PASSWORD_PARAM = param("password", Type.STRING, "The SQL database password");
+    private static final FunctionParameterSequenceType JDBC_USERNAME_PARAM = param("username", Type.STRING, "The SQL database username");
+    private static final FunctionParameterSequenceType JDBC_PROPERTIES_PARAM = optParam("properties", Type.ELEMENT, "The JDBC database connection properties in the form <properties><property name=\"\" value=\"\"/></properties>.");
+    private static final FunctionParameterSequenceType JDBC_URL_PARAM = param("url", Type.STRING, "The JDBC connection URL");
+    private static final FunctionParameterSequenceType JDBC_DRIVER_CLASSNAME_PARAM = param("driver-classname", Type.STRING, "The JDBC driver classname");
+    private static final FunctionParameterSequenceType CONNECTION_POOL_PARAM = param("pool-name", Type.STRING, "The connection pool name (as configured in conf.xml)");
 
-    protected static final FunctionParameterSequenceType JDBC_PASSWORD_PARAM = new FunctionParameterSequenceType("password", Type.STRING, Cardinality.EXACTLY_ONE, "The SQL database password");
+    private static final Logger LOGGER = LogManager.getLogger(GetConnectionFunction.class);
 
-    protected static final FunctionParameterSequenceType JDBC_USERNAME_PARAM = new FunctionParameterSequenceType("username", Type.STRING, Cardinality.EXACTLY_ONE, "The SQL database username");
+    private static final String FN_GET_CONNECTION = "get-connection";
+    public static final FunctionSignature[] FS_GET_CONNECTION = functionSignatures(
+        FN_GET_CONNECTION,
+        "Opens a connection to a SQL Database",
+        RETURN_TYPE,
+        arities(
+                arity(JDBC_DRIVER_CLASSNAME_PARAM, JDBC_URL_PARAM),
+                arity(JDBC_DRIVER_CLASSNAME_PARAM, JDBC_URL_PARAM, JDBC_PROPERTIES_PARAM),
+                arity(JDBC_DRIVER_CLASSNAME_PARAM, JDBC_URL_PARAM, JDBC_USERNAME_PARAM, JDBC_PASSWORD_PARAM)
+        )
+    );
 
-    protected static final FunctionParameterSequenceType JDBC_PROPERTIES_PARAM = new FunctionParameterSequenceType("properties", Type.ELEMENT, Cardinality.ZERO_OR_ONE, "The JDBC database connection properties in the form <properties><property name=\"\" value=\"\"/></properties>.");
+    private static final String FN_GET_CONNECTION_FROM_POOL = "get-connection-from-pool";
+    public static final FunctionSignature[] FS_GET_CONNECTION_FROM_POOL = functionSignatures(
+            FN_GET_CONNECTION_FROM_POOL,
+            "Retrieves a connection to a SQL Database from a connection pool",
+            RETURN_TYPE,
+            arities(
+                    arity(CONNECTION_POOL_PARAM),
+                    arity(CONNECTION_POOL_PARAM, JDBC_USERNAME_PARAM, JDBC_PASSWORD_PARAM)
+            )
+    );
 
-    protected static final FunctionParameterSequenceType JDBC_URL_PARAM = new FunctionParameterSequenceType("url", Type.STRING, Cardinality.EXACTLY_ONE, "The JDBC connection URL");
-
-    protected static final FunctionParameterSequenceType JDBC_DRIVER_CLASSNAME_PARAM = new FunctionParameterSequenceType("driver-classname", Type.STRING, Cardinality.EXACTLY_ONE, "The JDBC driver classname");
-
-    private static final Logger logger = LogManager.getLogger(GetConnectionFunction.class);
-
-    public final static FunctionSignature[] signatures = {
-            new FunctionSignature(
-                    new QName("get-connection", SQLModule.NAMESPACE_URI, SQLModule.PREFIX),
-                    "Opens a connection to a SQL Database",
-                    new SequenceType[]{JDBC_DRIVER_CLASSNAME_PARAM, JDBC_URL_PARAM},
-                    RETURN_TYPE),
-
-            new FunctionSignature(
-                    new QName("get-connection", SQLModule.NAMESPACE_URI, SQLModule.PREFIX),
-                    "Opens a connection to a SQL Database",
-                    new SequenceType[]{JDBC_DRIVER_CLASSNAME_PARAM, JDBC_URL_PARAM, JDBC_PROPERTIES_PARAM},
-                    RETURN_TYPE),
-
-            new FunctionSignature(
-                    new QName("get-connection", SQLModule.NAMESPACE_URI, SQLModule.PREFIX),
-                    "Opens a connection to a SQL Database",
-                    new SequenceType[]{JDBC_DRIVER_CLASSNAME_PARAM, JDBC_URL_PARAM, JDBC_USERNAME_PARAM, JDBC_PASSWORD_PARAM},
-                    RETURN_TYPE)
-    };
-
-    /**
-     * GetConnectionFunction Constructor.
-     *
-     * @param context   The Context of the calling XQuery
-     * @param signature DOCUMENT ME!
-     */
-    public GetConnectionFunction(XQueryContext context, FunctionSignature signature) {
+    public GetConnectionFunction(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
     /**
-     * evaluate the call to the xquery get-connection() function, it is really the main entry point of this class.
+     * Evaluate the call to the xquery get-connection() or get-connection-from-pool() functions,
+     * it is really the main entry point of this class.
      *
-     * @param args            arguments from the get-connection() function call
+     * @param args arguments from the get-connection() function call
      * @param contextSequence the Context Sequence to operate on (not used here internally!)
+     *
      * @return A xs:long representing a handle to the connection
-     * @throws XPathException DOCUMENT ME!
-     * @see org.exist.xquery.BasicFunction#eval(org.exist.xquery.value.Sequence[], org.exist.xquery.value.Sequence)
+     *
+     * @throws XPathException if an error occurs.
      */
-    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-        // was a db driver and url specified?
-        if (args[0].isEmpty() || args[1].isEmpty()) {
-            return (Sequence.EMPTY_SEQUENCE);
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final Connection connection;
+        if (isCalledAs(FN_GET_CONNECTION)) {
+            // was a db driver and url specified?
+            if (args[0].isEmpty() || args[1].isEmpty()) {
+                return Sequence.EMPTY_SEQUENCE;
+            }
+            connection = getConnection(args);
+
+        } else if (isCalledAs(FN_GET_CONNECTION_FROM_POOL)) {
+            connection = getConnectionFromPool(args);
+
+        } else {
+            throw new XPathException(this, "No function: " + getName() + "#" + getSignature().getArgumentCount());
         }
 
+        // store the Connection and return the uid handle of the Connection
+        return new IntegerValue(SQLModule.storeConnection(context, connection));
+    }
+
+    private Connection getConnection(final Sequence[] args) throws XPathException {
         // get the db connection details
-        String dbDriver = args[0].getStringValue();
-        String dbURL = args[1].getStringValue();
+        final String dbDriver = args[0].getStringValue();
+        final String dbURL = args[1].getStringValue();
 
         try {
-
-            // load the driver
-            Class.forName(dbDriver).newInstance();
-
-            Connection con = null;
 
             if (args.length == 2) {
 
                 // try and get the connection
-                con = DriverManager.getConnection(dbURL);
+                return DriverManager.getConnection(dbURL);
+
             } else if (args.length == 3) {
 
                 // try and get the connection
-                Properties props = ParametersExtractor.parseProperties(((NodeValue) args[2].itemAt(0)).getNode());
-                con = DriverManager.getConnection(dbURL, props);
+                final Properties props = ParametersExtractor.parseProperties(((NodeValue) args[2].itemAt(0)).getNode());
+                return DriverManager.getConnection(dbURL, props);
+
             } else if (args.length == 4) {
-                String dbUser = args[2].getStringValue();
-                String dbPassword = args[3].getStringValue();
+                final String dbUser = args[2].getStringValue();
+                final String dbPassword = args[3].getStringValue();
 
                 // try and get the connection
-                con = DriverManager.getConnection(dbURL, dbUser, dbPassword);
+                return DriverManager.getConnection(dbURL, dbUser, dbPassword);
+
+            } else {
+                throw new XPathException(this, "No function: " + getName() + "#" + getSignature().getArgumentCount());
             }
 
-            // store the Connection and return the uid handle of the Connection
-            return (new IntegerValue(SQLModule.storeConnection(context, con)));
-        } catch (IllegalAccessException iae) {
-            logger.error("sql:get-connection() Illegal Access to database driver class: {}", dbDriver, iae);
-            throw (new XPathException(this, "sql:get-connection() Illegal Access to database driver class: " + dbDriver, iae));
-        } catch (ClassNotFoundException cnfe) {
-            logger.error("sql:get-connection() Cannot find database driver class: {}", dbDriver, cnfe);
-            throw (new XPathException(this, "sql:get-connection() Cannot find database driver class: " + dbDriver, cnfe));
-        } catch (InstantiationException ie) {
-            logger.error("sql:get-connection() Cannot instantiate database driver class: {}", dbDriver, ie);
-            throw (new XPathException(this, "sql:get-connection() Cannot instantiate database driver class: " + dbDriver, ie));
-        } catch (SQLException sqle) {
-            logger.error("sql:get-connection() Cannot connect to database: {}", dbURL, sqle);
-            throw (new XPathException(this, "sql:get-connection() Cannot connect to database: " + dbURL, sqle));
+        } catch (final SQLException sqle) {
+            LOGGER.error("sql:get-connection() Cannot connect to database: {}", dbURL, sqle);
+            throw new XPathException(this, "sql:get-connection() Cannot connect to database: " + dbURL, sqle);
+        }
+    }
+
+    private Connection getConnectionFromPool(final Sequence[] args) throws XPathException {
+        final String poolName = args[0].getStringValue();
+        final HikariDataSource pool = SQLModule.getPool(poolName);
+        if (pool == null) {
+            throw new XPathException(this, "There is no configured connection pool named: " + poolName);
+        }
+
+        try {
+            if (args.length == 3) {
+                final String username = args[1].getStringValue();
+                final String password = args[2].getStringValue();
+                return pool.getConnection(username, password);
+            } else {
+                return pool.getConnection();
+            }
+        } catch (final SQLException sqle) {
+            LOGGER.error("sql:get-connection-from-pool() Cannot retrieve connection from pool: " + poolName, sqle);
+            throw new XPathException(this, "sql:get-connection-from-pool() Cannot retrieve connection from pool: " + poolName, sqle);
         }
     }
 }

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLModule.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLModule.java
@@ -1,14 +1,25 @@
 /*
- * eXist-db Open Source Native XML Database
- * Copyright (C) 2001 The eXist-db Authors
+ * Copyright (C) 2014, Evolved Binary Ltd
  *
- * info@exist-db.org
- * http://www.exist-db.org
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; version 2.1.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -21,6 +32,8 @@
  */
 package org.exist.xquery.modules.sql;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -33,25 +46,24 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.exist.xquery.modules.ModuleUtils;
 import org.exist.xquery.modules.ModuleUtils.ContextMapEntryModifier;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 
+import javax.annotation.Nullable;
+
 import static org.exist.xquery.FunctionDSL.functionDefs;
 
 /**
- * eXist SQL Module Extension.
- * <p>
- * An extension module for the eXist Native XML Database that allows queries against SQL Databases, returning an XML representation of the result
- * set.
+ * SQL Module Extension for XQuery.
  *
- * @author <a href="mailto:adam@exist-db.org">Adam Retter</a>
- * @author ljo
- * @version 1.2
- * @serial 2010-03-18
- * @see org.exist.xquery.AbstractInternalModule#AbstractInternalModule(org.exist.xquery.FunctionDef[], java.util.Map)
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class SQLModule extends AbstractInternalModule {
 
@@ -62,7 +74,8 @@ public class SQLModule extends AbstractInternalModule {
     public final static String RELEASED_IN_VERSION = "eXist-1.2";
 
     public static final FunctionDef[] functions = functionDefs(
-            functionDefs(GetConnectionFunction.class, GetConnectionFunction.signatures),
+            functionDefs(GetConnectionFunction.class, GetConnectionFunction.FS_GET_CONNECTION),
+            functionDefs(GetConnectionFunction.class, GetConnectionFunction.FS_GET_CONNECTION_FROM_POOL),
             functionDefs(GetJNDIConnectionFunction.class, GetJNDIConnectionFunction.signatures),
             functionDefs(ExecuteFunction.class, ExecuteFunction.FS_EXECUTE),
             functionDefs(PrepareFunction.class, PrepareFunction.signatures)
@@ -71,38 +84,99 @@ public class SQLModule extends AbstractInternalModule {
     public final static String CONNECTIONS_CONTEXTVAR = "_eXist_sql_connections";
     public final static String PREPARED_STATEMENTS_CONTEXTVAR = "_eXist_sql_prepared_statements";
 
-    public SQLModule(Map<String, List<?>> parameters) {
+    private static final Map<String, HikariDataSource> CONNECTION_POOLS = new ConcurrentHashMap<>();
+    private static final Pattern POOL_NAME_PATTERN = Pattern.compile("(pool\\.[0-9]+)\\.name");
+
+    public SQLModule(final Map<String, List<?>> parameters) {
         super(functions, parameters);
+
+        // create any connection pools that are not yet created
+        Matcher poolNameMatcher = null;
+        for (final Map.Entry<String, List<?>> parameter : parameters.entrySet()) {
+            if (poolNameMatcher == null) {
+                poolNameMatcher = POOL_NAME_PATTERN.matcher(parameter.getKey());
+            }  else {
+                 poolNameMatcher.reset(parameter.getKey());
+            }
+
+            if (poolNameMatcher.matches()) {
+                if (parameter.getValue() != null && parameter.getValue().size() == 1) {
+                    final String poolId = poolNameMatcher.group(1);
+                    final String poolName = parameter.getValue().get(0).toString();
+                    if (poolName != null && !poolName.isEmpty()) {
+                        if (!CONNECTION_POOLS.containsKey(poolName)) {
+
+                            final Properties poolProperties = new Properties();;
+                            poolProperties.setProperty("poolName", poolName);
+
+                            final String poolPropertiesPrefix = poolId + ".properties.";
+                            for (final Map.Entry<String, List<?>> poolParameter : parameters.entrySet()) {
+                                if (poolParameter.getKey().startsWith(poolPropertiesPrefix)) {
+                                    if (poolParameter.getValue() != null && poolParameter.getValue().size() == 1) {
+                                        final String propertyName = poolParameter.getKey().replace(poolPropertiesPrefix, "");
+                                        final String propertyValue = poolParameter.getValue().get(0).toString();
+                                        poolProperties.setProperty(propertyName, propertyValue);
+                                    }
+                                }
+                            }
+
+                            final HikariConfig hikariConfig = new HikariConfig(poolProperties);
+                            final HikariDataSource hikariDataSource = new HikariDataSource(hikariConfig);
+                            CONNECTION_POOLS.put(poolName, hikariDataSource);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     @Override
     public String getNamespaceURI() {
-        return (NAMESPACE_URI);
+        return NAMESPACE_URI;
     }
 
     @Override
     public String getDefaultPrefix() {
-        return (PREFIX);
+        return PREFIX;
     }
 
     @Override
     public String getDescription() {
-        return ("A module for performing SQL queries against Databases, returning XML representations of the result sets.");
+        return "A module for performing SQL queries against Databases, returning XML representations of the result sets.";
     }
 
     @Override
     public String getReleaseVersion() {
-        return (RELEASED_IN_VERSION);
+        return RELEASED_IN_VERSION;
+    }
+
+    static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
+        return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, paramTypes);
+    }
+
+    static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
+    }
+
+    /**
+     * Gets a Connection Pool.
+     *
+     * @param poolName the name of the connection pool.
+     *
+     * @return the connection pool, or null if there is no such pool
+     */
+    static @Nullable HikariDataSource getPool(final String poolName) {
+        return CONNECTION_POOLS.get(poolName);
     }
 
     /**
      * Retrieves a previously stored Connection from the Context of an XQuery.
      *
-     * @param context       The Context of the XQuery containing the Connection
+     * @param context The Context of the XQuery containing the Connection
      * @param connectionUID The UID of the Connection to retrieve from the Context of the XQuery
-     * @return DOCUMENT ME!
+     * @return the database connection for the UID, or null if there is no such connection.
      */
-    public static Connection retrieveConnection(XQueryContext context, long connectionUID) {
+    public static @Nullable Connection retrieveConnection(final XQueryContext context, final long connectionUID) {
         return ModuleUtils.retrieveObjectFromContextMap(context, SQLModule.CONNECTIONS_CONTEXTVAR, connectionUID);
     }
 
@@ -110,21 +184,21 @@ public class SQLModule extends AbstractInternalModule {
      * Stores a Connection in the Context of an XQuery.
      *
      * @param context The Context of the XQuery to store the Connection in
-     * @param con     The connection to store
+     * @param con The connection to store
      * @return A unique ID representing the connection
      */
-    public static synchronized long storeConnection(XQueryContext context, Connection con) {
+    public static long storeConnection(final XQueryContext context, final Connection con) {
         return ModuleUtils.storeObjectInContextMap(context, SQLModule.CONNECTIONS_CONTEXTVAR, con);
     }
 
     /**
      * Retrieves a previously stored PreparedStatement from the Context of an XQuery.
      *
-     * @param context              The Context of the XQuery containing the PreparedStatement
+     * @param context The Context of the XQuery containing the PreparedStatement
      * @param preparedStatementUID The UID of the PreparedStatement to retrieve from the Context of the XQuery
-     * @return DOCUMENT ME!
+     * @return the prepared statement for the UID, or null if there is no such prepared statement.
      */
-    public static PreparedStatementWithSQL retrievePreparedStatement(XQueryContext context, long preparedStatementUID) {
+    public static PreparedStatementWithSQL retrievePreparedStatement(final XQueryContext context, final long preparedStatementUID) {
         return ModuleUtils.retrieveObjectFromContextMap(context, SQLModule.PREPARED_STATEMENTS_CONTEXTVAR, preparedStatementUID);
     }
 
@@ -132,10 +206,10 @@ public class SQLModule extends AbstractInternalModule {
      * Stores a PreparedStatement in the Context of an XQuery.
      *
      * @param context The Context of the XQuery to store the PreparedStatement in
-     * @param stmt    preparedStatement The PreparedStatement to store
+     * @param stmt preparedStatement The PreparedStatement to store
      * @return A unique ID representing the PreparedStatement
      */
-    public static synchronized long storePreparedStatement(XQueryContext context, PreparedStatementWithSQL stmt) {
+    public static long storePreparedStatement(final XQueryContext context, final PreparedStatementWithSQL stmt) {
         return ModuleUtils.storeObjectInContextMap(context, SQLModule.PREPARED_STATEMENTS_CONTEXTVAR, stmt);
     }
 
@@ -145,7 +219,7 @@ public class SQLModule extends AbstractInternalModule {
      * @param xqueryContext The XQueryContext
      */
     @Override
-    public void reset(XQueryContext xqueryContext, boolean keepGlobals) {
+    public void reset(final XQueryContext xqueryContext, final boolean keepGlobals) {
         // reset the module context
         super.reset(xqueryContext, keepGlobals);
 
@@ -161,31 +235,28 @@ public class SQLModule extends AbstractInternalModule {
      *
      * @param xqueryContext The context to close JDBC Connections for
      */
-    private static void closeAllConnections(XQueryContext xqueryContext) {
+    private static void closeAllConnections(final XQueryContext xqueryContext) {
         ModuleUtils.modifyContextMap(xqueryContext, SQLModule.CONNECTIONS_CONTEXTVAR, new ContextMapEntryModifier<Connection>() {
 
             @Override
-            public void modify(Map<Long, Connection> map) {
+            public void modify(final Map<Long, Connection> map) {
                 super.modify(map);
 
-                //empty the map
+                // empty the map
                 map.clear();
             }
 
             @Override
-            public void modify(Entry<Long, Connection> entry) {
+            public void modify(final Entry<Long, Connection> entry) {
                 final Connection con = entry.getValue();
                 try {
                     // close the Connection
                     con.close();
-                } catch (SQLException se) {
+                } catch (final SQLException se) {
                     LOG.warn("Unable to close JDBC Connection: {}", se.getMessage(), se);
                 }
             }
         });
-
-        // update the context
-        //ModuleUtils.storeContextMap(xqueryContext, SQLModule.CONNECTIONS_CONTEXTVAR, connections);
     }
 
     /**
@@ -193,19 +264,19 @@ public class SQLModule extends AbstractInternalModule {
      *
      * @param xqueryContext The context to close JDBC PreparedStatements for
      */
-    private static void closeAllPreparedStatements(XQueryContext xqueryContext) {
+    private static void closeAllPreparedStatements(final XQueryContext xqueryContext) {
         ModuleUtils.modifyContextMap(xqueryContext, SQLModule.PREPARED_STATEMENTS_CONTEXTVAR, new ContextMapEntryModifier<PreparedStatementWithSQL>() {
 
             @Override
-            public void modify(Map<Long, PreparedStatementWithSQL> map) {
+            public void modify(final Map<Long, PreparedStatementWithSQL> map) {
                 super.modify(map);
 
-                //empty the map
+                // empty the map
                 map.clear();
             }
 
             @Override
-            public void modify(Entry<Long, PreparedStatementWithSQL> entry) {
+            public void modify(final Entry<Long, PreparedStatementWithSQL> entry) {
                 final PreparedStatementWithSQL stmt = entry.getValue();
                 try {
                     // close the PreparedStatement
@@ -215,8 +286,5 @@ public class SQLModule extends AbstractInternalModule {
                 }
             }
         });
-
-        // update the context
-        //ModuleUtils.storeContextMap(xqueryContext, SQLModule.PREPARED_STATEMENTS_CONTEXTVAR, preparedStatements);
     }
 }

--- a/extensions/modules/sql/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/sql/src/test/resources-filtered/conf.xml
@@ -744,7 +744,12 @@
         <builtin-modules>
 
             <!-- Module under test -->
-            <module uri="http://exist-db.org/xquery/sql" class="org.exist.xquery.modules.sql.SQLModule"/>
+            <module uri="http://exist-db.org/xquery/sql" class="org.exist.xquery.modules.sql.SQLModule">
+                <parameter name="pool.1.name" value="pool-1"/>
+                <parameter name="pool.1.properties.dataSourceClassName" value="org.h2.jdbcx.JdbcDataSource"/>
+                <parameter name="pool.1.properties.jdbcUrl" value="jdbc:h2:~/test"/>
+                <parameter name="pool.1.properties.maximumPoolSize" value="10"/>
+            </module>
 
         </builtin-modules>
     </xquery>


### PR DESCRIPTION
This feature is backported from FusionDB to eXist-db at the request of @PieterLamers

It allows connection pools to be established via eXist-db's conf.xml for the SQL Module. The connections can then be obtained via `sql:get-connection-from-pool`.