### PR TITLE
fix(ci): add J16 and allow failures

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -10,7 +10,7 @@ jobs:
         jdk: ['8', '11']
         include:
           - os: ubuntu-latest
-            jdk: '15'        
+            jdk: '16'   
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -26,5 +26,10 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 # NOTE(AR) The `-T 2C` enables multi-threaded builds below, faster, but may need to be disabled when diagnosing problems 
 # NOTE(DP): Reuse of build artefacts across workflows to (hopefully) limit network traffic
+      - name: Maven Build allow fail
+        if: ${{ matrix.jdk == '16' }}
+        run: mvn -V -B -q -T 2C -DskipTests=true "-Dmaven.javadoc.skip=true" install
+        continue-on-error: true
       - name: Maven Build
+        if: ${{ matrix.jdk != '16' }} 
         run: mvn -V -B -q -T 2C -DskipTests=true "-Dmaven.javadoc.skip=true" install

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -5,7 +5,7 @@ jobs:
     name: ${{ matrix.jdk }} Javadocs 
     strategy:
       matrix: 
-        jdk: ['11', '16']
+        jdk: ['8','11', '16']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,6 +22,10 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven Javadoc
+        if: ${{ matrix.jdk == '8' }} 
         run: mvn -V -B -q -T 2C javadoc:javadoc
-        continue-on-error: true
+      - name: Maven Javadoc allow fail
+        if: ${{ matrix.jdk != '8' }} 
+        run: mvn -V -B -q -T 2C javadoc:javadoc
+        continue-on-error: true  
         

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -2,16 +2,19 @@ name: Javadoc
 on: [push, pull_request]
 jobs:
   test:
-    name: Generate Javadocs
+    name: ${{ matrix.jdk }} Javadocs 
+    strategy:
+      matrix: 
+        jdk: ['11', '16']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
             fetch-depth: 0
-      - name: Set up JDK 8
+      - name: Set up JDK 
         uses: actions/setup-java@v1
         with:
-          java-version: '8'
+          java-version: ${{ matrix.jdk }}
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
@@ -19,4 +22,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven Javadoc
-        run: mvn -V -B -q -T 2C javadoc:javadoc    
+        run: mvn -V -B -q -T 2C javadoc:javadoc
+        continue-on-error: true
+        

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,7 @@ jobs:
         jdk: ['8', '11']
         include:
           - os: ubuntu-latest
-            jdk: '15'        
+            jdk: '16'      
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -24,8 +24,13 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Maven Test
+      - name: Maven Test allow fail
+        if: ${{ matrix.jdk == '16' }} 
         run: mvn -V -B clean verify
+        continue-on-error: true
+      - name: Maven Test 
+        if: ${{ matrix.jdk != '16' }} 
+        run: mvn -V -B clean verify    
       - name: Maven Code Coverage
         if: ${{ github.ref == 'refs/heads/develop' && matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
         env:


### PR DESCRIPTION
Drop J15, build and test on J16. Failures will not impact the overall result if they occur on J16 (yet). 
Build javadocs on J11 and J16 both are failing, ignore all failures of doc building, we still get the news of whats wrong.

I dropped J8 from the docs, as these haven't been deployed anywhere from what i could tell, correct me if i m wrong. 

supsersedes #3840