### PR TITLE
Update Apache XML-RPC

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -346,7 +346,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.xmlrpc</groupId>
+            <groupId>com.evolvedbinary.thirdparty.org.apache.xmlrpc</groupId>
             <artifactId>xmlrpc-common</artifactId>
             <exclusions>
                 <exclusion> <!-- conflicts with xerces 2.12.0 dependency on xml-apis version 1.4.01 -->
@@ -356,12 +356,12 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.xmlrpc</groupId>
+            <groupId>com.evolvedbinary.thirdparty.org.apache.xmlrpc</groupId>
             <artifactId>xmlrpc-client</artifactId>
             <version>${apache.xmlrpc.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.xmlrpc</groupId>
+            <groupId>com.evolvedbinary.thirdparty.org.apache.xmlrpc</groupId>
             <artifactId>xmlrpc-server</artifactId>
             <version>${apache.xmlrpc.version}</version>
         </dependency>
@@ -679,6 +679,8 @@
                                 <exclude>src/main/java/org/exist/util/CollectionOfArrayIterator.java</exclude>
                                 <exclude>src/test/java/org/exist/util/CollectionOfArrayIteratorTest.java</exclude>
                                 <exclude>src/main/java/org/exist/util/IPUtil.java</exclude>
+                                <exclude>src/main/java/org/exist/xmlrpc/ACEAiderParser.java</exclude>
+                                <exclude>src/main/java/org/exist/xmlrpc/ACEAiderSerializer.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/Cardinality.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/ImportModuleTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/XQueryContextAttributesTest.java</exclude>
@@ -822,6 +824,8 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/main/java/org/exist/util/CollectionOfArrayIterator.java</include>
                                 <include>src/test/java/org/exist/util/CollectionOfArrayIteratorTest.java</include>
                                 <include>src/main/java/org/exist/util/IPUtil.java</include>
+                                <include>src/main/java/org/exist/xmlrpc/ACEAiderParser.java</include>
+                                <include>src/main/java/org/exist/xmlrpc/ACEAiderSerializer.java</include>
                                 <include>src/main/java/org/exist/xquery/Cardinality.java</include>
                                 <include>src/test/java/org/exist/xquery/ImportModuleTest.java</include>
                                 <include>src/test/java/org/exist/xquery/XQueryContextAttributesTest.java</include>

--- a/exist-core/src/main/java/org/exist/management/TaskStatus.java
+++ b/exist-core/src/main/java/org/exist/management/TaskStatus.java
@@ -21,7 +21,6 @@
  */
 package org.exist.management;
 
-import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -32,9 +31,7 @@ import javax.management.openmbean.CompositeType;
 import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.SimpleType;
 
-public class TaskStatus implements Serializable {
-
-    private static final long serialVersionUID = -8405783622910875893L;
+public class TaskStatus {
 
     public enum Status {
         NA, NEVER_RUN, INIT, PAUSED, STOPPED_OK, STOPPED_ERROR, RUNNING_CHECK, RUNNING_BACKUP,

--- a/exist-core/src/main/java/org/exist/security/internal/aider/ACEAider.java
+++ b/exist-core/src/main/java/org/exist/security/internal/aider/ACEAider.java
@@ -21,7 +21,6 @@
  */
 package org.exist.security.internal.aider;
 
-import java.io.Serializable;
 import org.exist.security.ACLPermission.ACE_ACCESS_TYPE;
 import org.exist.security.ACLPermission.ACE_TARGET;
 
@@ -29,7 +28,7 @@ import org.exist.security.ACLPermission.ACE_TARGET;
  *
  * @author <a href="mailto:adam@exist-db.org">Adam Retter</a>
  */
-public class ACEAider implements Serializable {
+public class ACEAider {
     private ACE_ACCESS_TYPE accessType;
     private ACE_TARGET target;
     private String who;

--- a/exist-core/src/main/java/org/exist/xmlrpc/ACEAiderParser.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/ACEAiderParser.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xmlrpc;
+
+import org.apache.ws.commons.util.NamespaceContextImpl;
+import org.apache.xmlrpc.common.TypeFactory;
+import org.apache.xmlrpc.common.XmlRpcStreamConfig;
+import org.apache.xmlrpc.parser.RecursiveTypeParserImpl;
+import org.exist.security.ACLPermission.ACE_ACCESS_TYPE;
+import org.exist.security.ACLPermission.ACE_TARGET;
+import org.exist.security.internal.aider.ACEAider;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * XML-RPC type parser for objects of
+ * {@link org.exist.security.internal.aider.ACEAider}.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+class ACEAiderParser extends RecursiveTypeParserImpl {
+    private int level = 0;
+    private List<Object> list;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param context The namespace context.
+     * @param config  The request or response configuration.
+     * @param factory The type factory.
+     */
+    ACEAiderParser(final XmlRpcStreamConfig config, final NamespaceContextImpl context, final TypeFactory factory) {
+        super(config, context, factory);
+    }
+
+    @Override
+    public void startDocument() throws SAXException {
+        level = 0;
+        list = new ArrayList<>();
+        super.startDocument();
+    }
+
+    @Override
+    protected void addResult(final Object value) {
+        list.add(value);
+    }
+
+    @Override
+    public void endElement(final String uri, final String localName, final String qname) throws SAXException {
+        switch (--level) {
+            case 0:
+                setResult(toAceAider(list));
+                break;
+            case 1:
+                break;
+            case 2:
+                endValueTag();
+                break;
+            default:
+                super.endElement(uri, localName, qname);
+        }
+    }
+
+    @Override
+    public void startElement(final String uri, final String localName, final String qname, final Attributes attrs) throws SAXException {
+        switch (level++) {
+            case 0:
+                if (!XMLConstants.NULL_NS_URI.equals(uri) || !ACEAiderSerializer.ACEAIDER_TAG.equals(localName)) {
+                    throw new SAXParseException("Expected aceAider element, got "
+                            + new QName(uri, localName),
+                            getDocumentLocator());
+                }
+                break;
+            case 1:
+                if (!XMLConstants.NULL_NS_URI.equals(uri) || !ACEAiderSerializer.DATA_TAG.equals(localName)) {
+                    throw new SAXParseException("Expected data element, got "
+                            + new QName(uri, localName),
+                            getDocumentLocator());
+                }
+                break;
+            case 2:
+                if (!XMLConstants.NULL_NS_URI.equals(uri) || !ACEAiderSerializer.VALUE_TAG.equals(localName)) {
+                    throw new SAXParseException("Expected value element, got "
+                            + new QName(uri, localName),
+                            getDocumentLocator());
+                }
+                startValueTag();
+                break;
+            default:
+                super.startElement(uri, localName, qname, attrs);
+                break;
+        }
+    }
+
+    private static ACEAider toAceAider(final List<Object> list) throws SAXException {
+        if (list.size() != 4) {
+            throw new SAXException("Inavlis list size for ACEAider");
+        }
+
+        Object object = list.get(0);
+        final ACE_ACCESS_TYPE aceAccessType;
+        if (object instanceof String) {
+            try {
+                aceAccessType = ACE_ACCESS_TYPE.valueOf((String) object);
+            } catch (final IllegalArgumentException e) {
+                throw new SAXException(e);
+            }
+        } else {
+            throw new SAXException("Expected ACE_ACCESS_TYPE");
+        }
+
+        object = list.get(1);
+        final ACE_TARGET aceTarget;
+        if (object instanceof String) {
+            try {
+                aceTarget = ACE_TARGET.valueOf((String) object);
+            } catch (final IllegalArgumentException e) {
+                throw new SAXException(e);
+            }
+        } else {
+            throw new SAXException("Expected ACE_TARGET");
+        }
+
+        object = list.get(2);
+        final String aceWho;
+        if (object instanceof String) {
+            aceWho = (String) object;
+        } else {
+            throw new SAXException("Expected String");
+        }
+
+        object = list.get(3);
+        final int aceMode;
+        if (object instanceof Integer) {
+            aceMode = (Integer) object;
+        } else {
+            throw new SAXException("Expected Integer");
+        }
+
+        return new ACEAider(aceAccessType, aceTarget, aceWho, aceMode);
+    }
+}

--- a/exist-core/src/main/java/org/exist/xmlrpc/ACEAiderSerializer.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/ACEAiderSerializer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xmlrpc;
+
+import org.apache.xmlrpc.common.TypeFactory;
+import org.apache.xmlrpc.common.XmlRpcStreamConfig;
+import org.apache.xmlrpc.serializer.TypeSerializer;
+import org.apache.xmlrpc.serializer.TypeSerializerImpl;
+import org.exist.security.internal.aider.ACEAider;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+/**
+ * XML-RPC type serializer for objects of
+ * {@link org.exist.security.internal.aider.ACEAider}.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+class ACEAiderSerializer extends TypeSerializerImpl {
+    static final String ACEAIDER_TAG = "aceAider";
+    static final String DATA_TAG = "data";
+
+    private final TypeFactory typeFactory;
+    private final XmlRpcStreamConfig config;
+
+    ACEAiderSerializer(final TypeFactory typeFactory, final XmlRpcStreamConfig config) {
+        this.typeFactory = typeFactory;
+        this.config = config;
+    }
+
+    private void writeObject(final ContentHandler handler, final Object object) throws SAXException {
+        final TypeSerializer ts = typeFactory.getSerializer(config, object);
+        if (ts == null) {
+            throw new SAXException("Unsupported Java type: " + object.getClass().getName());
+        }
+        ts.write(handler, object);
+    }
+
+    private void writeData(final ContentHandler handler, final Object object) throws SAXException {
+        final ACEAider aceAider = (ACEAider) object;
+        writeObject(handler, aceAider.getAccessType().name());
+        writeObject(handler, aceAider.getTarget().name());
+        writeObject(handler, aceAider.getWho());
+        writeObject(handler, aceAider.getMode());
+    }
+
+    @Override
+    public void write(final ContentHandler pHandler, final Object pObject) throws SAXException {
+        pHandler.startElement("", VALUE_TAG, VALUE_TAG, ZERO_ATTRIBUTES);
+        pHandler.startElement("", ACEAIDER_TAG, ACEAIDER_TAG, ZERO_ATTRIBUTES);
+        pHandler.startElement("", DATA_TAG, DATA_TAG, ZERO_ATTRIBUTES);
+        writeData(pHandler, pObject);
+        pHandler.endElement("", DATA_TAG, DATA_TAG);
+        pHandler.endElement("", ACEAIDER_TAG, ACEAIDER_TAG);
+        pHandler.endElement("", VALUE_TAG, VALUE_TAG);
+    }
+}

--- a/exist-core/src/main/java/org/exist/xmlrpc/ExistRpcTypeFactory.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/ExistRpcTypeFactory.java
@@ -28,6 +28,7 @@ import org.apache.xmlrpc.common.XmlRpcController;
 import org.apache.xmlrpc.common.XmlRpcStreamConfig;
 import org.apache.xmlrpc.parser.TypeParser;
 import org.apache.xmlrpc.serializer.TypeSerializer;
+import org.exist.security.internal.aider.ACEAider;
 import org.xml.sax.SAXException;
 
 /**
@@ -45,6 +46,10 @@ public class ExistRpcTypeFactory extends TypeFactoryImpl {
     public TypeParser getParser(final XmlRpcStreamConfig config, final NamespaceContextImpl context, final String uri, final String localName) {
         if (TupleSerializer.TUPLE_TAG.equals(localName)) {
             return new TupleParser(config, context, this);
+
+        } else if (ACEAiderSerializer.ACEAIDER_TAG.equals(localName)) {
+            return new ACEAiderParser(config, context, this);
+
         } else {
             return super.getParser(config, context, uri, localName);
         }
@@ -54,6 +59,10 @@ public class ExistRpcTypeFactory extends TypeFactoryImpl {
     public TypeSerializer getSerializer(final XmlRpcStreamConfig config, final Object object) throws SAXException {
         if (object instanceof Tuple) {
             return new TupleSerializer(this, config);
+
+        } else if (object instanceof ACEAider) {
+            return new ACEAiderSerializer(this, config);
+
         } else {
             return super.getSerializer(config, object);
         }

--- a/exist-core/src/main/java/org/exist/xmlrpc/TupleParser.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/TupleParser.java
@@ -90,22 +90,22 @@ class TupleParser extends RecursiveTypeParserImpl {
     public void startElement(final String uri, final String localName, final String qname, final Attributes attrs) throws SAXException {
         switch (level++) {
             case 0:
-                if (!XMLConstants.NULL_NS_URI.equals(uri)  ||  !TupleSerializer.TUPLE_TAG.equals(localName)) {
+                if (!XMLConstants.NULL_NS_URI.equals(uri) || !TupleSerializer.TUPLE_TAG.equals(localName)) {
                     throw new SAXParseException("Expected tuple element, got "
                             + new QName(uri, localName),
                             getDocumentLocator());
                 }
                 break;
             case 1:
-                if (!XMLConstants.NULL_NS_URI.equals(uri)  ||  !TupleSerializer.DATA_TAG.equals(localName)) {
+                if (!XMLConstants.NULL_NS_URI.equals(uri) || !TupleSerializer.DATA_TAG.equals(localName)) {
                     throw new SAXParseException("Expected data element, got "
                             + new QName(uri, localName),
                             getDocumentLocator());
                 }
                 break;
             case 2:
-                if (!XMLConstants.NULL_NS_URI.equals(uri)  ||  !TypeSerializerImpl.VALUE_TAG.equals(localName)) {
-                    throw new SAXParseException("Expected data element, got "
+                if (!XMLConstants.NULL_NS_URI.equals(uri) || !TypeSerializerImpl.VALUE_TAG.equals(localName)) {
+                    throw new SAXParseException("Expected value element, got "
                             + new QName(uri, localName),
                             getDocumentLocator());
                 }

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -103,7 +103,7 @@
         <ant.version>1.10.12</ant.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
         <apache.httpcomponents.core.version>4.4.15</apache.httpcomponents.core.version>
-        <apache.xmlrpc.version>3.1.3</apache.xmlrpc.version>
+        <apache.xmlrpc.version>4.0.0</apache.xmlrpc.version>
         <aspectj.version>1.9.8.M1</aspectj.version>
         <exquery.distribution.version>0.2.0</exquery.distribution.version>
         <icu.version>59.1</icu.version>
@@ -263,7 +263,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.xmlrpc</groupId>
+                <groupId>com.evolvedbinary.thirdparty.org.apache.xmlrpc</groupId>
                 <artifactId>xmlrpc-common</artifactId>
                 <version>${apache.xmlrpc.version}</version>
                 <exclusions>


### PR DESCRIPTION
Update to Apache XML-RPC with latest Security Patches from Evolved Binary.
Addresses CVE-2019-17570 and CVE-2016-5002

**Note** - This PR changes XML-RPC API (and therefore also the XML:DB remote API).

Previously eXist-db was relying on the in-built Java Serialization for communicating ACL's, unfortunately that facility is inherently insecure. This PR now adds a custom XML-RPC Serializer and Parser for ACLs to ensure this is secure; the upshot is that the wire-protocol has to change to support this. This means users of the XML-RPC and XML:DB APIs (e.g. Java Admin Client, oXygen XML Editor, etc) will need to upgrade their libraries as this is not backwards compatible.

Closes https://github.com/eXist-db/exist/issues/3063
