### PR TITLE
Add eXist specific serialization options to fn:serialize

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/serializers/NativeSerializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/NativeSerializer.java
@@ -90,7 +90,7 @@ public class NativeSerializer extends Serializer {
     			return;
     	}
     	setDocument(p.getOwnerDocument());
-    	if (generateDocEvent) {
+    	if (generateDocEvent && !documentStarted) {
             receiver.startDocument();
         }
 

--- a/exist-core/src/main/java/org/exist/storage/serializers/NativeSerializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/NativeSerializer.java
@@ -104,40 +104,41 @@ public class NativeSerializer extends Serializer {
             receiver.endDocument();
         }
     }
-    
+
     protected void serializeToReceiver(DocumentImpl doc, boolean generateDocEvent) throws SAXException {
-    	final long start = System.currentTimeMillis();
-    	
-    	setDocument(doc);
-    	final NodeList children = doc.getChildNodes();
-    	if (generateDocEvent) 
-    		{receiver.startDocument();}
-		
-    	if (doc.getDoctype() != null){
-			if ("yes".equals(getProperty(EXistOutputKeys.OUTPUT_DOCTYPE, "no"))) {
-				final DocumentTypeImpl docType = (DocumentTypeImpl)doc.getDoctype();
-				serializeToReceiver(docType, null, docType.getOwnerDocument(), true, null, new TreeSet<>());
-			}
-		}
-    	
-    	// iterate through children
-    	for (int i = 0; i < children.getLength(); i++) {
-    		final IStoredNode<?> node = (IStoredNode<?>) children.item(i);
-    		try(final INodeIterator domIter = broker.getNodeIterator(node)) {
+        final long start = System.currentTimeMillis();
+
+        setDocument(doc);
+        final NodeList children = doc.getChildNodes();
+        if (generateDocEvent && !documentStarted) {
+            receiver.startDocument();
+        }
+
+        if (doc.getDoctype() != null){
+            if ("yes".equals(getProperty(EXistOutputKeys.OUTPUT_DOCTYPE, "no"))) {
+                final DocumentTypeImpl docType = (DocumentTypeImpl)doc.getDoctype();
+                serializeToReceiver(docType, null, docType.getOwnerDocument(), true, null, new TreeSet<>());
+            }
+        }
+
+        // iterate through children
+        for (int i = 0; i < children.getLength(); i++) {
+            final IStoredNode<?> node = (IStoredNode<?>) children.item(i);
+            try(final INodeIterator domIter = broker.getNodeIterator(node)) {
                 domIter.next();
                 final NodeProxy p = new NodeProxy(node);
                 serializeToReceiver(node, domIter, (DocumentImpl) node.getOwnerDocument(),
-                    true, p.getMatches(), new TreeSet<>());
+                        true, p.getMatches(), new TreeSet<>());
             } catch(final IOException ioe) {
                 LOG.warn("Unable to close node iterator", ioe);
             }
-    	}
+        }
 
-    	if (generateDocEvent) {receiver.endDocument();}
+        if (generateDocEvent) {receiver.endDocument();}
 
-    	if (LOG.isDebugEnabled())
-			{
-                LOG.debug("serializing document {} ({}) to SAX took {} msec", doc.getDocId(), doc.getURI(), System.currentTimeMillis() - start);}
+        if (LOG.isDebugEnabled())
+        {
+            LOG.debug("serializing document {} ({}) to SAX took {} msec", doc.getDocId(), doc.getURI(), System.currentTimeMillis() - start);}
 
     }
     

