### PR TITLE
Specify the COVERALLS_TOKEN in the correct way for CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Maven Test
         run: mvn -V -B clean verify
       - name: Maven Code Coverage
-        if: ${{ matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ github.ref == 'refs/heads/develop' && matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
         run: mvn -V -B jacoco:report coveralls:report -DrepoToken=${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -28,8 +28,4 @@ jobs:
         run: mvn -V -B clean verify
       - name: Maven Code Coverage
         if: ${{ matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-        run: |
-          echo "ADAM COVERALLS_TOKEN='${COVERALLS_TOKEN}'"
-          mvn -V -B jacoco:report coveralls:report
+        run: mvn -V -B jacoco:report coveralls:report -DrepoToken=${{ secrets.COVERALLS_TOKEN }}


### PR DESCRIPTION
It's easy when you know how ;-)

I expect this to fail in the PR for the GitHub Action `(JDK 8 / ubuntu-latest) Test`, as it won't be able to access the secrets. I have tested this change in a different project, and once merged it did work there.