### PR TITLE
[hotfix] use DiskFileItemFactory default threshhold

### DIFF
--- a/exist-core/src/main/java/org/exist/http/servlets/HttpRequestWrapper.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/HttpRequestWrapper.java
@@ -186,9 +186,6 @@ public class HttpRequestWrapper implements RequestWrapper {
         // Create a factory for disk-based file items
         final DiskFileItemFactory factory = new DiskFileItemFactory();
 
-        // Dizzzz: Wonder why this should be zero
-        factory.setSizeThreshold(0);
-
         // Create a new file upload handler
         final ServletFileUpload upload = new ServletFileUpload(factory);
 


### PR DESCRIPTION
This could improve performance when uploading a large number of smaller files by reducing IO traffic.

Even after running instances with this patch applied we could see no negative effects. And less code is always less code to maintain.

The below assumption was not reproducible in our testing.
~~Setting the SizeThreshhold to a low value can lead to
Unexpected EOF errors when decoding  multipart messages.~~
