### PR TITLE
[feature] Remove IPrange filter to be deployed automagically.

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -271,12 +271,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
+        <!--dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>exist-security-iprange</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
-        </dependency>
+        </dependency-->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>exist-security-ldap</artifactId>
@@ -766,7 +766,7 @@
                             <systemProperty>file.encoding=UTF-8</systemProperty>
                             <systemProperty>log4j.configurationFile=@BASEDIR@/etc/log4j2.xml</systemProperty>
                             <systemProperty>exist.home=@BASEDIR@</systemProperty>
-                            <systemProperty>exist.configurationFile=@BASEDIR@/etc/conf.xml</systemProperty>
+                            <systemProperty>exist.configurationFile=@cd BASEDIR@/etc/conf.xml</systemProperty>
                             <systemProperty>jetty.home=@BASEDIR@</systemProperty>
                             <systemProperty>exist.jetty.config=@BASEDIR@/etc/jetty/standard.enabled-jetty-configs</systemProperty>
                         </systemProperties>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -766,7 +766,7 @@
                             <systemProperty>file.encoding=UTF-8</systemProperty>
                             <systemProperty>log4j.configurationFile=@BASEDIR@/etc/log4j2.xml</systemProperty>
                             <systemProperty>exist.home=@BASEDIR@</systemProperty>
-                            <systemProperty>exist.configurationFile=@cd BASEDIR@/etc/conf.xml</systemProperty>
+                            <systemProperty>exist.configurationFile=@BASEDIR@/etc/conf.xml</systemProperty>
                             <systemProperty>jetty.home=@BASEDIR@</systemProperty>
                             <systemProperty>exist.jetty.config=@BASEDIR@/etc/jetty/standard.enabled-jetty-configs</systemProperty>
                         </systemProperties>


### PR DESCRIPTION
running `bin/start.sh`

```
25 May 2021 22:45:06,742 [main] INFO  (JettyStart.java [run]:287) - ----------------------------------------------------- 
25 May 2021 22:45:06,742 [main] INFO  (JettyStart.java [run]:288) - Server has started, listening on: 
25 May 2021 22:45:06,742 [main] INFO  (JettyStart.java [run]:290) - http://127.0.0.1:8080/ 
25 May 2021 22:45:06,742 [main] INFO  (JettyStart.java [run]:290) - https://127.0.0.1:8443/ 
25 May 2021 22:45:06,743 [main] INFO  (JettyStart.java [run]:293) - Configured contexts: 
25 May 2021 22:45:06,743 [main] INFO  (JettyStart.java [run]:299) - /exist (eXist XML Database) 
25 May 2021 22:45:06,744 [main] INFO  (JettyStart.java [run]:299) - / (eXist-db portal) 
25 May 2021 22:45:06,745 [main] INFO  (JettyStart.java [run]:323) - ----------------------------------------------------- 
```

the 2 lines with configured contexts for this filter have disappeared! 