### PR TITLE
[upgrade] switch to aspectj version 1.9.8-M1

### DIFF
--- a/exist-core/src/main/java/org/exist/webstart/JnlpServlet.java
+++ b/exist-core/src/main/java/org/exist/webstart/JnlpServlet.java
@@ -60,9 +60,9 @@ public class JnlpServlet extends HttpServlet {
 
         final Optional<Path> libDir = or(
             Optional.ofNullable(System.getProperty("app.repo")).map(Paths::get).filter(Files::exists),
-            (Supplier<Optional<Path>>) () -> or ( // using explicit type declaration in order to circumvent AspectJ compiler bug
+            (Supplier<Optional<Path>>) () -> or ( // using explicit type declaration in order to circumvent AspectJ compiler bug, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=553623
                     Optional.ofNullable(System.getProperty("app.home")).map(Paths::get).map(p -> p.resolve("lib")).filter(Files::exists),
-                    (Supplier<Optional<Path>>) () -> or ( // using explicit type declaration in order to circumvent AspectJ compiler bug
+                    (Supplier<Optional<Path>>) () -> or ( // using explicit type declaration in order to circumvent AspectJ compiler bug, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=553623
                             Optional.ofNullable(System.getProperty("exist.home")).map(Paths::get).map(p -> p.resolve("lib")).filter(Files::exists),
                             () -> Optional.ofNullable(getServletContext().getRealPath("/")).map(Paths::get).map(p -> p.resolve("lib")).filter(Files::exists)
                     )

--- a/exist-core/src/main/java/org/exist/webstart/JnlpServlet.java
+++ b/exist-core/src/main/java/org/exist/webstart/JnlpServlet.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.function.Supplier;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -59,9 +60,9 @@ public class JnlpServlet extends HttpServlet {
 
         final Optional<Path> libDir = or(
             Optional.ofNullable(System.getProperty("app.repo")).map(Paths::get).filter(Files::exists),
-            () -> or (
+            (Supplier<Optional<Path>>) () -> or ( // using explicit type declaration in order to circumvent AspectJ compiler bug
                     Optional.ofNullable(System.getProperty("app.home")).map(Paths::get).map(p -> p.resolve("lib")).filter(Files::exists),
-                    () -> or (
+                    (Supplier<Optional<Path>>) () -> or ( // using explicit type declaration in order to circumvent AspectJ compiler bug
                             Optional.ofNullable(System.getProperty("exist.home")).map(Paths::get).map(p -> p.resolve("lib")).filter(Files::exists),
                             () -> Optional.ofNullable(getServletContext().getRealPath("/")).map(Paths::get).map(p -> p.resolve("lib")).filter(Files::exists)
                     )

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -104,7 +104,7 @@
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
         <apache.httpcomponents.core.version>4.4.14</apache.httpcomponents.core.version>
         <apache.xmlrpc.version>3.1.3</apache.xmlrpc.version>
-        <aspectj.version>1.9.4</aspectj.version>
+        <aspectj.version>1.9.8.M1</aspectj.version>
         <exquery.distribution.version>0.2.0</exquery.distribution.version>
         <icu.version>59.1</icu.version>
         <izpack.version>5.1.3</izpack.version>


### PR DESCRIPTION
### Description:

Update the aspectj library to version 1.9.8-M1

Fix compatibility by providing Typehints in JnlpServlet.java