### PR TITLE
Improve file:sync

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -77,7 +77,6 @@
         <dependency>
             <groupId>com.evolvedbinary.multilock</groupId>
             <artifactId>multilock</artifactId>
-            <version>1.0.1</version>
         </dependency>
 
         <dependency>

--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -451,6 +451,9 @@ public class SerializerUtils {
                 //TODO(AR) implement `use-character-maps`
                 throw new UnsupportedOperationException(
                         "Not yet implemented support for the map serialization parameter: " + localParameterName);
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported type " + Type.getTypeName(parameterConvention.getType()) + " for parameter value: " + localParameterName);
         }
     }
 

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -190,6 +190,11 @@
                 <artifactId>j8fu</artifactId>
                 <version>1.23.0</version>
             </dependency>
+            <dependency>
+                <groupId>com.evolvedbinary.multilock</groupId>
+                <artifactId>multilock</artifactId>
+                <version>1.0.1</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>

--- a/extensions/modules/file/pom.xml
+++ b/extensions/modules/file/pom.xml
@@ -63,6 +63,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.evolvedbinary.multilock</groupId>
+            <artifactId>multilock</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -93,6 +99,7 @@
             <artifactId>jetty-deploy</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-jmx</artifactId>

--- a/extensions/modules/file/pom.xml
+++ b/extensions/modules/file/pom.xml
@@ -61,11 +61,9 @@
             <groupId>com.evolvedbinary.j8fu</groupId>
             <artifactId>j8fu</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.evolvedbinary.multilock</groupId>
             <artifactId>multilock</artifactId>
-            <version>1.0.1</version>
         </dependency>
 
         <dependency>

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
@@ -23,11 +23,16 @@ package org.exist.xquery.modules.file;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
+import java.net.URISyntaxException;
 import java.util.*;
+import java.util.stream.Stream;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -39,6 +44,7 @@ import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamSource;
 
+import org.apache.tools.ant.DirectoryScanner;
 import org.exist.collections.Collection;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
@@ -46,6 +52,7 @@ import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.lock.Lock.LockMode;
+import org.exist.storage.lock.ManagedLock;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.serializers.Serializer;
 import org.exist.util.FileUtils;
@@ -55,183 +62,356 @@ import org.exist.util.serializer.SerializerPool;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
+import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
-import org.exist.xquery.value.DateTimeValue;
-import org.exist.xquery.value.FunctionParameterSequenceType;
-import org.exist.xquery.value.FunctionReturnSequenceType;
-import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.SequenceType;
-import org.exist.xquery.value.Type;
+import org.exist.xquery.functions.map.AbstractMapType;
+import org.exist.xquery.value.*;
 import org.exist.xslt.TransformerFactoryAllocator;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
