### PR TITLE
Update Homebrew release notes

### DIFF
--- a/exist-ant/pom.xml
+++ b/exist-ant/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/exist-core-jcstress/pom.xml
+++ b/exist-core-jcstress/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/exist-installer/pom.xml
+++ b/exist-installer/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/exist-jetty-config/pom.xml
+++ b/exist-jetty-config/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.exist-db</groupId>
     <artifactId>exist-parent</artifactId>
-    <version>5.3.0</version>
+    <version>5.3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>eXist-db Parent</name>
@@ -61,7 +61,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <mailingLists>

--- a/exist-samples/pom.xml
+++ b/exist-samples/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/exist-service/pom.xml
+++ b/exist-service/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/exist-start/pom.xml
+++ b/exist-start/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/exist-versioning-release.md
+++ b/exist-versioning-release.md
@@ -296,30 +296,17 @@ Central (staging), Docker images to Docker Hub, and eXist-db distributions and i
 
 
 ### Releasing to Homebrew
-[Homebrew](http://brew.sh) is a popular command-line package manager for macOS. Once Homebrew is installed, applications like eXist can be installed via a simple command. eXist's presence on Homebrew is found in the Caskroom project, as a "cask", at [https://github.com/caskroom/homebrew-cask/blob/master/Casks/exist-db.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/exist-db.rb).
+[Homebrew](https://brew.sh) is a popular command-line package manager for macOS. Once Homebrew is installed, eXist can be installed via the simple command, `brew install exist-db`. eXist's "cask" can be viewed at  https://github.com/Homebrew/homebrew-cask/blob/master/Casks/exist-db.rb.
 
-> **Terminology:** "Caskroom" is the Homebrew extension project where pre-built binaries and GUI applications go, whereas the original "Homebrew" project is reserved for command-line utilities that can be built from source. Because the macOS version of eXist is released as an app bundle with GUI components, it is distributed via Caskroom.
+> **Terminology:** "Homebrew Cask" is the segment of Homebrew where pre-built binaries and GUI applications go, whereas the original "Homebrew" project is reserved for command-line utilities that can be built from source. Because the macOS version of eXist is released as an app bundle with GUI components, it is handled as a Homebrew Cask.
 
-When there is a new release of eXist, a member of the community can submit a pull request with the necessary changes to the eXist cask. [Follow the directions on the Homebrew-cask Github](https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask) - summarized here adapted to OpenRefine:
-
-```
-# install and setup script - only needed once
-brew install vitorgalvao/tiny-scripts/cask-repair
-cask-repair --help
-
-# use to update eXist
-cask-repair exist-db
-```
-
-The cask-repair tool will prompt you to enter the new version number. It will then use this version number to construct a download URL using the formula (where `{version}` represents the version number):
+When there is a new release of eXist, a member of the community can submit a pull request with the necessary changes to the eXist-db cask. Follow the directions on [the Homebrew Cask CONTRIBUTING page](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md). But basically, it's a one-line command. For example, to update eXist to version 5.3.0, use this command:
 
 ```
-https://github.com/eXist-db/exist/releases/download/eXist-{version}/eXist-db-{version}.dmg
+brew bump-cask-pr --version 5.3.0 exist-db
 ```
 
-**Note:** It is important that both version number components (the tag and version number) match, so that the formula can find the installer's URL.
-
-Once cask-repair has successfully downloaded the new installer, it will calculate the new SHA-256 fingerprint value and construct a pull request, like this one: [https://github.com/caskroom/homebrew-cask/pull/42509](https://github.com/caskroom/homebrew-cask/pull/42509). Once the pull request is submitted, continuous integration tests will run, and a member of the caskroom community will review the PR. At times there is a backlog on the CI servers, but once tests pass, the community review is typically completed in a matter of hours.
+This command will cause Homebrew to download the new version of eXist, calculate the installer's new SHA-256 fingerprint value, and construct a pull request. Here is one example PR: https://github.com/Homebrew/homebrew-cask/pull/107778. Once the pull request is submitted, continuous integration tests will run, and a member of the Homebrew community will review the PR. At times there is a backlog on the CI servers, but once tests pass, the community review is typically completed in a matter of hours.
 
 ## Comparison to the Old Versioning and Release Procedures
 

--- a/extensions/contentextraction/pom.xml
+++ b/extensions/contentextraction/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/extensions/exiftool/pom.xml
+++ b/extensions/exiftool/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/expath/pom.xml
+++ b/extensions/expath/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/exquery/modules/pom.xml
+++ b/extensions/exquery/modules/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -54,7 +54,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <modules>

--- a/extensions/exquery/modules/request/pom.xml
+++ b/extensions/exquery/modules/request/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../../exist-parent</relativePath>
     </parent>
 
@@ -55,7 +55,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/exquery/pom.xml
+++ b/extensions/exquery/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 
@@ -54,7 +54,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <modules>

--- a/extensions/exquery/restxq/pom.xml
+++ b/extensions/exquery/restxq/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -54,7 +54,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/indexes/lucene/pom.xml
+++ b/extensions/indexes/lucene/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
     
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
     
     <dependencies>

--- a/extensions/indexes/ngram/pom.xml
+++ b/extensions/indexes/ngram/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/indexes/pom.xml
+++ b/extensions/indexes/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <modules>

--- a/extensions/indexes/range/pom.xml
+++ b/extensions/indexes/range/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/indexes/sort/pom.xml
+++ b/extensions/indexes/sort/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
     
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
     
     <dependencies>

--- a/extensions/indexes/spatial/pom.xml
+++ b/extensions/indexes/spatial/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
     
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/extensions/modules/cache/pom.xml
+++ b/extensions/modules/cache/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/compression/pom.xml
+++ b/extensions/modules/compression/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/counter/pom.xml
+++ b/extensions/modules/counter/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/cqlparser/pom.xml
+++ b/extensions/modules/cqlparser/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/example/pom.xml
+++ b/extensions/modules/example/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/exi/pom.xml
+++ b/extensions/modules/exi/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/expathrepo/pom.xml
+++ b/extensions/modules/expathrepo/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/file/pom.xml
+++ b/extensions/modules/file/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/image/pom.xml
+++ b/extensions/modules/image/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/jndi/pom.xml
+++ b/extensions/modules/jndi/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/mail/pom.xml
+++ b/extensions/modules/mail/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/extensions/modules/persistentlogin/pom.xml
+++ b/extensions/modules/persistentlogin/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/extensions/modules/pom.xml
+++ b/extensions/modules/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <modules>

--- a/extensions/modules/process/pom.xml
+++ b/extensions/modules/process/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/scheduler/pom.xml
+++ b/extensions/modules/scheduler/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/simpleql/pom.xml
+++ b/extensions/modules/simpleql/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/sql/pom.xml
+++ b/extensions/modules/sql/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/xmldiff/pom.xml
+++ b/extensions/modules/xmldiff/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/modules/xslfo/pom.xml
+++ b/extensions/modules/xslfo/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <modules>

--- a/extensions/security/activedirectory/pom.xml
+++ b/extensions/security/activedirectory/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
     
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
     
     <dependencies>

--- a/extensions/security/iprange/pom.xml
+++ b/extensions/security/iprange/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-        <tag>eXist-5.3.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>

--- a/extensions/security/ldap/pom.xml
+++ b/extensions/security/ldap/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/extensions/security/pom.xml
+++ b/extensions/security/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <modules>

--- a/extensions/webdav/pom.xml
+++ b/extensions/webdav/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/extensions/xqdoc/pom.xml
+++ b/extensions/xqdoc/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>../../exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>5.3.0</version>
+        <version>5.3.1-SNAPSHOT</version>
         <relativePath>exist-parent</relativePath>
     </parent>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>eXist-5.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <modules>


### PR DESCRIPTION
### Description:

This PR updates the eXist release documentation with recent changes in Homebrew:

1. As of Homebrew 2.6.0:

    > All brew cask commands have been deprecated in favour of brew commands (with --cask) when necessary.

2. The old cask-repair utility is deprecated:

    > `cask-repair` is deprecated. I will accept PRs to fix bugs, but spending more time on it is difficult to justify. I recommend using `brew bump-cask-pr`. It doesn’t do as much in niche cases, but it does more in other slightly more relevant cases. It covers the vast majority os bump needs better. It ships in Homebrew, so there’s nothing to install. Do `brew bump-cask-pr --help` to see how to use it.

This switches our procedure to use the new, official `brew bump-cask-pr` utility recommended in the eXist CONTRIBUTING document.

### Reference:

1. https://brew.sh/2020/12/01/homebrew-2.6.0/
2. https://github.com/vitorgalvao/tiny-scripts/commit/09b68e4d83fa56e3a22f127f18f18f7816ccd548#diff-47b6313694b8a6f736f1a394498f41d0a0088b1ddf3277b1758d2bf7385e043f
3. https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md

### Type of tests:

n/a