### PR TITLE
Cleanup all module contexts

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -680,6 +680,7 @@
                                 <exclude>src/test/java/org/exist/util/CollectionOfArrayIteratorTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Cardinality.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportModuleTest.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/XQueryContextAttributesTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/map/MapType.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/session/AbstractSessionTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/xmldb/AbstractXMLDBTest.java</exclude>
@@ -819,6 +820,7 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/test/java/org/exist/util/CollectionOfArrayIteratorTest.java</include>
                                 <include>src/main/java/org/exist/xquery/Cardinality.java</include>
                                 <include>src/test/java/org/exist/xquery/ImportModuleTest.java</include>
+                                <include>src/test/java/org/exist/xquery/XQueryContextAttributesTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/map/MapType.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/session/AbstractSessionTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/xmldb/AbstractXMLDBTest.java</include>

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -209,7 +209,7 @@ public class XQueryContext implements BinaryValueManager, Context {
     protected XQueryWatchDog watchdog;
 
     /**
-     * Loaded modules.
+     * Loaded modules within this module.
      *
      * The format of the map is: <code>Map&lt;NamespaceURI, Modules&gt;</code>.
      */
@@ -1402,7 +1402,13 @@ public class XQueryContext implements BinaryValueManager, Context {
             watchdog.reset();
         }
 
-        for (final Module[] modules : allModules.values()) {
+        /*
+            NOTE: we use `modules` (and not `allModules`) here so as to only reset
+            the modules of this module.
+            The inner call to `module.reset` will be called on sub-modules
+            which in-turn will reset their modules, and so on.
+         */
+        for (final Module[] modules : modules.values()) {
             for (final Module module : modules) {
                 module.reset(this, keepGlobals);
             }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryContextAttributesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryContextAttributesTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import com.evolvedbinary.j8fu.function.Function2E;
+import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.dom.persistent.BinaryDocument;
+import org.exist.security.PermissionDeniedException;
+import org.exist.source.DBSource;
+import org.exist.source.Source;
+import org.exist.source.StringSource;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.XQueryPool;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.LockException;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.value.Sequence;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Properties;
+
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class XQueryContextAttributesTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void attributesOfMainModuleContextCleared() throws EXistException, LockException, TriggerException, PermissionDeniedException, IOException, XPathException {
+        final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+            final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+
+            final XmldbURI mainQueryUri = XmldbURI.create("/db/query1.xq");
+            final Source mainQuery = new StringSource("<not-important/>");
+            final DBSource mainQuerySource = storeQuery(broker, transaction, mainQueryUri, mainQuery);
+
+            final XQueryContext escapedMainQueryContext = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {
+                final XQueryContext mainQueryContext = mainCompiledQuery.getContext();
+
+                mainQueryContext.setAttribute("attr1", "value1");
+                mainQueryContext.setAttribute("attr2", "value2");
+
+                // execute the query
+                final Sequence result = executeQuery(broker, mainCompiledQuery);
+                assertEquals(1, result.getItemCount());
+
+                // intentionally escape the context from the lambda
+                return mainQueryContext;
+            });
+
+            assertNull(escapedMainQueryContext.getAttribute("attr1"));
+            assertNull(escapedMainQueryContext.getAttribute("attr2"));
+            assertTrue(escapedMainQueryContext.attributes.isEmpty());
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void attributesOfLibraryModuleContextCleared() throws EXistException, LockException, TriggerException, PermissionDeniedException, IOException, XPathException {
+        final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
+
+            final XmldbURI libraryQueryUri = XmldbURI.create("/db/mod1.xqm");
+            final Source libraryQuery = new StringSource(
+                    "module namespace mod1 = 'http://mod1';\n" +
+                            "declare function mod1:f1() { <not-important/> };"
+            );
+            storeQuery(broker, transaction, libraryQueryUri, libraryQuery);
+
+            final XmldbURI mainQueryUri = XmldbURI.create("/db/query1.xq");
+            final Source mainQuery = new StringSource(
+                    "import module namespace mod1 = 'http://mod1' at 'xmldb:exist://" + libraryQueryUri + "';\n" +
+                            "mod1:f1()"
+            );
+            final DBSource mainQuerySource = storeQuery(broker, transaction, mainQueryUri, mainQuery);
+
+            final Tuple2<XQueryContext, ModuleContext> escapedContexts = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {
+                final XQueryContext mainQueryContext = mainCompiledQuery.getContext();
+
+                // get the context of the library module
+                final Module[] libraryModules = mainQueryContext.getModules("http://mod1");
+                assertEquals(1, libraryModules.length);
+                assertTrue(libraryModules[0] instanceof ExternalModule);
+                final ExternalModule libraryModule = (ExternalModule) libraryModules[0];
+                final XQueryContext libraryQueryContext = libraryModule.getContext();
+                assertTrue(libraryQueryContext instanceof ModuleContext);
+
+                libraryQueryContext.setAttribute("attr1", "value1");
+                libraryQueryContext.setAttribute("attr2", "value2");
+
+                // execute the query
+                final Sequence result = executeQuery(broker, mainCompiledQuery);
+                assertEquals(1, result.getItemCount());
+
+                // intentionally escape the contexts from the lambda
+                return Tuple(mainQueryContext, (ModuleContext) libraryQueryContext);
+            });
+
+            final XQueryContext escapedMainQueryContext = escapedContexts._1;
+            final ModuleContext escapedLibraryQueryContext = escapedContexts._2;
+            assertTrue(escapedMainQueryContext != escapedLibraryQueryContext);
+
+            assertNull(escapedMainQueryContext.getAttribute("attr1"));
+            assertNull(escapedMainQueryContext.getAttribute("attr2"));
+            assertTrue(escapedMainQueryContext.attributes.isEmpty());
+
+            assertNull(escapedLibraryQueryContext.getAttribute("attr1"));
+            assertNull(escapedLibraryQueryContext.getAttribute("attr2"));
+            assertTrue(escapedLibraryQueryContext.attributes.isEmpty());
+
+            transaction.commit();
+        }
+    }
+
+    private static DBSource storeQuery(final DBBroker broker, final Txn transaction, final XmldbURI uri, final Source source) throws IOException, PermissionDeniedException, TriggerException, LockException, EXistException {
+        try (final InputStream is = source.getInputStream()) {
+            try (final Collection collection = broker.openCollection(uri.removeLastSegment(), Lock.LockMode.WRITE_LOCK)) {
+                final BinaryDocument doc = collection.addBinaryResource(transaction, broker, uri.lastSegment(), is, "application/xquery", -1);
+
+                return new DBSource(broker, doc, false);
+            }
+        }
+    }
+
+    private static <T> T withCompiledQuery(final DBBroker broker, final Source source, final Function2E<CompiledXQuery, T, XPathException, PermissionDeniedException> op) throws XPathException, PermissionDeniedException, IOException {
+        final BrokerPool pool = broker.getBrokerPool();
+        final XQuery xqueryService = pool.getXQueryService();
+        final XQueryPool xqueryPool = pool.getXQueryPool();
+        final CompiledXQuery compiledQuery = compileQuery(broker, xqueryService, xqueryPool, source);
+        try {
+            return op.apply(compiledQuery);
+        } finally {
+            if (compiledQuery != null) {
+                xqueryPool.returnCompiledXQuery(source, compiledQuery);
+            }
+        }
+    }
+
+    private static CompiledXQuery compileQuery(final DBBroker broker, final XQuery xqueryService, final XQueryPool xqueryPool, final Source query) throws PermissionDeniedException, XPathException, IOException {
+        CompiledXQuery compiled = xqueryPool.borrowCompiledXQuery(broker, query);
+        XQueryContext context;
+        if (compiled == null) {
+            context = new XQueryContext(broker.getBrokerPool());
+        } else {
+            context = compiled.getContext();
+            context.prepareForReuse();
+        }
+
+        if (compiled == null) {
+            compiled = xqueryService.compile(broker, context, query);
+        } else {
+            compiled.getContext().updateContext(context);
+            context.getWatchDog().reset();
+        }
+
+        return compiled;
+    }
+
+    static Sequence executeQuery(final DBBroker broker, final CompiledXQuery compiledXQuery) throws PermissionDeniedException, XPathException {
+        final BrokerPool pool = broker.getBrokerPool();
+        final XQuery xqueryService = pool.getXQueryService();
+        return xqueryService.execute(broker, compiledXQuery, null, new Properties());
+    }
+}

