### PR TITLE
Backport of sql:close-connection from FusionDB

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/modules/ModuleUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/modules/ModuleUtils.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.Nullable;
 import javax.xml.transform.Source;
 import javax.xml.transform.sax.SAXSource;
 
@@ -314,32 +315,82 @@ public class ModuleUtils {
             return lock;
         }
     }
-    
+
+    /**
+     * Stores an Object into the Context of an XQuery.
+     *
+     * @param context The Context of the XQuery to store the Object in
+     * @param contextMapName The name of the context map
+     * @param o The Object to store
+     * @param <T> the type of the object being stored
+     *
+     * @return A unique ID representing the Object
+     */
+    public static <T> long storeObjectInContextMap(final XQueryContext context, final String contextMapName, final T o) {
+        return modifyContextMap(context, contextMapName, contextMap -> {
+            // get an id for the map
+            long uid = 0;
+            while (uid == 0 || contextMap.keySet().contains(uid)) {
+                uid = getUID();
+            }
+
+            // place the object in the map
+            contextMap.put(uid, o);
+
+            return uid;
+        });
+    }
+
     /**
      * Retrieves a previously stored Object from the Context of an XQuery.
      *
-     * @param   context         The Context of the XQuery containing the Object
-     * @param   contextMapName  DOCUMENT ME!
-     * @param   objectUID       The UID of the Object to retrieve from the Context of the XQuery
-     * @param <T> class of the object stored in the context
-     * @return  the object stored in the context or null
-     */        
-    public static <T> T retrieveObjectFromContextMap(XQueryContext context, String contextMapName, long objectUID) {
-        try(final ManagedLock<ReadWriteLock> readLock = ManagedLock.acquire(contextMapLocks.getLock(contextMapName), LockMode.READ_LOCK)){
-            // get the existing object map from the context
-            final Map<Long, T> map = (HashMap<Long, T>)context.getAttribute(contextMapName);
-
-            if(map == null) {
-                return null;
-            }
-
-            // get the connection
-            return map.get(objectUID);
-        }
+     * @param context The Context of the XQuery containing the Object
+     * @param contextMapName The name of the context map
+     * @param objectUID The UID of the Object to retrieve from the Context of the XQuery
+     *
+     * @param <T> the type of the object being retrieved
+     *
+     * @return the object stored in the context or null
+     */
+    public static @Nullable <T> T retrieveObjectFromContextMap(final XQueryContext context, final String contextMapName, final long objectUID) {
+        return readContextMap(context, contextMapName, contextMap -> {
+            // get the object
+            return (T) contextMap.get(objectUID);
+        });
     }
-    
-    public static <T> void modifyContextMap(XQueryContext context, String contextMapName, ContextMapModifier<T> modifier) {
-        try(final ManagedLock<ReadWriteLock> writeLock = ManagedLock.acquire(contextMapLocks.getLock(contextMapName), LockMode.WRITE_LOCK)) {
+
+    /**
+     * Removes a previously stored Object from the Context of an XQuery.
+     *
+     * @param context The Context of the XQuery containing the Object
+     * @param contextMapName The name of the context map
+     * @param objectUID The UID of the Object to remove from the Context of the XQuery
+     *
+     * @param <T> the type of the object being removed
+     *
+     * @return the object that was removed from the context or null if there was no object for the UID
+     */
+    public static @Nullable <T> T removeObjectFromContextMap(final XQueryContext context, final String contextMapName, final long objectUID) {
+        return modifyContextMap(context, contextMapName, contextMap -> {
+            // get the object
+            return (T) contextMap.remove(objectUID);
+        });
+    }
+
+    /**
+     * Modify a context map.
+     *
+     * @param context the XQuery context
+     * @param contextMapName The name of the context map
+     * @param modifier the modification function
+     *
+     * @param <T> the type of the value in the map
+     * @param <U> the type of the return value of the modifier function
+     *
+     * @return the result of the modification function
+     */
+    public static @Nullable <T, U> U modifyContextMap(final XQueryContext context, final String contextMapName, final ContextMapModifier<T, U> modifier) {
+        try (final ManagedLock<ReadWriteLock> writeLock = ManagedLock.acquire(contextMapLocks.getLock(contextMapName), LockMode.WRITE_LOCK)) {
             // get the existing map from the context
             Map<Long, T> map = (Map<Long, T>)context.getAttribute(contextMapName);
             if(map == null) {
@@ -349,12 +400,24 @@ public class ModuleUtils {
             }
             
             //modify the map
-            modifier.modify(map);
+            return modifier.modify(map);
         }
     }
 
+    /**
+     * Read a context map.
+     *
+     * @param context the XQuery context
+     * @param contextMapName The name of the context map
+     * @param reader the reader function
+     *
+     * @param <T> the type of the value in the map
+     * @param <U> the type of the return value of the reader function
+     *
+     * @return the result of the reader function
+     */
     public static <T, U> U readContextMap(final XQueryContext context, final String contextMapName, final ContextMapReader<T, U> reader) {
-        try(final ManagedLock<ReadWriteLock> readLock = ManagedLock.acquire(contextMapLocks.getLock(contextMapName), LockMode.READ_LOCK)) {
+        try (final ManagedLock<ReadWriteLock> readLock = ManagedLock.acquire(contextMapLocks.getLock(contextMapName), LockMode.READ_LOCK)) {
             // get the existing map from the context
             Map<Long, T> map = (Map<Long, T>)context.getAttribute(contextMapName);
             if (map == null) {
@@ -367,64 +430,37 @@ public class ModuleUtils {
     }
 
     @FunctionalInterface
-    public interface ContextMapModifier<T> {
-        void modify(Map<Long, T> map);
+    public interface ContextMapModifier<T, U> {
+        U modify(final Map<Long, T> map);
+    }
+
+    @FunctionalInterface
+    public interface ContextMapModifierWithoutResult<T> extends ContextMapModifier<T, Void> {
+        @Override
+        default Void modify(final Map<Long, T> map) {
+            modifyWithoutResult(map);
+            return null;
+        }
+
+        void modifyWithoutResult(final Map<Long, T> map);
     }
 
     @FunctionalInterface
     public interface ContextMapReader<T, U> {
-        U read(Map<Long, T> map);
+        U read(final Map<Long, T> map);
     }
-    
-    public static abstract class ContextMapEntryModifier<T> implements ContextMapModifier<T> {
-        
+
+    public static abstract class ContextMapEntryModifier<T> implements ContextMapModifierWithoutResult<T> {
         @Override
-        public void modify(Map<Long, T> map) {
+        public void modifyWithoutResult(final Map<Long, T> map) {
             for(final Entry<Long, T> entry : map.entrySet()) {
-                modify(entry);
+                modifyEntry(entry);
             }
         }
-        
-        public abstract void modify(Entry<Long, T> entry);
+
+        public abstract void modifyEntry(final Entry<Long, T> entry);
     }
 
-    /**
-     * Stores an Object in the Context of an XQuery.
-     *
-     * @param   context         The Context of the XQuery to store the Object in
-     * @param   contextMapName  The name of the context map
-     * @param   o               The Object to store
-     * @param <T> the class of the object being stored
-     * @return  A unique ID representing the Object
-     */
-    public static <T> long storeObjectInContextMap(final XQueryContext context, final String contextMapName, final T o) {
-
-        try(final ManagedLock<ReadWriteLock> writeLock = ManagedLock.acquire(contextMapLocks.getLock(contextMapName), LockMode.WRITE_LOCK)) {
-
-            // get the existing map from the context
-            Map<Long, T> map = (Map<Long, T>)context.getAttribute(contextMapName);
-
-            if (map == null) {
-                // if there is no map, create a new one
-                map = new HashMap<>();
-            }
-
-            // get an id for the map
-            long uid = 0;
-            while (uid == 0 || map.keySet().contains(uid)) {
-                uid = getUID();
-            }
-
-            // place the object in the map
-            map.put(uid, o);
-
-            // store the map back in the context
-            context.setAttribute(contextMapName, map);
-
-            return uid;
-        }
-    }
-    
     private static long getUID() {
         final BigInteger bi = new BigInteger(64, random);
         return bi.longValue();

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailModule.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailModule.java
@@ -40,7 +40,7 @@ import javax.mail.Session;
 import javax.mail.Store;
 import org.exist.xquery.modules.ModuleUtils;
 import org.exist.xquery.modules.ModuleUtils.ContextMapEntryModifier;
-import org.exist.xquery.modules.ModuleUtils.ContextMapModifier;
+import org.exist.xquery.modules.ModuleUtils.ContextMapModifierWithoutResult;
 
 /**
  * eXist Mail Module Extension
@@ -186,7 +186,7 @@ public class MailModule extends AbstractInternalModule {
      */
     static void removeStore(XQueryContext context, final long storeHandle) {
         
-        ModuleUtils.modifyContextMap(context, MailModule.STORES_CONTEXTVAR, (ContextMapModifier<Store>) map -> map.remove(storeHandle));
+        ModuleUtils.modifyContextMap(context, MailModule.STORES_CONTEXTVAR, (ContextMapModifierWithoutResult<Store>) map -> map.remove(storeHandle));
         
         //update the context
         //context.setXQueryContextVar(MailModule.STORES_CONTEXTVAR, stores);
@@ -200,15 +200,15 @@ public class MailModule extends AbstractInternalModule {
     private static void closeAllStores(XQueryContext context)  {
         ModuleUtils.modifyContextMap(context,  MailModule.STORES_CONTEXTVAR, new ContextMapEntryModifier<Store>(){
             @Override
-            public void modify(Map<Long, Store> map) {
-                super.modify(map);
+            public void modifyWithoutResult(final Map<Long, Store> map) {
+                super.modifyWithoutResult(map);
                 
                 //remove all stores from map
                 map.clear();
             }
 
             @Override
-            public void modify(Entry<Long, Store> entry) {
+            public void modifyEntry(final Entry<Long, Store> entry) {
                 final Store store = entry.getValue();
                 try {
                     // close the store
@@ -258,14 +258,14 @@ public class MailModule extends AbstractInternalModule {
      */
     static void removeFolder(final XQueryContext context, final long folderHandle) {
             
-        ModuleUtils.modifyContextMap(context, MailModule.FOLDERS_CONTEXTVAR, (ContextMapModifier<Folder>) map -> {
+        ModuleUtils.modifyContextMap(context, MailModule.FOLDERS_CONTEXTVAR, (ContextMapModifierWithoutResult<Folder>) map -> {
 
             //remove the message lists for the folder
-            ModuleUtils.modifyContextMap(context, MailModule.FOLDERMSGLISTS_CONTEXTVAR, (ContextMapModifier<Map<Long, Message[]>>) map12 -> {
+            ModuleUtils.modifyContextMap(context, MailModule.FOLDERMSGLISTS_CONTEXTVAR, (ContextMapModifierWithoutResult<Map<Long, Message[]>>) map12 -> {
 
                 final Map<Long, Message[]> folderMsgList = map12.get(folderHandle);
 
-                ModuleUtils.modifyContextMap(context, MailModule.MSGLISTS_CONTEXTVAR, (ContextMapModifier<Message[]>) map1 -> folderMsgList.keySet().forEach(map1::remove));
+                ModuleUtils.modifyContextMap(context, MailModule.MSGLISTS_CONTEXTVAR, (ContextMapModifierWithoutResult<Message[]>) map1 -> folderMsgList.keySet().forEach(map1::remove));
 
                 //remove the folder message kist
                 map12.remove(folderHandle);
@@ -286,15 +286,15 @@ public class MailModule extends AbstractInternalModule {
         ModuleUtils.modifyContextMap(context, MailModule.FOLDERS_CONTEXTVAR, new ContextMapEntryModifier<Folder>(){
 
             @Override
-            public void modify(Map<Long, Folder> map) {
-                super.modify(map);
+            public void modifyWithoutResult(final Map<Long, Folder> map) {
+                super.modifyWithoutResult(map);
                 
                 //remove all from the folders map
                 map.clear();
             }
             
             @Override
-            public void modify(Entry<Long, Folder> entry) {
+            public void modifyEntry(final Entry<Long, Folder> entry) {
                 final Folder folder = entry.getValue();
 
                 //close the folder
@@ -340,7 +340,7 @@ public class MailModule extends AbstractInternalModule {
             
         final long msgListHandle = ModuleUtils.storeObjectInContextMap(context, MailModule.MSGLISTS_CONTEXTVAR, msgList);
 
-        ModuleUtils.modifyContextMap(context, MailModule.FOLDERMSGLISTS_CONTEXTVAR, (ContextMapModifier<Map<Long, Message[]>>) map -> {
+        ModuleUtils.modifyContextMap(context, MailModule.FOLDERMSGLISTS_CONTEXTVAR, (ContextMapModifierWithoutResult<Map<Long, Message[]>>) map -> {
             Map<Long, Message[]> folderMsgList = map.computeIfAbsent(folderHandle, k -> new HashMap<>());
 
             folderMsgList.put(msgListHandle, msgList);
@@ -356,7 +356,7 @@ public class MailModule extends AbstractInternalModule {
      * @param context The context to remove the MessageList for
      */
     static void removeMessageList(XQueryContext context, final long msgListHandle) {
-        ModuleUtils.modifyContextMap(context, MailModule.MSGLISTS_CONTEXTVAR, (ContextMapModifier<Message[]>) map -> map.remove(msgListHandle));
+        ModuleUtils.modifyContextMap(context, MailModule.MSGLISTS_CONTEXTVAR, (ContextMapModifierWithoutResult<Message[]>) map -> map.remove(msgListHandle));
         
         // update the context
         //context.setXQueryContextVar( MailModule.MSGLISTS_CONTEXTVAR, msgLists );
@@ -368,7 +368,7 @@ public class MailModule extends AbstractInternalModule {
      * @param context The context to close MessageLists for
      */
     private static void closeAllMessageLists(XQueryContext context) {
-        ModuleUtils.modifyContextMap(context, MailModule.MSGLISTS_CONTEXTVAR, (ContextMapModifier<Message[]>) Map::clear);
+        ModuleUtils.modifyContextMap(context, MailModule.MSGLISTS_CONTEXTVAR, (ContextMapModifierWithoutResult<Message[]>) Map::clear);
         
         // update the context
         //context.setXQueryContextVar( MailModule.MSGLISTS_CONTEXTVAR, msgLists );

--- a/extensions/modules/sql/pom.xml
+++ b/extensions/modules/sql/pom.xml
@@ -142,8 +142,10 @@
                                 <exclude>src/main/java/org/exist/xquery/modules/sql/SQLModule.java</exclude>
                                 <exclude>src/test/resources/jndi.properties</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/modules/sql/ConnectionPoolIT.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/H2DatabaseResource.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/modules/sql/Util.java</exclude>
                             </excludes>
                         </licenseSet>
 
@@ -158,8 +160,10 @@
                                 <include>src/main/java/org/exist/xquery/modules/sql/SQLModule.java</include>
                                 <include>src/test/resources/jndi.properties</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java</include>
+                                <include>src/test/java/org/exist/xquery/modules/sql/ConnectionPoolIT.java</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/H2DatabaseResource.java</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java</include>
+                                <include>src/test/java/org/exist/xquery/modules/sql/Util.java</include>
                             </includes>
 
                         </licenseSet>
@@ -171,6 +175,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>

--- a/extensions/modules/sql/pom.xml
+++ b/extensions/modules/sql/pom.xml
@@ -138,6 +138,7 @@
                             <header>${project.parent.relativePath}/LGPL-21-license.template.txt</header>
                             <excludes>
                                 <exclude>src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/modules/sql/CloseConnectionFunction.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/modules/sql/SQLModule.java</exclude>
                                 <exclude>src/test/resources/jndi.properties</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java</exclude>
@@ -153,6 +154,7 @@
                             <header>${project.parent.relativePath}/FDB-backport-LGPL-21-ONLY-license.template.txt</header>
                             <includes>
                                 <include>src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java</include>
+                                <include>src/main/java/org/exist/xquery/modules/sql/CloseConnectionFunction.java</include>
                                 <include>src/main/java/org/exist/xquery/modules/sql/SQLModule.java</include>
                                 <include>src/test/resources/jndi.properties</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java</include>

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/CloseConnectionFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/CloseConnectionFunction.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.modules.sql;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.exist.xquery.BasicFunction;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.*;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.modules.sql.SQLModule.functionSignature;
+
+
+/**
+ * SQL Module Extension function for XQuery to explicitly close a connection.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class CloseConnectionFunction extends BasicFunction {
+
+    private static final Logger LOGGER = LogManager.getLogger(GetConnectionFunction.class);
+
+    private static final String FN_CLOSE_CONNECTION = "close-connection";
+    public static final FunctionSignature FS_CLOSE_CONNECTION = functionSignature(
+            FN_CLOSE_CONNECTION,
+            "Closes a connection to a SQL Database, or if the connection was taken from a connection pool then it is returned to the pool",
+            returns(Type.BOOLEAN, "true if the connection was closed, false if there was no such connection"),
+            param("connection-handle", Type.LONG, "an xs:long representing the connection handle")
+    );
+
+    public CloseConnectionFunction(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    /**
+     * Evaluate the call to the xquery close-connection().
+     *
+     * @param args arguments from the close-connection() function call
+     * @param contextSequence the Context Sequence to operate on (not used here internally!)
+     *
+     * @return An empty sequence
+     *
+     * @throws XPathException if an error occurs.
+     */
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final IntegerValue connectionHandle = (IntegerValue) args[0].itemAt(0);
+        final long connectionUid = connectionHandle.toJavaObject(long.class);
+
+        final Connection connection = SQLModule.removeConnection(context, connectionUid);
+        if (connection == null) {
+            return BooleanValue.FALSE;
+        }
+
+        try {
+            if (connection.isClosed()) {
+                LOGGER.warn("sql:close-connection() Cannot close connection with handle: {}, as it is already closed!", connectionUid);
+                return BooleanValue.FALSE;
+            }
+
+            connection.close();
+            return BooleanValue.TRUE;
+
+        } catch (final SQLException e) {
+            throw new XPathException(this, "Unable to close connection with handle: " + connectionUid + ". " + e.getMessage());
+        }
+    }
+}

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
@@ -64,7 +64,7 @@ import static org.exist.xquery.modules.sql.SQLModule.functionSignatures;
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class GetConnectionFunction extends BasicFunction {
-    private static final FunctionReturnSequenceType RETURN_TYPE = returnsOpt(Type.LONG, "an xs:long representing the connection handle");
+    private static final FunctionReturnSequenceType RETURN_TYPE = returnsOpt(Type.LONG, "an xs:long representing the connection handle. The connection will be closed (or returned to the pool) automatically when the calling XQuery finishes execution, if you need to return it sooner you can call sql:close-connection#1");
     private static final FunctionParameterSequenceType JDBC_PASSWORD_PARAM = param("password", Type.STRING, "The SQL database password");
     private static final FunctionParameterSequenceType JDBC_USERNAME_PARAM = param("username", Type.STRING, "The SQL database username");
     private static final FunctionParameterSequenceType JDBC_PROPERTIES_PARAM = optParam("properties", Type.ELEMENT, "The JDBC database connection properties in the form <properties><property name=\"\" value=\"\"/></properties>.");

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLModule.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLModule.java
@@ -239,15 +239,15 @@ public class SQLModule extends AbstractInternalModule {
         ModuleUtils.modifyContextMap(xqueryContext, SQLModule.CONNECTIONS_CONTEXTVAR, new ContextMapEntryModifier<Connection>() {
 
             @Override
-            public void modify(final Map<Long, Connection> map) {
-                super.modify(map);
+            public void modifyWithoutResult(final Map<Long, Connection> map) {
+                super.modifyWithoutResult(map);
 
                 // empty the map
                 map.clear();
             }
 
             @Override
-            public void modify(final Entry<Long, Connection> entry) {
+            public void modifyEntry(final Entry<Long, Connection> entry) {
                 final Connection con = entry.getValue();
                 try {
                     // close the Connection
@@ -268,15 +268,15 @@ public class SQLModule extends AbstractInternalModule {
         ModuleUtils.modifyContextMap(xqueryContext, SQLModule.PREPARED_STATEMENTS_CONTEXTVAR, new ContextMapEntryModifier<PreparedStatementWithSQL>() {
 
             @Override
-            public void modify(final Map<Long, PreparedStatementWithSQL> map) {
-                super.modify(map);
+            public void modifyWithoutResult(final Map<Long, PreparedStatementWithSQL> map) {
+                super.modifyWithoutResult(map);
 
                 // empty the map
                 map.clear();
             }
 
             @Override
-            public void modify(final Entry<Long, PreparedStatementWithSQL> entry) {
+            public void modifyEntry(final Entry<Long, PreparedStatementWithSQL> entry) {
                 final PreparedStatementWithSQL stmt = entry.getValue();
                 try {
                     // close the PreparedStatement

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLModule.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLModule.java
@@ -76,6 +76,7 @@ public class SQLModule extends AbstractInternalModule {
     public static final FunctionDef[] functions = functionDefs(
             functionDefs(GetConnectionFunction.class, GetConnectionFunction.FS_GET_CONNECTION),
             functionDefs(GetConnectionFunction.class, GetConnectionFunction.FS_GET_CONNECTION_FROM_POOL),
+            functionDefs(CloseConnectionFunction.class, CloseConnectionFunction.FS_CLOSE_CONNECTION),
             functionDefs(GetJNDIConnectionFunction.class, GetJNDIConnectionFunction.signatures),
             functionDefs(ExecuteFunction.class, ExecuteFunction.FS_EXECUTE),
             functionDefs(PrepareFunction.class, PrepareFunction.signatures)
@@ -189,6 +190,17 @@ public class SQLModule extends AbstractInternalModule {
      */
     public static long storeConnection(final XQueryContext context, final Connection con) {
         return ModuleUtils.storeObjectInContextMap(context, SQLModule.CONNECTIONS_CONTEXTVAR, con);
+    }
+
+    /**
+     * Removes a Connection from the Context of an XQuery.
+     *
+     * @param context The Context of the XQuery to remove the Connection from
+     * @param connectionUID The UID of the Connection to remove from the Context of the XQuery
+     * @return the database connection for the UID, or null if there is no such connection.
+     */
+    public static @Nullable Connection removeConnection(final XQueryContext context, final long connectionUID) {
+        return ModuleUtils.removeObjectFromContextMap(context, SQLModule.CONNECTIONS_CONTEXTVAR, connectionUID);
     }
 
     /**

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ConnectionPoolIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ConnectionPoolIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.modules.sql;
+
+import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.source.Source;
+import org.exist.source.StringSource;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.modules.ModuleUtils;
+import org.exist.xquery.value.Sequence;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
+import static org.exist.xquery.modules.sql.Util.executeQuery;
+import static org.exist.xquery.modules.sql.Util.withCompiledQuery;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConnectionPoolIT {
+
+    @Rule
+    public ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void getConnectionFromPoolIsAutomaticallyClosed() throws EXistException, XPathException, PermissionDeniedException, IOException {
+        // NOTE: pool-1 is configured in src/test/resources-filtered/conf.xml
+        final String query =
+                "import module namespace sql = \"http://exist-db.org/xquery/sql\";\n" +
+                        "sql:get-connection-from-pool(\"pool-1\")";
+
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final Source source = new StringSource(query);
+        try (final DBBroker broker = pool.getBroker();
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            // execute query
+            final Tuple2<XQueryContext, Boolean> contextAndResult = withCompiledQuery(broker, source, compiledXQuery -> {
+                final Sequence result = executeQuery(broker, compiledXQuery);
+                return Tuple(compiledXQuery.getContext(), !result.isEmpty());
+            });
+
+            // check that the handle for the sql connection that was created is valid
+            assertTrue(contextAndResult._2);
+
+            // check the connections were closed
+            final int connectionsCount = ModuleUtils.readContextMap(contextAndResult._1, SQLModule.CONNECTIONS_CONTEXTVAR, Map::size);
+            assertEquals(0, connectionsCount);
+
+            transaction.commit();
+        }
+    }
+}

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/H2DatabaseResource.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/H2DatabaseResource.java
@@ -52,7 +52,7 @@ public class H2DatabaseResource extends ExternalResource {
 
     private static final Logger LOG =  LogManager.getLogger(H2DatabaseResource.class);
 
-    private static final String DEFAULT_URL = "jdbc:h2:~/test";
+    private static final String DEFAULT_URL = "jdbc:h2:mem:test-1";
     private static final String DEFAULT_USER = "sa";
     private static final String DEFAULT_PASSWORD = "sa";
 

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/Util.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/Util.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.modules.sql;
+
+import com.evolvedbinary.j8fu.function.Function2E;
+import org.exist.security.PermissionDeniedException;
+import org.exist.source.Source;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.XQueryPool;
+import org.exist.xquery.CompiledXQuery;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQuery;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.Sequence;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Tests utility methods.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class Util {
+    static Sequence executeQuery(final DBBroker broker, final CompiledXQuery compiledXQuery) throws PermissionDeniedException, XPathException {
+        final BrokerPool pool = broker.getBrokerPool();
+        final XQuery xqueryService = pool.getXQueryService();
+        return xqueryService.execute(broker, compiledXQuery, null, new Properties());
+    }
+
+    static <T> T withCompiledQuery(final DBBroker broker, final Source source, final Function2E<CompiledXQuery, T, XPathException, PermissionDeniedException> op) throws XPathException, PermissionDeniedException, IOException {
+        final BrokerPool pool = broker.getBrokerPool();
+        final XQuery xqueryService = pool.getXQueryService();
+        final XQueryPool xqueryPool = pool.getXQueryPool();
+        final CompiledXQuery compiledQuery = compileQuery(broker, xqueryService, xqueryPool, source);
+        try {
+            return op.apply(compiledQuery);
+        } finally {
+            if (compiledQuery != null) {
+                xqueryPool.returnCompiledXQuery(source, compiledQuery);
+            }
+        }
+    }
+
+    static CompiledXQuery compileQuery(final DBBroker broker, final XQuery xqueryService, final XQueryPool xqueryPool, final Source query) throws PermissionDeniedException, XPathException, IOException {
+        CompiledXQuery compiled = xqueryPool.borrowCompiledXQuery(broker, query);
+        XQueryContext context;
+        if (compiled == null) {
+            context = new XQueryContext(broker.getBrokerPool());
+        } else {
+            context = compiled.getContext();
+            context.prepareForReuse();
+        }
+
+        if (compiled == null) {
+            compiled = xqueryService.compile(broker, context, query);
+        } else {
+            compiled.getContext().updateContext(context);
+            context.getWatchDog().reset();
+        }
+
+        return compiled;
+    }
+}

--- a/extensions/modules/sql/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/sql/src/test/resources-filtered/conf.xml
@@ -747,7 +747,9 @@
             <module uri="http://exist-db.org/xquery/sql" class="org.exist.xquery.modules.sql.SQLModule">
                 <parameter name="pool.1.name" value="pool-1"/>
                 <parameter name="pool.1.properties.dataSourceClassName" value="org.h2.jdbcx.JdbcDataSource"/>
-                <parameter name="pool.1.properties.jdbcUrl" value="jdbc:h2:~/test"/>
+                <parameter name="pool.1.properties.dataSource.url" value="jdbc:h2:mem:test-pool-1"/>
+                <parameter name="pool.1.properties.dataSource.user" value="sa"/>
+                <parameter name="pool.1.properties.dataSource.password" value="sa"/>
                 <parameter name="pool.1.properties.maximumPoolSize" value="10"/>
             </module>
 


### PR DESCRIPTION
Allows the user to explicitly close (or return to a pool) a SQL connection before the XQuery completes, this is useful when working with Connection pools.