### PR TITLE
Further Map Immutability Tests

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -680,6 +680,7 @@
                                 <exclude>src/test/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticateTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/util/Eval.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/value/BifurcanMapTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/ItemComparator.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/SequenceComparator.java</exclude>
@@ -820,6 +821,7 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/test/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticateTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/util/Eval.java</include>
                                 <include>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</include>
+                                <include>src/test/java/org/exist/xquery/value/BifurcanMapTest.java</include>
                                 <include>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</include>
                                 <include>src/main/java/org/exist/xquery/value/ItemComparator.java</include>
                                 <include>src/main/java/org/exist/xquery/value/SequenceComparator.java</include>

--- a/exist-core/src/test/java/org/exist/xquery/value/BifurcanMapTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/BifurcanMapTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.value;
+
+import io.lacuna.bifurcan.IMap;
+import io.lacuna.bifurcan.LinearMap;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import static org.exist.xquery.functions.map.MapType.newLinearMap;
+import static org.junit.Assert.*;
+
+/**
+ * Tests to demonstrate Bifurcan Map behaviour
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class BifurcanMapTest {
+
+    /**
+     * Reproduces the XQSuite Test `mt:immutable-remove-then-remove()` from `maps.xql`:
+     *
+     * <code>
+     *     let $removed := map:remove(map { 1: true(), 2: true() }, 2)
+     *     let $expected := $removed(1)
+     *     let $result := map:remove($removed, 1)
+     *     return
+     *         (
+     *              $expected eq $removed(1),
+     *              $expected ne $result(1)
+     *         )
+     * </code>
+     */
+    @Test
+    public void immutableRemoveThenRemove() {
+
+        /*
+          1. Create the initial map: `map { 1: true(), 2: true() }`
+         */
+        final IMap<AtomicValue, Sequence> map = createMap();
+        checkMapIsForked(map);
+
+        /*
+          2. Remove the entry in the initial map with key `2`: `let $removed := map:remove(..., 2)`
+         */
+        final IMap<AtomicValue, Sequence> removed = removeFromMap(map, new IntegerValue(2));
+        // taken from MapType.java constructor
+        checkMapIsForked(removed);
+
+        /*
+          3. Get the entry in the removed map with key `1`: `$expected := $removed(1)`
+         */
+        final Sequence expected = getFromMap(removed, new IntegerValue(1));
+
+        /*
+         4. Remove the entry in the removed map with key `1`: `let $result := map:remove($removed, 1)`
+         */
+        final IMap<AtomicValue, Sequence> result = removeFromMap(removed, new IntegerValue(1));
+        // taken from MapType.java constructor
+        checkMapIsForked(result);
+
+        /*
+         `$expected eq $removed(1)`
+        */
+        assertEquals(expected, getFromMap(removed, new IntegerValue(1)));
+
+        /*
+         `$expected ne $result(1)`
+         */
+        assertNotEquals(expected, getFromMap(result, new IntegerValue(1)));
+    }
+
+    /*
+    Taken from MapExpr.java
+     */
+    private static IMap<AtomicValue, Sequence> createMap() {
+        final IMap<AtomicValue, Sequence> map = newLinearMap(null);
+        map.put(new IntegerValue(1), BooleanValue.TRUE);
+        map.put(new IntegerValue(2), BooleanValue.TRUE);
+
+        // return an immutable map
+        return map.forked();
+    }
+
+    /*
+    Taken from MapFunction.java MapFunction#remove(Sequence[])
+     */
+    private static IMap<AtomicValue, Sequence> removeFromMap(final IMap<AtomicValue, Sequence> map, final AtomicValue... keys) {
+        // create a transient map
+        IMap<AtomicValue, Sequence> newMap = map.linear();
+
+        for (final AtomicValue key: keys) {
+            newMap = newMap.remove(key);
+        }
+
+        // return an immutable map
+        return newMap.forked();
+    }
+
+    /*
+    Taken from MapType.java MapType#get(AtomicValue)
+     */
+    private static @Nullable Sequence getFromMap(final IMap<AtomicValue, Sequence> map, final AtomicValue key) {
+        return map.get(key, null);
+    }
+
+    @Test
+    public void bifurcanImmutableRemoveThenRemove() {
+
+        /*
+          1. Create the initial map: `map { 1: true(), 2: true() }`
+         */
+        IMap<Integer, Boolean> map = new LinearMap<>();
+        map.put(1, true);
+        map.put(2, true);
+        map = map.forked();  // make the map immutable
+        checkMapIsForked(map);
+
+        /*
+          2. Remove the entry in the initial map with key `2`: `let $removed := map:remove(..., 2)`
+         */
+        IMap<Integer, Boolean> removed = map.linear();  // create a transient map for modifications
+        assertFalse(removed == map);
+        removed = removed.remove(2);
+        removed = removed.forked();  // make the map immutable
+        checkMapIsForked(removed);
+
+        /*
+          3. Get the entry in the removed map with key `1`: `$expected := $removed(1)`
+         */
+        final Boolean expected = removed.get(1, null);
+
+        /*
+         4. Remove the entry in the removed map with key `1`: `let $result := map:remove($removed, 1)`
+         */
+        IMap<Integer, Boolean> result = removed.linear();  // create a transient map for modifications
+        assertFalse(result == removed);
+        result = result.remove(1);
+        result = result.forked();  // make the map immutable
+        checkMapIsForked(result);
+
+        /*
+         `$expected eq $removed(1)`
+        */
+        assertEquals(expected, removed.get(1, null));
+
+        /*
+         `$expected ne $result(1)`
+         */
+        assertNotEquals(expected, result.get(1, null));
+    }
+
+    /*
+     Taken from MapType.java constructor
+     */
+    private static <K,V> void checkMapIsForked(final IMap<K, V> map) throws IllegalArgumentException {
+        if (map.isLinear()) {
+            throw new IllegalArgumentException("Map must be immutable, but linear Map was provided");
+        }
+    }
+}

