### PR TITLE
[test] Increase timeout again for slower CI VMs

### DIFF
--- a/exist-core/src/test/java/org/exist/storage/lock/CollectionLocksTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/CollectionLocksTest.java
@@ -57,7 +57,7 @@ import static org.junit.Assert.fail;
 public class CollectionLocksTest {
 
     private static final int CONCURRENCY_LEVEL = Runtime.getRuntime().availableProcessors() * 3;
-    private static final int TEST_DEADLOCK_TIMEOUT = 12_000; // 12 seconds
+    private static final int TEST_DEADLOCK_TIMEOUT = 24_000; // 24 seconds
 
     /**
      * In the noDeadlock tests this is the maximum amount of time to wait for the second thread to acquire its lock


### PR DESCRIPTION
### Description:
Increase time out again in order to to the slower windows CI agents to complete.

This PR is precondition for #4095 to pass,