### PR TITLE
Improve how XSuite starts and stops the database

### DIFF
--- a/exist-core/src/main/java/org/exist/collections/triggers/XQueryStartupTrigger.java
+++ b/exist-core/src/main/java/org/exist/collections/triggers/XQueryStartupTrigger.java
@@ -260,7 +260,7 @@ public class XQueryStartupTrigger implements StartupTrigger {
                 context.setModuleLoadPath(moduleLoadPath);
 
                 // Compile query
-                CompiledXQuery compiledQuery = service.compile(broker, context, source);
+                CompiledXQuery compiledQuery = service.compile(context, source);
 
                 LOG.info("Starting XQuery at '{}'", path);
 

--- a/exist-core/src/main/java/org/exist/collections/triggers/XQueryTrigger.java
+++ b/exist-core/src/main/java/org/exist/collections/triggers/XQueryTrigger.java
@@ -254,7 +254,7 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
         try
         {
         	//compile the XQuery
-        	compiledQuery = service.compile(broker, context, query);
+        	compiledQuery = service.compile(context, query);
 
         	//declare external variables
         	context.declareVariable(bindingPrefix + "type", EVENT_TYPE_PREPARE);
@@ -325,7 +325,7 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
         CompiledXQuery compiledQuery = null;
         try {
         	//compile the XQuery
-        	compiledQuery = service.compile(broker, context, query);
+        	compiledQuery = service.compile(context, query);
         	
         	//declare external variables
         	context.declareVariable(bindingPrefix + "type", EVENT_TYPE_FINISH);
@@ -408,7 +408,7 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
         CompiledXQuery compiledQuery;
         try {
         	//compile the XQuery
-        	compiledQuery = service.compile(broker, context, query);
+        	compiledQuery = service.compile(context, query);
 
         	//declare user defined parameters as external variables
             for (Object o : userDefinedVariables.keySet()) {

--- a/exist-core/src/main/java/org/exist/http/AuditTrailSessionListener.java
+++ b/exist-core/src/main/java/org/exist/http/AuditTrailSessionListener.java
@@ -136,7 +136,7 @@ public class AuditTrailSessionListener implements HttpSessionListener {
                         context.setBaseURI(new AnyURIValue(pathUri.toString()));
 
                         if (compiled == null) {
-                            compiled = xquery.compile(broker, context, source);
+                            compiled = xquery.compile(context, source);
                         } else {
                             compiled.getContext().updateContext(context);
                             context.getWatchDog().reset();

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -1353,7 +1353,7 @@ public class RESTServer {
             final long compilationTime;
             if (compiled == null) {
                 final long compilationStart = System.currentTimeMillis();
-                compiled = xquery.compile(broker, context, source);
+                compiled = xquery.compile(context, source);
                 compilationTime = System.currentTimeMillis() - compilationStart;
             } else {
                 compiled.getContext().updateContext(context);
@@ -1546,7 +1546,7 @@ public class RESTServer {
             if (compiled == null) {
                 try {
                     final long compilationStart = System.currentTimeMillis();
-                    compiled = xquery.compile(broker, context, source);
+                    compiled = xquery.compile(context, source);
                     compilationTime = System.currentTimeMillis() - compilationStart;
                 } catch (final IOException e) {
                     throw new BadRequestException("Failed to read query from " + resource.getURI(), e);
@@ -1634,7 +1634,7 @@ public class RESTServer {
             if (compiled == null) {
                 try {
                     final long compilationStart = System.currentTimeMillis();
-                    compiled = xquery.compile(broker, context, source);
+                    compiled = xquery.compile(context, source);
                     compilationTime = System.currentTimeMillis() - compilationStart;
                 } catch (final IOException e) {
                     throw new BadRequestException("Failed to read query from "

--- a/exist-core/src/main/java/org/exist/http/servlets/RedirectorServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/RedirectorServlet.java
@@ -278,7 +278,7 @@ public class RedirectorServlet extends AbstractExistHttpServlet {
                 response.setHeader("X-XQuery-Cached", "false");
                 context = new XQueryContext(getPool());
                 context.setModuleLoadPath(XmldbURI.EMBEDDED_SERVER_URI.toString());
-                compiled = xquery.compile(broker, context, source);
+                compiled = xquery.compile(context, source);
             } else {
                 response.setHeader("X-XQuery-Cached", "true");
                 context = compiled.getContext();

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -473,7 +473,9 @@ public class XQueryURLRewrite extends HttpServlet {
 
         try (final DBBroker broker = pool.get(Optional.ofNullable(user))) {
 
-            model.getSourceInfo().source.validate(broker.getCurrentSubject(), Permission.EXECUTE);
+            if (model.getSourceInfo().source instanceof DBSource) {
+                ((DBSource) model.getSourceInfo().source).validate(Permission.EXECUTE);
+            }
 
             if (model.getSourceInfo().source.isValid(broker) != Source.Validity.VALID) {
                 urlCache.remove(url);
@@ -662,7 +664,7 @@ public class XQueryURLRewrite extends HttpServlet {
         declareVariables(queryContext, sourceInfo, staticRewrite, basePath, request, response);
         if (compiled == null) {
             try {
-                compiled = xquery.compile(broker, queryContext, sourceInfo.source);
+                compiled = xquery.compile(queryContext, sourceInfo.source);
             } catch (final IOException e) {
                 throw new ServletException("Failed to read query from " + query, e);
             }

--- a/exist-core/src/main/java/org/exist/management/impl/SanityReport.java
+++ b/exist-core/src/main/java/org/exist/management/impl/SanityReport.java
@@ -188,7 +188,7 @@ public class SanityReport extends NotificationBroadcasterSupport implements Sani
                 CompiledXQuery compiled = xqPool.borrowCompiledXQuery(broker, TEST_XQUERY);
                 if (compiled == null) {
                     final XQueryContext context = new XQueryContext(pool);
-                    compiled = xquery.compile(broker, context, TEST_XQUERY);
+                    compiled = xquery.compile(context, TEST_XQUERY);
                 } else {
                     compiled.getContext().prepareForReuse();
                 }

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -693,7 +693,7 @@ public class Deployment {
 
         CompiledXQuery compiled;
         try {
-            compiled = xqs.compile(broker, ctx, new FileSource(xquery, false));
+            compiled = xqs.compile(ctx, new FileSource(xquery, false));
             return xqs.execute(broker, compiled, null);
         } catch (final PermissionDeniedException e) {
             throw new PackageException(e.getMessage(), e);

--- a/exist-core/src/main/java/org/exist/scheduler/UserXQueryJob.java
+++ b/exist-core/src/main/java/org/exist/scheduler/UserXQueryJob.java
@@ -207,7 +207,7 @@ public class UserXQueryJob extends UserJob {
             if (compiled == null) {
 
                 try {
-                    compiled = xquery.compile(broker, context, source);
+                    compiled = xquery.compile(context, source);
                 } catch (final IOException e) {
                     abort("Failed to read query from " + xqueryResource);
                 }

--- a/exist-core/src/main/java/org/exist/security/internal/SMEvents.java
+++ b/exist-core/src/main/java/org/exist/security/internal/SMEvents.java
@@ -104,7 +104,7 @@ public class SMEvents implements Configurable {
             final XQuery xquery = broker.getBrokerPool().getXQueryService();
             final XQueryContext context = new XQueryContext(broker.getBrokerPool());
 
-            final CompiledXQuery compiled = xquery.compile(broker, context, source);
+            final CompiledXQuery compiled = xquery.compile(context, source);
 
 //            Sequence result = xquery.execute(compiled, subject.getName());
 

--- a/exist-core/src/main/java/org/exist/source/AbstractSource.java
+++ b/exist-core/src/main/java/org/exist/source/AbstractSource.java
@@ -29,6 +29,8 @@ import java.nio.charset.Charset;
 import net.jpountz.xxhash.XXHash64;
 import net.jpountz.xxhash.XXHashFactory;
 import org.exist.dom.QName;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.Subject;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.parser.DeclScanner;
 import org.exist.xquery.parser.XQueryLexer;
@@ -58,6 +60,11 @@ public abstract class AbstractSource implements Source {
     @Override
     public Charset getEncoding() throws IOException {
         return null;
+    }
+
+    @Deprecated
+    public void validate(final Subject subject, final int perm) throws PermissionDeniedException {
+        // no-op
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/source/BinarySource.java
+++ b/exist-core/src/main/java/org/exist/source/BinarySource.java
@@ -90,11 +90,6 @@ public class BinarySource extends AbstractSource {
     }
 
     @Override
-    public void validate(final Subject subject, final int perm) {
-        // TODO protected?
-    }
-
-    @Override
     public int hashCode() {
         return Arrays.hashCode(data);
     }

--- a/exist-core/src/main/java/org/exist/source/DBSource.java
+++ b/exist-core/src/main/java/org/exist/source/DBSource.java
@@ -183,6 +183,7 @@ public class DBSource extends AbstractSource {
      *
      * @deprecated These security checks should be done by the caller
      */
+    @Override
     @Deprecated
     public void validate(final Subject subject, final int mode) throws PermissionDeniedException {
         //TODO(AR) This check should not even be here! Its up to the database to refuse access not requesting source

--- a/exist-core/src/main/java/org/exist/source/DBSource.java
+++ b/exist-core/src/main/java/org/exist/source/DBSource.java
@@ -160,11 +160,32 @@ public class DBSource extends AbstractSource {
     	return doc.getDocumentURI();
     }
 
-    @Override
+    /**
+     * Check: has current subject requested permissions for this resource?
+     *
+     * @param mode The requested mode
+     * @throws PermissionDeniedException if user has not sufficient rights
+     *
+     * @deprecated These security checks should be done by the caller
+     */
+    @Deprecated
+    public void validate(final int mode) throws PermissionDeniedException {
+        //TODO(AR) This check should not even be here! Its up to the database to refuse access not requesting source
+        validate(broker.getCurrentSubject(), mode);
+    }
+
+    /**
+     * Check: has subject requested permissions for this resource?
+     *
+     * @param subject The subject
+     * @param mode The requested mode
+     * @throws PermissionDeniedException if user has not sufficient rights
+     *
+     * @deprecated These security checks should be done by the caller
+     */
+    @Deprecated
     public void validate(final Subject subject, final int mode) throws PermissionDeniedException {
-        
-        //TODO This check should not even be here! Its up to the database to refuse access not requesting source
-        
+        //TODO(AR) This check should not even be here! Its up to the database to refuse access not requesting source
         if (!doc.getPermissions().validate(subject, mode)) {
             final String modeStr = new UnixStylePermissionAider(mode).toString();
             throw new PermissionDeniedException("Subject '" + subject.getName() + "' does not have '" + modeStr + "' access to resource '" + doc.getURI() + "'.");

--- a/exist-core/src/main/java/org/exist/source/FileSource.java
+++ b/exist-core/src/main/java/org/exist/source/FileSource.java
@@ -151,11 +151,6 @@ public class FileSource extends AbstractSource {
     	return path();
     }
 
-	@Override
-	public void validate(final Subject subject, final int perm) {
-		// TODO protected?
-	}
-
     @Override
     public int hashCode() {
         return path.hashCode();

--- a/exist-core/src/main/java/org/exist/source/Source.java
+++ b/exist-core/src/main/java/org/exist/source/Source.java
@@ -135,6 +135,18 @@ public interface Source {
     @Nullable Charset getEncoding() throws IOException;
 
     /**
+     * Check: has subject requested permissions for this resource?
+     *
+     * @param subject The subject
+     * @param perm The requested permissions
+     * @throws PermissionDeniedException if user has not sufficient rights
+     *
+     * @deprecated These security checks only apply to {@link DBSource} and should be done by the caller
+     */
+    @Deprecated
+    void validate(Subject subject, int perm) throws PermissionDeniedException;
+
+    /**
      * Check if the source is an XQuery module. If it is, return a QName containing
      * the module prefix as local name and the module namespace as namespace URI.
      *

--- a/exist-core/src/main/java/org/exist/source/Source.java
+++ b/exist-core/src/main/java/org/exist/source/Source.java
@@ -133,15 +133,6 @@ public interface Source {
      * @throws IOException in case of an I/O error
      */
     @Nullable Charset getEncoding() throws IOException;
-    
-    /**
-     * Check: has subject requested permissions for this resource?
-     *
-     * @param subject The subject
-     * @param perm The requested permissions
-     * @throws PermissionDeniedException if user has not sufficient rights
-     */
-    void validate(Subject subject, int perm) throws PermissionDeniedException;
 
     /**
      * Check if the source is an XQuery module. If it is, return a QName containing

--- a/exist-core/src/main/java/org/exist/source/StringSource.java
+++ b/exist-core/src/main/java/org/exist/source/StringSource.java
@@ -80,11 +80,6 @@ public class StringSource extends AbstractSource {
         return content;
     }
 
-	@Override
-	public void validate(final Subject subject, final int perm) {
-		// TODO protected?
-	}
-
     @Override
     public int hashCode() {
         return content.hashCode();

--- a/exist-core/src/main/java/org/exist/source/URLSource.java
+++ b/exist-core/src/main/java/org/exist/source/URLSource.java
@@ -219,11 +219,6 @@ public class URLSource extends AbstractSource {
     }
 
     @Override
-    public void validate(final Subject subject, final int perm) {
-        // TODO protected?
-    }
-
-    @Override
     public QName isModule() throws IOException {
         try (final InputStream is = getInputStream()) {
             return getModuleDecl(is);

--- a/exist-core/src/main/java/org/exist/storage/XQueryPool.java
+++ b/exist-core/src/main/java/org/exist/storage/XQueryPool.java
@@ -43,6 +43,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
+import org.exist.source.DBSource;
 import org.exist.source.Source;
 import org.exist.util.Configuration;
 import org.exist.util.Holder;
@@ -182,7 +183,9 @@ public class XQueryPool implements BrokerPoolService {
         }
 
         //check execution permission
-        source.validate(broker.getCurrentSubject(), Permission.EXECUTE);
+        if (source instanceof DBSource) {
+            ((DBSource) source).validate(Permission.EXECUTE);
+        }
 
         return borrowedCompiledQuery.value;
     }

--- a/exist-core/src/main/java/org/exist/storage/serializers/XIncludeFilter.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/XIncludeFilter.java
@@ -436,7 +436,7 @@ public class XIncludeFilter implements Receiver {
 
                 if (compiled == null) {
                     try {
-                        compiled = xquery.compile(serializer.broker, context, source, xpointer != null);
+                        compiled = xquery.compile(context, source, xpointer != null);
                     } catch (final IOException e) {
                         throw new SAXException("I/O error while reading query for xinclude: " + e.getMessage(), e);
                     }

--- a/exist-core/src/main/java/org/exist/test/XQueryCompilationTest.java
+++ b/exist-core/src/main/java/org/exist/test/XQueryCompilationTest.java
@@ -49,7 +49,7 @@ public abstract class XQueryCompilationTest {
         final XQuery xqueryService = pool.getXQueryService();
         try (final DBBroker broker = pool.getBroker()) {
             try {
-                return Right(xqueryService.compile(broker, new XQueryContext(broker.getDatabase()), string));
+                return Right(xqueryService.compile(new XQueryContext(broker.getDatabase()), string));
             } catch (final XPathException e) {
                 return Left(e);
             }

--- a/exist-core/src/main/java/org/exist/test/runner/AbstractTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/AbstractTestRunner.java
@@ -97,7 +97,7 @@ public abstract class AbstractTestRunner extends Runner {
 
                 // compile or update the context
                 if (compiledQuery == null) {
-                    compiledQuery = xqueryService.compile(broker, context, query);
+                    compiledQuery = xqueryService.compile(context, query);
                 } else {
                     compiledQuery.getContext().updateContext(context);
                     context.getWatchDog().reset();

--- a/exist-core/src/main/java/org/exist/test/runner/AbstractTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/AbstractTestRunner.java
@@ -62,8 +62,7 @@ public abstract class AbstractTestRunner extends Runner {
         this.parallel = parallel;
     }
 
-    protected static Sequence executeQuery(final Source query, final List<Function<XQueryContext, Tuple2<String, Object>>> externalVariableBindings) throws EXistException, PermissionDeniedException, XPathException, IOException, DatabaseConfigurationException {
-        final BrokerPool brokerPool = XSuite.ExistServer.getRunningServer().getBrokerPool();
+    protected static Sequence executeQuery(final BrokerPool brokerPool, final Source query, final List<Function<XQueryContext, Tuple2<String, Object>>> externalVariableBindings) throws EXistException, PermissionDeniedException, XPathException, IOException, DatabaseConfigurationException {
         try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()))) {
             final XQueryPool queryPool = brokerPool.getXQueryPool();
             CompiledXQuery compiledQuery = queryPool.borrowCompiledXQuery(broker, query);

--- a/exist-core/src/main/java/org/exist/test/runner/XMLTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/XMLTestRunner.java
@@ -29,6 +29,7 @@ import org.exist.dom.memtree.SAXAdapter;
 import org.exist.security.PermissionDeniedException;
 import org.exist.source.ClassLoaderSource;
 import org.exist.source.Source;
+import org.exist.storage.BrokerPool;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.ExistSAXParserFactory;
 import org.exist.xquery.FunctionCall;
@@ -200,7 +201,9 @@ public class XMLTestRunner extends AbstractTestRunner {
                 context -> new Tuple2<>("test-finished-function", new FunctionReference(new FunctionCall(context, new ExtTestFinishedFunction(context, getSuiteName(), notifier))))
             );
 
-            executeQuery(query, externalVariableDeclarations);
+            // NOTE: at this stage EXIST_EMBEDDED_SERVER_CLASS_INSTANCE in XSuite will be usable
+            final BrokerPool brokerPool = XSuite.EXIST_EMBEDDED_SERVER_CLASS_INSTANCE.getBrokerPool();
+            executeQuery(brokerPool, query, externalVariableDeclarations);
 
 
         } catch(final DatabaseConfigurationException | IOException | EXistException | PermissionDeniedException | XPathException e) {

--- a/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
@@ -24,35 +24,32 @@ package org.exist.test.runner;
 
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
+import org.exist.dom.QName;
 import org.exist.security.PermissionDeniedException;
 import org.exist.source.ClassLoaderSource;
+import org.exist.source.FileSource;
 import org.exist.source.Source;
-import org.exist.source.StringSource;
 import org.exist.storage.BrokerPool;
-import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.Configuration;
+import org.exist.util.ConfigurationHelper;
 import org.exist.util.DatabaseConfigurationException;
-import org.exist.xquery.FunctionCall;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.util.FileUtils;
+import org.exist.xquery.*;
 import org.exist.xquery.value.AnyURIValue;
 import org.exist.xquery.value.FunctionReference;
-import org.exist.xquery.value.Sequence;
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.nio.file.Paths;
+import java.util.*;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * A JUnit test runner which can run the XQuery tests (XQSuite)
@@ -61,6 +58,8 @@ import java.util.List;
  * @author Adam Retter
  */
 public class XQueryTestRunner extends AbstractTestRunner {
+
+    private static final String XQSUITE_NAMESPACE = "http://exist-db.org/xquery/xqsuite";
 
     private final XQueryTestInfo info;
 
@@ -75,90 +74,91 @@ public class XQueryTestRunner extends AbstractTestRunner {
         this.info = extractTestInfo(path);
     }
 
+    private static Configuration getConfiguration() throws DatabaseConfigurationException {
+        final Optional<Path> home = Optional.ofNullable(System.getProperty("exist.home", System.getProperty("user.dir"))).map(Paths::get);
+        final Path confFile = ConfigurationHelper.lookup("conf.xml", home);
+
+        if (confFile.isAbsolute() && Files.exists(confFile)) {
+            return new Configuration(confFile.toAbsolutePath().toString());
+        } else {
+            return new Configuration(FileUtils.fileName(confFile), home);
+        }
+    }
+
     private static XQueryTestInfo extractTestInfo(final Path path) throws InitializationError {
-        // NOTE: at this stage EXIST_EMBEDDED_SERVER_CLASS_INSTANCE in XSuite will be null, as the @BeforeClass rule has not yet run
-        // TODO(AR) is there a way to get the info after @BeforeClass of XSuite has run? -- perhaps in run() for the event fireTestSuiteStarted ? <--- NO can't find one
-        // TODO(AR) otherwise could this be rewritten to just use eXist-db's XQuery Parser directly, or perhaps another XQuery parser?
-        final ExistEmbeddedServer existDbServer = XSuite.newExistDbServer();
         try {
-            // start the database
-            existDbServer.startDb();
+            final Configuration config = getConfiguration();
+            final XQueryContext xqueryContext = new XQueryContext(config);
 
-            final Source query = new StringSource("inspect:inspect-module(xs:anyURI(\"" + path.toAbsolutePath().toString() + "\"))");
-            final Sequence inspectionResults = executeQuery(existDbServer.getBrokerPool(), query, Collections.emptyList());
+            final Source xquerySource = new FileSource(path, UTF_8, false);
+            final XQuery xquery = new XQuery();
 
-            // extract the details
-            String prefix = null;
-            String namespace = null;
+            final CompiledXQuery compiledXQuery = xquery.compile(xqueryContext, xquerySource);
+
+            String moduleNsPrefix = null;
+            String moduleNsUri = null;
             final List<XQueryTestInfo.TestFunctionDef> testFunctions = new ArrayList<>();
 
-            if(inspectionResults != null && inspectionResults.hasOne()) {
-                final Element moduleElement = (Element)inspectionResults.itemAt(0);
+            final Iterator<UserDefinedFunction> localFunctions = compiledXQuery.getContext().localFunctions();
+            while (localFunctions.hasNext()) {
+                final UserDefinedFunction localFunction = localFunctions.next();
+                final FunctionSignature localFunctionSignature = localFunction.getSignature();
 
-                prefix = moduleElement.getAttribute("prefix");
-                namespace = moduleElement.getAttribute("uri");
+                String testName = null;
+                boolean isTest = false;
 
-                final NodeList children = moduleElement.getChildNodes();
-                for(int i = 0; i < children.getLength(); i++) {
-                    final Node child = children.item(i);
-                    if (child.getNodeType() == Node.ELEMENT_NODE && child.getNamespaceURI() == null) {
-
-                        if(child.getNodeName().equals("function")) {
-                            boolean isTestFunction = false;
-                            final NamedNodeMap functionAttributes = child.getAttributes();
-                            final String name = functionAttributes.getNamedItem("name").getNodeValue();
-
-                            String testFunctionAnnotatedName = null;
-                            final NodeList functionChildren = child.getChildNodes();
-                            for(int j = 0; j < functionChildren.getLength(); j++) {
-                                final Node functionChild = functionChildren.item(j);
-                                if (functionChild.getNodeType() == Node.ELEMENT_NODE && functionChild.getNamespaceURI() == null) {
-
-                                    // filter functions by annotations... we only want the test:assert* annotated ones!
-                                    if(functionChild.getNodeName().equals("annotation")) {
-                                        final NamedNodeMap annotationAttributes = functionChild.getAttributes();
-                                        final Node annotationAttributeName = annotationAttributes.getNamedItem("name");
-                                        if(annotationAttributeName.getNodeValue().startsWith("test:assert")) {
-                                            isTestFunction = true;
-                                        } else if(annotationAttributeName.getNodeValue().equals("test:name")) {
-                                            final NodeList annotationChildren = functionChild.getChildNodes();
-                                            for(int k = 0; k < annotationChildren.getLength(); k++) {
-                                                final Node annotationChild = annotationChildren.item(k);
-                                                if(annotationChild.getNodeType() == Node.ELEMENT_NODE && annotationChild.getNamespaceURI() == null) {
-                                                    if(annotationChild.getNodeName().equals("value")) {
-                                                        testFunctionAnnotatedName = annotationChild.getTextContent();
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
+                final Annotation[] annotations = localFunctionSignature.getAnnotations();
+                if (annotations != null) {
+                    for (final Annotation annotation : annotations) {
+                        final QName annotationName = annotation.getName();
+                        if (annotationName.getNamespaceURI().equals(XQSUITE_NAMESPACE)) {
+                            if (annotationName.getLocalPart().startsWith("assert")) {
+                                isTest = true;
+                                if (testName != null) {
+                                    break;
                                 }
-                            }
-
-                            if(isTestFunction) {
-                                // strip module prefix from function name
-                                String testFunctionLocalName = testFunctionAnnotatedName != null ? testFunctionAnnotatedName : name;
-                                if(testFunctionLocalName.startsWith(prefix + ':')) {
-                                    testFunctionLocalName = testFunctionLocalName.substring(testFunctionLocalName.indexOf(':') + 1);
-                                    testFunctions.add(new XQueryTestInfo.TestFunctionDef(testFunctionLocalName));
+                            } else if (annotationName.getLocalPart().equals("name")) {
+                                final LiteralValue[] annotationValues = annotation.getValue();
+                                if (annotationValues != null && annotationValues.length > 0) {
+                                    testName = annotationValues[0].getValue().getStringValue();
+                                    if (isTest) {
+                                        break;
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
 
-            return new XQueryTestInfo(prefix, namespace, testFunctions);
+                if (isTest) {
+                    if (testName == null) {
+                        testName = localFunctionSignature.getName().getLocalPart();
+                    }
 
-        } catch(final DatabaseConfigurationException | IOException | EXistException | PermissionDeniedException | XPathException e) {
+                    if (moduleNsPrefix == null) {
+                        moduleNsPrefix = localFunctionSignature.getName().getPrefix();
+                    }
+                    if (moduleNsUri == null) {
+                        moduleNsUri = localFunctionSignature.getName().getNamespaceURI();
+                    }
+
+                    testFunctions.add(new XQueryTestInfo.TestFunctionDef(testName));
+                }
+            } // end while
+
+            return new XQueryTestInfo(moduleNsPrefix, moduleNsUri, testFunctions);
+
+        } catch (final DatabaseConfigurationException | IOException | PermissionDeniedException | XPathException e) {
             throw new InitializationError(e);
-        } finally {
-            existDbServer.stopDb();
         }
     }
 
     private String getSuiteName() {
-         return namespaceToPackageName(info.getNamespace());
+        if (info.getNamespace() == null) {
+            return path.getFileName().toString();
+        }
+
+        return namespaceToPackageName(info.getNamespace());
     }
 
     private String namespaceToPackageName(final String namespace) {

--- a/exist-core/src/main/java/org/exist/validation/internal/DatabaseResources.java
+++ b/exist-core/src/main/java/org/exist/validation/internal/DatabaseResources.java
@@ -153,7 +153,7 @@ public class DatabaseResources {
                 context.declareVariable(CATALOG, catalogPath);
             }
             
-            CompiledXQuery compiled = xquery.compile(broker, context, new ClassLoaderSource(queryPath) );
+            CompiledXQuery compiled = xquery.compile(context, new ClassLoaderSource(queryPath) );
             
             result = xquery.execute(broker, compiled, null);
             

--- a/exist-core/src/main/java/org/exist/xmldb/LocalXPathQueryService.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalXPathQueryService.java
@@ -279,7 +279,7 @@ public class LocalXPathQueryService extends AbstractLocalService implements EXis
             setupContext(source, context);
 
             if (compiled == null) {
-                compiled = xquery.compile(broker, context, source);
+                compiled = xquery.compile(context, source);
             }
 
             try {
@@ -327,7 +327,7 @@ public class LocalXPathQueryService extends AbstractLocalService implements EXis
 
         try {
             setupContext(null, context);
-            final CompiledExpression expr = xquery.compile(broker, context, query);
+            final CompiledExpression expr = xquery.compile(context, query);
             if(LOG.isDebugEnabled()) {
                 LOG.debug("compilation took {}", System.currentTimeMillis() - start);
             }

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -351,7 +351,7 @@ public class RpcConnection implements RpcAPI {
             context.setStaticallyKnownDocuments(new XmldbURI[]{context.getBaseURI().toXmldbURI()});
         }
         if (compiled == null) {
-            compiled = xquery.compile(broker, context, source);
+            compiled = xquery.compile(context, source);
         }
         return compiled;
     }

--- a/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionFactory.java
@@ -353,7 +353,7 @@ public class FunctionFactory {
                 throw new XPathException(ast.getLine(), ast.getColumn(), ErrorCodes.XPST0017, buf.toString());
             }
         }
-        if ((Boolean) context.getBroker().getConfiguration()
+        if ((Boolean) context.getConfiguration()
                 .getProperty(PROPERTY_DISABLE_DEPRECATED_FUNCTIONS) &&
                 def.getSignature().isDeprecated()) {
             throw new XPathException(ast.getLine(), ast.getColumn(), ErrorCodes.XPST0017,

--- a/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
@@ -29,6 +29,7 @@ import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.security.Subject;
 import org.exist.storage.UpdateListener;
+import org.exist.util.Configuration;
 import org.exist.util.FileUtils;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.value.AnyURIValue;
@@ -70,8 +71,8 @@ public class ModuleContext extends XQueryContext {
         this.location = location;
         setParentContext(parentContext);
 
-        loadDefaults(getBroker().getConfiguration());
-        this.profiler = new Profiler(getBroker().getBrokerPool());
+        loadDefaults(getConfiguration());
+        this.profiler = new Profiler(getBroker() != null ? getBroker().getBrokerPool() : null);
     }
 
     @Override
@@ -180,6 +181,11 @@ public class ModuleContext extends XQueryContext {
             LOG.error(e);
         }
         return ctx;
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return parentContext.getConfiguration();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -22,6 +22,7 @@
 package org.exist.xquery;
 
 import org.exist.dom.QName;
+import org.exist.storage.DBBroker;
 import org.exist.xquery.functions.array.ArrayConstructor;
 import org.exist.xquery.pragmas.Optimize;
 import org.apache.logging.log4j.LogManager;
@@ -66,7 +67,8 @@ public class Optimizer extends DefaultExpressionVisitor {
 
     public Optimizer(XQueryContext context) {
         this.context = context;
-        this.rewriters = context.getBroker().getIndexController().getQueryRewriters(context);
+        final DBBroker broker = context.getBroker();
+        this.rewriters = broker != null ? broker.getIndexController().getQueryRewriters(context) : Collections.emptyList();
     }
 
     public boolean hasOptimized() {

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -60,6 +60,25 @@ public class XQuery {
     /**
      * Compiles an XQuery from a String.
      *
+     * @param broker the database broker (unused)
+     * @param context the XQuery context
+     * @param expression the expression to compile
+     *
+     * @return the compiled XQuery
+     *
+     * @throws XPathException if an error occurs during compilation
+     * @throws PermissionDeniedException if the caller is not permitted to compile the XQuery
+     *
+     * @deprecated Use {@link #compile(XQueryContext, String)} instead.
+     */
+    @Deprecated
+    public CompiledXQuery compile(final DBBroker broker, final XQueryContext context, final String expression) throws XPathException, PermissionDeniedException {
+        return compile(context, expression);
+    }
+
+    /**
+     * Compiles an XQuery from a String.
+     *
      * @param context the XQuery context
      * @param expression the expression to compile
      *
@@ -81,6 +100,26 @@ public class XQuery {
     /**
      * Compiles an XQuery from a Source.
      *
+     * @param broker the database broker (unused)
+     * @param context the XQuery context
+     * @param source the source of the XQuery to compile
+     *
+     * @return the compiled XQuery
+     *
+     * @throws XPathException if an error occurs during compilation
+     * @throws IOException if an IO error occurs when reading the source
+     * @throws PermissionDeniedException if the caller is not permitted to compile the XQuery
+     *
+     * @deprecated Use {@link #compile(XQueryContext, Source)} instead.
+     */
+    @Deprecated
+    public CompiledXQuery compile(final DBBroker broker, final XQueryContext context, final Source source) throws XPathException, IOException, PermissionDeniedException {
+        return compile(context, source);
+    }
+
+    /**
+     * Compiles an XQuery from a Source.
+     *
      * @param context the XQuery context
      * @param source the source of the XQuery to compile
      *
@@ -92,6 +131,27 @@ public class XQuery {
      */
     public CompiledXQuery compile(final XQueryContext context, final Source source) throws XPathException, IOException, PermissionDeniedException {
         return compile(context, source, false);
+    }
+
+    /**
+     * Compiles an XQuery from a Source.
+     *
+     * @param broker the database broker (unused)
+     * @param context the XQuery context
+     * @param source the source of the XQuery to compile
+     * @param xpointer true if the query is part of an XPointer, false otherwise
+     *
+     * @return the compiled XQuery
+     *
+     * @throws XPathException if an error occurs during compilation
+     * @throws IOException if an IO error occurs when reading the source
+     * @throws PermissionDeniedException if the caller is not permitted to compile the XQuery
+     *
+     * @deprecated Use {@link #compile(XQueryContext, Source, boolean)} instead.
+     */
+    @Deprecated
+    public CompiledXQuery compile(final DBBroker broker, final XQueryContext context, final Source source, final boolean xpointer) throws XPathException, IOException, PermissionDeniedException {
+        return compile(context, source, xpointer);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -56,36 +56,86 @@ import org.exist.xquery.value.Sequence;
 public class XQuery {
 
     private final static Logger LOG = LogManager.getLogger(XQuery.class);
-    
-    public CompiledXQuery compile(final DBBroker broker, final XQueryContext context, final String expression) throws XPathException, PermissionDeniedException {
+
+    /**
+     * Compiles an XQuery from a String.
+     *
+     * @param context the XQuery context
+     * @param expression the expression to compile
+     *
+     * @return the compiled XQuery
+     *
+     * @throws XPathException if an error occurs during compilation
+     * @throws PermissionDeniedException if the caller is not permitted to compile the XQuery
+     */
+    public CompiledXQuery compile(final XQueryContext context, final String expression) throws XPathException, PermissionDeniedException {
     	final Source source = new StringSource(expression);
     	try {
-            return compile(broker, context, source);
+            return compile(context, source);
         } catch(final IOException ioe) {
             //should not happen because expression is a String
             throw new XPathException(ioe.getMessage());
         }
     }
-    
-    public CompiledXQuery compile(final DBBroker broker, final XQueryContext context, final Source source) throws XPathException, IOException, PermissionDeniedException {
-        return compile(broker, context, source, false);
+
+    /**
+     * Compiles an XQuery from a Source.
+     *
+     * @param context the XQuery context
+     * @param source the source of the XQuery to compile
+     *
+     * @return the compiled XQuery
+     *
+     * @throws XPathException if an error occurs during compilation
+     * @throws IOException if an IO error occurs when reading the source
+     * @throws PermissionDeniedException if the caller is not permitted to compile the XQuery
+     */
+    public CompiledXQuery compile(final XQueryContext context, final Source source) throws XPathException, IOException, PermissionDeniedException {
+        return compile(context, source, false);
     }
-    
-    public CompiledXQuery compile(final DBBroker broker, final XQueryContext context, final Source source, final boolean xpointer) throws XPathException, IOException, PermissionDeniedException {
+
+    /**
+     * Compiles an XQuery from a Source.
+     *
+     * @param context the XQuery context
+     * @param source the source of the XQuery to compile
+     * @param xpointer true if the query is part of an XPointer, false otherwise
+     *
+     * @return the compiled XQuery
+     *
+     * @throws XPathException if an error occurs during compilation
+     * @throws IOException if an IO error occurs when reading the source
+     * @throws PermissionDeniedException if the caller is not permitted to compile the XQuery
+     */
+    public CompiledXQuery compile(final XQueryContext context, final Source source, final boolean xpointer) throws XPathException, IOException, PermissionDeniedException {
 
         context.setSource(source);
 
         try(final Reader reader = source.getReader()) {
-            return compile(broker, context, reader, xpointer);
+            return compile(context, reader, xpointer);
         } catch(final UnsupportedEncodingException e) {
             throw new XPathException(ErrorCodes.XQST0087, "unsupported encoding " + e.getMessage());
         }
     }
-    
-    private CompiledXQuery compile(final DBBroker broker, final XQueryContext context, final Reader reader, final boolean xpointer) throws XPathException, PermissionDeniedException {
-        
+
+    /**
+     * Compiles an XQuery from a Source.
+     *
+     * @param context the XQuery context
+     * @param reader the reader to use for obtaining theXQuery to compile
+     * @param xpointer true if the query is part of an XPointer, false otherwise
+     *
+     * @return the compiled XQuery
+     *
+     * @throws XPathException if an error occurs during compilation
+     * @throws PermissionDeniedException if the caller is not permitted to compile the XQuery
+     */
+    private CompiledXQuery compile(final XQueryContext context, final Reader reader, final boolean xpointer) throws XPathException, PermissionDeniedException {
+
         //check read permission
-        context.getSource().validate(broker.getCurrentSubject(), Permission.READ);
+        if (context.getSource() instanceof DBSource) {
+            ((DBSource) context.getSource()).validate(Permission.READ);
+        }
         
         
     	//TODO: move XQueryContext.getUserFromHttpSession() here, have to check if servlet.jar is in the classpath
@@ -197,7 +247,9 @@ public class XQuery {
     public Sequence execute(final DBBroker broker, final CompiledXQuery expression, Sequence contextSequence, final Properties outputProperties, final boolean resetContext) throws XPathException, PermissionDeniedException {
     	
         //check execute permissions
-        expression.getContext().getSource().validate(broker.getCurrentSubject(), Permission.EXECUTE);
+        if (expression.getContext().getSource() instanceof DBSource) {
+            ((DBSource) expression.getContext().getSource()).validate(Permission.EXECUTE);
+        }
         
         final long start = System.currentTimeMillis();
     	
@@ -288,13 +340,13 @@ public class XQuery {
 
     public Sequence execute(final DBBroker broker, final String expression, final Sequence contextSequence) throws XPathException, PermissionDeniedException {
         final XQueryContext context = new XQueryContext(broker.getBrokerPool());
-        final CompiledXQuery compiled = compile(broker, context, expression);
+        final CompiledXQuery compiled = compile(context, expression);
         return execute(broker, compiled, contextSequence);
     }
 	
     public Sequence execute(final DBBroker broker, File file, Sequence contextSequence) throws XPathException, IOException, PermissionDeniedException {
         final XQueryContext context = new XQueryContext(broker.getBrokerPool());
-        final CompiledXQuery compiled = compile(broker, context, new FileSource(file.toPath(), true));
+        final CompiledXQuery compiled = compile(context, new FileSource(file.toPath(), true));
         return execute(broker, compiled, contextSequence);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -385,6 +385,8 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     protected Database db;
 
+    protected Configuration configuration = null;
+
     private boolean analyzed = false;
 
     /**
@@ -416,6 +418,12 @@ public class XQueryContext implements BinaryValueManager, Context {
     public XQueryContext() {
         profiler = new Profiler(null);
         staticDecimalFormats.put(UNNAMED_DECIMAL_FORMAT, DecimalFormat.UNNAMED);
+    }
+
+    public XQueryContext(final Configuration configuration) {
+        this();
+        this.configuration = configuration;
+        loadDefaults(configuration);
     }
 
     public XQueryContext(final Database db) {
@@ -2006,7 +2014,17 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     @Override
     public DBBroker getBroker() {
-        return db.getActiveBroker();
+        if (db != null) {
+            return db.getActiveBroker();
+        }
+        return null;
+    }
+
+    public Configuration getConfiguration() {
+        if (db != null) {
+            return db.getConfiguration();
+        }
+        return configuration;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/XQueryWatchDog.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryWatchDog.java
@@ -86,8 +86,7 @@ public class XQueryWatchDog {
     }
 
     private void configureDefaults() {
-    	final DBBroker broker = context.getBroker();
-        final Configuration conf = broker.getBrokerPool().getConfiguration();
+        final Configuration conf = context.getConfiguration();
         Object option = conf.getProperty(PROPERTY_QUERY_TIMEOUT);
         if(option != null)
             {timeout = (Long) option;}

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLang.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLang.java
@@ -99,7 +99,7 @@ public class FunLang extends Function {
 	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
 		super.analyze(contextInfo);
 		try {
-			query = context.getBroker().getBrokerPool().getXQueryService().compile(context.getBroker(), context, queryString);
+			query = context.getBroker().getBrokerPool().getXQueryService().compile(context, queryString);
 		} catch (final PermissionDeniedException e) {
 			throw new XPathException(this, e);
 		}		

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
@@ -463,7 +463,7 @@ public class Eval extends BasicFunction {
         try {
             compiled = cache ? pool.borrowCompiledXQuery(broker, querySource) : null;
             if (compiled == null) {
-                compiled = xqueryService.compile(broker, innerContext, querySource);
+                compiled = xqueryService.compile(innerContext, querySource);
             } else {
                 compiled.getContext().updateContext(innerContext);
                 compiled.getContext().prepareForReuse();

--- a/exist-core/src/main/java/org/exist/xupdate/Conditional.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Conditional.java
@@ -86,7 +86,7 @@ public class Conditional extends Modification {
 		declareVariables(context);
 		if(compiled == null)
 			try {
-				compiled = xquery.compile(broker, context, source);
+				compiled = xquery.compile(context, source);
 			} catch (final IOException e) {
 				throw new EXistException("An exception occurred while compiling the query: " + e.getMessage());
 			}

--- a/exist-core/src/main/java/org/exist/xupdate/Modification.java
+++ b/exist-core/src/main/java/org/exist/xupdate/Modification.java
@@ -166,7 +166,7 @@ public abstract class Modification {
 		declareVariables(context);
 		if(compiled == null)
 			try {
-				compiled = xquery.compile(broker, context, source);
+				compiled = xquery.compile(context, source);
 			} catch (final IOException e) {
 				throw new EXistException("An exception occurred while compiling the query: " + e.getMessage());
 			}

--- a/exist-core/src/test/java/org/exist/TestDataGenerator.java
+++ b/exist-core/src/test/java/org/exist/TestDataGenerator.java
@@ -91,7 +91,7 @@ public class TestDataGenerator {
 
             final String query = IMPORT + xqueryContent;
 
-            final CompiledXQuery compiled = service.compile(broker, context, query);
+            final CompiledXQuery compiled = service.compile(context, query);
 
             for (int i = 0; i < count; i++) {
                 generatedFiles[i] = Files.createTempFile(prefix, ".xml");

--- a/exist-core/src/test/java/org/exist/storage/LowLevelTextTest.java
+++ b/exist-core/src/test/java/org/exist/storage/LowLevelTextTest.java
@@ -66,7 +66,7 @@ public class LowLevelTextTest {
 
 		final XQuery xquery = pool.getXQueryService();
 		final XQueryContext context = new XQueryContext(broker.getBrokerPool());
-		preCompiledXQuery = xquery.compile(broker, context, stringSource);
+		preCompiledXQuery = xquery.compile(context, stringSource);
 	}
 
 	@After

--- a/exist-core/src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -243,7 +243,7 @@ public class ConstructedNodesRecoveryTest {
 	        XQuery service = pool.getXQueryService();
 	        assertNotNull(service);
 	        
-	        CompiledXQuery compiled = service.compile(broker, new XQueryContext(pool), new StringSource(xquery));
+	        CompiledXQuery compiled = service.compile(new XQueryContext(pool), new StringSource(xquery));
 	        assertNotNull(compiled);
 	        
 	        Sequence result = service.execute(broker, compiled, null);

--- a/exist-core/src/test/java/org/exist/xquery/EmbeddedBinariesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/EmbeddedBinariesTest.java
@@ -99,7 +99,7 @@ public class EmbeddedBinariesTest extends AbstractBinariesTest<Sequence, Item, I
             final CompiledXQuery compiled;
             if (existingCompiled == null) {
                 context = new XQueryContext(brokerPool);
-                compiled = xquery.compile(broker, context, source);
+                compiled = xquery.compile(context, source);
             } else {
                 context = existingCompiled.getContext();
                 context.prepareForReuse();

--- a/exist-core/src/test/java/org/exist/xquery/ImportModuleTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ImportModuleTest.java
@@ -1453,7 +1453,7 @@ public class ImportModuleTest {
         }
 
         if (compiled == null) {
-            compiled = xqueryService.compile(broker, context, query);
+            compiled = xqueryService.compile(context, query);
         } else {
             compiled.getContext().updateContext(context);
             context.getWatchDog().reset();

--- a/exist-core/src/test/java/org/exist/xquery/XQueryContextAttributesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryContextAttributesTest.java
@@ -195,7 +195,7 @@ public class XQueryContextAttributesTest {
         }
 
         if (compiled == null) {
-            compiled = xqueryService.compile(broker, context, query);
+            compiled = xqueryService.compile(context, query);
         } else {
             compiled.getContext().updateContext(context);
             context.getWatchDog().reset();

--- a/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
@@ -1148,7 +1148,7 @@ public class XQueryTest {
                 context.declareVariable(new QName("s"), new IntegerValue(timestamp));
 
                 if(compiled == null) {
-                    compiled = xquery.compile(broker, context, source);
+                    compiled = xquery.compile(context, source);
                 }
 
                 final Sequence result = xquery.execute(broker, compiled, null, null);

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
@@ -74,7 +74,7 @@ public class XQueryUpdateTest {
             	"		</product>\n" +
             	"	into /products";
             XQueryContext context = new XQueryContext(pool);
-            CompiledXQuery compiled = xquery.compile(broker, context, query);
+            CompiledXQuery compiled = xquery.compile(context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
                 context.declareVariable("i", Integer.valueOf(i));
                 xquery.execute(broker, compiled, null);
@@ -109,7 +109,7 @@ public class XQueryUpdateTest {
             	"		attribute name { concat('n', $i) }\n" +
             	"	into //product[@num = $i]";
             XQueryContext context = new XQueryContext(pool);
-            CompiledXQuery compiled = xquery.compile(broker, context, query);
+            CompiledXQuery compiled = xquery.compile(context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
                 context.declareVariable("i", Integer.valueOf(i));
                 xquery.execute(broker, compiled, null);
@@ -169,7 +169,7 @@ public class XQueryUpdateTest {
                 "       </product>\n" +
                 "   preceding /products/product[1]";
             XQueryContext context = new XQueryContext(pool);
-            CompiledXQuery compiled = xquery.compile(broker, context, query);
+            CompiledXQuery compiled = xquery.compile(context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
                 context.declareVariable("i", Integer.valueOf(i));
                 xquery.execute(broker, compiled, null);
@@ -219,7 +219,7 @@ public class XQueryUpdateTest {
                 "       </product>\n" +
                 "   following /products/product[1]";
             XQueryContext context = new XQueryContext(pool);
-            CompiledXQuery compiled = xquery.compile(broker, context, query);
+            CompiledXQuery compiled = xquery.compile(context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
                 context.declareVariable("i", Integer.valueOf(i));
                 xquery.execute(broker, compiled, null);
@@ -409,7 +409,7 @@ public class XQueryUpdateTest {
             	"		</product>\n" +
             	"	into /products";
             XQueryContext context = new XQueryContext(pool);
-            CompiledXQuery compiled = xquery.compile(broker, context, query);
+            CompiledXQuery compiled = xquery.compile(context, query);
             for (int i = 0; i < ITEMS_TO_APPEND; i++) {
                 xquery.execute(broker, compiled, null);
             }

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/CollectionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/CollectionTest.java
@@ -84,7 +84,7 @@ public class CollectionTest {
             context.addDynamicallyAvailableCollection(collectionUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());
@@ -118,7 +118,7 @@ public class CollectionTest {
             context.addDynamicallyAvailableCollection(baseUri + collectionRelativeUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/DocTest.java
@@ -164,7 +164,7 @@ public class DocTest {
             context.addDynamicallyAvailableDocument(docUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());
@@ -198,7 +198,7 @@ public class DocTest {
             context.addDynamicallyAvailableDocument(baseUri + docRelativeUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());
@@ -230,7 +230,7 @@ public class DocTest {
             context.addDynamicallyAvailableDocument(docUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());
@@ -254,7 +254,7 @@ public class DocTest {
             context.addDynamicallyAvailableDocument(baseUri + docRelativeUri, (broker2, transaction, uri) -> asInMemoryDocument(doc));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/FunUnparsedTextTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/FunUnparsedTextTest.java
@@ -69,7 +69,7 @@ public class FunUnparsedTextTest {
             context.addDynamicallyAvailableTextResource(textUri, UTF_8, (broker2, transaction, uri, charset) -> new InputStreamReader(new ByteArrayInputStream(text.getBytes(UTF_8)), charset));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());
@@ -94,7 +94,7 @@ public class FunUnparsedTextTest {
             context.addDynamicallyAvailableTextResource(baseUri + textRelativeUri, UTF_8, (broker2, transaction, uri, charset) -> new InputStreamReader(new ByteArrayInputStream(text.getBytes(UTF_8)), charset));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());
@@ -117,7 +117,7 @@ public class FunUnparsedTextTest {
             context.addDynamicallyAvailableTextResource(textUri, UTF_8, (broker2, transaction, uri, charset) -> new InputStreamReader(new ByteArrayInputStream(text.getBytes(UTF_8)), charset));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());
@@ -141,7 +141,7 @@ public class FunUnparsedTextTest {
             context.addDynamicallyAvailableTextResource(baseUri + textRelativeUri, UTF_8, (broker2, transaction, uri, charset) -> new InputStreamReader(new ByteArrayInputStream(text.getBytes(UTF_8)), charset));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
 
             assertFalse(result.isEmpty());
@@ -164,7 +164,7 @@ public class FunUnparsedTextTest {
                     (broker2, transaction, uri, charset) -> new InputStreamReader(null, charset));
 
             final XQuery xqueryService = pool.getXQueryService();
-            final CompiledXQuery compiled = xqueryService.compile(broker, context, query);
+            final CompiledXQuery compiled = xqueryService.compile(context, query);
             final Sequence result = xqueryService.execute(broker, compiled, null);
         }
     }

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/XQueryCompiler.java
@@ -74,7 +74,7 @@ class XQueryCompiler {
                     //set the module load path for any module imports that are relative
                     context.setModuleLoadPath(XmldbURI.EMBEDDED_SERVER_URI_PREFIX + source.getDocumentPath().removeLastSegment());
                     
-                    return broker.getBrokerPool().getXQueryService().compile(broker, context, source);
+                    return broker.getBrokerPool().getXQueryService().compile(context, source);
                 } else {
                     throw new RestXqServiceCompilationException("Invalid mimetype '" +  document.getMimeType() + "' for XQuery: "  + document.getURI().toString());
                 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/AbstractFieldConfig.java
@@ -140,7 +140,7 @@ public abstract class AbstractFieldConfig {
         final XQuery xquery = broker.getBrokerPool().getXQueryService();
         final XQueryContext context = new XQueryContext(broker.getBrokerPool());
         try {
-            return xquery.compile(broker, context, code);
+            return xquery.compile(context, code);
         } catch (XPathException | PermissionDeniedException e) {
             LOG.error("Failed to compile expression: {}: {}", code, e.getMessage(), e);
             isValid = false;

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -592,7 +592,7 @@ public class LuceneIndexTest {
             assertNotNull(xquery);
 
             final XQueryContext context = new XQueryContext(broker.getBrokerPool());
-            final CompiledXQuery compiled = xquery.compile(broker, context, "declare variable $q external; " +
+            final CompiledXQuery compiled = xquery.compile(context, "declare variable $q external; " +
                     "ft:query(//p, parse-xml($q)/query)");
 
             context.declareVariable("q", "<query><term>heiterkeit</term></query>");

--- a/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/EmbeddedBinariesTest.java
+++ b/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/EmbeddedBinariesTest.java
@@ -101,7 +101,7 @@ public class EmbeddedBinariesTest extends AbstractBinariesTest<Sequence, Item, I
             final CompiledXQuery compiled;
             if (existingCompiled == null) {
                 context = new XQueryContext(brokerPool);
-                compiled = xquery.compile(broker, context, source);
+                compiled = xquery.compile(context, source);
             } else {
                 context = existingCompiled.getContext();
                 context.prepareForReuse();

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/Util.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/Util.java
@@ -84,7 +84,7 @@ public class Util {
         }
 
         if (compiled == null) {
-            compiled = xqueryService.compile(broker, context, query);
+            compiled = xqueryService.compile(context, query);
         } else {
             compiled.getContext().updateContext(context);
             context.getWatchDog().reset();

--- a/extensions/security/iprange/src/main/java/org/exist/security/realm/iprange/IPRangeRealm.java
+++ b/extensions/security/iprange/src/main/java/org/exist/security/realm/iprange/IPRangeRealm.java
@@ -122,7 +122,7 @@ public class IPRangeRealm extends AbstractRealm {
                     "iprange[" + ipToTest + " ge number(start) and " + ipToTest + " le number(end)]/../name";
             final XQueryContext context = new XQueryContext(broker.getBrokerPool());
 
-            final CompiledXQuery compiled = queryService.compile(broker, context, query);
+            final CompiledXQuery compiled = queryService.compile(context, query);
 
             final Properties outputProperties = new Properties();
 

--- a/extensions/xqdoc/src/main/java/org/exist/xqdoc/xquery/Scan.java
+++ b/extensions/xqdoc/src/main/java/org/exist/xqdoc/xquery/Scan.java
@@ -191,7 +191,7 @@ public class Scan extends BasicFunction {
             Source source = new ClassLoaderSource(NORMALIZE_XQUERY);
             XQueryContext xc = new XQueryContext(context.getBroker().getBrokerPool());
             try {
-                normalizeXQuery = xquery.compile(context.getBroker(), xc, source);
+                normalizeXQuery = xquery.compile(xc, source);
             } catch(final PermissionDeniedException e) {
                 throw new XPathException(this, e);
             }


### PR DESCRIPTION
This refactors XSuite (which is a JUnit Runner) to follow the JUnit `@BeforeClass` and `@AfterClass` approach to starting and stopping the database for each test suite. It also removes the need to start the database to introspect XQSuite tests, instead it now directly uses eXist-db's XQuery parser to find the tests.

This appears to fix some issues with the test suite that were identified by @reinhapa's JUnit 5 work.