### PR TITLE
[fix] unary lookups

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -1541,7 +1541,9 @@ argumentList throws XPathException
 
 argument throws XPathException
 :
-	argumentPlaceholder | exprSingle
+	(QUESTION! ( NCNAME | INTEGER_LITERAL | LPAREN | STAR )) => lookup
+	| argumentPlaceholder
+	| exprSingle
 	;
 
 argumentPlaceholder throws XPathException : QUESTION ;

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -1326,6 +1326,12 @@ lookup throws XPathException
     )
     ;
 
+unaryLookup throws XPathException
+:
+    l:lookup
+    { #unaryLookup= #(#[PARENTHESIZED, "Parenthesized"], #l); }
+    ;
+
 dynamicFunCall throws XPathException
 :
 	args:argumentList
@@ -1369,7 +1375,7 @@ primaryExpr throws XPathException
 	|
 	( eqName LPAREN ) => functionCall
 	|
-	( QUESTION ) => lookup
+	( QUESTION ) => unaryLookup
 	|
 	( STRING_CONSTRUCTOR_START ) => stringConstructor
 	|

--- a/exist-core/src/main/java/org/exist/xquery/Lookup.java
+++ b/exist-core/src/main/java/org/exist/xquery/Lookup.java
@@ -75,7 +75,10 @@ public class Lookup extends AbstractExpression {
             contextSequence = contextItem.toSequence();
         }
         Sequence leftSeq;
-        if (contextExpression == null) {
+        if (contextExpression == null && contextSequence == null) {
+            throw new XPathException(this, ErrorCodes.XPDY0002,
+                    "Lookup has nothing to select, the context item is absent");
+        } else if (contextExpression == null) {
             leftSeq = contextSequence;
         } else {
             leftSeq = contextExpression.eval(contextSequence);

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapExpr.java
@@ -118,7 +118,7 @@ public class MapExpr extends AbstractExpression {
         dumper.display("map {");
         for (final Mapping mapping : this.mappings) {
             mapping.key.dump(dumper);
-            dumper.display(" := ");
+            dumper.display(" : ");
             mapping.value.dump(dumper);
         }
         dumper.display("}");

--- a/exist-core/src/test/xquery/maps/mapsLookup.xql
+++ b/exist-core/src/test/xquery/maps/mapsLookup.xql
@@ -42,19 +42,39 @@ function mlt:wildcard_lookup_on_map() {
 declare
     %test:assertEquals("Tom", "Dick", "Harry")
 function mlt:postfix_lookup_on_maps() {
-    (map {"first": "Tom"}, map {"first": "Dick"}, map {"first": "Harry"})?first
+    (
+        map {"first": "Tom"},
+        map {"first": "Dick"},
+        map {"first": "Harry"}
+    )?first
 };
 
 declare
-%test:assertEquals( "null", "null")
-function mlt:null_lookup(){
-    let $serializationParams := <output:serialization-parameters> <output:method>json</output:method> </output:serialization-parameters>
+    %test:assertEquals("null", "null")
+function mlt:null_lookup() {
+    let $serializationParams :=
+        <output:serialization-parameters>
+            <output:method>json</output:method>
+        </output:serialization-parameters>
 
-    let $json1 := parse-json( '{"total":[{"data":null}]}' )
+    let $json1 := parse-json('{"total":[{"data":null}]}')
     let $test1 := $json1?total?*?foobar
 
-    let $json2 := parse-json( '{"total":[{"data":null}]}' )
+    let $json2 := parse-json('{"total":[{"data":null}]}')
     let $test2 :=  $json2?total?*?foobar?aaa
 
-    return ( serialize($test1, $serializationParams) , serialize($test2, $serializationParams) )
+    return (
+        serialize($test1, $serializationParams),
+        serialize($test2, $serializationParams)
+    )
+};
+
+declare
+    %test:assertEquals("err:XPDY0002", "1", "1")
+function mlt:wildcard-lookup-without-context () {
+    try {
+        util:eval("?noctx", false(), (), true())
+    } catch * {
+        xs:string($err:code), $err:line-number, $err:column-number
+    }
 };

--- a/exist-core/src/test/xquery/xquery3/bang.xql
+++ b/exist-core/src/test/xquery/xquery3/bang.xql
@@ -272,20 +272,31 @@ function bang:mixed-function-types-call-parenthesized-context-item () {
     return (function ($a) {1}, $id, sum#1, [1], map{1:1}) ! (.)(1)
 };
 
-(:~
- : parse error needs to be fixed first
- : https://github.com/eXist-db/exist/issues/1655
-
+(: https://github.com/eXist-db/exist/issues/1655 :)
 declare
     %test:assertEquals(1,2,3)
 function bang:array-lookup-implicit-context () {
     ([1], [2], [3]) ! ?1
 };
 
+(: https://github.com/eXist-db/exist/issues/1655 :)
 declare
     %test:assertEquals(1,2,3)
 function bang:map-lookup-implicit-context () {
     (map {'a':1}, map {'a':2}, map {'a':3}) ! ?a
 };
 
- :)
+(: https://github.com/eXist-db/exist/issues/3491 :)
+declare
+    %test:assertEquals(3,4,5)
+function bang:map-lookup-implicit-context-as-argument () {
+    (map {'a': (1,2)}, map {'a': (2,2)}, map {'a':(2,3)}) ! sum(?a)
+};
+
+(: https://github.com/eXist-db/exist/issues/3491 :)
+declare
+    %test:assertEquals("1|2|3", "a|b|c")
+function bang:array-to-sequence-as-parameter () {
+    ([1,2,3], ['a', 'b', 'c'])
+      ! string-join(?*, '|')
+};


### PR DESCRIPTION
### Description:

Allow unary lookups in function calls, (anywhere) in predicates and after the simple map operator.

The XQuery grammar now

- wraps unary lookups in a parenthesised expression that is removed in the optimisation phase
- function argument recognises a unary lookup first before attempting to match argument placeholder (`?`)

Examples:

```xquery
([1, 2], ["a", "b"]) ! string-join(?*, "|")
```
```xquery
(map{1: 1}, map{1: 3}, map{1: 2})[1 > ?1] ! ?1
```

**Additional change:** correct the syntax of a dumped map expression to use current syntax.
For the second example that produces:

```
DEBUG (XQuery.java [compile]:143) - Query diagnostics:
(
    map {1 : 1}, map {1 : 3}, map {1 : 2}
) [1 > ?1] ! ?1
```

### Reference:

fixes #1655 
fixes #3491 

Relevant XQuery 3.1 specification: [3.11.3.1 Unary Lookup](https://www.w3.org/TR/xquery-31/#doc-xquery31-UnaryLookup)

### Type of tests:

Added and uncommented XQSuite tests 