+import uk.ac.ic.doc.slurp.multilock.MultiLock;
 
 public class Sync extends BasicFunction {
 
-	public final static FunctionSignature signature =
-		new FunctionSignature(
-            new QName("sync", FileModule.NAMESPACE_URI, FileModule.PREFIX),
-            "Synchronize a collection with a directory hierarchy. Compares last modified time stamps. " +
-            "If $dateTime is given, only resources modified after this time stamp are taken into account. " +
-    		"This method is only available to the DBA role.",
-            new SequenceType[]{
-            	new FunctionParameterSequenceType("collection", Type.STRING, 
-                        Cardinality.EXACTLY_ONE, "The collection to sync."),
-                new FunctionParameterSequenceType("targetPath", Type.ITEM, 
-                        Cardinality.EXACTLY_ONE, "The full path or URI to the directory"),
-                new FunctionParameterSequenceType("dateTime", Type.DATE_TIME, 
-                        Cardinality.ZERO_OR_ONE,
-                		"Optional: only resources modified after the given date/time will be synchronized.")
-            },
-            new FunctionReturnSequenceType(Type.BOOLEAN, Cardinality.EXACTLY_ONE, "true if successful, false otherwise")
-        );
-	
-	private final static Properties DEFAULT_PROPERTIES = new Properties();
-	static {
-		DEFAULT_PROPERTIES.put(OutputKeys.INDENT, "yes");
-		DEFAULT_PROPERTIES.put(OutputKeys.OMIT_XML_DECLARATION, "no");
+    public static final String PRUNE_OPT = "prune";
+    public static final String AFTER_OPT = "after";
+    public static final String EXCLUDES_OPT = "excludes";
+
+    public static final QName FileSyncElement = new QName("sync", FileModule.NAMESPACE_URI);
+    public static final QName FileUpdateElement = new QName("update", FileModule.NAMESPACE_URI);
+    public static final QName FileDeleteElement = new QName("delete", FileModule.NAMESPACE_URI);
+    public static final QName FileErrorElement = new QName("error", FileModule.NAMESPACE_URI);
+
+    // TODO(JL) Figure out which namespace all attributes should be in (possible breaking change)
+    public static final QName FileCollectionAttribute = new QName("collection", FileModule.NAMESPACE_URI);
+    public static final QName FileDirAttribute = new QName("dir", FileModule.NAMESPACE_URI);
+
+    public static final QName FileAttribute = new QName("file", XMLConstants.NULL_NS_URI);
+    public static final QName NameAttribute = new QName("name", XMLConstants.NULL_NS_URI);
+    public static final QName CollectionAttribute = new QName("collection", XMLConstants.NULL_NS_URI);
+    public static final QName TypeAttribute = new QName("type", XMLConstants.NULL_NS_URI);
+    public static final QName ModifiedAttribute = new QName("modified", XMLConstants.NULL_NS_URI);
+
+    public static final FunctionSignature signature =
+            new FunctionSignature(
+                    new QName("sync", FileModule.NAMESPACE_URI, FileModule.PREFIX),
+                    "Synchronize a collection with a directory hierarchy." +
+                            "This method is only available to the DBA role. ",
+                    new SequenceType[]{
+                            new FunctionParameterSequenceType("collection", Type.STRING, Cardinality.EXACTLY_ONE,
+                                    "Absolute path to the collection to synchronize to disk."),
+                            new FunctionParameterSequenceType("targetPath", Type.ITEM, Cardinality.EXACTLY_ONE,
+                                    "The path or URI to the target directory. Relative paths resolve against EXIST_HOME."),
+                            new FunctionParameterSequenceType("dateTimeOrOptionsMap", Type.ITEM, Cardinality.ZERO_OR_ONE,
+                                    "Options as map(*). The available settings are:" +
+                                            "\"" + PRUNE_OPT + "\": delete any file/dir that does not correspond to a doc/collection in the DB. " +
+                                            "\"" + AFTER_OPT + "\": only resources modified after this date will be taken into account." +
+                                            "\"" + EXCLUDES_OPT + "\": files on the file system matching any of these patterns will be left untouched." +
+                                            "(deprecated) If the third parameter is of type xs:dateTime, it is the same as setting the \"" + AFTER_OPT + "\" option.")
+                    },
+                    new FunctionReturnSequenceType(Type.DOCUMENT, Cardinality.EXACTLY_ONE, "A report (file:sync) which files and directories were updated (file:update) or deleted (file:delete).")
+            );
+
+    private static final Properties DEFAULT_PROPERTIES = new Properties();
+
+    static {
+        DEFAULT_PROPERTIES.put(OutputKeys.INDENT, "yes");
+        DEFAULT_PROPERTIES.put(OutputKeys.OMIT_XML_DECLARATION, "no");
         DEFAULT_PROPERTIES.put(EXistOutputKeys.EXPAND_XINCLUDES, "no");
-	}
-	
-	public Sync(final XQueryContext context) {
-		super(context, signature);
-	}
+    }
 
-	@Override
-	public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
-        
-		if (!context.getSubject().hasDbaRole()) {
-			throw new XPathException(this, "Function file:sync is only available to the DBA role");
-		}
-		
-		final String collectionPath = args[0].getStringValue();
-		Date startDate = null;
-		if (args[2].hasOne()) {
-			DateTimeValue dtv = (DateTimeValue) args[2].itemAt(0);
-			startDate = dtv.getDate();
-		}
-        
-		final String target = args[1].getStringValue();
-        Path targetDir = FileModuleHelper.getFile(target);
-        
-		
-		context.pushDocumentContext();
-		final MemTreeBuilder output = context.getDocumentBuilder();
-		try {
-			if (!targetDir.isAbsolute()) {
-				final Optional<Path> home = context.getBroker().getConfiguration().getExistHome();
-				targetDir = FileUtils.resolve(home, target);
-			}
-			
-			output.startDocument();
-			output.startElement(new QName("sync", FileModule.NAMESPACE_URI), null);
-			output.addAttribute(new QName("collection", FileModule.NAMESPACE_URI), collectionPath);
-			output.addAttribute(new QName("dir", FileModule.NAMESPACE_URI), targetDir.toAbsolutePath().toString());
-			
-			saveCollection(XmldbURI.create(collectionPath), targetDir, startDate, output);
-			
-			output.endElement();
-			output.endDocument();
-        } catch(final PermissionDeniedException | LockException e) {
-            throw new XPathException(this, e);
-		} finally {
-			context.popDocumentContext();
-		}
-		return output.getDocument();
-	}
+    public Sync(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
 
-	private void saveCollection(final XmldbURI collectionPath, Path targetDir, final Date startDate, final MemTreeBuilder output) throws PermissionDeniedException, LockException {
-		try {
-			targetDir = Files.createDirectories(targetDir);
-		} catch(final IOException ioe) {
-			reportError(output, "Failed to create output directory: " + targetDir.toAbsolutePath().toString() +
-					" for collection " + collectionPath);
-			return;
-		}
+    @Override
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
 
-		if (!Files.isWritable(targetDir)) {
-			reportError(output, "Failed to write to output directory: " + targetDir.toAbsolutePath().toString());
-			return;
-		}
-		
-		List<XmldbURI> subcollections = null;
-		try(final Collection collection = context.getBroker().openCollection(collectionPath, LockMode.READ_LOCK)) {
-			if (collection == null) {
-				reportError(output, "Collection not found: " + collectionPath);
-				return;
-			}
-			for (final Iterator<DocumentImpl> i = collection.iterator(context.getBroker()); i.hasNext(); ) {
-				DocumentImpl doc = i.next();
-				if (startDate == null || doc.getLastModified() > startDate.getTime()) {
-					if (doc.getResourceType() == DocumentImpl.BINARY_FILE) {
-						saveBinary(targetDir, (BinaryDocument) doc, output);
-					} else {
-						saveXML(targetDir, doc, output);
-					}
-				}
-			}
-			
-			subcollections = new ArrayList<>(collection.getChildCollectionCount(context.getBroker()));
-			for (final Iterator<XmldbURI> i = collection.collectionIterator(context.getBroker()); i.hasNext(); ) {
-				subcollections.add(i.next());
-			}
-		}
-		
-		for (final XmldbURI childURI : subcollections) {
-			final Path childDir = targetDir.resolve(childURI.lastSegment().toString());
-			saveCollection(collectionPath.append(childURI), childDir, startDate, output);
-		}
-	}
+        if (!context.getSubject().hasDbaRole()) {
+            throw new XPathException(this, "Function file:sync is only available to the DBA role");
+        }
 
-	private void reportError(final MemTreeBuilder output,final String msg) {
-		output.startElement(new QName("error", FileModule.NAMESPACE_URI), null);
-		output.characters(msg);
-		output.endElement();
-	}
+        final String collectionPath = args[0].getStringValue();
+        final String target = args[1].getStringValue();
+        final HashMap<String, Sequence> options = getOptions(args[2]);
 
-	private void saveXML(final Path targetDir, final DocumentImpl doc, final MemTreeBuilder output) {
-		Path targetFile = targetDir.resolve(doc.getFileURI().toASCIIString());
-		final SAXSerializer sax = (SAXSerializer)SerializerPool.getInstance().borrowObject( SAXSerializer.class );
-		try {
-			if (Files.exists(targetFile) && Files.getLastModifiedTime(targetFile).compareTo(FileTime.fromMillis(doc.getLastModified())) >= 0) {
-				return;
-			}
-    	    boolean isRepoXML = Files.exists(targetFile) && FileUtils.fileName(targetFile).equals("repo.xml");
+        return startSync(target, collectionPath, options);
+    }
 
-			output.startElement(new QName("update", FileModule.NAMESPACE_URI), null);
-			output.addAttribute(new QName("file", XMLConstants.NULL_NS_URI), targetFile.toAbsolutePath().toString());
-			output.addAttribute(new QName("name", XMLConstants.NULL_NS_URI), doc.getFileURI().toString());
-			output.addAttribute(new QName("collection", XMLConstants.NULL_NS_URI), doc.getCollection().getURI().toString());
-			output.addAttribute(new QName("type", XMLConstants.NULL_NS_URI), "xml");
-			output.addAttribute(new QName("modified", XMLConstants.NULL_NS_URI), new DateTimeValue(new Date(doc.getLastModified())).getStringValue());
+    private HashMap<String, Sequence> getOptions(final Sequence parameter) throws XPathException {
+        HashMap<String, Sequence> options = new HashMap<>();
+        options.put(AFTER_OPT, Sequence.EMPTY_SEQUENCE);
+        options.put(PRUNE_OPT, new BooleanValue(false));
+        options.put(EXCLUDES_OPT, Sequence.EMPTY_SEQUENCE);
+
+        if (parameter.isEmpty()) {
+            return options;
+        }
+
+        final Item item = parameter.itemAt(0);
+
+        if (item.getType() == Type.MAP) {
+            final AbstractMapType optionsMap = (AbstractMapType) item;
+
+            final Sequence seq = optionsMap.get(new StringValue(EXCLUDES_OPT));
+            if (!seq.isEmpty() && seq.getItemType() != Type.STRING) {
+                throw new XPathException(this, ErrorCodes.XPTY0004,
+                        "Invalid value for option \"excludes\", expected xs:string* got " +
+                                Type.getTypeName(seq.getItemType()));
+            }
+            options.put(EXCLUDES_OPT, seq);
+
+            checkOption(optionsMap, PRUNE_OPT, Type.BOOLEAN, options);
+            checkOption(optionsMap, AFTER_OPT, Type.DATE_TIME, options);
+        } else if (parameter.itemAt(0).getType() == Type.DATE_TIME) {
+            // QUESTION(JL) LOG deprecation warning?
+            options.put(AFTER_OPT, parameter);
+        } else {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Invalid 3rd parameter, allowed are xs:dateTime or map(*) got " + Type.getTypeName(item.getType()));
+        }
+        return options;
+    }
+
+    private void checkOption(
+            final AbstractMapType optionsMap,
+            final String name,
+            final int expectedType,
+            final HashMap<String, Sequence> options
+    ) throws XPathException {
+        final Sequence p = optionsMap.get(new StringValue(name));
+
+        if (p.isEmpty()) {
+            return; // nothing to do, continue
+        }
+
+        if (p.hasMany() || p.getItemType() != expectedType) {
+            throw new XPathException(this, ErrorCodes.XPTY0004,
+                    "Invalid value for option \"" + name + "\", expected " +
+                            Type.getTypeName(expectedType) + " got " +
+                            Type.getTypeName(p.itemAt(0).getType()));
+        }
+
+        options.put(name, p);
+    }
+
+    private Sequence startSync(
+            final String target,
+            final String collectionPath,
+            final HashMap<String, Sequence> options
+    ) throws XPathException {
+        final Date startDate = options.get(AFTER_OPT).hasOne() ? ((DateTimeValue) options.get(AFTER_OPT)).getDate() : null;
+
+        boolean prune = ((BooleanValue) options.get(PRUNE_OPT)).getValue();
+
+        final List<String> excludes = new ArrayList<>(Collections.emptyList());
+        for (final SequenceIterator si = options.get(EXCLUDES_OPT).iterate(); si.hasNext(); ) {
+            excludes.add(si.nextItem().getStringValue());
+        }
+
+        final Path p = FileModuleHelper.getFile(target);
+        context.pushDocumentContext();
+        final MemTreeBuilder output = context.getDocumentBuilder();
+        final Path targetDir;
+        try {
+            if (p.isAbsolute()) {
+                targetDir = p;
+            } else {
+                final Optional<Path> home = context.getBroker().getConfiguration().getExistHome();
+                targetDir = FileUtils.resolve(home, target);
+            }
+
+            output.startDocument();
+            output.startElement(Sync.FileSyncElement, null);
+            output.addAttribute(Sync.FileCollectionAttribute, collectionPath);
+            output.addAttribute(Sync.FileDirAttribute, targetDir.toAbsolutePath().toString());
+
+            final String rootTargetAbsPath = targetDir.toAbsolutePath().toString();
+            final String separator = rootTargetAbsPath.endsWith(File.separator) ? "" : File.separator;
+            syncCollection(XmldbURI.create(collectionPath), rootTargetAbsPath + separator, targetDir, startDate, prune, excludes, output);
+
             output.endElement();
+            output.endDocument();
+        } catch (final PermissionDeniedException | LockException e) {
+            throw new XPathException(this, e);
+        } finally {
+            context.popDocumentContext();
+        }
+        return output.getDocument();
+    }
+
+    private void syncCollection(
+            final XmldbURI collectionPath,
+            final String rootTargetAbsPath,
+            final Path targetDir,
+            final Date startDate,
+            final boolean prune,
+            final List<String> excludes,
+            final MemTreeBuilder output
+    ) throws PermissionDeniedException, LockException {
+        final Path targetDirectory;
+        try {
+            targetDirectory = Files.createDirectories(targetDir);
+        } catch (final IOException ioe) {
+            reportError(output, "Failed to create output directory: " + targetDir.toAbsolutePath() +
+                    " for collection " + collectionPath);
+            return;
+        }
+
+        if (!Files.isWritable(targetDirectory)) {
+            reportError(output, "Failed to write to output directory: " + targetDirectory.toAbsolutePath());
+            return;
+        }
+
+        List<XmldbURI> subCollections = handleCollection(collectionPath, rootTargetAbsPath, targetDirectory, startDate, prune, excludes, output);
+
+        for (final XmldbURI childURI : subCollections) {
+            final Path childDir = targetDirectory.resolve(childURI.lastSegment().toString());
+            syncCollection(collectionPath.append(childURI), rootTargetAbsPath, childDir, startDate, prune, excludes, output);
+        }
+    }
+
+    private List<XmldbURI> handleCollection(
+            final XmldbURI collectionPath,
+            final String rootTargetAbsPath,
+            final Path targetDirectory,
+            final Date startDate,
+            final boolean prune,
+            final List<String> excludes,
+            final MemTreeBuilder output
+    ) throws PermissionDeniedException, LockException {
+        List<XmldbURI> subCollections;
+        try (final Collection collection = context.getBroker().openCollection(collectionPath, LockMode.READ_LOCK)) {
+            if (collection == null) {
+                reportError(output, "Collection not found: " + collectionPath);
+                return Collections.emptyList();
+            }
+
+            if (prune) {
+                pruneCollectionEntries(collection, rootTargetAbsPath, targetDirectory, excludes, output);
+            }
+
+            for (final Iterator<DocumentImpl> i = collection.iterator(context.getBroker()); i.hasNext(); ) {
+                final DocumentImpl doc = i.next();
+                final Path targetFile = targetDirectory.resolve(doc.getFileURI().toASCIIString());
+                saveFile(targetFile, doc, startDate, output);
+            }
+
+            subCollections = new ArrayList<>(collection.getChildCollectionCount(context.getBroker()));
+            for (final Iterator<XmldbURI> i = collection.collectionIterator(context.getBroker()); i.hasNext(); ) {
+                subCollections.add(i.next());
+            }
+        }
+        return subCollections;
+    }
+
+    private void pruneCollectionEntries(
+            final Collection collection,
+            final String rootTargetAbsPath,
+            final Path targetDir,
+            final List<String> excludes,
+            final MemTreeBuilder output) {
+        try (final Stream<Path> fileStream = Files.walk(targetDir, 1)) {
+            fileStream.forEach(path -> {
+                try {
+                    // guard against deletion of output folder
+                    if (rootTargetAbsPath.startsWith(path.toString())) {
+                        return;
+                    }
+
+                    if (isExcludedPath(rootTargetAbsPath, path, excludes)) {
+                        return;
+                    }
+
+                    final String fileName = path.getFileName().toString();
+                    final XmldbURI dbname = XmldbURI.xmldbUriFor(fileName);
+                    final String currentCollection = collection.getURI().getCollectionPath();
+
+                    if (collection.hasDocument(context.getBroker(), dbname)
+                            || collection.hasChildCollection(context.getBroker(), dbname)
+                            || currentCollection.endsWith("/" + fileName)) {
+                        return;
+                    }
+
+                    // handle non-empty directories
+                    if (Files.isDirectory(path)) {
+                        deleteWithExcludes(rootTargetAbsPath, path, excludes, output);
+                    } else {
+                        Files.deleteIfExists(path);
+                        // reporting
+                        output.startElement(Sync.FileDeleteElement, null);
+                        output.addAttribute(Sync.FileAttribute, path.toAbsolutePath().toString());
+                        output.addAttribute(Sync.NameAttribute, fileName);
+                        output.endElement();
+                    }
+
+                } catch (IOException | URISyntaxException
+                        | PermissionDeniedException | LockException e) {
+                    reportError(output, e.getMessage());
+                }
+            });
+        } catch (IOException e) {
+            reportError(output, e.getMessage());
+        }
+    }
+
+    private void saveFile(final Path targetFile, final DocumentImpl doc, final Date startDate, final MemTreeBuilder output) throws LockException {
+        try (final ManagedLock<MultiLock[]> lock = context.getBroker().getBrokerPool().getLockManager().acquireDocumentReadLock(doc.getURI())) {
+            if (startDate == null || (
+                    doc.getLastModified() > startDate.getTime() && (
+                            !Files.exists(targetFile) ||
+                                    Files.getLastModifiedTime(targetFile).compareTo(FileTime.fromMillis(doc.getLastModified())) >= 0
+                    ))) {
+                output.startElement(Sync.FileUpdateElement, null);
+                output.addAttribute(Sync.FileAttribute, targetFile.toAbsolutePath().toString());
+                output.addAttribute(Sync.NameAttribute, doc.getFileURI().toString());
+                output.addAttribute(Sync.CollectionAttribute, doc.getCollection().getURI().toString());
+                output.addAttribute(Sync.ModifiedAttribute, new DateTimeValue(new Date(doc.getLastModified())).getStringValue());
+
+                if (doc.getResourceType() == DocumentImpl.BINARY_FILE) {
+                    output.addAttribute(Sync.TypeAttribute, "binary");
+                    output.endElement();
+                    saveBinary(targetFile, (BinaryDocument) doc, output);
+                } else {
+                    output.addAttribute(Sync.TypeAttribute, "xml");
+                    output.endElement();
+                    saveXML(targetFile, doc, output);
+                }
+            }
+        } catch (final XPathException e) {
+            reportError(output, e.getMessage());
+        } catch (final IOException e) {
+            reportError(output, "IO error while saving file: " + targetFile.toAbsolutePath().toString());
+        }
+    }
+
+    private void saveXML(final Path targetFile, final DocumentImpl doc, final MemTreeBuilder output) throws IOException {
+        final SAXSerializer sax = (SAXSerializer) SerializerPool.getInstance().borrowObject(SAXSerializer.class);
+        try {
+            boolean isRepoXML = Files.exists(targetFile) && FileUtils.fileName(targetFile).equals("repo.xml");
 
             if (isRepoXML) {
                 processRepoDesc(targetFile, doc, sax, output);
             } else {
-				final Serializer serializer = context.getBroker().borrowSerializer();
-				try(final Writer writer = new OutputStreamWriter(new BufferedOutputStream(Files.newOutputStream(targetFile)), StandardCharsets.UTF_8)) {
-					sax.setOutput(writer, DEFAULT_PROPERTIES);
-					serializer.setProperties(DEFAULT_PROPERTIES);
+                final Serializer serializer = context.getBroker().borrowSerializer();
+                try (final Writer writer = new OutputStreamWriter(new BufferedOutputStream(Files.newOutputStream(targetFile)), StandardCharsets.UTF_8)) {
+                    sax.setOutput(writer, DEFAULT_PROPERTIES);
+                    serializer.setProperties(DEFAULT_PROPERTIES);
 
-					serializer.setSAXHandlers(sax, sax);
-					serializer.toSAX(doc);
-				} finally {
-					context.getBroker().returnSerializer(serializer);
-				}
+                    serializer.setSAXHandlers(sax, sax);
+                    serializer.toSAX(doc);
+                } finally {
+                    context.getBroker().returnSerializer(serializer);
+                }
             }
-		} catch (final IOException e) {
-			reportError(output, "IO error while saving file: " + targetFile.toAbsolutePath().toString());
-		} catch (final SAXException e) {
-			reportError(output, "SAX exception while saving file " + targetFile.toAbsolutePath().toString() + ": " + e.getMessage());
-		} catch (final XPathException e) {
-			reportError(output, e.getMessage());
-		} finally {
-			SerializerPool.getInstance().returnObject(sax);
-		}		
-	}
+        } catch (final SAXException e) {
+            reportError(output, "SAX exception while saving file " + targetFile.toAbsolutePath().toString() + ": " + e.getMessage());
+        } finally {
+            SerializerPool.getInstance().returnObject(sax);
+        }
+    }
 
     /**
      * Merge repo.xml modified by user with original file. This is necessary because we have to
@@ -243,13 +423,13 @@ public class Sync extends BasicFunction {
             final DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             final Document original = builder.parse(targetFile.toFile());
 
-			final Serializer serializer = context.getBroker().borrowSerializer();
+            final Serializer serializer = context.getBroker().borrowSerializer();
 
             try (final Writer writer = new OutputStreamWriter(new BufferedOutputStream(Files.newOutputStream(targetFile)), StandardCharsets.UTF_8)) {
                 sax.setOutput(writer, DEFAULT_PROPERTIES);
-                
+
                 final StreamSource stylesource = new StreamSource(Sync.class.getResourceAsStream("repo.xsl"));
-                
+
                 final SAXTransformerFactory factory = TransformerFactoryAllocator.getTransformerFactory(context.getBroker().getBrokerPool());
                 final TransformerHandler handler = factory.newTransformerHandler(stylesource);
                 handler.getTransformer().setParameter("original", original.getDocumentElement());
@@ -258,11 +438,11 @@ public class Sync extends BasicFunction {
                 serializer.reset();
                 serializer.setProperties(DEFAULT_PROPERTIES);
                 serializer.setSAXHandlers(handler, handler);
-                
+
                 serializer.toSAX(doc);
             } finally {
-				context.getBroker().returnSerializer(serializer);
-			}
+                context.getBroker().returnSerializer(serializer);
+            }
         } catch (final ParserConfigurationException e) {
             reportError(output, "Parser exception while saving file " + targetFile.toAbsolutePath().toString() + ": " + e.getMessage());
         } catch (final SAXException e) {
@@ -274,28 +454,124 @@ public class Sync extends BasicFunction {
         }
     }
 
-	private void saveBinary(final Path targetDir, final BinaryDocument binary, final MemTreeBuilder output) {
-		final Path targetFile = targetDir.resolve(binary.getFileURI().toASCIIString());
-		try {
-			if (Files.exists(targetFile) && Files.getLastModifiedTime(targetFile).compareTo(FileTime.fromMillis(binary.getLastModified())) >= 0) {
-				return;
-			}
+    private void saveBinary(final Path targetFile, final BinaryDocument binary, final MemTreeBuilder output) {
+        try (final InputStream is = context.getBroker().getBinaryResource(binary)) {
+            Files.copy(is, targetFile, StandardCopyOption.REPLACE_EXISTING);
+        } catch (final Exception e) {
+            reportError(output, e.getMessage());
+        }
+    }
 
-			output.startElement(new QName("update", FileModule.NAMESPACE_URI), null);
-			output.addAttribute(new QName("file"), targetFile.toAbsolutePath().toString());
-			output.addAttribute(new QName("name"), binary.getFileURI().toString());
-			output.addAttribute(new QName("collection"), binary.getCollection().getURI().toString());
-			output.addAttribute(new QName("type"), "binary");
-			output.addAttribute(new QName("modified"), new DateTimeValue(new Date(binary.getLastModified())).getStringValue());
+    private void reportError(final MemTreeBuilder output, final String msg) {
+        output.startElement(Sync.FileErrorElement, null);
+        output.characters(msg);
+        output.endElement();
+    }
+
+    /**
+     * We need to convert to a relative path in relation to rootTargetAbsPath,
+     * as all the exclusion patterns are relative to rootTargetAbsPath.
+     *
+     * @param rootTargetAbsPath the root target (abs)path
+     * @param path              (abs)path to check for being excluded. Should be subdir of rootTargetAbsPath
+     * @param excludes          exclude patterns (in the convention of DirectoryScanner.match)
+     * @return true if the (rel)path in question is matched by some of the exclusion patterns
+     */
+    private static boolean isExcludedPath(String rootTargetAbsPath, Path path, List<String> excludes) {
+        if (excludes.isEmpty()) {
+            return false;
+        }
+        // root folder cannot be excluded
+        // path will then also be one character shorter than rootTargetApsPath
+        // and throw when attempting to construct the relative path
+        if (rootTargetAbsPath.startsWith(path.toString())) {
+            return false;
+        }
+
+        final String absPath = path.toAbsolutePath().toString();
+        final String relPath = absPath.substring(rootTargetAbsPath.length());
+        final String normalizedPath = relPath.startsWith(File.separator)
+                ? relPath.substring(File.separator.length())
+                : relPath;
+
+        return matchAny(excludes, normalizedPath);
+    }
+
+    /**
+     * Check if any of the patterns matches the path.
+     */
+    public static boolean matchAny(final Iterable<String> patterns, final String path) {
+        for (final String pattern : patterns) {
+            if (DirectoryScanner.match(pattern, path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void deleteWithExcludes(String root, final Path path, List<String> excludes, final MemTreeBuilder output) throws IOException {
+        if (Files.isDirectory(path)) {
+            Files.walkFileTree(path, new DeleteDirWithExcludesVisitor(root, excludes, output));
+        } else {
+            Files.deleteIfExists(path);
+        }
+    }
+
+    private static class DeleteDirWithExcludesVisitor extends SimpleFileVisitor<Path> {
+
+        private final List<String> excludes;
+        private final String root;
+        private final MemTreeBuilder output;
+        private boolean hasExcludedChildren = false;
+
+        public DeleteDirWithExcludesVisitor(final String root, final List<String> excludes, final MemTreeBuilder output) {
+            this.output = output;
+            this.excludes = excludes;
+            this.root = root;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) {
+            if (isExcludedPath(root, dir, excludes)) {
+                hasExcludedChildren = true;
+                return FileVisitResult.SKIP_SUBTREE;
+            }
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+            if (isExcludedPath(root, file, excludes)) {
+                hasExcludedChildren = true;
+                return FileVisitResult.CONTINUE;
+            }
+            Files.deleteIfExists(file);
+
+            output.startElement(Sync.FileDeleteElement, null);
+            output.addAttribute(Sync.FileAttribute, file.toAbsolutePath().toString());
+            output.addAttribute(Sync.NameAttribute, file.getFileName().toString());
             output.endElement();
 
-			try(final InputStream is = context.getBroker().getBinaryResource(binary)) {
-				Files.copy(is, targetFile, StandardCopyOption.REPLACE_EXISTING);
-			}
-		} catch (final IOException e) {
-			reportError(output, "IO error while saving file: " + targetFile.toAbsolutePath().toString());
-		} catch (final Exception e) {
-			reportError(output, e.getMessage());
-		}
-	}
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+            if (exc != null) {
+                throw exc;
+            }
+            // deletion would fail due to non-empty directory
+            if (hasExcludedChildren) {
+                return FileVisitResult.CONTINUE;
+            }
+            Files.deleteIfExists(dir);
+
+            output.startElement(Sync.FileDeleteElement, null);
+            output.addAttribute(Sync.FileAttribute, dir.toAbsolutePath().toString());
+            output.addAttribute(Sync.NameAttribute, dir.getFileName().toString());
+            output.endElement();
+
+            return FileVisitResult.CONTINUE;
+        }
+    }
 }

--- a/extensions/modules/file/src/test/resources/util/fixtures.xqm
+++ b/extensions/modules/file/src/test/resources/util/fixtures.xqm
@@ -1,0 +1,59 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures";
+import module namespace util="http://exist-db.org/xquery/util";
+
+(: file contents :)
+
+declare variable $fixtures:XML := document {<foo><bar/></foo>};
+declare variable $fixtures:TXT :=
+``[12 12
+This is just a Text
+]``
+;
+declare variable $fixtures:XQY := "xquery version ""3.1""; 0 to 9";
+declare variable $fixtures:BIN := "To bin or not to bin...";
+
+(: modification dates :)
+
+declare variable $fixtures:now := current-dateTime();
+declare variable $fixtures:mod-date := $fixtures:now + xs:dayTimeDuration('PT1H');
+declare variable $fixtures:mod-date-2 := $fixtures:now + xs:dayTimeDuration('PT2H');
+
+(: collections :)
+
+declare variable $fixtures:collection-name := "file-module-test";
+declare variable $fixtures:child-collection-name := "data";
+declare variable $fixtures:collection := "/db/" || $fixtures:collection-name;
+declare variable $fixtures:child-collection := $fixtures:collection || "/" || $fixtures:child-collection-name;
+
+(: file sync results :)
+
+declare variable $fixtures:ALL-UPDATED := ("test-text.txt", "test-query.xq", "bin", "test-data.xml");
+
+declare variable $fixtures:ROOT-FS := ("bin", "test-text.txt", "test-query.xq", "data");
+
+declare variable $fixtures:EXTRA-DATA := ("test", ".env");
+
+declare variable $fixtures:ROOT-FS-EXTRA := ("test", "bin", ".env", "test-text.txt", "test-query.xq", "data");

--- a/extensions/modules/file/src/test/resources/util/fixtures.xqm
+++ b/extensions/modules/file/src/test/resources/util/fixtures.xqm
@@ -22,7 +22,6 @@
 xquery version "3.1";
 
 module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures";
-import module namespace util="http://exist-db.org/xquery/util";
 
 (: file contents :)
 

--- a/extensions/modules/file/src/test/resources/util/helper.xqm
+++ b/extensions/modules/file/src/test/resources/util/helper.xqm
@@ -1,0 +1,192 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace helper="http://exist-db.org/xquery/test/util/helper";
+import module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures" at "fixtures.xqm";
+import module namespace file="http://exist-db.org/xquery/file";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
+import module namespace util="http://exist-db.org/xquery/util";
+
+declare variable $helper:error := xs:QName("helper:assert-sync-error");
+
+(:
+/db
+    /file-module-test
+        /data
+            test-data.xml
+        test-text.txt
+        test-query.xq
+        bin
+:)
+declare function helper:setup-db() as empty-sequence() {
+    (
+        xmldb:create-collection("/db", $fixtures:collection-name),
+        helper:create-db-resource($fixtures:collection, "test-text.txt", $fixtures:TXT),
+        helper:create-db-resource($fixtures:collection, "test-query.xq", $fixtures:XQY),
+        helper:create-db-resource($fixtures:collection, "bin", $fixtures:BIN),
+
+        xmldb:create-collection($fixtures:collection, $fixtures:child-collection-name),
+        helper:create-db-resource($fixtures:child-collection, "test-data.xml", $fixtures:XML)
+    )
+    => helper:to-empty-sequence()
+};
+
+declare function helper:clear-db() {
+    xmldb:remove($fixtures:collection)
+};
+
+declare function helper:create-db-resource($collection as xs:string, $resource as xs:string, $content as item()) as empty-sequence() {
+    (
+        xmldb:store($collection, $resource, $content),
+        xmldb:touch($collection, $resource, $fixtures:mod-date)
+    )
+    => helper:to-empty-sequence()
+};
+
+declare function helper:modify-db-resource($collection as xs:string, $resource as xs:string) as empty-sequence() {
+    xmldb:touch($collection, $resource, $fixtures:mod-date-2)
+    => helper:to-empty-sequence()
+};
+
+declare function helper:clear-suite-fs ($suite as xs:string) as empty-sequence() {
+    helper:glue-path((
+        util:system-property("java.io.tmpdir"),
+        $suite
+    ))
+    => helper:clear-fs()
+};
+
+declare function helper:clear-fs ($directory as xs:string) as empty-sequence() {
+    file:delete($directory)
+    => helper:to-empty-sequence()
+};
+
+declare function helper:get-test-directory ($suite as xs:string) as xs:string {
+    helper:glue-path((
+        util:system-property("java.io.tmpdir"),
+        $suite,
+        util:uuid()
+    ))
+};
+
+declare function helper:glue-path ($parts as xs:string+) as xs:string {
+    string-join($parts, "/")
+};
+
+(:
+ : clear FS state and simulate additional data on the file system in a specific directory
+ : @returns given directory to allow use in pipeline (chain of arrow operators)
+ :)
+declare function helper:setup-fs-extra ($directory as xs:string) as xs:string {
+    let $action1 := file:mkdirs($directory)
+    let $action2 := file:mkdirs($directory || "/test")
+    let $action3 := (
+        (: cannot use fixtures here because this will lead to consumed input streams! :)
+        file:serialize-binary(
+            util:string-to-binary("SERVER_SECRET=123!"),
+            $directory || "/.env"),
+        file:serialize-binary(
+            util:string-to-binary("..."),
+            $directory || "/test/three.s")
+    )
+
+    return $directory
+};
+
+declare function helper:get-deleted-from-sync-result ($result as element(file:sync)) as xs:string* {
+    $result//file:delete/@name/string()
+};
+
+declare function helper:get-dir-from-sync-result ($result as element(file:sync)) as xs:string* {
+    $result/@file:dir/string()
+};
+
+declare function helper:get-updated-from-sync-result ($result as element(file:sync)) as xs:string* {
+    $result//file:update/@name/string()
+};
+
+declare function helper:list-files-and-directories ($directory as xs:string) as xs:string* {
+    file:list($directory)//(file:file|file:directory)/@name/string()
+};
+
+declare function helper:sync-with-options ($directory as xs:string, $options as item()?) as element(file:sync) {
+    file:sync($fixtures:collection, $directory, $options)/*
+};
+
+declare function helper:assert-sync-result (
+    $result as element(file:sync),
+    $expected as map(xs:string, xs:string*)
+) as xs:boolean {
+    helper:assert-permutation-of(
+        $expected?updated,
+        helper:get-updated-from-sync-result($result)
+    )
+    and
+    helper:assert-permutation-of(
+        $expected?deleted,
+        helper:get-deleted-from-sync-result($result)
+    )
+    and
+    helper:assert-permutation-of(
+        $expected?fs,
+        helper:get-dir-from-sync-result($result)
+        => helper:list-files-and-directories()
+    )
+};
+
+declare function helper:assert-permutation-of($expected as xs:anyAtomicType*, $actual as xs:anyAtomicType*) {
+    let $test := fold-left(
+        $expected,
+        [true(), $actual],
+        helper:permutation-reducer#2
+    )
+
+    return
+        if (not($test?1 or exists($test?2)))
+        then error($helper:error,
+        "Assertion failed: expected permutation of " ||
+               "(" || string-join($expected, ", ") || ")" ||
+               " but got (" || string-join($actual, ", ") || ")")
+        else true()
+};
+
+declare function helper:permutation-reducer ($result, $next) {
+    let $first-index := index-of($result?2, $next)[1]
+    return [
+        $result?1 and $first-index > 0,
+        helper:maybe-remove-item-at-index($result?2, $first-index)
+    ]
+};
+
+declare function helper:maybe-remove-item-at-index($sequence as xs:anyAtomicType*, $index as xs:integer?) {
+    if ($index = 1)
+    then subsequence($sequence, 2)
+    else if ($index > 1)
+    then (
+        subsequence($sequence, 1, $index - 1),
+        subsequence($sequence, $index + 1)
+    )
+    else $sequence (: do nothing - will be handled later :)
+};
+
+declare function helper:to-empty-sequence($_ as item()*) as empty-sequence() {};

--- a/extensions/modules/file/src/test/resources/util/helper.xqm
+++ b/extensions/modules/file/src/test/resources/util/helper.xqm
@@ -39,7 +39,7 @@ declare variable $helper:error := xs:QName("helper:assert-sync-error");
         bin
 :)
 declare function helper:setup-db() as empty-sequence() {
-    (
+    let $_ := (
         xmldb:create-collection("/db", $fixtures:collection-name),
         helper:create-db-resource($fixtures:collection, "test-text.txt", $fixtures:TXT),
         helper:create-db-resource($fixtures:collection, "test-query.xq", $fixtures:XQY),
@@ -48,7 +48,7 @@ declare function helper:setup-db() as empty-sequence() {
         xmldb:create-collection($fixtures:collection, $fixtures:child-collection-name),
         helper:create-db-resource($fixtures:child-collection, "test-data.xml", $fixtures:XML)
     )
-    => helper:to-empty-sequence()
+    return ()
 };
 
 declare function helper:clear-db() {
@@ -56,29 +56,29 @@ declare function helper:clear-db() {
 };
 
 declare function helper:create-db-resource($collection as xs:string, $resource as xs:string, $content as item()) as empty-sequence() {
-    (
+    let $_ := (
         xmldb:store($collection, $resource, $content),
         xmldb:touch($collection, $resource, $fixtures:mod-date)
     )
-    => helper:to-empty-sequence()
+    return ()
 };
 
 declare function helper:modify-db-resource($collection as xs:string, $resource as xs:string) as empty-sequence() {
-    xmldb:touch($collection, $resource, $fixtures:mod-date-2)
-    => helper:to-empty-sequence()
+    let $_ := xmldb:touch($collection, $resource, $fixtures:mod-date-2)
+    return ()
 };
 
 declare function helper:clear-suite-fs ($suite as xs:string) as empty-sequence() {
-    helper:glue-path((
+    let $_ := helper:glue-path((
         util:system-property("java.io.tmpdir"),
         $suite
     ))
-    => helper:clear-fs()
+    return ()
 };
 
 declare function helper:clear-fs ($directory as xs:string) as empty-sequence() {
-    file:delete($directory)
-    => helper:to-empty-sequence()
+    let $_ := file:delete($directory)
+    return ()
 };
 
 declare function helper:get-test-directory ($suite as xs:string) as xs:string {
@@ -134,22 +134,22 @@ declare function helper:sync-with-options ($directory as xs:string, $options as 
 };
 
 declare function helper:assert-sync-result (
-    $result as element(file:sync),
+    $result as document-node(element(file:sync)),
     $expected as map(xs:string, xs:string*)
 ) as xs:boolean {
     helper:assert-permutation-of(
         $expected?updated,
-        helper:get-updated-from-sync-result($result)
+        helper:get-updated-from-sync-result($result/*)
     )
     and
     helper:assert-permutation-of(
         $expected?deleted,
-        helper:get-deleted-from-sync-result($result)
+        helper:get-deleted-from-sync-result($result/*)
     )
     and
     helper:assert-permutation-of(
         $expected?fs,
-        helper:get-dir-from-sync-result($result)
+        helper:get-dir-from-sync-result($result/*)
         => helper:list-files-and-directories()
     )
 };
@@ -188,5 +188,3 @@ declare function helper:maybe-remove-item-at-index($sequence as xs:anyAtomicType
     )
     else $sequence (: do nothing - will be handled later :)
 };
-
-declare function helper:to-empty-sequence($_ as item()*) as empty-sequence() {};

--- a/extensions/modules/file/src/test/resources/util/helper.xqm
+++ b/extensions/modules/file/src/test/resources/util/helper.xqm
@@ -154,7 +154,7 @@ declare function helper:assert-sync-result (
     )
 };
 
-declare function helper:assert-permutation-of($expected as xs:anyAtomicType*, $actual as xs:anyAtomicType*) {
+declare function helper:assert-permutation-of($expected as xs:anyAtomicType*, $actual as xs:anyAtomicType*) as xs:boolean {
     let $test := fold-left(
         $expected,
         [true(), $actual],
@@ -170,7 +170,7 @@ declare function helper:assert-permutation-of($expected as xs:anyAtomicType*, $a
         else true()
 };
 
-declare function helper:permutation-reducer ($result, $next) {
+declare function helper:permutation-reducer ($result, $next) as array(*) {
     let $first-index := index-of($result?2, $next)[1]
     return [
         $result?1 and $first-index > 0,
@@ -178,7 +178,7 @@ declare function helper:permutation-reducer ($result, $next) {
     ]
 };
 
-declare function helper:maybe-remove-item-at-index($sequence as xs:anyAtomicType*, $index as xs:integer?) {
+declare function helper:maybe-remove-item-at-index($sequence as xs:anyAtomicType*, $index as xs:integer?) as xs:anyAtomicType* {
     if ($index = 1)
     then subsequence($sequence, 2)
     else if ($index > 1)

--- a/extensions/modules/file/src/test/xquery/modules/file/read-binary.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/read-binary.xqm
@@ -19,19 +19,35 @@
  : License along with this library; if not, write to the Free Software
  : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  :)
-xquery version "3.0";
+xquery version "3.1";
 
-module namespace read-binary="http://exist-db.org/testsuite/modules/file/read-binary";
+module namespace readbinary="http://exist-db.org/testsuite/modules/file/read-binary";
+import module namespace helper="http://exist-db.org/xquery/test/util/helper" at "resource:util/helper.xqm";
+import module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures" at "resource:util/fixtures.xqm";
 
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
 import module namespace file="http://exist-db.org/xquery/file";
+import module namespace util="http://exist-db.org/xquery/util";
 
+declare variable $readbinary:suite := "read-binary";
 
 declare
-    %test:pending("TODO need to mechanism to setup a temporary file to work with")
-    %test:assertEquals("<root>bla</root>")
-function read-binary:without-serialization() {
-  let $binData := file:read-binary("VERSION.txt")
-  return
-    element { "root" } { "bla" }
+    %test:setUp
+function readbinary:setup() as empty-sequence() {
+};
+
+declare
+    %test:tearDown
+function readbinary:tear-down() as empty-sequence() {
+    helper:clear-suite-fs($readbinary:suite)
+};
+
+declare
+    %test:assertEquals("SERVER_SECRET=123!")
+function readbinary:without-serialization() {
+    helper:get-test-directory($readbinary:suite)
+    => helper:setup-fs-extra()
+    => concat("/.env")
+    => file:read-binary()
+    => util:binary-to-string()
 };

--- a/extensions/modules/file/src/test/xquery/modules/file/read-binary.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/read-binary.xqm
@@ -22,12 +22,14 @@
 xquery version "3.1";
 
 module namespace readbinary="http://exist-db.org/testsuite/modules/file/read-binary";
-import module namespace helper="http://exist-db.org/xquery/test/util/helper" at "resource:util/helper.xqm";
-import module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures" at "resource:util/fixtures.xqm";
 
-import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+
 import module namespace file="http://exist-db.org/xquery/file";
 import module namespace util="http://exist-db.org/xquery/util";
+import module namespace helper="http://exist-db.org/xquery/test/util/helper" at "resource:util/helper.xqm";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
 
 declare variable $readbinary:suite := "read-binary";
 
@@ -45,9 +47,11 @@ function readbinary:tear-down() as empty-sequence() {
 declare
     %test:assertEquals("SERVER_SECRET=123!")
 function readbinary:without-serialization() {
-    helper:get-test-directory($readbinary:suite)
-    => helper:setup-fs-extra()
-    => concat("/.env")
-    => file:read-binary()
-    => util:binary-to-string()
+    let $directory := helper:get-test-directory($readbinary:suite)
+    let $_ := helper:setup-fs-extra($directory)
+
+    return
+        concat($directory, "/.env")
+        => file:read-binary()
+        => util:binary-to-string()
 };

--- a/extensions/modules/file/src/test/xquery/modules/file/serialize.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/serialize.xqm
@@ -19,9 +19,9 @@
  : License along with this library; if not, write to the Free Software
  : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  :)
-xquery version "3.0";
+xquery version "3.1";
 
-module namespace serialization="http://exist-db.org/testsuite/modules/file/serialization";
+module namespace serialize="http://exist-db.org/testsuite/modules/file/serialize";
 
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
 import module namespace file="http://exist-db.org/xquery/file";
@@ -30,7 +30,7 @@ import module namespace file="http://exist-db.org/xquery/file";
 declare
     %test:pending("need to mechanism to setup a temporary file to work with")
     %test:assertEquals("datadata", "true", "true", "true")
-function serialization:append() {
+function serialize:append() {
 
     let $node-set := text {"data"}
     let $path := system:get-exist-home() || "/test.txt"
@@ -47,7 +47,7 @@ function serialization:append() {
 declare
     %test:pending("need to mechanism to setup a temporary file to work with")
     %test:assertEquals("data", "true", "true", "true")
-function serialization:overwrite() {
+function serialize:overwrite() {
 
     let $node-set := text {"data"}
     let $path := system:get-exist-home() || "/test.txt"

--- a/extensions/modules/file/src/test/xquery/modules/file/sync.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/sync.xqm
@@ -1,0 +1,288 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace sync="http://exist-db.org/xquery/test/file/sync";
+import module namespace helper="http://exist-db.org/xquery/test/util/helper" at "resource:util/helper.xqm";
+import module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures" at "resource:util/fixtures.xqm";
+import module namespace file="http://exist-db.org/xquery/file";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
+import module namespace util="http://exist-db.org/xquery/util";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $sync:suite := "sync";
+
+declare
+    %test:setUp
+function sync:setup() as empty-sequence() {
+    helper:setup-db()
+};
+
+declare
+    %test:tearDown
+function sync:tear-down() {
+    helper:clear-db(),
+    helper:clear-suite-fs($sync:suite)
+};
+
+declare
+    %test:assertTrue
+function sync:simple() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options(())
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": (),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertTrue
+function sync:empty-options-map() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options(map{})
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": (),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertError
+function sync:deprecated-options() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options($fixtures:mod-date)
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": (),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function sync:bad-options-1() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options(xs:date("2012-12-21"))
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function sync:bad-options-2() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options("2012-12-21T10:12:21")
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function sync:bad-options-3() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options("lizard")
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function sync:bad-options-4() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options("")
+};
+
+(:
+ : TODO(JL) should also report %test:assertError("err:XPTY0004")
+ : it is wrapped in org.exist.xquery.XPathException and therefore not recognized
+ :)
+declare
+    %test:assertError
+function sync:bad-options-5() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options((1, map{}, ""))
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function sync:bad-options-6() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options(map{ "prune": "true" })
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function sync:bad-options-7() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options(map{ "prune": "no" })
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function sync:bad-options-8() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options(map{ "after": 1234325 })
+};
+
+declare
+    %test:assertError("err:XPTY0004")
+function sync:bad-options-9() {
+    helper:get-test-directory($sync:suite)
+    => helper:sync-with-options(map{ "excludes": [] })
+};
+
+declare
+    %test:assertTrue
+function sync:do-not-prune() {
+    helper:get-test-directory($sync:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "prune": false() })
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": (),
+        "fs": $fixtures:ROOT-FS-EXTRA
+    })
+};
+
+declare
+    %test:assertTrue
+function sync:prune() {
+    helper:get-test-directory($sync:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "prune": true() })
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": ("test", "three.s", ".env"),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertTrue
+function sync:prune-with-excludes-matching-none() {
+    helper:get-test-directory($sync:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "prune": true(), "excludes": "*.txt" })
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": ("test", "three.s", ".env"),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertTrue
+function sync:after() {
+    helper:get-test-directory($sync:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "after": $fixtures:mod-date })
+    => helper:assert-sync-result(map {
+        "updated": (),
+        "deleted": (),
+        "fs": ($fixtures:EXTRA-DATA, "data") (: TODO: data should not be here! :)
+    })
+};
+
+declare
+    %test:assertTrue
+function sync:after-mod-date-2() {
+    helper:get-test-directory($sync:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "after": $fixtures:mod-date-2 })
+    => helper:assert-sync-result(map {
+        "updated": (),
+        "deleted": (),
+        "fs": ($fixtures:EXTRA-DATA, "data") (: TODO: data should not be here! :)
+    })
+};
+
+declare
+    %test:assertTrue
+function sync:after-with-excludes() {
+    helper:get-test-directory($sync:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "after": $fixtures:mod-date, "excludes": ".env" })
+    => helper:assert-sync-result(map {
+        "updated": (),
+        "deleted": (),
+        "fs": ($fixtures:EXTRA-DATA, "data") (: TODO: data should not be here! :)
+    })
+};
+
+declare
+    %test:assertTrue
+function sync:prune-with-after-and-excludes() {
+    helper:get-test-directory($sync:suite)
+    => helper:setup-fs-extra()
+    => (function ($directory as xs:string) {
+        let $action := (
+            file:serialize-binary(
+                util:string-to-binary("1"),
+                $directory || "/excluded.xq"
+            ),
+            file:serialize-binary(
+                util:string-to-binary("1"),
+                $directory || "/pruned.xql"
+            ),
+            file:serialize-binary(
+                util:string-to-binary("oh oh"),
+                $directory || "/readme.md"
+            )
+        )
+        return $directory
+    })()
+    => helper:sync-with-options(map{
+        "after": $fixtures:mod-date,
+        "excludes": "*.xq",
+        "prune": true()
+    })
+    => helper:assert-sync-result(map {
+        "updated": (),
+        "deleted": ("three.s", "test", ".env", "pruned.xql", "readme.md"),
+        "fs": ("excluded.xq", "data") (: TODO: data should not be here! :)
+    })
+};
+
+declare
+    %test:assertTrue
+function sync:prunes-a-directory() {
+    helper:get-test-directory($sync:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "prune": true(), "excludes": ".*" })
+    => helper:assert-sync-result(map {
+        "updated": (),
+        "deleted": ("test", "three.s"),
+        "fs": ($fixtures:ROOT-FS, ".env")
+    })
+};
+
+declare
+    %test:pending
+    %test:assertTrue
+function sync:prunes-a-file() {
+    helper:get-test-directory($sync:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "prune": true(), "excludes": "test/*" })
+    => helper:assert-sync-result(map {
+        "updated": (),
+        "deleted": (".env"),
+        "fs": ($fixtures:ROOT-FS, "test")
+    })
+};

--- a/extensions/modules/file/src/test/xquery/modules/file/sync.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/sync.xqm
@@ -24,9 +24,6 @@ xquery version "3.1";
 module namespace sync="http://exist-db.org/xquery/test/file/sync";
 import module namespace helper="http://exist-db.org/xquery/test/util/helper" at "resource:util/helper.xqm";
 import module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures" at "resource:util/fixtures.xqm";
-import module namespace file="http://exist-db.org/xquery/file";
-import module namespace xmldb="http://exist-db.org/xquery/xmldb";
-import module namespace util="http://exist-db.org/xquery/util";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 

--- a/extensions/modules/file/src/test/xquery/modules/file/syncmod.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/syncmod.xqm
@@ -1,0 +1,232 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace syncmod="http://exist-db.org/xquery/test/file/syncmod";
+import module namespace helper="http://exist-db.org/xquery/test/util/helper" at "resource:util/helper.xqm";
+import module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures" at "resource:util/fixtures.xqm";
+
+import module namespace file="http://exist-db.org/xquery/file";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
+import module namespace util="http://exist-db.org/xquery/util";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $syncmod:suite := "sync-modified";
+
+(:
+ : Same setup as for basic sync tests in sync.xqm
+ : In addition this time two files are modified an hour after ($fixtures:mod-date)
+ :)
+declare
+    %test:setUp
+function syncmod:setup() as empty-sequence() {
+    helper:setup-db(),
+    helper:modify-db-resource($fixtures:child-collection, "test-data.xml"),
+    helper:modify-db-resource($fixtures:collection, "test-text.txt")
+};
+
+declare
+    %test:tearDown
+function syncmod:tearDown() {
+    helper:clear-db(),
+    helper:clear-suite-fs($syncmod:suite)
+};
+
+declare
+    %test:assertTrue
+function syncmod:simple() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:sync-with-options(())
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": (),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertTrue
+function syncmod:empty-options() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:sync-with-options(map{})
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": (),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertError
+function syncmod:deprecated-options() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:sync-with-options($fixtures:mod-date)
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": (),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertTrue
+function syncmod:do-not-prune() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "prune": false() })
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": (),
+        "fs": $fixtures:ROOT-FS-EXTRA
+    })
+};
+
+declare
+    %test:assertTrue
+function syncmod:prune() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "prune": true() })
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": ("test", "three.s", ".env"),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertTrue
+function syncmod:prune-with-excludes-matching-none() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "prune": true(), "excludes": "*.txt" })
+    => helper:assert-sync-result(map {
+        "updated": $fixtures:ALL-UPDATED,
+        "deleted": ("test", "three.s", ".env"),
+        "fs": $fixtures:ROOT-FS
+    })
+};
+
+declare
+    %test:assertTrue
+function syncmod:after() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "after": $fixtures:mod-date })
+    => helper:assert-sync-result(map {
+        "updated": ("test-text.txt", "test-data.xml"),
+        "deleted": (),
+        "fs": ("test", ".env", "test-text.txt", "data")
+    })
+};
+
+(: collections seem to be synced regardless of their content :)
+declare
+    %test:assertTrue
+function syncmod:after-mod-date-2() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:sync-with-options(map{ "after": $fixtures:mod-date-2 })
+    => helper:assert-sync-result(map {
+        "updated": (),
+        "deleted": (),
+        "fs": ("data") (: TODO: data should not be here! :)
+    })
+};
+
+declare
+    %test:pending("this would only work if exclude patterns would exclude DB resources from syncing")
+    %test:assertTrue
+function syncmod:exclude-changed-files() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:sync-with-options(map{ "excludes":("*.txt", "data/*"), "after": $fixtures:mod-date })
+    => helper:assert-sync-result(map {
+        "updated": (),
+        "deleted": (),
+        "fs": ()
+    })
+};
+
+declare
+    %test:assertTrue
+function syncmod:prune-with-after-and-excludes-matching-none() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{
+            "after": $fixtures:mod-date,
+            "excludes": "QQQ",
+            "prune": true()
+        })
+    => helper:assert-sync-result(map {
+        "updated": ("test-text.txt", "test-data.xml"),
+        "deleted": (".env", "test"),
+        "fs": ("test-text.txt", "data")
+    })
+};
+
+declare
+    %test:assertTrue
+function syncmod:prune-with-after-and-excludes-matching-all() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{
+            "after": $fixtures:mod-date,
+            "excludes": "**",
+            "prune": true()
+        })
+    => helper:assert-sync-result(map {
+        "updated": ("test-text.txt"), (: TODO , "test-data.xml" is missing here :)
+        "deleted": (),
+        "fs": (".env", "test", "test-text.txt", "data")
+    })
+};
+
+declare
+    %test:assertTrue
+function syncmod:prunes-a-directory-with-after() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{ "prune": true(), "excludes": ".*", "after": $fixtures:mod-date })
+    => helper:assert-sync-result(map {
+        "updated": ("test-text.txt", "test-data.xml"),
+        "deleted": ("test", "three.s"),
+        "fs": (".env", "test-text.txt", "data")
+    })
+};
+
+declare
+    %test:pending
+    %test:assertTrue
+function syncmod:prunes-a-file-with-after() {
+    helper:get-test-directory($syncmod:suite)
+    => helper:setup-fs-extra()
+    => helper:sync-with-options(map{
+            "after": $fixtures:mod-date,
+            "excludes": "test/*",
+            "prune": true()
+        })
+    => helper:assert-sync-result(map {
+        "updated": ("test-text.txt", "test-data.xml"),
+        "deleted": (".env"),
+        "fs": ("test", "test-text.txt", "data")
+    })
+};

--- a/extensions/modules/file/src/test/xquery/modules/file/syncmod.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/syncmod.xqm
@@ -25,10 +25,6 @@ module namespace syncmod="http://exist-db.org/xquery/test/file/syncmod";
 import module namespace helper="http://exist-db.org/xquery/test/util/helper" at "resource:util/helper.xqm";
 import module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures" at "resource:util/fixtures.xqm";
 
-import module namespace file="http://exist-db.org/xquery/file";
-import module namespace xmldb="http://exist-db.org/xquery/xmldb";
-import module namespace util="http://exist-db.org/xquery/util";
-
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 declare variable $syncmod:suite := "sync-modified";


### PR DESCRIPTION
### Description:

Improve `file:sync`

The third parameter can now be either an xs:dateTime (kept for backwards compatibility) or a map.

The map has three keys at the moment:

- prune `xs:boolean` flag to control if surplus files on the filesystem should be removed
- exclude `xs:string*` sequence of glob patterns with support of `*`, `?`, `**` placeholders. Files that match will not be removed from disk ~~nor synced to the filesystem~~.
- after `xs:dateTime?` synchronise only files newer than the dateTime provided

Example:

```xquery

file:sync("/db/apps/my-app", "/Users/me/projects/my-app", map {
  "after": current-dateTime() - xs:dayTimeDuration("PT1D"), (: changes in the last day :)
  "excludes": (".git", ".env"), (: leave local settings and version control untouched  :)
  "prune": true() (: remove anything not in the database :)
})

```

Example of deprecated call:

```xquery
file:sync("/db/apps/my-app", "/Users/me/projects/my-app", 
  current-dateTime() - xs:dayTimeDuration("PT1D") (: changes in the last day :)
) 
```

Whenever `file:sync` selects a file or folder for deletion it will report this in the returned file:sync element.

Example report with deletions

```xml
<file:sync xmlns:file="http://exist-db.org/xquery/file" collection="/db/apps/my-app" dir="/Users/me/projects/my-app">
    <file:delete file="/Users/me/projects/my-app/.gitignore" name=".gitignore"/>
</file:sync>
```

The above also shows that `.*` is a reasonable excludes pattern.

Fixes the Function Signature to correctly state it returns a document-node() (was xs:boolean).

The function describes itself now as such
(NOTE: I found no way to force line-breaks before the option names)

```
Synchronize a collection with a directory hierarchy.This method is only available to the DBA role.

$collection as xs:string
    Absolute path to the collection to synchronize to disk.

$targetPath as item()
    The path or URI to the target directory. Relative paths resolve against EXIST_HOME.

$dateTimeOrOptionsMap as item()?
    Options as map(*). The available settings are:
    "prune": delete any file/dir that does not correspond to a doc/collection in the DB.
    "after": only resources modified after this date will be taken into account.
    "excludes": files on the file system matching any of these patterns will be left untouched.
    (deprecated) If the third parameter is of type xs:dateTime, it is the same as setting the "after" option.

Returns: document-node()
    A report (file:sync) which files and directories were updated (file:update) or deleted (file:delete). 
````

### Reference:

closes #3084
closes #2627

This is a follow up on #3084 rebased onto current HEAD (existdb-5.4.0-SNAPSHOT)
With this PR applied we can consider #2627 implemented.



### Type of tests:

2 XSuites with 33 Tests
