### PR TITLE
fix(Docker): rename dejavu font package

### DIFF
--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   expat \
   fontconfig \
   liblcms2-2 \
-  ttf-dejavu-core
+  fonts-dejavu-core
 
 FROM gcr.io/distroless/java:8
 


### PR DESCRIPTION
close #4027

deb package was renamed https://packages.debian.org/stretch/ttf-dejavu-core 

restores old functionality, `deploy.yml` on CI should run without errors again.  
