### PR TITLE
Bump tika.version from 1.26 to 1.28

### DIFF
--- a/extensions/contentextraction/pom.xml
+++ b/extensions/contentextraction/pom.xml
@@ -46,7 +46,7 @@
     </scm>
 
     <properties>
-        <tika.version>1.26</tika.version>
+        <tika.version>1.28</tika.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Description:

Updates the version of Tika used in eXist to 1.28

### Reference:

https://downloads.apache.org/tika/1.28/CHANGES-1.28.txt

### Type of tests:

n/a