--- a/extensions/modules/sql/pom.xml
+++ b/extensions/modules/sql/pom.xml
@@ -144,6 +144,7 @@
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/ConnectionPoolIT.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/H2DatabaseResource.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/modules/sql/ImplicitConnectionCloseIT.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/modules/sql/Util.java</exclude>
                             </excludes>
@@ -162,6 +163,7 @@
                                 <include>src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/ConnectionPoolIT.java</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/H2DatabaseResource.java</include>
+                                <include>src/test/java/org/exist/xquery/modules/sql/ImplicitConnectionCloseIT.java</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java</include>
                                 <include>src/test/java/org/exist/xquery/modules/sql/Util.java</include>
                             </includes>

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/CloseConnectionFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/CloseConnectionFunction.java
@@ -35,17 +35,15 @@ package org.exist.xquery.modules.sql;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.dom.QName;
+import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 
 import static org.exist.xquery.FunctionDSL.*;
-import static org.exist.xquery.modules.sql.SQLModule.functionSignature;
+import static org.exist.xquery.modules.sql.SQLModule.*;
 
 
 /**
@@ -101,5 +99,9 @@ public class CloseConnectionFunction extends BasicFunction {
         } catch (final SQLException e) {
             throw new XPathException(this, "Unable to close connection with handle: " + connectionUid + ". " + e.getMessage());
         }
+    }
+
+    private static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
+        return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, paramTypes);
     }
 }

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
@@ -67,7 +67,7 @@ import javax.annotation.Nullable;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.xquery.FunctionDSL.*;
-import static org.exist.xquery.modules.sql.SQLUtils.functionSignatures;
+import static org.exist.xquery.modules.sql.SQLModule.functionSignatures;
 
 
 /**

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
@@ -106,7 +106,7 @@ public class ExecuteFunction extends BasicFunction {
                     ),
                     arity(
                             FS_PARAM_CONNECTION_HANDLE,
-                            param("statement-handle", Type.INTEGER, "The prepared statement handle"),
+                            param("statement-handle", Type.LONG, "The prepared statement handle"),
                             optParam("parameters", Type.ELEMENT, "Parameters for the prepared statement. e.g. <sql:parameters><sql:param sql:type=\"long\">1234</sql:param><sql:param sql:type=\"varchar\"><sql:null/></sql:param></sql:parameters>"),
                             FS_PARAM_MAKE_NODE_FROM_COLUMN_NAME
                     )

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
@@ -27,22 +27,14 @@ import org.apache.logging.log4j.Logger;
 import org.exist.dom.memtree.*;
 import org.exist.util.XMLReaderPool;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import org.exist.Namespaces;
 import org.exist.dom.QName;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.ErrorCodes;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
-import org.exist.xquery.value.BooleanValue;
-import org.exist.xquery.value.FunctionParameterSequenceType;
-import org.exist.xquery.value.IntegerValue;
-import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.Type;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -59,7 +51,6 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
 
-import org.exist.xquery.value.DateTimeValue;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 
@@ -67,7 +58,8 @@ import javax.annotation.Nullable;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.xquery.FunctionDSL.*;
-import static org.exist.xquery.modules.sql.SQLModule.functionSignatures;
+import static org.exist.xquery.modules.sql.SQLModule.NAMESPACE_URI;
+import static org.exist.xquery.modules.sql.SQLModule.PREFIX;
 
 
 /**
@@ -215,15 +207,15 @@ public class ExecuteFunction extends BasicFunction {
 
     private void setParametersOnPreparedStatement(final Statement stmt, final Element parametersElement) throws SQLException, XPathException {
         final String ns = parametersElement.getNamespaceURI();
-        if (ns != null && ns.equals(SQLModule.NAMESPACE_URI) && parametersElement.getLocalName().equals(PARAMETERS_ELEMENT_NAME)) {
-            final NodeList paramElements = parametersElement.getElementsByTagNameNS(SQLModule.NAMESPACE_URI, PARAM_ELEMENT_NAME);
+        if (ns != null && ns.equals(NAMESPACE_URI) && parametersElement.getLocalName().equals(PARAMETERS_ELEMENT_NAME)) {
+            final NodeList paramElements = parametersElement.getElementsByTagNameNS(NAMESPACE_URI, PARAM_ELEMENT_NAME);
 
             for (int i = 0; i < paramElements.getLength(); i++) {
                 final Element param = ((Element) paramElements.item(i));
                 Node child = param.getFirstChild();
 
                 final int sqlType;
-                final String type = param.getAttributeNS(SQLModule.NAMESPACE_URI, TYPE_ATTRIBUTE_NAME);
+                final String type = param.getAttributeNS(NAMESPACE_URI, TYPE_ATTRIBUTE_NAME);
                 if (type != null) {
                     sqlType = SQLUtils.sqlTypeFromString(type);
                 } else {
@@ -239,7 +231,7 @@ public class ExecuteFunction extends BasicFunction {
                     if (child instanceof Element) {
                         // check for <sql:null/>
                         final Element elem = (Element)child;
-                        if ("null".equals(elem.getLocalName()) && SQLModule.NAMESPACE_URI.equals(elem.getNamespaceURI())) {
+                        if ("null".equals(elem.getLocalName()) && NAMESPACE_URI.equals(elem.getNamespaceURI())) {
                             value = null;
                         } else {
                             value = child.getNodeValue();
@@ -280,7 +272,7 @@ public class ExecuteFunction extends BasicFunction {
 
             builder.startDocument();
 
-            builder.startElement(new QName("result", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+            builder.startElement(new QName("result", NAMESPACE_URI, PREFIX), null);
             builder.addAttribute(new QName("count", null, null), "-1");
             builder.addAttribute(new QName("updateCount", null, null), String.valueOf(stmt.getUpdateCount()));
 
@@ -309,7 +301,7 @@ public class ExecuteFunction extends BasicFunction {
                     final int iColumns = rsmd.getColumnCount();
 
                     while (rs.next()) {
-                        builder.startElement(new QName("row", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+                        builder.startElement(new QName("row", NAMESPACE_URI, PREFIX), null);
                         builder.addAttribute(new QName("index", null, null), String.valueOf(rs.getRow()));
 
                         // get each tuple in the row
@@ -330,7 +322,7 @@ public class ExecuteFunction extends BasicFunction {
                                     colElement = SQLUtils.escapeXmlAttr(columnName.replace(' ', '_'));
                                 }
 
-                                builder.startElement(new QName(colElement, SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+                                builder.startElement(new QName(colElement, NAMESPACE_URI, PREFIX), null);
 
                                 if (!makeNodeFromColumnName || columnName.length() <= 0) {
                                     final String name;
@@ -343,7 +335,7 @@ public class ExecuteFunction extends BasicFunction {
                                     builder.addAttribute(new QName("name", null, null), name);
                                 }
 
-                                builder.addAttribute(new QName(TYPE_ATTRIBUTE_NAME, SQLModule.NAMESPACE_URI, SQLModule.PREFIX), rsmd.getColumnTypeName(i + 1));
+                                builder.addAttribute(new QName(TYPE_ATTRIBUTE_NAME, NAMESPACE_URI, PREFIX), rsmd.getColumnTypeName(i + 1));
                                 builder.addAttribute(new QName(TYPE_ATTRIBUTE_NAME, Namespaces.SCHEMA_NS, "xs"), Type.getTypeName(SQLUtils.sqlTypeToXMLType(rsmd.getColumnType(i + 1))));
 
                                 //get the content
@@ -354,7 +346,7 @@ public class ExecuteFunction extends BasicFunction {
 
                                         if (rs.wasNull()) {
                                             // Add a null indicator attribute if the value was SQL Null
-                                            builder.addAttribute(new QName("null", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), "true");
+                                            builder.addAttribute(new QName("null", NAMESPACE_URI, PREFIX), "true");
                                         } else {
                                             try (final Reader charStream = sqlXml.getCharacterStream()) {
                                                 final InputSource src = new InputSource(charStream);
@@ -383,7 +375,7 @@ public class ExecuteFunction extends BasicFunction {
 
                                     if (rs.wasNull()) {
                                         // Add a null indicator attribute if the value was SQL Null
-                                        builder.addAttribute(new QName("null", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), "true");
+                                        builder.addAttribute(new QName("null", NAMESPACE_URI, PREFIX), "true");
                                     } else {
                                         if (colValue != null) {
                                             builder.characters(colValue);
@@ -435,23 +427,23 @@ public class ExecuteFunction extends BasicFunction {
             final MemTreeBuilder builder = context.getDocumentBuilder();
 
             builder.startDocument();
-            builder.startElement(new QName("exception", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+            builder.startElement(new QName("exception", NAMESPACE_URI, PREFIX), null);
 
             final boolean recoverable = sqle instanceof SQLRecoverableException;
             builder.addAttribute(new QName("recoverable", null, null), String.valueOf(recoverable));
 
-            builder.startElement(new QName("state", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+            builder.startElement(new QName("state", NAMESPACE_URI, PREFIX), null);
             builder.characters(sqle.getSQLState());
             builder.endElement();
 
-            builder.startElement(new QName("message", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+            builder.startElement(new QName("message", NAMESPACE_URI, PREFIX), null);
             final String state = sqle.getMessage();
             if (state != null) {
                 builder.characters(state);
             }
             builder.endElement();
 
-            builder.startElement(new QName("stack-trace", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+            builder.startElement(new QName("stack-trace", NAMESPACE_URI, PREFIX), null);
             try (final UnsynchronizedByteArrayOutputStream bufStackTrace = new UnsynchronizedByteArrayOutputStream();
                  final PrintStream ps = new PrintStream(bufStackTrace)) {
                 sqle.printStackTrace(ps);
@@ -461,25 +453,25 @@ public class ExecuteFunction extends BasicFunction {
             }
             builder.endElement();
 
-            builder.startElement(new QName("sql", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+            builder.startElement(new QName("sql", NAMESPACE_URI, PREFIX), null);
             builder.characters(sql);
             builder.endElement();
 
             if (parametersElement != null) {
                 final String ns = parametersElement.getNamespaceURI();
-                if (ns != null && ns.equals(SQLModule.NAMESPACE_URI) && parametersElement.getLocalName().equals(PARAMETERS_ELEMENT_NAME)) {
-                    final NodeList paramElements = parametersElement.getElementsByTagNameNS(SQLModule.NAMESPACE_URI, PARAM_ELEMENT_NAME);
+                if (ns != null && ns.equals(NAMESPACE_URI) && parametersElement.getLocalName().equals(PARAMETERS_ELEMENT_NAME)) {
+                    final NodeList paramElements = parametersElement.getElementsByTagNameNS(NAMESPACE_URI, PARAM_ELEMENT_NAME);
 
-                    builder.startElement(new QName(PARAMETERS_ELEMENT_NAME, SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+                    builder.startElement(new QName(PARAMETERS_ELEMENT_NAME, NAMESPACE_URI, PREFIX), null);
 
                     for (int i = 0; i < paramElements.getLength(); i++) {
                         final Element param = ((Element) paramElements.item(i));
                         final Node valueNode = param.getFirstChild();
                         final String value = valueNode != null ? valueNode.getNodeValue() : null;
-                        final String type = param.getAttributeNS(SQLModule.NAMESPACE_URI, TYPE_ATTRIBUTE_NAME);
+                        final String type = param.getAttributeNS(NAMESPACE_URI, TYPE_ATTRIBUTE_NAME);
 
-                        builder.startElement(new QName(PARAM_ELEMENT_NAME, SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
-                        builder.addAttribute(new QName(TYPE_ATTRIBUTE_NAME, SQLModule.NAMESPACE_URI, SQLModule.PREFIX), type);
+                        builder.startElement(new QName(PARAM_ELEMENT_NAME, NAMESPACE_URI, PREFIX), null);
+                        builder.addAttribute(new QName(TYPE_ATTRIBUTE_NAME, NAMESPACE_URI, PREFIX), type);
                         builder.characters(value);
                         builder.endElement();
                     }
@@ -488,7 +480,7 @@ public class ExecuteFunction extends BasicFunction {
                 }
             }
 
-            builder.startElement(new QName("xquery", SQLModule.NAMESPACE_URI, SQLModule.PREFIX), null);
+            builder.startElement(new QName("xquery", NAMESPACE_URI, PREFIX), null);
             builder.addAttribute(new QName("line", null, null), String.valueOf(getLine()));
             builder.addAttribute(new QName("column", null, null), String.valueOf(getColumn()));
             builder.endElement();
@@ -500,5 +492,9 @@ public class ExecuteFunction extends BasicFunction {
         } finally {
             context.popDocumentContext();
         }
+    }
+
+    private static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
     }
 }

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
@@ -135,7 +135,6 @@ public class GetConnectionFunction extends BasicFunction {
 
     private Connection getConnection(final Sequence[] args) throws XPathException {
         // get the db connection details
-        final String dbDriver = args[0].getStringValue();
         final String dbURL = args[1].getStringValue();
 
         try {

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
@@ -130,7 +130,7 @@ public class GetConnectionFunction extends BasicFunction {
         }
 
         // store the Connection and return the uid handle of the Connection
-        return new IntegerValue(SQLModule.storeConnection(context, connection));
+        return new IntegerValue(SQLModule.storeConnection(context, connection), Type.LONG);
     }
 
     private Connection getConnection(final Sequence[] args) throws XPathException {

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetConnectionFunction.java
@@ -36,11 +36,9 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import org.exist.dom.QName;
 import org.exist.util.ParametersExtractor;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
 import org.exist.xquery.value.IntegerValue;
@@ -55,7 +53,8 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 import static org.exist.xquery.FunctionDSL.*;
-import static org.exist.xquery.modules.sql.SQLModule.functionSignatures;
+import static org.exist.xquery.modules.sql.SQLModule.NAMESPACE_URI;
+import static org.exist.xquery.modules.sql.SQLModule.PREFIX;
 
 
 /**
@@ -186,5 +185,9 @@ public class GetConnectionFunction extends BasicFunction {
             LOGGER.error("sql:get-connection-from-pool() Cannot retrieve connection from pool: " + poolName, sqle);
             throw new XPathException(this, "sql:get-connection-from-pool() Cannot retrieve connection from pool: " + poolName, sqle);
         }
+    }
+
+    private static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
     }
 }

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetJNDIConnectionFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/GetJNDIConnectionFunction.java
@@ -126,7 +126,7 @@ public class GetJNDIConnectionFunction extends BasicFunction {
             }
 
             // store the connection and return the uid handle of the connection
-            return (new IntegerValue(SQLModule.storeConnection(context, con)));
+            return (new IntegerValue(SQLModule.storeConnection(context, con), Type.LONG));
         } catch (Exception e) {
             throw (new XPathException(this, e.getMessage()));
         }

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/PrepareFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/PrepareFunction.java
@@ -112,7 +112,7 @@ public class PrepareFunction extends BasicFunction {
             stmt = con.prepareStatement(sql);
 
             // store the PreparedStatement and return the uid handle of the PreparedStatement
-            return (new IntegerValue(SQLModule.storePreparedStatement(context, new PreparedStatementWithSQL(sql, stmt))));
+            return (new IntegerValue(SQLModule.storePreparedStatement(context, new PreparedStatementWithSQL(sql, stmt)), Type.LONG));
         } catch (SQLException sqle) {
             LOG.error("sql:prepare() Caught SQLException \"{}\" for SQL: \"{}\"", sqle.getMessage(), sql, sqle);
 

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLModule.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLModule.java
@@ -151,14 +151,6 @@ public class SQLModule extends AbstractInternalModule {
         return RELEASED_IN_VERSION;
     }
 
-    static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
-        return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, paramTypes);
-    }
-
-    static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
-        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
-    }
-
     /**
      * Gets a Connection Pool.
      *

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLUtils.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/SQLUtils.java
@@ -201,9 +201,4 @@ public final class SQLUtils {
 
         return (work);
     }
-
-    static FunctionSignature[] functionSignatures(final String name, final String description,
-            final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
-        return FunctionDSL.functionSignatures(new QName(name, SQLModule.NAMESPACE_URI, SQLModule.PREFIX), description, returnType, variableParamTypes);
-    }
 }

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ImplicitConnectionCloseIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ImplicitConnectionCloseIT.java
@@ -1,0 +1,623 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.modules.sql;
+
+import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.collections.triggers.TriggerException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.source.Source;
+import org.exist.source.StringSource;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.LockException;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.*;
+import org.exist.xquery.modules.ModuleUtils;
+import org.exist.xquery.value.IntegerValue;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.Type;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.osjava.sj.loader.JndiLoader;
+
+import javax.naming.*;
+import javax.naming.spi.ObjectFactory;
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
+import static org.exist.xquery.modules.sql.Util.executeQuery;
+import static org.exist.xquery.modules.sql.Util.withCompiledQuery;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Uses JNDI to provide a StubDataSourceFactory
+ * which tracks whether .close is called
+ * (implicitly) on a Connection after an XQuery
+ * finishes executing.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class ImplicitConnectionCloseIT {
+
+    private static final String JNDI_DS_NAME = "com.fusiondb.xquery.modules.sql.MockDataSource";
+    private static final String STUB_JDBC_URL = "jdbc:stub:test-1";
+    private static final String STUB_JDBC_USER = "sa";
+    private static final String STUB_JDBC_PASSWORD = "sa";
+
+    @Rule
+    public ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    private Context ctx = null;
+
+    @Before
+    public void setupJndiEnvironment() throws NamingException {
+        final Properties properties = new Properties();
+        properties.setProperty(JNDI_DS_NAME + ".type", StubDataSource.class.getName());
+        properties.setProperty(JNDI_DS_NAME + ".javaxNamingSpiObjectFactory", StubDataSourceFactory.class.getName());
+        properties.setProperty(JNDI_DS_NAME + ".url", STUB_JDBC_URL);
+        properties.setProperty(JNDI_DS_NAME + ".user", STUB_JDBC_USER);
+        properties.setProperty(JNDI_DS_NAME + ".password", STUB_JDBC_PASSWORD);
+        properties.setProperty(JNDI_DS_NAME + ".description", "Stub JNDI DataSource");
+
+        ctx = new InitialContext();
+        final JndiLoader loader = new JndiLoader(ctx.getEnvironment());
+        loader.load(properties, ctx);
+    }
+
+    @After
+    public void teardownJndiEnvironment() throws NamingException {
+        ctx.unbind(JNDI_DS_NAME);
+        ctx.close();
+
+        StubDataSourceFactory.CREATED_DATA_SOURCES.clear();
+    }
+
+    @Test
+    public void getJndiConnectionIsAutomaticallyClosed() throws EXistException, XPathException, PermissionDeniedException, IOException {
+        final String mainQuery =
+                "import module namespace sql = \"http://exist-db.org/xquery/sql\";\n" +
+                "sql:get-jndi-connection(\"" + JNDI_DS_NAME + "\", \"" + STUB_JDBC_USER + "\", \"" + STUB_JDBC_PASSWORD + "\")";
+
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final Source mainQuerySource = new StringSource(mainQuery);
+        try (final DBBroker broker = pool.getBroker();
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            final XQueryContext escapedMainQueryContext = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {
+                final XQueryContext mainQueryContext = mainCompiledQuery.getContext();
+
+                // execute the query
+                final Sequence result = executeQuery(broker, mainCompiledQuery);
+
+                // check that the handle for the sql connection that was created was valid
+                assertEquals(1, result.getItemCount());
+                assertTrue(result.itemAt(0) instanceof IntegerValue);
+                assertEquals(Type.LONG, result.itemAt(0).getType());
+                final long connectionHandle = result.itemAt(0).toJavaObject(long.class);
+                assertFalse(connectionHandle == 0);
+
+                return mainQueryContext;
+            });
+
+            // check the connections map is empty
+            final int connectionsCount = ModuleUtils.readContextMap(escapedMainQueryContext, SQLModule.CONNECTIONS_CONTEXTVAR, Map::size);
+            assertEquals(0, connectionsCount);
+
+            // check the connections from our StubDataSource, they should all be closed
+            final Deque<StubDataSource> createdDataSources = StubDataSourceFactory.CREATED_DATA_SOURCES;
+            assertEquals(1, createdDataSources.size());
+            final StubDataSource stubDataSource = createdDataSources.peek();
+            final Deque<StubConnection> createdConnections = stubDataSource.createdConnections;
+            assertEquals(1, createdConnections.size());
+            final StubConnection stubConnection = createdConnections.peek();
+            assertTrue(stubConnection.isClosed());
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void getJndiConnectionFromModuleIsAutomaticallyClosed() throws EXistException, XPathException, PermissionDeniedException, IOException, LockException, TriggerException {
+        final String moduleQuery =
+                "module namespace mymodule = \"http://mymodule.com\";\n" +
+                        "import module namespace sql = \"http://exist-db.org/xquery/sql\";\n" +
+                        "declare function mymodule:get-handle() {\n" +
+                        "    sql:get-jndi-connection(\"" + JNDI_DS_NAME + "\", \"" + STUB_JDBC_USER + "\", \"" + STUB_JDBC_PASSWORD + "\")\n" +
+                        "};\n";
+        final Source moduleQuerySource = new StringSource(moduleQuery);
+
+        final String mainQuery =
+                "import module namespace mymodule = \"http://mymodule.com\" at \"xmldb:exist:///db/mymodule.xqm\";\n" +
+                        "mymodule:get-handle()";
+        final Source mainQuerySource = new StringSource(mainQuery);
+
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = pool.getTransactionManager().beginTransaction()) {
+
+            // store module
+            try (final InputStream is = moduleQuerySource.getInputStream()) {
+                try (final Collection collection = broker.openCollection(XmldbURI.create("/db"), Lock.LockMode.WRITE_LOCK)) {
+                    collection.addBinaryResource(transaction, broker, XmldbURI.create("mymodule.xqm"), is, "application/xquery", -1);
+                }
+            }
+
+            final Tuple2<XQueryContext, ModuleContext> escapedContexts = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {
+                final XQueryContext mainQueryContext = mainCompiledQuery.getContext();
+
+                // get the context of the library module
+                final Module[] libraryModules = mainQueryContext.getModules("http://mymodule.com");
+                assertEquals(1, libraryModules.length);
+                assertTrue(libraryModules[0] instanceof ExternalModule);
+                final ExternalModule libraryModule = (ExternalModule) libraryModules[0];
+                final XQueryContext libraryQueryContext = libraryModule.getContext();
+                assertTrue(libraryQueryContext instanceof ModuleContext);
+
+                // execute the query
+                final Sequence result = executeQuery(broker, mainCompiledQuery);
+
+                // check that the handle for the sql connection that was created was valid
+                assertEquals(1, result.getItemCount());
+                assertTrue(result.itemAt(0) instanceof IntegerValue);
+                assertEquals(Type.LONG, result.itemAt(0).getType());
+                final long connectionHandle = result.itemAt(0).toJavaObject(long.class);
+                assertFalse(connectionHandle == 0);
+
+                // intentionally escape the contexts from the lambda
+                return Tuple(mainQueryContext, (ModuleContext) libraryQueryContext);
+            });
+
+            final XQueryContext escapedMainQueryContext = escapedContexts._1;
+            final ModuleContext escapedLibraryQueryContext = escapedContexts._2;
+            assertTrue(escapedMainQueryContext != escapedLibraryQueryContext);
+
+            // check the connections were closed in the main module
+            final int mainConnectionsCount = ModuleUtils.readContextMap(escapedMainQueryContext, SQLModule.CONNECTIONS_CONTEXTVAR, Map::size);
+            assertEquals(0, mainConnectionsCount);
+
+            // check the connections were closed in the library module
+            final int libraryConnectionsCount = ModuleUtils.readContextMap(escapedLibraryQueryContext, SQLModule.CONNECTIONS_CONTEXTVAR, Map::size);
+            assertEquals(0, libraryConnectionsCount);
+
+            // check the connections from our StubDataSource, they should all be closed
+            final Deque<StubDataSource> createdDataSources = StubDataSourceFactory.CREATED_DATA_SOURCES;
+            assertEquals(1, createdDataSources.size());
+            final StubDataSource stubDataSource = createdDataSources.peek();
+            final Deque<StubConnection> createdConnections = stubDataSource.createdConnections;
+            assertEquals(1, createdConnections.size());
+            final StubConnection stubConnection = createdConnections.peek();
+            assertTrue(stubConnection.isClosed());
+
+            transaction.commit();
+        }
+    }
+
+    public static class StubDataSourceFactory implements ObjectFactory {
+        public static final Deque<StubDataSource> CREATED_DATA_SOURCES = new ConcurrentLinkedDeque<>();
+
+        @Override
+        public Object getObjectInstance(final Object obj, final Name name, final Context nameCtx, final Hashtable<?, ?> environment) throws Exception {
+            if (obj instanceof Reference) {
+                final Reference reference = (Reference)obj;
+                if (reference.getClassName().equals(StubDataSource.class.getName())) {
+                    final StubDataSource dataSource = new StubDataSource();
+                    dataSource.setURL((String)reference.get("url").getContent());
+                    dataSource.setUser((String)reference.get("user").getContent());
+                    dataSource.setPassword((String)reference.get("password").getContent());
+                    dataSource.setDescription((String)reference.get("description").getContent());
+
+                    CREATED_DATA_SOURCES.push(dataSource);
+
+                    return dataSource;
+                }
+            }
+            return null;
+        }
+    }
+
+    public static class StubDataSource implements DataSource {
+        public final Deque<StubConnection> createdConnections = new ArrayDeque<>();
+
+        private String url;
+        private String user;
+        private String password;
+        private String description;
+
+        @Override
+        public Connection getConnection() {
+            final StubConnection conn = new StubConnection();
+            createdConnections.push(conn);
+            return conn;
+        }
+
+        @Override
+        public Connection getConnection(final String username, final String password) {
+            final StubConnection conn = new StubConnection(username, password);
+            createdConnections.push(conn);
+            return conn;
+        }
+
+        @Override
+        public <T> T unwrap(final Class<T> iface) {
+            return null;
+        }
+
+        @Override
+        public boolean isWrapperFor(final Class<?> iface) {
+            return false;
+        }
+
+        @Override
+        public PrintWriter getLogWriter() {
+            return null;
+        }
+
+        @Override
+        public void setLogWriter(final PrintWriter out) {
+
+        }
+
+        @Override
+        public void setLoginTimeout(final int seconds) {
+
+        }
+
+        @Override
+        public int getLoginTimeout()  {
+            return 0;
+        }
+
+        @Override
+        public Logger getParentLogger() {
+            return null;
+        }
+
+        public void setURL(final String url) {
+            this.url = url;
+        }
+
+        public void setUser(final String user) {
+            this.user = user;
+        }
+
+        public void setPassword(final String password) {
+            this.password = password;
+        }
+
+        public void setDescription(final String description) {
+            this.description = description;
+        }
+    }
+
+    public static class StubConnection implements Connection {
+        private final String username;
+        private final String password;
+
+        public int closedCount = 0;
+
+        public StubConnection() {
+            this(null, null);
+        }
+
+        public StubConnection(final String username, final String password) {
+            this.username = username;
+            this.password = password;
+        }
+
+        @Override
+        public Statement createStatement() {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(final String sql) {
+            return null;
+        }
+
+        @Override
+        public CallableStatement prepareCall(final String sql) {
+            return null;
+        }
+
+        @Override
+        public String nativeSQL(final String sql) {
+            return null;
+        }
+
+        @Override
+        public void setAutoCommit(final boolean autoCommit) {
+
+        }
+
+        @Override
+        public boolean getAutoCommit() {
+            return false;
+        }
+
+        @Override
+        public void commit() {
+
+        }
+
+        @Override
+        public void rollback() {
+
+        }
+
+        @Override
+        public void close() {
+            closedCount++;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closedCount > 0;
+        }
+
+        @Override
+        public DatabaseMetaData getMetaData() {
+            return null;
+        }
+
+        @Override
+        public void setReadOnly(final boolean readOnly) {
+
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return false;
+        }
+
+        @Override
+        public void setCatalog(final String catalog) {
+
+        }
+
+        @Override
+        public String getCatalog() {
+            return null;
+        }
+
+        @Override
+        public void setTransactionIsolation(final int level) {
+
+        }
+
+        @Override
+        public int getTransactionIsolation() {
+            return Connection.TRANSACTION_NONE;
+        }
+
+        @Override
+        public SQLWarning getWarnings() {
+            return null;
+        }
+
+        @Override
+        public void clearWarnings() {
+
+        }
+
+        @Override
+        public Statement createStatement(final int resultSetType, final int resultSetConcurrency) {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(final String sql, final int resultSetType, final int resultSetConcurrency) {
+            return null;
+        }
+
+        @Override
+        public CallableStatement prepareCall(final String sql, final int resultSetType, final int resultSetConcurrency) {
+            return null;
+        }
+
+        @Override
+        public Map<String, Class<?>> getTypeMap() {
+            return null;
+        }
+
+        @Override
+        public void setTypeMap(final Map<String, Class<?>> map) {
+
+        }
+
+        @Override
+        public void setHoldability(final int holdability) {
+
+        }
+
+        @Override
+        public int getHoldability() {
+            return 0;
+        }
+
+        @Override
+        public Savepoint setSavepoint() {
+            return null;
+        }
+
+        @Override
+        public Savepoint setSavepoint(final String name) {
+            return null;
+        }
+
+        @Override
+        public void rollback(final Savepoint savepoint) {
+
+        }
+
+        @Override
+        public void releaseSavepoint(final Savepoint savepoint) {
+
+        }
+
+        @Override
+        public Statement createStatement(final int resultSetType, final int resultSetConcurrency, final int resultSetHoldability) {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(final String sql, final int resultSetType, final int resultSetConcurrency, final int resultSetHoldability) {
+            return null;
+        }
+
+        @Override
+        public CallableStatement prepareCall(final String sql, final int resultSetType, final int resultSetConcurrency, final int resultSetHoldability) {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(final String sql, final int autoGeneratedKeys) {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(final String sql, final int[] columnIndexes) {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(final String sql, final String[] columnNames) {
+            return null;
+        }
+
+        @Override
+        public Clob createClob() {
+            return null;
+        }
+
+        @Override
+        public Blob createBlob() {
+            return null;
+        }
+
+        @Override
+        public NClob createNClob() {
+            return null;
+        }
+
+        @Override
+        public SQLXML createSQLXML() {
+            return null;
+        }
+
+        @Override
+        public boolean isValid(final int timeout) {
+            return false;
+        }
+
+        @Override
+        public void setClientInfo(final String name, final String value) {
+
+        }
+
+        @Override
+        public void setClientInfo(final Properties properties) {
+
+        }
+
+        @Override
+        public String getClientInfo(final String name) {
+            return null;
+        }
+
+        @Override
+        public Properties getClientInfo() {
+            return null;
+        }
+
+        @Override
+        public Array createArrayOf(final String typeName, final Object[] elements) {
+            return null;
+        }
+
+        @Override
+        public Struct createStruct(final String typeName, final Object[] attributes) {
+            return null;
+        }
+
+        @Override
+        public void setSchema(final String schema) {
+
+        }
+
+        @Override
+        public String getSchema() {
+            return null;
+        }
+
+        @Override
+        public void abort(final Executor executor) {
+
+        }
+
+        @Override
+        public void setNetworkTimeout(final Executor executor, final int milliseconds) {
+
+        }
+
+        @Override
+        public int getNetworkTimeout() {
+            return 0;
+        }
+
+        @Override
+        public <T> T unwrap(final Class<T> iface) {
+            return null;
+        }
+
+        @Override
+        public boolean isWrapperFor(final Class<?> iface) {
+            return false;
+        }
+    }
+}

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
@@ -46,10 +46,11 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.modules.ModuleUtils;
+import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.Type;
 import org.h2.jdbcx.JdbcDataSource;
 import org.h2.jdbcx.JdbcDataSourceFactory;
 import org.junit.After;
@@ -61,18 +62,16 @@ import org.osjava.sj.loader.JndiLoader;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.xquery.modules.sql.Util.executeQuery;
 import static org.exist.xquery.modules.sql.Util.withCompiledQuery;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * SQL Connection Integration Tests.
@@ -115,26 +114,33 @@ public class JndiConnectionIT {
 
     @Test
     public void getJndiConnectionIsAutomaticallyClosed() throws EXistException, XPathException, PermissionDeniedException, IOException {
-        final String query =
+        final String mainQuery =
                 "import module namespace sql = \"http://exist-db.org/xquery/sql\";\n" +
                 "sql:get-jndi-connection(\"" + JNDI_DS_NAME + "\", \"" + h2Database.getUser() + "\", \"" + h2Database.getPassword() + "\")";
 
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        final Source source = new StringSource(query);
+        final Source mainQuerySource = new StringSource(mainQuery);
         try (final DBBroker broker = pool.getBroker();
              final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
-            // execute query
-            final Tuple2<XQueryContext, Boolean> contextAndResult = withCompiledQuery(broker, source, compiledXQuery -> {
-                final Sequence result = executeQuery(broker, compiledXQuery);
-                return Tuple(compiledXQuery.getContext(), !result.isEmpty());
+            final XQueryContext escapedMainQueryContext = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {
+                final XQueryContext mainQueryContext = mainCompiledQuery.getContext();
+
+                // execute the query
+                final Sequence result = executeQuery(broker, mainCompiledQuery);
+
+                // check that the handle for the sql connection that was created was valid
+                assertEquals(1, result.getItemCount());
+                assertTrue(result.itemAt(0) instanceof IntegerValue);
+                assertEquals(Type.LONG, result.itemAt(0).getType());
+                final long connectionHandle = result.itemAt(0).toJavaObject(long.class);
+                assertFalse(connectionHandle == 0);
+
+                return mainQueryContext;
             });
 
-            // check that the handle for the sql connection that was created is valid
-            assertTrue(contextAndResult._2);
-
-            // check the connections were closed
-            final int connectionsCount = ModuleUtils.readContextMap(contextAndResult._1, SQLModule.CONNECTIONS_CONTEXTVAR, Map::size);
+            // check the connections map is empty
+            final int connectionsCount = ModuleUtils.readContextMap(escapedMainQueryContext, SQLModule.CONNECTIONS_CONTEXTVAR, Map::size);
             assertEquals(0, connectionsCount);
 
             transaction.commit();
@@ -143,42 +149,66 @@ public class JndiConnectionIT {
 
     @Test
     public void getJndiConnectionFromModuleIsAutomaticallyClosed() throws EXistException, XPathException, PermissionDeniedException, IOException, LockException, TriggerException {
-        final String module =
+        final String moduleQuery =
                 "module namespace mymodule = \"http://mymodule.com\";\n" +
                 "import module namespace sql = \"http://exist-db.org/xquery/sql\";\n" +
                 "declare function mymodule:get-handle() {\n" +
                 "    sql:get-jndi-connection(\"" + JNDI_DS_NAME + "\", \"" + h2Database.getUser() + "\", \"" + h2Database.getPassword() + "\")\n" +
                 "};\n";
+        final Source moduleQuerySource = new StringSource(moduleQuery);
 
-        final String query =
+        final String mainQuery =
                 "import module namespace mymodule = \"http://mymodule.com\" at \"xmldb:exist:///db/mymodule.xqm\";\n" +
                 "mymodule:get-handle()";
+        final Source mainQuerySource = new StringSource(mainQuery);
 
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
-        final Source source = new StringSource(query);
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
              final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // store module
-            final byte[] moduleData = module.getBytes(UTF_8);
-            try (final ByteArrayInputStream bais = new ByteArrayInputStream(moduleData)) {
+            try (final InputStream is = moduleQuerySource.getInputStream()) {
                 try (final Collection collection = broker.openCollection(XmldbURI.create("/db"), Lock.LockMode.WRITE_LOCK)) {
-                    collection.addBinaryResource(transaction, broker, XmldbURI.create("mymodule.xqm"), bais, "application/xquery", moduleData.length);
+                    collection.addBinaryResource(transaction, broker, XmldbURI.create("mymodule.xqm"), is, "application/xquery", -1);
                 }
             }
 
-            // execute query
-            final Tuple2<XQueryContext, Boolean> contextAndResult = withCompiledQuery(broker, source, compiledXQuery -> {
-                final Sequence result = executeQuery(broker, compiledXQuery);
-                return Tuple(compiledXQuery.getContext(), !result.isEmpty());
+            final Tuple2<XQueryContext, ModuleContext> escapedContexts = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {
+                final XQueryContext mainQueryContext = mainCompiledQuery.getContext();
+
+                // get the context of the library module
+                final Module[] libraryModules = mainQueryContext.getModules("http://mymodule.com");
+                assertEquals(1, libraryModules.length);
+                assertTrue(libraryModules[0] instanceof ExternalModule);
+                final ExternalModule libraryModule = (ExternalModule) libraryModules[0];
+                final XQueryContext libraryQueryContext = libraryModule.getContext();
+                assertTrue(libraryQueryContext instanceof ModuleContext);
+
+                // execute the query
+                final Sequence result = executeQuery(broker, mainCompiledQuery);
+
+                // check that the handle for the sql connection that was created was valid
+                assertEquals(1, result.getItemCount());
+                assertTrue(result.itemAt(0) instanceof IntegerValue);
+                assertEquals(Type.LONG, result.itemAt(0).getType());
+                final long connectionHandle = result.itemAt(0).toJavaObject(long.class);
+                assertFalse(connectionHandle == 0);
+
+                // intentionally escape the contexts from the lambda
+                return Tuple(mainQueryContext, (ModuleContext) libraryQueryContext);
             });
 
-            // check that the handle for the sql connection that was created is valid
-            assertTrue(contextAndResult._2);
+            final XQueryContext escapedMainQueryContext = escapedContexts._1;
+            final ModuleContext escapedLibraryQueryContext = escapedContexts._2;
+            assertTrue(escapedMainQueryContext != escapedLibraryQueryContext);
 
-            // check the connections were closed
-            final int connectionsCount = ModuleUtils.readContextMap(contextAndResult._1, SQLModule.CONNECTIONS_CONTEXTVAR, Map::size);
-            assertEquals(0, connectionsCount);
+            // check the connections were closed in the main module
+            final int mainConnectionsCount = ModuleUtils.readContextMap(escapedMainQueryContext, SQLModule.CONNECTIONS_CONTEXTVAR, Map::size);
+            assertEquals(0, mainConnectionsCount);
+
+            // check the connections were closed in the library module
+            final int libraryConnectionsCount = ModuleUtils.readContextMap(escapedLibraryQueryContext, SQLModule.CONNECTIONS_CONTEXTVAR, Map::size);
+            assertEquals(0, libraryConnectionsCount);
 
             transaction.commit();
         }

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
@@ -32,7 +32,6 @@
  */
 package org.exist.xquery.modules.sql;
 
