### PR TITLE
Only run the github-release-plugin when mvn release:perform is performed

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -1066,39 +1066,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>de.jutzig</groupId>
-                <artifactId>github-release-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>github-upload</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>release</goal>
-                        </goals>
-                        <inherited>false</inherited>
-                        <configuration>
-                            <description>
-                                Release Notes: https://exist-db.org/exist/apps/wiki/blogs/eXist/exist${project.version}
-
-                                Maven Central: https://search.maven.org/search?q=g:org.exist-db
-                            </description>
-                            <releaseName>eXist-db ${project.version}</releaseName>
-                            <tag>eXist-${project.version}</tag>
-                            <fileSets>
-                                <fileSet>
-                                    <directory>${project.build.directory}</directory>
-                                    <includes>
-                                        <include>eXist-db-${project.version}.dmg</include>
-                                        <include>${project.artifactId}-${project.version}-unix.tar.bz2</include>
-                                        <include>${project.artifactId}-${project.version}-win.zip</include>
-                                    </includes>
-                                </fileSet>
-                            </fileSets>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -1277,6 +1244,49 @@
                                         <argument>${mac.codesign.identity}</argument>
                                         <argument>${mac.dmg}</argument>
                                     </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <!-- NOTE: this is activated by the maven-release-plugin -->
+            <id>exist-release</id>
+            <build>
+                <plugins>
+                    <!-- This is needed in a profile to workaround https://github.com/jutzig/github-release-plugin/issues/50 -->
+                    <plugin>
+                        <groupId>de.jutzig</groupId>
+                        <artifactId>github-release-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>github-upload</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>release</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <description>
+                                        Release Notes: https://exist-db.org/exist/apps/wiki/blogs/eXist/exist${project.version}
+
+                                        Maven Central: https://search.maven.org/search?q=g:org.exist-db
+                                    </description>
+                                    <releaseName>eXist-db ${project.version}</releaseName>
+                                    <tag>eXist-${project.version}</tag>
+                                    <fileSets>
+                                        <fileSet>
+                                            <directory>${project.build.directory}</directory>
+                                            <includes>
+                                                <include>eXist-db-${project.version}.dmg</include>
+                                                <include>${project.artifactId}-${project.version}-unix.tar.bz2</include>
+                                                <include>${project.artifactId}-${project.version}-win.zip</include>
+                                            </includes>
+                                        </fileSet>
+                                    </fileSets>
                                 </configuration>
                             </execution>
                         </executions>

--- a/exist-installer/pom.xml
+++ b/exist-installer/pom.xml
@@ -135,37 +135,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>de.jutzig</groupId>
-                <artifactId>github-release-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>github-upload</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>release</goal>
-                        </goals>
-                        <inherited>true</inherited>
-                        <configuration>
-                            <description>
-                                Release Notes: https://exist-db.org/exist/apps/wiki/blogs/eXist/exist${project.version}
-
-                                Maven Central: https://search.maven.org/search?q=g:org.exist-db
-                            </description>
-                            <releaseName>eXist-db ${project.version}</releaseName>
-                            <tag>eXist-${project.version}</tag>
-                            <fileSets>
-                                <fileSet>
-                                    <directory>${project.build.directory}</directory>
-                                    <includes>
-                                        <include>${project.artifactId}-${project.version}.jar</include>
-                                    </includes>
-                                </fileSet>
-                            </fileSets>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -194,6 +163,47 @@
                                     <storepass>${existdb.release.keystore.pass}</storepass>
                                     <alias>${existdb.release.keystore.key.alias}</alias>
                                     <keypass>${existdb.release.keystore.key.pass}</keypass>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <!-- NOTE: this is activated by the maven-release-plugin -->
+            <id>exist-release</id>
+            <build>
+                <plugins>
+                    <!-- This is needed in a profile to workaround https://github.com/jutzig/github-release-plugin/issues/50 -->
+                    <plugin>
+                        <groupId>de.jutzig</groupId>
+                        <artifactId>github-release-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>github-upload</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>release</goal>
+                                </goals>
+                                <inherited>true</inherited>
+                                <configuration>
+                                    <description>
+                                        Release Notes: https://exist-db.org/exist/apps/wiki/blogs/eXist/exist${project.version}
+
+                                        Maven Central: https://search.maven.org/search?q=g:org.exist-db
+                                    </description>
+                                    <releaseName>eXist-db ${project.version}</releaseName>
+                                    <tag>eXist-${project.version}</tag>
+                                    <fileSets>
+                                        <fileSet>
+                                            <directory>${project.build.directory}</directory>
+                                            <includes>
+                                                <include>${project.artifactId}-${project.version}.jar</include>
+                                            </includes>
+                                        </fileSet>
+                                    </fileSets>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This stoped the github-release-plugin trying to publish `SNAPSHOT`s to GitHub Releases. This should fix the problem with the Nightly Builds service.