### PR TITLE
[bugfix] throw error in `repo:get-resource` if file does not exist

### DIFF
--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/GetResource.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/GetResource.java
@@ -50,11 +50,11 @@ public class GetResource extends BasicFunction {
 			},
 			new FunctionReturnSequenceType(Type.BASE64_BINARY, Cardinality.ZERO_OR_ONE, 
 					"<status result=\"ok\"/> if deployment was ok. Throws an error otherwise."));
-	
+
 	public GetResource(XQueryContext context) {
 		super(context, signature);
 	}
-	
+
 	@Override
 	public Sequence eval(Sequence[] args, Sequence contextSequence)
 		throws XPathException {
@@ -71,8 +71,8 @@ public class GetResource extends BasicFunction {
                             // FileSystemResolver already returns an input stream
                             StreamSource source = (StreamSource) pkg.getResolver().resolveResource(path);
                             return Base64BinaryDocument.getInstance(context, source.getInputStream());
-                        } catch (Storage.NotExistException ex) {
-                            // nothing
+                        } catch (Storage.NotExistException e) {
+                            throw new XPathException(ErrorCodes.FODC0002, "Resource " + path + " does not exist.", e);
                         }
                     }
                 }


### PR DESCRIPTION
### Description:
`repo:get-resource` now throws an XPathException if the resource does not exist

### Reference:
https://github.com/eXist-db/exist/issues/3895

### Type of tests:
none