--- a/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
@@ -782,6 +782,11 @@ public abstract class Serializer implements XMLReader {
 		LOG.debug("compiling stylesheet took {}", System.currentTimeMillis() - start);
         if(templates != null) {
         	xslHandler = factory.get().newTransformerHandler(templates);
+			try {
+				xslHandler.startDocument();
+			} catch (final SAXException e) {
+				throw new TransformerConfigurationException(e.getMessage(), e);
+			}
         }
 //			xslHandler.getTransformer().setOutputProperties(outputProperties);
         checkStylesheetParams();

--- a/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
@@ -192,6 +192,8 @@ public abstract class Serializer implements XMLReader {
     protected Subject user = null;
     
     protected XQueryContext.HttpContext httpContext = null;
+
+	protected boolean documentStarted = false;
     
     public void setHttpContext(final XQueryContext.HttpContext httpContext) {
     	this.httpContext = httpContext;
@@ -784,6 +786,7 @@ public abstract class Serializer implements XMLReader {
         	xslHandler = factory.get().newTransformerHandler(templates);
 			try {
 				xslHandler.startDocument();
+				documentStarted = true;
 			} catch (final SAXException e) {
 				throw new TransformerConfigurationException(e.getMessage(), e);
 			}

--- a/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
@@ -808,22 +808,32 @@ public abstract class Serializer implements XMLReader {
 			final SAXResult result = new SAXResult();
 			boolean processXInclude =
 				"yes".equals(getProperty(EXistOutputKeys.EXPAND_XINCLUDES, "yes"));
-			ReceiverToSAX filter;
+
+			final ReceiverToSAX filter;
 			if (processXInclude) {
-				filter = (ReceiverToSAX)xinclude.getReceiver();
+				final Receiver xincludeReceiver = xinclude.getReceiver();
+				if (xincludeReceiver != null && xincludeReceiver instanceof SAXSerializer) {
+					filter = new ReceiverToSAX((SAXSerializer) xincludeReceiver);
+				} else {
+					filter = (ReceiverToSAX) xincludeReceiver;
+				}
 			} else {
 				filter = (ReceiverToSAX) receiver;
 			}
+
 			result.setHandler(filter.getContentHandler());
 			result.setLexicalHandler(filter.getLexicalHandler());
+
 			filter.setLexicalHandler(xslHandler);
 			filter.setContentHandler(xslHandler);
+
 			xslHandler.setResult(result);
 			if (processXInclude) {
 				xinclude.setReceiver(new ReceiverToSAX(xslHandler));
 				receiver = xinclude;
-			} else
-				{receiver = new ReceiverToSAX(xslHandler);}
+			} else {
+				receiver = new ReceiverToSAX(xslHandler);
+			}
 		}
         if (root != null && getHighlightingMode() != TAG_NONE) {
             final IndexController controller = broker.getIndexController();

--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -156,7 +156,9 @@ public class SerializerUtils {
      * for Exist xquery specific functions
      */
     public enum ExistParameterConvention implements ParameterConvention<QName> {
-        EXPAND_XINCLUDE("expand-xincludes", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE);
+        EXPAND_XINCLUDE("expand-xincludes", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
+        ADD_EXIST_ID("add-exist-id", Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("none"));
+
 
         private final QName parameterName;
         private final int type;

--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -157,6 +157,8 @@ public class SerializerUtils {
      */
     public enum ExistParameterConvention implements ParameterConvention<QName> {
         EXPAND_XINCLUDE("expand-xincludes", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
+        PROCESS_XSL_PI("process-xsl-pi", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
+        JSON_IGNORE_WHITE_SPACE_TEXT_NODES("json-ignore-whitespace-text-nodes", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
         HIGHLIGHT_MATCHES("highlight-matches", Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("none")),
         JSONP("jsonp", Type.STRING, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),
         ADD_EXIST_ID("add-exist-id", Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("none"));
@@ -222,6 +224,7 @@ public class SerializerUtils {
             while (reader.hasNext() && (reader.next() != XMLStreamReader.START_ELEMENT)) {
                 //
             }
+
             if (!Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(reader.getNamespaceURI())) {
                 throw new XPathException(parent, FnModule.SENR0001, "serialization parameter elements should be in the output namespace");
             }

--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -158,6 +158,7 @@ public class SerializerUtils {
     public enum ExistParameterConvention implements ParameterConvention<QName> {
         EXPAND_XINCLUDE("expand-xincludes", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
         HIGHLIGHT_MATCHES("highlight-matches", Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("none")),
+        JSONP("jsonp", Type.STRING, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),
         ADD_EXIST_ID("add-exist-id", Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("none"));
 
 
@@ -218,7 +219,9 @@ public class SerializerUtils {
     public static void getSerializationOptions(final Expression parent, final NodeValue parameters, final Properties properties) throws XPathException {
         try {
             final XMLStreamReader reader = parent.getContext().getXMLStreamReader(parameters);
-            while (reader.hasNext() && (reader.next() != XMLStreamReader.START_ELEMENT)) { }
+            while (reader.hasNext() && (reader.next() != XMLStreamReader.START_ELEMENT)) {
+                //
+            }
             if (!Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(reader.getNamespaceURI())) {
                 throw new XPathException(parent, FnModule.SENR0001, "serialization parameter elements should be in the output namespace");
             }
@@ -400,9 +403,7 @@ public class SerializerUtils {
     }
 
     private static void setPropertyForMap(final Properties properties, final ParameterConvention<?> parameterConvention, final Sequence parameterValue) throws XPathException {
-        //TODO(YB): have a discussion about DECIMAL TYPE
-        // ignore "admit" i.e. "standalone" empty sequence
-        // ignore "absent" i.e. empty sequence
+        // ignore "absent","admit" i.e. "standalone" empty sequence
         if(parameterValue.isEmpty()) {
             return;
         }

--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -157,6 +157,7 @@ public class SerializerUtils {
      */
     public enum ExistParameterConvention implements ParameterConvention<QName> {
         EXPAND_XINCLUDE("expand-xincludes", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
+        HIGHLIGHT_MATCHES("highlight-matches", Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("none")),
         ADD_EXIST_ID("add-exist-id", Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("none"));
 
 

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -675,24 +675,24 @@ function ser:adaptive-xs-strings-map-params() {
         ser:adaptive-map-params($input, ",")
 };
 
- declare
+declare
   %test:assertXPath("contains($result, 'include')")
-  function ser:exist-expand-xinclude-false() {
-  let $doc := document{               <article xmlns:xi="http://www.w3.org/2001/XInclude">
-                                        <title>My Title</title>
-                                        <xi:include href="{$ser:collection}/test.xml"/>
-                                      </article>
-                     } return
-    fn:serialize($doc, map { xs:QName("exist:expand-xincludes"): false() })
-  };
+function ser:exist-expand-xinclude-false() {
+    let $doc := document{<article xmlns:xi="http://www.w3.org/2001/XInclude">
+                            <title>My Title</title>
+                            <xi:include href="{$ser:collection}/test.xml"/>
+                        </article>}
+    return
+        fn:serialize($doc, map { xs:QName("exist:expand-xincludes"): false() })
+};
 
 declare
  %test:assertXPath("contains($result, 'comment')")
- function ser:exist-expand-xinclude-true() {
- let $doc := document{               <article xmlns:xi="http://www.w3.org/2001/XInclude">
-                                       <title>My Title</title>
-                                       <xi:include href="{$ser:collection}/test.xml"/>
-                                     </article>
-                    } return
-   fn:serialize($doc, map {  xs:QName("exist:expand-xincludes"): true() })
- };
+function ser:exist-expand-xinclude-true() {
+    let $doc := document{<article xmlns:xi="http://www.w3.org/2001/XInclude">
+                            <title>My Title</title>
+                            <xi:include href="{$ser:collection}/test.xml"/>
+                        </article>}
+    return
+        fn:serialize($doc, map {  xs:QName("exist:expand-xincludes"): true() })
+};

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -105,7 +105,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 
 declare variable $ser:test-xsl := document {
-    <?xml-stylesheet href="xmldb:exist://db/serialization-test/test.xsl" type="text/xsl"?>,
+    <?xml-stylesheet href="xmldb:exist:///db/serialization-test/test.xsl" type="text/xsl"?>,
     <elem a="abc"><!--comment--><b>123</b></elem>
 };
 

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -676,7 +676,7 @@ function ser:adaptive-xs-strings-map-params() {
 };
 
 declare
-  %test:assertXPath("contains($result, 'include')")
+    %test:assertXPath("contains($result, 'include')")
 function ser:exist-expand-xinclude-false() {
     let $doc := document{<article xmlns:xi="http://www.w3.org/2001/XInclude">
                             <title>My Title</title>
@@ -687,7 +687,7 @@ function ser:exist-expand-xinclude-false() {
 };
 
 declare
- %test:assertXPath("contains($result, 'comment')")
+    %test:assertXPath("contains($result, 'comment')")
 function ser:exist-expand-xinclude-true() {
     let $doc := document{<article xmlns:xi="http://www.w3.org/2001/XInclude">
                             <title>My Title</title>

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -696,3 +696,25 @@ function ser:exist-expand-xinclude-true() {
     return
         fn:serialize($doc, map {  xs:QName("exist:expand-xincludes"): true() })
 };
+
+declare
+    %test:assertXPath("contains($result, 'true')")
+function ser:exist-add-exist-id-all() {
+    let $doc := doc($ser:collection || "/test.xml")
+    return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "all" }) eq '<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b exist:id="2.3">123</b></elem>'
+};
+
+declare
+    %test:assertXPath("contains($result, 'true')")
+function ser:exist-add-exist-id-element() {
+    let $doc := doc($ser:collection || "/test.xml")
+    return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "element" })  eq '<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b>123</b></elem>'
+};
+
+declare
+     %test:assertXPath("not(contains($result, 'exist:id'))")
+function ser:exist-add-exist-id-none() {
+    let $doc := doc($ser:collection || "/test.xml")
+    return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "none" })
+};
+

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -742,33 +742,16 @@ function ser:exist-jsonp() {
     return fn:serialize($node, map {"method":"json", "media-type":"application/json", xs:QName("exist:jsonp"):"functionName"}) eq 'functionName({"author":["John Doe","Robert Smith"]})'
 };
 
-
 declare
-    %test:assertXPath("contains($result, 'null')")
-function ser:exist-json-ignore-whitespace-text-nodes-false() {
-      let $node := <book>
-          <author>John Doe</author>
-          <author>Robert Smith</author>
-          <author>  </author>
-      </book>
-    return fn:serialize($node, map {"method":"json", "media-type":"application/json", xs:QName("exist:json-ignore-whitespace-text-nodes"): false()})
-};
-
-declare
-    %test:assertXPath("contains($result, 'true')")
-function ser:exist-json-ignore-whitespace-text-nodes-true() {
-    let $node := <a z='99'>
-                <b x='1'/>
-                <b x='2'></b>
-                <b x='3'>stuff</b>
-                <b>           </b>
-               </a>
-    return fn:serialize($node, map {"method":"json", "media-type":"application/json", xs:QName("exist:json-ignore-whitespace-text-nodes"): false()})
-};
-
-declare
-    %test:assertXPath("contains($result, 'true')")
+    %test:assertEquals('processed')
 function ser:exist-process-xsl-pi-true() {
     let $doc := doc($ser:collection || "/test-xsl.xml")
     return fn:serialize($doc, map {xs:QName("exist:process-xsl-pi"): true()})
+};
+
+declare
+    %test:assertXPath("contains($result, 'stylesheet')")
+function ser:exist-process-xsl-pi-false() {
+    let $doc := doc($ser:collection || "/test-xsl.xml")
+    return fn:serialize($doc, map {xs:QName("exist:process-xsl-pi"): false()})
 };

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -674,3 +674,25 @@ function ser:adaptive-xs-strings-map-params() {
     return
         ser:adaptive-map-params($input, ",")
 };
+
+ declare
+  %test:assertXPath("contains($result, 'include')")
+  function ser:exist-expand-xinclude-false() {
+  let $doc := document{               <article xmlns:xi="http://www.w3.org/2001/XInclude">
+                                        <title>My Title</title>
+                                        <xi:include href="{$ser:collection}/test.xml"/>
+                                      </article>
+                     } return
+    fn:serialize($doc, map { xs:QName("exist:expand-xincludes"): false() })
+  };
+
+declare
+ %test:assertXPath("contains($result, 'comment')")
+ function ser:exist-expand-xinclude-true() {
+ let $doc := document{               <article xmlns:xi="http://www.w3.org/2001/XInclude">
+                                       <title>My Title</title>
+                                       <xi:include href="{$ser:collection}/test.xml"/>
+                                     </article>
+                    } return
+   fn:serialize($doc, map {  xs:QName("exist:expand-xincludes"): true() })
+ };

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -718,3 +718,13 @@ function ser:exist-add-exist-id-none() {
     return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "none" })
 };
 
+declare
+    %test:assertXPath("contains($result, 'true')")
+function ser:exist-jsonp() {
+      let $node := <book>
+          <author>John Doe</author>
+          <author>Robert Smith</author>
+      </book>
+    return fn:serialize($node, map {"method":"json", "media-type":"application/json", xs:QName("exist:jsonp"):"functionName"}) eq 'functionName({"author":["John Doe","Robert Smith"]})'
+};
+

--- a/extensions/indexes/lucene/src/test/xquery/lucene/serialize.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/serialize.xql
@@ -1,0 +1,193 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace ser="http://exist-db.org/xquery/test/serialize";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare %private function ser:adaptive($data, $itemSep as xs:string?) {
+    let $options :=
+        <output:serialization-parameters
+            xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
+            <output:method value="adaptive"/>
+            <output:indent>no</output:indent>
+            {
+                if ($itemSep) then
+                    <output:item-separator>{$itemSep}</output:item-separator>
+                else
+                    ()
+            }
+        </output:serialization-parameters>
+    return
+        fn:serialize($data, $options)
+};
+
+declare %private function ser:adaptive-map-params($data, $itemSep as xs:string?) {
+    let $options :=
+        map {
+            "method": "adaptive",
+            "indent": false(),
+            "item-separator": $itemSep
+        }
+    return
+        fn:serialize($data, $options)
+};
+
+declare %private function ser:adaptive($data) {
+    ser:adaptive($data, ())
+};
+
+declare %private function ser:adaptive-map-params($data) {
+    ser:adaptive-map-params($data, ())
+};
+
+declare variable $ser:atomic :=
+    <atomic:root xmlns:atomic="http://www.w3.org/XQueryTest" xmlns:foo="http://www.example.com/foo"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <atomic:duration>P1Y2M3DT10H30M</atomic:duration>
+      <atomic:dateTime>2002-04-02T12:00:00Z</atomic:dateTime>
+      <atomic:time>13:20:10.5Z</atomic:time>
+      <atomic:date>2000-01-01+05:00</atomic:date>
+      <atomic:gYearMonth>2001-12</atomic:gYearMonth>
+      <atomic:gYear>2001</atomic:gYear>
+      <atomic:gMonthDay>--12-17</atomic:gMonthDay>
+      <atomic:gDay>---17</atomic:gDay>
+      <atomic:gMonth>--12</atomic:gMonth>
+      <atomic:boolean>true</atomic:boolean>
+      <atomic:base64Binary>R0lGODlhcgGSALMAAAQCAEMmCZtuMFQxDS8b</atomic:base64Binary>
+      <atomic:hexBinary>A9FD64E12C</atomic:hexBinary>
+      <atomic:float>1267.43233E12</atomic:float>
+      <atomic:double>1267.43233E12</atomic:double>
+      <atomic:anyURI>http://www.example.com</atomic:anyURI>
+      <atomic:NCName atomic:attr="aNCname">aNCname</atomic:NCName>
+      <atomic:QName atomic:attr="foo:aQname">foo:aQname</atomic:QName>
+      <atomic:string>A String Function</atomic:string>
+      <atomic:normalizedString>aNormalizedString</atomic:normalizedString>
+      <atomic:language>EN</atomic:language>
+      <atomic:decimal atomic:attr="12678967.543233">12678967.543233</atomic:decimal>
+      <atomic:integer>12678967543233</atomic:integer>
+      <atomic:nonPositiveInteger>-1</atomic:nonPositiveInteger>
+      <atomic:long>12678967543233</atomic:long>
+      <atomic:nonNegativeInteger>12678967543233</atomic:nonNegativeInteger>
+      <atomic:negativeInteger>-12678967543233</atomic:negativeInteger>
+      <atomic:int>126789675</atomic:int>
+      <atomic:unsignedLong>12678967543233</atomic:unsignedLong>
+      <atomic:positiveInteger>12678967543233</atomic:positiveInteger>
+      <atomic:short>12678</atomic:short>
+      <atomic:unsignedInt>1267896754</atomic:unsignedInt>
+      <atomic:byte>126</atomic:byte>
+      <atomic:unsignedShort>12678</atomic:unsignedShort>
+      <atomic:unsignedByte>126</atomic:unsignedByte>
+      <atomic:id1>id1</atomic:id1>
+      <atomic:id2>id2</atomic:id2>
+      <atomic:idrefs atomic:attr="id1 id2">id1 id2</atomic:idrefs>
+    </atomic:root>;
+
+declare variable $ser:test-xml := document {
+    <?pi?>,
+    <elem a="abc"><!--comment--><b>123</b></elem>
+};
+
+declare variable $ser:test-xml-collection-xconf := document {
+    <collection xmlns="http://exist-db.org/collection-config/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <index>
+            <lucene>
+                <text qname="b"/>
+            </lucene>
+        </index>
+    </collection>
+};
+declare variable $ser:collection-name := "serialization-test";
+
+declare variable $ser:collection := "/db/" || $ser:collection-name;
+
+declare
+    %test:setUp
+function ser:setup() {
+    xmldb:create-collection("/db", "system"),
+    xmldb:create-collection("/db/system", "config"),
+    xmldb:create-collection("/db/system/config", "db"),
+    xmldb:create-collection("/db/system/config/db", $ser:collection-name),
+    xmldb:store("/db/system/config/db/serialization-test", "collection.xconf", $ser:test-xml-collection-xconf),
+    xmldb:create-collection("/db", $ser:collection-name),
+    xmldb:store($ser:collection, "test.xml", $ser:test-xml)
+};
+
+declare
+    %test:tearDown
+function ser:teardown() {
+    xmldb:remove($ser:collection)
+};
+
+declare
+    %test:assertXPath("contains($result, 'exist:id')")
+function ser:exist-add-exist-id-all() {
+    let $doc := doc($ser:collection || "/test.xml")
+    return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "all" })
+};
+
+declare
+    %test:assertXPath("contains($result, 'exist:id')")
+function ser:exist-add-exist-id-element() {
+    let $doc := doc($ser:collection || "/test.xml")
+    return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "element" })
+};
+
+declare
+     %test:assertXPath("not(contains($result, 'exist:id'))")
+function ser:exist-add-exist-id-none() {
+    let $doc := doc($ser:collection || "/test.xml")
+    return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "none" })
+};
+
+declare
+     %test:assertXPath("contains($result, 'exist:match')")
+function ser:exist-highlight-matches-both() {
+    let $doc := doc($ser:collection || "/test.xml")
+    for $hit in $doc//b[ft:query(., "123")]
+    return fn:serialize($hit, map { xs:QName("exist:highlight-matches"): "both" })
+};
+
+declare
+     %test:assertXPath("contains($result, 'exist:match')")
+function ser:exist-highlight-matches-elements() {
+    let $doc := doc($ser:collection || "/test.xml")
+    for $hit in $doc//b[ft:query(., "123")]
+    return fn:serialize($hit, map { xs:QName("exist:highlight-matches"): "elements" })
+};
+
+declare
+     %test:assertXPath("contains($result, 'exist:match')")
+function ser:exist-highlight-matches-attributes() {
+    let $doc := doc($ser:collection || "/test.xml")
+    for $hit in $doc//b[ft:query(., "123")]
+    return fn:serialize($hit, map { xs:QName("exist:highlight-matches"): "attributes" })
+};
+
+declare
+     %test:assertXPath("not(contains($result, 'exist:match'))")
+function ser:exist-highlight-matches-none() {
+    let $doc := doc($ser:collection || "/test.xml")
+    for $hit in $doc//b[ft:query(., "123")]
+    return fn:serialize($hit, map { xs:QName("exist:highlight-matches"): "none" })
+};

--- a/extensions/indexes/lucene/src/test/xquery/lucene/serialize.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/serialize.xql
@@ -140,27 +140,6 @@ function ser:teardown() {
 };
 
 declare
-    %test:assertXPath("contains($result, 'exist:id')")
-function ser:exist-add-exist-id-all() {
-    let $doc := doc($ser:collection || "/test.xml")
-    return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "all" })
-};
-
-declare
-    %test:assertXPath("contains($result, 'exist:id')")
-function ser:exist-add-exist-id-element() {
-    let $doc := doc($ser:collection || "/test.xml")
-    return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "element" })
-};
-
-declare
-     %test:assertXPath("not(contains($result, 'exist:id'))")
-function ser:exist-add-exist-id-none() {
-    let $doc := doc($ser:collection || "/test.xml")
-    return fn:serialize($doc, map { xs:QName("exist:add-exist-id"): "none" })
-};
-
-declare
      %test:assertXPath("contains($result, 'exist:match')")
 function ser:exist-highlight-matches-both() {
     let $doc := doc($ser:collection || "/test.xml")


### PR DESCRIPTION
Implementation of eXist-specific serialization parameters 
Closes https://github.com/eXist-db/exist/issues/2394
Documentation https://github.com/eXist-db/documentation/pull/672

You can now directly apply the serialization parameter using `fn:serialize`
```xquery
fn:serialize($node, map { xs:QName("exist:expand-xincludes") : false() })
```