-import com.evolvedbinary.j8fu.function.Function2E;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
@@ -42,15 +41,12 @@ import org.exist.source.Source;
 import org.exist.source.StringSource;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.XQueryPool;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
 import org.exist.xmldb.XmldbURI;
-import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XPathException;
-import org.exist.xquery.XQuery;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.modules.ModuleUtils;
 import org.exist.xquery.value.Sequence;
@@ -73,6 +69,8 @@ import java.util.Properties;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.exist.xquery.modules.sql.Util.executeQuery;
+import static org.exist.xquery.modules.sql.Util.withCompiledQuery;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -184,45 +182,5 @@ public class JndiConnectionIT {
 
             transaction.commit();
         }
-    }
-
-    private Sequence executeQuery(final DBBroker broker, final CompiledXQuery compiledXQuery) throws PermissionDeniedException, XPathException {
-        final BrokerPool pool = broker.getBrokerPool();
-        final XQuery xqueryService = pool.getXQueryService();
-        return xqueryService.execute(broker, compiledXQuery, null, new Properties());
-    }
-
-    private <T> T withCompiledQuery(final DBBroker broker, final Source source, final Function2E<CompiledXQuery, T, XPathException, PermissionDeniedException> op) throws XPathException, PermissionDeniedException, IOException {
-        final BrokerPool pool = broker.getBrokerPool();
-        final XQuery xqueryService = pool.getXQueryService();
-        final XQueryPool xqueryPool = pool.getXQueryPool();
-        final CompiledXQuery compiledQuery = compileQuery(broker, xqueryService, xqueryPool, source);
-        try {
-            return op.apply(compiledQuery);
-        } finally {
-            if (compiledQuery != null) {
-                xqueryPool.returnCompiledXQuery(source, compiledQuery);
-            }
-        }
-    }
-
-    private CompiledXQuery compileQuery(final DBBroker broker, final XQuery xqueryService, final XQueryPool xqueryPool, final Source query) throws PermissionDeniedException, XPathException, IOException {
-        CompiledXQuery compiled = xqueryPool.borrowCompiledXQuery(broker, query);
-        XQueryContext context;
-        if (compiled == null) {
-            context = new XQueryContext(broker.getBrokerPool());
-        } else {
-            context = compiled.getContext();
-            context.prepareForReuse();
-        }
-
-        if (compiled == null) {
-            compiled = xqueryService.compile(broker, context, query);
-        } else {
-            compiled.getContext().updateContext(context);
-            context.getWatchDog().reset();
-        }
-
-        return compiled;
     }
 }


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/3889

Previously Library Modules were reset with the wrong context, i.e. they were provided with the Main Module's context and not the Library Module's Context.
This meant that not all resources stored in context variables were correctly cleaned up, therefore leaking resources and memory. In addition *reset* was previously called more than once for the same module which was unnecessary; therefore we should also see a small performance improvement from this fix.

Many thanks to @xatapult and @pieterlamers for their patience in reporting this and helping to track down the issue.
As a result all SQL Connections should now also be correctly and implicitly closed when a query finishes execution.