### PR TITLE
Docker updates 

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -15,6 +15,11 @@ jobs:
         with:
           distribution: temurin
           java-version: '8'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/amd64,linux/arm64 
+          # platforms: all
       - name: Make buildkit default
         uses: docker/setup-buildx-action@v1
         id: buildx
@@ -60,6 +65,8 @@ jobs:
         run: mvn -q -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
         working-directory: ./exist-docker
       # NOTE (DP): This is for debugging, publishes an experimental image from inside PRs against develop
+      # TODO(DP): adjust maven build for multi-arch, maybe limit platforms even more.
+      #  see https://blog.oddbit.com/post/2020-09-25-building-multi-architecture-im/
       - name: Publish experimental images
         if: github.base_ref == 'develop'
         env:

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -60,12 +60,12 @@ jobs:
         run: mvn -q -Ddocker.tag=release -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
         working-directory: ./exist-docker
       # NOTE (DP): This is for debugging, publishes an experimental image from inside PRs against develop
-      # - name: Publish experimental images
-      #   if: github.base_ref == 'develop'
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      #   run: mvn -Ddocker.tag=experimental -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
-      #   working-directory: ./exist-docker  
+      - name: Publish experimental images
+        if: github.base_ref == 'develop'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: mvn -Ddocker.tag=experimental -Ddocker.username=$DOCKER_USERNAME -Ddocker.password=$DOCKER_PASSWORD docker:build docker:push
+        working-directory: ./exist-docker  
       

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ target/
 
 # OS specific files
 .DS_Store
+
+# Jenv
+.java-version

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -20,8 +20,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-FROM openjdk:8-jdk-slim as builder
-
+FROM openjdk:11-jdk-slim-bullseye as builder
+# TODO (DP) use dpgk to add both AMD and Intel arch
 # Install tools required by FOP
 WORKDIR /usr/local
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -30,18 +30,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   liblcms2-2 \
   fonts-dejavu-core
 
-FROM gcr.io/distroless/java:8
+FROM gcr.io/distroless/java11-debian11:latest
 
 # Copy over dependancies for Apache FOP, missing from gcr's JRE
 # TODO (DP): Arch specific paths e.g. /usr/lib/aarch64-linux-gnu
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libfreetype.so.6 /usr/lib/x86_64-linux-gnu/libfreetype.so.6
-COPY --from=builder /usr/lib/x86_64-linux-gnu/liblcms2.so.2 /usr/lib/x86_64-linux-gnu/liblcms2.so.2
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libpng16.so.16 /usr/lib/x86_64-linux-gnu/libpng16.so.16
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libfontconfig.so.1 /usr/lib/x86_64-linux-gnu/libfontconfig.so.1
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libfreetype.so.6 /usr/lib/aarch64-linux-gnu/libfreetype.so.6
+COPY --from=builder /usr/lib/aarch64-linux-gnu/liblcms2.so.2 /usr/lib/aarch64-linux-gnu/liblcms2.so.2
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libpng16.so.16 /usr/lib/aarch64-linux-gnu/libpng16.so.16
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libfontconfig.so.1 /usr/lib/aarch64-linux-gnu/libfontconfig.so.1
 
 # Copy dependancies for Apache Batik (used by Apache FOP to handle SVG rendering)
 COPY --from=builder /etc/fonts /etc/fonts
-COPY --from=builder /lib/x86_64-linux-gnu/libexpat.so.1 /lib/x86_64-linux-gnu/libexpat.so.1
+COPY --from=builder /lib/aarch64-linux-gnu/libexpat.so.1 /lib/aarch64-linux-gnu/libexpat.so.1
 COPY --from=builder /usr/share/fontconfig /usr/share/fontconfig
 COPY --from=builder /usr/share/fonts/truetype/dejavu /usr/share/fonts/truetype/dejavu
 

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM gcr.io/distroless/java:8
 
 # Copy over dependancies for Apache FOP, missing from gcr's JRE
