### PR TITLE
[hotfix] fix docker pom (manual rollback)

### DIFF
--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.1-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 


### PR DESCRIPTION
Revert the pom.xml of exist-docker to its state before the botched release.
`mvn release:rollback` did not catch it.
