### PR TITLE
Separate Memtree from in-memory DOM Document

### DIFF
--- a/exist-core/src/main/java/org/exist/backup/xquery/ListBackups.java
+++ b/exist-core/src/main/java/org/exist/backup/xquery/ListBackups.java
@@ -120,7 +120,7 @@ public class ListBackups extends BasicFunction
                 }
             }
             builder.endElement();
-            return( builder.getDocument().getNode( nodeNr ) );
+            return( builder.getMemtree().getNode( nodeNr ) );
         } catch (final IOException ioe) {
             throw new XPathException(this, ioe);
         }

--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentBuilderReceiver.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentBuilderReceiver.java
@@ -98,7 +98,7 @@ public class DocumentBuilderReceiver implements ContentHandler, LexicalHandler, 
 
     @Override
     public Document getDocument() {
-        return builder.getDocument();
+        return builder.getMemtree();
     }
 
     public XQueryContext getContext() {

--- a/exist-core/src/main/java/org/exist/dom/memtree/Memtree.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/Memtree.java
@@ -1,0 +1,114 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.dom.memtree;
+
+import com.evolvedbinary.j8fu.function.ConsumerE;
+import org.exist.dom.QName;
+import org.exist.dom.persistent.NodeProxy;
+import org.exist.numbering.NodeId;
+import org.exist.numbering.NodeIdFactory;
+import org.exist.storage.serializers.Serializer;
+import org.exist.util.serializer.Receiver;
+import org.w3c.dom.DOMException;
+import org.xml.sax.SAXException;
+
+import javax.annotation.Nullable;
+
+/**
+ * An in-memory representation of a Node Tree for DOM purposes.
+ */
+public interface Memtree {
+
+    void reset();
+
+    int getSize();
+
+    short getTreeLevel(final int nodeNumber);
+
+    short getNodeType(final int nodeNumber);
+
+    QName getNodeName(final int nodeNumber);
+
+    NodeId getNodeId(final int nodeNumber);
+
+    int getDocumentElement();
+
+    int getAttributesCountFor(final int nodeNumber);
+
+    int getNamespacesCountFor(final int nodeNumber);
+
+    int getChildCountFor(final int nodeNumber);
+
+    int getFirstChildFor(final int nodeNumber);
+
+    int getLastChildFor(final int nodeNumber);
+
+    int getNextSiblingFor(final int nodeNumber);
+
+    int getParentNodeFor(final int nodeNumber);
+
+    int getLastNode();
+
+    int getIdAttribute(final int nodeNumber, final String id);
+
+    int getIdrefAttribute(final int nodeNumber, final String id);
+
+    int getLastAttr();
+
+    int addNode(final short kind, final short level, final QName qname);
+
+    int addNamespace(final int nodeNumber, final QName qname);
+
+    int addAttribute(final int nodeNumber, final QName qname, final String value, final int type) throws DOMException;
+
+    void addChars(final int nodeNumber, final char[] ch, final int start, final int len);
+
+    void addChars(final int nodeNumber, final CharSequence s);
+
+    void appendChars(final int nodeNumber, final char[] ch, final int start, final int len);
+
+    void appendChars(final int nodeNumber, final CharSequence s);
+
+    void addReferenceNode(final int nodeNumber, final NodeProxy proxy);
+
+    boolean hasReferenceNodes();
+
+    void replaceReferenceNode(final int nodeNumber, final CharSequence ch);
+
+
+    // TODO(AR) should these functions below this point be in this interface or moved elsewhere?
+
+    void computeNodeIds(final NodeIdFactory nodeIdFactory);
+
+    void copyTo(int nodeNumber, final DocumentBuilderReceiver receiver, @Nullable final ConsumerE<NodeProxy, SAXException> referenceNodeReceiver) throws SAXException;
+
+    /**
+     * Stream the specified document fragment to a receiver. This method
+     * is called by the serializer to output in-memory nodes.
+     *
+     * @param serializer the serializer
+     * @param nodeNumber       node to be serialized
+     * @param receiver   the receiver
+     * @throws SAXException if an error occurs
+     */
+    void streamTo(final Serializer serializer, final int nodeNumber, final Receiver receiver) throws SAXException;
+}

--- a/exist-core/src/main/java/org/exist/dom/memtree/MemtreeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/MemtreeImpl.java
@@ -1,0 +1,857 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.dom.memtree;
+
+import com.evolvedbinary.j8fu.function.ConsumerE;
+import org.exist.dom.QName;
+import org.exist.dom.persistent.NodeProxy;
+import org.exist.numbering.NodeId;
+import org.exist.numbering.NodeIdFactory;
+import org.exist.storage.ElementValue;
+import org.exist.storage.serializers.Serializer;
+import org.exist.util.hashtable.NamePool;
+import org.exist.util.serializer.AttrList;
+import org.exist.util.serializer.Receiver;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import javax.annotation.Nullable;
+import javax.xml.XMLConstants;
+import java.util.Arrays;
+
+/**
+ * An in-memory representation of a Node Tree for DOM purposes.
+ * <p>
+ * Nodes are stored in a series of arrays which are all indexed by the {@code nodeNum} (Node Number).
+ * Nodes are stored into the arrays in a Depth First Preorder (Root, Left, Right) Traversal.
+ * The {@code nodeNum} starts at 0, the array {@link #nodeKind} indicates the type of the Node.
+ * For example, for a complete XML Document, when {@code nodeNum == 0}, then {@code nodeKind[nodeNum] == org.w3c.dom.Node.DOCUMENT_NODE}.
+ * <p>
+ * The array {@link #treeLevel} indicates at what level in the tree the node appears, the root of the tree is 0.
+ * For example, for a complete XML Document, when {@code nodeNum == 0}, then {@code treeLevel[nodeNum] == 0}.
+ * <p>
+ * The array {@link #next} gives the {@code nodeNum} of the next node in the tree,
+ * for example {@code int nextNodeNum = next[nodeNum]}.
+ * <p>
+ * The following arrays hold the data of the nodes themselves:
+ * * {@link #namespaceParent}
+ * * {@link #namespaceCode}
+ * * {@link #nodeName}
+ * * {@link #alpha}
+ * * {@link #alphaLen}
+ * * {@link #characters}
+ * * {@link #nodeId}
+ * * {@link #attrName}
+ * * {@link #attrType}
+ * * {@link #attrNodeId}
+ * * {@link #attrParent}
+ * * {@link #attrValue}
+ * * {@link #references}
+ * <p>
+ * This implementation stores all node data in the document object. Nodes from another document, i.e. a persistent document in the database, can be
+ * stored as reference nodes, i.e. the nodes are not copied into this document object. Instead a reference is inserted which will only be expanded
+ * during serialization.
+ */
+public class MemtreeImpl implements Memtree {
+
+    private static final int NODE_SIZE = 16;
+    private static final int ATTR_SIZE = 8;
+    private static final int CHAR_BUF_SIZE = 256;
+    private static final int REF_SIZE = 8;
+
+    // holds the node type of a node
+    protected short[] nodeKind = null;
+
+    // the tree level of a node
+    protected short[] treeLevel;
+
+    // the node number of the next sibling
+    protected int[] next;
+
+    // pointer into the namePool
+    protected QName[] nodeName;
+
+    protected NodeId[] nodeId;  // TODO(AR) each of these could be computed the first time they are needed from the level and nodeNum
+
+    //alphanumeric content
+    protected int[] alpha;
+    protected int[] alphaLen;
+    protected char[] characters = null;
+    protected int nextChar = 0;
+
+    // attributes
+    protected QName[] attrName;
+    protected int[] attrType;
+    protected NodeId[] attrNodeId;
+    protected int[] attrParent;
+    protected String[] attrValue;
+    protected int nextAttr = 0;
+
+    // namespaces
+    protected int[] namespaceParent = null;
+    protected QName[] namespaceCode = null;
+    protected int nextNamespace = 0;
+
+    // the current number of nodes in the doc
+    protected int size = 1;
+
+    // reference nodes (link to an external, persistent document fragment)
+    protected NodeProxy[] references = null;
+    protected int nextReferenceIdx = 0;
+    // end reference nodes
+
+    protected NamePool namePool;
+
+    boolean replaceAttribute = false;
+
+    public MemtreeImpl() {
+        this(null);
+    }
+
+    public MemtreeImpl(@Nullable final NamePool namePool) {
+        if (namePool == null) {
+            this.namePool = new NamePool();
+        } else {
+            this.namePool = namePool;
+        }
+    }
+
+    private void init() {
+        nodeKind = new short[NODE_SIZE];
+        treeLevel = new short[NODE_SIZE];
+        next = new int[NODE_SIZE];
+        Arrays.fill(next, -1);
+        nodeName = new QName[NODE_SIZE];
+        nodeId = new NodeId[NODE_SIZE];
+        alpha = new int[NODE_SIZE];
+        alphaLen = new int[NODE_SIZE];
+        Arrays.fill(alphaLen, -1);
+        attrName = new QName[ATTR_SIZE];
+        attrParent = new int[ATTR_SIZE];
+        attrValue = new String[ATTR_SIZE];
+        attrType = new int[ATTR_SIZE];
+        attrNodeId = new NodeId[NODE_SIZE];
+        treeLevel[0] = 0;
+        nodeKind[0] = Node.DOCUMENT_NODE;
+    }
+
+    @Override
+    public void reset() {
+        size = 0;
+        nextChar = 0;
+        nextAttr = 0;
+        nextReferenceIdx = 0;
+        references = null;
+    }
+
+    @Override
+    public int getSize() {
+        return size;
+    }
+
+    @Override
+    public short getTreeLevel(final int nodeNumber) {
+        return treeLevel[nodeNumber];
+    }
+
+    @Override
+    public short getNodeType(final int nodeNumber) {
+        if (nodeKind == null || nodeNumber < 0) {
+            return -1;
+        }
+        return nodeKind[nodeNumber];
+    }
+
+    @Override
+    public QName getNodeName(final int nodeNumber) {
+        return nodeName[nodeNumber];
+    }
+
+    @Override
+    public NodeId getNodeId(final int nodeNumber) {
+        return nodeId[nodeNumber];
+    }
+
+    @Override
+    public int getDocumentElement() {
+        if (size == 1) {
+            return -1;
+        }
+
+        int nodeNumber = 1;
+        while (nodeKind[nodeNumber] != Node.ELEMENT_NODE) {
+            if (next[nodeNumber] < nodeNumber) {
+                return -1;
+            }
+            nodeNumber = next[nodeNumber];
+        }
+        return nodeNumber;
+    }
+
+    @Override
+    public int getAttributesCountFor(final int nodeNumber) {
+        int count = 0;
+        int attr = alpha[nodeNumber];
+        if (attr > -1) {
+            while (attr < nextAttr && attrParent[attr++] == nodeNumber) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public int getNamespacesCountFor(final int nodeNumber) {
+        int count = 0;
+        int ns = alphaLen[nodeNumber];
+        if (ns > -1) {
+            while (ns < nextNamespace && namespaceParent[ns++] == nodeNumber) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public int getChildCountFor(final int nodeNumber) {
+        int count = 0;
+        int nextNode = getFirstChildFor(nodeNumber);
+        while (nextNode > nodeNumber) {
+            count++;
+            nextNode = next[nextNode];
+        }
+        return count;
+    }
+
+    @Override
+    public int getFirstChildFor(final int nodeNumber) {
+        if (nodeNumber == 0) {
+            // optimisation for document-node
+            if (size > 1) {
+                return 1;
+            } else {
+                return -1;
+            }
+        }
+
+        final short level = treeLevel[nodeNumber];
+        final int nextNode = nodeNumber + 1;
+        if (nextNode < size && treeLevel[nextNode] > level) {
+            return nextNode;
+        }
+        return -1;
+    }
+
+    @Override
+    public int getLastChildFor(final int nodeNumber) {
+        int lastChild = -1;
+        final short childLevel = (short) (treeLevel[nodeNumber] + 1);
+        int nextNode = nodeNumber + 1;
+        while (nextNode < size && treeLevel[nextNode] >= childLevel) {
+            if (treeLevel[nextNode] == childLevel) {
+                lastChild = nextNode;
+            }
+            nextNode++;
+        }
+        return lastChild;
+    }
+
+    @Override
+    public int getNextSiblingFor(final int nodeNumber) {
+        final int nextNode = next[nodeNumber];
+        return nextNode < nodeNumber ? -1 : nextNode;
+    }
+
+    @Override
+    public int getParentNodeFor(final int nodeNumber) {
+        int nextNode = next[nodeNumber];
+        while (nextNode > nodeNumber) {
+            nextNode = next[nextNode];
+        }
+        return nextNode;
+    }
+
+    @Override
+    public int getIdAttribute(final int nodeNumber, final String id) {
+        int attr = alpha[nodeNumber];
+        if (attr > -1) {
+            while (attr < nextAttr && attrParent[attr] == nodeNumber) {
+                if (attrType[attr] == AttrImpl.ATTR_ID_TYPE && id.equals(attrValue[attr])) {
+                    return attr;
+                }
+                attr++;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public int getIdrefAttribute(final int nodeNumber, final String id) {
+        int attr = alpha[nodeNumber];
+        if (attr > -1) {
+            while (attr < nextAttr && attrParent[attr] == nodeNumber) {
+                if (attrType[attr] == AttrImpl.ATTR_IDREF_TYPE && id.equals(attrValue[attr])) {
+                    return attr;
+                }
+                attr++;
+            }
+        }
+
+        return -1;
+    }
+
+    @Override
+    public int getLastNode() {
+        return size - 1;
+    }
+
+    @Override
+    public int getLastAttr() {
+        if (nextAttr == 0) {
+            return -1;
+        }
+        return nextAttr - 1;
+    }
+
+    @Override
+    public int addNode(final short kind, final short level, final QName qname) {
+        if (nodeKind == null) {
+            init();
+        }
+        if (size == nodeKind.length) {
+            grow();
+        }
+        nodeKind[size] = kind;
+        treeLevel[size] = level;
+        nodeName[size] = qname != null ? namePool.getSharedName(qname) : null;
+        alpha[size] = -1; // undefined
+        next[size] = -1;
+        return size++;
+    }
+
+    @Override
+    public int addNamespace(final int nodeNumber, final QName qname) {
+        if (nodeKind == null) {
+            init();
+        }
+        if (namespaceCode == null || nextNamespace == namespaceCode.length) {
+            growNamespaces();
+        }
+        namespaceCode[nextNamespace] = namePool.getSharedName(qname);
+        namespaceParent[nextNamespace] = nodeNumber;
+        if (alphaLen[nodeNumber] < 0) {
+            alphaLen[nodeNumber] = nextNamespace;
+        }
+        return nextNamespace++;
+    }
+
+    @Override
+    public int addAttribute(final int nodeNumber, final QName qname, final String value, final int type) throws DOMException {
+        if (nodeKind == null) {
+            init();
+        }
+        if (nodeNumber > 0 && !(nodeKind[nodeNumber] == Node.ELEMENT_NODE || nodeKind[nodeNumber] == NodeImpl.NAMESPACE_NODE)) {
+            throw new DOMException(DOMException.INUSE_ATTRIBUTE_ERR,
+                    "err:XQTY0024: An attribute node cannot follow a node that is not an element or namespace node.");
+        }
+        int prevAttr = nextAttr - 1;
+        int attrN;
+        //Check if an attribute with the same qname exists in the parent element
+        while (nodeNumber > 0 && prevAttr > -1 && attrParent[prevAttr] == nodeNumber) {
+            attrN = prevAttr--;
+            final QName prevQn = attrName[attrN];
+            if (prevQn.equals(qname)) {
+                if (replaceAttribute) {
+                    attrValue[attrN] = value;
+                    attrType[attrN] = type;
+                    return attrN;
+                } else {
+                    throw new DOMException(DOMException.INUSE_ATTRIBUTE_ERR,
+                            "err:XQDY0025: element has more than one attribute '" + qname + "'");
+                }
+            }
+        }
+        if (nextAttr == attrName.length) {
+            growAttributes();
+        }
+        final QName attrQname = new QName(qname.getLocalPart(), qname.getNamespaceURI(), qname.getPrefix(), ElementValue.ATTRIBUTE);
+        attrParent[nextAttr] = nodeNumber;
+        attrName[nextAttr] = namePool.getSharedName(attrQname);
+        attrValue[nextAttr] = value;
+        attrType[nextAttr] = type;
+        if (alpha[nodeNumber] < 0) {
+            alpha[nodeNumber] = nextAttr;
+        }
+        return nextAttr++;
+    }
+
+    @Override
+    public void addChars(final int nodeNumber, final char[] ch, final int start, final int len) {
+        if (nodeKind == null) {
+            init();
+        }
+        if (characters == null) {
+            characters = new char[Math.max(len, CHAR_BUF_SIZE)];
+        } else if (nextChar + len >= characters.length) {
+            int newLen = (characters.length * 3) / 2;
+            if (newLen < nextChar + len) {
+                newLen = nextChar + len;
+            }
+            final char[] nc = new char[newLen];
+            System.arraycopy(characters, 0, nc, 0, characters.length);
+            characters = nc;
+        }
+        alpha[nodeNumber] = nextChar;
+        alphaLen[nodeNumber] = len;
+        System.arraycopy(ch, start, characters, nextChar, len);
+        nextChar += len;
+    }
+
+    @Override
+    public void addChars(final int nodeNumber, final CharSequence s) {
+        if (nodeKind == null) {
+            init();
+        }
+        int len = (s == null) ? 0 : s.length();
+        if (characters == null) {
+            characters = new char[Math.max(len, CHAR_BUF_SIZE)];
+        } else if (nextChar + len >= characters.length) {
+            int newLen = (characters.length * 3) / 2;
+            if (newLen < nextChar + len) {
+                newLen = nextChar + len;
+            }
+            final char[] nc = new char[newLen];
+            System.arraycopy(characters, 0, nc, 0, characters.length);
+            characters = nc;
+        }
+        alpha[nodeNumber] = nextChar;
+        alphaLen[nodeNumber] = len;
+        for (int i = 0; i < len; i++) {
+            characters[nextChar++] = s.charAt(i);
+        }
+    }
+
+    @Override
+    public void appendChars(final int nodeNumber, final char[] ch, final int start, final int len) {
+        if (characters == null) {
+            characters = new char[Math.max(len, CHAR_BUF_SIZE)];
+        } else if (nextChar + len >= characters.length) {
+            int newLen = (characters.length * 3) / 2;
+            if (newLen < nextChar + len) {
+                newLen = nextChar + len;
+            }
+            final char[] nc = new char[newLen];
+            System.arraycopy(characters, 0, nc, 0, characters.length);
+            characters = nc;
+        }
+        alphaLen[nodeNumber] = alphaLen[nodeNumber] + len;
+        System.arraycopy(ch, start, characters, nextChar, len);
+        nextChar += len;
+    }
+
+    @Override
+    public void appendChars(final int nodeNumber, final CharSequence s) {
+        final int len = s.length();
+        if (characters == null) {
+            characters = new char[Math.max(len, CHAR_BUF_SIZE)];
+        } else if (nextChar + len >= characters.length) {
+            int newLen = (characters.length * 3) / 2;
+            if (newLen < nextChar + len) {
+                newLen = nextChar + len;
+            }
+            final char[] nc = new char[newLen];
+            System.arraycopy(characters, 0, nc, 0, characters.length);
+            characters = nc;
+        }
+        alphaLen[nodeNumber] = alphaLen[nodeNumber] + len;
+        for (int i = 0; i < len; i++) {
+            characters[nextChar++] = s.charAt(i);
+        }
+    }
+
+    @Override
+    public void addReferenceNode(final int nodeNumber, final NodeProxy proxy) {
+        if (nodeKind == null) {
+            init();
+        }
+        if (references == null || nextReferenceIdx == references.length) {
+            growReferences();
+        }
+        references[nextReferenceIdx] = proxy;
+        alpha[nodeNumber] = nextReferenceIdx++;
+    }
+
+    @Override
+    public boolean hasReferenceNodes() {
+        return nextReferenceIdx > 0;
+    }
+
+    @Override
+    public void replaceReferenceNode(final int nodeNumber, final CharSequence ch) {
+        nodeKind[nodeNumber] = Node.TEXT_NODE;
+        references[alpha[nodeNumber]] = null;
+        addChars(nodeNumber, ch);
+    }
+
+    private void grow() {
+        final int newSize = (size * 3) / 2;
+
+        final short[] newNodeKind = new short[newSize];
+        System.arraycopy(nodeKind, 0, newNodeKind, 0, size);
+        nodeKind = newNodeKind;
+
+        final short[] newTreeLevel = new short[newSize];
+        System.arraycopy(treeLevel, 0, newTreeLevel, 0, size);
+        treeLevel = newTreeLevel;
+
+        final int[] newNext = new int[newSize];
+        Arrays.fill(newNext, -1);
+        System.arraycopy(next, 0, newNext, 0, size);
+        next = newNext;
+
+        final QName[] newNodeName = new QName[newSize];
+        System.arraycopy(nodeName, 0, newNodeName, 0, size);
+        nodeName = newNodeName;
+
+        final NodeId[] newNodeId = new NodeId[newSize];
+        System.arraycopy(nodeId, 0, newNodeId, 0, size);
+        nodeId = newNodeId;
+
+        final int[] newAlpha = new int[newSize];
+        System.arraycopy(alpha, 0, newAlpha, 0, size);
+        alpha = newAlpha;
+
+        final int[] newAlphaLen = new int[newSize];
+        Arrays.fill(newAlphaLen, -1);
+        System.arraycopy(alphaLen, 0, newAlphaLen, 0, size);
+        alphaLen = newAlphaLen;
+    }
+
+    private void growAttributes() {
+        final int size = attrName.length;
+        final int newSize = (size * 3) / 2;
+
+        final QName[] newAttrName = new QName[newSize];
+        System.arraycopy(attrName, 0, newAttrName, 0, size);
+        attrName = newAttrName;
+
+        final int[] newAttrParent = new int[newSize];
+        System.arraycopy(attrParent, 0, newAttrParent, 0, size);
+        attrParent = newAttrParent;
+
+        final String[] newAttrValue = new String[newSize];
+        System.arraycopy(attrValue, 0, newAttrValue, 0, size);
+        attrValue = newAttrValue;
+
+        final int[] newAttrType = new int[newSize];
+        System.arraycopy(attrType, 0, newAttrType, 0, size);
+        attrType = newAttrType;
+
+        final NodeId[] newNodeId = new NodeId[newSize];
+        System.arraycopy(attrNodeId, 0, newNodeId, 0, size);
+        attrNodeId = newNodeId;
+    }
+
+    private void growReferences() {
+        if (references == null) {
+            references = new NodeProxy[REF_SIZE];
+        } else {
+            final int size = references.length;
+            final int newSize = (size * 3) / 2;
+            final NodeProxy[] newReferences = new NodeProxy[newSize];
+            System.arraycopy(references, 0, newReferences, 0, size);
+            references = newReferences;
+        }
+    }
+
+    private void growNamespaces() {
+        if (namespaceCode == null) {
+            namespaceCode = new QName[5];
+            namespaceParent = new int[5];
+        } else {
+            final int size = namespaceCode.length;
+            final int newSize = (size * 3) / 2;
+
+            final QName[] newCodes = new QName[newSize];
+            System.arraycopy(namespaceCode, 0, newCodes, 0, size);
+            namespaceCode = newCodes;
+
+            final int[] newParents = new int[newSize];
+            System.arraycopy(namespaceParent, 0, newParents, 0, size);
+            namespaceParent = newParents;
+        }
+    }
+
+    @Override
+    public void computeNodeIds(final NodeIdFactory nodeIdFactory) {
+        if (nodeId[0] != null) {
+            return;
+        }
+
+        nodeId[0] = nodeIdFactory.documentNodeId();
+        if (size == 1) {
+            return;
+        }
+
+        NodeId nextId = nodeIdFactory.createInstance();
+        int next = 1;
+        while (next > 0) {
+            computeNodeIds(nextId, next);
+            next = getNextSiblingFor(next);
+            nextId = nextId.nextSibling();
+        }
+    }
+
+    private void computeNodeIds(final NodeId id, final int nodeNumber) {
+        nodeId[nodeNumber] = id;
+        if (nodeKind[nodeNumber] == Node.ELEMENT_NODE) {
+            NodeId nextId = id.newChild();
+            int attr = alpha[nodeNumber];
+            if (attr > -1) {
+                while (attr < nextAttr && attrParent[attr] == nodeNumber) {
+                    attrNodeId[attr] = nextId;
+                    nextId = nextId.nextSibling();
+                    attr++;
+                }
+            }
+            int nextNode = getFirstChildFor(nodeNumber);
+            while (nextNode > nodeNumber) {
+                computeNodeIds(nextId, nextNode);
+                nextNode = next[nextNode];
+                if (nextNode > nodeNumber) {
+                    nextId = nextId.nextSibling();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void copyTo(int nodeNumber, final DocumentBuilderReceiver receiver, @Nullable final ConsumerE<NodeProxy, SAXException> referenceNodeReceiver) throws SAXException {
+        final int topNodeNumber = nodeNumber;
+        while (nodeNumber > -1) {
+            copyStartNode(nodeNumber, receiver, referenceNodeReceiver);
+
+            int nextNode;
+            if (nodeKind[nodeNumber] == NodeImpl.REFERENCE_NODE) {
+                //Nothing more to stream ?
+                nextNode = -1;
+            } else {
+                nextNode = getFirstChildFor(nodeNumber);
+            }
+
+            while (nextNode == -1) {
+                copyEndNode(nodeNumber, receiver);
+                if (topNodeNumber == nodeNumber) {
+                    break;
+                }
+                //No nextNode if the top node is a Document node
+                nextNode = getNextSiblingFor(nodeNumber);
+                if (nextNode == -1) {
+                    nodeNumber = getParentNodeFor(nodeNumber);
+                    if (nodeNumber == -1 || topNodeNumber == nodeNumber) {
+                        copyEndNode(nodeNumber, receiver);
+                        break;
+                    }
+                }
+            }
+            nodeNumber = nextNode;
+        }
+    }
+
+    private void copyStartNode(final int nodeNumber, final DocumentBuilderReceiver receiver, @Nullable final ConsumerE<NodeProxy, SAXException> referenceNodeReceiver) throws SAXException {
+        switch (nodeKind[nodeNumber]) {
+            case Node.ELEMENT_NODE: {
+                final QName qn = nodeName[nodeNumber];
+                receiver.startElement(qn, null);
+                int attr = alpha[nodeNumber];
+                if (attr > -1) {
+                    while (attr < nextAttr && attrParent[attr] == nodeNumber) {
+                        final QName attrQName = attrName[attr];
+                        receiver.attribute(attrQName, attrValue[attr]);
+                        attr++;
+                    }
+                }
+                int ns = alphaLen[nodeNumber];
+                if (ns > -1) {
+                    while (ns < nextNamespace && namespaceParent[ns] == nodeNumber) {
+                        final QName nsQName = namespaceCode[ns];
+                        receiver.addNamespaceNode(nsQName);
+                        ns++;
+                    }
+                }
+                break;
+            }
+
+            case Node.TEXT_NODE:
+                receiver.characters(characters, alpha[nodeNumber], alphaLen[nodeNumber]);
+                break;
+
+            case Node.CDATA_SECTION_NODE:
+                receiver.cdataSection(characters, alpha[nodeNumber], alphaLen[nodeNumber]);
+                break;
+
+            case Node.ATTRIBUTE_NODE:
+                final QName attrQName = attrName[nodeNumber];
+                receiver.attribute(attrQName, attrValue[nodeNumber]);
+                break;
+
+            case Node.COMMENT_NODE:
+                receiver.comment(characters, alpha[nodeNumber], alphaLen[nodeNumber]);
+                break;
+
+            case Node.PROCESSING_INSTRUCTION_NODE:
+                final QName piQName = nodeName[nodeNumber];
+                final String data = new String(characters, alpha[nodeNumber], alphaLen[nodeNumber]);
+                receiver.processingInstruction(piQName.getLocalPart(), data);
+                break;
+
+            case NodeImpl.NAMESPACE_NODE:
+                receiver.addNamespaceNode(namespaceCode[nodeNumber]);
+                break;
+
+            case NodeImpl.REFERENCE_NODE:
+                if (referenceNodeReceiver != null) {
+                    referenceNodeReceiver.accept(references[alpha[nodeNumber]]);
+                } else {
+                    receiver.addReferenceNode(references[alpha[nodeNumber]]);
+                }
+                break;
+        }
+    }
+
+    private void copyEndNode(final int nodeNumber, final DocumentBuilderReceiver receiver) throws SAXException {
+        if (nodeKind[nodeNumber] == Node.ELEMENT_NODE) {
+            receiver.endElement(nodeName[nodeNumber]);
+        }
+    }
+
+    @Override
+    public void streamTo(final Serializer serializer, int nodeNumber, final Receiver receiver) throws SAXException {
+        final int topNodeNumber = nodeNumber;
+        while (nodeNumber > -1) {
+            startNode(serializer, nodeNumber, receiver);
+            int nextNode;
+            if (nodeKind[nodeNumber] == NodeImpl.REFERENCE_NODE) {
+                //Nothing more to stream ?
+                nextNode = -1;
+            } else {
+                nextNode = getFirstChildFor(nodeNumber);
+            }
+
+            while (nextNode == -1) {
+                endNode(nodeNumber, receiver);
+                if (topNodeNumber == nodeNumber) {
+                    break;
+                }
+                nextNode = getNextSiblingFor(nodeNumber);
+                if (nextNode == -1) {
+                    nodeNumber = getParentNodeFor(nodeNumber);
+                    if (nodeNumber == -1 || topNodeNumber == nodeNumber) {
+                        endNode(nodeNumber, receiver);
+                        break;
+                    }
+                }
+            }
+            nodeNumber = nextNode;
+        }
+    }
+
+    private void startNode(final Serializer serializer, final int nodeNumber, final Receiver receiver) throws SAXException {
+        switch (nodeKind[nodeNumber]) {
+            case Node.ELEMENT_NODE:
+                final QName qn = nodeName[nodeNumber];
+                //Output required namespace declarations
+                int ns = alphaLen[nodeNumber];
+                if (ns > -1) {
+                    while ((ns < nextNamespace) && (namespaceParent[ns] == nodeNumber)) {
+                        final QName nsQName = namespaceCode[ns];
+                        if (XMLConstants.XMLNS_ATTRIBUTE.equals(nsQName.getLocalPart())) {
+                            receiver.startPrefixMapping(XMLConstants.DEFAULT_NS_PREFIX, nsQName.getNamespaceURI());
+                        } else {
+                            receiver.startPrefixMapping(nsQName.getLocalPart(), nsQName.getNamespaceURI());
+                        }
+                        ns++;
+                    }
+                }
+                //Create the attribute list
+                AttrList attribs = null;
+                int attr = alpha[nodeNumber];
+                if (attr > -1) {
+                    attribs = new AttrList();
+                    while ((attr < nextAttr) && (attrParent[attr] == nodeNumber)) {
+                        final QName attrQName = attrName[attr];
+                        attribs.addAttribute(attrQName, attrValue[attr]);
+                        attr++;
+                    }
+                }
+                receiver.startElement(qn, attribs);
+                break;
+
+            case Node.TEXT_NODE:
+                receiver.characters(new String(characters, alpha[nodeNumber], alphaLen[nodeNumber]));
+                break;
+
+            case Node.ATTRIBUTE_NODE:
+                final QName attrQName = attrName[nodeNumber];
+                receiver.attribute(attrQName, attrValue[nodeNumber]);
+                break;
+
+            case Node.COMMENT_NODE:
+                receiver.comment(characters, alpha[nodeNumber], alphaLen[nodeNumber]);
+                break;
+
+            case Node.PROCESSING_INSTRUCTION_NODE:
+                final QName piQName = nodeName[nodeNumber];
+                final String data = new String(characters, alpha[nodeNumber], alphaLen[nodeNumber]);
+                receiver.processingInstruction(piQName.getLocalPart(), data);
+                break;
+
+            case Node.CDATA_SECTION_NODE:
+                receiver.cdataSection(characters, alpha[nodeNumber], alphaLen[nodeNumber]);
+                break;
+
+            case NodeImpl.REFERENCE_NODE:
+                serializer.toReceiver(references[alpha[nodeNumber]], true, false);
+                break;
+        }
+    }
+
+    private void endNode(final int nodeNumber, final Receiver receiver) throws SAXException {
+        if (nodeKind[nodeNumber] == Node.ELEMENT_NODE) {
+            receiver.endElement(nodeName[nodeNumber]);
+            //End all prefix mappings used for the element
+            int ns = alphaLen[nodeNumber];
+            if (ns > -1) {
+                while (ns < nextNamespace && namespaceParent[ns] == nodeNumber) {
+                    final QName nsQName = namespaceCode[ns];
+                    if (XMLConstants.XMLNS_ATTRIBUTE.equals(nsQName.getLocalPart())) {
+                        receiver.endPrefixMapping(XMLConstants.DEFAULT_NS_PREFIX);
+                    } else {
+                        receiver.endPrefixMapping(nsQName.getLocalPart());
+                    }
+                    ns++;
+                }
+            }
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/dom/memtree/MemtreeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/MemtreeImpl.java
@@ -660,7 +660,9 @@ public class MemtreeImpl implements Memtree {
             }
 
             while (nextNode == -1) {
-                copyEndNode(nodeNumber, receiver);
+                if (nodeNumber != -1) {
+                    copyEndNode(nodeNumber, receiver);
+                }
                 if (topNodeNumber == nodeNumber) {
                     break;
                 }
@@ -669,7 +671,9 @@ public class MemtreeImpl implements Memtree {
                 if (nextNode == -1) {
                     nodeNumber = getParentNodeFor(nodeNumber);
                     if (nodeNumber == -1 || topNodeNumber == nodeNumber) {
-                        copyEndNode(nodeNumber, receiver);
+                        if (nodeNumber != -1) {
+                            copyEndNode(nodeNumber, receiver);
+                        }
                         break;
                     }
                 }
@@ -767,7 +771,9 @@ public class MemtreeImpl implements Memtree {
                 if (nextNode == -1) {
                     nodeNumber = getParentNodeFor(nodeNumber);
                     if (nodeNumber == -1 || topNodeNumber == nodeNumber) {
-                        endNode(nodeNumber, receiver);
+                        if (nodeNumber != -1) {
+                            endNode(nodeNumber, receiver);
+                        }
                         break;
                     }
                 }

--- a/exist-core/src/main/java/org/exist/dom/memtree/SAXAdapter.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/SAXAdapter.java
@@ -66,8 +66,8 @@ public class SAXAdapter implements ContentHandler, LexicalHandler {
         this.builder = builder;
     }
 
-    public DocumentImpl getDocument() {
-        return builder.getDocument();
+    public Memtree getMemtree() {
+        return builder.getMemtree();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXtoXML.java
@@ -285,7 +285,7 @@ public class JMXtoXML {
             e.printStackTrace();
             LOG.warn("Could not generate XML report from JMX: {}", e.getMessage());
         }
-        return (Element) builder.getDocument().getNode(1);
+        return (Element) builder.getMemtree().getNode(1);
     }
 
     public String getDataDir() {
@@ -344,7 +344,7 @@ public class JMXtoXML {
                     e.printStackTrace();
                     LOG.warn("Could not generate XML report from JMX: {}", e.getMessage());
                 }
-                return (Element) builder.getDocument().getNode(1);
+                return (Element) builder.getMemtree().getNode(1);
             }
         }
         return null;

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -613,7 +613,7 @@ public class Deployment {
             throw new PackageException("Error while updating repo.xml in-memory: " + e.getMessage(), e);
         }
         builder.endDocument();
-        final DocumentImpl updatedXML = builder.getDocument();
+        final DocumentImpl updatedXML = builder.getMemtree();
 
         try {
             final Collection collection = broker.getOrCreateCollection(transaction, targetCollection);

--- a/exist-core/src/main/java/org/exist/xqj/Marshaller.java
+++ b/exist-core/src/main/java/org/exist/xqj/Marshaller.java
@@ -320,11 +320,11 @@ public class Marshaller {
         }
         builder.endDocument();
         if (rootType == Type.DOCUMENT)
-            {return builder.getDocument();}
+            {return builder.getMemtree();}
         else if (rootType == Type.ELEMENT)
-            {return (NodeImpl) builder.getDocument().getDocumentElement();}
+            {return (NodeImpl) builder.getMemtree().getDocumentElement();}
         else
-            {return (NodeImpl) builder.getDocument().getFirstChild();}
+            {return (NodeImpl) builder.getMemtree().getFirstChild();}
     }
     
     
@@ -422,7 +422,7 @@ public class Marshaller {
             if (finish) {break;}
         }
         builder.endDocument();
-        return builder.getDocument().getDocumentElement();
+        return builder.getMemtree().getDocumentElement();
     }
 }
 

--- a/exist-core/src/main/java/org/exist/xquery/CDATAConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/CDATAConstructor.java
@@ -63,7 +63,7 @@ public class CDATAConstructor extends NodeConstructor {
 
         try {
             final MemTreeBuilder builder = context.getDocumentBuilder();
-            final NodeImpl node = builder.getDocument().getNode(builder.cdataSection(cdata));
+            final NodeImpl node = builder.getMemtree().getNode(builder.cdataSection(cdata));
 
             if (context.getProfiler().isEnabled()) {
                 context.getProfiler().end(this, "", node);

--- a/exist-core/src/main/java/org/exist/xquery/CommentConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/CommentConstructor.java
@@ -55,7 +55,7 @@ public class CommentConstructor extends NodeConstructor {
         try {
             final MemTreeBuilder builder = context.getDocumentBuilder();
             final int nodeNr = builder.comment(data);
-            final NodeImpl node = builder.getDocument().getNode(nodeNr);
+            final NodeImpl node = builder.getMemtree().getNode(nodeNr);
             return node;
         } finally {
             if (newDocumentContext)

--- a/exist-core/src/main/java/org/exist/xquery/DocumentConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/DocumentConstructor.java
@@ -131,7 +131,7 @@ public class DocumentConstructor extends NodeConstructor {
                 ExpressionDumper.dump(this));
         }
         context.popDocumentContext();
-        final NodeImpl node =  builder.getDocument();
+        final NodeImpl node =  builder.getMemtree();
         if (context.getProfiler().isEnabled())
             {context.getProfiler().end(this, "", node);}
         return node;

--- a/exist-core/src/main/java/org/exist/xquery/DynamicAttributeConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicAttributeConstructor.java
@@ -139,7 +139,7 @@ public class DynamicAttributeConstructor extends NodeConstructor {
             node = null;
             try {
                 final int nodeNr = builder.addAttribute(qn, value);
-                node = builder.getDocument().getAttribute(nodeNr);
+                node = builder.getMemtree().getAttribute(nodeNr);
             } catch (final DOMException e) {
                 throw new XPathException(this, ErrorCodes.XQDY0025, "element has more than one attribute '" + qn + "'");
             } 

--- a/exist-core/src/main/java/org/exist/xquery/DynamicCommentConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicCommentConstructor.java
@@ -90,7 +90,7 @@ public class DynamicCommentConstructor extends NodeConstructor {
                         "'" + buf.toString() + "' is not a valid comment");
                 }
                 final int nodeNr = builder.comment(buf.toString());
-                result = builder.getDocument().getNode(nodeNr);
+                result = builder.getMemtree().getNode(nodeNr);
             }
         } finally {
             if (newDocumentContext)

--- a/exist-core/src/main/java/org/exist/xquery/DynamicPIConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicPIConstructor.java
@@ -122,7 +122,7 @@ public class DynamicPIConstructor extends NodeConstructor {
             if (contentString.contains("?>"))
                 {throw new XPathException(this, ErrorCodes.XQDY0026, contentString + "' is not a valid processing intruction content", contentSeq);}
             final int nodeNo = builder.processingInstruction(nameSeq.getStringValue(), contentString);
-            final Sequence result = ((DocumentImpl)builder.getDocument()).getNode(nodeNo);
+            final Sequence result = ((DocumentImpl)builder.getMemtree()).getNode(nodeNo);
             if (context.getProfiler().isEnabled())
                 {context.getProfiler().end(this, "", result);}
             return result;

--- a/exist-core/src/main/java/org/exist/xquery/DynamicTextConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicTextConstructor.java
@@ -96,7 +96,7 @@ public class DynamicTextConstructor extends NodeConstructor {
                     {result = Sequence.EMPTY_SEQUENCE;}
                 else {
                     final int nodeNr = builder.characters(buf);
-                    result = builder.getDocument().getNode(nodeNr);
+                    result = builder.getMemtree().getNode(nodeNr);
                 }
             }
         } finally {

--- a/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/ElementConstructor.java
@@ -330,7 +330,7 @@ public class ElementConstructor extends NodeConstructor {
                 content.eval(contextSequence, contextItem);
             }
             builder.endElement();
-            final NodeImpl node = builder.getDocument().getNode(nodeNr);
+            final NodeImpl node = builder.getMemtree().getNode(nodeNr);
             return node;
         } finally {
             context.popInScopeNamespaces();

--- a/exist-core/src/main/java/org/exist/xquery/NamespaceConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/NamespaceConstructor.java
@@ -121,7 +121,7 @@ public class NamespaceConstructor extends NodeConstructor {
 
         //context.declareInScopeNamespace(prefix, value);
         final int nodeNr = builder.namespaceNode(prefix, value);
-        final Sequence result = builder.getDocument().getNamespaceNode(nodeNr);
+        final Sequence result = builder.getMemtree().getNamespaceNode(nodeNr);
 
         if (context.getProfiler().isEnabled()) {
             context.getProfiler().end(this, "", result);

--- a/exist-core/src/main/java/org/exist/xquery/PIConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/PIConstructor.java
@@ -75,7 +75,7 @@ public class PIConstructor extends NodeConstructor {
         try {
             final MemTreeBuilder builder = context.getDocumentBuilder();
             final int nodeNr = builder.processingInstruction(target, data);
-            final NodeImpl node = builder.getDocument().getNode(nodeNr);
+            final NodeImpl node = builder.getMemtree().getNode(nodeNr);
             return node;
         } finally {
             if (newDocumentContext)

--- a/exist-core/src/main/java/org/exist/xquery/TextConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/TextConstructor.java
@@ -61,7 +61,7 @@ public class TextConstructor extends NodeConstructor {
             final MemTreeBuilder builder = context.getDocumentBuilder();
             context.proceed(this, builder);
             final int nodeNr = builder.characters(text);
-            final NodeImpl node = builder.getDocument().getNode(nodeNr);
+            final NodeImpl node = builder.getMemtree().getNode(nodeNr);
             return node;
         } finally {
             if (newDocumentContext)

--- a/exist-core/src/main/java/org/exist/xquery/XPathUtil.java
+++ b/exist-core/src/main/java/org/exist/xquery/XPathUtil.java
@@ -143,9 +143,9 @@ public class XPathUtil {
                 streamer.setContentHandler(receiver);
                 streamer.serialize((Node) obj, false);
                 if(obj instanceof Document) {
-                    return builder.getDocument();
+                    return builder.getMemtree();
                 } else {
-                    return builder.getDocument().getNode(1);
+                    return builder.getMemtree().getNode(1);
                 }
             } catch (final SAXException e) {
                 throw new XPathException(expression,
@@ -181,13 +181,13 @@ public class XPathUtil {
                 streamer.setContentHandler(receiver);
                 final ValueSequence seq = new ValueSequence();
                 final NodeList nl = (NodeList) obj;
-                int last = builder.getDocument().getLastNode();
+                int last = builder.getMemtree().getLastNode();
                 for (int i = 0; i < nl.getLength(); i++) {
                     final Node n = nl.item(i);
                     streamer.serialize(n, false);
-                    final NodeImpl created = builder.getDocument().getNode(last + 1);
+                    final NodeImpl created = builder.getMemtree().getNode(last + 1);
                     seq.add(created);
-                    last = builder.getDocument().getLastNode();
+                    last = builder.getMemtree().getLastNode();
                 }
                 return seq;
             } catch (final SAXException e) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
@@ -117,7 +117,7 @@ public class FunAnalyzeString extends BasicFunction {
             }
             builder.endElement();
             builder.endDocument();
-            return (NodeValue) builder.getDocument().getDocumentElement();
+            return (NodeValue) builder.getMemtree().getDocumentElement();
         } finally {
             context.popDocumentContext();
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/JSON.java
@@ -194,7 +194,7 @@ public class JSON extends BasicFunction {
             builder.startDocument();
             factory.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, false);
             jsonToXml(builder, parser);
-            return builder.getDocument() == null ? Sequence.EMPTY_SEQUENCE : builder.getDocument();
+            return builder.getMemtree() == null ? Sequence.EMPTY_SEQUENCE : builder.getMemtree();
         }  catch (IOException e) {
             throw new XPathException(this, ErrorCodes.FOJS0001, e.getMessage());
         } catch (XPathException e) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectFunction.java
@@ -51,7 +51,7 @@ public class InspectFunction extends BasicFunction {
             context.pushDocumentContext();
             final MemTreeBuilder builder = context.getDocumentBuilder();
             final int nodeNr = InspectFunctionHelper.generateDocs(sig, null, builder);
-            return builder.getDocument().getNode(nodeNr);
+            return builder.getMemtree().getNode(nodeNr);
         } finally {
             context.popDocumentContext();
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
@@ -138,7 +138,7 @@ public class InspectModule extends BasicFunction {
                     }
                 }
                 builder.endElement();
-                return builder.getDocument().getNode(nodeNr);
+                return builder.getMemtree().getNode(nodeNr);
             } finally {
                 context.popDocumentContext();
             }

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/IdFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/IdFunction.java
@@ -91,7 +91,7 @@ public class IdFunction extends BasicFunction {
 
             builder.endDocument();
 
-            return builder.getDocument();
+            return builder.getMemtree();
         } finally {
             context.popDocumentContext();
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/PermissionsFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/PermissionsFunction.java
@@ -458,7 +458,7 @@ public class PermissionsFunction extends BasicFunction {
 
         builder.endDocument();
 
-        final org.exist.dom.memtree.DocumentImpl doc = builder.getDocument();
+        final org.exist.dom.memtree.DocumentImpl doc = builder.getMemtree();
 
         context.popDocumentContext();
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/FnExport.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/FnExport.java
@@ -134,7 +134,7 @@ public class FnExport extends BasicFunction {
             } else {
                 builder.endElement();
                 builder.endDocument();
-                return (NodeValue) builder.getDocument().getDocumentElement();
+                return (NodeValue) builder.getMemtree().getDocumentElement();
             }
 
         } finally {

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/FnImport.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/FnImport.java
@@ -136,7 +136,7 @@ public class FnImport extends BasicFunction {
 			} else {
 				builder.endElement();
 				builder.endDocument();
-				return (NodeValue) builder.getDocument().getDocumentElement();
+				return (NodeValue) builder.getMemtree().getDocumentElement();
 			}
 		} finally {
         	if (builder != null) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/FunctionTrace.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/FunctionTrace.java
@@ -110,7 +110,7 @@ public class FunctionTrace extends BasicFunction {
                 brokerPool.getPerformanceStats().toXML(builder);
                 builder.endDocument();
                 logger.info("Exiting " + SystemModule.PREFIX + ":{}", getName().getLocalPart());
-                return (NodeValue) builder.getDocument().getDocumentElement();
+                return (NodeValue) builder.getMemtree().getDocumentElement();
             } finally {
                 context.popDocumentContext();
             }

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/GetRunningJobs.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/GetRunningJobs.java
@@ -89,7 +89,7 @@ public class GetRunningJobs extends BasicFunction {
             builder.endElement();
             builder.endDocument();
 
-            return (NodeValue) builder.getDocument().getDocumentElement();
+            return (NodeValue) builder.getMemtree().getDocumentElement();
         } finally {
             context.popDocumentContext();
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/GetRunningXQueries.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/GetRunningXQueries.java
@@ -101,7 +101,7 @@ public class GetRunningXQueries extends BasicFunction
 
 			builder.endElement();
 
-			xmlResponse = (NodeValue) builder.getDocument().getDocumentElement();
+			xmlResponse = (NodeValue) builder.getMemtree().getDocumentElement();
 
 			return (xmlResponse);
 		} finally {

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/GetScheduledJobs.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/GetScheduledJobs.java
@@ -106,7 +106,7 @@ public class GetScheduledJobs extends BasicFunction {
             builder.endElement();
             builder.endDocument();
 
-            return ((NodeValue) builder.getDocument().getDocumentElement());
+            return ((NodeValue) builder.getMemtree().getDocumentElement());
         } finally {
             context.popDocumentContext();
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/Restore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/Restore.java
@@ -125,7 +125,7 @@ public class Restore extends BasicFunction {
 
             builder.endElement();
             builder.endDocument();
-            return (NodeValue) builder.getDocument().getDocumentElement();
+            return (NodeValue) builder.getMemtree().getDocumentElement();
         } finally {
             context.popDocumentContext();
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
@@ -235,7 +235,7 @@ public class Transform extends BasicFunction {
                 }
 
                 errorListener.checkForErrors();
-                Node next = builder.getDocument().getFirstChild();
+                Node next = builder.getMemtree().getFirstChild();
                 while (next != null) {
                     seq.add((NodeValue) next);
                     next = next.getNextSibling();

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Compile.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Compile.java
@@ -192,7 +192,7 @@ public class Compile extends BasicFunction {
 
 			builder.endElement();
 
-			return builder.getDocument().getNode(1);
+			return builder.getMemtree().getNode(1);
 		} finally {
 			context.popDocumentContext();
 		}

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/DescribeFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/DescribeFunction.java
@@ -110,7 +110,7 @@ public class DescribeFunction extends Function {
 				}
 			}
 			builder.endElement();
-			return ((DocumentImpl) builder.getDocument()).getNode(nodeNr);
+			return ((DocumentImpl) builder.getMemtree()).getNode(nodeNr);
 		} finally {
 			context.popDocumentContext();
 		}

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Expand.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Expand.java
@@ -134,11 +134,11 @@ public class Expand extends BasicFunction {
                 builder.endDocument();
 
                 if (Node.DOCUMENT_NODE == nodeType) {
-                    result.add(builder.getDocument());
+                    result.add(builder.getMemtree().getDocumentNode());
                 } else if (Node.ATTRIBUTE_NODE == nodeType) {
-                    result.add(builder.getDocument().getAttribute(attrNr));
+                    result.add(builder.getMemtree().getAttribute(attrNr));
                 } else {
-                    result.add(builder.getDocument().getNode(1));
+                    result.add(builder.getMemtree().getNode(1));
                 }
 
                 builder.reset(getContext());

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/InspectFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/InspectFunction.java
@@ -58,7 +58,7 @@ public class InspectFunction extends BasicFunction {
             context.pushDocumentContext();
             final MemTreeBuilder builder = context.getDocumentBuilder();
             final int nodeNr = InspectFunctionHelper.generateDocs(sig, null, builder);
-            return builder.getDocument().getNode(nodeNr);
+            return builder.getMemtree().getNode(nodeNr);
         } finally {
             context.popDocumentContext();
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/ModuleInfo.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/ModuleInfo.java
@@ -216,7 +216,7 @@ public class ModuleInfo extends BasicFunction {
 						outputModule(builder, module);
 					}
 				}
-				return builder.getDocument().getNode(1);
+				return builder.getMemtree().getNode(1);
 			} finally {
 				context.popDocumentContext();
 			}

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/GrammarTooling.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/GrammarTooling.java
@@ -268,7 +268,7 @@ public class GrammarTooling extends BasicFunction  {
 
         builder.endElement();
         
-        return builder.getDocument().getNode(nodeNr);
+        return builder.getMemtree().getNode(nodeNr);
     }
     
     private void writeGrammar(Grammar grammar,  MemTreeBuilder builder){

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Jaxp.java
@@ -330,7 +330,7 @@ public class Jaxp extends BasicFunction {
 
             if (contenthandler instanceof DocumentBuilderReceiver) {
                 //DocumentBuilderReceiver dbr = (DocumentBuilderReceiver) contenthandler;
-                return instanceBuilder.getDocument().getNode(0);
+                return instanceBuilder.getMemtree().getNode(0);
 
             } else {
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/validation/Shared.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/validation/Shared.java
@@ -380,7 +380,7 @@ public class Shared {
         builder.endElement();
 
         // return result
-        return builder.getDocument().getNode(nodeNr);
+        return builder.getMemtree().getNode(nodeNr);
 
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/update/Modification.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/Modification.java
@@ -201,13 +201,13 @@ public abstract class Modification extends AbstractExpression
                 }
                 if (Type.subTypeOf(item.getType(), Type.NODE)) {
                     if (((NodeValue)item).getImplementationType() == NodeValue.PERSISTENT_NODE) {
-                        final int last = builder.getDocument().getLastNode();
+                        final int last = builder.getMemtree().getLastNode();
                         final NodeProxy p = (NodeProxy) item;
                         serializer.toReceiver(p, false, false);
                         if (p.getNodeType() == Node.ATTRIBUTE_NODE)
-                            {item = builder.getDocument().getLastAttr();}
+                            {item = builder.getMemtree().getLastAttr();}
                         else
-                            {item = builder.getDocument().getNode(last + 1);}
+                            {item = builder.getMemtree().getNode(last + 1);}
                     } else {
                         ((org.exist.dom.memtree.NodeImpl)item).deepCopy();
                     }

--- a/exist-core/src/test/java/org/exist/dom/memtree/DOMTest.java
+++ b/exist-core/src/test/java/org/exist/dom/memtree/DOMTest.java
@@ -85,7 +85,7 @@ public class DOMTest {
         builder.characters("text");
         builder.endElement();
         builder.endDocument();
-        DocumentImpl doc = builder.getDocument();
+        DocumentImpl doc = builder.getMemtree();
         Node top = doc.getFirstChild();
         assertEquals(Node.ELEMENT_NODE, top.getNodeType());
         assertEquals("top", top.getNodeName());
@@ -103,7 +103,7 @@ public class DOMTest {
         builder.endElement();
         builder.endElement();
         builder.endDocument();
-        DocumentImpl doc = builder.getDocument();
+        DocumentImpl doc = builder.getMemtree();
         Node top = doc.getFirstChild();
         assertEquals(Node.ELEMENT_NODE, top.getNodeType());
         assertEquals("top", top.getNodeName());
@@ -152,7 +152,7 @@ public class DOMTest {
         builder.endElement();
         builder.endDocument();
 
-        DocumentImpl doc = builder.getDocument();
+        DocumentImpl doc = builder.getMemtree();
 
         Node nXQuery = doc.getFirstChild();
         assertTrue(nXQuery.getNodeType() == Node.ELEMENT_NODE);

--- a/exist-core/src/test/java/org/exist/dom/memtree/DocumentBuilderReceiverTest.java
+++ b/exist-core/src/test/java/org/exist/dom/memtree/DocumentBuilderReceiverTest.java
@@ -78,7 +78,7 @@ public class DocumentBuilderReceiverTest {
         
         verify(mockContext);
         
-        Document doc = builder.getDocument();
+        Document doc = builder.getMemtree();
         Node entryNode = doc.getFirstChild();
         
         assertEquals(entry_name, entryNode.getNodeName());
@@ -116,7 +116,7 @@ public class DocumentBuilderReceiverTest {
 
         verify(mockContext);
 
-        Document doc = builder.getDocument();
+        Document doc = builder.getMemtree();
         Node entryNode = doc.getFirstChild();
 
         assertEquals("Explicit namespace prefix should be preserved", titleQName, entryNode.getNodeName());
@@ -151,7 +151,7 @@ public class DocumentBuilderReceiverTest {
 
         verify(mockContext);
 
-        Document doc = builder.getDocument();
+        Document doc = builder.getMemtree();
         Node entryNode = doc.getFirstChild();
 
         assertEquals("Explicit namespace prefix should be preserved", "a:title", entryNode.getNodeName());

--- a/exist-core/src/test/java/org/exist/dom/memtree/MemtreeImplTest.java
+++ b/exist-core/src/test/java/org/exist/dom/memtree/MemtreeImplTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
  * @author Adam Retter <adam@evolvedbinary.com>
  */
 @RunWith(ParallelRunner.class)
-public class MemtreeTest {
+public class MemtreeImplTest {
 
     private final static String XML =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -586,6 +586,7 @@ public class MemtreeTest {
 
         reader.setProperty(Namespaces.SAX_LEXICAL_HANDLER, adapter);
         reader.parse(src);
+        adapter.
         return adapter.getDocument();
     }
 }

--- a/exist-core/src/test/java/org/exist/dom/memtree/TextImplTest.java
+++ b/exist-core/src/test/java/org/exist/dom/memtree/TextImplTest.java
@@ -50,7 +50,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("helloworld", text.getTextContent());
 
@@ -73,7 +73,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("helloworld", text.getTextContent());
 
@@ -96,7 +96,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("helloworld", text.getTextContent());
 
@@ -119,7 +119,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text)doc.getDocumentElement().getFirstChild();
         assertEquals("helloworld", text.getTextContent());
 
@@ -142,7 +142,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -168,7 +168,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -194,7 +194,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -220,7 +220,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -246,7 +246,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -272,7 +272,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -291,7 +291,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -317,7 +317,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("helloworld", text.getTextContent());
 
@@ -340,7 +340,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -366,7 +366,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -392,7 +392,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -418,7 +418,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -437,7 +437,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("hello", text.getTextContent());
 
@@ -460,7 +460,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("1230 North Ave. Dallas, Texas 98551", text.getTextContent());
 
@@ -477,7 +477,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("1230 North Ave. Dallas, Texas 98551", text.getTextContent());
 
@@ -494,7 +494,7 @@ public class TextImplTest {
         builder.endElement();
         builder.endDocument();
 
-        final Document doc = builder.getDocument();
+        final Document doc = builder.getMemtree();
         final Text text = (Text) doc.getDocumentElement().getFirstChild();
         assertEquals("1230 North Ave. Dallas, Texas 98551", text.getTextContent());
 

--- a/exist-core/src/test/java/org/exist/xquery/XQueryDeclareContextItemTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryDeclareContextItemTest.java
@@ -226,7 +226,7 @@ public class XQueryDeclareContextItemTest {
             builder.endElement();
             builder.endDocument();
 
-            final ElementImpl elem = (ElementImpl)builder.getDocument().getDocumentElement();
+            final ElementImpl elem = (ElementImpl)builder.getMemtree().getDocumentElement();
 
             final Sequence result = xquery.execute(broker, query, elem);
             assertEquals(1, result.getItemCount());

--- a/exist-core/src/test/java/org/exist/xquery/value/ValueSequenceTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/value/ValueSequenceTest.java
@@ -77,9 +77,9 @@ public class ValueSequenceTest {
             final NodeProxy docProxy = new NodeProxy(null, doc);
             final NodeProxy nodeProxy = new NodeProxy(null, doc, ((NodeImpl)doc.getFirstChild()).getNodeId());
 
-            seq.add(memtree.getDocument());
+            seq.add(memtree.getMemtree());
             seq.add(docProxy);
-            seq.add((org.exist.dom.memtree.NodeImpl)memtree.getDocument().getFirstChild());
+            seq.add((org.exist.dom.memtree.NodeImpl)memtree.getMemtree().getFirstChild());
             seq.add(nodeProxy);
 
             //call sort

--- a/extensions/contentextraction/src/main/java/org/exist/contentextraction/xquery/ContentFunctions.java
+++ b/extensions/contentextraction/src/main/java/org/exist/contentextraction/xquery/ContentFunctions.java
@@ -159,7 +159,7 @@ public class ContentFunctions extends BasicFunction {
                         builder.endElement();
                         builder.endElement();
                         builder.endDocument();
-                        return builder.getDocument();
+                        return builder.getMemtree();
                     } finally {
                         context.popDocumentContext();
                     }

--- a/extensions/expath/src/main/java/org/expath/exist/ZipFileFunctions.java
+++ b/extensions/expath/src/main/java/org/expath/exist/ZipFileFunctions.java
@@ -226,7 +226,7 @@ public class ZipFileFunctions extends BasicFunction {
             }
 
             builder.endElement();
-            xmlResponse = (NodeValue) builder.getDocument().getDocumentElement();
+            xmlResponse = (NodeValue) builder.getMemtree().getDocumentElement();
             return (xmlResponse);
         } finally {
             context.popDocumentContext();

--- a/extensions/expath/src/main/java/org/expath/httpclient/model/exist/EXistTreeBuilder.java
+++ b/extensions/expath/src/main/java/org/expath/httpclient/model/exist/EXistTreeBuilder.java
@@ -73,7 +73,7 @@ public class EXistTreeBuilder implements TreeBuilder {
     
     public DocumentImpl close() {
         builder.endDocument();
-        final DocumentImpl doc = builder.getDocument();
+        final DocumentImpl doc = builder.getMemtree();
         builder.getContext().popDocumentContext();
         return doc;
     }

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/RegistryFunctions.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/RegistryFunctions.java
@@ -123,7 +123,7 @@ public class RegistryFunctions extends BasicFunction {
         builder.endElement();
         builder.endDocument();
 
-        return builder.getDocument();
+        return builder.getMemtree();
     }
 
     /**

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/exist/RegistryFunctions.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/xquery/exist/RegistryFunctions.java
@@ -271,7 +271,7 @@ public class RegistryFunctions extends BasicFunction {
             builder.endElement();
             builder.endDocument();
 
-            return builder.getDocument();
+            return builder.getMemtree();
         } finally {
             context.popDocumentContext();
         }
@@ -310,7 +310,7 @@ public class RegistryFunctions extends BasicFunction {
             builder.endElement();
             builder.endDocument();
 
-            return builder.getDocument();
+            return builder.getMemtree();
         } finally {
             context.popDocumentContext();
         }

--- a/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/xquery/RegistryFunctionsTest.java
+++ b/extensions/exquery/restxq/src/test/java/org/exist/extensions/exquery/restxq/impl/xquery/RegistryFunctionsTest.java
@@ -87,7 +87,7 @@ public class RegistryFunctionsTest {
         builder.endDocument();
 
         //assert result
-        final String xmlResult = documentToString(builder.getDocument());
+        final String xmlResult = documentToString(builder.getMemtree());
 
         final Source srcExpected = Input.fromString("<media-type xmlns=\"http://www.w3.org/2010/xslt-xquery-serialization\">" + internetMediaType + "</media-type>").build();
         final Source srcActual = Input.fromString(xmlResult).build();
@@ -128,7 +128,7 @@ public class RegistryFunctionsTest {
         builder.endDocument();
 
         //assert result
-        final String xmlResult = documentToString(builder.getDocument());
+        final String xmlResult = documentToString(builder.getMemtree());
 
         final Source srcExpected = Input.fromString("<method xmlns=\"http://www.w3.org/2010/xslt-xquery-serialization\">" + methodStr + "</method>").build();
         final Source srcActual = Input.fromString(xmlResult).build();

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -746,7 +746,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 //System.out.println(builder.getDocument().toString());
 
                 // TODO check
-                return builder.getDocument().getNode(nodeNr);
+                return builder.getMemtree().getNode(nodeNr);
             } finally {
                 context.popDocumentContext();
             }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -262,7 +262,7 @@ public class Field extends BasicFunction {
                     builder.characters(content.substring(currentPos));
                 }
                 builder.endElement();
-                result.add(builder.getDocument().getNode(nodeNr));
+                result.add(builder.getMemtree().getNode(nodeNr));
             }
             return result;
         } finally {

--- a/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/HighlightMatches.java
+++ b/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/HighlightMatches.java
@@ -90,7 +90,7 @@ public class HighlightMatches extends BasicFunction {
             for (SequenceIterator i = args[0].iterate(); i.hasNext(); ) {
                 NodeValue v = (NodeValue) i.nextItem();
                 try {
-                    int nodeNr = builder.getDocument().getLastNode();
+                    int nodeNr = builder.getMemtree().getLastNode();
                     if (v.getImplementationType() == NodeValue.IN_MEMORY_NODE) {
                         ((NodeImpl) v).copyTo(context.getBroker(), docBuilder);
                     } else {
@@ -106,7 +106,7 @@ public class HighlightMatches extends BasicFunction {
                         serializer.setReceiver(receiver);
                         serializer.toReceiver((NodeProxy) v, false);
                     }
-                    result.add(builder.getDocument().getNode(++nodeNr));
+                    result.add(builder.getMemtree().getNode(++nodeNr));
                 } catch (SAXException e) {
                     LOG.warn(e.getMessage(), e);
                     throw new XPathException(this, e.getMessage());

--- a/extensions/modules/exi/src/main/java/org/exist/xquery/modules/exi/DecodeExiFunction.java
+++ b/extensions/modules/exi/src/main/java/org/exist/xquery/modules/exi/DecodeExiFunction.java
@@ -120,7 +120,7 @@ public class DecodeExiFunction extends BasicFunction {
 					decoder.parse(new InputSource(inputStream));
 				}
 
-				return (NodeValue) builder.getDocument().getDocumentElement();
+				return (NodeValue) builder.getMemtree().getDocumentElement();
 			} finally {
 				context.popDocumentContext();
 			}

--- a/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/Deploy.java
+++ b/extensions/modules/expathrepo/src/main/java/org/exist/xquery/modules/expathrepo/Deploy.java
@@ -257,7 +257,7 @@ public class Deploy extends BasicFunction {
 			builder.startElement(STATUS_ELEMENT, attrs);
 			builder.endElement();
 			
-			return builder.getDocument().getNode(1);
+			return builder.getMemtree().getNode(1);
 		} finally {
 			context.popDocumentContext();
 		}

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Directory.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Directory.java
@@ -163,7 +163,7 @@ public class Directory extends BasicFunction {
 
             builder.endElement();
 
-            return (NodeValue) builder.getDocument().getDocumentElement();
+            return (NodeValue) builder.getMemtree().getDocumentElement();
         } catch(final IOException ioe) {
             throw new XPathException(this, ioe);
         } finally {

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
@@ -24,7 +24,6 @@ package org.exist.xquery.modules.file;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Date;
 
 import org.apache.logging.log4j.LogManager;
@@ -171,7 +170,7 @@ public class DirectoryList extends BasicFunction {
 
             builder.endElement();
 
-            return (NodeValue) builder.getDocument().getDocumentElement();
+            return (NodeValue) builder.getMemtree().getDocumentElement();
         } catch (final IOException e) {
             throw new XPathException(this, e.getMessage());
         } finally {

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
@@ -253,7 +253,7 @@ public class Sync extends BasicFunction {
         } finally {
             context.popDocumentContext();
         }
-        return output.getDocument();
+        return output.getMemtree();
     }
 
     private void syncCollection(

--- a/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/SearchFunction.java
+++ b/extensions/modules/jndi/src/main/java/org/exist/xquery/modules/jndi/SearchFunction.java
@@ -224,7 +224,7 @@ public class SearchFunction extends BasicFunction
 			builder.endElement();
 			builder.endElement();
 
-			xmlResult = (NodeValue) builder.getDocument().getDocumentElement();
+			xmlResult = (NodeValue) builder.getMemtree().getDocumentElement();
 
 			return (xmlResult);
 		} finally {

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MessageFunctions.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MessageFunctions.java
@@ -252,7 +252,7 @@ public class MessageFunctions extends BasicFunction {
 
             builder.endElement();
             builder.endDocument();
-            ret = (NodeValue) builder.getDocument().getDocumentElement();
+            ret = (NodeValue) builder.getMemtree().getDocumentElement();
             return (ret);
         } finally {
             context.popDocumentContext();

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MessageListFunctions.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MessageListFunctions.java
@@ -427,7 +427,7 @@ public class MessageListFunctions extends BasicFunction
 
 				builder.endElement();
 
-				ret = (NodeValue) builder.getDocument().getDocumentElement();
+				ret = (NodeValue) builder.getMemtree().getDocumentElement();
 			} finally {
 				context.popDocumentContext();
 

--- a/extensions/modules/process/src/main/java/org/exist/xquery/modules/process/Execute.java
+++ b/extensions/modules/process/src/main/java/org/exist/xquery/modules/process/Execute.java
@@ -185,7 +185,7 @@ public class Execute extends BasicFunction {
 
             builder.endElement();
 
-            return (ElementImpl) builder.getDocument().getNode(nodeNr);
+            return (ElementImpl) builder.getMemtree().getNode(nodeNr);
         } finally {
             context.popDocumentContext();
         }

--- a/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
+++ b/extensions/modules/sql/src/main/java/org/exist/xquery/modules/sql/ExecuteFunction.java
@@ -396,7 +396,7 @@ public class ExecuteFunction extends BasicFunction {
                 builder.endElement();
 
                 // Change the root element count attribute to have the correct value
-                final ElementImpl docElement = (ElementImpl) builder.getDocument().getDocumentElement();
+                final ElementImpl docElement = (ElementImpl) builder.getMemtree().getDocumentElement();
                 final Node count = docElement.getNode().getAttributes().getNamedItem("count");
                 if (count != null) {
                     count.setNodeValue(String.valueOf(rowCount));
@@ -488,7 +488,7 @@ public class ExecuteFunction extends BasicFunction {
             builder.endElement();
             builder.endDocument();
 
-            return (ElementImpl) builder.getDocument().getDocumentElement();
+            return (ElementImpl) builder.getMemtree().getDocumentElement();
         } finally {
             context.popDocumentContext();
         }

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ExecuteFunctionTest.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ExecuteFunctionTest.java
@@ -197,7 +197,7 @@ public class ExecuteFunctionTest {
 
         paramBuilder.endDocument();
 
-        final ElementImpl sqlParams = (ElementImpl) paramBuilder.getDocument().getFirstChild();
+        final ElementImpl sqlParams = (ElementImpl) paramBuilder.getMemtree().getFirstChild();
 
         execute.eval(new Sequence[]{
                 new IntegerValue(connId),
@@ -262,7 +262,7 @@ public class ExecuteFunctionTest {
 
         paramBuilder.endDocument();
 
-        final ElementImpl sqlParams = (ElementImpl) paramBuilder.getDocument().getFirstChild();
+        final ElementImpl sqlParams = (ElementImpl) paramBuilder.getMemtree().getFirstChild();
 
         Sequence res = execute.eval(new Sequence[]{
                 new IntegerValue(connId),
@@ -362,7 +362,7 @@ public class ExecuteFunctionTest {
 
         paramBuilder.endDocument();
 
-        final ElementImpl sqlParams = (ElementImpl) paramBuilder.getDocument().getFirstChild();
+        final ElementImpl sqlParams = (ElementImpl) paramBuilder.getMemtree().getFirstChild();
 
         try {
             execute.eval(new Sequence[]{


### PR DESCRIPTION
This now allows eXist-db to distinguish between in-memory document nodes and other in-memory nodes.

Closes https://github.com/eXist-db/exist/issues/1463