### PR TITLE
Update Homebrew release directions

### DIFF
--- a/exist-versioning-release.md
+++ b/exist-versioning-release.md
@@ -298,28 +298,15 @@ Central (staging), Docker images to Docker Hub, and eXist-db distributions and i
 ### Releasing to Homebrew
 [Homebrew](http://brew.sh) is a popular command-line package manager for macOS. Once Homebrew is installed, applications like eXist can be installed via a simple command. eXist's presence on Homebrew is found in the Caskroom project, as a "cask", at [https://github.com/caskroom/homebrew-cask/blob/master/Casks/exist-db.rb](https://github.com/caskroom/homebrew-cask/blob/master/Casks/exist-db.rb).
 
-> **Terminology:** "Caskroom" is the Homebrew extension project where pre-built binaries and GUI applications go, whereas the original "Homebrew" project is reserved for command-line utilities that can be built from source. Because the macOS version of eXist is released as an app bundle with GUI components, it is distributed via Caskroom.
+**Terminology:** "Homebrew Cask" is the segment of Homebrew where pre-built binaries and GUI applications go, whereas the original "Homebrew" project is reserved for command-line utilities that can be built from source. Because the macOS version of eXist-db is released as an app bundle with GUI components, it is handled as a Homebrew Cask.
 
-When there is a new release of eXist, a member of the community can submit a pull request with the necessary changes to the eXist cask. [Follow the directions on the Homebrew-cask Github](https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask) - summarized here adapted to OpenRefine:
-
-```
-# install and setup script - only needed once
-brew install vitorgalvao/tiny-scripts/cask-repair
-cask-repair --help
-
-# use to update eXist
-cask-repair exist-db
-```
-
-The cask-repair tool will prompt you to enter the new version number. It will then use this version number to construct a download URL using the formula (where `{version}` represents the version number):
+When there is a new release of eXist, registering the new release with Homebrew can be easily accomplished using Homebrew's `brew bump-cask-pr` command. Full directions for this utility as well as procedures for more complex PRs can be found on [the Homebrew Cask CONTRIBUTING page](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md), but, a simple version bump is a one-line command. For example, to update Homebrew's version of eXist-db to 5.3.0, use this command:
 
 ```
-https://github.com/eXist-db/exist/releases/download/eXist-{version}/eXist-db-{version}.dmg
+brew bump-cask-pr --version 5.3.0 exist-db
 ```
 
-**Note:** It is important that both version number components (the tag and version number) match, so that the formula can find the installer's URL.
-
-Once cask-repair has successfully downloaded the new installer, it will calculate the new SHA-256 fingerprint value and construct a pull request, like this one: [https://github.com/caskroom/homebrew-cask/pull/42509](https://github.com/caskroom/homebrew-cask/pull/42509). Once the pull request is submitted, continuous integration tests will run, and a member of the caskroom community will review the PR. At times there is a backlog on the CI servers, but once tests pass, the community review is typically completed in a matter of hours.
+This command will cause your local Homebrew installation to download the new version of eXist-db, calculate the installer's new SHA-256 fingerprint value, and construct a pull request under your GitHub account, like [this one](https://github.com/Homebrew/homebrew-cask/pull/107778). Once the pull request is submitted, continuous integration tests will run, and a member of the Homebrew community will review the PR. At times there is a backlog on the CI servers, but once tests pass, the community review is typically completed in a matter of hours.
 
 ## Comparison to the Old Versioning and Release Procedures
 


### PR DESCRIPTION
### Description:

Updates the documentation to account for changes in Homebrew, including the deeper integration of Caskroom into Homebrew (now "Homebrew Cask"), the deprecation of the `brew cask` commands [in Homebrew 2.6.0](https://brew.sh/2020/12/01/homebrew-2.6.0/), the [deprecation of the old `cask-repair` utility](https://github.com/vitorgalvao/tiny-scripts/commit/09b68e4d83fa56e3a22f127f18f18f7816ccd548#diff-47b6313694b8a6f736f1a394498f41d0a0088b1ddf3277b1758d2bf7385e043f), and the creation of the new standard `brew bump-cask-pr` utility recommended in [Homebrew Cask's CONTRIBUTING directions](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md).

### Reference:

Closes https://github.com/eXist-db/exist/issues/4118

### Type of tests:

n/a