### PR TITLE
Switch to Evolved Binary's mirror of nvd.nist.gov

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -531,6 +531,10 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <version>6.2.2</version>
                     <configuration>
+                        <!-- Use Evolved Binary's mirror of nvd.nist.gov -->
+                        <cveUrlModified>https://nvd.mirror.evolvedbinary.com/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz</cveUrlModified>
+                        <cveUrlBase>https://nvd.mirror.evolvedbinary.com/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz</cveUrlBase>
+
                         <archiveAnalyzerEnabled>false</archiveAnalyzerEnabled>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <autoconfAnalyzerEnabled>false</autoconfAnalyzerEnabled>


### PR DESCRIPTION
We are kindly offering this service to the eXist-db community.
This should help with builds in CI that get errors due to the dependency-check-plugin exhausting the GitHub quota for access to nvd.nist.gov.