### PR TITLE
Implement map:merge#2

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapModule.java
@@ -21,8 +21,13 @@
  */
 package org.exist.xquery.functions.map;
 
+import org.exist.dom.QName;
 import org.exist.xquery.AbstractInternalModule;
+import org.exist.xquery.FunctionDSL;
 import org.exist.xquery.FunctionDef;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.FunctionReturnSequenceType;
 
 import java.util.List;
 import java.util.Map;
@@ -38,7 +43,8 @@ public class MapModule extends AbstractInternalModule {
     public static final String PREFIX = "map";
 
     private static final FunctionDef[] functions = {
-            new FunctionDef(MapFunction.FNS_MERGE, MapFunction.class),
+            new FunctionDef(MapFunction.FS_MERGE[0], MapFunction.class),
+            new FunctionDef(MapFunction.FS_MERGE[1], MapFunction.class),
             new FunctionDef(MapFunction.FNS_SIZE, MapFunction.class),
             new FunctionDef(MapFunction.FNS_KEYS, MapFunction.class),
             new FunctionDef(MapFunction.FNS_CONTAINS, MapFunction.class),
@@ -67,5 +73,13 @@ public class MapModule extends AbstractInternalModule {
 
     public String getReleaseVersion() {
         return "eXist-2.0.x";
+    }
+
+    static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
+        return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, paramTypes);
+    }
+
+    static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
     }
 }

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -680,6 +680,7 @@ function mt:multi-merge() {
 declare variable $mt:test-key-one := 1;
 declare variable $mt:test-key-two := 2;
 declare variable $mt:test-key-three := 3;
+
 declare function mt:create-test-map() {
     map {
         $mt:test-key-one : true(),
@@ -836,11 +837,10 @@ function mt:immutable-merge2-then-remove() {
     let $result := map:remove($merged, $mt:test-key-one)
     return
         (
-            map:size($merged),
-            $expected eq $merged($mt:test-key-one),
-            fn:empty($result($mt:test-key-one)),
-            $expected ne $result($mt:test-key-one),
-            map:size($result)
+           map:size($merged),
+           $expected eq $merged($mt:test-key-one),
+           fn:empty($result($mt:test-key-one)),
+           map:size($result)
         )
 };
 

--- a/exist-core/src/test/xquery/maps/maps.xql
+++ b/exist-core/src/test/xquery/maps/maps.xql
@@ -219,6 +219,38 @@ function mt:merge-duplicate-keys-use-last-implicit-2() {
 };
 
 declare
+    %test:assertEquals("Saturday", "Saturday")
+function mt:merge-duplicate-keys-use-first-explicit-1() {
+    let $specialWeek := map:merge(($mt:integerKeys, map { 7 : "Caturday" }), map { "duplicates": "use-first" })
+    return
+        ($mt:integerKeys(7), $specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Saturday", "Caturday")
+function mt:merge-duplicate-keys-use-first-explicit-2() {
+    let $specialWeek := map:merge((map { 7 : "Caturday" }, $mt:integerKeys), map { "duplicates": "use-first" })
+    return
+        ($mt:integerKeys(7), $specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Saturday", "Caturday")
+function mt:merge-duplicate-keys-use-last-explicit-1() {
+    let $specialWeek := map:merge(($mt:integerKeys, map { 7 : "Caturday" }), map { "duplicates": "use-last" })
+    return
+        ($mt:integerKeys(7), $specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Saturday", "Saturday")
+function mt:merge-duplicate-keys-use-last-explicit-2() {
+    let $specialWeek := map:merge((map { 7 : "Caturday" }, $mt:integerKeys), map { "duplicates": "use-last" })
+    return
+        ($mt:integerKeys(7), $specialWeek(7))
+};
+
+declare
     %test:assertEmpty
 function mt:mapEmptyValue() {
     let $map := $mt:mapOfSequences


### PR DESCRIPTION
This takes just the map:merge#2 function from https://github.com/eXist-db/exist/pull/3738 but preserves the incorrect behaviour of eXist-db choosing the Merge Last strategy (whereas the spec says the stratergy should be Merge First).

This is suitable for inclusion in 5.x.x.