+# TODO (DP): Arch specific paths e.g. /usr/lib/aarch64-linux-gnu
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libfreetype.so.6 /usr/lib/x86_64-linux-gnu/libfreetype.so.6
 COPY --from=builder /usr/lib/x86_64-linux-gnu/liblcms2.so.2 /usr/lib/x86_64-linux-gnu/liblcms2.so.2
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libpng16.so.16 /usr/lib/x86_64-linux-gnu/libpng16.so.16

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -68,6 +68,7 @@ EXPOSE 8080 8443
 # make CACHE_MEM and MAX_BROKER available to users
 ARG CACHE_MEM
 ARG MAX_BROKER
+ARG JVM_MAX_RAM_PERCENTAGE
 
 ENV EXIST_HOME "/exist"
 ENV CLASSPATH=/exist/lib/${exist.uber.jar.filename}
@@ -83,11 +84,10 @@ ENV JAVA_TOOL_OPTIONS \
   -Dexist.configurationFile=/exist/etc/conf.xml \
   -Djetty.home=/exist \
   -Dexist.jetty.config=/exist/etc/jetty/standard.enabled-jetty-configs \
-  -XX:+UnlockExperimentalVMOptions \
-  -XX:+UseCGroupMemoryLimitForHeap \
   -XX:+UseG1GC \
   -XX:+UseStringDeduplication \
