### PR TITLE
Simplify storage of predicates for a step

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/DefaultExpressionVisitor.java
+++ b/exist-core/src/main/java/org/exist/xquery/DefaultExpressionVisitor.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery;
 
+import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 
@@ -96,10 +97,13 @@ public class DefaultExpressionVisitor extends BasicExpressionVisitor {
         conditional.getElseExpr().accept(this);
     }
 
-    public void visitLocationStep(LocationStep locationStep) {
-        final List<Predicate> predicates = locationStep.getPredicates();
-        for (final Predicate pred : predicates) {
-			pred.accept(this);
+    @Override
+    public void visitLocationStep(final LocationStep locationStep) {
+        @Nullable final Predicate[] predicates = locationStep.getPredicates();
+        if (predicates != null) {
+            for (final Predicate pred : predicates) {
+                pred.accept(this);
+            }
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -105,8 +105,10 @@ public class LocationStep extends Step {
 
         // TODO : normally, we should call this one...
         // int deps = super.getDependencies(); ???
-        for (final Predicate pred : predicates) {
-            deps |= pred.getDependencies();
+        if (predicates != null) {
+            for (final Predicate pred : predicates) {
+                deps |= pred.getDependencies();
+            }
         }
 
         // TODO : should we remove the CONTEXT_ITEM dependency returned by the
@@ -165,7 +167,7 @@ public class LocationStep extends Step {
         if (contextSequence == null) {
             return Sequence.EMPTY_SEQUENCE;
         }
-        if (predicates.size() == 0
+        if (predicates == null
                 || !applyPredicate
                 || (!(contextSequence instanceof VirtualNodeSet) && contextSequence
                 .isEmpty()))
@@ -174,7 +176,7 @@ public class LocationStep extends Step {
             return contextSequence;
         }
         Sequence result;
-        final Predicate pred = predicates.get(0);
+        final Predicate pred = predicates[0];
         // If the current step is an // abbreviated step, we have to treat the
         // predicate
         // specially to get the context position right. //a[1] translates to
@@ -219,15 +221,16 @@ public class LocationStep extends Step {
 
     private Sequence processPredicate(Sequence outerSequence, final Sequence contextSequence) throws XPathException {
         Sequence result = contextSequence;
-        for (final Iterator<Predicate> i = predicates.iterator(); i.hasNext()
-                && (result instanceof VirtualNodeSet || !result.isEmpty()); ) {
-            // TODO : log and/or profile ?
-            final Predicate pred = i.next();
-            pred.setContextDocSet(getContextDocSet());
-            result = pred.evalPredicate(outerSequence, result, axis);
-            // subsequent predicates operate on the result of the previous one
-            outerSequence = null;
-            context.setContextSequencePosition(0, null);
+        if (predicates != null) {
+            for (int i = 0; i < predicates.length && (result instanceof VirtualNodeSet || !result.isEmpty()); i++) {
+                // TODO : log and/or profile ?
+                final Predicate pred = predicates[i];
+                pred.setContextDocSet(getContextDocSet());
+                result = pred.evalPredicate(outerSequence, result, axis);
+                // subsequent predicates operate on the result of the previous one
+                outerSequence = null;
+                context.setContextSequencePosition(0, null);
+            }
         }
         return result;
     }
@@ -997,7 +1000,7 @@ public class LocationStep extends Step {
     private int computeLimit() throws XPathException {
         int position = -1;
         if (this.checkPositionalFilters(this.inPredicate)) {
-            final Predicate pred = predicates.get(0);
+            final Predicate pred = predicates[0];
             final Sequence seq = pred.preprocess();
 
             final NumericValue v = (NumericValue) seq.itemAt(0);

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -30,6 +30,7 @@ import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.AtomicValue;
 import org.exist.xquery.value.Type;
 
+import javax.annotation.Nullable;
 import java.util.*;
 
 import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
@@ -73,7 +74,8 @@ public class Optimizer extends DefaultExpressionVisitor {
         return hasOptimized;
     }
 
-    public void visitLocationStep(LocationStep locationStep) {
+    @Override
+    public void visitLocationStep(final LocationStep locationStep) {
         super.visitLocationStep(locationStep);
 
         // check query rewriters if they want to rewrite the location step
@@ -93,8 +95,8 @@ public class Optimizer extends DefaultExpressionVisitor {
 
         boolean optimize = false;
         // only location steps with predicates can be optimized:
-        if (locationStep.hasPredicates()) {
-            final List<Predicate> preds = locationStep.getPredicates();
+        @Nullable final Predicate[] preds = locationStep.getPredicates();
+        if (preds != null) {
             // walk through the predicates attached to the current location step.
             // try to find a predicate containing an expression which is an instance
             // of Optimizable.

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
@@ -35,6 +35,7 @@ import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.Type;
 
+import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 
@@ -190,10 +191,13 @@ public class Optimize extends Pragma {
                 }
             }
 
-            public void visitLocationStep(LocationStep locationStep) {
-                final List<Predicate> predicates = locationStep.getPredicates();
-                for (final Predicate pred : predicates) {
-                    pred.accept(this);
+            @Override
+            public void visitLocationStep(final LocationStep locationStep) {
+                @Nullable final Predicate[] predicates = locationStep.getPredicates();
+                if (predicates != null) {
+                    for (final Predicate pred : predicates) {
+                        pred.accept(this);
+                    }
                 }
             }
 

--- a/exist-core/src/test/java/org/exist/xquery/LocationStepTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/LocationStepTest.java
@@ -1,0 +1,174 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.xquery.util.ExpressionDumper;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertArrayEquals;
+
+public class LocationStepTest {
+
+    @Test
+    public void insertPredicateNoPrevious() {
+        final XQueryContext mockContext = mock(XQueryContext.class);
+        expect(mockContext.nextExpressionId()).andReturn(Expression.EXPRESSION_ID_INVALID);
+
+        final Predicate mockPredicate1 = mock(Predicate.class);
+        final Predicate mockPredicate2 = mock(Predicate.class);
+        final Predicate mockPredicate3 = mock(Predicate.class);
+        final Predicate mockNotPreviousPredicate = mock(Predicate.class);
+
+        mockPredicate1.dump(anyObject(ExpressionDumper.class));
+        mockPredicate2.dump(anyObject(ExpressionDumper.class));
+        mockNotPreviousPredicate.dump(anyObject(ExpressionDumper.class));
+
+        replay(mockContext, mockPredicate1, mockPredicate2, mockPredicate3, mockNotPreviousPredicate);
+
+        final LocationStep locationStep = new LocationStep(mockContext, Constants.UNKNOWN_AXIS);
+
+        locationStep.addPredicate(mockPredicate1);
+        locationStep.addPredicate(mockPredicate2);
+
+        locationStep.insertPredicate(mockNotPreviousPredicate, mockPredicate3);
+        assertArrayEquals(new Predicate[]{ mockPredicate1, mockPredicate2}, locationStep.getPredicates());
+
+        verify(mockContext, mockPredicate1, mockPredicate2, mockPredicate3, mockNotPreviousPredicate);
+    }
+
+    @Test
+    public void insertPredicateInMiddleOddFirst() {
+        final XQueryContext mockContext = mock(XQueryContext.class);
+        expect(mockContext.nextExpressionId()).andReturn(Expression.EXPRESSION_ID_INVALID);
+
+        final Predicate mockPredicate1 = mock(Predicate.class);
+        final Predicate mockPredicate2 = mock(Predicate.class);
+        final Predicate mockPredicate3 = mock(Predicate.class);
+
+        replay(mockContext, mockPredicate1, mockPredicate2, mockPredicate3);
+
+        final LocationStep locationStep = new LocationStep(mockContext, Constants.UNKNOWN_AXIS);
+
+        locationStep.addPredicate(mockPredicate1);
+        locationStep.addPredicate(mockPredicate2);
+
+        locationStep.insertPredicate(mockPredicate1, mockPredicate3);
+        assertArrayEquals(new Predicate[]{ mockPredicate1, mockPredicate3, mockPredicate2}, locationStep.getPredicates());
+
+        verify(mockContext, mockPredicate1, mockPredicate2, mockPredicate3);
+    }
+
+    @Test
+    public void insertPredicateInMiddleOddSecond() {
+        final XQueryContext mockContext = mock(XQueryContext.class);
+        expect(mockContext.nextExpressionId()).andReturn(Expression.EXPRESSION_ID_INVALID);
+
+        final Predicate mockPredicate1 = mock(Predicate.class);
+        final Predicate mockPredicate2 = mock(Predicate.class);
+        final Predicate mockPredicate3 = mock(Predicate.class);
+
+        replay(mockContext, mockPredicate1, mockPredicate2, mockPredicate3);
+
+        final LocationStep locationStep = new LocationStep(mockContext, Constants.UNKNOWN_AXIS);
+
+        locationStep.addPredicate(mockPredicate1);
+        locationStep.addPredicate(mockPredicate2);
+
+        locationStep.insertPredicate(mockPredicate2, mockPredicate3);
+        assertArrayEquals(new Predicate[]{ mockPredicate1, mockPredicate2, mockPredicate3}, locationStep.getPredicates());
+
+        verify(mockContext, mockPredicate1, mockPredicate2, mockPredicate3);
+    }
+
+    @Test
+    public void insertPredicateInMiddleEvenFirst() {
+        final XQueryContext mockContext = mock(XQueryContext.class);
+        expect(mockContext.nextExpressionId()).andReturn(Expression.EXPRESSION_ID_INVALID);
+
+        final Predicate mockPredicate1 = mock(Predicate.class);
+        final Predicate mockPredicate2 = mock(Predicate.class);
+        final Predicate mockPredicate3 = mock(Predicate.class);
+        final Predicate mockPredicate4 = mock(Predicate.class);
+
+        replay(mockContext, mockPredicate1, mockPredicate2, mockPredicate3, mockPredicate4);
+
+        final LocationStep locationStep = new LocationStep(mockContext, Constants.UNKNOWN_AXIS);
+
+        locationStep.addPredicate(mockPredicate1);
+        locationStep.addPredicate(mockPredicate2);
+        locationStep.addPredicate(mockPredicate3);
+
+        locationStep.insertPredicate(mockPredicate1, mockPredicate4);
+        assertArrayEquals(new Predicate[]{ mockPredicate1, mockPredicate4, mockPredicate2, mockPredicate3}, locationStep.getPredicates());
+
+        verify(mockContext, mockPredicate1, mockPredicate2, mockPredicate3, mockPredicate4);
+    }
+
+    @Test
+    public void insertPredicateInMiddleEvenSecond() {
+        final XQueryContext mockContext = mock(XQueryContext.class);
+        expect(mockContext.nextExpressionId()).andReturn(Expression.EXPRESSION_ID_INVALID);
+
+        final Predicate mockPredicate1 = mock(Predicate.class);
+        final Predicate mockPredicate2 = mock(Predicate.class);
+        final Predicate mockPredicate3 = mock(Predicate.class);
+        final Predicate mockPredicate4 = mock(Predicate.class);
+
+        replay(mockContext, mockPredicate1, mockPredicate2, mockPredicate3, mockPredicate4);
+
+        final LocationStep locationStep = new LocationStep(mockContext, Constants.UNKNOWN_AXIS);
+
+        locationStep.addPredicate(mockPredicate1);
+        locationStep.addPredicate(mockPredicate2);
+        locationStep.addPredicate(mockPredicate3);
+
+        locationStep.insertPredicate(mockPredicate2, mockPredicate4);
+        assertArrayEquals(new Predicate[]{ mockPredicate1, mockPredicate2, mockPredicate4, mockPredicate3}, locationStep.getPredicates());
+
+        verify(mockContext, mockPredicate1, mockPredicate2, mockPredicate3, mockPredicate4);
+    }
+
+    @Test
+    public void insertPredicateInMiddleEvenThird() {
+        final XQueryContext mockContext = mock(XQueryContext.class);
+        expect(mockContext.nextExpressionId()).andReturn(Expression.EXPRESSION_ID_INVALID);
+
+        final Predicate mockPredicate1 = mock(Predicate.class);
+        final Predicate mockPredicate2 = mock(Predicate.class);
+        final Predicate mockPredicate3 = mock(Predicate.class);
+        final Predicate mockPredicate4 = mock(Predicate.class);
+
+        replay(mockContext, mockPredicate1, mockPredicate2, mockPredicate3, mockPredicate4);
+
+        final LocationStep locationStep = new LocationStep(mockContext, Constants.UNKNOWN_AXIS);
+
+        locationStep.addPredicate(mockPredicate1);
+        locationStep.addPredicate(mockPredicate2);
+        locationStep.addPredicate(mockPredicate3);
+
+        locationStep.insertPredicate(mockPredicate3, mockPredicate4);
+        assertArrayEquals(new Predicate[]{ mockPredicate1, mockPredicate2, mockPredicate3, mockPredicate4}, locationStep.getPredicates());
+
+        verify(mockContext, mockPredicate1, mockPredicate2, mockPredicate3, mockPredicate4);
+    }
+}

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/RangeQueryRewriter.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/RangeQueryRewriter.java
@@ -26,6 +26,7 @@ import org.exist.storage.NodePath;
 import org.exist.xquery.*;
 import org.exist.xquery.Constants.Comparison;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,21 +41,21 @@ public class RangeQueryRewriter extends QueryRewriter {
     }
 
     @Override
-    public Pragma rewriteLocationStep(LocationStep locationStep) throws XPathException {
+    public Pragma rewriteLocationStep(final LocationStep locationStep) throws XPathException {
         int axis = locationStep.getAxis();
         if (!(axis == Constants.CHILD_AXIS || axis == Constants.DESCENDANT_AXIS ||
                 axis == Constants.DESCENDANT_SELF_AXIS || axis == Constants.ATTRIBUTE_AXIS ||
                 axis == Constants.DESCENDANT_ATTRIBUTE_AXIS || axis == Constants.SELF_AXIS)) {
             return null;
         }
-        if (locationStep.hasPredicates()) {
-            Expression parentExpr = locationStep.getParentExpression();
+
+        @Nullable final Predicate[] preds = locationStep.getPredicates();
+        if (preds != null) {
+            final Expression parentExpr = locationStep.getParentExpression();
             if ((parentExpr instanceof RewritableExpression)) {
                 // Step 1: replace all optimizable expressions within predicates with
                 // calls to the range functions. If those functions are used or not will
                 // be decided at run time.
-
-                final List<Predicate> preds = locationStep.getPredicates();
 
                 // will become true if optimizable expression is found
                 boolean canOptimize = false;


### PR DESCRIPTION
* Removes unnecessary use of `CopyOnWriteArrayList` in code that is non-concurrent
* Optimised for the case where there are no or very few predicates on each step - which is typical in XQuery!
    * Uses zero memory to store predicates when there are no predicates on a path step
    * Reduces unnecessary processing per step