### PR TITLE
Refactor DBBroker into an Interface

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/DBBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/DBBroker.java
@@ -77,15 +77,15 @@ import java.util.function.Function;
 public interface DBBroker extends AutoCloseable {
 
 	// Matching types
-	int MATCH_EXACT 		= 0;
-	int MATCH_REGEXP 		= 1;
+    int MATCH_EXACT 		= 0;
+    int MATCH_REGEXP 		= 1;
     int MATCH_WILDCARDS 	= 2;  // no longer used!
-	int MATCH_CONTAINS 		= 3;
-	int MATCH_STARTSWITH 	= 4;
-	int MATCH_ENDSWITH 		= 5;
+    int MATCH_CONTAINS 		= 3;
+    int MATCH_STARTSWITH 	= 4;
+    int MATCH_ENDSWITH 		= 5;
 	
 	//TODO : move elsewhere
-	String CONFIGURATION_ELEMENT_NAME = "xupdate";
+    String CONFIGURATION_ELEMENT_NAME = "xupdate";
     
     //TODO : move elsewhere
     String XUPDATE_FRAGMENTATION_FACTOR_ATTRIBUTE = "allowed-fragmentation";

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -695,7 +695,7 @@ public class NativeBroker implements DBBroker {
         if (uri.startsWith(XmldbURI.ROOT_COLLECTION_URI)) {
             return uri;
         }
-        return uri.prepend(XmldbURI.ROOT_COLLECTION_URI);
+        return XmldbURI.ROOT_COLLECTION_URI.append(uri);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -167,8 +167,6 @@ public class NativeBroker implements DBBroker {
 
     private final static DigestType BINARY_RESOURCE_DIGEST_TYPE = DigestType.BLAKE_256;
 
-    private boolean caseSensitive = true;
-
     private Configuration config;
 
     private BrokerPool pool;
@@ -224,7 +222,6 @@ public class NativeBroker implements DBBroker {
     private IEmbeddedXMLStreamReader streamReader;
 
     private final LockManager lockManager;
-    private final Optional<JournalManager> logManager;
 
     /**
      * Observer Design Pattern: List of ContentLoadingObserver objects
@@ -236,15 +233,10 @@ public class NativeBroker implements DBBroker {
     // initialize database; read configuration, etc.
     public NativeBroker(final BrokerPool pool, final Configuration config) throws EXistException {
         this.config = config;
-        final Boolean temp = (Boolean) config.getProperty(NativeValueIndex.PROPERTY_INDEX_CASE_SENSITIVE);
-        if (temp != null) {
-            caseSensitive = temp;
-        }
         this.pool = pool;
         this.preserveOnCopy = config.getProperty(PRESERVE_ON_COPY_PROPERTY, PreserveType.NO_PRESERVE);
 
         this.lockManager = pool.getLockManager();
-        this.logManager = pool.getJournalManager();
         LOG.debug("Initializing broker {}", hashCode());
 
         final String prependDB = (String) config.getProperty("db-connection.prepend-db");

--- a/exist-core/src/main/java/org/exist/storage/NativeValueIndex.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeValueIndex.java
@@ -189,8 +189,8 @@ public class NativeValueIndex implements ContentLoadingObserver {
                     cacheValueThresHold);
             config.setProperty(getConfigKeyForFile(), nativeFile);
         }
-        dbValues = nativeFile;
-        caseSensitive = Optional.ofNullable((Boolean) config.getProperty(NativeValueIndex.PROPERTY_INDEX_CASE_SENSITIVE)).orElse(false);
+        this.dbValues = nativeFile;
+        this.caseSensitive = Optional.ofNullable((Boolean) config.getProperty(NativeValueIndex.PROPERTY_INDEX_CASE_SENSITIVE)).orElse(false);
 
         broker.addContentLoadingObserver(getInstance());
     }


### PR DESCRIPTION
Previously `DBBroker` was an Abstract Class, however for as long as I can remember there has only been a single sub-class which is `NativeBroker`. Whilst eXist-db was originally designed to have different brokers (e.g. MySQL as an option), that ability has long since disappeared. The mixing of code between DBBroker and NativeBroker was confusing.
DBBroker should have been an interface and now is.

PR https://github.com/eXist-db/exist/pull/3992 should be merged first ideally.

**NOTE** - These changes are API *backwards compatible* at the source level only! They are not backwards compatible at the *compilation level*. That is to say that libraries compiled against versions of eXist-db before this change may (if they use this class) raise the error :
```java
java.lang.IncompatibleClassChangeError: Found interface org.exist.storage.DBBroker, but class was expected
```