-  -XX:MaxRAMFraction=1 \
+  -XX:+UseContainerSupport \
+  -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0}  \
   -XX:+ExitOnOutOfMemoryError
 
 HEALTHCHECK CMD [ "java", \

--- a/exist-docker/src/main/resources-filtered/README.md
+++ b/exist-docker/src/main/resources-filtered/README.md
@@ -1,4 +1,5 @@
 # ${project.description}
+
 ${project.description}
 
 [![Build Status](https://travis-ci.com/eXist-db/exist.png?branch=develop)](https://travis-ci.com/eXist-db/exist)
@@ -14,10 +15,13 @@ The images are based on Google Cloud Platform's ["Distroless" Docker Images](htt
 
 
 ## Requirements
+
 *   [Docker](https://www.docker.com): `18-stable`
+
 ### For building
+
 *   [maven](https://maven.apache.org/): `^3.6.0`
-*   [java](https://www.java.com/): `8`
+*   [java](https://www.java.com/): `^1.8.0_205`
 *   [bats](https://github.com/bats-core/bats-core): `^1.1.0` (for testing)
 
 ## How to use
@@ -27,11 +31,13 @@ There are two continuously updated channels:
 *   `latest` for the latest commit to the [`develop` branch](https://github.com/eXist-db/exist/tree/develop).
 
 To download the image run:
+
 ```bash
 docker pull existdb/existdb:latest
 ```
 
 Once the download is complete, you can run the image
+
 ```bash
 docker run -dit -p 8080:8080 -p 8443:8443 --name exist existdb/existdb:latest
 ```
@@ -49,6 +55,7 @@ For a full list of available options see the official [Docker documentation](htt
 After running the `pull` and `run` commands, you can access eXist-db via [localhost:8080](localhost:8080) in your browser.
 
 To stop the container issue:
+
 ```bash
 docker stop exist
 ```
@@ -56,6 +63,7 @@ docker stop exist
 or if you omitted the `-d` flag earlier press `CTRL-C` inside the terminal showing the exist logs.
 
 ### Interacting with the running container
+
 You can interact with a running container as if it were a regular Linux host (without a shell in our case). 
 You can issue shell-like commands to the Java admin client, as we do throughout this readme, but you can't open the shell in interactive mode.
 
@@ -70,13 +78,16 @@ docker exec exist java -version
 ```
 
 Containers build from this image run periodical healthchecks to ensure that eXist-db is operating normally. 
-If `docker ps` reports `unhealthy` you can get a more detailed report with this command:  
+If `docker ps` reports `unhealthy` you can get a more detailed report with this command:
+
 ```bash
 docker inspect --format='{{json .State.Health}}' exist
 ```
 
 ### Logging
+
 There is a slight modification to eXist's logger to ease access to the logs via:
+
 ```bash
 docker logs exist
 ```
@@ -84,12 +95,15 @@ docker logs exist
 This works best when providing the `-t` flag when running an image.
 
 ## Use as base image
+
 A common usage of these images is as a base image for your own applications. 
 We'll take a quick look at three scenarios of increasing complexity, to demonstrate how to achieve common tasks from inside `Dockerfile`.
 
 ### A simple app image
+
 The simplest and straightforward case assumes that you have a `.xar` app inside a `build` folder on the same level as the `Dockerfile`. 
 To get an image of an eXist-db instance with your app installed and running, simply adopt the `docker cp ...` command to the appropriate `Dockerfile` syntax.
+
 ```docker
 FROM existdb/existdb:5.0.0
 
@@ -137,6 +151,7 @@ As for the sequence of the commands, those with the most frequent changes should
 Chances are, you wouldn't change the admin password very often, but the `.xar` might change more frequently.
 
 ### Multi-stage build with ant
+
 Lastly, you can eliminate external dependencies even further by using a multi-stage build. 
 To ensure compatibility between different Java engines we recommend sticking with debian based images for the builder stage.
 
@@ -192,6 +207,7 @@ only the files necessary to run your app should go into the final stage. The pos
 but with this example and the `Dockerfile` in this repo you should get a pretty good idea of how you might apply this idea to your own projects.
 
 ## Development use via `docker-compose`
+
 We highly recommend use of a `docker-compose.yml` for use with [docker-compose](https://docs.docker.com/compose/). 
 docker-compose for local development or integration into multi-container environments. 
 For options on how to configure your own compose file, follow the link at the beginning of this paragraph.
@@ -221,12 +237,15 @@ docker-compose pull
 ```
 
 ### Caveat
+
 As with normal installations, the password for the default dba user `admin` is empty. 
 Change it via the [usermanager](http://localhost:8080/exist/apps/usermanager/index.html) or from CLI \(s.a.\).
 
 ## Building the Image
+
 Building is integrated into maven via the [fabric8 plugin](https://dmp.fabric8.io): 
 To build a docker image from a local clone of exist:
+
 ```bash
 mvn -Pdocker -DskipTests -Ddependency-check.skip=true clean package
 ```
@@ -241,21 +260,27 @@ mvn docker:push
 For a full list see the plugin documentation. 
 
 ### Testing
+
 There are unit tests for our images that run on CI using the [bats](https://github.com/bats-core/bats-core) framework. The test are located in `exist-docker/src/test/bats`.
 
 To execute them run:
+
 ```bash
 bats exist-docker/src/test/bats/*.bats 
 ```
+
 The tests use fixtures and are creating a modified image call `ex-mod`. By default they expect a name container `exist-ci` to be up and running. When running test locally you must ensure that no previous image `ex-mod` exists, and that `exist-ci` is running before starting the testsuite. 
 
 ### Available Arguments and Defaults
+
 eXist-db's cache size and maximum brokers can be configured at build time using the following syntax.
+
 ```bash
 mvn -DskipTests clean package docker:build --build-arg MAX_CACHE=312 MAX_BROKER=15 .
 ```
 
 NOTE: Due to the fact that the final images does not provide a shell, setting ENV variables via docker does not work.
+
 ```bash
 # !This has no effect!
 docker run -dit -p8080:8080 -e MAX_BROKER=10 ae4d6d653d30
@@ -271,6 +296,7 @@ ARG MAX_BROKER=10
 Or modify eXist-db's configuration files via xslt scripts located at `exist-docker/src/main/xslt/`.
 For multi-stage builds e.g. [xmlstarlet](http://xmlstar.sourceforge.net) let's you modify the default config files from within the builder stage, 
 e.g.:
+
 ```docker
 # Config files are modified here
 RUN echo 'modifying conf files'\
@@ -283,15 +309,17 @@ RUN echo 'modifying conf files'\
 
 
 #### JVM configuration
+
 This image uses an advanced JVM configuration, via the  `JAVA_TOOL_OPTIONS` env variable inside the Dockerfile. 
 You should avoid the traditional way of setting the heap size via `-Xmx` arguments, 
 this can lead to frequent crashes since Java8 and Docker are (literally) not on the same page concerning available memory.
 
-Instead, use the `-XX:MaxRAMFraction=1` argument to modify the memory available to the JVM *inside* the container. 
-For production use we recommend to increase the value to `2` or even `4`. 
-This value expresses a ratio, so setting it to `2` means half the container's memory will be available to the JVM, '4' means ¼,  etc.
+Instead, use the `-XX:MaxRAMPercentage` argument to modify the memory available to the JVM *inside* the container. 
+The default of `75%` should be save for production use. 
+To allocate e.g. 600mb to the container *around* the JVM use, however, you can tweak this at buildtime via the `JVM_MAX_RAM_PERCENTAGE` argument. Note that percentages should include a decimal point `80.0` = `80%`.
 
-To allocate e.g. 600mb to the container *around* the JVM use:
+To allocate e.g. 600mb to the container around the JVM use:
+
 ```bash
 docker run -m 600m …
 ```
@@ -300,6 +328,4 @@ Lastly, this image uses a new garbage collection mechanism
 [garbage first (G1)](https://docs.oracle.com/javase/9/gctuning/garbage-first-garbage-collector.htm#JSGCT-GUID-ED3AB6D3-FD9B-4447-9EDF-983ED2F7A573) `-XX:+UseG1GC` 
 and [string deduplication](http://openjdk.java.net/jeps/192) `-XX:+UseStringDeduplication` to improve performance.
 
-To disable or further tweak these features edit the relevant parts of the `Dockerfile`, or when running the image. 
-As always when using the latest and greatest, YMMV. 
-Feedback about real world experiences with this features in connection with eXist-db is very much welcome.
+Customizing individual arguments is not possible at run time. To adjust individual parameters the the whole `JAVA_TOOL_OPTIONS` environment variable must be passed to `docker run …`

--- a/exist-docker/src/main/resources-filtered/README.md
+++ b/exist-docker/src/main/resources-filtered/README.md
@@ -13,7 +13,6 @@ This module holds the source files for building a minimal docker image of the [e
 database, images are automatically updated as part of the build-test life-cycle. 
 The images are based on Google Cloud Platform's ["Distroless" Docker Images](https://github.com/GoogleCloudPlatform/distroless).
 
-
 ## Requirements
 
 *   [Docker](https://www.docker.com): `18-stable`
@@ -25,6 +24,7 @@ The images are based on Google Cloud Platform's ["Distroless" Docker Images](htt
 *   [bats](https://github.com/bats-core/bats-core): `^1.1.0` (for testing)
 
 ## How to use
+
 Pre-build images are available on [DockerHub](https://hub.docker.com/r/existdb/existdb/). 
 There are two continuously updated channels:
 *   `release` for the stable releases based on the [`master` branch](https://github.com/eXist-db/exist/tree/master)
@@ -213,6 +213,7 @@ docker-compose for local development or integration into multi-container environ
 For options on how to configure your own compose file, follow the link at the beginning of this paragraph.
 
 To start exist using a compose file, type:
+
 ```bash
 # starting eXist-db
 docker-compose up -d
@@ -232,6 +233,7 @@ You can configure additional volumes e.g. for backups,
 or additional services such as an nginx reverse proxy via a `docker-compose.yml`, to suite your needs.
 
 To update the exist-docker image from a newer version
+
 ```bash
 docker-compose pull
 ```
@@ -306,7 +308,6 @@ RUN echo 'modifying conf files'\
  -r //AppenderRefTMP -v AppenderRef \
  log4j2.xml
 ```
-
 
 #### JVM configuration
 


### PR DESCRIPTION
Update `JAVA_TOOL_OPTIONS` to be in line with newly backported J8 features. Most notably `MAX_RAM` is now a percentage (75% by default), no longer a whole fraction.

Dropped deprecated arguments, minor tweaks to the readme

  
