### PR TITLE
Further attempt to get Coveralls plugin working

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -28,4 +28,10 @@ jobs:
         run: mvn -V -B clean verify
       - name: Maven Code Coverage
         if: ${{ github.ref == 'refs/heads/develop' && matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
+        env:
+          CI_NAME: github
+          BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
+          CI_BUILD_NUMBER: ${{ github.run_id }}
+          CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
+          COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}
         run: mvn -V -B jacoco:report coveralls:report -DrepoToken=${{ secrets.COVERALLS_TOKEN }}


### PR DESCRIPTION
The settings we have here work perfectly well in other repositories I have setup with GitHub actions. At the moment I am at a complete loss as to explain why they don't work in this repository. As a last-ditch attempt, I am trying to set some additional env variables, see: https://github.com/trautonen/coveralls-maven-plugin/issues/136