--- a/exist-core/src/test/xquery/maps/MapsLookup.xml
+++ b/exist-core/src/test/xquery/maps/MapsLookup.xml
@@ -35,13 +35,19 @@
         <remove-collection collection="/db/xq3-test"/>
     </tearDown>
 
-    <!-- fix - "variable declaration of '$var' cannot be executed because of a circularity" -->
+    <!-- TODO(AR) - this raises "err:XQST0054 It is a static error if a variable depends on itself" because dependencies are calculated over zealously -->
     <test output="text" id="maps-lookup-001" ignore="true">
         <task>maps-lookup-001</task>
         <code><![CDATA[xquery version "3.0";
 
-declare variable $var := map { 'a':local:fun#1, 'b':0 };
-declare function local:fun($a) { $var?b = $a };
+declare variable $var := map {
+    'a' : local:fun#1,
+    'b' : 0
+};
+
+declare function local:fun($a) {
+    $var?b = $a
+};
 local:fun(1)
 
 ]]></code>

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -644,93 +644,92 @@ declare
     %test:assertTrue
 function mt:immutable-put-then-put() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
-    let $expected := $extended?($mt:test-key-one)
+    let $expected := $extended($mt:test-key-one)
     let $result := map:put($extended, $mt:test-key-one, false())
-
-    return $expected eq $extended?($mt:test-key-one)
+    return $expected eq $extended($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-put-then-remove() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
-    let $expected := $extended?($mt:test-key-one)
+    let $expected := $extended($mt:test-key-one)
     let $result := map:remove($extended, $mt:test-key-one)
 
-    return $expected eq $extended?($mt:test-key-one)
+    return $expected eq $extended($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-put-then-merge() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
-    let $expected := $extended?($mt:test-key-one)
+    let $expected := $extended($mt:test-key-one)
     let $result := map:merge(($extended, map { $mt:test-key-one : false() }))
 
-    return $expected eq $extended?($mt:test-key-one)
+    return $expected eq $extended($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-remove-then-put() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
-    let $expected := $removed?($mt:test-key-one)
+    let $expected := $removed($mt:test-key-one)
 
     let $result := map:put($removed, $mt:test-key-one, false())
 
-    return $expected eq $removed?($mt:test-key-one)
+    return $expected eq $removed($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-remove-then-remove() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
-    let $expected := $removed?($mt:test-key-one)
+    let $expected := $removed($mt:test-key-one)
 
     let $result := map:put($removed, $mt:test-key-one, false())
 
-    return $expected eq $removed?($mt:test-key-one)
+    return $expected eq $removed($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-remove-then-merge() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
-    let $expected := $removed?($mt:test-key-one)
+    let $expected := $removed($mt:test-key-one)
     let $result := map:merge(($removed, map { $mt:test-key-one : false() }))
 
-    return $expected eq $removed?($mt:test-key-one)
+    return $expected eq $removed($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-merge-then-put() {
     let $merged := map:merge(mt:create-test-map())
-    let $expected := $merged?($mt:test-key-one)
+    let $expected := $merged($mt:test-key-one)
 
     let $result := map:put($merged, $mt:test-key-one, false())
 
-    return $expected eq $merged?($mt:test-key-one)
+    return $expected eq $merged($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-merge-then-remove() {
     let $merged := map:merge(mt:create-test-map())
-    let $expected := $merged?($mt:test-key-one)
+    let $expected := $merged($mt:test-key-one)
 
     let $result := map:remove($merged, $mt:test-key-one)
 
-    return $expected eq $merged?($mt:test-key-one)
+    return $expected eq $merged($mt:test-key-one)
 };
 
 declare
     %test:assertTrue
 function mt:immutable-merge-then-merge() {
     let $merged := map:merge(mt:create-test-map())
-    let $expected := $merged?($mt:test-key-one)
+    let $expected := $merged($mt:test-key-one)
 
     let $result := map:merge(($merged, map { $mt:test-key-one : false() }))
 
-    return $expected eq $merged?($mt:test-key-one)
+    return $expected eq $merged($mt:test-key-one)
 };

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -693,15 +693,18 @@ function mt:immutable-remove-then-put() {
 };
 
 declare
-    %test:assertEquals("true", "true")
+    %test:assertEquals("true", 1, "true", "true", 0)
 function mt:immutable-remove-then-remove() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed($mt:test-key-one)
     let $result := map:remove($removed, $mt:test-key-one)
     return
         (
+            fn:empty($removed($mt:test-key-two)),
+            map:size($removed),
             $expected eq $removed($mt:test-key-one),
-            $expected ne $result($mt:test-key-one)
+            fn:empty($result($mt:test-key-one)),
+            map:size($result)
         )
 };
 
@@ -732,15 +735,17 @@ function mt:immutable-merge-then-put() {
 };
 
 declare
-    %test:assertEquals("true", "true")
+    %test:assertEquals(2, "true", "true", 1)
 function mt:immutable-merge-then-remove() {
     let $merged := map:merge(mt:create-test-map())
     let $expected := $merged($mt:test-key-one)
     let $result := map:remove($merged, $mt:test-key-one)
     return
         (
+            map:size($merged),
             $expected eq $merged($mt:test-key-one),
-            $expected ne $result($mt:test-key-one)
+            fn:empty($result($mt:test-key-one)),
+            map:size($result)
         )
 };
 

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -695,10 +695,9 @@ declare
 function mt:immutable-remove-then-remove() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed($mt:test-key-one)
-
-    let $result := map:put($removed, $mt:test-key-one, false())
-
-    return $expected eq $removed($mt:test-key-one)
+    let $result := map:remove($removed, $mt:test-key-one)
+    return
+        $expected eq $removed($mt:test-key-one),
 };
 
 declare

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -641,32 +641,42 @@ declare function mt:create-test-map() {
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-put-then-put() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended($mt:test-key-one)
     let $result := map:put($extended, $mt:test-key-one, false())
-    return $expected eq $extended($mt:test-key-one)
+    return
+        (
+            $expected eq $extended($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-put-then-remove() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended($mt:test-key-one)
     let $result := map:remove($extended, $mt:test-key-one)
-
-    return $expected eq $extended($mt:test-key-one)
+    return
+        (
+            $expected eq $extended($mt:test-key-one),
+            empty($result($mt:test-key-one))
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-put-then-merge() {
     let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended($mt:test-key-one)
     let $result := map:merge(($extended, map { $mt:test-key-one : false() }))
-
-    return $expected eq $extended($mt:test-key-one)
+    return
+        (
+            $expected eq $extended($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -627,3 +627,110 @@ function mt:multi-merge() {
   	    map { "wolfgang": "de" }
   	))?*
 };
+
+(:
+  immutability tests for https://github.com/eXist-db/exist/issues/3724
+:)
+declare variable $mt:test-key-one := 1;
+declare variable $mt:test-key-two := 2;
+declare function mt:get-test-map () {
+    map {
+        $mt:test-key-one : true(),
+        $mt:test-key-two : true()
+    }
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-put-after-put () {
+    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+    let $expected := $extended?($mt:test-key-one)
+    let $result := map:put($extended, $mt:test-key-one, false())
+
+    return $expected eq $extended?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-remove-after-put () {
+    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+    let $expected := $extended?($mt:test-key-one)
+    let $result := map:remove($extended, $mt:test-key-one)
+
+    return $expected eq $extended?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-merge-after-put () {
+    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+    let $expected := $extended?($mt:test-key-one)
+    let $result := map:merge(($extended, map { $mt:test-key-one : false() }))
+
+    return $expected eq $extended?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-put-after-remove () {
+    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+    let $expected := $removed?($mt:test-key-one)
+
+    let $result := map:put($removed, $mt:test-key-one, false())
+
+    return $expected eq $removed?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-remove-after-remove () {
+    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+    let $expected := $removed?($mt:test-key-one)
+
+    let $result := map:put($removed, $mt:test-key-one, false())
+
+    return $expected eq $removed?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-merge-after-remove () {
+    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+    let $expected := $removed?($mt:test-key-one)
+    let $result := map:merge(($removed, map { $mt:test-key-one : false() }))
+
+    return $expected eq $removed?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-put-after-merge () {
+    let $merged := map:merge(mt:get-test-map())
+    let $expected := $merged?($mt:test-key-one)
+
+    let $result := map:put($merged, $mt:test-key-one, false())
+
+    return $expected eq $merged?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-remove-after-merge () {
+    let $merged := map:merge(mt:get-test-map())
+    let $expected := $merged?($mt:test-key-one)
+
+    let $result := map:remove($merged, $mt:test-key-one)
+
+    return $expected eq $merged?($mt:test-key-one)
+};
+
+declare
+    %test:assertTrue
+function mt:immutable-merge-after-merge () {
+    let $merged := map:merge(mt:get-test-map())
+    let $expected := $merged?($mt:test-key-one)
+
+    let $result := map:merge(($merged, map { $mt:test-key-one : false() }))
+
+    return $expected eq $merged?($mt:test-key-one)
+};

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -196,10 +196,24 @@ function mt:createWithSingleKey() {
         $map("Su")
 };
 
+(:~
+ : TODO(AR) implicit behaviour of map:merge according to XQ3.1 specification should be use-first not use-last
+:)
 declare
     %test:assertEquals("Saturday", "Caturday")
-function mt:overwriteKeyInNewMap() {
+function mt:merge-duplicate-keys-use-last-implicit-1() {
     let $specialWeek := map:merge(($mt:integerKeys, map { 7 : "Caturday" }))
+    return
+        ($mt:integerKeys(7), $specialWeek(7))
+};
+
+(:~
+ : TODO(AR) implicit behaviour of map:merge according to XQ3.1 specification should be use-first not use-last
+:)
+declare
+    %test:assertEquals("Saturday", "Saturday")
+function mt:merge-duplicate-keys-use-last-implicit-2() {
+    let $specialWeek := map:merge((map { 7 : "Caturday" }, $mt:integerKeys))
     return
         ($mt:integerKeys(7), $specialWeek(7))
 };

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -680,65 +680,79 @@ function mt:immutable-put-then-merge() {
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-remove-then-put() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed($mt:test-key-one)
-
     let $result := map:put($removed, $mt:test-key-one, false())
-
-    return $expected eq $removed($mt:test-key-one)
+    return
+        (
+            $expected eq $removed($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-remove-then-remove() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed($mt:test-key-one)
     let $result := map:remove($removed, $mt:test-key-one)
     return
-        $expected eq $removed($mt:test-key-one),
+        (
+            $expected eq $removed($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-remove-then-merge() {
     let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed($mt:test-key-one)
     let $result := map:merge(($removed, map { $mt:test-key-one : false() }))
-
-    return $expected eq $removed($mt:test-key-one)
+    return
+        (
+            $expected eq $removed($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-merge-then-put() {
     let $merged := map:merge(mt:create-test-map())
     let $expected := $merged($mt:test-key-one)
-
     let $result := map:put($merged, $mt:test-key-one, false())
-
-    return $expected eq $merged($mt:test-key-one)
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-merge-then-remove() {
     let $merged := map:merge(mt:create-test-map())
     let $expected := $merged($mt:test-key-one)
-
     let $result := map:remove($merged, $mt:test-key-one)
-
-    return $expected eq $merged($mt:test-key-one)
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };
 
 declare
-    %test:assertTrue
+    %test:assertEquals("true", "true")
 function mt:immutable-merge-then-merge() {
     let $merged := map:merge(mt:create-test-map())
     let $expected := $merged($mt:test-key-one)
-
     let $result := map:merge(($merged, map { $mt:test-key-one : false() }))
-
-    return $expected eq $merged($mt:test-key-one)
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
 };

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -633,7 +633,7 @@ function mt:multi-merge() {
 :)
 declare variable $mt:test-key-one := 1;
 declare variable $mt:test-key-two := 2;
-declare function mt:get-test-map () {
+declare function mt:create-test-map() {
     map {
         $mt:test-key-one : true(),
         $mt:test-key-two : true()
@@ -642,8 +642,8 @@ declare function mt:get-test-map () {
 
 declare
     %test:assertTrue
-function mt:immutable-put-after-put () {
-    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+function mt:immutable-put-then-put() {
+    let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended?($mt:test-key-one)
     let $result := map:put($extended, $mt:test-key-one, false())
 
@@ -652,8 +652,8 @@ function mt:immutable-put-after-put () {
 
 declare
     %test:assertTrue
-function mt:immutable-remove-after-put () {
-    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+function mt:immutable-put-then-remove() {
+    let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended?($mt:test-key-one)
     let $result := map:remove($extended, $mt:test-key-one)
 
@@ -662,8 +662,8 @@ function mt:immutable-remove-after-put () {
 
 declare
     %test:assertTrue
-function mt:immutable-merge-after-put () {
-    let $extended := map:put(mt:get-test-map(), $mt:test-key-two, false())
+function mt:immutable-put-then-merge() {
+    let $extended := map:put(mt:create-test-map(), $mt:test-key-two, false())
     let $expected := $extended?($mt:test-key-one)
     let $result := map:merge(($extended, map { $mt:test-key-one : false() }))
 
@@ -672,8 +672,8 @@ function mt:immutable-merge-after-put () {
 
 declare
     %test:assertTrue
-function mt:immutable-put-after-remove () {
-    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+function mt:immutable-remove-then-put() {
+    let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed?($mt:test-key-one)
 
     let $result := map:put($removed, $mt:test-key-one, false())
@@ -683,8 +683,8 @@ function mt:immutable-put-after-remove () {
 
 declare
     %test:assertTrue
-function mt:immutable-remove-after-remove () {
-    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+function mt:immutable-remove-then-remove() {
+    let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed?($mt:test-key-one)
 
     let $result := map:put($removed, $mt:test-key-one, false())
@@ -694,8 +694,8 @@ function mt:immutable-remove-after-remove () {
 
 declare
     %test:assertTrue
-function mt:immutable-merge-after-remove () {
-    let $removed := map:remove(mt:get-test-map(), $mt:test-key-two)
+function mt:immutable-remove-then-merge() {
+    let $removed := map:remove(mt:create-test-map(), $mt:test-key-two)
     let $expected := $removed?($mt:test-key-one)
     let $result := map:merge(($removed, map { $mt:test-key-one : false() }))
 
@@ -704,8 +704,8 @@ function mt:immutable-merge-after-remove () {
 
 declare
     %test:assertTrue
-function mt:immutable-put-after-merge () {
-    let $merged := map:merge(mt:get-test-map())
+function mt:immutable-merge-then-put() {
+    let $merged := map:merge(mt:create-test-map())
     let $expected := $merged?($mt:test-key-one)
 
     let $result := map:put($merged, $mt:test-key-one, false())
@@ -715,8 +715,8 @@ function mt:immutable-put-after-merge () {
 
 declare
     %test:assertTrue
-function mt:immutable-remove-after-merge () {
-    let $merged := map:merge(mt:get-test-map())
+function mt:immutable-merge-then-remove() {
+    let $merged := map:merge(mt:create-test-map())
     let $expected := $merged?($mt:test-key-one)
 
     let $result := map:remove($merged, $mt:test-key-one)
@@ -726,8 +726,8 @@ function mt:immutable-remove-after-merge () {
 
 declare
     %test:assertTrue
-function mt:immutable-merge-after-merge () {
-    let $merged := map:merge(mt:get-test-map())
+function mt:immutable-merge-then-merge() {
+    let $merged := map:merge(mt:create-test-map())
     let $expected := $merged?($mt:test-key-one)
 
     let $result := map:merge(($merged, map { $mt:test-key-one : false() }))

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -647,10 +647,17 @@ function mt:multi-merge() {
 :)
 declare variable $mt:test-key-one := 1;
 declare variable $mt:test-key-two := 2;
+declare variable $mt:test-key-three := 3;
 declare function mt:create-test-map() {
     map {
         $mt:test-key-one : true(),
         $mt:test-key-two : true()
+    }
+};
+
+declare function mt:create-test-map2() {
+    map {
+        $mt:test-key-three : true()
     }
 };
 
@@ -769,6 +776,96 @@ function mt:immutable-merge-then-merge() {
     let $merged := map:merge(mt:create-test-map())
     let $expected := $merged($mt:test-key-one)
     let $result := map:merge(($merged, map { $mt:test-key-one : false() }))
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
+};
+
+declare
+    %test:assertEquals("true", "true")
+function mt:immutable-merge2-then-put() {
+    let $merged := map:merge((mt:create-test-map(), mt:create-test-map2()))
+    let $expected := $merged($mt:test-key-one)
+    let $result := map:put($merged, $mt:test-key-one, false())
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
+};
+
+declare
+    %test:assertEquals(3, "true", "true", 2)
+function mt:immutable-merge2-then-remove() {
+    let $merged := map:merge((mt:create-test-map(), mt:create-test-map2()))
+    let $expected := $merged($mt:test-key-one)
+    let $result := map:remove($merged, $mt:test-key-one)
+    return
+        (
+            map:size($merged),
+            $expected eq $merged($mt:test-key-one),
+            fn:empty($result($mt:test-key-one)),
+            $expected ne $result($mt:test-key-one),
+            map:size($result)
+        )
+};
+
+(:~
+ : TODO(AR) implicit behaviour of map:merge according to XQ3.1 specification should be use-first not use-last,
+ :          therefore the result should be ("true", "true") instead
+:)
+declare
+    %test:assertEquals("true", "false")
+function mt:immutable-merge2-then-merge() {
+    let $merged := map:merge((mt:create-test-map(), mt:create-test-map2()))
+    let $expected := $merged($mt:test-key-one)
+    let $result := map:merge((map { $mt:test-key-one : false() }, $merged))
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
+};
+declare
+    %test:assertEquals("true", "true")
+function mt:immutable-merge-duplicates-then-put() {
+    let $merged := map:merge((mt:create-test-map(), mt:create-test-map()))
+    let $expected := $merged($mt:test-key-one)
+    let $result := map:put($merged, $mt:test-key-one, false())
+    return
+        (
+            $expected eq $merged($mt:test-key-one),
+            $expected ne $result($mt:test-key-one)
+        )
+};
+
+declare
+    %test:assertEquals(2, "true", "true", 1)
+function mt:immutable-merge-duplicates-then-remove() {
+    let $merged := map:merge((mt:create-test-map(), mt:create-test-map()))
+    let $expected := $merged($mt:test-key-one)
+    let $result := map:remove($merged, $mt:test-key-one)
+    return
+        (
+            map:size($merged),
+            $expected eq $merged($mt:test-key-one),
+            fn:empty($result($mt:test-key-one)),
+            map:size($result)
+        )
+};
+
+(:~
+ : TODO(AR) implicit behaviour of map:merge according to XQ3.1 specification should be use-first not use-last,
+ :          therefore the result should be ("true", "true") instead
+:)
+declare
+    %test:assertEquals("true", "false")
+function mt:immutable-merge-duplicates-then-merge() {
+    let $merged := map:merge((mt:create-test-map(), mt:create-test-map()))
+    let $expected := $merged($mt:test-key-one)
+    let $result := map:merge((map { $mt:test-key-one : false() }, $merged))
     return
         (
             $expected eq $merged($mt:test-key-one),


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/pull/3725
This contains just the test improvements from https://github.com/eXist-db/exist/pull/3738.
After this is merged we can rebase https://github.com/eXist-db/exist/pull/3738 and decide if we want to extract `map:merge#2` without changing implicit map:merge ordering for 5.x.x too...