### PR TITLE
[feat] change packages bundled with existdb

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -671,16 +671,13 @@
                                     <abbrev>monex</abbrev>
                                 </package>
                                 <package>
-                                    <abbrev>markdown</abbrev>
-                                </package>
-                                <package>
                                     <abbrev>packageservice</abbrev>
                                 </package>
                                 <package>
                                     <abbrev>semver-xq</abbrev>
                                 </package>
                                 <package>
-                                    <abbrev>shared</abbrev>
+                                    <abbrev>templating</abbrev>
                                 </package>
                             </packages>
                         </configuration>


### PR DESCRIPTION
- remove **markdown** and **shared** package
  there is no longer a bundle app that depends on it
- add new dependency to **templating** library module used by most of
  the bundled application packages
