### PR TITLE
Introduce new Store Document API

### DIFF
--- a/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
@@ -27,7 +27,6 @@ import org.exist.Namespaces;
 import org.exist.backup.BackupDescriptor;
 import org.exist.backup.restore.listener.RestoreListener;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentTypeImpl;
@@ -43,9 +42,7 @@ import org.exist.storage.lock.ManagedCollectionLock;
 import org.exist.storage.lock.ManagedDocumentLock;
 import org.exist.storage.txn.TransactionException;
 import org.exist.storage.txn.Txn;
-import org.exist.util.EXistInputSource;
-import org.exist.util.LockException;
-import org.exist.util.XMLReaderPool;
+import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.util.URIUtils;
@@ -59,7 +56,6 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.*;
 
@@ -242,15 +238,15 @@ public class RestoreHandler extends DefaultHandler {
     }
 
     private DeferredPermission restoreResourceEntry(final Attributes atts) throws SAXException {
-        final String skip = atts.getValue( "skip" );
+        @Nullable final String skip = atts.getValue( "skip" );
 
         // Don't process entries which should be skipped
-        if(skip != null && !"no".equals(skip)) {
+        if (skip != null && !"no".equals(skip)) {
             return new SkippedEntryDeferredPermission();
         }
 
-        final String name = atts.getValue("name");
-        if(name == null) {
+        @Nullable final String name = atts.getValue("name");
+        if (name == null) {
             throw new SAXException("Resource requires a name attribute");
         }
 
@@ -262,13 +258,13 @@ public class RestoreHandler extends DefaultHandler {
 
         final String filename = getAttr(atts, "filename", name);
 
-        final String mimeType = atts.getValue("mimetype");
-        final String created = atts.getValue("created");
-        final String modified = atts.getValue("modified");
+        @Nullable final String mimeTypeStr = atts.getValue("mimetype");
+        @Nullable final String dateCreatedStr = atts.getValue("created");
+        @Nullable final String dateModifiedStr = atts.getValue("modified");
 
-        final String publicId = atts.getValue("publicid");
-        final String systemId = atts.getValue("systemid");
-        final String nameDocType = atts.getValue("namedoctype");
+        @Nullable final String publicId = atts.getValue("publicid");
+        @Nullable final String systemId = atts.getValue("systemid");
+        @Nullable final String nameDocType = atts.getValue("namedoctype");
 
         final XmldbURI docName;
         if (version >= STRICT_URI_VERSION) {
@@ -304,21 +300,37 @@ public class RestoreHandler extends DefaultHandler {
             }
         }
 
+        MimeType mimeType = null;
+        if (mimeTypeStr != null) {
+            mimeType = MimeTable.getInstance().getContentType(mimeTypeStr);
+        }
+        if (mimeType == null) {
+            mimeType = xmlType ? MimeType.XML_TYPE : MimeType.BINARY_TYPE;
+        }
+
         Date dateCreated = null;
-        Date dateModified = null;
-        if (created != null) {
+        if (dateCreatedStr != null) {
             try {
-                dateCreated = (new DateTimeValue(created)).getDate();
-            } catch(final XPathException xpe) {
+                dateCreated = new DateTimeValue(dateCreatedStr).getDate();
+            } catch (final XPathException xpe) {
                 listener.warn("Illegal creation date. Ignoring date...");
             }
         }
-        if (modified != null) {
+
+        Date dateModified = null;
+        if (dateModifiedStr != null) {
             try {
-                dateModified = (new DateTimeValue(modified)).getDate();
-            } catch(final XPathException xpe) {
+                dateModified = new DateTimeValue(dateModifiedStr).getDate();
+            } catch (final XPathException xpe) {
                 listener.warn("Illegal modification date. Ignoring date...");
             }
+        }
+
+        final DocumentType docType;
+        if (publicId != null || systemId != null) {
+            docType = new DocumentTypeImpl(nameDocType, publicId, systemId);
+        } else {
+            docType = null;
         }
 
         final XmldbURI docUri = currentCollectionUri.append(docName);
@@ -330,28 +342,8 @@ public class RestoreHandler extends DefaultHandler {
                     try (final Collection collection = broker.openCollection(currentCollectionUri, Lock.LockMode.WRITE_LOCK);
                          final ManagedDocumentLock docLock = broker.getBrokerPool().getLockManager().acquireDocumentWriteLock(docUri)) {
 
-                        if (xmlType) {
-                            final IndexInfo info = collection.validateXMLResource(transaction, broker, docName, is);
-                            validated = true;
-
-                            info.getDocument().setMimeType(mimeType);
-                            if (dateCreated != null) {
-                                info.getDocument().setCreated(dateCreated.getTime());
-                            }
-                            if (dateModified != null) {
-                                info.getDocument().setLastModified(dateModified.getTime());
-                            }
-                            if (publicId != null || systemId != null) {
-                                final DocumentType docType = new DocumentTypeImpl(nameDocType, publicId, systemId);
-                                info.getDocument().setDocType(docType);
-                            }
-                            collection.store(transaction, broker, info, is);
-
-                        } else {
-                            try (final InputStream stream = is.getByteStream()) {
-                                collection.addBinaryResource(transaction, broker, docName, stream, mimeType, -1, dateCreated, dateModified);
-                            }
-                        }
+                        collection.storeDocument(transaction, broker, docName, is, mimeType, dateCreated, dateModified, null, docType, null);
+                        validated = true;
 
                         transaction.commit();
 
@@ -546,9 +538,9 @@ public class RestoreHandler extends DefaultHandler {
         return date_created;
     }
 
-    private String getAttr(final Attributes atts, final String name, final String fallback) {
+    private static String getAttr(final Attributes atts, final String name, final String fallback) {
         final String value = atts.getValue(name);
-        if(value == null) {
+        if (value == null) {
             return fallback;
         }
         return value;

--- a/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
@@ -342,7 +342,7 @@ public class RestoreHandler extends DefaultHandler {
                     try (final Collection collection = broker.openCollection(currentCollectionUri, Lock.LockMode.WRITE_LOCK);
                          final ManagedDocumentLock docLock = broker.getBrokerPool().getLockManager().acquireDocumentWriteLock(docUri)) {
 
-                        collection.storeDocument(transaction, broker, docName, is, mimeType, dateCreated, dateModified, null, docType, null);
+                        broker.storeDocument(transaction, docName, is, mimeType, dateCreated, dateModified, null, docType, null, collection);
                         validated = true;
 
                         transaction.commit();

--- a/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
@@ -21,6 +21,7 @@
  */
 package org.exist.backup.restore;
 
+import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.Namespaces;
@@ -32,6 +33,7 @@ import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentTypeImpl;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.ACLPermission;
+import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.security.SecurityManager;
 import org.exist.security.internal.RealmImpl;
@@ -59,6 +61,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.*;
 
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 // TODO(AR) consider merging with org.exist.backup.restore.SystemImportHandler
@@ -210,8 +213,8 @@ public class RestoreHandler extends DefaultHandler {
                     final ManagedCollectionLock colLock = lockManager.acquireCollectionWriteLock(collUri)) {
                 Collection collection = broker.getCollection(collUri);
                 if (collection == null) {
-                    collection = broker.getOrCreateCollection(transaction, collUri);
-                    collection.setCreated(getDateFromXSDateTimeStringForItem(created, name).getTime());
+                    final Tuple2<Permission, Long> creationAttributes = Tuple(null, getDateFromXSDateTimeStringForItem(created, name).getTime());
+                    collection = broker.getOrCreateCollection(transaction, collUri, Optional.of(creationAttributes));
                     broker.saveCollection(transaction, collection);
                 }
 

--- a/exist-core/src/main/java/org/exist/backup/restore/SystemImportHandler.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/SystemImportHandler.java
@@ -376,7 +376,7 @@ public class SystemImportHandler extends DefaultHandler {
 
             try (final Txn transaction = beginTransaction()) {
 
-                currentCollection.storeDocument(transaction, broker, docUri, is, mimeType, dateCreated, dateModified, null, docType, null);
+                broker.storeDocument(transaction, docUri, is, mimeType, dateCreated, dateModified, null, docType, null, currentCollection);
 
 
                 try (final LockedDocument doc = currentCollection.getDocumentWithLock(broker, docUri, Lock.LockMode.READ_LOCK)) {

--- a/exist-core/src/main/java/org/exist/collections/Collection.java
+++ b/exist-core/src/main/java/org/exist/collections/Collection.java
@@ -35,7 +35,9 @@ import org.exist.storage.lock.*;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.Txn;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
+import org.w3c.dom.DocumentType;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -634,6 +636,106 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
             throws PermissionDeniedException, LockException, TriggerException;
 
     /**
+     * Stores a document.
+     * Since the process is dependent on the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        The name (without path) of the document
+     * @param source      The source of the content for the new document to store
+     * @param mimeType    The mimeType of the document to store, or null if unknown.
+     *
+     * @throws PermissionDeniedException if user has not sufficient rights
+     * @throws LockException if broker is locked
+     * @throws IOException in case of I/O errors
+     * @throws TriggerException in case of eXist-db trigger error
+     * @throws EXistException general eXist-db exception
+     * @throws SAXException internal SAXException
+     *
+     */
+    //TODO(AR) consider implementing Broker.storeDocument(txn, collection, ...) and making that the public API instead! Could allow us to more easily move to collections as labels in future
+    void storeDocument(Txn transaction, DBBroker broker, XmldbURI name, InputSource source, @Nullable MimeType mimeType) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
+     * Stores a document.
+     * Since the process is dependent on the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        The name (without path) of the document
+     * @param source      The source of the content for the new document to store
+     * @param mimeType    The mimeType of the document to store, or null if unknown.
+     *                    If null, application/octet-stream will be used to store a binary document.
+     * @param createdDate The created date to set for the document, or if null the date is set to 'now'
+     * @param lastModifiedDate The lastModified date to set for the document, or if null the date is set to the {@code createdDate}
+     * @param permission A specific permission to set on the document, or null for the default permission
+     * @param documentType A document type declaration, or null if absent or a binary document is being stored
+     * @param xmlReader A custom XML Reader (e.g. a HTML to XHTML converting reader), or null to use the default XML reader or if a binary document is being stored
+     *
+     * @throws PermissionDeniedException if user has not sufficient rights
+     * @throws LockException if broker is locked
+     * @throws IOException in case of I/O errors
+     * @throws TriggerException in case of eXist-db trigger error
+     * @throws EXistException general eXist-db exception
+     * @throws SAXException internal SAXException
+     *
+     */
+    //TODO(AR) consider implementing Broker.storeDocument(txn, collection, ...) and making that the public API instead! Could allow us to more easily move to collections as labels in future
+    void storeDocument(Txn transaction, DBBroker broker, XmldbURI name, InputSource source, @Nullable MimeType mimeType, @Nullable Date createdDate, @Nullable Date lastModifiedDate, @Nullable Permission permission, @Nullable DocumentType documentType, @Nullable XMLReader xmlReader) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
+     * Stores a document.
+     * Since the process is dependent on the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        The name (without path) of the document
+     * @param node        The DOM Node to store as a new document
+     * @param mimeType    The mimeType of the document to store, or null if unknown.
+     *
+     * @throws PermissionDeniedException if user has not sufficient rights
+     * @throws LockException if broker is locked
+     * @throws IOException in case of I/O errors
+     * @throws TriggerException in case of eXist-db trigger error
+     * @throws EXistException general eXist-db exception
+     * @throws SAXException internal SAXException
+     *
+     */
+    //TODO(AR) consider implementing Broker.storeDocument(txn, collection, ...) and making that the public API instead! Could allow us to more easily move to collections as labels in future
+    void storeDocument(Txn transaction, DBBroker broker, XmldbURI name, Node node, @Nullable MimeType mimeType) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
+     * Stores a document.
+     * Since the process is dependent on the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        The name (without path) of the document
+     * @param node        The DOM Node to store as a new document
+     * @param mimeType    The mimeType of the document to store, or null if unknown.
+     *                    If null, application/octet-stream will be used to store a binary document.
+     * @param createdDate The created date to set for the document, or if null the date is set to 'now'
+     * @param lastModifiedDate The lastModified date to set for the document, or if null the date is set to the {@code createdDate}
+     * @param permission A specific permission to set on the document, or null for the default permission
+     * @param documentType A document type declaration, or null if absent or a binary document is being stored
+     * @param xmlReader A custom XML Reader (e.g. a HTML to XHTML converting reader), or null to use the default XML reader or if a binary document is being stored
+     *
+     * @throws PermissionDeniedException if user has not sufficient rights
+     * @throws LockException if broker is locked
+     * @throws IOException in case of I/O errors
+     * @throws TriggerException in case of eXist-db trigger error
+     * @throws EXistException general eXist-db exception
+     * @throws SAXException internal SAXException
+     *
+     */
+    //TODO(AR) consider implementing Broker.storeDocument(txn, collection, ...) and making that the public API instead! Could allow us to more easily move to collections as labels in future
+    void storeDocument(Txn transaction, DBBroker broker, XmldbURI name, Node node, @Nullable MimeType mimeType, @Nullable Date createdDate, @Nullable Date lastModifiedDate, @Nullable Permission permission, @Nullable DocumentType documentType, @Nullable XMLReader xmlReader) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
      * Validates an XML document and prepares it for further storage.
      * Launches prepare and postValidate triggers.
      * Since the process is dependent from the collection configuration,
@@ -643,7 +745,9 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param broker      The database broker
      * @param name        the name (without path) of the document
      * @param source      The source of the document to store
+     *
      * @return An {@link IndexInfo} with a write lock on the document
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
@@ -651,7 +755,9 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
      *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, InputSource source)
             throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
 
@@ -667,14 +773,19 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param name        the name (without path) of the document
      * @param source      The source of the document to store
      * @param reader      The XML reader to use for reading the {@code source}
+     *
      * @return An {@link IndexInfo} with a write lock on the document
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
+     *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, InputSource source, XMLReader reader)
             throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
 
@@ -688,14 +799,19 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param broker      The database broker
      * @param name        the name (without path) of the document
      * @param data        The data of the document to store
+     *
      * @return An {@link IndexInfo} with a write lock on the document
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
+     *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, String data)
             throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
 
@@ -709,14 +825,19 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param broker      The database broker
      * @param name        the name (without path) of the document
      * @param node        The document node of the document to store
+     *
      * @return An {@link IndexInfo} with a write lock on the document
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
+     *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, Node, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, Node node)
             throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
 
@@ -730,12 +851,16 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param broker      The database broker
      * @param info        Tracks information between validate and store phases
      * @param source      The source of the document to store
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
+     *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     void store(Txn transaction, DBBroker broker, IndexInfo info, InputSource source)
             throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException;
 
@@ -750,12 +875,16 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param info        Tracks information between validate and store phases
      * @param source      The source of the document to store
      * @param reader      The XML reader to use for reading the {@code source}
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked*
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
+     *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final InputSource source, final XMLReader reader)
             throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException;
 
@@ -769,12 +898,16 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param broker      The database broker
      * @param info        Tracks information between validate and store phases
      * @param data        The data of the document to store
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
+     *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     void store(Txn transaction, DBBroker broker, IndexInfo info, String data)
             throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException;
 
@@ -788,12 +921,16 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param broker      The database broker
      * @param info        Tracks information between validate and store phases
      * @param node        The document node of the document to store
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
+     *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, Node, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     void store(Txn transaction, DBBroker broker, IndexInfo info, Node node)
             throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException;
 
@@ -803,12 +940,17 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param transaction The database transaction
      * @param broker      The database broker
      * @param name        the name (without path) of the document
+     *
+     * @return The Binary Document object
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
-     * @return The Binary Document object
+     *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     BinaryDocument validateBinaryResource(Txn transaction, DBBroker broker, XmldbURI name)
             throws PermissionDeniedException, LockException, TriggerException, IOException;
 
@@ -825,19 +967,56 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param name        the name (without path) of the document
      * @param is          The content for the document
      * @param mimeType    The Internet Media Type of the document
-     * @param size        The size in bytes of the document
+     * @param size        The size in bytes of the document (unused - size is calculated during storage)
      * @param created     The created timestamp of the document
      * @param modified    The modified timestamp of the document
+     *
+     * @return The stored Binary Document object
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception*
      *
-     * @return The stored Binary Document object
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, InputStream is, String mimeType,
-            long size, Date created, Date modified) throws EXistException, PermissionDeniedException, LockException,
+            @Deprecated long size, Date created, Date modified) throws EXistException, PermissionDeniedException, LockException,
+            TriggerException, IOException;
+
+    /**
+     * Store a binary document into the Collection (streaming)
+     *
+     * Locks the collection while the resource is being saved. Triggers will be called after the collection
+     * has been unlocked while keeping a lock on the resource to prevent modification.
+     *
+     * Callers should not lock the collection before calling this method as this may lead to deadlocks.
+     *
+     * @param transaction The database transaction
+     * @param broker      The database broker
+     * @param name        the name (without path) of the document
+     * @param is          The content for the document
+     * @param mimeType    The Internet Media Type of the document
+     * @param size        The size in bytes of the document (unused - size is calculated during storage)
+     * @param created     The created timestamp of the document
+     * @param modified    The modified timestamp of the document
+     * @param permission A specific permission to set on the document, or null for the default permission
+     *
+     * @return The stored Binary Document object
+     *
+     * @throws PermissionDeniedException if user has not sufficient rights
+     * @throws LockException if broker is locked
+     * @throws IOException in case of I/O errors
+     * @throws TriggerException in case of eXist-db trigger error
+     * @throws EXistException general eXist-db exception*
+     *
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     */
+    @Deprecated
+    BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, InputStream is, String mimeType,
+            @Deprecated long size, Date created, Date modified, @Nullable Permission permission) throws EXistException, PermissionDeniedException, LockException,
             TriggerException, IOException;
 
     /**
@@ -853,12 +1032,14 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param name        the name (without path) of the document
      * @param data        The content for the document
      * @param mimeType    The Internet Media Type of the document
+     *
+     * @return The stored Binary Document object
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
-     * @return The stored Binary Document object
      *
      * @deprecated Use {@link #addBinaryResource(Txn, DBBroker, XmldbURI, InputStream, String, long)}
      */
@@ -881,13 +1062,14 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param mimeType    The Internet Media Type of the document
      * @param created     The created timestamp of the document
      * @param modified    The modified timestamp of the document
+     *
+     * @return The stored Binary Document object
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
-     *
-     * @return The stored Binary Document object
      *
      * @deprecated Use {@link #addBinaryResource(Txn, DBBroker, BinaryDocument, InputStream, String, long, Date, Date)}
      */
@@ -909,18 +1091,21 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param name        the name (without path) of the document
      * @param is          The content for the document
      * @param mimeType    The Internet Media Type of the document
-     * @param size        The size in bytes of the document
+     * @param size        The size in bytes of the document (unused - size is calculated during storage)
+     *
+     * @return The stored Binary Document object
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
-
      *
-     * @return The stored Binary Document object
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, InputStream is,
-            String mimeType, long size) throws EXistException, PermissionDeniedException, LockException,
+            String mimeType, @Deprecated long size) throws EXistException, PermissionDeniedException, LockException,
             TriggerException, IOException;
 
     /**
@@ -936,20 +1121,23 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param blob        the binary resource to store the data into
      * @param is          The content for the document
      * @param mimeType    The Internet Media Type of the document
-     * @param size        The size in bytes of the document
+     * @param size        The size in bytes of the document (unused - size is calculated during storage)
      * @param created     The created timestamp of the document
      * @param modified    The modified timestamp of the document
+     *
+     * @return The stored Binary Document object
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
-
      *
-     * @return The stored Binary Document object
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, BinaryDocument blob, InputStream is,
-            String mimeType, long size, Date created, Date modified) throws EXistException, PermissionDeniedException,
+            String mimeType, @Deprecated long size, Date created, Date modified) throws EXistException, PermissionDeniedException,
             LockException, TriggerException, IOException;
 
     /**
@@ -965,23 +1153,26 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @param blob        the binary resource to store the data into
      * @param is          The content for the document
      * @param mimeType    The Internet Media Type of the document
-     * @param size        The size in bytes of the document
+     * @param size        The size in bytes of the document (unused - size is calculated during storage)
      * @param created     The created timestamp of the document
      * @param modified    The modified timestamp of the document
      * @param preserve    In the case of a copy, cause the copy process to preserve the following attributes of each
      *                    source in the copy: modification time, file mode, user ID, and group ID, as allowed by
      *                    permissions. Access Control Lists (ACLs) will also be preserved.
+     *
+     * @return The stored Binary Document object
+     *
      * @throws PermissionDeniedException if user has not sufficient rights
      * @throws LockException if broker is locked
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
-
      *
-     * @return The stored Binary Document object
+     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
      */
+    @Deprecated
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, BinaryDocument blob, InputStream is,
-            String mimeType, long size, Date created, Date modified, DBBroker.PreserveType preserve)
+            String mimeType, @Deprecated long size, Date created, Date modified, DBBroker.PreserveType preserve)
             throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException;
 
     /**

--- a/exist-core/src/main/java/org/exist/collections/Collection.java
+++ b/exist-core/src/main/java/org/exist/collections/Collection.java
@@ -640,6 +640,8 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * Since the process is dependent on the collection configuration,
      * the collection acquires a write lock during the process.
      *
+     * NOTE: This should only be called from {@link NativeBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)}
+     *
      * @param transaction The database transaction
      * @param broker      The database broker
      * @param name        The name (without path) of the document
@@ -652,9 +654,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
-     *
      */
-    //TODO(AR) consider implementing Broker.storeDocument(txn, collection, ...) and making that the public API instead! Could allow us to more easily move to collections as labels in future
     void storeDocument(Txn transaction, DBBroker broker, XmldbURI name, InputSource source, @Nullable MimeType mimeType) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
 
     /**
@@ -662,6 +662,8 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * Since the process is dependent on the collection configuration,
      * the collection acquires a write lock during the process.
      *
+     * NOTE: This should only be called from {@link NativeBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)}
+     *
      * @param transaction The database transaction
      * @param broker      The database broker
      * @param name        The name (without path) of the document
@@ -680,15 +682,15 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
-     *
      */
-    //TODO(AR) consider implementing Broker.storeDocument(txn, collection, ...) and making that the public API instead! Could allow us to more easily move to collections as labels in future
     void storeDocument(Txn transaction, DBBroker broker, XmldbURI name, InputSource source, @Nullable MimeType mimeType, @Nullable Date createdDate, @Nullable Date lastModifiedDate, @Nullable Permission permission, @Nullable DocumentType documentType, @Nullable XMLReader xmlReader) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
 
     /**
      * Stores a document.
      * Since the process is dependent on the collection configuration,
      * the collection acquires a write lock during the process.
+     *
+     * NOTE: This should only be called from {@link NativeBroker#storeDocument(Txn, XmldbURI, Node, MimeType, Collection)}
      *
      * @param transaction The database transaction
      * @param broker      The database broker
@@ -702,15 +704,15 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
-     *
      */
-    //TODO(AR) consider implementing Broker.storeDocument(txn, collection, ...) and making that the public API instead! Could allow us to more easily move to collections as labels in future
     void storeDocument(Txn transaction, DBBroker broker, XmldbURI name, Node node, @Nullable MimeType mimeType) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
 
     /**
      * Stores a document.
      * Since the process is dependent on the collection configuration,
      * the collection acquires a write lock during the process.
+     *
+     * NOTE: This should only be called from {@link NativeBroker#storeDocument(Txn, XmldbURI, Node, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)}
      *
      * @param transaction The database transaction
      * @param broker      The database broker
@@ -730,9 +732,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
-     *
      */
-    //TODO(AR) consider implementing Broker.storeDocument(txn, collection, ...) and making that the public API instead! Could allow us to more easily move to collections as labels in future
     void storeDocument(Txn transaction, DBBroker broker, XmldbURI name, Node node, @Nullable MimeType mimeType, @Nullable Date createdDate, @Nullable Date lastModifiedDate, @Nullable Permission permission, @Nullable DocumentType documentType, @Nullable XMLReader xmlReader) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
 
     /**
@@ -755,7 +755,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, InputSource source)
@@ -783,7 +783,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, InputSource source, XMLReader reader)
@@ -809,7 +809,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, String data)
@@ -835,7 +835,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, Node, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, Node, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     IndexInfo validateXMLResource(Txn transaction, DBBroker broker, XmldbURI name, Node node)
@@ -858,7 +858,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     void store(Txn transaction, DBBroker broker, IndexInfo info, InputSource source)
@@ -882,7 +882,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final InputSource source, final XMLReader reader)
@@ -905,7 +905,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     void store(Txn transaction, DBBroker broker, IndexInfo info, String data)
@@ -928,7 +928,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws EXistException general eXist-db exception
      * @throws SAXException internal SAXException
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, Node, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, Node, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     void store(Txn transaction, DBBroker broker, IndexInfo info, Node node)
@@ -948,7 +948,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws IOException in case of I/O errors
      * @throws TriggerException in case of eXist-db trigger error
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     BinaryDocument validateBinaryResource(Txn transaction, DBBroker broker, XmldbURI name)
@@ -979,7 +979,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception*
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, InputStream is, String mimeType,
@@ -1012,7 +1012,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception*
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, InputStream is, String mimeType,
@@ -1101,7 +1101,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, XmldbURI name, InputStream is,
@@ -1133,7 +1133,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, BinaryDocument blob, InputStream is,
@@ -1168,7 +1168,7 @@ public interface Collection extends Resource, Comparable<Collection>, AutoClosea
      * @throws TriggerException in case of eXist-db trigger error
      * @throws EXistException general eXist-db exception
      *
-     * @deprecated Use {@link #storeDocument(Txn, DBBroker, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader)} instead.
+     * @deprecated Use {@link DBBroker#storeDocument(Txn, XmldbURI, InputSource, MimeType, Date, Date, Permission, DocumentType, XMLReader, Collection)} instead.
      */
     @Deprecated
     BinaryDocument addBinaryResource(Txn transaction, DBBroker broker, BinaryDocument blob, InputStream is,

--- a/exist-core/src/main/java/org/exist/collections/CollectionConfigurationManager.java
+++ b/exist-core/src/main/java/org/exist/collections/CollectionConfigurationManager.java
@@ -130,7 +130,7 @@ public class CollectionConfigurationManager implements BrokerPoolService {
 
             broker.saveCollection(txn, confCol);
 
-            confCol.storeDocument(txn, broker, configurationDocumentName, new StringInputSource(config), MimeType.XML_TYPE);
+            broker.storeDocument(txn, configurationDocumentName, new StringInputSource(config), MimeType.XML_TYPE, confCol);
 
             // broker.sync(Sync.MAJOR_SYNC);
         } catch (final CollectionConfigurationException e) {

--- a/exist-core/src/main/java/org/exist/collections/CollectionConfigurationManager.java
+++ b/exist-core/src/main/java/org/exist/collections/CollectionConfigurationManager.java
@@ -36,6 +36,8 @@ import org.exist.storage.lock.ManagedLock;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.XMLReaderPool;
 import org.exist.util.sanity.SanityCheck;
 import org.exist.xmldb.XmldbURI;
@@ -127,9 +129,9 @@ public class CollectionConfigurationManager implements BrokerPoolService {
             }
 
             broker.saveCollection(txn, confCol);
-            final IndexInfo info = confCol.validateXMLResource(txn, broker, configurationDocumentName, config);
-            // TODO : unlock the collection here ?
-            confCol.store(txn, broker, info, config);
+
+            confCol.storeDocument(txn, broker, configurationDocumentName, new StringInputSource(config), MimeType.XML_TYPE);
+
             // broker.sync(Sync.MAJOR_SYNC);
         } catch (final CollectionConfigurationException e) {
             throw e;

--- a/exist-core/src/main/java/org/exist/collections/LockedCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/LockedCollection.java
@@ -35,12 +35,15 @@ import org.exist.storage.lock.LockedDocumentMap;
 import org.exist.storage.lock.ManagedCollectionLock;
 import org.exist.storage.txn.Txn;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
+import org.w3c.dom.DocumentType;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
@@ -355,53 +358,88 @@ public class LockedCollection implements Collection {
     }
 
     @Override
+    public void storeDocument(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputSource source, @Nullable final MimeType mimeType) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        collection.storeDocument(transaction, broker, name, source, mimeType);
+    }
+
+    @Override
+    public void storeDocument(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputSource source, @Nullable final MimeType mimeType, @Nullable final Date createdDate, @Nullable final Date lastModifiedDate, @Nullable final Permission permission, @Nullable final DocumentType documentType, @Nullable final XMLReader xmlReader) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        collection.storeDocument(transaction, broker, name, source, mimeType, createdDate, lastModifiedDate, permission, documentType, xmlReader);
+    }
+
+    @Override
+    public void storeDocument(final Txn transaction, final DBBroker broker, final XmldbURI name, final Node node, @Nullable final MimeType mimeType) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        collection.storeDocument(transaction, broker, name, node, mimeType);
+    }
+
+    @Override
+    public void storeDocument(final Txn transaction, final DBBroker broker, final XmldbURI name, final Node node, @Nullable final MimeType mimeType, @Nullable final Date createdDate, @Nullable final Date lastModifiedDate, @Nullable final Permission permission, @Nullable final DocumentType documentType, @Nullable final XMLReader xmlReader) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        collection.storeDocument(transaction, broker, name, node, mimeType, createdDate, lastModifiedDate, permission, documentType, xmlReader);
+    }
+
+    @Deprecated
+    @Override
     public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputSource source) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
         return collection.validateXMLResource(transaction, broker, name, source);
     }
 
+    @Deprecated
     @Override
     public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputSource source, final XMLReader reader) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
         return collection.validateXMLResource(transaction, broker, name, source, reader);
     }
 
+    @Deprecated
     @Override
     public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final String data) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
         return collection.validateXMLResource(transaction, broker, name, data);
     }
 
+    @Deprecated
     @Override
     public IndexInfo validateXMLResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final Node node) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
         return collection.validateXMLResource(transaction, broker, name, node);
     }
 
+    @Deprecated
     @Override
     public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final InputSource source) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
         collection.store(transaction, broker, info, source);
     }
 
+    @Deprecated
     @Override
     public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final InputSource source, final XMLReader reader) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
         collection.store(transaction, broker, info, source, reader);
     }
 
+    @Deprecated
     @Override
     public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final String data) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
         collection.store(transaction, broker, info, data);
     }
 
+    @Deprecated
     @Override
     public void store(final Txn transaction, final DBBroker broker, final IndexInfo info, final Node node) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException {
         collection.store(transaction, broker, info, node);
     }
 
+    @Deprecated
     @Override
     public BinaryDocument validateBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name) throws PermissionDeniedException, LockException, TriggerException, IOException {
         return collection.validateBinaryResource(transaction, broker, name);
     }
 
+    @Deprecated
     @Override
     public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputStream is, final String mimeType, final long size, final Date created, final Date modified) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
         return collection.addBinaryResource(transaction, broker, name, is, mimeType, size, created, modified);
+    }
+
+    @Override
+    public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputStream is, final String mimeType, final long size, final Date created, final Date modified, @Nullable final Permission permission) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
+        return collection.addBinaryResource(transaction, broker, name, is, mimeType, size, created, modified, permission);
     }
 
     @Override
@@ -416,16 +454,19 @@ public class LockedCollection implements Collection {
         return collection.addBinaryResource(transaction, broker, name, data, mimeType, created, modified);
     }
 
+    @Deprecated
     @Override
     public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputStream is, final String mimeType, final long size) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
         return collection.addBinaryResource(transaction, broker, name, is, mimeType, size);
     }
 
+    @Deprecated
     @Override
     public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final BinaryDocument blob, final InputStream is, final String mimeType, final long size, final Date created, final Date modified) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
         return collection.addBinaryResource(transaction, broker, blob, is, mimeType, size, created, modified);
     }
 
+    @Deprecated
     @Override
     public BinaryDocument addBinaryResource(final Txn transaction, final DBBroker broker, final BinaryDocument blob, final InputStream is, final String mimeType, final long size, final Date created, final Date modified, final DBBroker.PreserveType preserve) throws EXistException, PermissionDeniedException, LockException, TriggerException, IOException {
         return collection.addBinaryResource(transaction, broker, blob, is, mimeType, size, created, modified, preserve);

--- a/exist-core/src/main/java/org/exist/collections/LockedCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/LockedCollection.java
@@ -359,7 +359,7 @@ public class LockedCollection implements Collection {
 
     @Override
     public void storeDocument(final Txn transaction, final DBBroker broker, final XmldbURI name, final InputSource source, @Nullable final MimeType mimeType) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
-        collection.storeDocument(transaction, broker, name, source, mimeType);
+        broker.storeDocument(transaction, name, source, mimeType, collection);
     }
 
     @Override
@@ -369,7 +369,7 @@ public class LockedCollection implements Collection {
 
     @Override
     public void storeDocument(final Txn transaction, final DBBroker broker, final XmldbURI name, final Node node, @Nullable final MimeType mimeType) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
-        collection.storeDocument(transaction, broker, name, node, mimeType);
+        broker.storeDocument(transaction, name, node, mimeType, collection);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/config/Configurator.java
+++ b/exist-core/src/main/java/org/exist/config/Configurator.java
@@ -1311,7 +1311,7 @@ public class Configurator {
                 systemResourcePermission.setGroup(systemSubject.getDefaultGroup());
                 systemResourcePermission.setMode(Permission.DEFAULT_SYSTEM_RESOURCE_PERM);
 
-                collection.storeDocument(txn, broker, uri, new StringInputSource(data), MimeType.XML_TYPE, null, null, systemResourcePermission, null, null);
+                broker.storeDocument(txn, uri, new StringInputSource(data), MimeType.XML_TYPE, null, null, systemResourcePermission, null, null, collection);
 
                 broker.saveCollection(txn, collection);
                 if (!txnInProgress) {

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -1064,7 +1064,7 @@ public class RESTServer {
             try (final FilterInputStreamCache cache = FilterInputStreamCacheFactory.getCacheInstance(()
                     -> (String) broker.getConfiguration().getProperty(Configuration.BINARY_CACHE_CLASS_PROPERTY), request.getInputStream());
                 final CachingFilterInputStream cfis = new CachingFilterInputStream(cache)) {
-                collection.storeDocument(transaction, broker, docUri, new CachingFilterInputStreamInputSource(cfis), mime);
+                broker.storeDocument(transaction, docUri, new CachingFilterInputStreamInputSource(cfis), mime, collection);
             }
             response.setStatus(HttpServletResponse.SC_CREATED);
 

--- a/exist-core/src/main/java/org/exist/protocolhandler/embedded/EmbeddedOutputStream.java
+++ b/exist-core/src/main/java/org/exist/protocolhandler/embedded/EmbeddedOutputStream.java
@@ -132,7 +132,7 @@ public class EmbeddedOutputStream extends OutputStream {
                 final MimeType mime = MimeTable.getInstance().getContentTypeFor(documentUri);
                 final TransactionManager transact = pool.getTransactionManager();
                 try (final Txn txn = transact.beginTransaction()) {
-                    collection.storeDocument(txn, broker, documentUri, new FileInputSource(tempFile), mime);
+                    broker.storeDocument(txn, documentUri, new FileInputSource(tempFile), mime, collection);
 
                     txn.commit();
                 }

--- a/exist-core/src/main/java/org/exist/protocolhandler/embedded/InMemoryOutputStream.java
+++ b/exist-core/src/main/java/org/exist/protocolhandler/embedded/InMemoryOutputStream.java
@@ -129,7 +129,7 @@ public class InMemoryOutputStream extends OutputStream {
 
           final MimeType mime = MimeTable.getInstance().getContentTypeFor(documentUri);
           try (final ManagedDocumentLock lock = lockManager.acquireDocumentWriteLock(documentUri)) {
-            collection.storeDocument(txn, broker, documentUri, new CachingFilterInputStreamInputSource(cfis), mime);
+            broker.storeDocument(txn, documentUri, new CachingFilterInputStreamInputSource(cfis), mime, collection);
           }
         }
 

--- a/exist-core/src/main/java/org/exist/protocolhandler/embedded/InMemoryOutputStream.java
+++ b/exist-core/src/main/java/org/exist/protocolhandler/embedded/InMemoryOutputStream.java
@@ -29,8 +29,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
-import org.exist.dom.persistent.DocumentImpl;
 import org.exist.protocolhandler.xmldb.XmldbURL;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
@@ -38,12 +36,16 @@ import org.exist.storage.lock.LockManager;
 import org.exist.storage.lock.ManagedDocumentLock;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.exist.util.CachingFilterInputStreamInputSource;
+import org.exist.util.Configuration;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
 import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.exist.util.io.CachingFilterInputStream;
+import org.exist.util.io.FilterInputStreamCache;
+import org.exist.util.io.FilterInputStreamCacheFactory;
 import org.exist.xmldb.XmldbURI;
-import org.xml.sax.InputSource;
 
 /**
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
@@ -94,7 +96,7 @@ public class InMemoryOutputStream extends OutputStream {
     }
   }
 
-  public void stream(final XmldbURL xmldbURL, final InputStream is, final int length) throws IOException {
+  public void stream(final XmldbURL xmldbURL, final InputStream is, @Deprecated final int length) throws IOException {
     BrokerPool db;
     try {
       db = BrokerPool.getInstance();
@@ -121,23 +123,13 @@ public class InMemoryOutputStream extends OutputStream {
           throw new IOException("Resource " + documentUri.toString() + " is a collection.");
         }
 
-        MimeType mime = MimeTable.getInstance().getContentTypeFor(documentUri);
-        String contentType = null;
-        if (mime != null) {
-          contentType = mime.getName();
-        } else {
-          mime = MimeType.BINARY_TYPE;
-        }
+        try (final FilterInputStreamCache cache = FilterInputStreamCacheFactory.getCacheInstance(()
+                -> (String) broker.getConfiguration().getProperty(Configuration.BINARY_CACHE_CLASS_PROPERTY), is);
+             final CachingFilterInputStream cfis = new CachingFilterInputStream(cache)) {
 
-        try(final ManagedDocumentLock lock = lockManager.acquireDocumentWriteLock(documentUri)) {
-          if (mime.isXMLType()) {
-            final InputSource inputsource = new InputSource(is);
-            final IndexInfo info = collection.validateXMLResource(txn, broker, documentUri, inputsource);
-            final DocumentImpl doc = info.getDocument();
-            doc.setMimeType(contentType);
-            collection.store(txn, broker, info, inputsource);
-          } else {
-            collection.addBinaryResource(txn, broker, documentUri, is, contentType, length);
+          final MimeType mime = MimeTable.getInstance().getContentTypeFor(documentUri);
+          try (final ManagedDocumentLock lock = lockManager.acquireDocumentWriteLock(documentUri)) {
+            collection.storeDocument(txn, broker, documentUri, new CachingFilterInputStreamInputSource(cfis), mime);
           }
         }
 

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -800,7 +800,7 @@ public class Deployment {
 
                     try (final FileInputSource is = new FileInputSource(file)) {
 
-                        targetCollection.storeDocument(transaction, broker, name, is, mime, null, null, permission, null, null);
+                        broker.storeDocument(transaction, name, is, mime, null, null, permission, null, null, targetCollection);
 
                     } catch (final EXistException | PermissionDeniedException | LockException | SAXException | IOException e) {
                         //check for .html ending
@@ -824,7 +824,7 @@ public class Deployment {
             IOException, EXistException, PermissionDeniedException, LockException, SAXException {
 
         final InputSource is = new FileInputSource(file);
-        targetCollection.storeDocument(transaction, broker, name, is, new MimeType(mime.getName(), MimeType.BINARY), null, null, permission, null, null);
+        broker.storeDocument(transaction, name, is, new MimeType(mime.getName(), MimeType.BINARY), null, null, permission, null, null, targetCollection);
     }
 
     private void storeBinaryResources(final DBBroker broker, final Txn transaction, final Path directory, final Collection targetCollection,

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -27,11 +27,9 @@ import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.SystemProperties;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.*;
-import org.exist.dom.persistent.BinaryDocument;
 import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.security.PermissionFactory;
@@ -59,6 +57,7 @@ import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -619,11 +618,12 @@ public class Deployment {
         try {
             final Collection collection = broker.getOrCreateCollection(transaction, targetCollection);
             final XmldbURI name = XmldbURI.createInternal("repo.xml");
-            final IndexInfo info = collection.validateXMLResource(transaction, broker, name, updatedXML);
-            final Permission permission = info.getDocument().getPermissions();
+
+            final Permission permission = PermissionFactory.getDefaultResourcePermission(broker.getBrokerPool().getSecurityManager());
             setPermissions(broker, requestedPerms, false, MimeType.XML_TYPE, permission);
 
-            collection.store(transaction, broker, info, updatedXML);
+            collection.storeDocument(transaction, broker, name, updatedXML, MimeType.XML_TYPE, null, null, permission, null, null);
+
         } catch (final PermissionDeniedException | IOException | SAXException | LockException | EXistException e) {
             throw new PackageException("Error while storing updated repo.xml: " + e.getMessage(), e);
         }
@@ -795,38 +795,21 @@ public class Deployment {
                 final XmldbURI name = XmldbURI.create(FileUtils.fileName(file));
 
                 try {
-                    if (mime.isXMLType()) {
-                        final InputSource is = new FileInputSource(file);
-                        IndexInfo info = null;
-                        try {
-                            info = targetCollection.validateXMLResource(transaction, broker, name, is);
-                        } catch (EXistException | PermissionDeniedException | LockException | SAXException | IOException e) {
-                            //check for .html ending
-                            if(mime.getName().equals(MimeType.HTML_TYPE.getName())){
-                                //store it as binary resource
-                                storeBinary(broker, transaction, targetCollection, file, mime, name, requestedPerms);
-                            } else {
-                                // could neither store as xml nor binary: give up and report failure in outer catch
-                                throw new EXistException(FileUtils.fileName(file) + " cannot be stored");
-                            }
-                        }
-                        if (info != null) {
-                            info.getDocument().setMimeType(mime.getName());
-                            final Permission permission = info.getDocument().getPermissions();
-                            setPermissions(broker, requestedPerms, false, mime, permission);
+                    final Permission permission = PermissionFactory.getDefaultResourcePermission(broker.getBrokerPool().getSecurityManager());
+                    setPermissions(broker, requestedPerms, false, mime, permission);
 
-                            targetCollection.store(transaction, broker, info, is);
-                        }
-                    } else {
-                        final long size = Files.size(file);
-                        try(final InputStream is = new BufferedInputStream(Files.newInputStream(file))) {
-                            final BinaryDocument doc =
-                                    targetCollection.addBinaryResource(transaction, broker, name, is, mime.getName(), size);
+                    try (final FileInputSource is = new FileInputSource(file)) {
 
-                            final Permission permission = doc.getPermissions();
-                            setPermissions(broker, requestedPerms, false, mime, permission);
-                            doc.setMimeType(mime.getName());
-                            broker.storeXMLResource(transaction, doc);
+                        targetCollection.storeDocument(transaction, broker, name, is, mime, null, null, permission, null, null);
+
+                    } catch (final EXistException | PermissionDeniedException | LockException | SAXException | IOException e) {
+                        //check for .html ending
+                        if (mime.getName().equals(MimeType.HTML_TYPE.getName())) {
+                            //store it as binary resource
+                            storeBinary(broker, transaction, targetCollection, file, mime, name, permission);
+                        } else {
+                            // could neither store as xml nor binary: give up and report failure in outer catch
+                            throw new EXistException(FileUtils.fileName(file) + " cannot be stored");
                         }
                     }
                 } catch (final SAXException | EXistException | PermissionDeniedException | LockException | IOException e) {
@@ -837,29 +820,25 @@ public class Deployment {
         }
     }
 
-    private void storeBinary(final DBBroker broker, final Txn transaction, final Collection targetCollection, final Path file, final MimeType mime, final XmldbURI name, final Optional<RequestedPerms> requestedPerms) throws
-            IOException, EXistException, PermissionDeniedException, LockException, TriggerException {
-        final long size = Files.size(file);
-        try (final InputStream is = new BufferedInputStream(Files.newInputStream(file))) {
-            final BinaryDocument doc =
-                    targetCollection.addBinaryResource(transaction, broker, name, is, mime.getName(), size);
+    private void storeBinary(final DBBroker broker, final Txn transaction, final Collection targetCollection, final Path file, final MimeType mime, final XmldbURI name, @Nullable final Permission permission) throws
+            IOException, EXistException, PermissionDeniedException, LockException, SAXException {
 
-            final Permission permission = doc.getPermissions();
-            setPermissions(broker, requestedPerms, false, mime, permission);
-            doc.setMimeType(mime.getName());
-            broker.storeXMLResource(transaction, doc);
-        }
+        final InputSource is = new FileInputSource(file);
+        targetCollection.storeDocument(transaction, broker, name, is, new MimeType(mime.getName(), MimeType.BINARY), null, null, permission, null, null);
     }
 
     private void storeBinaryResources(final DBBroker broker, final Txn transaction, final Path directory, final Collection targetCollection,
             final Optional<RequestedPerms> requestedPerms, final List<String> errors) throws IOException, EXistException,
             PermissionDeniedException, LockException, TriggerException {
-        try(DirectoryStream<Path> stream = Files.newDirectoryStream(directory)) {
+        try (final DirectoryStream<Path> stream = Files.newDirectoryStream(directory)) {
             for (final Path entry: stream) {
                 if (!Files.isDirectory(entry)) {
                     final XmldbURI name = XmldbURI.create(FileUtils.fileName(entry));
                     try {
-                        storeBinary(broker, transaction, targetCollection, entry, MimeType.BINARY_TYPE, name, requestedPerms);
+                        final Permission permission = PermissionFactory.getDefaultResourcePermission(broker.getBrokerPool().getSecurityManager());
+                        setPermissions(broker, requestedPerms, false, MimeType.BINARY_TYPE, permission);
+
+                        storeBinary(broker, transaction, targetCollection, entry, MimeType.BINARY_TYPE, name, permission);
                     } catch (final Exception e) {
                         LOG.error(e.getMessage(), e);
                         errors.add(e.getMessage());

--- a/exist-core/src/main/java/org/exist/storage/BrokerPool.java
+++ b/exist-core/src/main/java/org/exist/storage/BrokerPool.java
@@ -1107,8 +1107,6 @@ public class BrokerPool extends BrokerPools implements BrokerPoolConstants, Data
      * Returns a pool in which the database instance's readers are stored.
      *
      * @return The pool
-     *
-     * @deprecated Use {@link #getXmlReaderPool()} instead
      */
     public XMLReaderPool getXmlReaderPool() {
         return xmlReaderPool;

--- a/exist-core/src/main/java/org/exist/storage/DBBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/DBBroker.java
@@ -359,7 +359,7 @@ public abstract class DBBroker implements AutoCloseable {
      *
      * @param transaction The transaction, which registers the acquired write locks. The locks should be released on commit/abort.
      * @param uri The collection's URI
-     * @param creationAttributes the attributes to use if the collection needs to be created.
+     * @param creationAttributes the attributes to use if the collection needs to be created, the first item is a Permission (or null for default), the second item is a Creation Date.
      * @return The collection or <code>null</code> if no collection matches the path
      * @throws PermissionDeniedException If the current user does not have appropriate permissions
      * @throws IOException If an error occurs whilst reading (get) or writing (create) a Collection to disk

--- a/exist-core/src/main/java/org/exist/storage/DBBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/DBBroker.java
@@ -57,6 +57,11 @@ import org.exist.util.crypto.digest.MessageDigest;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.TerminatedException;
 import org.w3c.dom.Document;
+import org.w3c.dom.DocumentType;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
@@ -362,6 +367,98 @@ public abstract class DBBroker implements AutoCloseable {
      */
     public abstract Collection getOrCreateCollection(Txn transaction, XmldbURI uri, Optional<Tuple2<Permission, Long>> creationAttributes)
             throws PermissionDeniedException, IOException, TriggerException;
+
+    /**
+     * Stores a document.
+     * Since the process is dependent on the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction The database transaction
+     * @param name        The name (without path) of the document
+     * @param source      The source of the content for the new document to store
+     * @param mimeType    The mimeType of the document to store, or null if unknown.
+     * @param collection  The collection to store the document into
+     *
+     * @throws PermissionDeniedException if user has not sufficient rights
+     * @throws LockException if broker is locked
+     * @throws IOException in case of I/O errors
+     * @throws TriggerException in case of eXist-db trigger error
+     * @throws EXistException general eXist-db exception
+     * @throws SAXException internal SAXException
+     */
+    public abstract void storeDocument(Txn transaction, XmldbURI name, InputSource source, @Nullable MimeType mimeType, Collection collection) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
+     * Stores a document.
+     * Since the process is dependent on the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction       The database transaction
+     * @param name              The name (without path) of the document
+     * @param source            The source of the content for the new document to store
+     * @param mimeType          The mimeType of the document to store, or null if unknown.
+     *                          If null, application/octet-stream will be used to store a binary document.
+     * @param createdDate       The created date to set for the document, or if null the date is set to 'now'
+     * @param lastModifiedDate  The lastModified date to set for the document, or if null the date is set to the {@code createdDate}
+     * @param permission        A specific permission to set on the document, or null for the default permission
+     * @param documentType      A document type declaration, or null if absent or a binary document is being stored
+     * @param xmlReader         A custom XML Reader (e.g. a HTML to XHTML converting reader), or null to use the default XML reader or if a binary document is being stored
+     * @param collection        The collection to store the document into
+     *
+     * @throws PermissionDeniedException if user has not sufficient rights
+     * @throws LockException if broker is locked
+     * @throws IOException in case of I/O errors
+     * @throws TriggerException in case of eXist-db trigger error
+     * @throws EXistException general eXist-db exception
+     * @throws SAXException internal SAXException
+     */
+    public abstract void storeDocument(Txn transaction, XmldbURI name, InputSource source, @Nullable MimeType mimeType, @Nullable Date createdDate, @Nullable Date lastModifiedDate, @Nullable Permission permission, @Nullable DocumentType documentType, @Nullable XMLReader xmlReader, Collection collection) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
+     * Stores a document.
+     * Since the process is dependent on the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction The database transaction
+     * @param name        The name (without path) of the document
+     * @param node        The DOM Node to store as a new document
+     * @param mimeType    The mimeType of the document to store, or null if unknown.
+     * @param collection  The collection to store the document into
+     *
+     * @throws PermissionDeniedException if user has not sufficient rights
+     * @throws LockException if broker is locked
+     * @throws IOException in case of I/O errors
+     * @throws TriggerException in case of eXist-db trigger error
+     * @throws EXistException general eXist-db exception
+     * @throws SAXException internal SAXException
+     */
+    public abstract void storeDocument(Txn transaction, XmldbURI name, Node node, @Nullable MimeType mimeType, Collection collection) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
+
+    /**
+     * Stores a document.
+     * Since the process is dependent on the collection configuration,
+     * the collection acquires a write lock during the process.
+     *
+     * @param transaction       The database transaction
+     * @param name              The name (without path) of the document
+     * @param node              The DOM Node to store as a new document
+     * @param mimeType          The mimeType of the document to store, or null if unknown.
+     *                          If null, application/octet-stream will be used to store a binary document.
+     * @param createdDate       The created date to set for the document, or if null the date is set to 'now'
+     * @param lastModifiedDate  The lastModified date to set for the document, or if null the date is set to the {@code createdDate}
+     * @param permission        A specific permission to set on the document, or null for the default permission
+     * @param documentType      A document type declaration, or null if absent or a binary document is being stored
+     * @param xmlReader         A custom XML Reader (e.g. a HTML to XHTML converting reader), or null to use the default XML reader or if a binary document is being stored
+     * @param collection        The collection to store the document into
+     *
+     * @throws PermissionDeniedException if user has not sufficient rights
+     * @throws LockException if broker is locked
+     * @throws IOException in case of I/O errors
+     * @throws TriggerException in case of eXist-db trigger error
+     * @throws EXistException general eXist-db exception
+     * @throws SAXException internal SAXException
+     */
+    public abstract void storeDocument(Txn transaction, XmldbURI name, Node node, @Nullable MimeType mimeType, @Nullable Date createdDate, @Nullable Date lastModifiedDate, @Nullable Permission permission, @Nullable DocumentType documentType, @Nullable XMLReader xmlReader, Collection collection) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException;
 
     /**
      * Returns the configuration object used to initialize the current database

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -634,6 +634,7 @@ public class NativeBroker extends DBBroker {
      *
      * @param transaction The current transaction
      * @param path The Collection's URI
+     * @param creationAttributes the attributes to use if the collection needs to be created, the first item is a Permission (or null for default), the second item is a Creation Date.
      *
      * @return A tuple whose first boolean value is set to true if the
      * collection was created, or false if the collection already existed. The

--- a/exist-core/src/main/java/org/exist/storage/NativeBroker.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeBroker.java
@@ -99,6 +99,9 @@ import java.util.regex.Pattern;
 
 import org.exist.storage.dom.INodeIterator;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.security.Permission.DEFAULT_TEMPORARY_COLLECTION_PERM;
@@ -2127,6 +2130,26 @@ public class NativeBroker extends DBBroker {
         }
 
         return getResource(uri, Permission.READ);
+    }
+
+    @Override
+    public void storeDocument(final Txn transaction, final XmldbURI name, final InputSource source, final @Nullable MimeType mimeType, final Collection collection) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        collection.storeDocument(transaction, this, name, source, mimeType);
+    }
+
+    @Override
+    public void storeDocument(final Txn transaction, final XmldbURI name, final InputSource source, final @Nullable MimeType mimeType, final @Nullable Date createdDate, final @Nullable Date lastModifiedDate, final @Nullable Permission permission, final @Nullable DocumentType documentType, final @Nullable XMLReader xmlReader, final Collection collection) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        collection.storeDocument(transaction, this, name, source, mimeType, createdDate, lastModifiedDate, permission, documentType, xmlReader);
+    }
+
+    @Override
+    public void storeDocument(final Txn transaction, final XmldbURI name, final Node node, final @Nullable MimeType mimeType, final Collection collection) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        collection.storeDocument(transaction, this, name, node, mimeType);
+    }
+
+    @Override
+    public void storeDocument(final Txn transaction, final XmldbURI name, final Node node, final @Nullable MimeType mimeType, final @Nullable Date createdDate, final @Nullable Date lastModifiedDate, final @Nullable Permission permission, final @Nullable DocumentType documentType, final @Nullable XMLReader xmlReader, final Collection collection) throws EXistException, PermissionDeniedException, TriggerException, SAXException, LockException, IOException {
+        collection.storeDocument(transaction, this, name, node, mimeType, createdDate, lastModifiedDate, permission, documentType, xmlReader);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/util/BinaryValueInputSource.java
+++ b/exist-core/src/main/java/org/exist/util/BinaryValueInputSource.java
@@ -1,0 +1,192 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.util;
+
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.xquery.value.BinaryValue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Optional;
+
+/**
+ * Input Source for a Binary Value.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class BinaryValueInputSource extends EXistInputSource {
+    private final static Logger LOG = LogManager.getLogger(BinaryValueInputSource.class);
+
+    private Optional<BinaryValue> binaryValue = Optional.empty();
+    private Optional<InputStream> inputStream = Optional.empty();
+    private long length = -1;
+
+    /**
+     * Constructor which calls {@link #setBinaryValue(BinaryValue)}
+     * @param binaryValue
+     * The binaryValue passed to {@link #setBinaryValue(BinaryValue)}
+     */
+    public BinaryValueInputSource(final BinaryValue binaryValue) {
+        super();
+        setBinaryValue(binaryValue);
+    }
+
+    /**
+     * If a binary file source has been set, the BinaryValue
+     * object used for that is returned
+     *
+     * @return The BinaryValue object.
+     */
+    public BinaryValue getBinaryValue() {
+        return binaryValue.orElse(null);
+    }
+
+    /**
+     * This method sets the BinaryValue object
+     *
+     * @param binaryValue The BinaryValue.
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    public void setBinaryValue(final BinaryValue binaryValue) {
+        assertOpen();
+
+        close();
+        this.binaryValue = Optional.of(binaryValue);
+        reOpen();
+    }
+
+    /**
+     * This method was re-implemented to open a
+     * new InputStream each time it is called.
+     *
+     * @return If the binaryvalue was set, and it could be opened, an InputStream object.
+     * null, otherwise.
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public InputStream getByteStream() {
+        assertOpen();
+
+        // close any open stream first
+        close();
+
+        if (binaryValue.isPresent()) {
+            this.inputStream = Optional.of(binaryValue.get().getInputStream());
+            reOpen();
+            return inputStream.get();
+        }
+
+        return null;
+    }
+
+    /**
+     * This method now does nothing, so collateral
+     * effects from superclass with this one are avoided
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public void setByteStream(final InputStream is) {
+        assertOpen();
+        // Nothing, so collateral effects are avoided!
+    }
+
+    /**
+     * This method now does nothing, so collateral
+     * effects from superclass with this one are avoided
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public void setCharacterStream(final Reader r) {
+        assertOpen();
+        // Nothing, so collateral effects are avoided!
+    }
+
+    /**
+     * This method now does nothing, so collateral
+     * effects from superclass with this one are avoided
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public void setSystemId(final String systemId) {
+        assertOpen();
+        // Nothing, so collateral effects are avoided!
+    }
+
+    /**
+     * @see EXistInputSource#getByteStreamLength()
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public long getByteStreamLength() {
+        assertOpen();
+        if (length == -1 && binaryValue.isPresent()) {
+            try (final CountingOutputStream cos = new CountingOutputStream(NullOutputStream.NULL_OUTPUT_STREAM)) {
+                binaryValue.get().streamBinaryTo(cos);
+                length = cos.getByteCount();
+            } catch(final IOException e) {
+                LOG.error(e);
+            }
+        }
+
+        return length;
+    }
+
+    /**
+     * @see EXistInputSource#getSymbolicPath()
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public String getSymbolicPath() {
+        assertOpen();
+        return null;
+    }
+
+    @Override
+    public void close() {
+        if(!isClosed()) {
+            try {
+                if (inputStream.isPresent()) {
+                    try {
+                        inputStream.get().close();
+                    } catch (final IOException e) {
+                        LOG.warn(e);
+                    }
+                    inputStream = Optional.empty();
+                    length = -1;
+                }
+            } finally {
+                super.close();
+            }
+        }
+    }
+}

--- a/exist-core/src/main/java/org/exist/util/CachingFilterInputStreamInputSource.java
+++ b/exist-core/src/main/java/org/exist/util/CachingFilterInputStreamInputSource.java
@@ -1,0 +1,135 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.util;
+
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.exist.util.io.CachingFilterInputStream;
+import org.exist.util.io.InputStreamUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class CachingFilterInputStreamInputSource extends EXistInputSource {
+    private static final Logger LOG = LogManager.getLogger(CachingFilterInputStreamInputSource.class);
+
+    private CachingFilterInputStream cachingFilterInputStream;
+    private long length = -1;
+
+    public CachingFilterInputStreamInputSource(final CachingFilterInputStream cachingFilterInputStream) {
+        super();
+        this.cachingFilterInputStream = cachingFilterInputStream;
+    }
+
+    @Override
+    public Reader getCharacterStream() {
+        assertOpen();
+
+        return null;
+    }
+
+    /**
+     * This method now does nothing, so collateral
+     * effects from superclass with this one are avoided
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public void setCharacterStream(final Reader r) {
+        assertOpen();
+        throw new IllegalStateException("CachingFilterInputStreamInputSource is immutable");
+    }
+
+    @Override
+    public InputStream getByteStream() {
+        assertOpen();
+
+        try {
+            return new CachingFilterInputStream(cachingFilterInputStream);
+        } catch (final InstantiationException e) {
+            LOG.error(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * @see EXistInputSource#getByteStreamLength()
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public long getByteStreamLength() {
+        assertOpen();
+        if (length == -1) {
+            try (final CachingFilterInputStream is = new CachingFilterInputStream(cachingFilterInputStream);
+                 final CountingOutputStream cos = new CountingOutputStream(NullOutputStream.NULL_OUTPUT_STREAM)) {
+                InputStreamUtil.copy(is, cos);
+                length = cos.getByteCount();
+            } catch (final InstantiationException | IOException e) {
+                LOG.error(e.getMessage(), e);
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Set a byte stream input.
+     *
+     * @param is the input stream.
+     *
+     * @throws IllegalStateException this class is immutable!
+     */
+    @Override
+    public void setByteStream(final InputStream is) {
+        assertOpen();
+        throw new IllegalStateException("CachingFilterInputStreamInputSource is immutable");
+    }
+
+    /**
+     * This method now does nothing, so collateral
+     * effects from superclass with this one are avoided
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public void setSystemId(final String systemId) {
+        assertOpen();
+        // Nothing, so collateral effects are avoided!
+    }
+
+    /**
+     * @see EXistInputSource#getSymbolicPath()
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public String getSymbolicPath() {
+        assertOpen();
+        return null;
+    }
+}

--- a/exist-core/src/main/java/org/exist/util/FileInputSource.java
+++ b/exist-core/src/main/java/org/exist/util/FileInputSource.java
@@ -33,7 +33,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 public class FileInputSource extends EXistInputSource {
-	private final static Logger LOG = LogManager.getLogger(FileInputSource.class);
+	private static final Logger LOG = LogManager.getLogger(FileInputSource.class);
 
 	private Optional<Path> file = Optional.empty();
 	private Optional<InputStream> inputStream = Optional.empty();
@@ -115,7 +115,7 @@ public class FileInputSource extends EXistInputSource {
 	@Override
 	public void setByteStream(final InputStream is) {
 		assertOpen();
-		// Nothing, so collateral effects are avoided!
+		throw new IllegalStateException("FileInputSource is immutable");
 	}
 	
 	/**
@@ -127,7 +127,7 @@ public class FileInputSource extends EXistInputSource {
 	@Override
 	public void setCharacterStream(final Reader r) {
 		assertOpen();
-		// Nothing, so collateral effects are avoided!
+		throw new IllegalStateException("FileInputSource is immutable");
 	}
 
 	/**
@@ -139,7 +139,7 @@ public class FileInputSource extends EXistInputSource {
 	@Override
 	public void setSystemId(final String systemId) {
 		assertOpen();
-		// Nothing, so collateral effects are avoided!
+		throw new IllegalStateException("FileInputSource is immutable");
 	}
 
 	/**

--- a/exist-core/src/main/java/org/exist/util/InputStreamSupplierInputSource.java
+++ b/exist-core/src/main/java/org/exist/util/InputStreamSupplierInputSource.java
@@ -1,0 +1,110 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.util;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.function.Supplier;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class InputStreamSupplierInputSource extends EXistInputSource {
+
+    final Supplier<InputStream> inputStreamSupplier;
+
+    public InputStreamSupplierInputSource(final Supplier<InputStream> inputStreamSupplier) {
+        super();
+        this.inputStreamSupplier = inputStreamSupplier;
+    }
+
+    @Override
+    public Reader getCharacterStream() {
+        assertOpen();
+        return null;
+    }
+
+    /**
+     * This method now does nothing, so collateral
+     * effects from superclass with this one are avoided
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public void setCharacterStream(final Reader r) {
+        assertOpen();
+        throw new IllegalStateException("InputStreamSupplierInputSource is immutable");
+    }
+
+    @Override
+    public InputStream getByteStream() {
+        assertOpen();
+        return inputStreamSupplier.get();
+    }
+
+    /**
+     * @see EXistInputSource#getByteStreamLength()
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public long getByteStreamLength() {
+        assertOpen();
+        return -1;
+    }
+
+    /**
+     * Set a byte stream input.
+     *
+     * @param is the input stream.
+     *
+     * @throws IllegalStateException this class is immutable!
+     */
+    @Override
+    public void setByteStream(final InputStream is) {
+        assertOpen();
+        throw new IllegalStateException("InputStreamSupplierInputSource is immutable");
+    }
+
+    /**
+     * This method now does nothing, so collateral
+     * effects from superclass with this one are avoided
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public void setSystemId(final String systemId) {
+        assertOpen();
+        // Nothing, so collateral effects are avoided!
+    }
+
+    /**
+     * @see EXistInputSource#getSymbolicPath()
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public String getSymbolicPath() {
+        assertOpen();
+        return null;
+    }
+}

--- a/exist-core/src/main/java/org/exist/util/MimeType.java
+++ b/exist-core/src/main/java/org/exist/util/MimeType.java
@@ -54,13 +54,15 @@ public class MimeType {
         new MimeType("text/plain", BINARY);
     public final static MimeType URL_ENCODED_TYPE =
     	new MimeType("application/x-www-form-urlencoded", BINARY);
+    public final static MimeType EXPATH_PKG_TYPE =
+        new MimeType("application/expath+xar", BINARY);
 
 
-    private String name;
+    private final String name;
     private String description;
-    private int type = MimeType.XML;
+    private final int type;
  
-    public MimeType(String name, int type) {
+    public MimeType(final String name, final int type) {
         this.name = name;
         this.type = type;
     }
@@ -84,7 +86,8 @@ public class MimeType {
     public boolean isXMLType() {
         return type == XML;
     }
-    
+
+    @Override
     public String toString() {
         return name + ": " + description;
     }

--- a/exist-core/src/main/java/org/exist/util/StringInputSource.java
+++ b/exist-core/src/main/java/org/exist/util/StringInputSource.java
@@ -24,14 +24,16 @@ package org.exist.util;
 
 import com.evolvedbinary.j8fu.Either;
 import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
-import org.xml.sax.InputSource;
 
 import java.io.*;
 
 import static com.evolvedbinary.j8fu.Either.Left;
 import static com.evolvedbinary.j8fu.Either.Right;
 
-public class StringInputSource extends InputSource {
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class StringInputSource extends EXistInputSource {
 
     private final Either<byte[], String> source;
 
@@ -61,6 +63,8 @@ public class StringInputSource extends InputSource {
 
     @Override
     public Reader getCharacterStream() {
+        assertOpen();
+
         if (source.isLeft()) {
             return null;
         } else {
@@ -69,23 +73,39 @@ public class StringInputSource extends InputSource {
     }
 
     /**
-     * Set a character stream input.
+     * This method now does nothing, so collateral
+     * effects from superclass with this one are avoided
      *
-     * @param r the reader
-     *
-     * @throws IllegalStateException this class is immutable!
+     * @throws IllegalStateException if the InputSource was previously closed
      */
     @Override
     public void setCharacterStream(final Reader r) {
+        assertOpen();
         throw new IllegalStateException("StringInputSource is immutable");
     }
 
     @Override
     public InputStream getByteStream() {
+        assertOpen();
         if (source.isLeft()) {
             return new UnsynchronizedByteArrayInputStream(source.left().get());
         } else {
             return null;
+        }
+    }
+
+    /**
+     * @see EXistInputSource#getByteStreamLength()
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public long getByteStreamLength() {
+        assertOpen();
+        if (source.isLeft()) {
+            return source.left().get().length;
+        } else {
+            return -1;
         }
     }
 
@@ -98,6 +118,30 @@ public class StringInputSource extends InputSource {
      */
     @Override
     public void setByteStream(final InputStream is) {
+        assertOpen();
         throw new IllegalStateException("StringInputSource is immutable");
+    }
+
+    /**
+     * This method now does nothing, so collateral
+     * effects from superclass with this one are avoided
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public void setSystemId(final String systemId) {
+        assertOpen();
+        // Nothing, so collateral effects are avoided!
+    }
+
+    /**
+     * @see EXistInputSource#getSymbolicPath()
+     *
+     * @throws IllegalStateException if the InputSource was previously closed
+     */
+    @Override
+    public String getSymbolicPath() {
+        assertOpen();
+        return null;
     }
 }

--- a/exist-core/src/main/java/org/exist/util/io/CachingFilterInputStream.java
+++ b/exist-core/src/main/java/org/exist/util/io/CachingFilterInputStream.java
@@ -63,7 +63,7 @@ public class CachingFilterInputStream extends FilterInputStream {
      *
      * @throws InstantiationException if the construction fails
      */
-    public CachingFilterInputStream(InputStream inputStream) throws InstantiationException {
+    public CachingFilterInputStream(final InputStream inputStream) throws InstantiationException {
         super(null);
 
         if (inputStream instanceof CachingFilterInputStream) {

--- a/exist-core/src/main/java/org/exist/util/serializer/DOMStreamer.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/DOMStreamer.java
@@ -49,17 +49,15 @@ import javax.xml.XMLConstants;
  */
 public class DOMStreamer {
 
-    private final static Logger LOG = LogManager.getLogger(DOMStreamer.class);
+    private static final Logger LOG = LogManager.getLogger(DOMStreamer.class);
 
     private ContentHandler contentHandler = null;
     private LexicalHandler lexicalHandler = null;
-    private NamespaceSupport nsSupport = new NamespaceSupport();
+    private final NamespaceSupport nsSupport = new NamespaceSupport();
     private final Map<String, String> namespaceDecls = new HashMap<>();
     private final Deque<ElementInfo> stack = new ArrayDeque<>();
 
     public DOMStreamer() {
-        //TODUNDERSTAND : what is this class ? java.lang.Object ?
-        super();
     }
 
     public DOMStreamer(final ContentHandler contentHandler, final LexicalHandler lexicalHandler) {

--- a/exist-core/src/main/java/org/exist/xmldb/LocalCollection.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalCollection.java
@@ -598,9 +598,9 @@ public class LocalCollection extends AbstractLocal implements EXistCollection {
                 final MimeType mimeType = strMimeType != null ? MimeTable.getInstance().getContentType(strMimeType) : null;
                 final long conLength = res.getStreamLength();
                 if (conLength != -1) {
-                    collection.storeDocument(transaction, broker, resURI, new InputStreamSupplierInputSource(() -> Try(() -> res.getStreamContent(broker, transaction)).getOrElse((InputStream) null)), mimeType, res.datecreated, res.datemodified, null, null, null);
+                    broker.storeDocument(transaction, resURI, new InputStreamSupplierInputSource(() -> Try(() -> res.getStreamContent(broker, transaction)).getOrElse((InputStream) null)), mimeType, res.datecreated, res.datemodified, null, null, null, collection);
                 } else {
-                    collection.storeDocument(transaction, broker, resURI, new StringInputSource((byte[]) res.getContent(broker, transaction)), mimeType, res.datecreated, res.datemodified, null, null, null);
+                    broker.storeDocument(transaction, resURI, new StringInputSource((byte[]) res.getContent(broker, transaction)), mimeType, res.datecreated, res.datemodified, null, null, null, collection);
                 }
             } catch(final EXistException | SAXException e) {
                 throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
@@ -652,7 +652,7 @@ public class LocalCollection extends AbstractLocal implements EXistCollection {
                         reader = null;
                     }
 
-                    collection.storeDocument(transaction, broker, resURI, source, mimeType, res.datecreated, res.datemodified, null, null, reader);
+                    broker.storeDocument(transaction, resURI, source, mimeType, res.datecreated, res.datemodified, null, null, reader, collection);
                 }
 
                 // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme

--- a/exist-core/src/main/java/org/exist/xmldb/LocalCollection.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalCollection.java
@@ -22,7 +22,6 @@
 package org.exist.xmldb;
 
 import java.io.InputStream;
-import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.util.*;
 import javax.xml.transform.OutputKeys;
@@ -30,7 +29,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockToken;
 import org.exist.dom.persistent.LockedDocument;
@@ -44,7 +42,7 @@ import org.exist.storage.lock.ManagedDocumentLock;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.storage.sync.Sync;
 import org.exist.storage.txn.Txn;
-import org.exist.util.HtmlToXmlParser;
+import org.exist.util.*;
 import com.evolvedbinary.j8fu.Either;
 import com.evolvedbinary.j8fu.function.FunctionE;
 import org.exist.xmldb.function.LocalXmldbCollectionFunction;
@@ -58,8 +56,10 @@ import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.BinaryResource;
 import org.xmldb.api.modules.XMLResource;
 
+import static com.evolvedbinary.j8fu.Try.Try;
+
 /**
- *  A local implementation of the Collection interface. This
+ * A local implementation of the Collection interface. This
  * is used when the database is running in embedded mode.
  *
  * Extends Observable to allow status callbacks during indexing.
@@ -71,7 +71,7 @@ import org.xmldb.api.modules.XMLResource;
  */
 public class LocalCollection extends AbstractLocal implements EXistCollection {
 
-    private static Logger LOG = LogManager.getLogger(LocalCollection.class);
+    private static final Logger LOG = LogManager.getLogger(LocalCollection.class);
 
     /**
      * Property to be passed to {@link #setProperty(String, String)}.
@@ -594,15 +594,15 @@ public class LocalCollection extends AbstractLocal implements EXistCollection {
 
         modify().apply((collection, broker, transaction) -> {
             try {
+                final String strMimeType = res.getMimeType(broker, transaction);
+                final MimeType mimeType = strMimeType != null ? MimeTable.getInstance().getContentType(strMimeType) : null;
                 final long conLength = res.getStreamLength();
                 if (conLength != -1) {
-                    try (InputStream is = res.getStreamContent(broker, transaction)) {
-                        collection.addBinaryResource(transaction, broker, resURI, is, res.getMimeType(broker, transaction), conLength, res.datecreated, res.datemodified);
-                    }
+                    collection.storeDocument(transaction, broker, resURI, new InputStreamSupplierInputSource(() -> Try(() -> res.getStreamContent(broker, transaction)).getOrElse((InputStream) null)), mimeType, res.datecreated, res.datemodified, null, null, null);
                 } else {
-                    collection.addBinaryResource(transaction, broker, resURI, (byte[]) res.getContent(broker, transaction), res.getMimeType(broker, transaction), res.datecreated, res.datemodified);
+                    collection.storeDocument(transaction, broker, resURI, new StringInputSource((byte[]) res.getContent(broker, transaction)), mimeType, res.datecreated, res.datemodified, null, null, null);
                 }
-            } catch(final EXistException e) {
+            } catch(final EXistException | SAXException e) {
                 throw new XMLDBException(ErrorCodes.VENDOR_ERROR, e.getMessage(), e);
             }
             return null;
@@ -628,12 +628,13 @@ public class LocalCollection extends AbstractLocal implements EXistCollection {
 //          }
 
             try(final ManagedDocumentLock documentLock = broker.getBrokerPool().getLockManager().acquireDocumentWriteLock(collection.getURI().append(resURI))) {
-                XMLReader reader = null;
 
-                /* validate */
-                final IndexInfo info;
+                final String strMimeType = res.getMimeType(broker, transaction);
+                final MimeType mimeType = strMimeType != null ? MimeTable.getInstance().getContentType(strMimeType) : null;
+
                 if (res.root != null) {
-                    info = collection.validateXMLResource(transaction, broker, resURI, res.root);
+                    collection.storeDocument(transaction, broker, resURI, res.root, mimeType, res.datecreated, res.datemodified, null, null, null);
+
                 } else {
                     final InputSource source;
                     if (uri != null) {
@@ -641,54 +642,24 @@ public class LocalCollection extends AbstractLocal implements EXistCollection {
                     } else if (res.inputSource != null) {
                         source = res.inputSource;
                     } else {
-                        source = new InputSource(new StringReader(res.content));
+                        source = new StringInputSource(res.content);
                     }
 
+                    final XMLReader reader;
                     if (useHtmlReader(broker, transaction, res)) {
                         reader = getHtmlReader();
-                        info = collection.validateXMLResource(transaction, broker, resURI, source, reader);
                     } else {
-                        info = collection.validateXMLResource(transaction, broker, resURI, source);
-                    }
-                }
-
-                //Notice : the document should now have a LockMode.WRITE_LOCK update lock
-                //TODO : check that no exception occurs in order to allow it to be released
-                info.getDocument().setMimeType(res.getMimeType(broker, transaction));
-                if (res.datecreated != null) {
-                    info.getDocument().setCreated(res.datecreated.getTime());
-                }
-                if (res.datemodified != null) {
-                    info.getDocument().setLastModified(res.datemodified.getTime());
-                }
-
-
-                /* store */
-                if (res.root != null) {
-                    collection.store(transaction, broker, info, res.root);
-                } else {
-                    final InputSource source;
-                    if (uri != null) {
-                        source = new InputSource(uri);
-                    } else if (res.inputSource != null) {
-                        source = res.inputSource;
-                    } else {
-                        source = new InputSource(new StringReader(res.content));
+                        reader = null;
                     }
 
-                    if (reader != null) {
-                        collection.store(transaction, broker, info, source, reader);
-                    } else {
-                        collection.store(transaction, broker, info, source);
-                    }
+                    collection.storeDocument(transaction, broker, resURI, source, mimeType, res.datecreated, res.datemodified, null, null, reader);
                 }
 
                 // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
                 collection.close();
 
                 return null;
-            
-//              collection.deleteObservers();
+
             } catch(final EXistException | SAXException e) {
 
                 // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -1352,7 +1352,7 @@ public class RpcConnection implements RpcAPI {
                 final long startTime = System.currentTimeMillis();
 
                 final MimeType mime = MimeTable.getInstance().getContentTypeFor(docUri.lastSegment());
-                collection.storeDocument(transaction, broker, docUri.lastSegment(), source, mime, created, modified, null, null, null);
+                broker.storeDocument(transaction, docUri.lastSegment(), source, mime, created, modified, null, null, null, collection);
 
                 // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
                 collection.close();
@@ -1479,11 +1479,10 @@ public class RpcConnection implements RpcAPI {
                 try (final FileInputSource source = sourceSupplier.get()) {
                     final MimeType mime = Optional.ofNullable(MimeTable.getInstance().getContentType(mimeType)).orElse(MimeType.BINARY_TYPE);
 
-                    collection.storeDocument(transaction, broker, docUri.lastSegment(), source, mime, created, modified, null, null, null);
+                    broker.storeDocument(transaction, docUri.lastSegment(), source, mime, created, modified, null, null, null, collection);
 
                     // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
                     collection.close();
-
 
                     return true;
                 }
@@ -1530,7 +1529,7 @@ public class RpcConnection implements RpcAPI {
                     LOG.debug("Storing binary resource to collection {}", collection.getURI());
                 }
 
-                collection.storeDocument(transaction, broker, docUri.lastSegment(), new StringInputSource(data), MimeTable.getInstance().getContentType(mimeType), created, modified, null, null, null);
+                broker.storeDocument(transaction, docUri.lastSegment(), new StringInputSource(data), MimeTable.getInstance().getContentType(mimeType), created, modified, null, null, null, collection);
 
                 // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
                 collection.close();

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -34,7 +34,6 @@ import org.exist.backup.Backup;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.memtree.NodeImpl;
 import org.exist.numbering.NodeId;
 import org.exist.protocolhandler.embedded.EmbeddedInputStream;
@@ -73,7 +72,6 @@ import org.exist.storage.txn.Txn;
 import org.exist.util.*;
 import org.exist.util.crypto.digest.DigestType;
 import org.exist.util.crypto.digest.MessageDigest;
-import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.exist.util.io.TemporaryFileManager;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.serializer.SerializerPool;
@@ -1333,7 +1331,7 @@ public class RpcConnection implements RpcAPI {
     }
 
     private boolean parse(final byte[] xml, final XmldbURI docUri,
-                          final int overwrite, final Date created, final Date modified) throws EXistException, PermissionDeniedException {
+                          final int overwrite, @Nullable final Date created, @Nullable final Date modified) throws EXistException, PermissionDeniedException {
 
         return this.<Boolean>writeCollection(docUri.removeLastSegment()).apply((collection, broker, transaction) -> {
 
@@ -1349,33 +1347,19 @@ public class RpcConnection implements RpcAPI {
                     }
                 }
 
-            try (final InputStream is = new UnsynchronizedByteArrayInputStream(xml)) {
+                final InputSource source = new StringInputSource(xml);
 
-                    final InputSource source = new InputSource(is);
+                final long startTime = System.currentTimeMillis();
 
-                    final long startTime = System.currentTimeMillis();
+                final MimeType mime = MimeTable.getInstance().getContentTypeFor(docUri.lastSegment());
+                collection.storeDocument(transaction, broker, docUri.lastSegment(), source, mime, created, modified, null, null, null);
 
-                    final IndexInfo info = collection.validateXMLResource(transaction, broker, docUri.lastSegment(), source);
-                    final MimeType mime = MimeTable.getInstance().getContentTypeFor(docUri.lastSegment());
-                    if (mime != null && mime.isXMLType()) {
-                        info.getDocument().setMimeType(mime.getName());
-                    }
-                    if (created != null) {
-                        info.getDocument().setCreated(created.getTime());
-                    }
-                    if (modified != null) {
-                        info.getDocument().setLastModified(modified.getTime());
-                    }
-
-                    collection.store(transaction, broker, info, source);
-
-                    // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
-                    collection.close();
-                    if(LOG.isDebugEnabled()) {
-                        LOG.debug("parsing {} took {}ms.", docUri, System.currentTimeMillis() - startTime);
-                    }
-                    return true;
+                // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
+                collection.close();
+                if(LOG.isDebugEnabled()) {
+                    LOG.debug("parsing {} took {}ms.", docUri, System.currentTimeMillis() - startTime);
                 }
+                return true;
             }
         });
     }
@@ -1489,41 +1473,17 @@ public class RpcConnection implements RpcAPI {
                     }
 
                     sourceSupplier = () -> new FileInputSource(path);
-            }
+                }
 
-            // parse the source
-            try (final FileInputSource source = sourceSupplier.get()) {
-                final MimeType mime = Optional.ofNullable(MimeTable.getInstance().getContentType(mimeType)).orElse(MimeType.BINARY_TYPE);
-                final boolean treatAsXML = (isXML != null && isXML) || (isXML == null && mime.isXMLType());
+                // parse the source
+                try (final FileInputSource source = sourceSupplier.get()) {
+                    final MimeType mime = Optional.ofNullable(MimeTable.getInstance().getContentType(mimeType)).orElse(MimeType.BINARY_TYPE);
 
-                    if (treatAsXML) {
-                        final IndexInfo info = collection.validateXMLResource(transaction, broker, docUri.lastSegment(), source);
-                        if (created != null) {
-                            info.getDocument().setCreated(created.getTime());
-                        }
-                        if (modified != null) {
-                            info.getDocument().setLastModified(modified.getTime());
-                        }
-                        collection.store(transaction, broker, info, source);
+                    collection.storeDocument(transaction, broker, docUri.lastSegment(), source, mime, created, modified, null, null, null);
 
-                        // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
-                        collection.close();
+                    // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
+                    collection.close();
 
-                    } else {
-                        try (final InputStream is = source.getByteStream()) {
-                            final DocumentImpl doc = collection.addBinaryResource(transaction, broker, docUri.lastSegment(), is, mime.getName(), source.getByteStreamLength());
-
-                            // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
-                            collection.close();
-
-                            if (created != null) {
-                                doc.setCreated(created.getTime());
-                            }
-                            if (modified != null) {
-                                doc.setLastModified(modified.getTime());
-                            }
-                        }
-                    }
 
                     return true;
                 }
@@ -1570,25 +1530,12 @@ public class RpcConnection implements RpcAPI {
                     LOG.debug("Storing binary resource to collection {}", collection.getURI());
                 }
 
-                final DocumentImpl doc = collection.addBinaryResource(transaction, broker, docUri.lastSegment(), data, mimeType);
-                if(doc != null) {
-                    if (created != null) {
-                        doc.setCreated(created.getTime());
-                    }
-                    if (modified != null) {
-                        doc.setLastModified(modified.getTime());
-                    }
+                collection.storeDocument(transaction, broker, docUri.lastSegment(), new StringInputSource(data), MimeTable.getInstance().getContentType(mimeType), created, modified, null, null, null);
 
-                    // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
-                    collection.close();
+                // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
+                collection.close();
 
-                    return true;
-                } else {
-                    // NOTE: early release of Collection lock inline with Asymmetrical Locking scheme
-                    collection.close();
-
-                    return false;
-                }
+                return true;
             }
         });
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAbstractCollectionManipulator.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAbstractCollectionManipulator.java
@@ -50,7 +50,7 @@ import org.xmldb.api.modules.CollectionManagementService;
  */
 public abstract class XMLDBAbstractCollectionManipulator extends BasicFunction {
 
-    protected static final Logger logger = LogManager.getLogger(XMLDBAbstractCollectionManipulator.class);
+    private static final Logger LOGGER = LogManager.getLogger(XMLDBAbstractCollectionManipulator.class);
 
     private final boolean errorIfAbsent;
 
@@ -121,19 +121,19 @@ public abstract class XMLDBAbstractCollectionManipulator extends BasicFunction {
         final Item item = args[paramNumber].itemAt(0);
         if (Type.subTypeOf(item.getType(), Type.NODE)) {
             final NodeValue node = (NodeValue) item;
-            if (logger.isDebugEnabled()) {
-                logger.debug("Found node");
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Found node");
             }
             if (node.getImplementationType() == NodeValue.PERSISTENT_NODE) {
                 final org.exist.collections.Collection internalCol = ((NodeProxy) node).getOwnerDocument().getCollection();
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Found node");
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Found node");
                 }
                 try {
                     //TODO: use xmldbURI
                     collection = getLocalCollection(context, internalCol.getURI().toString());
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Loaded collection {}", collection.getName());
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Loaded collection {}", collection.getName());
                     }
                 } catch (final XMLDBException e) {
                     throw new XPathException(this, "Failed to access collection: " + internalCol.getURI(), e);

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBModule.java
@@ -57,9 +57,9 @@ public class XMLDBModule extends AbstractInternalModule {
     public final static FunctionDef[] functions = {
             new FunctionDef(XMLDBCreateCollection.signature, XMLDBCreateCollection.class),
             new FunctionDef(XMLDBRegisterDatabase.signature, XMLDBRegisterDatabase.class),
-            new FunctionDef(XMLDBStore.signatures[0], XMLDBStore.class),
-            new FunctionDef(XMLDBStore.signatures[1], XMLDBStore.class),
-            new FunctionDef(XMLDBStore.signatures[2], XMLDBStore.class),
+            new FunctionDef(XMLDBStore.FS_STORE[0], XMLDBStore.class),
+            new FunctionDef(XMLDBStore.FS_STORE[1], XMLDBStore.class),
+            new FunctionDef(XMLDBStore.FS_STORE_BINARY, XMLDBStore.class),
             new FunctionDef(XMLDBLoadFromPattern.signatures[0], XMLDBLoadFromPattern.class),
             new FunctionDef(XMLDBLoadFromPattern.signatures[1], XMLDBLoadFromPattern.class),
             new FunctionDef(XMLDBLoadFromPattern.signatures[2], XMLDBLoadFromPattern.class),

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBModule.java
@@ -115,25 +115,16 @@ public class XMLDBModule extends AbstractInternalModule {
         super(functions, parameters, true);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#getDescription()
-     */
     @Override
     public String getDescription() {
         return "A module for database manipulation functions.";
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#getNamespaceURI()
-     */
     @Override
     public String getNamespaceURI() {
         return NAMESPACE_URI;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Module#getDefaultPrefix()
-     */
     @Override
     public String getDefaultPrefix() {
         return PREFIX;

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
@@ -70,7 +70,7 @@ import org.xmldb.api.modules.XMLResource;
  */
 public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
 
-    protected static final Logger logger = LogManager.getLogger(XMLDBStore.class);
+    private static final Logger LOGGER = LogManager.getLogger(XMLDBStore.class);
 
     protected static final FunctionParameterSequenceType ARG_COLLECTION = new FunctionParameterSequenceType("collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collection URI");
     protected static final FunctionParameterSequenceType ARG_RESOURCE_NAME = new FunctionParameterSequenceType("resource-name", Type.STRING, Cardinality.ZERO_OR_ONE, "The resource name");
@@ -159,26 +159,23 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
         }
 
         final Item item = args[2].itemAt(0);
-        String mimeType = MimeType.XML_TYPE.getName();
-        boolean binary = !Type.subTypeOf(item.getType(), Type.NODE);
 
+        // determine the mime type
+        final boolean storeAsBinary = isCalledAs(FS_STORE_BINARY_NAME);
+        MimeType mimeType = null;
         if (getSignature().getArgumentCount() == 4) {
-            mimeType = args[3].getStringValue();
-            final MimeType mime = MimeTable.getInstance().getContentType(mimeType);
-            if (mime != null) {
-                binary = !mime.isXMLType();
-            }
-
-        } else if (docName != null) {
-            final MimeType mime = MimeTable.getInstance().getContentTypeFor(docName);
-            if (mime != null) {
-                mimeType = mime.getName();
-                binary = !mime.isXMLType();
-            }
+            final String strMimeType = args[3].getStringValue();
+            mimeType = MimeTable.getInstance().getContentType(strMimeType);
         }
 
-        if (getSignature().getName().getLocalPart().equals("store-as-binary")) {
-            binary = true;
+        if (mimeType == null && docName != null) {
+            mimeType = MimeTable.getInstance().getContentTypeFor(docName);
+        }
+
+        if (mimeType == null) {
+            mimeType = (storeAsBinary || !Type.subTypeOf(item.getType(), Type.NODE)) ? MimeType.BINARY_TYPE : MimeType.XML_TYPE;
+        } else if (storeAsBinary) {
+            mimeType = new MimeType(mimeType.getName(), MimeType.BINARY);
         }
 
         Resource resource;
@@ -186,29 +183,29 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
             if (Type.subTypeOf(item.getType(), Type.JAVA_OBJECT)) {
                 final Object obj = ((JavaObjectValue) item).getObject();
                 if(obj instanceof java.io.File) {
-                    resource = loadFromFile(collection, ((java.io.File)obj).toPath(), docName, binary, mimeType);
+                    resource = loadFromFile(collection, ((java.io.File)obj).toPath(), docName, mimeType);
                 } else if(obj instanceof java.nio.file.Path) {
-                    resource = loadFromFile(collection, (Path)obj, docName, binary, mimeType);
+                    resource = loadFromFile(collection, (Path)obj, docName, mimeType);
                 } else {
-                    logger.error("Passed java object should be either a java.nio.file.Path or java.io.File");
+                    LOGGER.error("Passed java object should be either a java.nio.file.Path or java.io.File");
                     throw new XPathException(this, "Passed java object should be either a java.nio.file.Path or java.io.File");
                 }
 
             } else if (Type.subTypeOf(item.getType(), Type.ANY_URI)) {
                 try {
                     final URI uri = new URI(item.getStringValue());
-                    resource = loadFromURI(collection, uri, docName, binary, mimeType);
+                    resource = loadFromURI(collection, uri, docName, mimeType);
 
                 } catch (final URISyntaxException e) {
-                    logger.error("Invalid URI: {}", item.getStringValue());
+                    LOGGER.error("Invalid URI: {}", item.getStringValue());
                     throw new XPathException(this, "Invalid URI: " + item.getStringValue(), e);
                 }
 
             } else {
-                if (binary) {
-                    resource = collection.createResource(docName, "BinaryResource");
-                } else {
+                if (mimeType.isXMLType()) {
                     resource = collection.createResource(docName, "XMLResource");
+                } else {
+                    resource = collection.createResource(docName, "BinaryResource");
                 }
 
                 if (Type.subTypeOf(item.getType(), Type.STRING)) {
@@ -218,35 +215,37 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
                     resource.setContent(((BinaryValue) item).toJavaObject());
 
                 } else if (Type.subTypeOf(item.getType(), Type.NODE)) {
-                    if (binary) {
-                        final StringWriter writer = new StringWriter();
-                        final SAXSerializer serializer = new SAXSerializer();
-                        serializer.setOutput(writer, null);
-                        item.toSAX(context.getBroker(), serializer, SERIALIZATION_PROPERTIES);
-                        resource.setContent(writer.toString());
-                    } else {
+                    if (mimeType.isXMLType()) {
                         final ContentHandler handler = ((XMLResource) resource).setContentAsSAX();
                         handler.startDocument();
-
                         item.toSAX(context.getBroker(), handler, SERIALIZATION_PROPERTIES);
                         handler.endDocument();
+                    } else {
+                        try (final StringWriter writer = new StringWriter()) {
+                            final SAXSerializer serializer = new SAXSerializer();
+                            serializer.setOutput(writer, null);
+                            item.toSAX(context.getBroker(), serializer, SERIALIZATION_PROPERTIES);
+                            resource.setContent(writer.toString());
+                        } catch (final IOException e) {
+                            LOGGER.error(e.getMessage(), e);
+                        }
                     }
                 } else {
-                    logger.error("Data should be either a node or a string");
+                    LOGGER.error("Data should be either a node or a string");
                     throw new XPathException(this, "Data should be either a node or a string");
                 }
 
-                ((EXistResource) resource).setMimeType(mimeType);
+                ((EXistResource) resource).setMimeType(mimeType.getName());
                 collection.storeResource(resource);
             }
 
         } catch (final XMLDBException e) {
-            logger.error(e.getMessage(), e);
+            LOGGER.error(e.getMessage(), e);
             throw new XPathException(this,
-                    "XMLDB reported an exception while storing document" + e, e);
+                    "XMLDB reported an exception while storing document: " + e.getMessage(), e);
 
         } catch (final SAXException e) {
-            logger.error(e.getMessage());
+            LOGGER.error(e.getMessage());
             throw new XPathException(this, "SAX reported an exception while storing document", e);
         }
 
@@ -258,7 +257,7 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
                 //TODO : use dedicated function in XmldbURI
                 return new StringValue(collection.getName() + "/" + resource.getId());
             } catch (final XMLDBException e) {
-                logger.error(e.getMessage());
+                LOGGER.error(e.getMessage());
                 throw new XPathException(this, "XMLDB reported an exception while retrieving the "
                         + "stored document", e);
             }
@@ -266,7 +265,7 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
         }
     }
 
-    private Resource loadFromURI(Collection collection, URI uri, String docName, boolean binary, String mimeType)
+    private Resource loadFromURI(final Collection collection, final URI uri, final String docName, final MimeType mimeType)
             throws XPathException {
         Resource resource;
         if ("file".equals(uri.getScheme())) {
@@ -278,7 +277,7 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
             if (!Files.isReadable(file)) {
                 throw new XPathException(this, "Cannot read path: " + path);
             }
-            resource = loadFromFile(collection, file, docName, binary, mimeType);
+            resource = loadFromFile(collection, file, docName, mimeType);
 
         } else {
             final TemporaryFileManager temporaryFileManager = TemporaryFileManager.getInstance();
@@ -287,7 +286,7 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
                 temp = temporaryFileManager.getTemporaryFile();
                 try(final InputStream is = uri.toURL().openStream()) {
                     Files.copy(is, temp);
-                    resource = loadFromFile(collection, temp, docName, binary, mimeType);
+                    resource = loadFromFile(collection, temp, docName, mimeType);
                 } finally {
                     if(temp != null) {
                         temporaryFileManager.returnTemporaryFile(temp);
@@ -304,7 +303,7 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
         return resource;
     }
 
-    private Resource loadFromFile(final Collection collection, final Path file, String docName, final boolean binary, final String mimeType)
+    private Resource loadFromFile(final Collection collection, final Path file, String docName, final MimeType mimeType)
             throws XPathException {
         if (!Files.isDirectory(file)) {
             if (docName == null) {
@@ -313,12 +312,12 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
 
             try {
                 final Resource resource;
-                if (binary) {
-                    resource = collection.createResource(docName, BinaryResource.RESOURCE_TYPE);
-                } else {
+                if (mimeType.isXMLType()) {
                     resource = collection.createResource(docName, XMLResource.RESOURCE_TYPE);
+                } else {
+                    resource = collection.createResource(docName, BinaryResource.RESOURCE_TYPE);
                 }
-                ((EXistResource) resource).setMimeType(mimeType);
+                ((EXistResource) resource).setMimeType(mimeType.getName());
                 resource.setContent(file);
                 collection.storeResource(resource);
                 return resource;

--- a/exist-core/src/test/java/org/exist/IndexerTest.java
+++ b/exist-core/src/test/java/org/exist/IndexerTest.java
@@ -176,7 +176,7 @@ public class IndexerTest {
 	    		final Txn txn = txnMgr.beginTransaction()) {
 
             try (final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI)) {
-				collection.storeDocument(txn, broker, TestConstants.TEST_XML_URI, new StringInputSource(xml), MimeType.XML_TYPE);
+				broker.storeDocument(txn, TestConstants.TEST_XML_URI, new StringInputSource(xml), MimeType.XML_TYPE, collection);
 
 				broker.flush();
 				broker.saveCollection(txn, collection);

--- a/exist-core/src/test/java/org/exist/IndexerTest.java
+++ b/exist-core/src/test/java/org/exist/IndexerTest.java
@@ -28,7 +28,6 @@ import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.security.AuthenticationException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -38,6 +37,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -174,15 +175,14 @@ public class IndexerTest {
     	try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate("admin", "")));
 	    		final Txn txn = txnMgr.beginTransaction()) {
 
-            final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
-            final IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, xml);
-            //TODO : unlock the collection here ?
-            collection.store(txn, broker, info, xml);
-            @SuppressWarnings("unused")
-			final org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
-            broker.flush();
-            broker.saveCollection(txn, collection);
+            try (final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI)) {
+				collection.storeDocument(txn, broker, TestConstants.TEST_XML_URI, new StringInputSource(xml), MimeType.XML_TYPE);
+
+				broker.flush();
+				broker.saveCollection(txn, collection);
+			}
             txnMgr.commit(txn);
+
         }
 	
     }

--- a/exist-core/src/test/java/org/exist/IndexerTest2.java
+++ b/exist-core/src/test/java/org/exist/IndexerTest2.java
@@ -134,7 +134,7 @@ public class IndexerTest2 {
                 final Txn txn = txnMgr.beginTransaction()) {
 
             try (final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI)) {
-                collection.storeDocument(txn, broker, TestConstants.TEST_XML_URI2, new StringInputSource(XML), MimeType.XML_TYPE);
+                broker.storeDocument(txn, TestConstants.TEST_XML_URI2, new StringInputSource(XML), MimeType.XML_TYPE, collection);
 
                 broker.flush();
                 broker.saveCollection(txn, collection);

--- a/exist-core/src/test/java/org/exist/IndexerTest3.java
+++ b/exist-core/src/test/java/org/exist/IndexerTest3.java
@@ -337,7 +337,7 @@ public class IndexerTest3 {
                 final Txn txn = txnMgr.beginTransaction()) {
 
             try (final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI)) {
-                collection.storeDocument(txn, broker, TestConstants.TEST_XML_URI, new StringInputSource(xml), MimeType.XML_TYPE);
+                broker.storeDocument(txn, TestConstants.TEST_XML_URI, new StringInputSource(xml), MimeType.XML_TYPE, collection);
 
                 broker.flush();
                 broker.saveCollection(txn, collection);

--- a/exist-core/src/test/java/org/exist/IndexerTest3.java
+++ b/exist-core/src/test/java/org/exist/IndexerTest3.java
@@ -27,10 +27,7 @@ import java.util.Optional;
 import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
-import org.exist.EXistException;
-import org.exist.Indexer;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.security.AuthenticationException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -39,11 +36,10 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.serializer.SAXSerializer;
-import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.value.Item;
@@ -340,14 +336,12 @@ public class IndexerTest3 {
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate("admin", "")));
                 final Txn txn = txnMgr.beginTransaction()) {
 
-            final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
-            final IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, xml);
-            //TODO : unlock the collection here ?
-            collection.store(txn, broker, info, xml);
-            @SuppressWarnings("unused")
-            final org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
-            broker.flush();
-            broker.saveCollection(txn, collection);
+            try (final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI)) {
+                collection.storeDocument(txn, broker, TestConstants.TEST_XML_URI, new StringInputSource(xml), MimeType.XML_TYPE);
+
+                broker.flush();
+                broker.saveCollection(txn, collection);
+            }
             txnMgr.commit(txn);
         }
     }

--- a/exist-core/src/test/java/org/exist/backup/DeepEmbeddedBackupRestoreTest.java
+++ b/exist-core/src/test/java/org/exist/backup/DeepEmbeddedBackupRestoreTest.java
@@ -26,13 +26,14 @@ import net.jpountz.xxhash.XXHashFactory;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.DatabaseImpl;
 import org.exist.xmldb.XmldbURI;
 import org.junit.BeforeClass;
@@ -43,14 +44,12 @@ import org.xml.sax.SAXException;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.XMLDBException;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 
 /**
@@ -151,21 +150,18 @@ public class DeepEmbeddedBackupRestoreTest {
                                     // store XML document
                                     final XmldbURI xmlName = XmldbURI.create("doc_" + x + ".xml");
                                     final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + EOL + "<position id=\"" + x + "\" d=\"" + d + "\" w=\"" + w + "\"/>";
-                                    final IndexInfo indexInfo = sibCollection.validateXMLResource(transaction, broker, xmlName, xml);
-                                    sibCollection.store(transaction, broker, indexInfo, xml);
+                                    sibCollection.storeDocument(transaction, broker, xmlName, new StringInputSource(xml), MimeType.XML_TYPE);
 
-                                    final byte[] xmlData = xml.getBytes(StandardCharsets.UTF_8);
+                                    final byte[] xmlData = xml.getBytes(UTF_8);
                                     final long xmlHash = hash64.hash(xmlData, 0, xmlData.length, XXHASH64_SEED);
                                     documentInfos.add(new ResourceInfo(sibCollectionUri.append(xmlName), xmlHash));
 
                                     // store Binary document
                                     final XmldbURI binName = XmldbURI.create("doc_" + x + ".bin");
                                     final String bin = x + ":" + d + ":" + w;
-                                    try (final InputStream is = new ByteArrayInputStream(bin.getBytes(StandardCharsets.UTF_8))) {
-                                        sibCollection.addBinaryResource(transaction, broker, binName, is, "application/octet-stream", -1, null, null);
-                                    }
+                                    sibCollection.storeDocument(transaction, broker, binName, new StringInputSource(bin.getBytes(UTF_8)), MimeType.BINARY_TYPE);
 
-                                    final byte[] binData = bin.getBytes(StandardCharsets.UTF_8);
+                                    final byte[] binData = bin.getBytes(UTF_8);
                                     final long binHash = hash64.hash(binData, 0, binData.length, XXHASH64_SEED);
                                     documentInfos.add(new ResourceInfo(sibCollectionUri.append(binName), binHash));
                                 }

--- a/exist-core/src/test/java/org/exist/backup/DeepEmbeddedBackupRestoreTest.java
+++ b/exist-core/src/test/java/org/exist/backup/DeepEmbeddedBackupRestoreTest.java
@@ -150,7 +150,7 @@ public class DeepEmbeddedBackupRestoreTest {
                                     // store XML document
                                     final XmldbURI xmlName = XmldbURI.create("doc_" + x + ".xml");
                                     final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + EOL + "<position id=\"" + x + "\" d=\"" + d + "\" w=\"" + w + "\"/>";
-                                    sibCollection.storeDocument(transaction, broker, xmlName, new StringInputSource(xml), MimeType.XML_TYPE);
+                                    broker.storeDocument(transaction, xmlName, new StringInputSource(xml), MimeType.XML_TYPE, sibCollection);
 
                                     final byte[] xmlData = xml.getBytes(UTF_8);
                                     final long xmlHash = hash64.hash(xmlData, 0, xmlData.length, XXHASH64_SEED);
@@ -159,7 +159,7 @@ public class DeepEmbeddedBackupRestoreTest {
                                     // store Binary document
                                     final XmldbURI binName = XmldbURI.create("doc_" + x + ".bin");
                                     final String bin = x + ":" + d + ":" + w;
-                                    sibCollection.storeDocument(transaction, broker, binName, new StringInputSource(bin.getBytes(UTF_8)), MimeType.BINARY_TYPE);
+                                    broker.storeDocument(transaction, binName, new StringInputSource(bin.getBytes(UTF_8)), MimeType.BINARY_TYPE, sibCollection);
 
                                     final byte[] binData = bin.getBytes(UTF_8);
                                     final long binHash = hash64.hash(binData, 0, binData.length, XXHASH64_SEED);

--- a/exist-core/src/test/java/org/exist/backup/SystemExportFiltersTest.java
+++ b/exist-core/src/test/java/org/exist/backup/SystemExportFiltersTest.java
@@ -113,7 +113,7 @@ public class SystemExportFiltersTest {
             storeXMLDocument(txn, broker, test, doc02uri.lastSegment(), XML2);
             storeXMLDocument(txn, broker, test, doc03uri.lastSegment(), XML3);
 
-            test.storeDocument(txn, broker, doc11uri.lastSegment(), new StringInputSource(BINARY.getBytes(UTF_8)), MimeType.BINARY_TYPE);
+            broker.storeDocument(txn, doc11uri.lastSegment(), new StringInputSource(BINARY.getBytes(UTF_8)), MimeType.BINARY_TYPE, test);
 
             txn.commit();
         }
@@ -206,6 +206,6 @@ public class SystemExportFiltersTest {
     }
 
     private static void storeXMLDocument(final Txn txn, final DBBroker broker, final Collection col, final XmldbURI name, final String data) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
-        col.storeDocument(txn, broker, name, new StringInputSource(data), MimeType.XML_TYPE);
+        broker.storeDocument(txn, name, new StringInputSource(data), MimeType.XML_TYPE, col);
     }
 }

--- a/exist-core/src/test/java/org/exist/backup/SystemExportFiltersTest.java
+++ b/exist-core/src/test/java/org/exist/backup/SystemExportFiltersTest.java
@@ -28,7 +28,6 @@ import org.exist.backup.restore.listener.RestoreListener;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
@@ -40,6 +39,8 @@ import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.io.InputStreamUtil;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
@@ -112,7 +113,7 @@ public class SystemExportFiltersTest {
             storeXMLDocument(txn, broker, test, doc02uri.lastSegment(), XML2);
             storeXMLDocument(txn, broker, test, doc03uri.lastSegment(), XML3);
 
-            test.addBinaryResource(txn, broker, doc11uri.lastSegment(), BINARY.getBytes(), null);
+            test.storeDocument(txn, broker, doc11uri.lastSegment(), new StringInputSource(BINARY.getBytes(UTF_8)), MimeType.BINARY_TYPE);
 
             txn.commit();
         }
@@ -204,12 +205,7 @@ public class SystemExportFiltersTest {
         return col;
     }
 
-    private static DocumentImpl storeXMLDocument(Txn txn, DBBroker broker, Collection col, XmldbURI name, String data) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
-        IndexInfo info = col.validateXMLResource(txn, broker, name, data);
-        assertNotNull(info);
-
-        col.store(txn, broker, info, data);
-
-        return info.getDocument();
+    private static void storeXMLDocument(final Txn txn, final DBBroker broker, final Collection col, final XmldbURI name, final String data) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
+        col.storeDocument(txn, broker, name, new StringInputSource(data), MimeType.XML_TYPE);
     }
 }

--- a/exist-core/src/test/java/org/exist/backup/SystemExportImportTest.java
+++ b/exist-core/src/test/java/org/exist/backup/SystemExportImportTest.java
@@ -42,7 +42,6 @@ import org.exist.backup.restore.listener.RestoreListener;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
@@ -57,6 +56,8 @@ import static org.exist.test.TestConstants.TEST_COLLECTION_URI;
 
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.io.InputStreamUtil;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
@@ -227,19 +228,10 @@ public class SystemExportImportTest {
             final CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(transaction, broker, test, COLLECTION_CONFIG);
 
-            IndexInfo info = test.validateXMLResource(transaction, broker, doc01uri.lastSegment(), XML1);
-            assertNotNull(info);
-            test.store(transaction, broker, info, XML1);
-
-            info = test.validateXMLResource(transaction, broker, doc02uri.lastSegment(), XML2);
-            assertNotNull(info);
-            test.store(transaction, broker, info, XML2);
-
-            info = test.validateXMLResource(transaction, broker, doc03uri.lastSegment(), XML3);
-            assertNotNull(info);
-            test.store(transaction, broker, info, XML3);
-
-            test.addBinaryResource(transaction, broker, doc11uri.lastSegment(), BINARY.getBytes(), null);
+            test.storeDocument(transaction, broker, doc01uri.lastSegment(), new StringInputSource(XML1), MimeType.XML_TYPE);
+            test.storeDocument(transaction, broker, doc02uri.lastSegment(), new StringInputSource(XML2), MimeType.XML_TYPE);
+            test.storeDocument(transaction, broker, doc03uri.lastSegment(), new StringInputSource(XML3), MimeType.XML_TYPE);
+            test.storeDocument(transaction, broker, doc11uri.lastSegment(), new StringInputSource(BINARY.getBytes(UTF_8)), MimeType.BINARY_TYPE);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/backup/SystemExportImportTest.java
+++ b/exist-core/src/test/java/org/exist/backup/SystemExportImportTest.java
@@ -228,10 +228,10 @@ public class SystemExportImportTest {
             final CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(transaction, broker, test, COLLECTION_CONFIG);
 
-            test.storeDocument(transaction, broker, doc01uri.lastSegment(), new StringInputSource(XML1), MimeType.XML_TYPE);
-            test.storeDocument(transaction, broker, doc02uri.lastSegment(), new StringInputSource(XML2), MimeType.XML_TYPE);
-            test.storeDocument(transaction, broker, doc03uri.lastSegment(), new StringInputSource(XML3), MimeType.XML_TYPE);
-            test.storeDocument(transaction, broker, doc11uri.lastSegment(), new StringInputSource(BINARY.getBytes(UTF_8)), MimeType.BINARY_TYPE);
+            broker.storeDocument(transaction, doc01uri.lastSegment(), new StringInputSource(XML1), MimeType.XML_TYPE, test);
+            broker.storeDocument(transaction, doc02uri.lastSegment(), new StringInputSource(XML2), MimeType.XML_TYPE, test);
+            broker.storeDocument(transaction, doc03uri.lastSegment(), new StringInputSource(XML3), MimeType.XML_TYPE, test);
+            broker.storeDocument(transaction, doc11uri.lastSegment(), new StringInputSource(BINARY.getBytes(UTF_8)), MimeType.BINARY_TYPE, test);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/collections/CollectionOrderTest.java
+++ b/exist-core/src/test/java/org/exist/collections/CollectionOrderTest.java
@@ -302,7 +302,7 @@ public class CollectionOrderTest {
                 for (final String documentName : documentNames) {
                     final String xml = "<document id='" + UUID.randomUUID().toString() + "'><name>" + documentName + "</name></document>";
 
-                    testCollection.storeDocument(transaction, broker, XmldbURI.create(documentName), new StringInputSource(xml), MimeType.XML_TYPE);
+                    broker.storeDocument(transaction, XmldbURI.create(documentName), new StringInputSource(xml), MimeType.XML_TYPE, testCollection);
                 }
             }
 

--- a/exist-core/src/test/java/org/exist/collections/CollectionOrderTest.java
+++ b/exist-core/src/test/java/org/exist/collections/CollectionOrderTest.java
@@ -33,6 +33,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.Before;
@@ -300,8 +302,7 @@ public class CollectionOrderTest {
                 for (final String documentName : documentNames) {
                     final String xml = "<document id='" + UUID.randomUUID().toString() + "'><name>" + documentName + "</name></document>";
 
-                    final IndexInfo indexInfo = testCollection.validateXMLResource(transaction, broker, XmldbURI.create(documentName), xml);
-                    testCollection.store(transaction, broker, indexInfo, xml);
+                    testCollection.storeDocument(transaction, broker, XmldbURI.create(documentName), new StringInputSource(xml), MimeType.XML_TYPE);
                 }
             }
 

--- a/exist-core/src/test/java/org/exist/collections/CollectionRemovalTest.java
+++ b/exist-core/src/test/java/org/exist/collections/CollectionRemovalTest.java
@@ -213,7 +213,7 @@ public class CollectionRemovalTest {
                 broker.saveCollection(transaction, collection);
 
                 // store document
-                collection.storeDocument(transaction, broker, XmldbURI.create("document.xml"), new StringInputSource(DATA), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("document.xml"), new StringInputSource(DATA), MimeType.XML_TYPE, collection);
             }
 
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/collections/CollectionRemovalTest.java
+++ b/exist-core/src/test/java/org/exist/collections/CollectionRemovalTest.java
@@ -39,6 +39,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.EXistXPathQueryService;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
@@ -211,9 +213,7 @@ public class CollectionRemovalTest {
                 broker.saveCollection(transaction, collection);
 
                 // store document
-                final IndexInfo info = collection.validateXMLResource(transaction, broker, XmldbURI.create("document.xml"), DATA);
-                assertNotNull(info);
-                collection.store(transaction, broker, info, DATA);
+                collection.storeDocument(transaction, broker, XmldbURI.create("document.xml"), new StringInputSource(DATA), MimeType.XML_TYPE);
             }
 
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/collections/CollectionStoreTest.java
+++ b/exist-core/src/test/java/org/exist/collections/CollectionStoreTest.java
@@ -76,7 +76,7 @@ public class CollectionStoreTest {
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = pool.getTransactionManager().beginTransaction()) {
             try (final Collection col = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI)) {
-                col.storeDocument(transaction, broker, TEST_XML_DOC_URI, new StringInputSource(TEST_XML_DOC), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, TEST_XML_DOC_URI, new StringInputSource(TEST_XML_DOC), MimeType.XML_TYPE, col);
                 broker.saveCollection(transaction, col);
             }
 

--- a/exist-core/src/test/java/org/exist/collections/CollectionStoreTest.java
+++ b/exist-core/src/test/java/org/exist/collections/CollectionStoreTest.java
@@ -37,6 +37,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.LockException;
 import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -74,8 +76,7 @@ public class CollectionStoreTest {
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = pool.getTransactionManager().beginTransaction()) {
             try (final Collection col = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI)) {
-                final IndexInfo indexInfo = col.validateXMLResource(transaction, broker, TEST_XML_DOC_URI, TEST_XML_DOC);
-                col.store(transaction, broker, indexInfo, TEST_XML_DOC);
+                col.storeDocument(transaction, broker, TEST_XML_DOC_URI, new StringInputSource(TEST_XML_DOC), MimeType.XML_TYPE);
                 broker.saveCollection(transaction, col);
             }
 

--- a/exist-core/src/test/java/org/exist/collections/triggers/HistoryTriggerTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/HistoryTriggerTest.java
@@ -75,7 +75,7 @@ public class HistoryTriggerTest {
             // create and store the collection.xconf for the test collection
             Collection configCollection = broker.getOrCreateCollection(transaction, TEST_CONFIG_COLLECTION_URI);
             broker.saveCollection(transaction, configCollection);
-            configCollection.storeDocument(transaction, broker, CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI, new StringInputSource(COLLECTION_CONFIG), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI, new StringInputSource(COLLECTION_CONFIG), MimeType.XML_TYPE, configCollection);
 
             // create the test collection
             Collection testCollection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
@@ -184,7 +184,7 @@ public class HistoryTriggerTest {
 
             assertNotNull(testCollection);
 
-            testCollection.storeDocument(transaction, broker, docName, new StringInputSource(docContent), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, docName, new StringInputSource(docContent), MimeType.XML_TYPE, testCollection);
         }
     }
 

--- a/exist-core/src/test/java/org/exist/collections/triggers/HistoryTriggerTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/HistoryTriggerTest.java
@@ -25,7 +25,6 @@ package org.exist.collections.triggers;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfiguration;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.DocumentSet;
@@ -37,6 +36,8 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
 import org.xml.sax.SAXException;
@@ -74,8 +75,7 @@ public class HistoryTriggerTest {
             // create and store the collection.xconf for the test collection
             Collection configCollection = broker.getOrCreateCollection(transaction, TEST_CONFIG_COLLECTION_URI);
             broker.saveCollection(transaction, configCollection);
-            final IndexInfo indexInfo = configCollection.validateXMLResource(transaction, broker, CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI, COLLECTION_CONFIG);
-            configCollection.store(transaction, broker, indexInfo, COLLECTION_CONFIG);
+            configCollection.storeDocument(transaction, broker, CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI, new StringInputSource(COLLECTION_CONFIG), MimeType.XML_TYPE);
 
             // create the test collection
             Collection testCollection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
@@ -184,9 +184,7 @@ public class HistoryTriggerTest {
 
             assertNotNull(testCollection);
 
-            final IndexInfo indexInfo = testCollection.validateXMLResource(transaction, broker, docName, docContent);
-            testCollection.store(transaction, broker, indexInfo, docContent);
-
+            testCollection.storeDocument(transaction, broker, docName, new StringInputSource(docContent), MimeType.XML_TYPE);
         }
     }
 

--- a/exist-core/src/test/java/org/exist/collections/triggers/TestTrigger.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/TestTrigger.java
@@ -62,7 +62,7 @@ public class TestTrigger extends SAXTrigger implements DocumentTrigger {
                 // IMPORTANT: temporarily disable triggers on the collection.
                 // We would end up in infinite recursion if we don't do that
                 broker.setTriggersEnabled(false);
-                parent.storeDocument(transaction, broker, docPath, new StringInputSource(TEMPLATE), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, docPath, new StringInputSource(TEMPLATE), MimeType.XML_TYPE, parent);
                 this.doc = parent.getDocument(broker, docPath);
             }
 

--- a/exist-core/src/test/java/org/exist/collections/triggers/TestTrigger.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/TestTrigger.java
@@ -21,12 +21,13 @@
  */
 package org.exist.collections.triggers;
 
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.Txn;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xupdate.Modification;
 import org.exist.xupdate.XUpdateProcessor;
@@ -61,10 +62,8 @@ public class TestTrigger extends SAXTrigger implements DocumentTrigger {
                 // IMPORTANT: temporarily disable triggers on the collection.
                 // We would end up in infinite recursion if we don't do that
                 broker.setTriggersEnabled(false);
-                IndexInfo info = parent.validateXMLResource(transaction, broker, docPath, TEMPLATE);
-                //TODO : unlock the collection here ?
-                parent.store(transaction, broker, info, TEMPLATE);
-                this.doc = info.getDocument();
+                parent.storeDocument(transaction, broker, docPath, new StringInputSource(TEMPLATE), MimeType.XML_TYPE);
+                this.doc = parent.getDocument(broker, docPath);
             }
 
         } catch (Exception e) {

--- a/exist-core/src/test/java/org/exist/config/TwoDatabasesTest.java
+++ b/exist-core/src/test/java/org/exist/config/TwoDatabasesTest.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -41,9 +40,13 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
+import org.xml.sax.SAXException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -99,12 +102,12 @@ public class TwoDatabasesTest {
     }
 
     @Test
-    public void putGet() throws LockException, TriggerException, PermissionDeniedException, EXistException, IOException {
+    public void putGet() throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
         put();
         get();
     }
 
-    private void put() throws EXistException, LockException, TriggerException, PermissionDeniedException, IOException {
+    private void put() throws EXistException, LockException, SAXException, PermissionDeniedException, IOException {
         final BrokerPool pool1 = existEmbeddedServer1.getBrokerPool();
         try (final DBBroker broker1 = pool1.get(Optional.of(user1));
              final Txn transaction1 = pool1.getTransactionManager().beginTransaction()) {
@@ -136,10 +139,10 @@ public class TwoDatabasesTest {
 
     private static final String bin = "ABCDEFG";
 
-    private Collection storeBin(final DBBroker broker, final Txn txn, String suffix) throws PermissionDeniedException, LockException, TriggerException, EXistException, IOException {
+    private Collection storeBin(final DBBroker broker, final Txn txn, String suffix) throws PermissionDeniedException, LockException, SAXException, EXistException, IOException {
         String data = bin + suffix;
         Collection top = broker.openCollection(XmldbURI.create("xmldb:exist:///db"), LockMode.WRITE_LOCK);
-        top.addBinaryResource(txn, broker, XmldbURI.create("bin"), data.getBytes(), "text/plain");
+        top.storeDocument(txn, broker, XmldbURI.create("bin"), new StringInputSource(data.getBytes(UTF_8)), MimeType.TEXT_TYPE);
         return top;
     }
 

--- a/exist-core/src/test/java/org/exist/config/TwoDatabasesTest.java
+++ b/exist-core/src/test/java/org/exist/config/TwoDatabasesTest.java
@@ -142,7 +142,7 @@ public class TwoDatabasesTest {
     private Collection storeBin(final DBBroker broker, final Txn txn, String suffix) throws PermissionDeniedException, LockException, SAXException, EXistException, IOException {
         String data = bin + suffix;
         Collection top = broker.openCollection(XmldbURI.create("xmldb:exist:///db"), LockMode.WRITE_LOCK);
-        top.storeDocument(txn, broker, XmldbURI.create("bin"), new StringInputSource(data.getBytes(UTF_8)), MimeType.TEXT_TYPE);
+        broker.storeDocument(txn, XmldbURI.create("bin"), new StringInputSource(data.getBytes(UTF_8)), MimeType.TEXT_TYPE, top);
         return top;
     }
 

--- a/exist-core/src/test/java/org/exist/dom/memtree/DOMIndexerTest.java
+++ b/exist-core/src/test/java/org/exist/dom/memtree/DOMIndexerTest.java
@@ -107,7 +107,7 @@ public class DOMIndexerTest {
                 final Txn txn = txnMgr.beginTransaction()) {
 
             try (final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI)) {
-                collection.storeDocument(txn, broker, TestConstants.TEST_XML_URI, new StringInputSource(XML), MimeType.XML_TYPE);
+                broker.storeDocument(txn, TestConstants.TEST_XML_URI, new StringInputSource(XML), MimeType.XML_TYPE, collection);
                 broker.flush();
                 broker.saveCollection(txn, collection);
             }

--- a/exist-core/src/test/java/org/exist/dom/memtree/DOMIndexerTest.java
+++ b/exist-core/src/test/java/org/exist/dom/memtree/DOMIndexerTest.java
@@ -31,7 +31,6 @@ import com.googlecode.junittoolbox.ParallelRunner;
 import org.exist.EXistException;
 
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.security.AuthenticationException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -41,6 +40,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
@@ -105,14 +106,12 @@ public class DOMIndexerTest {
     	try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().authenticate("admin", "")));
                 final Txn txn = txnMgr.beginTransaction()) {
 
-            final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI);
-            final IndexInfo info = collection.validateXMLResource(txn, broker, TestConstants.TEST_XML_URI, XML);
-            //TODO : unlock the collection here ?
-            collection.store(txn, broker, info, XML);
-            @SuppressWarnings("unused")
-            final org.exist.dom.persistent.DocumentImpl doc = info.getDocument();
-            broker.flush();
-            broker.saveCollection(txn, collection);
+            try (final Collection collection = broker.getOrCreateCollection(txn, TestConstants.TEST_COLLECTION_URI)) {
+                collection.storeDocument(txn, broker, TestConstants.TEST_XML_URI, new StringInputSource(XML), MimeType.XML_TYPE);
+                broker.flush();
+                broker.saveCollection(txn, collection);
+            }
+
             txnMgr.commit(txn);
         }
     }

--- a/exist-core/src/test/java/org/exist/dom/persistent/BasicNodeSetTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/BasicNodeSetTest.java
@@ -547,10 +547,10 @@ public class BasicNodeSetTest {
                 try (final InputStream is = SAMPLES.getShakespeareSample(sampleName)) {
                     sample = InputStreamUtil.readString(is, UTF_8);
                 }
-                root.storeDocument(transaction, broker, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE, root);
             }
 
-            root.storeDocument(transaction, broker, XmldbURI.create("nested.xml"), new StringInputSource(NESTED_XML), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("nested.xml"), new StringInputSource(NESTED_XML), MimeType.XML_TYPE, root);
             transact.commit(transaction);
 
             //for the tests

--- a/exist-core/src/test/java/org/exist/dom/persistent/BasicNodeSetTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/BasicNodeSetTest.java
@@ -29,11 +29,12 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.storage.lock.Lock;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.io.InputStreamUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.ElementValue;
@@ -546,12 +547,10 @@ public class BasicNodeSetTest {
                 try (final InputStream is = SAMPLES.getShakespeareSample(sampleName)) {
                     sample = InputStreamUtil.readString(is, UTF_8);
                 }
-                final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(sampleName), sample);
-                root.store(transaction, broker, info, sample);
+                root.storeDocument(transaction, broker, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE);
             }
 
-            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("nested.xml"), NESTED_XML);
-            root.store(transaction, broker, info, NESTED_XML);
+            root.storeDocument(transaction, broker, XmldbURI.create("nested.xml"), new StringInputSource(NESTED_XML), MimeType.XML_TYPE);
             transact.commit(transaction);
 
             //for the tests

--- a/exist-core/src/test/java/org/exist/dom/persistent/CommentTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/CommentTest.java
@@ -61,7 +61,7 @@ public class CommentTest {
                 final Txn transaction = pool.getTransactionManager().beginTransaction();
              final Collection collection = broker.openCollection(XmldbURI.ROOT_COLLECTION_URI, Lock.LockMode.WRITE_LOCK)) {
 
-            collection.storeDocument(transaction, broker, docUri, new StringInputSource(xml), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, docUri, new StringInputSource(xml), MimeType.XML_TYPE, collection);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/dom/persistent/CommentTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/CommentTest.java
@@ -24,7 +24,6 @@ package org.exist.dom.persistent;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
@@ -32,6 +31,8 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -60,8 +61,7 @@ public class CommentTest {
                 final Txn transaction = pool.getTransactionManager().beginTransaction();
              final Collection collection = broker.openCollection(XmldbURI.ROOT_COLLECTION_URI, Lock.LockMode.WRITE_LOCK)) {
 
-            final IndexInfo indexInfo = collection.validateXMLResource(transaction, broker, docUri, xml);
-            collection.store(transaction, broker, indexInfo, xml);
+            collection.storeDocument(transaction, broker, docUri, new StringInputSource(xml), MimeType.XML_TYPE);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/dom/persistent/DocTypeTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/DocTypeTest.java
@@ -36,7 +36,6 @@ import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
@@ -101,10 +100,7 @@ public class DocTypeTest {
 			final InputSource is = new FileInputSource(testFile);
 
 			try(final Txn transaction = transact.beginTransaction()) {
-                final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test2.xml"), is);
-
-                assertNotNull(info);
-                root.store(transaction, broker, info, is);
+                root.storeDocument(transaction, broker, XmldbURI.create("test2.xml"), is, MimeType.XML_TYPE);
 
                 transact.commit(transaction);
             }
@@ -166,10 +162,8 @@ public class DocTypeTest {
             assertNotNull(root);
             broker.saveCollection(transaction, root);
             
-            IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), XML);
+            root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(XML), MimeType.XML_TYPE);
             //TODO : unlock the collection here ?
-            assertNotNull(info);
-            root.store(transaction, broker, info, XML);
             
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/dom/persistent/DocTypeTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/DocTypeTest.java
@@ -100,7 +100,7 @@ public class DocTypeTest {
 			final InputSource is = new FileInputSource(testFile);
 
 			try(final Txn transaction = transact.beginTransaction()) {
-                root.storeDocument(transaction, broker, XmldbURI.create("test2.xml"), is, MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("test2.xml"), is, MimeType.XML_TYPE, root);
 
                 transact.commit(transaction);
             }
@@ -162,7 +162,7 @@ public class DocTypeTest {
             assertNotNull(root);
             broker.saveCollection(transaction, root);
             
-            root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(XML), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(XML), MimeType.XML_TYPE, root);
             //TODO : unlock the collection here ?
             
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/dom/persistent/NodeTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/NodeTest.java
@@ -23,7 +23,6 @@ package org.exist.dom.persistent;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -33,6 +32,8 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
 import org.w3c.dom.*;
@@ -240,9 +241,7 @@ public class NodeTest {
             assertNotNull(root);
             broker.saveCollection(transaction, root);
             
-            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), XML);
-            assertNotNull(info);
-            root.store(transaction, broker, info, XML);
+            root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(XML), MimeType.XML_TYPE);
             
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/dom/persistent/NodeTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/NodeTest.java
@@ -241,7 +241,7 @@ public class NodeTest {
             assertNotNull(root);
             broker.saveCollection(transaction, root);
             
-            root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(XML), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(XML), MimeType.XML_TYPE, root);
             
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/dom/persistent/PersistentDomTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/PersistentDomTest.java
@@ -490,7 +490,7 @@ public class PersistentDomTest {
             final Collection collection = broker.getOrCreateCollection(transaction, collectionUri);
             broker.saveCollection(transaction, collection);
             for (final Tuple2<XmldbURI, String> doc : docs) {
-                collection.storeDocument(transaction, broker, doc._1, new StringInputSource(doc._2), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, doc._1, new StringInputSource(doc._2), MimeType.XML_TYPE, collection);
             }
         }
     }

--- a/exist-core/src/test/java/org/exist/dom/persistent/PersistentDomTest.java
+++ b/exist-core/src/test/java/org/exist/dom/persistent/PersistentDomTest.java
@@ -25,7 +25,6 @@ package org.exist.dom.persistent;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -37,6 +36,8 @@ import org.exist.storage.serializers.Serializer;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.util.serializer.SerializerPool;
 import org.exist.xmldb.XmldbURI;
@@ -489,14 +490,9 @@ public class PersistentDomTest {
             final Collection collection = broker.getOrCreateCollection(transaction, collectionUri);
             broker.saveCollection(transaction, collection);
             for (final Tuple2<XmldbURI, String> doc : docs) {
-                storeXml(broker, transaction, collection, doc._1, doc._2);
+                collection.storeDocument(transaction, broker, doc._1, new StringInputSource(doc._2), MimeType.XML_TYPE);
             }
         }
-    }
-
-    private static void storeXml(final DBBroker broker, final Txn transaction, final Collection collection, final XmldbURI name, final String xml) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
-        final IndexInfo indexInfo = collection.validateXMLResource(transaction, broker, name, xml);
-        collection.store(transaction, broker, indexInfo, xml);
     }
 
     private static void deleteCollection(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws PermissionDeniedException, IOException, TriggerException {

--- a/exist-core/src/test/java/org/exist/http/AuditTrailSessionListenerTest.java
+++ b/exist-core/src/test/java/org/exist/http/AuditTrailSessionListenerTest.java
@@ -136,8 +136,8 @@ public class AuditTrailSessionListenerTest {
                 final Txn transaction = existEmbeddedServer.getBrokerPool().getTransactionManager().beginTransaction()) {
 
             final Collection testCollection = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
-            testCollection.storeDocument(transaction, broker, XmldbURI.create(CREATE_SCRIPT), new StringInputSource("<create/>".getBytes(UTF_8)), MimeType.XQUERY_TYPE);
-            testCollection.storeDocument(transaction, broker, XmldbURI.create(DESTROYED_SCRIPT), new StringInputSource("</destroyed>".getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create(CREATE_SCRIPT), new StringInputSource("<create/>".getBytes(UTF_8)), MimeType.XQUERY_TYPE, testCollection);
+            broker.storeDocument(transaction, XmldbURI.create(DESTROYED_SCRIPT), new StringInputSource("</destroyed>".getBytes(UTF_8)), MimeType.XQUERY_TYPE, testCollection);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/http/AuditTrailSessionListenerTest.java
+++ b/exist-core/src/test/java/org/exist/http/AuditTrailSessionListenerTest.java
@@ -34,12 +34,15 @@ import org.exist.storage.lock.LockManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
 
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionEvent;
@@ -47,6 +50,7 @@ import javax.servlet.http.HttpSessionEvent;
 import java.io.IOException;
 import java.util.Optional;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.assertFalse;
 
@@ -121,19 +125,19 @@ public class AuditTrailSessionListenerTest {
     }
 
     @BeforeClass
-    public static void setup() throws EXistException, LockException, TriggerException, PermissionDeniedException, IOException {
+    public static void setup() throws EXistException, LockException, SAXException, PermissionDeniedException, IOException {
         storeScripts();
         System.setProperty(AuditTrailSessionListener.REGISTER_CREATE_XQUERY_SCRIPT_PROPERTY, CREATE_SCRIPT_PATH);
         System.setProperty(AuditTrailSessionListener.REGISTER_DESTROY_XQUERY_SCRIPT_PROPERTY, DESTROYED_SCRIPT_PATH);
     }
 
-    private static void storeScripts() throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
+    private static void storeScripts() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         try(final DBBroker broker = existEmbeddedServer.getBrokerPool().get(Optional.of(existEmbeddedServer.getBrokerPool().getSecurityManager().getSystemSubject()));
                 final Txn transaction = existEmbeddedServer.getBrokerPool().getTransactionManager().beginTransaction()) {
 
             final Collection testCollection = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
-            testCollection.addBinaryResource(transaction, broker, XmldbURI.create(CREATE_SCRIPT), "<create/>".getBytes(), "application/xquery");
-            testCollection.addBinaryResource(transaction, broker, XmldbURI.create(DESTROYED_SCRIPT), "</destroyed>".getBytes(), "application/xquery");
+            testCollection.storeDocument(transaction, broker, XmldbURI.create(CREATE_SCRIPT), new StringInputSource("<create/>".getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+            testCollection.storeDocument(transaction, broker, XmldbURI.create(DESTROYED_SCRIPT), new StringInputSource("</destroyed>".getBytes(UTF_8)), MimeType.XQUERY_TYPE);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/numbering/DLNStorageTest.java
+++ b/exist-core/src/test/java/org/exist/numbering/DLNStorageTest.java
@@ -129,7 +129,7 @@ public class DLNStorageTest {
             Collection test = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
             broker.saveCollection(transaction, test);
 
-            test.storeDocument(transaction, broker, XmldbURI.create("test_string.xml"), new StringInputSource(TEST_XML), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test_string.xml"), new StringInputSource(TEST_XML), MimeType.XML_TYPE, test);
             //TODO : unlock the collection here ?
 
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/numbering/DLNStorageTest.java
+++ b/exist-core/src/test/java/org/exist/numbering/DLNStorageTest.java
@@ -23,7 +23,6 @@ package org.exist.numbering;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.NodeHandle;
 import org.exist.dom.persistent.NodeProxy;
@@ -34,6 +33,8 @@ import org.exist.storage.StorageAddress;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.value.Sequence;
@@ -128,12 +129,8 @@ public class DLNStorageTest {
             Collection test = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
             broker.saveCollection(transaction, test);
 
-            IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create("test_string.xml"),
-                    TEST_XML);
+            test.storeDocument(transaction, broker, XmldbURI.create("test_string.xml"), new StringInputSource(TEST_XML), MimeType.XML_TYPE);
             //TODO : unlock the collection here ?
-            assertNotNull(info);
-
-            test.store(transaction, broker, info, TEST_XML);
 
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/security/FnDocSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/security/FnDocSecurityTest.java
@@ -23,10 +23,7 @@ package org.exist.security;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
-import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.internal.aider.ACEAider;
 import org.exist.security.internal.aider.GroupAider;
 import org.exist.security.internal.aider.UserAider;
@@ -36,6 +33,8 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.SyntaxException;
 import org.exist.util.serializer.XQuerySerializer;
 import org.exist.xmldb.XmldbURI;
@@ -265,8 +264,7 @@ public class FnDocSecurityTest {
 
     private static void createDocument(final DBBroker broker, final Txn transaction, final String collectionUri, final String docName, final String content, final String modeStr) throws PermissionDeniedException, LockException, SAXException, EXistException, IOException, SyntaxException {
         try (final Collection collection = broker.openCollection(XmldbURI.create(collectionUri), Lock.LockMode.WRITE_LOCK)) {
-            final IndexInfo indexInfo = collection.validateXMLResource(transaction, broker, XmldbURI.create(docName), content);
-            collection.store(transaction, broker, indexInfo, content);
+            collection.storeDocument(transaction, broker, XmldbURI.create(docName), new StringInputSource(content), MimeType.XML_TYPE);
 
             PermissionFactory.chmod_str(broker, transaction, XmldbURI.create(collectionUri).append(docName), Optional.of(modeStr), Optional.empty());
         }

--- a/exist-core/src/test/java/org/exist/security/FnDocSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/security/FnDocSecurityTest.java
@@ -264,7 +264,7 @@ public class FnDocSecurityTest {
 
     private static void createDocument(final DBBroker broker, final Txn transaction, final String collectionUri, final String docName, final String content, final String modeStr) throws PermissionDeniedException, LockException, SAXException, EXistException, IOException, SyntaxException {
         try (final Collection collection = broker.openCollection(XmldbURI.create(collectionUri), Lock.LockMode.WRITE_LOCK)) {
-            collection.storeDocument(transaction, broker, XmldbURI.create(docName), new StringInputSource(content), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create(docName), new StringInputSource(content), MimeType.XML_TYPE, collection);
 
             PermissionFactory.chmod_str(broker, transaction, XmldbURI.create(collectionUri).append(docName), Optional.of(modeStr), Optional.empty());
         }

--- a/exist-core/src/test/java/org/exist/stax/EmbeddedXMLStreamReaderTest.java
+++ b/exist-core/src/test/java/org/exist/stax/EmbeddedXMLStreamReaderTest.java
@@ -418,7 +418,7 @@ public class EmbeddedXMLStreamReaderTest {
             final Collection collection = broker.getOrCreateCollection(transaction, collectionUri);
             broker.saveCollection(transaction, collection);
             for (final Tuple2<XmldbURI, String> doc : docs) {
-                collection.storeDocument(transaction, broker, doc._1, new StringInputSource(doc._2), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, doc._1, new StringInputSource(doc._2), MimeType.XML_TYPE, collection);
             }
         }
     }

--- a/exist-core/src/test/java/org/exist/stax/EmbeddedXMLStreamReaderTest.java
+++ b/exist-core/src/test/java/org/exist/stax/EmbeddedXMLStreamReaderTest.java
@@ -26,7 +26,6 @@ import com.evolvedbinary.j8fu.tuple.Tuple2;
 import com.googlecode.junittoolbox.ParallelRunner;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.dom.persistent.NodeHandle;
@@ -39,6 +38,8 @@ import org.exist.storage.lock.ManagedCollectionLock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -417,14 +418,9 @@ public class EmbeddedXMLStreamReaderTest {
             final Collection collection = broker.getOrCreateCollection(transaction, collectionUri);
             broker.saveCollection(transaction, collection);
             for (final Tuple2<XmldbURI, String> doc : docs) {
-                storeXml(broker, transaction, collection, doc._1, doc._2);
+                collection.storeDocument(transaction, broker, doc._1, new StringInputSource(doc._2), MimeType.XML_TYPE);
             }
         }
-    }
-
-    private static void storeXml(final DBBroker broker, final Txn transaction, final Collection collection, final XmldbURI name, final String xml) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
-        final IndexInfo indexInfo = collection.validateXMLResource(transaction, broker, name, xml);
-        collection.store(transaction, broker, indexInfo, xml);
     }
 
     private static void deleteCollection(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws PermissionDeniedException, IOException, TriggerException {

--- a/exist-core/src/test/java/org/exist/storage/AbstractRecoverTest.java
+++ b/exist-core/src/test/java/org/exist/storage/AbstractRecoverTest.java
@@ -37,7 +37,6 @@ import com.evolvedbinary.j8fu.function.Runnable5E;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.collections.Collection;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
@@ -56,6 +55,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -90,7 +90,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeAndLoad() throws LockException, TriggerException, PermissionDeniedException, EXistException,
+    public void storeAndLoad() throws LockException, SAXException, PermissionDeniedException, EXistException,
             IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
 
@@ -105,7 +105,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeAndLoad_isRepeatable() throws LockException, TriggerException, PermissionDeniedException,
+    public void storeAndLoad_isRepeatable() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         storeAndLoad();
         existEmbeddedServer.restart();
@@ -117,7 +117,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeWithoutCommitAndLoad() throws LockException, TriggerException, PermissionDeniedException,
+    public void storeWithoutCommitAndLoad() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
 
@@ -132,7 +132,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeWithoutCommitAndLoad_isRepeatable() throws LockException, TriggerException,
+    public void storeWithoutCommitAndLoad_isRepeatable() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         storeWithoutCommitAndLoad();
         existEmbeddedServer.restart();
@@ -144,7 +144,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeThenDeleteAndLoad() throws LockException, TriggerException, PermissionDeniedException,
+    public void storeThenDeleteAndLoad() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
 
@@ -160,7 +160,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeThenDeleteAndLoad_isRepeatable() throws LockException, TriggerException, PermissionDeniedException,
+    public void storeThenDeleteAndLoad_isRepeatable() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         storeThenDeleteAndLoad();
         existEmbeddedServer.restart();
@@ -172,7 +172,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeWithoutCommitThenDeleteAndLoad() throws LockException, TriggerException, PermissionDeniedException,
+    public void storeWithoutCommitThenDeleteAndLoad() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
 
@@ -188,7 +188,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeWithoutCommitThenDeleteAndLoad_isRepeatable() throws LockException, TriggerException,
+    public void storeWithoutCommitThenDeleteAndLoad_isRepeatable() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         storeWithoutCommitThenDeleteAndLoad();
         existEmbeddedServer.restart();
@@ -200,7 +200,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeThenDeleteWithoutCommitAndLoad() throws LockException, TriggerException, PermissionDeniedException,
+    public void storeThenDeleteWithoutCommitAndLoad() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
 
@@ -216,7 +216,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeThenDeleteWithoutCommitAndLoad_isRepeatable() throws LockException, TriggerException,
+    public void storeThenDeleteWithoutCommitAndLoad_isRepeatable() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         storeThenDeleteWithoutCommitAndLoad();
         existEmbeddedServer.restart();
@@ -228,7 +228,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeWithoutCommitThenDeleteWithoutCommitAndLoad() throws LockException, TriggerException,
+    public void storeWithoutCommitThenDeleteWithoutCommitAndLoad() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
 
@@ -244,7 +244,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void storeWithoutCommitThenDeleteWithoutCommitAndLoad_isRepeatable() throws LockException, TriggerException,
+    public void storeWithoutCommitThenDeleteWithoutCommitAndLoad_isRepeatable() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         storeWithoutCommitThenDeleteWithoutCommitAndLoad();
         existEmbeddedServer.restart();
@@ -256,7 +256,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void deleteAndLoad() throws LockException, TriggerException, PermissionDeniedException, EXistException,
+    public void deleteAndLoad() throws LockException, SAXException, PermissionDeniedException, EXistException,
             IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
 
@@ -276,7 +276,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void deleteAndLoad_isRepeatable() throws LockException, TriggerException, PermissionDeniedException,
+    public void deleteAndLoad_isRepeatable() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         deleteAndLoad();
         existEmbeddedServer.restart();
@@ -288,7 +288,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void deleteWithoutCommitAndLoad() throws LockException, TriggerException, PermissionDeniedException,
+    public void deleteWithoutCommitAndLoad() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
 
@@ -308,7 +308,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void deleteWithoutCommitAndLoad_isRepeatable() throws LockException, TriggerException,
+    public void deleteWithoutCommitAndLoad_isRepeatable() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         deleteWithoutCommitAndLoad();
         existEmbeddedServer.restart();
@@ -320,7 +320,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void replaceAndLoad() throws LockException, TriggerException, PermissionDeniedException, EXistException,
+    public void replaceAndLoad() throws LockException, SAXException, PermissionDeniedException, EXistException,
             IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
         final String testFilename = FileUtils.fileName(testFile);
@@ -344,7 +344,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void replaceAndLoad_isRepeatable() throws LockException, TriggerException, PermissionDeniedException,
+    public void replaceAndLoad_isRepeatable() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         replaceAndLoad();
         existEmbeddedServer.restart();
@@ -356,7 +356,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void replaceWithoutCommitAndLoad() throws LockException, TriggerException, PermissionDeniedException,
+    public void replaceWithoutCommitAndLoad() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
         final String testFilename = FileUtils.fileName(testFile);
@@ -380,7 +380,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void replaceWithoutCommitAndLoad_isRepeatable() throws LockException, TriggerException,
+    public void replaceWithoutCommitAndLoad_isRepeatable() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         replaceWithoutCommitAndLoad();
         existEmbeddedServer.restart();
@@ -392,7 +392,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void replaceThenDeleteAndLoad() throws LockException, TriggerException, PermissionDeniedException,
+    public void replaceThenDeleteAndLoad() throws LockException, SAXException, PermissionDeniedException,
             EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
         final String testFilename = FileUtils.fileName(testFile);
@@ -417,7 +417,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void replaceThenDeleteAndLoad_isRepeatable() throws LockException, TriggerException,
+    public void replaceThenDeleteAndLoad_isRepeatable() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         replaceThenDeleteAndLoad();
         existEmbeddedServer.restart();
@@ -466,7 +466,7 @@ public abstract class AbstractRecoverTest {
      */
     @Ignore("Only possible from a single-thread by programming error. Journal is not expected to recover such cases!")
     @Test
-    public void replaceWithoutCommitThenDeleteAndLoad() throws LockException, TriggerException,
+    public void replaceWithoutCommitThenDeleteAndLoad() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
         final String testFilename = FileUtils.fileName(testFile);
@@ -528,7 +528,7 @@ public abstract class AbstractRecoverTest {
      */
     @Ignore("Only possible from a single-thread by programming error. Journal is not expected to recover such cases!")
     @Test
-    public void replaceWithoutCommitThenDeleteAndLoad_isRepeatable() throws LockException, TriggerException,
+    public void replaceWithoutCommitThenDeleteAndLoad_isRepeatable() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         replaceWithoutCommitThenDeleteAndLoad();
         existEmbeddedServer.restart();
@@ -540,7 +540,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void replaceThenDeleteWithoutCommitAndLoad() throws LockException, TriggerException,
+    public void replaceThenDeleteWithoutCommitAndLoad() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
         final String testFilename = FileUtils.fileName(testFile);
@@ -565,7 +565,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void replaceThenDeleteWithoutCommitAndLoad_isRepeatable() throws LockException, TriggerException,
+    public void replaceThenDeleteWithoutCommitAndLoad_isRepeatable() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         replaceThenDeleteWithoutCommitAndLoad();
         existEmbeddedServer.restart();
@@ -577,7 +577,7 @@ public abstract class AbstractRecoverTest {
     }
 
     @Test
-    public void replaceWithoutCommitThenDeleteWithoutCommitAndLoad() throws LockException, TriggerException,
+    public void replaceWithoutCommitThenDeleteWithoutCommitAndLoad() throws LockException, SAXException,
             PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         final Path testFile = getTestFile1();
         final String testFilename = FileUtils.fileName(testFile);
@@ -603,7 +603,7 @@ public abstract class AbstractRecoverTest {
 
     @Test
     public void replaceWithoutCommitThenDeleteWithoutCommitAndLoad_isRepeatable() throws LockException,
-            TriggerException, PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
+            SAXException, PermissionDeniedException, EXistException, IOException, DatabaseConfigurationException, InterruptedException {
         replaceWithoutCommitThenDeleteWithoutCommitAndLoad();
         existEmbeddedServer.restart();
 
@@ -624,7 +624,7 @@ public abstract class AbstractRecoverTest {
      * @param file The file that to store
      */
     protected void store(final boolean commitAndClose, final Path file) throws EXistException, PermissionDeniedException,
-            IOException, TriggerException, LockException, InterruptedException {
+            IOException, SAXException, LockException, InterruptedException {
         store(commitAndClose, file, FileUtils.fileName(file));
     }
 
@@ -637,7 +637,7 @@ public abstract class AbstractRecoverTest {
      * @param dbFilename the name to use when storing the file in the database
      */
     private void store(final boolean commitAndClose, final Path file, final String dbFilename) throws EXistException,
-            PermissionDeniedException, IOException, TriggerException, LockException, InterruptedException {
+            PermissionDeniedException, IOException, SAXException, LockException, InterruptedException {
         store(commitAndClose, new FileInputSource(file), dbFilename);
     }
 
@@ -650,7 +650,7 @@ public abstract class AbstractRecoverTest {
      * @param dbFilename the name to use when storing the file in the database
      */
     protected void store(final boolean commitAndClose, final InputSource data, final String dbFilename) throws EXistException,
-            PermissionDeniedException, IOException, TriggerException, LockException, InterruptedException {
+            PermissionDeniedException, IOException, SAXException, LockException, InterruptedException {
 
 
         runSync(new BrokerTask(existEmbeddedServer.getBrokerPool(), (broker, transaction) -> {
@@ -680,7 +680,7 @@ public abstract class AbstractRecoverTest {
      */
     protected abstract void storeAndVerify(final DBBroker broker, final Txn transaction, final Collection collection,
             final InputSource data, final String dbFilename) throws EXistException, PermissionDeniedException,
-            IOException, TriggerException, LockException;
+            IOException, SAXException, LockException;
 
     /**
      * Read a document from the database.
@@ -750,7 +750,7 @@ public abstract class AbstractRecoverTest {
      * @param file The file that was previously stored, that should be deleted
      */
     private void delete(final boolean commitAndClose, final Path file)
-            throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException, InterruptedException {
+            throws EXistException, PermissionDeniedException, IOException, SAXException, LockException, InterruptedException {
         delete(commitAndClose, FileUtils.fileName(file));
     }
 
@@ -762,7 +762,7 @@ public abstract class AbstractRecoverTest {
      * @param dbFilename The name of the file that was previously stored, that should be deleted
      */
     private void delete(final boolean commitAndClose, final String dbFilename)
-            throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException, InterruptedException {
+            throws EXistException, PermissionDeniedException, IOException, SAXException, LockException, InterruptedException {
 
         runSync(new BrokerTask(existEmbeddedServer.getBrokerPool(), (broker, transaction) -> {
             final Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
@@ -797,7 +797,7 @@ public abstract class AbstractRecoverTest {
     }
 
     private int runSyncId = 0;
-    private void runSync(final BrokerTask brokerTask) throws InterruptedException, LockException, TriggerException, PermissionDeniedException, EXistException, IOException {
+    private void runSync(final BrokerTask brokerTask) throws InterruptedException, LockException, SAXException, PermissionDeniedException, EXistException, IOException {
         final String brokerTaskName = "AbstractRecoveryTest#runSync-" + runSyncId++;
         final Thread thread = new Thread(brokerTask, brokerTaskName);
         thread.start();
@@ -806,11 +806,11 @@ public abstract class AbstractRecoverTest {
     }
 
     private static class BrokerTask implements Runnable {
-        private final BiConsumer5E<DBBroker, Txn, EXistException, PermissionDeniedException, IOException, TriggerException, LockException> task;
+        private final BiConsumer5E<DBBroker, Txn, EXistException, PermissionDeniedException, IOException, SAXException, LockException> task;
         private final BrokerPool pool;
-        private volatile Runnable5E<EXistException, PermissionDeniedException, IOException, TriggerException, LockException> exception = null;
+        private volatile Runnable5E<EXistException, PermissionDeniedException, IOException, SAXException, LockException> exception = null;
 
-        public BrokerTask(final BrokerPool pool, final BiConsumer5E<DBBroker, Txn, EXistException, PermissionDeniedException, IOException, TriggerException, LockException> task) {
+        public BrokerTask(final BrokerPool pool, final BiConsumer5E<DBBroker, Txn, EXistException, PermissionDeniedException, IOException, SAXException, LockException> task) {
             this.pool = pool;
             this.task = task;
         }
@@ -822,7 +822,7 @@ public abstract class AbstractRecoverTest {
                 final Txn transaction = transact.beginTransaction();
 
                 task.accept(broker, transaction);
-            } catch (final EXistException | PermissionDeniedException | IOException | TriggerException | LockException e) {
+            } catch (final EXistException | PermissionDeniedException | IOException | SAXException | LockException e) {
                 this.exception = () -> { throw e; };
             }
         }
@@ -830,7 +830,7 @@ public abstract class AbstractRecoverTest {
         /**
          * If an exception is present, throw it
          */
-        public void throwIfException() throws LockException, TriggerException, PermissionDeniedException, EXistException, IOException {
+        public void throwIfException() throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
             if (exception != null) {
                 exception.run();
             }

--- a/exist-core/src/test/java/org/exist/storage/AbstractUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/storage/AbstractUpdateTest.java
@@ -122,7 +122,7 @@ public abstract class AbstractUpdateTest {
 	        final Collection test = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI.append("test2"));
 	        broker.saveCollection(transaction, test);
 	        
-	        test.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(TEST_XML), MimeType.XML_TYPE);
+	        broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(TEST_XML), MimeType.XML_TYPE, test);
             doc = test.getDocument(broker, XmldbURI.create("test.xml"));
 	        //TODO : unlock the collection here ?
 	

--- a/exist-core/src/test/java/org/exist/storage/AbstractUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/storage/AbstractUpdateTest.java
@@ -23,8 +23,8 @@ package org.exist.storage;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DefaultDocumentSet;
+import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.security.PermissionDeniedException;
@@ -35,6 +35,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -69,9 +71,9 @@ public abstract class AbstractUpdateTest {
             final TransactionManager transact = pool.getTransactionManager();
 
             try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
-                final IndexInfo info = init(broker, transact);
+                final DocumentImpl doc = init(broker, transact);
                 final MutableDocumentSet docs = new DefaultDocumentSet();
-                docs.add(info.getDocument());
+                docs.add(doc);
 
                 doUpdate(broker, transact, docs);
 
@@ -110,9 +112,9 @@ public abstract class AbstractUpdateTest {
         }
     }
 
-    protected IndexInfo init(final DBBroker broker, final TransactionManager transact) throws PermissionDeniedException, IOException, SAXException, LockException, EXistException {
-    	IndexInfo info = null;
-    	try(final Txn transaction = transact.beginTransaction()) {
+    protected DocumentImpl init(final DBBroker broker, final TransactionManager transact) throws PermissionDeniedException, IOException, SAXException, LockException, EXistException {
+    	DocumentImpl doc = null;
+        try(final Txn transaction = transact.beginTransaction()) {
 	        
 	        final Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
 	        broker.saveCollection(transaction, root);
@@ -120,13 +122,13 @@ public abstract class AbstractUpdateTest {
 	        final Collection test = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI.append("test2"));
 	        broker.saveCollection(transaction, test);
 	        
-	        info = test.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), TEST_XML);
+	        test.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(TEST_XML), MimeType.XML_TYPE);
+            doc = test.getDocument(broker, XmldbURI.create("test.xml"));
 	        //TODO : unlock the collection here ?
-	        test.store(transaction, broker, info, TEST_XML);
 	
 	        transact.commit(transaction);	
 	    }
-	    return info;
+	    return doc;
     }
     
     protected BrokerPool startDb() throws DatabaseConfigurationException, EXistException, IOException {

--- a/exist-core/src/test/java/org/exist/storage/BinaryDocumentTest.java
+++ b/exist-core/src/test/java/org/exist/storage/BinaryDocumentTest.java
@@ -62,14 +62,14 @@ public class BinaryDocumentTest {
             broker.saveCollection(transaction, thingCollection);
 
             // add a binary document to the collection
-            thingCollection.storeDocument(transaction, broker, XmldbURI.create("file1.bin"), new StringInputSource("binary-file1".getBytes(UTF_8)), MimeType.BINARY_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("file1.bin"), new StringInputSource("binary-file1".getBytes(UTF_8)), MimeType.BINARY_TYPE, thingCollection);
 
             // remove the collection
             assertTrue(broker.removeCollection(transaction, thingCollection));
 
             // try and store a binary doc with the same name as the thing collection (should succeed)
             final Collection testCollection = broker.getCollection(testCollectionUri);
-            testCollection.storeDocument(transaction, broker, XmldbURI.create("thing"), new StringInputSource("binary-file2".getBytes(UTF_8)), MimeType.BINARY_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("thing"), new StringInputSource("binary-file2".getBytes(UTF_8)), MimeType.BINARY_TYPE, testCollection);
         }
     }
 
@@ -90,7 +90,7 @@ public class BinaryDocumentTest {
             final Collection testCollection = broker.getCollection(testCollectionUri);
 
             try {
-                testCollection.storeDocument(transaction, broker, thingUri.lastSegment(), new StringInputSource("binary-file".getBytes(UTF_8)), MimeType.BINARY_TYPE);
+                broker.storeDocument(transaction, thingUri.lastSegment(), new StringInputSource("binary-file".getBytes(UTF_8)), MimeType.BINARY_TYPE, testCollection);
                 fail("Should not have been able to overwrite Collection with Binary Document");
 
             } catch (final EXistException e) {

--- a/exist-core/src/test/java/org/exist/storage/BinaryDocumentTest.java
+++ b/exist-core/src/test/java/org/exist/storage/BinaryDocumentTest.java
@@ -24,18 +24,18 @@ package org.exist.storage;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
-import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -49,7 +49,7 @@ public class BinaryDocumentTest {
     public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
     @Test
-    public void removeCollection() throws PermissionDeniedException, IOException, TriggerException, LockException, EXistException {
+    public void removeCollection() throws PermissionDeniedException, IOException, SAXException, LockException, EXistException {
         final XmldbURI testCollectionUri = XmldbURI.create("/db/remove-collection-test");
         final XmldbURI thingUri = testCollectionUri.append("thing");
 
@@ -62,25 +62,19 @@ public class BinaryDocumentTest {
             broker.saveCollection(transaction, thingCollection);
 
             // add a binary document to the collection
-            final byte[] binaryData1 = "binary-file1".getBytes(UTF_8);
-            try (final InputStream is = new UnsynchronizedByteArrayInputStream(binaryData1)) {
-                thingCollection.addBinaryResource(transaction, broker, XmldbURI.create("file1.bin"), is, "application/octet-stream", binaryData1.length);
-            }
+            thingCollection.storeDocument(transaction, broker, XmldbURI.create("file1.bin"), new StringInputSource("binary-file1".getBytes(UTF_8)), MimeType.BINARY_TYPE);
 
             // remove the collection
             assertTrue(broker.removeCollection(transaction, thingCollection));
 
             // try and store a binary doc with the same name as the thing collection (should succeed)
             final Collection testCollection = broker.getCollection(testCollectionUri);
-            final byte[] binaryData2 = "binary-file2".getBytes(UTF_8);
-            try (final InputStream is = new UnsynchronizedByteArrayInputStream(binaryData2)) {
-                testCollection.addBinaryResource(transaction, broker, XmldbURI.create("thing"), is, "application/octet-stream", binaryData2.length);
-            }
+            testCollection.storeDocument(transaction, broker, XmldbURI.create("thing"), new StringInputSource("binary-file2".getBytes(UTF_8)), MimeType.BINARY_TYPE);
         }
     }
 
     @Test
-    public void overwriteCollection() throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
+    public void overwriteCollection() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final XmldbURI testCollectionUri = XmldbURI.create("/db/overwrite-collection-test");
         final XmldbURI thingUri = testCollectionUri.append("thing");
 
@@ -95,19 +89,15 @@ public class BinaryDocumentTest {
             // attempt to create a binary document with the same uri as the thingCollection (should fail)
             final Collection testCollection = broker.getCollection(testCollectionUri);
 
-            final byte[] binaryData = "binary-file".getBytes(UTF_8);
-            try (final InputStream is = new UnsynchronizedByteArrayInputStream(binaryData)) {
+            try {
+                testCollection.storeDocument(transaction, broker, thingUri.lastSegment(), new StringInputSource("binary-file".getBytes(UTF_8)), MimeType.BINARY_TYPE);
+                fail("Should not have been able to overwrite Collection with Binary Document");
 
-                try {
-                    testCollection.addBinaryResource(transaction, broker, thingUri.lastSegment(), is, "application/octet-stream", binaryData.length);
-                    fail("Should not have been able to overwrite Collection with Binary Document");
-
-                } catch (final EXistException e) {
-                    assertEquals(
-                            "The collection '" + testCollectionUri.getRawCollectionPath() + "' already has a sub-collection named '" + thingUri.lastSegment().toString() + "', you cannot create a Document with the same name as an existing collection.",
-                            e.getMessage()
-                    );
-                }
+            } catch (final EXistException e) {
+                assertEquals(
+                        "The collection '" + testCollectionUri.getRawCollectionPath() + "' already has a sub-collection named '" + thingUri.lastSegment().toString() + "', you cannot create a Document with the same name as an existing collection.",
+                        e.getMessage()
+                );
             }
         }
     }

--- a/exist-core/src/test/java/org/exist/storage/ConcurrentBrokerPoolTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ConcurrentBrokerPoolTest.java
@@ -176,7 +176,7 @@ public class ConcurrentBrokerPoolTest {
 
                     final String docContent = docContent(uuid);
 
-                    collection.storeDocument(transaction, broker, docName(uuid), new StringInputSource(docContent), MimeType.XML_TYPE);
+                    broker.storeDocument(transaction, docName(uuid), new StringInputSource(docContent), MimeType.XML_TYPE, collection);
 
                     transaction.commit();
                 }

--- a/exist-core/src/test/java/org/exist/storage/ConcurrentBrokerPoolTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ConcurrentBrokerPoolTest.java
@@ -25,16 +25,13 @@ package org.exist.storage;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.journal.Journal;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
-import org.exist.util.DatabaseConfigurationException;
-import org.exist.util.FileUtils;
-import org.exist.util.LockException;
+import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
 import org.junit.Test;
 import org.xml.sax.SAXException;
@@ -177,11 +174,9 @@ public class ConcurrentBrokerPoolTest {
                     final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
                 try (final Collection collection = broker.openCollection(XmldbURI.DB, Lock.LockMode.WRITE_LOCK)){
 
-
                     final String docContent = docContent(uuid);
 
-                    final IndexInfo indexInfo = collection.validateXMLResource(transaction, broker, docName(uuid), docContent);
-                    collection.store(transaction, broker, indexInfo, docContent);
+                    collection.storeDocument(transaction, broker, docName(uuid), new StringInputSource(docContent), MimeType.XML_TYPE);
 
                     transaction.commit();
                 }

--- a/exist-core/src/test/java/org/exist/storage/ConcurrentStoreTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ConcurrentStoreTest.java
@@ -154,7 +154,7 @@ public class ConcurrentStoreTest {
                 for (final String sampleName : SAMPLES.getShakespeareXmlSampleNames()) {
                     try (final InputStream is = SAMPLES.getShakespeareSample(sampleName)) {
                         final String sample = InputStreamUtil.readString(is, UTF_8);
-                        test.storeDocument(transaction, broker, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE);
+                        broker.storeDocument(transaction, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE, test);
                     } catch (SAXException e) {
                         System.err.println("Error found while parsing document: " + sampleName + ": " + e.getMessage());
                     }
@@ -195,7 +195,7 @@ public class ConcurrentStoreTest {
 
                 try (final InputStream is = SAMPLES.getHamletSample()) {
                     final String sample = InputStreamUtil.readString(is, UTF_8);
-                    test.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
+                    broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE, test);
                 } catch (SAXException e) {
                     System.err.println("Error found while parsing document: hamlet.xml: " + e.getMessage());
                 }

--- a/exist-core/src/test/java/org/exist/storage/ConcurrentStoreTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ConcurrentStoreTest.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.ConcurrencyTest;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
@@ -151,13 +150,11 @@ public class ConcurrentStoreTest {
             try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                     final Txn transaction = transact.beginTransaction()) {
 
-                IndexInfo info;
                 // store some documents into the test collection
                 for (final String sampleName : SAMPLES.getShakespeareXmlSampleNames()) {
                     try (final InputStream is = SAMPLES.getShakespeareSample(sampleName)) {
                         final String sample = InputStreamUtil.readString(is, UTF_8);
-                        info = test.validateXMLResource(transaction, broker, XmldbURI.create(sampleName), sample);
-                        test.store(transaction, broker, info, sample);
+                        test.storeDocument(transaction, broker, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE);
                     } catch (SAXException e) {
                         System.err.println("Error found while parsing document: " + sampleName + ": " + e.getMessage());
                     }
@@ -198,8 +195,7 @@ public class ConcurrentStoreTest {
 
                 try (final InputStream is = SAMPLES.getHamletSample()) {
                     final String sample = InputStreamUtil.readString(is, UTF_8);
-                    IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), sample);
-                    test.store(transaction, broker, info, sample);
+                    test.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
                 } catch (SAXException e) {
                     System.err.println("Error found while parsing document: hamlet.xml: " + e.getMessage());
                 }

--- a/exist-core/src/test/java/org/exist/storage/CopyCollectionRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/CopyCollectionRecoveryTest.java
@@ -137,7 +137,7 @@ public class CopyCollectionRecoveryTest {
             broker.saveCollection(transaction, test);
 
             final String sample = getSampleData();
-            test.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE, test);
 
             final Collection dest = broker.getOrCreateCollection(transaction, XmldbURI.ROOT_COLLECTION_URI.append("destination"));
             broker.saveCollection(transaction, dest);
@@ -180,7 +180,7 @@ public class CopyCollectionRecoveryTest {
 
                 final String sample = getSampleData();
 
-                test2.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE, test2);
 
                 transact.commit(transaction);
             }

--- a/exist-core/src/test/java/org/exist/storage/CopyCollectionRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/CopyCollectionRecoveryTest.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.lock.Lock.LockMode;
@@ -38,6 +37,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.io.InputStreamUtil;
 import org.exist.xmldb.DatabaseImpl;
 import org.exist.xmldb.EXistCollectionManagementService;
@@ -136,9 +137,7 @@ public class CopyCollectionRecoveryTest {
             broker.saveCollection(transaction, test);
 
             final String sample = getSampleData();
-            final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"),
-                    sample);
-            test.store(transaction, broker, info, sample);
+            test.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
 
             final Collection dest = broker.getOrCreateCollection(transaction, XmldbURI.ROOT_COLLECTION_URI.append("destination"));
             broker.saveCollection(transaction, dest);
@@ -181,8 +180,7 @@ public class CopyCollectionRecoveryTest {
 
                 final String sample = getSampleData();
 
-                IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), sample);
-                test2.store(transaction, broker, info, sample);
+                test2.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
 
                 transact.commit(transaction);
             }

--- a/exist-core/src/test/java/org/exist/storage/CopyResourceRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/CopyResourceRecoveryTest.java
@@ -112,7 +112,7 @@ public class CopyResourceRecoveryTest {
                     assertNotNull(is);
                     sample = InputStreamUtil.readString(is, UTF_8);
                 }
-                subTestCollection.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(sample), MimeType.XML_TYPE, subTestCollection);
                 doc = subTestCollection.getDocument(broker, XmldbURI.create("test.xml"));
 
                 transact.commit(transaction);
@@ -169,7 +169,7 @@ public class CopyResourceRecoveryTest {
                     assertNotNull(is);
                     sample = InputStreamUtil.readString(is, UTF_8);
                 }
-                subTestCollection.storeDocument(transaction, broker, XmldbURI.create("test2.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("test2.xml"), new StringInputSource(sample), MimeType.XML_TYPE, subTestCollection);
                 doc = subTestCollection.getDocument(broker, XmldbURI.create("test2.xml"));
 
                 transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/storage/CopyResourceTest.java
+++ b/exist-core/src/test/java/org/exist/storage/CopyResourceTest.java
@@ -505,28 +505,28 @@ public class CopyResourceTest {
                 final Collection collection = broker.openCollection(TEST_COLLECTION_URI, LockMode.WRITE_LOCK)) {
 
             final String u1d1xml = "<empty1/>";
-            collection.storeDocument(transaction, broker, USER1_DOC1, new StringInputSource(u1d1xml), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, USER1_DOC1, new StringInputSource(u1d1xml), MimeType.XML_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC1), USER1_DOC1_MODE);
 
             final String u1d2xml = "<empty2/>";
-            collection.storeDocument(transaction, broker, USER1_DOC2, new StringInputSource(u1d2xml), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, USER1_DOC2, new StringInputSource(u1d2xml), MimeType.XML_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC2), USER1_DOC2_MODE);
 
             final String u1d3xml = "<empty3/>";
-            collection.storeDocument(transaction, broker, USER1_DOC3, new StringInputSource(u1d3xml), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, USER1_DOC3, new StringInputSource(u1d3xml), MimeType.XML_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC3), USER1_DOC3_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC3), GROUP1_NAME);
 
             final String u1d1bin = "bin1";
-            collection.storeDocument(transaction, broker, USER1_BIN_DOC1, new StringInputSource(u1d1bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
+            broker.storeDocument(transaction, USER1_BIN_DOC1, new StringInputSource(u1d1bin.getBytes(UTF_8)), MimeType.TEXT_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC1), USER1_BIN_DOC1_MODE);
 
             final String u1d2bin = "bin2";
-            collection.storeDocument(transaction, broker, USER1_BIN_DOC2,  new StringInputSource(u1d2bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
+            broker.storeDocument(transaction, USER1_BIN_DOC2, new StringInputSource(u1d2bin.getBytes(UTF_8)), MimeType.TEXT_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC2), USER1_BIN_DOC2_MODE);
 
             final String u1d3bin = "bin3";
-            collection.storeDocument(transaction, broker, USER1_BIN_DOC3,  new StringInputSource(u1d3bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
+            broker.storeDocument(transaction, USER1_BIN_DOC3, new StringInputSource(u1d3bin.getBytes(UTF_8)), MimeType.TEXT_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC3), USER1_BIN_DOC3_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC3), GROUP1_NAME);
 
@@ -540,20 +540,20 @@ public class CopyResourceTest {
                 final Collection collection = broker.openCollection(TEST_COLLECTION_URI, LockMode.WRITE_LOCK)) {
 
             final String u2d2xml = "<empty2/>";
-            collection.storeDocument(transaction, broker, USER2_DOC2, new StringInputSource(u2d2xml), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, USER2_DOC2, new StringInputSource(u2d2xml), MimeType.XML_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER2_DOC2), USER2_DOC2_MODE);
 
             final String u2d3xml = "<empty3/>";
-            collection.storeDocument(transaction, broker, USER2_DOC3, new StringInputSource(u2d3xml), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, USER2_DOC3, new StringInputSource(u2d3xml), MimeType.XML_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER2_DOC3), USER2_DOC3_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER2_DOC3), GROUP1_NAME);
 
             final String u2d2bin = "bin2";
-            collection.storeDocument(transaction, broker, USER2_BIN_DOC2, new StringInputSource(u2d2bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
+            broker.storeDocument(transaction, USER2_BIN_DOC2, new StringInputSource(u2d2bin.getBytes(UTF_8)), MimeType.TEXT_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER2_BIN_DOC2), USER2_BIN_DOC2_MODE);
 
             final String u2d3bin = "bin3";
-            collection.storeDocument(transaction, broker, USER2_BIN_DOC3, new StringInputSource(u2d3bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
+            broker.storeDocument(transaction, USER2_BIN_DOC3, new StringInputSource(u2d3bin.getBytes(UTF_8)), MimeType.TEXT_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER2_BIN_DOC3), USER2_BIN_DOC3_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER2_BIN_DOC3), GROUP1_NAME);
 

--- a/exist-core/src/test/java/org/exist/storage/CopyResourceTest.java
+++ b/exist-core/src/test/java/org/exist/storage/CopyResourceTest.java
@@ -23,7 +23,6 @@ package org.exist.storage;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
@@ -36,6 +35,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.hamcrest.Matcher;
 import org.junit.*;
@@ -504,31 +505,28 @@ public class CopyResourceTest {
                 final Collection collection = broker.openCollection(TEST_COLLECTION_URI, LockMode.WRITE_LOCK)) {
 
             final String u1d1xml = "<empty1/>";
-            final IndexInfo u1d1ii = collection.validateXMLResource(transaction, broker, USER1_DOC1, u1d1xml);
-            collection.store(transaction, broker, u1d1ii, u1d1xml);
+            collection.storeDocument(transaction, broker, USER1_DOC1, new StringInputSource(u1d1xml), MimeType.XML_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC1), USER1_DOC1_MODE);
 
             final String u1d2xml = "<empty2/>";
-            final IndexInfo u1d2ii = collection.validateXMLResource(transaction, broker, USER1_DOC2, u1d2xml);
-            collection.store(transaction, broker, u1d2ii, u1d2xml);
+            collection.storeDocument(transaction, broker, USER1_DOC2, new StringInputSource(u1d2xml), MimeType.XML_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC2), USER1_DOC2_MODE);
 
             final String u1d3xml = "<empty3/>";
-            final IndexInfo u1d3ii = collection.validateXMLResource(transaction, broker, USER1_DOC3, u1d3xml);
-            collection.store(transaction, broker, u1d3ii, u1d3xml);
+            collection.storeDocument(transaction, broker, USER1_DOC3, new StringInputSource(u1d3xml), MimeType.XML_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC3), USER1_DOC3_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC3), GROUP1_NAME);
 
             final String u1d1bin = "bin1";
-            collection.addBinaryResource(transaction, broker, USER1_BIN_DOC1, u1d1bin.getBytes(UTF_8), "text/plain");
+            collection.storeDocument(transaction, broker, USER1_BIN_DOC1, new StringInputSource(u1d1bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC1), USER1_BIN_DOC1_MODE);
 
             final String u1d2bin = "bin2";
-            collection.addBinaryResource(transaction, broker, USER1_BIN_DOC2, u1d2bin.getBytes(UTF_8), "text/plain");
+            collection.storeDocument(transaction, broker, USER1_BIN_DOC2,  new StringInputSource(u1d2bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC2), USER1_BIN_DOC2_MODE);
 
             final String u1d3bin = "bin3";
-            collection.addBinaryResource(transaction, broker, USER1_BIN_DOC3, u1d3bin.getBytes(UTF_8), "text/plain");
+            collection.storeDocument(transaction, broker, USER1_BIN_DOC3,  new StringInputSource(u1d3bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC3), USER1_BIN_DOC3_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC3), GROUP1_NAME);
 
@@ -542,22 +540,20 @@ public class CopyResourceTest {
                 final Collection collection = broker.openCollection(TEST_COLLECTION_URI, LockMode.WRITE_LOCK)) {
 
             final String u2d2xml = "<empty2/>";
-            final IndexInfo u2d2ii = collection.validateXMLResource(transaction, broker, USER2_DOC2, u2d2xml);
-            collection.store(transaction, broker, u2d2ii, u2d2xml);
+            collection.storeDocument(transaction, broker, USER2_DOC2, new StringInputSource(u2d2xml), MimeType.XML_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER2_DOC2), USER2_DOC2_MODE);
 
             final String u2d3xml = "<empty3/>";
-            final IndexInfo u2d3ii = collection.validateXMLResource(transaction, broker, USER2_DOC3, u2d3xml);
-            collection.store(transaction, broker, u2d3ii, u2d3xml);
+            collection.storeDocument(transaction, broker, USER2_DOC3, new StringInputSource(u2d3xml), MimeType.XML_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER2_DOC3), USER2_DOC3_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER2_DOC3), GROUP1_NAME);
 
             final String u2d2bin = "bin2";
-            collection.addBinaryResource(transaction, broker, USER2_BIN_DOC2, u2d2bin.getBytes(UTF_8), "text/plain");
+            collection.storeDocument(transaction, broker, USER2_BIN_DOC2, new StringInputSource(u2d2bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER2_BIN_DOC2), USER2_BIN_DOC2_MODE);
 
             final String u2d3bin = "bin3";
-            collection.addBinaryResource(transaction, broker, USER2_BIN_DOC3, u2d3bin.getBytes(UTF_8), "text/plain");
+            collection.storeDocument(transaction, broker, USER2_BIN_DOC3, new StringInputSource(u2d3bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER2_BIN_DOC3), USER2_BIN_DOC3_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER2_BIN_DOC3), GROUP1_NAME);
 

--- a/exist-core/src/test/java/org/exist/storage/DirtyShutdownTest.java
+++ b/exist-core/src/test/java/org/exist/storage/DirtyShutdownTest.java
@@ -28,10 +28,11 @@ import org.exist.EXistException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.test.TestConstants;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 
@@ -101,9 +102,7 @@ public class DirtyShutdownTest {
             for (int i = 0; i < 50; i++) {
                 try(final Txn transaction = transact.beginTransaction()) {
 
-                    final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), data);
-                    assertNotNull(info);
-                    root.store(transaction, broker, info, data);
+                    root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(data), MimeType.XML_TYPE);
 
                     transact.commit(transaction);
                 }

--- a/exist-core/src/test/java/org/exist/storage/DirtyShutdownTest.java
+++ b/exist-core/src/test/java/org/exist/storage/DirtyShutdownTest.java
@@ -102,7 +102,7 @@ public class DirtyShutdownTest {
             for (int i = 0; i < 50; i++) {
                 try(final Txn transaction = transact.beginTransaction()) {
 
-                    root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(data), MimeType.XML_TYPE);
+                    broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(data), MimeType.XML_TYPE, root);
 
                     transact.commit(transaction);
                 }

--- a/exist-core/src/test/java/org/exist/storage/LargeValuesTest.java
+++ b/exist-core/src/test/java/org/exist/storage/LargeValuesTest.java
@@ -24,7 +24,6 @@ package org.exist.storage;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
@@ -34,9 +33,7 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.DatabaseConfigurationException;
-import org.exist.util.FileUtils;
-import org.exist.util.LockException;
+import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
 import org.exist.TestUtils;
 
@@ -107,10 +104,8 @@ public class LargeValuesTest {
 
             final Path file = createDocument();
             try(final Txn transaction = transact.beginTransaction()) {
-                final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"),
-                        new InputSource(file.toUri().toASCIIString()));
-                assertNotNull(info);
-                root.store(transaction, broker, info, new InputSource(file.toUri().toASCIIString()));
+                root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new InputSource(file.toUri().toASCIIString()), MimeType.XML_TYPE);
+
                 broker.saveCollection(transaction, root);
 
                 transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/storage/LargeValuesTest.java
+++ b/exist-core/src/test/java/org/exist/storage/LargeValuesTest.java
@@ -104,7 +104,7 @@ public class LargeValuesTest {
 
             final Path file = createDocument();
             try(final Txn transaction = transact.beginTransaction()) {
-                root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new InputSource(file.toUri().toASCIIString()), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("test.xml"), new InputSource(file.toUri().toASCIIString()), MimeType.XML_TYPE, root);
 
                 broker.saveCollection(transaction, root);
 

--- a/exist-core/src/test/java/org/exist/storage/ModificationTimeTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ModificationTimeTest.java
@@ -23,8 +23,6 @@ package org.exist.storage;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
@@ -32,10 +30,13 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.test.TestConstants.TEST_COLLECTION_URI;
 import static org.junit.Assert.*;
 
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -43,7 +44,6 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.util.Optional;
-
 
 public class ModificationTimeTest {
 
@@ -60,7 +60,7 @@ public class ModificationTimeTest {
      * have been updated afterwards.
      */
     @Test
-    public void check_if_modification_time_is_updated_binary() throws EXistException, InterruptedException, PermissionDeniedException, LockException, IOException, TriggerException {
+    public void check_if_modification_time_is_updated_binary() throws EXistException, InterruptedException, PermissionDeniedException, LockException, IOException, SAXException {
 
         final String mimeType = "application/octet-stream";
         final String filename = "data.dat";
@@ -146,12 +146,13 @@ public class ModificationTimeTest {
     @ClassRule
     public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
-    private BinaryDocument storeBinary(final DBBroker broker, final Txn transaction, final String name,  final String data, final String mimeType) throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
+    private BinaryDocument storeBinary(final DBBroker broker, final Txn transaction, final String name,  final String data, final String mimeType) throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
         broker.saveCollection(transaction, root);
         assertNotNull(root);
 
-        return root.addBinaryResource(transaction, broker, XmldbURI.create(name), data.getBytes(), mimeType);
+        root.storeDocument(transaction, broker, XmldbURI.create(name), new StringInputSource(data.getBytes(UTF_8)), new MimeType(mimeType, MimeType.BINARY));
+        return (BinaryDocument) root.getDocument(broker, XmldbURI.create(name));
     }
 
     private void storeXML(final DBBroker broker, final Txn transaction, final String name, final String xml) throws EXistException, PermissionDeniedException, IOException, LockException, SAXException {
@@ -159,12 +160,10 @@ public class ModificationTimeTest {
         broker.saveCollection(transaction, root);
         assertNotNull(root);
 
-        final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(name), xml);
-        root.store(transaction, broker, info, xml);
+        root.storeDocument(transaction, broker, XmldbURI.create(name), new StringInputSource(xml), MimeType.XML_TYPE);
     }
 
     private long getDocLastModified(final DBBroker broker, final Txn transaction, final String name) throws PermissionDeniedException {
-        final long modificationTimeBefore;
         try (final LockedDocument lockedDocument = broker.getXMLResource(TEST_COLLECTION_URI.append(name), Lock.LockMode.READ_LOCK)) {
             assertNotNull(lockedDocument);
             return lockedDocument.getDocument().getLastModified();

--- a/exist-core/src/test/java/org/exist/storage/ModificationTimeTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ModificationTimeTest.java
@@ -160,7 +160,7 @@ public class ModificationTimeTest {
         broker.saveCollection(transaction, root);
         assertNotNull(root);
 
-        root.storeDocument(transaction, broker, XmldbURI.create(name), new StringInputSource(xml), MimeType.XML_TYPE);
+        broker.storeDocument(transaction, XmldbURI.create(name), new StringInputSource(xml), MimeType.XML_TYPE, root);
     }
 
     private long getDocLastModified(final DBBroker broker, final Txn transaction, final String name) throws PermissionDeniedException {

--- a/exist-core/src/test/java/org/exist/storage/MoveCollectionRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveCollectionRecoveryTest.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
@@ -40,6 +39,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.io.InputStreamUtil;
 import org.exist.xmldb.EXistCollectionManagementService;
 import org.exist.xmldb.DatabaseImpl;
@@ -145,9 +146,7 @@ public class MoveCollectionRecoveryTest {
                 sample = InputStreamUtil.readString(is, UTF_8);
             }
 
-            final IndexInfo info = test.validateXMLResource(transaction, broker, TestConstants.TEST_XML_URI, sample);
-            assertNotNull(info);
-            test.store(transaction, broker, info, sample);
+            test.storeDocument(transaction, broker, TestConstants.TEST_XML_URI, new StringInputSource(sample), MimeType.XML_TYPE);
 
             final Collection dest = broker.getOrCreateCollection(transaction, TestConstants.DESTINATION_COLLECTION_URI);
             assertNotNull(dest);
@@ -195,9 +194,7 @@ public class MoveCollectionRecoveryTest {
                     assertNotNull(is);
                     sample = InputStreamUtil.readString(is, UTF_8);
                 }
-                final IndexInfo info = test2.validateXMLResource(transaction, broker, TestConstants.TEST_XML_URI, sample);
-                assertNotNull(info);
-                test2.store(transaction, broker, info, sample);
+                test2.storeDocument(transaction, broker, TestConstants.TEST_XML_URI, new StringInputSource(sample), MimeType.XML_TYPE);
 
                 transact.commit(transaction);
             }

--- a/exist-core/src/test/java/org/exist/storage/MoveCollectionRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveCollectionRecoveryTest.java
@@ -146,7 +146,7 @@ public class MoveCollectionRecoveryTest {
                 sample = InputStreamUtil.readString(is, UTF_8);
             }
 
-            test.storeDocument(transaction, broker, TestConstants.TEST_XML_URI, new StringInputSource(sample), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, TestConstants.TEST_XML_URI, new StringInputSource(sample), MimeType.XML_TYPE, test);
 
             final Collection dest = broker.getOrCreateCollection(transaction, TestConstants.DESTINATION_COLLECTION_URI);
             assertNotNull(dest);
@@ -194,7 +194,7 @@ public class MoveCollectionRecoveryTest {
                     assertNotNull(is);
                     sample = InputStreamUtil.readString(is, UTF_8);
                 }
-                test2.storeDocument(transaction, broker, TestConstants.TEST_XML_URI, new StringInputSource(sample), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, TestConstants.TEST_XML_URI, new StringInputSource(sample), MimeType.XML_TYPE, test2);
 
                 transact.commit(transaction);
             }

--- a/exist-core/src/test/java/org/exist/storage/MoveOverwriteCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveOverwriteCollectionTest.java
@@ -115,9 +115,9 @@ public class MoveOverwriteCollectionTest {
             final Collection test2 = createCollection(transaction, broker, SUB_TEST_COLLECTION_URI);
             final Collection test3 = createCollection(transaction, broker, TEST3_COLLECTION_URI);
 
-            test1.storeDocument(transaction, broker, doc1Name, new StringInputSource(XML1), MimeType.XML_TYPE);
-            test2.storeDocument(transaction, broker, doc2Name, new StringInputSource(XML2), MimeType.XML_TYPE);
-            test3.storeDocument(transaction, broker, doc3Name, new StringInputSource(XML3), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, doc1Name, new StringInputSource(XML1), MimeType.XML_TYPE, test1);
+            broker.storeDocument(transaction, doc2Name, new StringInputSource(XML2), MimeType.XML_TYPE, test2);
+            broker.storeDocument(transaction, doc3Name, new StringInputSource(XML3), MimeType.XML_TYPE, test3);
 
             transaction.commit();
 

--- a/exist-core/src/test/java/org/exist/storage/MoveOverwriteCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveOverwriteCollectionTest.java
@@ -22,9 +22,7 @@
 package org.exist.storage;
 
 import com.evolvedbinary.j8fu.tuple.Tuple3;
-import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.*;
@@ -32,12 +30,12 @@ import org.exist.indexing.StructuralIndex;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
-import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.NodeSelector;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -117,9 +115,9 @@ public class MoveOverwriteCollectionTest {
             final Collection test2 = createCollection(transaction, broker, SUB_TEST_COLLECTION_URI);
             final Collection test3 = createCollection(transaction, broker, TEST3_COLLECTION_URI);
 
-            store(transaction, broker, test1, doc1Name, XML1);
-            store(transaction, broker, test2, doc2Name, XML2);
-            store(transaction, broker, test3, doc3Name, XML3);
+            test1.storeDocument(transaction, broker, doc1Name, new StringInputSource(XML1), MimeType.XML_TYPE);
+            test2.storeDocument(transaction, broker, doc2Name, new StringInputSource(XML2), MimeType.XML_TYPE);
+            test3.storeDocument(transaction, broker, doc3Name, new StringInputSource(XML3), MimeType.XML_TYPE);
 
             transaction.commit();
 
@@ -131,11 +129,6 @@ public class MoveOverwriteCollectionTest {
         final Collection col = broker.getOrCreateCollection(txn, uri);
         broker.saveCollection(txn, col);
         return col;
-    }
-
-    private void store(final Txn txn, final DBBroker broker, final Collection col, final XmldbURI name, final String data) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
-        final IndexInfo info = col.validateXMLResource(txn, broker, name, data);
-        col.store(txn, broker, info, data);
     }
 
     private void moveToRoot(final DBBroker broker, final Collection sourceCollection) throws Exception {

--- a/exist-core/src/test/java/org/exist/storage/MoveOverwriteResourceTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveOverwriteResourceTest.java
@@ -110,8 +110,8 @@ public class MoveOverwriteResourceTest {
             test1 = createCollection(transaction, broker, TEST_COLLECTION_URI);
             test2 = createCollection(transaction, broker, SUB_TEST_COLLECTION_URI);
 
-            test1.storeDocument(transaction, broker, doc1Name, new StringInputSource(XML1), MimeType.XML_TYPE);
-            test2.storeDocument(transaction, broker, doc2Name,  new StringInputSource(XML2), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, doc1Name, new StringInputSource(XML1), MimeType.XML_TYPE, test1);
+            broker.storeDocument(transaction, doc2Name, new StringInputSource(XML2), MimeType.XML_TYPE, test2);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/storage/MoveOverwriteResourceTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveOverwriteResourceTest.java
@@ -22,9 +22,7 @@
 package org.exist.storage;
 
 import org.exist.Database;
-import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.*;
@@ -34,9 +32,7 @@ import org.exist.storage.btree.BTree;
 import org.exist.storage.btree.DBException;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
-import org.exist.util.DatabaseConfigurationException;
-import org.exist.util.LockException;
-import org.exist.util.Occurrences;
+import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.NodeSelector;
 import org.exist.xquery.QueryRewriter;
@@ -45,7 +41,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -115,8 +110,8 @@ public class MoveOverwriteResourceTest {
             test1 = createCollection(transaction, broker, TEST_COLLECTION_URI);
             test2 = createCollection(transaction, broker, SUB_TEST_COLLECTION_URI);
 
-            store(transaction, broker, test1, doc1Name, XML1);
-            store(transaction, broker, test2, doc2Name, XML2);
+            test1.storeDocument(transaction, broker, doc1Name, new StringInputSource(XML1), MimeType.XML_TYPE);
+            test2.storeDocument(transaction, broker, doc2Name,  new StringInputSource(XML2), MimeType.XML_TYPE);
 
             transaction.commit();
         }
@@ -126,11 +121,6 @@ public class MoveOverwriteResourceTest {
         Collection col = broker.getOrCreateCollection(txn, uri);
         broker.saveCollection(txn, col);
         return col;
-    }
-
-    private void store(Txn txn, DBBroker broker, Collection col, XmldbURI name, String data) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
-        IndexInfo info = col.validateXMLResource(txn, broker, name, data);
-        col.store(txn, broker, info, data);
     }
 
     private void move(final Database db) throws Exception {

--- a/exist-core/src/test/java/org/exist/storage/MoveResourceRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveResourceRecoveryTest.java
@@ -120,7 +120,7 @@ public class MoveResourceRecoveryTest {
                 sample = InputStreamUtil.readString(is, UTF_8);
             }
 
-            test2.storeDocument(transaction, broker, TestConstants.TEST_XML_URI, new StringInputSource(sample), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, TestConstants.TEST_XML_URI, new StringInputSource(sample), MimeType.XML_TYPE, test2);
 
             final DocumentImpl doc = test2.getDocument(broker, TestConstants.TEST_XML_URI);
             assertNotNull(doc);
@@ -172,7 +172,7 @@ public class MoveResourceRecoveryTest {
                     sample = InputStreamUtil.readString(is, UTF_8);
                 }
 
-                test2.storeDocument(transaction, broker, XmldbURI.create("new_test2.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("new_test2.xml"), new StringInputSource(sample), MimeType.XML_TYPE, test2);
 
                 transact.commit(transaction);
             }

--- a/exist-core/src/test/java/org/exist/storage/MoveResourceRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveResourceRecoveryTest.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
@@ -41,6 +40,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.io.InputStreamUtil;
 import org.exist.xmldb.DatabaseImpl;
 import org.exist.xmldb.XmldbURI;
@@ -119,9 +120,7 @@ public class MoveResourceRecoveryTest {
                 sample = InputStreamUtil.readString(is, UTF_8);
             }
 
-            final IndexInfo info = test2.validateXMLResource(transaction, broker, TestConstants.TEST_XML_URI, sample);
-            assertNotNull(info);
-            test2.store(transaction, broker, info, sample);
+            test2.storeDocument(transaction, broker, TestConstants.TEST_XML_URI, new StringInputSource(sample), MimeType.XML_TYPE);
 
             final DocumentImpl doc = test2.getDocument(broker, TestConstants.TEST_XML_URI);
             assertNotNull(doc);
@@ -173,8 +172,7 @@ public class MoveResourceRecoveryTest {
                     sample = InputStreamUtil.readString(is, UTF_8);
                 }
 
-                final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create("new_test2.xml"), sample);
-                test2.store(transaction, broker, info, sample);
+                test2.storeDocument(transaction, broker, XmldbURI.create("new_test2.xml"), new StringInputSource(sample), MimeType.XML_TYPE);
 
                 transact.commit(transaction);
             }

--- a/exist-core/src/test/java/org/exist/storage/RangeIndexUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RangeIndexUpdateTest.java
@@ -25,7 +25,6 @@ import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.MutableDocumentSet;
@@ -193,15 +192,11 @@ public class RangeIndexUpdateTest {
 
             docs = new DefaultDocumentSet();
 
-            IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_string.xml"), XML);
-            assertNotNull(info);
-            root.store(transaction, broker, info, XML);
-            docs.add(info.getDocument());
+            root.storeDocument(transaction, broker, XmldbURI.create("test_string.xml"), new StringInputSource(XML), MimeType.XML_TYPE);
+            docs.add(root.getDocument(broker, XmldbURI.create("test_string.xml")));
 
-            info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_string2.xml"), XML2);
-            assertNotNull(info);
-            root.store(transaction, broker, info, XML2);
-            docs.add(info.getDocument());
+            root.storeDocument(transaction, broker, XmldbURI.create("test_string2.xml"), new StringInputSource(XML2), MimeType.XML_TYPE);
+            docs.add(root.getDocument(broker, XmldbURI.create("test_string2.xml")));
 
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/storage/RangeIndexUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RangeIndexUpdateTest.java
@@ -192,10 +192,10 @@ public class RangeIndexUpdateTest {
 
             docs = new DefaultDocumentSet();
 
-            root.storeDocument(transaction, broker, XmldbURI.create("test_string.xml"), new StringInputSource(XML), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test_string.xml"), new StringInputSource(XML), MimeType.XML_TYPE, root);
             docs.add(root.getDocument(broker, XmldbURI.create("test_string.xml")));
 
-            root.storeDocument(transaction, broker, XmldbURI.create("test_string2.xml"), new StringInputSource(XML2), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test_string2.xml"), new StringInputSource(XML2), MimeType.XML_TYPE, root);
             docs.add(root.getDocument(broker, XmldbURI.create("test_string2.xml")));
 
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/storage/RecoverBinaryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoverBinaryTest.java
@@ -40,18 +40,19 @@ import java.util.Arrays;
 import org.apache.commons.io.input.CountingInputStream;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.txn.Txn;
 import org.exist.util.FileInputSource;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.junit.Assert.assertEquals;
@@ -89,12 +90,12 @@ public class RecoverBinaryTest extends AbstractRecoverTest {
     @Override
     protected void storeAndVerify(final DBBroker broker, final Txn transaction, final Collection collection,
             final InputSource data, final String dbFilename) throws EXistException, PermissionDeniedException, IOException,
-            TriggerException, LockException {
+            SAXException, LockException {
 
         final Path file = ((FileInputSource)data).getFile();
 
-        final byte[] content = Files.readAllBytes(file);
-        final BinaryDocument doc = collection.addBinaryResource(transaction, broker, XmldbURI.create(dbFilename), content, "application/octet-stream");
+        collection.storeDocument(transaction, broker, XmldbURI.create(dbFilename), new FileInputSource(file), MimeType.BINARY_TYPE);
+        final BinaryDocument doc = (BinaryDocument) collection.getDocument(broker, XmldbURI.create(dbFilename));
 
         assertNotNull(doc);
         assertEquals(Files.size(file), doc.getContentLength());

--- a/exist-core/src/test/java/org/exist/storage/RecoverBinaryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoverBinaryTest.java
@@ -94,7 +94,7 @@ public class RecoverBinaryTest extends AbstractRecoverTest {
 
         final Path file = ((FileInputSource)data).getFile();
 
-        collection.storeDocument(transaction, broker, XmldbURI.create(dbFilename), new FileInputSource(file), MimeType.BINARY_TYPE);
+        broker.storeDocument(transaction, XmldbURI.create(dbFilename), new FileInputSource(file), MimeType.BINARY_TYPE, collection);
         final BinaryDocument doc = (BinaryDocument) collection.getDocument(broker, XmldbURI.create(dbFilename));
 
         assertNotNull(doc);

--- a/exist-core/src/test/java/org/exist/storage/RecoverBinaryTest2.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoverBinaryTest2.java
@@ -142,7 +142,7 @@ public class RecoverBinaryTest2 {
                 if (Files.isRegularFile(f)) {
                     final XmldbURI uri = test2.getURI().append(j + "_" + FileUtils.fileName(f));
 
-                    test2.storeDocument(transaction, broker, uri, new FileInputSource(f), MimeType.BINARY_TYPE);
+                    broker.storeDocument(transaction, uri, new FileInputSource(f), MimeType.BINARY_TYPE, test2);
                     final BinaryDocument doc = (BinaryDocument) test2.getDocument(broker, uri);
                     assertNotNull(doc);
                 }

--- a/exist-core/src/test/java/org/exist/storage/RecoverXmlTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoverXmlTest.java
@@ -124,7 +124,7 @@ public class RecoverXmlTest extends AbstractRecoverTest {
             IOException, LockException {
         final XmldbURI docUri = XmldbURI.create(dbFilename);
         try {
-            collection.storeDocument(transaction, broker, docUri, data, MimeType.XML_TYPE);
+            broker.storeDocument(transaction, docUri, data, MimeType.XML_TYPE, collection);
 
         } catch (final SAXException e) {
             throw new IOException(e);

--- a/exist-core/src/test/java/org/exist/storage/RecoverXmlTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoverXmlTest.java
@@ -34,17 +34,12 @@ package org.exist.storage;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.Permission;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.journal.Journal;
 import org.exist.storage.txn.Txn;
-import org.exist.util.DatabaseConfigurationException;
-import org.exist.util.FileInputSource;
-import org.exist.util.LockException;
-import org.exist.util.StringInputSource;
+import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -89,7 +84,7 @@ public class RecoverXmlTest extends AbstractRecoverTest {
     }
 
     @Test
-    public void storeLargeAndLoad() throws LockException, TriggerException, PermissionDeniedException, EXistException,
+    public void storeLargeAndLoad() throws LockException, SAXException, PermissionDeniedException, EXistException,
             IOException, DatabaseConfigurationException, InterruptedException {
         // generate a string filled with random a-z characters which is larger than the journal buffer
         final byte[] buf = new byte[Journal.BUFFER_SIZE * 3]; // 3 * the journal buffer size
@@ -129,10 +124,7 @@ public class RecoverXmlTest extends AbstractRecoverTest {
             IOException, LockException {
         final XmldbURI docUri = XmldbURI.create(dbFilename);
         try {
-            final IndexInfo indexInfo =
-                    collection.validateXMLResource(transaction, broker, docUri, data);
-
-            collection.store(transaction, broker, indexInfo, data);
+            collection.storeDocument(transaction, broker, docUri, data, MimeType.XML_TYPE);
 
         } catch (final SAXException e) {
             throw new IOException(e);

--- a/exist-core/src/test/java/org/exist/storage/RecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoveryTest.java
@@ -116,7 +116,7 @@ public class RecoveryTest {
                 test2 = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI2);
                 broker.saveCollection(transaction, test2);
 
-                test2.storeDocument(transaction, broker, TestConstants.TEST_BINARY_URI, new StringInputSource("Some text data".getBytes(UTF_8)), MimeType.BINARY_TYPE);
+                broker.storeDocument(transaction, TestConstants.TEST_BINARY_URI, new StringInputSource("Some text data".getBytes(UTF_8)), MimeType.BINARY_TYPE, test2);
                 binaryDocument = (BinaryDocument) test2.getDocument(broker, TestConstants.TEST_BINARY_URI);
                 assertNotNull(binaryDocument);
 
@@ -126,7 +126,7 @@ public class RecoveryTest {
                     try (final InputStream is = SAMPLES.getShakespeareSample(sampleName)) {
                         sample = InputStreamUtil.readString(is, UTF_8);
                     }
-                    test2.storeDocument(transaction, broker, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE);
+                    broker.storeDocument(transaction, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE, test2);
                 }
 
                 // replace some documents
@@ -135,10 +135,10 @@ public class RecoveryTest {
                     try (final InputStream is = SAMPLES.getShakespeareSample(sampleName)) {
                         sample = InputStreamUtil.readString(is, UTF_8);
                     }
-                    test2.storeDocument(transaction, broker, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE);
+                    broker.storeDocument(transaction, XmldbURI.create(sampleName), new StringInputSource(sample), MimeType.XML_TYPE, test2);
                 }
 
-                test2.storeDocument(transaction, broker, XmldbURI.create("test_string.xml"), new StringInputSource(TEST_XML), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("test_string.xml"), new StringInputSource(TEST_XML), MimeType.XML_TYPE, test2);
 
                 //TODO : unlock the collection here ?
 

--- a/exist-core/src/test/java/org/exist/storage/RecoveryTest2.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoveryTest2.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.btree.BTreeException;
@@ -45,6 +44,7 @@ import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.Test;
@@ -101,9 +101,7 @@ public class RecoveryTest2 {
             final Path dir = Paths.get(xmlDir);
             final List<Path> docs = FileUtils.list(dir);
             for (final Path f : docs) {
-                final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
-                assertNotNull(info);
-                test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
+                test2.storeDocument(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()), MimeType.XML_TYPE);
             }
 
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/storage/RecoveryTest2.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoveryTest2.java
@@ -101,7 +101,7 @@ public class RecoveryTest2 {
             final Path dir = Paths.get(xmlDir);
             final List<Path> docs = FileUtils.list(dir);
             for (final Path f : docs) {
-                test2.storeDocument(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()), MimeType.XML_TYPE, test2);
             }
 
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/storage/RecoveryTest3.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoveryTest3.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.lock.Lock.LockMode;
@@ -37,10 +36,7 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.DatabaseConfigurationException;
-import org.exist.util.FileUtils;
-import org.exist.util.LockException;
-import org.exist.util.XMLFilenameFilter;
+import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.Test;
@@ -96,9 +92,7 @@ public class RecoveryTest3 {
             for (int i = 0; i < files.size() && i < RESOURCE_COUNT; i++) {
                 final Path f = files.get(i);
                 try {
-                    final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
-                    assertNotNull(info);
-                    test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
+                    test2.storeDocument(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()), MimeType.XML_TYPE);
                 } catch (final SAXException e) {
                     fail("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
                 }
@@ -144,9 +138,7 @@ public class RecoveryTest3 {
                     for (int i = 0; i < files.size() && i < RESOURCE_COUNT; i++) {
                         final Path f = files.get(i);
                         try {
-                            final IndexInfo info = test2.validateXMLResource(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()));
-                            assertNotNull(info);
-                            test2.store(transaction, broker, info, new InputSource(f.toUri().toASCIIString()));
+                            test2.storeDocument(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()), MimeType.XML_TYPE);
                         } catch (SAXException e) {
                             fail("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
                         }

--- a/exist-core/src/test/java/org/exist/storage/RecoveryTest3.java
+++ b/exist-core/src/test/java/org/exist/storage/RecoveryTest3.java
@@ -92,7 +92,7 @@ public class RecoveryTest3 {
             for (int i = 0; i < files.size() && i < RESOURCE_COUNT; i++) {
                 final Path f = files.get(i);
                 try {
-                    test2.storeDocument(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()), MimeType.XML_TYPE);
+                    broker.storeDocument(transaction, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()), MimeType.XML_TYPE, test2);
                 } catch (final SAXException e) {
                     fail("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
                 }
@@ -138,7 +138,7 @@ public class RecoveryTest3 {
                     for (int i = 0; i < files.size() && i < RESOURCE_COUNT; i++) {
                         final Path f = files.get(i);
                         try {
-                            test2.storeDocument(transaction, broker, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()), MimeType.XML_TYPE);
+                            broker.storeDocument(transaction, XmldbURI.create(FileUtils.fileName(f)), new InputSource(f.toUri().toASCIIString()), MimeType.XML_TYPE, test2);
                         } catch (SAXException e) {
                             fail("Error found while parsing document: " + FileUtils.fileName(f) + ": " + e.getMessage());
                         }

--- a/exist-core/src/test/java/org/exist/storage/ReindexRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ReindexRecoveryTest.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.lock.Lock.LockMode;
@@ -113,9 +112,7 @@ public class ReindexRecoveryTest {
     private void storeDocument(final DBBroker broker, final Txn transaction, final Collection collection,
             final XmldbURI docName, final String data) {
         try {
-            final IndexInfo info = collection.validateXMLResource(transaction, broker, docName, data);
-            assertNotNull(info);
-            collection.store(transaction, broker, info, data);
+            collection.storeDocument(transaction, broker, docName, new StringInputSource(data), MimeType.XML_TYPE);
         } catch (final SAXException | EXistException | PermissionDeniedException | LockException | IOException e) {
             fail("Error found while parsing document: " + docName + ": " + e.getMessage());
         }

--- a/exist-core/src/test/java/org/exist/storage/ReindexRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ReindexRecoveryTest.java
@@ -112,7 +112,7 @@ public class ReindexRecoveryTest {
     private void storeDocument(final DBBroker broker, final Txn transaction, final Collection collection,
             final XmldbURI docName, final String data) {
         try {
-            collection.storeDocument(transaction, broker, docName, new StringInputSource(data), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, docName, new StringInputSource(data), MimeType.XML_TYPE, collection);
         } catch (final SAXException | EXistException | PermissionDeniedException | LockException | IOException e) {
             fail("Error found while parsing document: " + docName + ": " + e.getMessage());
         }

--- a/exist-core/src/test/java/org/exist/storage/ReindexTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ReindexTest.java
@@ -206,7 +206,7 @@ public class ReindexTest {
             assertNotNull(collection);
             broker.saveCollection(transaction, collection);
 
-            collection.storeDocument(transaction, broker, docName, new StringInputSource(doc), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, docName, new StringInputSource(doc), MimeType.XML_TYPE, collection);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/storage/ReindexTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ReindexTest.java
@@ -24,13 +24,14 @@ package org.exist.storage;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -205,9 +206,7 @@ public class ReindexTest {
             assertNotNull(collection);
             broker.saveCollection(transaction, collection);
 
-            final IndexInfo info = collection.validateXMLResource(transaction, broker, docName, doc);
-            assertNotNull(info);
-            collection.store(transaction, broker, info, doc);
+            collection.storeDocument(transaction, broker, docName, new StringInputSource(doc), MimeType.XML_TYPE);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/storage/RemoveCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RemoveCollectionTest.java
@@ -163,7 +163,7 @@ public class RemoveCollectionTest {
                 for (final Iterator<DocumentImpl> i = test.iterator(broker); i.hasNext() && j < files.length; j++) {
                     final DocumentImpl doc = i.next();
                     final InputSource is = new InputSource(files[j].toUri().toASCIIString());
-                    test.storeDocument(transaction, broker, doc.getURI(), is, MimeType.XML_TYPE);
+                    broker.storeDocument(transaction, doc.getURI(), is, MimeType.XML_TYPE, test);
                 }
                 generator.releaseAll();
                 transact.commit(transaction);
@@ -189,7 +189,7 @@ public class RemoveCollectionTest {
             for(final Path file : files) {
                 final InputSource is = new InputSource(file.toUri().toASCIIString());
 
-                test.storeDocument(transaction, broker, XmldbURI.create(file.getFileName().toString()), is, MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create(file.getFileName().toString()), is, MimeType.XML_TYPE, test);
             }
             generator.releaseAll();
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/storage/RemoveCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RemoveCollectionTest.java
@@ -25,7 +25,6 @@ package org.exist.storage;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
@@ -36,6 +35,7 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.exist.TestDataGenerator;
 import org.junit.After;
@@ -163,10 +163,7 @@ public class RemoveCollectionTest {
                 for (final Iterator<DocumentImpl> i = test.iterator(broker); i.hasNext() && j < files.length; j++) {
                     final DocumentImpl doc = i.next();
                     final InputSource is = new InputSource(files[j].toUri().toASCIIString());
-                    assertNotNull(is);
-                    final IndexInfo info = test.validateXMLResource(transaction, broker, doc.getURI(), is);
-                    assertNotNull(info);
-                    test.store(transaction, broker, info, is);
+                    test.storeDocument(transaction, broker, doc.getURI(), is, MimeType.XML_TYPE);
                 }
                 generator.releaseAll();
                 transact.commit(transaction);
@@ -191,10 +188,8 @@ public class RemoveCollectionTest {
             final Path[] files = generator.generate(broker, test, generateXQ);
             for(final Path file : files) {
                 final InputSource is = new InputSource(file.toUri().toASCIIString());
-                assertNotNull(is);
-                final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create(file.getFileName().toString()), is);
-                assertNotNull(info);
-                test.store(transaction, broker, info, is);
+
+                test.storeDocument(transaction, broker, XmldbURI.create(file.getFileName().toString()), is, MimeType.XML_TYPE);
             }
             generator.releaseAll();
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/storage/RemoveRootCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RemoveRootCollectionTest.java
@@ -21,20 +21,18 @@
  */
 package org.exist.storage;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 import static org.exist.samples.Samples.SAMPLES;
 
-import java.io.InputStream;
 import java.util.Optional;
 
 import org.exist.collections.*;
 import org.exist.storage.txn.*;
 import org.exist.test.ExistEmbeddedServer;
-import org.exist.util.io.InputStreamUtil;
+import org.exist.util.InputStreamSupplierInputSource;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
-
 
 public class RemoveRootCollectionTest {
 
@@ -100,13 +98,8 @@ public class RemoveRootCollectionTest {
     private void addDocumentToRoot() throws Exception {
         final BrokerPool pool = BrokerPool.getInstance();
         final TransactionManager transact = pool.getTransactionManager();
-        try (final Txn transaction = transact.beginTransaction();
-             final InputStream is = SAMPLES.getHamletSample()) {
-            assertNotNull(is);
-            final String sample = InputStreamUtil.readString(is, UTF_8);
-            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("hamlet.xml"), sample);
-            assertNotNull(info);
-            root.store(transaction, broker, info, sample);
+        try (final Txn transaction = transact.beginTransaction()) {
+            root.storeDocument(transaction, broker, XmldbURI.create("hamlet.xml"), new InputStreamSupplierInputSource(() -> SAMPLES.getHamletSample()), MimeType.XML_TYPE);
             transact.commit(transaction);
         }
     }

--- a/exist-core/src/test/java/org/exist/storage/RemoveRootCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/RemoveRootCollectionTest.java
@@ -99,7 +99,7 @@ public class RemoveRootCollectionTest {
         final BrokerPool pool = BrokerPool.getInstance();
         final TransactionManager transact = pool.getTransactionManager();
         try (final Txn transaction = transact.beginTransaction()) {
-            root.storeDocument(transaction, broker, XmldbURI.create("hamlet.xml"), new InputStreamSupplierInputSource(() -> SAMPLES.getHamletSample()), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("hamlet.xml"), new InputStreamSupplierInputSource(() -> SAMPLES.getHamletSample()), MimeType.XML_TYPE, root);
             transact.commit(transaction);
         }
     }

--- a/exist-core/src/test/java/org/exist/storage/ResourceTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ResourceTest.java
@@ -90,7 +90,7 @@ public class ResourceTest {
             
             broker.saveCollection(transaction, collection);
 
-            collection.storeDocument(transaction, broker, DOCUMENT_NAME_URI, new StringInputSource(EMPTY_BINARY_FILE.getBytes(UTF_8)), MimeType.TEXT_TYPE);
+            broker.storeDocument(transaction, DOCUMENT_NAME_URI, new StringInputSource(EMPTY_BINARY_FILE.getBytes(UTF_8)), MimeType.TEXT_TYPE, collection);
             
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/storage/ResourceTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ResourceTest.java
@@ -37,14 +37,14 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
-import org.exist.util.Configuration;
-import org.exist.util.DatabaseConfigurationException;
-import org.exist.util.LockException;
+import org.exist.util.*;
 import org.exist.xmldb.XmldbURI;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
+import org.xml.sax.SAXException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 
@@ -68,7 +68,7 @@ public class ResourceTest {
     }
 
     @Test
-    public void storeAndRead() throws TriggerException, PermissionDeniedException, DatabaseConfigurationException, IOException, LockException, EXistException {
+    public void storeAndRead() throws SAXException, PermissionDeniedException, DatabaseConfigurationException, IOException, LockException, EXistException {
         BrokerPool.FORCE_CORRUPTION = true;
         BrokerPool pool = startDb();
         store(pool);
@@ -79,7 +79,7 @@ public class ResourceTest {
         read(pool);
     }
 
-    private void store(final BrokerPool pool) throws EXistException, DatabaseConfigurationException, PermissionDeniedException, IOException, TriggerException, LockException {
+    private void store(final BrokerPool pool) throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final TransactionManager transact = pool.getTransactionManager();
 
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
@@ -89,17 +89,14 @@ public class ResourceTest {
                     .getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             
             broker.saveCollection(transaction, collection);
-            
-            @SuppressWarnings("unused")
-			final BinaryDocument doc =
-                    collection.addBinaryResource(transaction, broker,
-                    DOCUMENT_NAME_URI , EMPTY_BINARY_FILE.getBytes(), "text/text");
+
+            collection.storeDocument(transaction, broker, DOCUMENT_NAME_URI, new StringInputSource(EMPTY_BINARY_FILE.getBytes(UTF_8)), MimeType.TEXT_TYPE);
             
             transact.commit(transaction);
         }
     }
 
-    private void read(final BrokerPool pool) throws EXistException, DatabaseConfigurationException, PermissionDeniedException, IOException, LockException, TriggerException {
+    private void read(final BrokerPool pool) throws EXistException,  PermissionDeniedException, IOException, LockException, TriggerException {
         final TransactionManager transact = pool.getTransactionManager();
         
         byte[] data = null;
@@ -139,7 +136,7 @@ public class ResourceTest {
     }
 
     @Test
-    public void storeAndRead2() throws TriggerException, PermissionDeniedException, DatabaseConfigurationException, IOException, LockException, EXistException {
+    public void storeAndRead2() throws SAXException, PermissionDeniedException, DatabaseConfigurationException, IOException, LockException, EXistException {
         BrokerPool.FORCE_CORRUPTION = false;
         BrokerPool pool = startDb();
     	store(pool);

--- a/exist-core/src/test/java/org/exist/storage/ShutdownTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ShutdownTest.java
@@ -72,7 +72,7 @@ public class ShutdownTest {
 
                 // store some documents.
 	            for(final String sampleName : SAMPLES.getShakespeareXmlSampleNames()) {
-                    test.storeDocument(transaction, broker, XmldbURI.create(sampleName), new InputStreamSupplierInputSource(() -> SAMPLES.getShakespeareSample(sampleName)), MimeType.XML_TYPE);
+                    broker.storeDocument(transaction, XmldbURI.create(sampleName), new InputStreamSupplierInputSource(() -> SAMPLES.getShakespeareSample(sampleName)), MimeType.XML_TYPE, test);
                 }
 
                 final XQuery xquery = pool.getXQueryService();

--- a/exist-core/src/test/java/org/exist/storage/ShutdownTest.java
+++ b/exist-core/src/test/java/org/exist/storage/ShutdownTest.java
@@ -22,20 +22,16 @@
 package org.exist.storage;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Optional;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.*;
-import org.exist.util.io.InputStreamUtil;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -43,10 +39,8 @@ import org.exist.xquery.value.Sequence;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 import static org.exist.samples.Samples.SAMPLES;
 
 import org.xml.sax.SAXException;
@@ -57,13 +51,13 @@ public class ShutdownTest {
     public static ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
     @Test
-	public void shutdown() throws EXistException, LockException, TriggerException, PermissionDeniedException, XPathException, IOException {
+	public void shutdown() throws EXistException, LockException, SAXException, PermissionDeniedException, XPathException, IOException {
 		for (int i = 0; i < 2; i++) {
 			storeAndShutdown();
 		}
 	}
 	
-	public void storeAndShutdown() throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException, XPathException {
+	public void storeAndShutdown() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException, XPathException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
 
@@ -78,14 +72,7 @@ public class ShutdownTest {
 
                 // store some documents.
 	            for(final String sampleName : SAMPLES.getShakespeareXmlSampleNames()) {
-                    try (final InputStream is = SAMPLES.getShakespeareSample(sampleName)) {
-                        final String sample = InputStreamUtil.readString(is, UTF_8);
-                        final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create(sampleName), sample);
-                        assertNotNull(info);
-                        test.store(transaction, broker, info, sample);
-                    } catch (SAXException e) {
-                        fail("Error found while parsing document: " + sampleName + ": " + e.getMessage());
-                    }
+                    test.storeDocument(transaction, broker, XmldbURI.create(sampleName), new InputStreamSupplierInputSource(() -> SAMPLES.getShakespeareSample(sampleName)), MimeType.XML_TYPE);
                 }
 
                 final XQuery xquery = pool.getXQueryService();

--- a/exist-core/src/test/java/org/exist/storage/StoreBinaryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/StoreBinaryTest.java
@@ -36,7 +36,9 @@ import org.exist.test.TestConstants;
 import org.exist.collections.Collection;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.xml.sax.SAXException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 
 /**
@@ -46,7 +48,7 @@ import static org.junit.Assert.*;
 public class StoreBinaryTest {
 
     @Test
-    public void check_MimeType_is_preserved() throws EXistException, PermissionDeniedException, LockException, IOException, TriggerException, DatabaseConfigurationException {
+    public void check_MimeType_is_preserved() throws EXistException, PermissionDeniedException, LockException, IOException, SAXException, DatabaseConfigurationException {
 
         final String xqueryMimeType = "application/xquery";
         final String xqueryFilename = "script.xql";
@@ -103,7 +105,7 @@ public class StoreBinaryTest {
         return binaryDoc;
     }
 
-    private BinaryDocument storeBinary(String name,  String data, String mimeType) throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
+    private BinaryDocument storeBinary(final String name, final String data, final String mimeType) throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         final TransactionManager transact = pool.getTransactionManager();
 
@@ -115,7 +117,8 @@ public class StoreBinaryTest {
     		broker.saveCollection(transaction, root);
             assertNotNull(root);
 
-            binaryDoc = root.addBinaryResource(transaction, broker, XmldbURI.create(name), data.getBytes(), mimeType);
+            root.storeDocument(transaction, broker, XmldbURI.create(name), new StringInputSource(data.getBytes(UTF_8)), new MimeType(mimeType, MimeType.BINARY));
+            binaryDoc = (BinaryDocument) root.getDocument(broker, XmldbURI.create(name));
 
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/storage/StoreResourceTest.java
+++ b/exist-core/src/test/java/org/exist/storage/StoreResourceTest.java
@@ -110,7 +110,7 @@ public class StoreResourceTest {
              final Collection col = broker.openCollection(uri.removeLastSegment(), Lock.LockMode.WRITE_LOCK)) {
 
 
-            col.storeDocument(transaction, broker, uri.lastSegment(), new StringInputSource(content), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, uri.lastSegment(), new StringInputSource(content), MimeType.XML_TYPE, col);
 
             transaction.commit();
         }
@@ -143,7 +143,7 @@ public class StoreResourceTest {
              final Txn transaction = pool.getTransactionManager().beginTransaction();
              final Collection col = broker.openCollection(uri.removeLastSegment(), Lock.LockMode.WRITE_LOCK)) {
 
-            col.storeDocument(transaction, broker, uri.lastSegment(), new StringInputSource(content.getBytes(UTF_8)), MimeType.BINARY_TYPE);
+            broker.storeDocument(transaction, uri.lastSegment(), new StringInputSource(content.getBytes(UTF_8)), MimeType.BINARY_TYPE, col);
 
             transaction.commit();
         }
@@ -223,12 +223,12 @@ public class StoreResourceTest {
              final Collection collection = broker.openCollection(TEST_COLLECTION_URI, Lock.LockMode.WRITE_LOCK)) {
 
             final String u1d3xml = "<empty3/>";
-            collection.storeDocument(transaction, broker, USER1_DOC1, new StringInputSource(u1d3xml), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, USER1_DOC1, new StringInputSource(u1d3xml), MimeType.XML_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC1), USER1_DOC1_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER1_DOC1), GROUP1_NAME);
 
             final String u1d3bin = "bin3";
-            collection.storeDocument(transaction, broker, USER1_BIN_DOC1, new StringInputSource(u1d3bin.getBytes(UTF_8)), MimeType.TEXT_TYPE);
+            broker.storeDocument(transaction, USER1_BIN_DOC1, new StringInputSource(u1d3bin.getBytes(UTF_8)), MimeType.TEXT_TYPE, collection);
             chmod(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC1), USER1_BIN_DOC1_MODE);
             chgrp(broker, transaction, TEST_COLLECTION_URI.append(USER1_BIN_DOC1), GROUP1_NAME);
 

--- a/exist-core/src/test/java/org/exist/storage/UpdateRecoverTest.java
+++ b/exist-core/src/test/java/org/exist/storage/UpdateRecoverTest.java
@@ -120,7 +120,7 @@ public class UpdateRecoverTest {
                 assertNotNull(test2);
                 broker.saveCollection(transaction, test2);
 
-                test2.storeDocument(transaction, broker, TestConstants.TEST_XML_URI, new StringInputSource(TEST_XML), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, TestConstants.TEST_XML_URI, new StringInputSource(TEST_XML), MimeType.XML_TYPE, test2);
                 doc = test2.getDocument(broker, TestConstants.TEST_XML_URI);
                 //TODO : unlock the collection here ?
 

--- a/exist-core/src/test/java/org/exist/storage/UpdateRecoverTest.java
+++ b/exist-core/src/test/java/org/exist/storage/UpdateRecoverTest.java
@@ -23,8 +23,8 @@ package org.exist.storage;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.DefaultDocumentSet;
+import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.dom.persistent.MutableDocumentSet;
 import org.exist.security.PermissionDeniedException;
@@ -36,6 +36,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.EXistCollectionManagementService;
 import org.exist.xmldb.DatabaseImpl;
 import org.exist.xmldb.XmldbURI;
@@ -102,13 +104,12 @@ public class UpdateRecoverTest {
         xmldbRead(pool);
     }
 
-    private void store(final BrokerPool pool) throws IllegalAccessException, DatabaseConfigurationException, InstantiationException, ClassNotFoundException, XMLDBException, EXistException, PermissionDeniedException, IOException, SAXException, LockException, ParserConfigurationException, XPathException {
+    private void store(final BrokerPool pool) throws EXistException, PermissionDeniedException, IOException, SAXException, LockException, ParserConfigurationException, XPathException {
         final TransactionManager transact = pool.getTransactionManager();
 
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
 
-            IndexInfo info;
-
+            DocumentImpl doc;
             try(final Txn transaction = transact.beginTransaction()) {
 
                 final Collection root = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
@@ -119,11 +120,9 @@ public class UpdateRecoverTest {
                 assertNotNull(test2);
                 broker.saveCollection(transaction, test2);
 
-                info = test2.validateXMLResource(transaction, broker, TestConstants.TEST_XML_URI, TEST_XML);
-                assertNotNull(info);
+                test2.storeDocument(transaction, broker, TestConstants.TEST_XML_URI, new StringInputSource(TEST_XML), MimeType.XML_TYPE);
+                doc = test2.getDocument(broker, TestConstants.TEST_XML_URI);
                 //TODO : unlock the collection here ?
-
-                test2.store(transaction, broker, info, TEST_XML);
 
                 transact.commit(transaction);
             }
@@ -131,7 +130,7 @@ public class UpdateRecoverTest {
             try(final Txn transaction = transact.beginTransaction()) {
 
                 final MutableDocumentSet docs = new DefaultDocumentSet();
-                docs.add(info.getDocument());
+                docs.add(doc);
                 final XUpdateProcessor proc = new XUpdateProcessor(broker, docs);
                 assertNotNull(proc);
                 // insert some nodes

--- a/exist-core/src/test/java/org/exist/storage/journal/JournalBinaryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/journal/JournalBinaryTest.java
@@ -448,7 +448,7 @@ public class JournalBinaryTest extends AbstractJournalTest<JournalBinaryTest.Bin
 
         assertTrue(data instanceof FileInputSource);
 
-        collection.storeDocument(transaction, broker, XmldbURI.create(dbFilename), data, MimeType.BINARY_TYPE);
+        broker.storeDocument(transaction, XmldbURI.create(dbFilename), data, MimeType.BINARY_TYPE, collection);
         final BinaryDocument doc = (BinaryDocument) collection.getDocument(broker, XmldbURI.create(dbFilename));
         assertNotNull(doc);
         assertEquals(Files.size(((FileInputSource)data).getFile()), doc.getContentLength());

--- a/exist-core/src/test/java/org/exist/storage/journal/JournalBinaryTest.java
+++ b/exist-core/src/test/java/org/exist/storage/journal/JournalBinaryTest.java
@@ -47,6 +47,7 @@ import org.exist.storage.txn.Txn;
 import org.exist.util.FileInputSource;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
 import org.exist.util.crypto.digest.DigestType;
 import org.exist.util.crypto.digest.StreamableDigest;
 import org.exist.xmldb.XmldbURI;
@@ -54,6 +55,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -442,16 +444,14 @@ public class JournalBinaryTest extends AbstractJournalTest<JournalBinaryTest.Bin
     @Override
     protected BinaryDocLocator storeAndVerify(final DBBroker broker, final Txn transaction, final Collection collection,
             final InputSource data, final String dbFilename) throws EXistException, PermissionDeniedException, IOException,
-            TriggerException, LockException {
+            SAXException, LockException {
 
         assertTrue(data instanceof FileInputSource);
-        final Path file = ((FileInputSource)data).getFile();
 
-        final byte[] content = Files.readAllBytes(file);
-        final BinaryDocument doc = collection.addBinaryResource(transaction, broker, XmldbURI.create(dbFilename), content, "application/octet-stream");
-
+        collection.storeDocument(transaction, broker, XmldbURI.create(dbFilename), data, MimeType.BINARY_TYPE);
+        final BinaryDocument doc = (BinaryDocument) collection.getDocument(broker, XmldbURI.create(dbFilename));
         assertNotNull(doc);
-        assertEquals(Files.size(file), doc.getContentLength());
+        assertEquals(Files.size(((FileInputSource)data).getFile()), doc.getContentLength());
 
         return new BinaryDocLocator(collection.getURI().append(dbFilename).getRawCollectionPath(), doc.getBlobId());
     }

--- a/exist-core/src/test/java/org/exist/storage/journal/JournalXmlTest.java
+++ b/exist-core/src/test/java/org/exist/storage/journal/JournalXmlTest.java
@@ -627,7 +627,7 @@ public class JournalXmlTest extends AbstractJournalTest<String> {
             final InputSource data, final String dbFilename) throws EXistException, PermissionDeniedException, IOException,
             SAXException, LockException {
 
-        collection.storeDocument(transaction, broker, XmldbURI.create(dbFilename), data, MimeType.XML_TYPE);
+        broker.storeDocument(transaction, XmldbURI.create(dbFilename), data, MimeType.XML_TYPE, collection);
 
         assertNotNull(collection.getDocument(broker, XmldbURI.create(dbFilename)));
 

--- a/exist-core/src/test/java/org/exist/storage/journal/JournalXmlTest.java
+++ b/exist-core/src/test/java/org/exist/storage/journal/JournalXmlTest.java
@@ -34,7 +34,6 @@ package org.exist.storage.journal;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.numbering.DLN;
@@ -43,6 +42,7 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.Txn;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
 import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.junit.BeforeClass;
@@ -627,8 +627,7 @@ public class JournalXmlTest extends AbstractJournalTest<String> {
             final InputSource data, final String dbFilename) throws EXistException, PermissionDeniedException, IOException,
             SAXException, LockException {
 
-        final IndexInfo indexInfo = collection.validateXMLResource(transaction, broker, XmldbURI.create(dbFilename), data);
-        collection.store(transaction, broker, indexInfo, data);
+        collection.storeDocument(transaction, broker, XmldbURI.create(dbFilename), data, MimeType.XML_TYPE);
 
         assertNotNull(collection.getDocument(broker, XmldbURI.create(dbFilename)));
 

--- a/exist-core/src/test/java/org/exist/storage/lock/DeadlockTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/DeadlockTest.java
@@ -249,7 +249,7 @@ public class DeadlockTest {
                             final InputSource is = new InputSource(files[j].toUri()
                                     .toASCIIString());
 
-							coll.storeDocument(transaction, broker, XmldbURI.create("test" + fileCount + ".xml"), is, MimeType.XML_TYPE);
+							broker.storeDocument(transaction, XmldbURI.create("test" + fileCount + ".xml"), is, MimeType.XML_TYPE, coll);
                             transact.commit(transaction);
                         }
                     }

--- a/exist-core/src/test/java/org/exist/storage/lock/DeadlockTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/DeadlockTest.java
@@ -36,7 +36,6 @@ import org.exist.EXistException;
 import org.exist.TestDataGenerator;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
-import org.exist.collections.IndexInfo;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
@@ -46,6 +45,7 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
 import org.exist.xmldb.EXistXPathQueryService;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
@@ -246,14 +246,10 @@ public class DeadlockTest {
                     final Path[] files = generator.generate(broker, coll, generateXQ);
                     for (int j = 0; j < files.length; j++, fileCount++) {
                         try(final Txn transaction = transact.beginTransaction()) {
-                            InputSource is = new InputSource(files[j].toUri()
+                            final InputSource is = new InputSource(files[j].toUri()
                                     .toASCIIString());
-                            assertNotNull(is);
-                            IndexInfo info = coll.validateXMLResource(transaction,
-                                    broker, XmldbURI.create("test" + fileCount
-                                            + ".xml"), is);
-                            assertNotNull(info);
-                            coll.store(transaction, broker, info, is);
+
+							coll.storeDocument(transaction, broker, XmldbURI.create("test" + fileCount + ".xml"), is, MimeType.XML_TYPE);
                             transact.commit(transaction);
                         }
                     }

--- a/exist-core/src/test/java/org/exist/storage/lock/GetXMLResourceNoLockTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/GetXMLResourceNoLockTest.java
@@ -25,13 +25,13 @@ package org.exist.storage.lock;
 import java.io.IOException;
 import java.util.Optional;
 
-import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
 import org.exist.test.ExistWebServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.junit.*;
-import org.exist.dom.persistent.BinaryDocument;
 import org.exist.EXistException;
 import org.exist.xmldb.XmldbURI;
 import org.exist.test.TestConstants;
@@ -41,8 +41,10 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
+import org.xml.sax.SAXException;
 import uk.ac.ic.doc.slurp.multilock.MultiLock;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 
 /**
@@ -59,7 +61,7 @@ public class GetXMLResourceNoLockTest {
     private static XmldbURI DOCUMENT_NAME_URI = XmldbURI.create("empty.txt");
 	
 	@Test
-	public void testCollectionMaintainsLockWhenResourceIsSelectedNoLock() throws EXistException, InterruptedException, LockException, TriggerException, PermissionDeniedException, IOException {
+	public void testCollectionMaintainsLockWhenResourceIsSelectedNoLock() throws EXistException, LockException, SAXException, PermissionDeniedException, IOException {
 
 		storeTestResource();
 
@@ -83,7 +85,7 @@ public class GetXMLResourceNoLockTest {
 		}
 	}
 
-    private void storeTestResource() throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
+    private void storeTestResource() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final BrokerPool pool = BrokerPool.getInstance();
 
         final TransactionManager transact = pool.getTransactionManager();
@@ -94,11 +96,9 @@ public class GetXMLResourceNoLockTest {
                     .getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
             
             broker.saveCollection(transaction, collection);
-            
-            @SuppressWarnings("unused")
-			final BinaryDocument doc =
-                    collection.addBinaryResource(transaction, broker,
-                    DOCUMENT_NAME_URI , EMPTY_BINARY_FILE.getBytes(), "text/text");
+
+            collection.storeDocument(transaction, broker,
+                    DOCUMENT_NAME_URI , new StringInputSource(EMPTY_BINARY_FILE.getBytes(UTF_8)), MimeType.TEXT_TYPE);
             
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/storage/lock/GetXMLResourceNoLockTest.java
+++ b/exist-core/src/test/java/org/exist/storage/lock/GetXMLResourceNoLockTest.java
@@ -97,8 +97,7 @@ public class GetXMLResourceNoLockTest {
             
             broker.saveCollection(transaction, collection);
 
-            collection.storeDocument(transaction, broker,
-                    DOCUMENT_NAME_URI , new StringInputSource(EMPTY_BINARY_FILE.getBytes(UTF_8)), MimeType.TEXT_TYPE);
+            broker.storeDocument(transaction, DOCUMENT_NAME_URI , new StringInputSource(EMPTY_BINARY_FILE.getBytes(UTF_8)), MimeType.TEXT_TYPE, collection);
             
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/storage/txn/ConcurrentTransactionsTest.java
+++ b/exist-core/src/test/java/org/exist/storage/txn/ConcurrentTransactionsTest.java
@@ -184,7 +184,7 @@ public class ConcurrentTransactionsTest {
             assertNotNull(test);
             broker.saveCollection(transaction, test);
 
-            test.storeDocument(transaction, broker, XmldbURI.create("hamlet.xml"), new InputStreamSupplierInputSource(() -> SAMPLES.getHamletSample()), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("hamlet.xml"), new InputStreamSupplierInputSource(() -> SAMPLES.getHamletSample()), MimeType.XML_TYPE, test);
 
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/storage/txn/ConcurrentTransactionsTest.java
+++ b/exist-core/src/test/java/org/exist/storage/txn/ConcurrentTransactionsTest.java
@@ -35,7 +35,6 @@ package org.exist.storage.txn;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
@@ -43,21 +42,18 @@ import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TransactionTestDSL;
-import org.exist.util.FileInputSource;
+import org.exist.util.InputStreamSupplierInputSource;
 import org.exist.util.LockException;
-import org.exist.util.io.InputStreamUtil;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.junit.*;
-import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.concurrent.*;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.test.TransactionTestDSL.ExecutionListener;
 import static org.exist.test.TransactionTestDSL.NULL_SCHEDULE_LISTENER;
 import static org.exist.test.TransactionTestDSL.STD_OUT_SCHEDULE_LISTENER;
@@ -188,15 +184,7 @@ public class ConcurrentTransactionsTest {
             assertNotNull(test);
             broker.saveCollection(transaction, test);
 
-            final String sample;
-            try (final InputStream is = SAMPLES.getHamletSample()) {
-                assertNotNull(is);
-                sample = InputStreamUtil.readString(is, UTF_8);
-            }
-
-            final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create("hamlet.xml"), sample);
-            assertNotNull(info);
-            test.store(transaction, broker, info, sample);
+            test.storeDocument(transaction, broker, XmldbURI.create("hamlet.xml"), new InputStreamSupplierInputSource(() -> SAMPLES.getHamletSample()), MimeType.XML_TYPE);
 
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/util/XMLReaderExpansionTest.java
+++ b/exist-core/src/test/java/org/exist/util/XMLReaderExpansionTest.java
@@ -24,7 +24,6 @@ package org.exist.util;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -80,8 +79,7 @@ public class XMLReaderExpansionTest extends AbstractXMLReaderSecurityTest {
                 //debugReader("expandExternalEntities", broker, testCollection);
 
                 final String docContent = EXPANSION_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._2.toUri().toString());
-                final IndexInfo indexInfo = testCollection.validateXMLResource(transaction, broker, docName, docContent);
-                testCollection.store(transaction, broker, indexInfo, docContent);
+                testCollection.storeDocument(transaction, broker, docName, new StringInputSource(docContent), MimeType.XML_TYPE);
             }
 
             transaction.commit();

--- a/exist-core/src/test/java/org/exist/util/XMLReaderExpansionTest.java
+++ b/exist-core/src/test/java/org/exist/util/XMLReaderExpansionTest.java
@@ -79,7 +79,7 @@ public class XMLReaderExpansionTest extends AbstractXMLReaderSecurityTest {
                 //debugReader("expandExternalEntities", broker, testCollection);
 
                 final String docContent = EXPANSION_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._2.toUri().toString());
-                testCollection.storeDocument(transaction, broker, docName, new StringInputSource(docContent), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, docName, new StringInputSource(docContent), MimeType.XML_TYPE, testCollection);
             }
 
             transaction.commit();

--- a/exist-core/src/test/java/org/exist/util/XMLReaderSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/util/XMLReaderSecurityTest.java
@@ -89,8 +89,7 @@ public class XMLReaderSecurityTest extends AbstractXMLReaderSecurityTest {
                 //debugReader("cannotExpandExternalEntitiesWhenDisabled", broker, testCollection);
 
                 final String docContent = EXPANSION_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._2.toUri().toString());
-                final IndexInfo indexInfo = testCollection.validateXMLResource(transaction, broker, docName, docContent);
-                testCollection.store(transaction, broker, indexInfo, docContent);
+                testCollection.storeDocument(transaction, broker, docName, new StringInputSource(docContent), MimeType.XML_TYPE);
             }
 
             transaction.commit();

--- a/exist-core/src/test/java/org/exist/util/XMLReaderSecurityTest.java
+++ b/exist-core/src/test/java/org/exist/util/XMLReaderSecurityTest.java
@@ -89,7 +89,7 @@ public class XMLReaderSecurityTest extends AbstractXMLReaderSecurityTest {
                 //debugReader("cannotExpandExternalEntitiesWhenDisabled", broker, testCollection);
 
                 final String docContent = EXPANSION_DOC.replace(EXTERNAL_FILE_PLACEHOLDER, secret._2.toUri().toString());
-                testCollection.storeDocument(transaction, broker, docName, new StringInputSource(docContent), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, docName, new StringInputSource(docContent), MimeType.XML_TYPE, testCollection);
             }
 
             transaction.commit();

--- a/exist-core/src/test/java/org/exist/validation/TestTools.java
+++ b/exist-core/src/test/java/org/exist/validation/TestTools.java
@@ -23,30 +23,19 @@
 package org.exist.validation;
 
 import org.exist.EXistException;
-import org.exist.TestUtils;
-import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
-import org.exist.storage.txn.Txn;
-import org.exist.util.LockException;
 import org.exist.util.io.InputStreamUtil;
-import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.value.Sequence;
-import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  *  A set of helper methods for the validation tests.
@@ -71,24 +60,6 @@ public class TestTools {
         final URLConnection connection = url.openConnection();
         try (final OutputStream os = connection.getOutputStream()) {
             InputStreamUtil.copy(document, os);
-        }
-    }
-
-    public static void storeDocument(final DBBroker broker, final Txn txn, final Collection collection, final String name, final Path data) throws EXistException, PermissionDeniedException, SAXException, LockException, IOException {
-        final String content = new String(TestUtils.readFile(data), UTF_8);
-        storeDocument(broker, txn, collection, name, content);
-    }
-
-    public static void storeDocument(final DBBroker broker, final Txn txn, final Collection collection, final String name, final String content) throws EXistException, PermissionDeniedException, SAXException, LockException, IOException {
-        final XmldbURI docUri  = XmldbURI.create(name);
-        final IndexInfo info = collection.validateXMLResource(txn, broker, docUri, content);
-        collection.store(txn, broker, info, content);
-    }
-
-    public static void storeTextDocument(final DBBroker broker, final Txn txn, final Collection collection, final String name, final Path data) throws EXistException, PermissionDeniedException, SAXException, LockException, IOException {
-        final XmldbURI docUri  = XmldbURI.create(name);
-        try(final InputStream is = Files.newInputStream(data)) {
-            collection.addBinaryResource(txn, broker, docUri, is, "text/plain", Files.size(data));
         }
     }
 

--- a/exist-core/src/test/java/org/exist/xqj/MarshallerTest.java
+++ b/exist-core/src/test/java/org/exist/xqj/MarshallerTest.java
@@ -160,7 +160,7 @@ public class MarshallerTest {
             final Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
             broker.saveCollection(transaction, root);
 
-            root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(TEST_DOC), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(TEST_DOC), MimeType.XML_TYPE, root);
 
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/xqj/MarshallerTest.java
+++ b/exist-core/src/test/java/org/exist/xqj/MarshallerTest.java
@@ -32,11 +32,12 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.util.serializer.SAXSerializer;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.value.*;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.xmldb.XmldbURI;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.NodeProxy;
@@ -159,8 +160,7 @@ public class MarshallerTest {
             final Collection root = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI);
             broker.saveCollection(transaction, root);
 
-            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), TEST_DOC);
-            root.store(transaction, broker, info, TEST_DOC);
+            root.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(TEST_DOC), MimeType.XML_TYPE);
 
             transact.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -23,7 +23,6 @@ package org.exist.xquery;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
@@ -40,6 +39,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.value.Sequence;
 import org.exist.util.serializer.SAXSerializer;
@@ -47,10 +48,8 @@ import org.exist.util.serializer.SerializerPool;
 
 import org.junit.After;
 import org.junit.Test;
-import org.xml.sax.InputSource;
 
 import java.io.IOException;
-import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Optional;
 import java.util.Properties;
@@ -130,9 +129,7 @@ public class ConstructedNodesRecoveryTest {
             broker.saveCollection(transaction, root);
 
             //store test document
-            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(documentName), testDocument);
-            assertNotNull(info);
-            root.store(transaction, broker, info, new InputSource(new StringReader(testDocument)));
+            root.storeDocument(transaction, broker, XmldbURI.create(documentName), new StringInputSource(testDocument), MimeType.XML_TYPE);
 
             //commit the transaction
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ConstructedNodesRecoveryTest.java
@@ -129,7 +129,7 @@ public class ConstructedNodesRecoveryTest {
             broker.saveCollection(transaction, root);
 
             //store test document
-            root.storeDocument(transaction, broker, XmldbURI.create(documentName), new StringInputSource(testDocument), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create(documentName), new StringInputSource(testDocument), MimeType.XML_TYPE, root);
 
             //commit the transaction
             transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/xquery/EmbeddedBinariesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/EmbeddedBinariesTest.java
@@ -59,7 +59,7 @@ public class EmbeddedBinariesTest extends AbstractBinariesTest<Sequence, Item, I
             try(final ManagedCollectionLock collectionLock = brokerPool.getLockManager().acquireCollectionWriteLock(filePath.removeLastSegment())) {
                 final Collection collection = broker.getOrCreateCollection(transaction, filePath.removeLastSegment());
 
-                collection.storeDocument(transaction, broker, filePath.lastSegment(), new StringInputSource(content), MimeType.BINARY_TYPE);
+                broker.storeDocument(transaction, filePath.lastSegment(), new StringInputSource(content), MimeType.BINARY_TYPE, collection);
 
                 broker.saveCollection(transaction, collection);
             }

--- a/exist-core/src/test/java/org/exist/xquery/EmbeddedBinariesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/EmbeddedBinariesTest.java
@@ -32,14 +32,14 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.lock.ManagedCollectionLock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
-import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.value.*;
 import org.junit.ClassRule;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Optional;
 
 /**
@@ -58,13 +58,10 @@ public class EmbeddedBinariesTest extends AbstractBinariesTest<Sequence, Item, I
 
             try(final ManagedCollectionLock collectionLock = brokerPool.getLockManager().acquireCollectionWriteLock(filePath.removeLastSegment())) {
                 final Collection collection = broker.getOrCreateCollection(transaction, filePath.removeLastSegment());
-                try(final InputStream is = new UnsynchronizedByteArrayInputStream(content)) {
 
-                    collection.addBinaryResource(transaction, broker, filePath.lastSegment(), is, "application/octet-stream", content.length);
+                collection.storeDocument(transaction, broker, filePath.lastSegment(), new StringInputSource(content), MimeType.BINARY_TYPE);
 
-                    broker.saveCollection(transaction, collection);
-
-                }
+                broker.saveCollection(transaction, collection);
             }
 
             transaction.commit();

--- a/exist-core/src/test/java/org/exist/xquery/ImportModuleTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ImportModuleTest.java
@@ -47,24 +47,26 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.value.Sequence;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.Diff;
 
 import javax.annotation.Nullable;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Properties;
 
-import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static org.junit.Assert.*;
 
 /**
@@ -79,7 +81,7 @@ public class ImportModuleTest {
      * Checks that the prefix part of an `import module` statement cannot be the value "xml".
      */
     @Test
-    public void prefixXml() throws TriggerException, PermissionDeniedException, IOException, LockException, XPathException, EXistException {
+    public void prefixXml() throws SAXException, PermissionDeniedException, IOException, LockException, EXistException {
         final ErrorCodes.ErrorCode errorCode = prefixNot("xml");
         assertEquals(ErrorCodes.XQST0070, errorCode);
     }
@@ -88,7 +90,7 @@ public class ImportModuleTest {
      * Checks that the prefix part of an `import module` statement cannot be the value "xmlns".
      */
     @Test
-    public void prefixXmlNs() throws TriggerException, PermissionDeniedException, IOException, LockException, XPathException, EXistException {
+    public void prefixXmlNs() throws SAXException, PermissionDeniedException, IOException, LockException, EXistException {
         final ErrorCodes.ErrorCode errorCode = prefixNot("xmlns");
         assertEquals(ErrorCodes.XQST0070, errorCode);
     }
@@ -100,7 +102,7 @@ public class ImportModuleTest {
      *
      * @return the error code from executing the query, or null if there was no error.
      */
-    private @Nullable ErrorCodes.ErrorCode prefixNot(final String prefix) throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    private @Nullable ErrorCodes.ErrorCode prefixNot(final String prefix) throws EXistException, IOException, PermissionDeniedException, LockException, SAXException {
         final String module =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -146,7 +148,7 @@ public class ImportModuleTest {
      * of another `import module` statement within the same module.
      */
     @Test
-    public void prefixSameAsOtherImport() throws EXistException, IOException, TriggerException, PermissionDeniedException, LockException {
+    public void prefixSameAsOtherImport() throws EXistException, IOException, SAXException, PermissionDeniedException, LockException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -204,7 +206,7 @@ public class ImportModuleTest {
      * of a namespace declaration within the same module.
      */
     @Test
-    public void prefixSameAsOtherNamespaceDeclaration() throws EXistException, IOException, TriggerException, PermissionDeniedException, LockException {
+    public void prefixSameAsOtherNamespaceDeclaration() throws EXistException, IOException, SAXException, PermissionDeniedException, LockException {
         final String module =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -251,7 +253,7 @@ public class ImportModuleTest {
      * of the library module in which it resides.
      */
     @Test
-    public void prefixSameAsModuleDeclaration() throws EXistException, IOException, TriggerException, PermissionDeniedException, LockException {
+    public void prefixSameAsModuleDeclaration() throws EXistException, IOException, SAXException, PermissionDeniedException, LockException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -308,7 +310,7 @@ public class ImportModuleTest {
      * Checks that XQST0088 is raised if the namespace part of an `import module` statement is empty.
      */
     @Test
-    public void emptyNamespace() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException {
+    public void emptyNamespace() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException {
         final String module =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -354,7 +356,7 @@ public class ImportModuleTest {
      * of another `import module` statement within the same module.
      */
     @Test
-    public void namespaceSameAsOtherImport() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void namespaceSameAsOtherImport() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -483,7 +485,7 @@ public class ImportModuleTest {
      * Checks that XQST0034 is raised if two modules contain a function of the same name and arity.
      */
     @Test
-    public void functionSameAsOtherModule() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void functionSameAsOtherModule() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -632,7 +634,7 @@ public class ImportModuleTest {
      * Checks that XQST0034 is raised if an imported module and the importing module contain a function of the same name and arity.
      */
     @Test
-    public void functionSameAsImportingModule() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void functionSameAsImportingModule() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException {
         final String module =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -684,7 +686,7 @@ public class ImportModuleTest {
      * Checks that XQST0049 is raised if two modules contain a variable of the same name.
      */
     @Test
-    public void variableSameAsOtherModule() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void variableSameAsOtherModule() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -736,7 +738,7 @@ public class ImportModuleTest {
      * Checks that XQST0049 is raised if an imported module and the importing module contain a variable of the same name.
      */
     @Test
-    public void variableSameAsImportingModule() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void variableSameAsImportingModule() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException {
         final String module =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -783,7 +785,7 @@ public class ImportModuleTest {
      * Imports a single XQuery Library Module containing functions into a target namespace.
      */
     @Test
-    public void functionsSingleLocationHint() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void functionsSingleLocationHint() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException, XPathException {
         final String module =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -838,7 +840,7 @@ public class ImportModuleTest {
      * Imports multiple XQuery Library Modules containing functions into the same target namespace.
      */
     @Test
-    public void functionsCompositeFromMultipleLocationHints() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void functionsCompositeFromMultipleLocationHints() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException, XPathException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -918,7 +920,7 @@ public class ImportModuleTest {
      * Imports multiple XQuery Library Modules containing functions into the same target namespace.
      */
     @Test
-    public void functionsCompositeFromMultipleLocationHintsWithDifferingPrefixes() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void functionsCompositeFromMultipleLocationHintsWithDifferingPrefixes() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException, XPathException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                         "module namespace impl1 = \"http://example.com/impl\";\n" +
@@ -998,7 +1000,7 @@ public class ImportModuleTest {
      * Imports a single XQuery Library Module containing variables into a target namespace.
      */
     @Test
-    public void variablesSingleLocationHint() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void variablesSingleLocationHint() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException, XPathException {
         final String module =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -1051,7 +1053,7 @@ public class ImportModuleTest {
      * Imports multiple XQuery Library Modules containing variables into the same target namespace.
      */
     @Test
-    public void variablesCompositeFromMultipleLocationHints() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void variablesCompositeFromMultipleLocationHints() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException, XPathException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl = \"http://example.com/impl\";\n" +
@@ -1125,7 +1127,7 @@ public class ImportModuleTest {
      * Imports multiple XQuery Library Modules into the same target namespace.
      */
     @Test
-    public void variablesCompositeFromMultipleLocationHintsWithDifferingPrefixes() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void variablesCompositeFromMultipleLocationHintsWithDifferingPrefixes() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException, XPathException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl1 = \"http://example.com/impl\";\n" +
@@ -1196,7 +1198,7 @@ public class ImportModuleTest {
     }
 
     @Test
-    public void variablesBetweenModules() throws EXistException, PermissionDeniedException, IOException, LockException, TriggerException, XPathException {
+    public void variablesBetweenModules() throws EXistException, PermissionDeniedException, IOException, LockException, SAXException, XPathException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace mod1 = \"http://example.com/mod1\";\n" +
@@ -1281,7 +1283,7 @@ public class ImportModuleTest {
      */
     @Ignore("eXist-db does not have cyclic import checks, but it should!")
     @Test
-    public void cyclic1() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void cyclic1() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl1 = \"http://example.com/impl1\";\n" +
@@ -1342,7 +1344,7 @@ public class ImportModuleTest {
      */
     @Ignore("eXist-db does not have cyclic import checks, but it should!")
     @Test
-    public void cyclic2() throws EXistException, IOException, PermissionDeniedException, LockException, TriggerException, XPathException {
+    public void cyclic2() throws EXistException, IOException, PermissionDeniedException, LockException, SAXException {
         final String module1 =
                 "xquery version \"1.0\";\n" +
                 "module namespace impl1 = \"http://example.com/impl1\";\n" +
@@ -1408,16 +1410,14 @@ public class ImportModuleTest {
         }
     }
 
-    private void storeModules(final DBBroker broker, final Txn transaction, final String collectionUri, final Tuple2<String, String>... modules) throws PermissionDeniedException, IOException, TriggerException, LockException, EXistException {
+    private void storeModules(final DBBroker broker, final Txn transaction, final String collectionUri, final Tuple2<String, String>... modules) throws PermissionDeniedException, IOException, SAXException, LockException, EXistException {
         // store modules
         try (final Collection collection = broker.openCollection(XmldbURI.create(collectionUri), Lock.LockMode.WRITE_LOCK)) {
 
             for (final Tuple2<String, String> module : modules) {
                 final XmldbURI moduleName = XmldbURI.create(module._1);
-                final byte[] moduleData = module._2.getBytes(UTF_8);
-                try (final ByteArrayInputStream bais = new ByteArrayInputStream(moduleData)) {
-                    collection.addBinaryResource(transaction, broker, moduleName, bais, "application/xquery", moduleData.length);
-                }
+
+                collection.storeDocument(transaction, broker, moduleName, new StringInputSource(module._2.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
             }
         }
     }

--- a/exist-core/src/test/java/org/exist/xquery/ImportModuleTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ImportModuleTest.java
@@ -1417,7 +1417,7 @@ public class ImportModuleTest {
             for (final Tuple2<String, String> module : modules) {
                 final XmldbURI moduleName = XmldbURI.create(module._1);
 
-                collection.storeDocument(transaction, broker, moduleName, new StringInputSource(module._2.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+                broker.storeDocument(transaction, moduleName, new StringInputSource(module._2.getBytes(UTF_8)), MimeType.XQUERY_TYPE, collection);
             }
         }
     }

--- a/exist-core/src/test/java/org/exist/xquery/LexerTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/LexerTest.java
@@ -84,7 +84,7 @@ public class LexerTest {
 	            Collection collection = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
 	            broker.saveCollection(transaction, collection);
 	
-	            collection.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(xml), MimeType.XML_TYPE);
+	            broker.storeDocument(transaction, XmldbURI.create("test.xml"), new StringInputSource(xml), MimeType.XML_TYPE, collection);
 	            //TODO : unlock the collection here ?
 
 	            transact.commit(transaction);

--- a/exist-core/src/test/java/org/exist/xquery/LexerTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/LexerTest.java
@@ -29,7 +29,6 @@ import antlr.RecognitionException;
 import antlr.TokenStreamException;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
@@ -38,6 +37,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.parser.XQueryLexer;
 import org.exist.xquery.parser.XQueryParser;
@@ -83,9 +84,9 @@ public class LexerTest {
 	            Collection collection = broker.getOrCreateCollection(transaction, TestConstants.TEST_COLLECTION_URI);
 	            broker.saveCollection(transaction, collection);
 	
-	            IndexInfo info = collection.validateXMLResource(transaction, broker, XmldbURI.create("test.xml"), xml);
+	            collection.storeDocument(transaction, broker, XmldbURI.create("test.xml"), new StringInputSource(xml), MimeType.XML_TYPE);
 	            //TODO : unlock the collection here ?
-	            collection.store(transaction, broker, info, xml);
+
 	            transact.commit(transaction);
 			}
 

--- a/exist-core/src/test/java/org/exist/xquery/XQueryContextAttributesTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryContextAttributesTest.java
@@ -164,7 +164,7 @@ public class XQueryContextAttributesTest {
 
     private static DBSource storeQuery(final DBBroker broker, final Txn transaction, final XmldbURI uri, final InputSource source) throws IOException, PermissionDeniedException, SAXException, LockException, EXistException {
         try (final Collection collection = broker.openCollection(uri.removeLastSegment(), Lock.LockMode.WRITE_LOCK)) {
-            collection.storeDocument(transaction, broker, uri.lastSegment(), source, MimeType.XQUERY_TYPE);
+            broker.storeDocument(transaction, uri.lastSegment(), source, MimeType.XQUERY_TYPE, collection);
             final BinaryDocument doc = (BinaryDocument) collection.getDocument(broker, uri.lastSegment());
 
             return new DBSource(broker, doc, false);

--- a/exist-core/src/test/java/org/exist/xquery/XQueryDeclareContextItemTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryDeclareContextItemTest.java
@@ -25,7 +25,6 @@ package org.exist.xquery;
 import com.googlecode.junittoolbox.ParallelRunner;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.ElementImpl;
@@ -38,6 +37,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.NodeValue;
@@ -81,10 +82,7 @@ public class XQueryDeclareContextItemTest {
             assertNotNull(root);
             broker.saveCollection(transaction, root);
 
-            final IndexInfo info = root.validateXMLResource(transaction, broker,
-                    XmldbURI.create("sysevent.xml"), SYSEVENT_XML);
-            assertNotNull(info);
-            root.store(transaction, broker, info, SYSEVENT_XML);
+            root.storeDocument(transaction, broker, XmldbURI.create("sysevent.xml"), new StringInputSource(SYSEVENT_XML), MimeType.XML_TYPE);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryDeclareContextItemTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryDeclareContextItemTest.java
@@ -82,7 +82,7 @@ public class XQueryDeclareContextItemTest {
             assertNotNull(root);
             broker.saveCollection(transaction, root);
 
-            root.storeDocument(transaction, broker, XmldbURI.create("sysevent.xml"), new StringInputSource(SYSEVENT_XML), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("sysevent.xml"), new StringInputSource(SYSEVENT_XML), MimeType.XML_TYPE, root);
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.PermissionDeniedException;
@@ -37,6 +36,8 @@ import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
@@ -503,9 +504,8 @@ public class XQueryUpdateTest {
             root = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
             broker.saveCollection(transaction, root);
 
-            IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(docName), data);
+            root.storeDocument(transaction, broker, XmldbURI.create(docName), new StringInputSource(data), MimeType.XML_TYPE);
             //TODO : unlock the collection here ?
-            root.store(transaction, broker, info, data);
 
             mgr.commit(transaction);
         }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryUpdateTest.java
@@ -504,7 +504,7 @@ public class XQueryUpdateTest {
             root = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
             broker.saveCollection(transaction, root);
 
-            root.storeDocument(transaction, broker, XmldbURI.create(docName), new StringInputSource(data), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create(docName), new StringInputSource(data), MimeType.XML_TYPE, root);
             //TODO : unlock the collection here ?
 
             mgr.commit(transaction);

--- a/exist-core/src/test/java/org/exist/xquery/functions/inspect/InspectModuleTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/inspect/InspectModuleTest.java
@@ -33,7 +33,8 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
-import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -42,9 +43,9 @@ import org.exist.xquery.value.Sequence;
 import org.junit.*;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -257,16 +258,14 @@ public class InspectModuleTest {
     }
 
     @BeforeClass
-    public static void setup() throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
+    public static void setup() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
         try(final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
                 final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             final Collection testCollection = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
 
-            try (final InputStream is = new UnsynchronizedByteArrayInputStream(MODULE.getBytes(UTF_8))) {
-                testCollection.addBinaryResource(transaction, broker, TEST_MODULE, is, "application/xquery", MODULE.getBytes(UTF_8).length);
-            }
+            testCollection.storeDocument(transaction, broker, TEST_MODULE, new StringInputSource(MODULE.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
 
             broker.saveCollection(transaction, testCollection);
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/inspect/InspectModuleTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/inspect/InspectModuleTest.java
@@ -265,7 +265,7 @@ public class InspectModuleTest {
 
             final Collection testCollection = broker.getOrCreateCollection(transaction, TEST_COLLECTION);
 
-            testCollection.storeDocument(transaction, broker, TEST_MODULE, new StringInputSource(MODULE.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+            broker.storeDocument(transaction, TEST_MODULE, new StringInputSource(MODULE.getBytes(UTF_8)), MimeType.XQUERY_TYPE, testCollection);
 
             broker.saveCollection(transaction, testCollection);
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChmodTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChmodTest.java
@@ -271,12 +271,12 @@ public class PermissionsFunctionChmodTest {
             broker.saveCollection(transaction, u1c2);
 
             final String xml1 = "<empty1/>";
-            collection.storeDocument(transaction, broker, USER1_DOC1, new StringInputSource(xml1), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, USER1_DOC1, new StringInputSource(xml1), MimeType.XML_TYPE, collection);
 
             final String xquery1 =
                     "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
                             "sm:id()";
-            collection.storeDocument(transaction, broker, USER1_XQUERY1, new StringInputSource(xquery1.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+            broker.storeDocument(transaction, USER1_XQUERY1, new StringInputSource(xquery1.getBytes(UTF_8)), MimeType.XQUERY_TYPE, collection);
             PermissionFactory.chmod_str(broker, transaction, collection.getURI().append(USER1_XQUERY1), Optional.of("u+s,g+s"), Optional.empty());
 
             transaction.commit();

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChmodTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChmodTest.java
@@ -26,9 +26,7 @@ import com.evolvedbinary.j8fu.function.Runnable4E;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
-import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.*;
@@ -42,6 +40,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -271,14 +271,13 @@ public class PermissionsFunctionChmodTest {
             broker.saveCollection(transaction, u1c2);
 
             final String xml1 = "<empty1/>";
-            final IndexInfo indexInfo1 = collection.validateXMLResource(transaction, broker, USER1_DOC1, xml1);
-            collection.store(transaction, broker, indexInfo1, xml1);
+            collection.storeDocument(transaction, broker, USER1_DOC1, new StringInputSource(xml1), MimeType.XML_TYPE);
 
             final String xquery1 =
                     "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
                             "sm:id()";
-            final BinaryDocument uqxq1 = collection.addBinaryResource(transaction, broker, USER1_XQUERY1, xquery1.getBytes(UTF_8), "application/xquery");
-            PermissionFactory.chmod_str(broker, transaction, uqxq1.getURI(), Optional.of("u+s,g+s"), Optional.empty());
+            collection.storeDocument(transaction, broker, USER1_XQUERY1, new StringInputSource(xquery1.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+            PermissionFactory.chmod_str(broker, transaction, collection.getURI().append(USER1_XQUERY1), Optional.of("u+s,g+s"), Optional.empty());
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
@@ -1668,12 +1668,12 @@ public class PermissionsFunctionChownTest {
             broker.saveCollection(transaction, u1c2);
 
             final String xml1 = "<empty1/>";
-            collection.storeDocument(transaction, broker, USER1_DOC1, new StringInputSource(xml1), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, USER1_DOC1, new StringInputSource(xml1), MimeType.XML_TYPE, collection);
 
             final String xquery1 =
                     "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
                     "sm:id()";
-            collection.storeDocument(transaction, broker, USER1_XQUERY1, new StringInputSource(xquery1.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+            broker.storeDocument(transaction, USER1_XQUERY1, new StringInputSource(xquery1.getBytes(UTF_8)), MimeType.XQUERY_TYPE, collection);
             PermissionFactory.chmod_str(broker, transaction, collection.getURI().append(USER1_XQUERY1), Optional.of("u+s,g+s"), Optional.empty());
 
             transaction.commit();

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/PermissionsFunctionChownTest.java
@@ -27,9 +27,7 @@ import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.TestUtils;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
-import org.exist.dom.persistent.BinaryDocument;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
 import org.exist.security.*;
@@ -44,6 +42,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.Configuration;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -1668,14 +1668,13 @@ public class PermissionsFunctionChownTest {
             broker.saveCollection(transaction, u1c2);
 
             final String xml1 = "<empty1/>";
-            final IndexInfo indexInfo1 = collection.validateXMLResource(transaction, broker, USER1_DOC1, xml1);
-            collection.store(transaction, broker, indexInfo1, xml1);
+            collection.storeDocument(transaction, broker, USER1_DOC1, new StringInputSource(xml1), MimeType.XML_TYPE);
 
             final String xquery1 =
                     "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
                     "sm:id()";
-            final BinaryDocument uqxq1 = collection.addBinaryResource(transaction, broker, USER1_XQUERY1, xquery1.getBytes(UTF_8), "application/xquery");
-            PermissionFactory.chmod_str(broker, transaction, uqxq1.getURI(), Optional.of("u+s,g+s"), Optional.empty());
+            collection.storeDocument(transaction, broker, USER1_XQUERY1, new StringInputSource(xquery1.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+            PermissionFactory.chmod_str(broker, transaction, collection.getURI().append(USER1_XQUERY1), Optional.of("u+s,g+s"), Optional.empty());
 
             transaction.commit();
         }

--- a/exist-core/src/test/java/org/exist/xquery/functions/transform/TransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/transform/TransformTest.java
@@ -24,7 +24,6 @@ package org.exist.xquery.functions.transform;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -34,6 +33,8 @@ import org.exist.storage.lock.ManagedCollectionLock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -421,14 +422,9 @@ public class TransformTest {
             final Collection collection = broker.getOrCreateCollection(transaction, collectionUri);
             broker.saveCollection(transaction, collection);
             for (final Tuple2<XmldbURI, String> doc : docs) {
-                storeXml(broker, transaction, collection, doc._1, doc._2);
+                collection.storeDocument(transaction, broker, doc._1, new StringInputSource(doc._2), MimeType.XML_TYPE);
             }
         }
-    }
-
-    private static void storeXml(final DBBroker broker, final Txn transaction, final Collection collection, final XmldbURI name, final String xml) throws LockException, SAXException, PermissionDeniedException, EXistException, IOException {
-        final IndexInfo indexInfo = collection.validateXMLResource(transaction, broker, name, xml);
-        collection.store(transaction, broker, indexInfo, xml);
     }
 
     private static void deleteCollection(final DBBroker broker, final Txn transaction, final XmldbURI collectionUri) throws PermissionDeniedException, IOException, TriggerException {

--- a/exist-core/src/test/java/org/exist/xquery/functions/transform/TransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/transform/TransformTest.java
@@ -422,7 +422,7 @@ public class TransformTest {
             final Collection collection = broker.getOrCreateCollection(transaction, collectionUri);
             broker.saveCollection(transaction, collection);
             for (final Tuple2<XmldbURI, String> doc : docs) {
-                collection.storeDocument(transaction, broker, doc._1, new StringInputSource(doc._2), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, doc._1, new StringInputSource(doc._2), MimeType.XML_TYPE, collection);
             }
         }
     }

--- a/extensions/debuggee/src/test/java/org/exist/debugger/DebuggerTest.java
+++ b/extensions/debuggee/src/test/java/org/exist/debugger/DebuggerTest.java
@@ -459,7 +459,7 @@ public class DebuggerTest implements ResponseListener {
 		//System.out.println("getResponse command = "+command);
 	}
 	
-    private static void store(String name,  String data) throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
+    private static void store(final String name, final String data) throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
     	final Database pool = BrokerPool.getInstance();
         final TransactionManager transact = pool.getTransactionManager();
 
@@ -470,7 +470,7 @@ public class DebuggerTest implements ResponseListener {
 			broker.saveCollection(transaction, root);
 			assertNotNull(root);
 
-			root.addBinaryResource(transaction, broker, XmldbURI.create(name), data.getBytes(), "application/xquery");
+			root.storeDocument(transaction, broker, XmldbURI.create(name), new StringInputSource(data), MimeType.XML_TYPE);
 
 			transact.commit(transaction);
 		}

--- a/extensions/debuggee/src/test/java/org/exist/debugger/DebuggerTest.java
+++ b/extensions/debuggee/src/test/java/org/exist/debugger/DebuggerTest.java
@@ -470,7 +470,7 @@ public class DebuggerTest implements ResponseListener {
 			broker.saveCollection(transaction, root);
 			assertNotNull(root);
 
-			root.storeDocument(transaction, broker, XmldbURI.create(name), new StringInputSource(data), MimeType.XML_TYPE);
+			broker.storeDocument(transaction, XmldbURI.create(name), new StringInputSource(data), MimeType.XML_TYPE, root);
 
 			transact.commit(transaction);
 		}

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -1272,7 +1272,7 @@ public class LuceneIndexTest {
                 mgr.addConfiguration(transaction, broker, root, configuration);
             }
 
-            root.storeDocument(transaction, broker, XmldbURI.create(docName), new StringInputSource(data), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create(docName), new StringInputSource(data), MimeType.XML_TYPE, root);
 
             docs.add(root.getDocument(broker, XmldbURI.create(docName)));
             transact.commit(transaction);
@@ -1296,7 +1296,7 @@ public class LuceneIndexTest {
             }
 
             for (final String sampleName : sampleNames) {
-                root.storeDocument(transaction, broker, XmldbURI.create(sampleName), new InputStreamSupplierInputSource(() -> SAMPLES.getShakespeareSample(sampleName)), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create(sampleName), new InputStreamSupplierInputSource(() -> SAMPLES.getShakespeareSample(sampleName)), MimeType.XML_TYPE, root);
                 docs.add(root.getDocument(broker, XmldbURI.create(sampleName)));
             }
             transact.commit(transaction);

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneIndexTest.java
@@ -21,13 +21,11 @@
  */
 package org.exist.indexing.lucene;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.util.PropertiesBuilder.propertiesBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringReader;
 import java.util.*;
 import javax.xml.XMLConstants;
@@ -39,7 +37,6 @@ import org.exist.TestUtils;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationManager;
 import org.exist.collections.CollectionConfigurationException;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.DefaultDocumentSet;
@@ -56,7 +53,6 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.*;
-import org.exist.util.io.InputStreamUtil;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XQuery;
 import org.exist.xquery.XQueryContext;
@@ -1276,11 +1272,9 @@ public class LuceneIndexTest {
                 mgr.addConfiguration(transaction, broker, root, configuration);
             }
 
-            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(docName), data);
-            assertNotNull(info);
-            root.store(transaction, broker, info, data);
+            root.storeDocument(transaction, broker, XmldbURI.create(docName), new StringInputSource(data), MimeType.XML_TYPE);
 
-            docs.add(info.getDocument());
+            docs.add(root.getDocument(broker, XmldbURI.create(docName)));
             transact.commit(transaction);
         }
 
@@ -1302,13 +1296,8 @@ public class LuceneIndexTest {
             }
 
             for (final String sampleName : sampleNames) {
-                try (final InputStream is = SAMPLES.getShakespeareSample(sampleName)) {
-                    final String sample = InputStreamUtil.readString(is, UTF_8);
-                    final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create(sampleName), sample);
-                    assertNotNull(info);
-                    root.store(transaction, broker, info, sample);
-                    docs.add(info.getDocument());
-                }
+                root.storeDocument(transaction, broker, XmldbURI.create(sampleName), new InputStreamSupplierInputSource(() -> SAMPLES.getShakespeareSample(sampleName)), MimeType.XML_TYPE);
+                docs.add(root.getDocument(broker, XmldbURI.create(sampleName)));
             }
             transact.commit(transaction);
         }

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneMatchListenerTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneMatchListenerTest.java
@@ -385,7 +385,7 @@ public class LuceneMatchListenerTest {
             final CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(transaction, broker, root, config);
 
-            root.storeDocument(transaction, broker, XmldbURI.create("test_matches.xml"), new StringInputSource(data), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test_matches.xml"), new StringInputSource(data), MimeType.XML_TYPE, root);
 
             transact.commit(transaction);
         }

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneMatchListenerTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/LuceneMatchListenerTest.java
@@ -32,7 +32,6 @@ import org.exist.TestUtils;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -45,6 +44,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -384,9 +385,7 @@ public class LuceneMatchListenerTest {
             final CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(transaction, broker, root, config);
 
-            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_matches.xml"), XML);
-            assertNotNull(info);
-            root.store(transaction, broker, info, data);
+            root.storeDocument(transaction, broker, XmldbURI.create("test_matches.xml"), new StringInputSource(data), MimeType.XML_TYPE);
 
             transact.commit(transaction);
         }

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/SerializeAttrMatchesTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/SerializeAttrMatchesTest.java
@@ -26,7 +26,6 @@ import org.exist.TestUtils;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.memtree.ElementImpl;
 import org.exist.dom.persistent.DefaultDocumentSet;
@@ -40,6 +39,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -52,7 +53,6 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class SerializeAttrMatchesTest {
@@ -112,11 +112,9 @@ public class SerializeAttrMatchesTest {
                 mgr.addConfiguration(transaction, broker, test, configuration);
             }
 
-            final IndexInfo info = test.validateXMLResource(transaction, broker, XmldbURI.create(docName), data);
-            assertNotNull(info);
-            test.store(transaction, broker, info, data);
+            test.storeDocument(transaction, broker, XmldbURI.create(docName), new StringInputSource(data), MimeType.XML_TYPE);
 
-            docs.add(info.getDocument());
+            docs.add(test.getDocument(broker, XmldbURI.create(docName)));
             transact.commit(transaction);
         }
 

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/SerializeAttrMatchesTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/SerializeAttrMatchesTest.java
@@ -112,7 +112,7 @@ public class SerializeAttrMatchesTest {
                 mgr.addConfiguration(transaction, broker, test, configuration);
             }
 
-            test.storeDocument(transaction, broker, XmldbURI.create(docName), new StringInputSource(data), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create(docName), new StringInputSource(data), MimeType.XML_TYPE, test);
 
             docs.add(test.getDocument(broker, XmldbURI.create(docName)));
             transact.commit(transaction);

--- a/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/CustomIndexTest.java
@@ -628,10 +628,10 @@ public class CustomIndexTest {
 
             docs = new DefaultDocumentSet();
 
-            root.storeDocument(transaction, broker, XmldbURI.create("test_string.xml"), new StringInputSource(XML), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test_string.xml"), new StringInputSource(XML), MimeType.XML_TYPE, root);
             docs.add(root.getDocument(broker, XmldbURI.create("test_string.xml")));
 
-            root.storeDocument(transaction, broker, XmldbURI.create("test_string2.xml"), new StringInputSource(XML2), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test_string2.xml"), new StringInputSource(XML2), MimeType.XML_TYPE, root);
             docs.add(root.getDocument(broker, XmldbURI.create("test_string2.xml")));
 
             transact.commit(transaction);

--- a/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/CustomIndexTest.java
+++ b/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/CustomIndexTest.java
@@ -25,7 +25,6 @@ import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DefaultDocumentSet;
 import org.exist.dom.persistent.DocumentSet;
@@ -629,17 +628,11 @@ public class CustomIndexTest {
 
             docs = new DefaultDocumentSet();
 
-            IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_string.xml"), XML);
-            assertNotNull(info);
-            root.store(transaction, broker, info, XML);
+            root.storeDocument(transaction, broker, XmldbURI.create("test_string.xml"), new StringInputSource(XML), MimeType.XML_TYPE);
+            docs.add(root.getDocument(broker, XmldbURI.create("test_string.xml")));
 
-            docs.add(info.getDocument());
-
-            info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_string2.xml"), XML2);
-            assertNotNull(info);
-            root.store(transaction, broker, info, XML2);
-
-            docs.add(info.getDocument());
+            root.storeDocument(transaction, broker, XmldbURI.create("test_string2.xml"), new StringInputSource(XML2), MimeType.XML_TYPE);
+            docs.add(root.getDocument(broker, XmldbURI.create("test_string2.xml")));
 
             transact.commit(transaction);
         }

--- a/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/MatchListenerTest.java
+++ b/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/MatchListenerTest.java
@@ -566,7 +566,7 @@ public class MatchListenerTest {
             final CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(transaction, broker, root, config);
 
-            root.storeDocument(transaction, broker, XmldbURI.create("test_matches.xml"), new StringInputSource(xml), MimeType.XML_TYPE);
+            broker.storeDocument(transaction, XmldbURI.create("test_matches.xml"), new StringInputSource(xml), MimeType.XML_TYPE, root);
             
             transact.commit(transaction);
         }

--- a/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/MatchListenerTest.java
+++ b/extensions/indexes/ngram/src/test/java/org/exist/indexing/ngram/MatchListenerTest.java
@@ -42,7 +42,6 @@ import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
@@ -55,6 +54,8 @@ import org.exist.test.ExistEmbeddedServer;
 import org.exist.test.TestConstants;
 import org.exist.util.DatabaseConfigurationException;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -565,9 +566,7 @@ public class MatchListenerTest {
             final CollectionConfigurationManager mgr = pool.getConfigurationManager();
             mgr.addConfiguration(transaction, broker, root, config);
 
-            final IndexInfo info = root.validateXMLResource(transaction, broker, XmldbURI.create("test_matches.xml"), xml);
-            assertNotNull(info);
-            root.store(transaction, broker, info, xml);
+            root.storeDocument(transaction, broker, XmldbURI.create("test_matches.xml"), new StringInputSource(xml), MimeType.XML_TYPE);
             
             transact.commit(transaction);
         }

--- a/extensions/indexes/spatial/src/test/java/org/exist/indexing/spatial/GMLIndexTest.java
+++ b/extensions/indexes/spatial/src/test/java/org/exist/indexing/spatial/GMLIndexTest.java
@@ -121,7 +121,7 @@ public class GMLIndexTest {
 
             for (int i = 0; i < FILES.length; i++) {
                 final URL url = GMLIndexTest.class.getResource("/" + FILES[i]);
-                testCollection.storeDocument(transaction, broker, XmldbURI.create(FILES[i]), new FileInputSource(Paths.get(url.toURI())), MimeType.XML_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create(FILES[i]), new FileInputSource(Paths.get(url.toURI())), MimeType.XML_TYPE, testCollection);
             }
 
             transaction.commit();

--- a/extensions/indexes/spatial/src/test/java/org/exist/indexing/spatial/GMLIndexTest.java
+++ b/extensions/indexes/spatial/src/test/java/org/exist/indexing/spatial/GMLIndexTest.java
@@ -22,11 +22,9 @@
 package org.exist.indexing.spatial;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -42,7 +40,6 @@ import org.exist.EXistException;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfigurationException;
 import org.exist.collections.CollectionConfigurationManager;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.dom.persistent.LockedDocument;
@@ -56,7 +53,9 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.ExistSAXParserFactory;
+import org.exist.util.FileInputSource;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -122,17 +121,7 @@ public class GMLIndexTest {
 
             for (int i = 0; i < FILES.length; i++) {
                 final URL url = GMLIndexTest.class.getResource("/" + FILES[i]);
-                final IndexInfo indexInfo;
-                try (final InputStream is = Files.newInputStream(Paths.get(url.toURI()))) {
-                    final InputSource source = new InputSource();
-                    source.setByteStream(is);
-                    indexInfo = testCollection.validateXMLResource(transaction, broker, XmldbURI.create(FILES[i]), source);
-                }
-                try (final InputStream is = Files.newInputStream(Paths.get(url.toURI()))) {
-                    final InputSource source = new InputSource();
-                    source.setByteStream(is);
-                    testCollection.store(transaction, broker, indexInfo, source);
-                }
+                testCollection.storeDocument(transaction, broker, XmldbURI.create(FILES[i]), new FileInputSource(Paths.get(url.toURI())), MimeType.XML_TYPE);
             }
 
             transaction.commit();

--- a/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java
+++ b/extensions/modules/compression/src/main/java/org/exist/xquery/modules/compression/EntryFunctions.java
@@ -285,7 +285,7 @@ public class EntryFunctions extends BasicFunction {
                             try (final Collection collection = context.getBroker().openCollection(destPath.removeLastSegment(), Lock.LockMode.WRITE_LOCK)) {
                                 final BinaryValue binaryValue = (BinaryValue) data.get();
                                 final MimeType mimeType = MimeTable.getInstance().getContentTypeFor(destPath.lastSegment());
-                                collection.storeDocument(transaction, context.getBroker(), destPath.lastSegment(), new BinaryValueInputSource(binaryValue), mimeType);
+                                context.getBroker().storeDocument(transaction, destPath.lastSegment(), new BinaryValueInputSource(binaryValue), mimeType, collection);
                             }
                             transaction.commit();
                         } catch (final IOException | PermissionDeniedException | EXistException | LockException | SAXException e) {

--- a/extensions/modules/expathrepo/expathrepo-trigger-test/src/main/java/org/exist/repo/ExampleTrigger.java
+++ b/extensions/modules/expathrepo/expathrepo-trigger-test/src/main/java/org/exist/repo/ExampleTrigger.java
@@ -24,7 +24,6 @@ package org.exist.repo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.CollectionTrigger;
 import org.exist.collections.triggers.DocumentTrigger;
 import org.exist.collections.triggers.SAXTrigger;
@@ -33,11 +32,9 @@ import org.exist.dom.persistent.DocumentImpl;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
-import org.xml.sax.InputSource;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 
 public class ExampleTrigger extends SAXTrigger implements DocumentTrigger, CollectionTrigger {
 
@@ -107,13 +104,7 @@ public class ExampleTrigger extends SAXTrigger implements DocumentTrigger, Colle
         try (final Collection collection = broker.openCollection(document.getCollection().getURI(), Lock.LockMode.WRITE_LOCK)) {
 
             // Stream into database
-            try (final InputStream bais = new ByteArrayInputStream(data);) {
-                final IndexInfo info = collection.validateXMLResource(txn, broker, newDocumentURI, new InputSource(bais));
-                final DocumentImpl doc = info.getDocument();
-                doc.setMimeType("application/xml");
-                bais.reset();
-                collection.store(txn, broker, info, new InputSource(bais));
-            }
+            collection.storeDocument(txn, broker, newDocumentURI, new StringInputSource(data), MimeType.XML_TYPE);
 
         } catch (Exception e) {
             LOG.error(e);

--- a/extensions/modules/expathrepo/expathrepo-trigger-test/src/main/java/org/exist/repo/ExampleTrigger.java
+++ b/extensions/modules/expathrepo/expathrepo-trigger-test/src/main/java/org/exist/repo/ExampleTrigger.java
@@ -104,7 +104,7 @@ public class ExampleTrigger extends SAXTrigger implements DocumentTrigger, Colle
         try (final Collection collection = broker.openCollection(document.getCollection().getURI(), Lock.LockMode.WRITE_LOCK)) {
 
             // Stream into database
-            collection.storeDocument(txn, broker, newDocumentURI, new StringInputSource(data), MimeType.XML_TYPE);
+            broker.storeDocument(txn, newDocumentURI, new StringInputSource(data), MimeType.XML_TYPE, collection);
 
         } catch (Exception e) {
             LOG.error(e);

--- a/extensions/modules/expathrepo/pom.xml
+++ b/extensions/modules/expathrepo/pom.xml
@@ -89,12 +89,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <!-- needed for resolving the XAR for PackageTriggerTest -->
             <groupId>org.exist-db</groupId>
             <artifactId>exist-expathrepo-trigger-test</artifactId>

--- a/extensions/modules/expathrepo/src/test/java/org/exist/repo/PackageTriggerTest.java
+++ b/extensions/modules/expathrepo/src/test/java/org/exist/repo/PackageTriggerTest.java
@@ -21,19 +21,18 @@
  */
 package org.exist.repo;
 
-import org.apache.commons.io.IOUtils;
 import org.exist.EXistException;
 import org.exist.Version;
 import org.exist.collections.Collection;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.ManagedCollectionLock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.InputStreamSupplierInputSource;
 import org.exist.util.LockException;
-import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
+import org.exist.util.MimeType;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQuery;
@@ -42,9 +41,9 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Optional;
 
 import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE;
@@ -59,7 +58,7 @@ public class PackageTriggerTest {
     public static ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(false, true);
 
     @BeforeClass
-    public static void setup() throws PermissionDeniedException, IOException, TriggerException, EXistException, IOException, LockException, XPathException {
+    public static void setup() throws PermissionDeniedException, SAXException, EXistException, IOException, LockException, XPathException {
 
         final BrokerPool brokerPool = existEmbeddedServer.getBrokerPool();
 
@@ -72,24 +71,15 @@ public class PackageTriggerTest {
             transaction.commit();
         }
 
-        // Load XAR file
-        byte[] content;
-        try (InputStream resourceAsStream = PackageTriggerTest.class.getResourceAsStream("/" + xarFile)) {
-            Assert.assertNotNull(resourceAsStream);
-            content = IOUtils.toByteArray(resourceAsStream);
-        }
-
         // Store XAR in database
         try (final DBBroker broker = brokerPool.get(Optional.of(brokerPool.getSecurityManager().getSystemSubject()));
              final Txn transaction = brokerPool.getTransactionManager().beginTransaction()) {
 
             try (final ManagedCollectionLock collectionLock = brokerPool.getLockManager().acquireCollectionWriteLock(xarUri.removeLastSegment())) {
                 final Collection collection = broker.getOrCreateCollection(transaction, xarUri.removeLastSegment());
-                try (final InputStream is = new UnsynchronizedByteArrayInputStream(content)) {
 
-                    collection.addBinaryResource(transaction, broker, xarUri.lastSegment(), is, "application/expath+xar", content.length);
-                    broker.saveCollection(transaction, collection);
-                }
+                collection.storeDocument(transaction, broker, xarUri.lastSegment(), new InputStreamSupplierInputSource(() -> PackageTriggerTest.class.getResourceAsStream("/" + xarFile)), MimeType.EXPATH_PKG_TYPE);
+                broker.saveCollection(transaction, collection);
             }
 
             transaction.commit();

--- a/extensions/modules/expathrepo/src/test/java/org/exist/repo/PackageTriggerTest.java
+++ b/extensions/modules/expathrepo/src/test/java/org/exist/repo/PackageTriggerTest.java
@@ -78,7 +78,7 @@ public class PackageTriggerTest {
             try (final ManagedCollectionLock collectionLock = brokerPool.getLockManager().acquireCollectionWriteLock(xarUri.removeLastSegment())) {
                 final Collection collection = broker.getOrCreateCollection(transaction, xarUri.removeLastSegment());
 
-                collection.storeDocument(transaction, broker, xarUri.lastSegment(), new InputStreamSupplierInputSource(() -> PackageTriggerTest.class.getResourceAsStream("/" + xarFile)), MimeType.EXPATH_PKG_TYPE);
+                broker.storeDocument(transaction, xarUri.lastSegment(), new InputStreamSupplierInputSource(() -> PackageTriggerTest.class.getResourceAsStream("/" + xarFile)), MimeType.EXPATH_PKG_TYPE, collection);
                 broker.saveCollection(transaction, collection);
             }
 

--- a/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/EmbeddedBinariesTest.java
+++ b/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/EmbeddedBinariesTest.java
@@ -61,7 +61,7 @@ public class EmbeddedBinariesTest extends AbstractBinariesTest<Sequence, Item, I
             try(final ManagedCollectionLock collectionLock = brokerPool.getLockManager().acquireCollectionWriteLock(filePath.removeLastSegment())) {
                 final Collection collection = broker.getOrCreateCollection(transaction, filePath.removeLastSegment());
 
-                collection.storeDocument(transaction, broker, filePath.lastSegment(), new StringInputSource(content), MimeType.BINARY_TYPE);
+                broker.storeDocument(transaction, filePath.lastSegment(), new StringInputSource(content), MimeType.BINARY_TYPE, collection);
 
                 broker.saveCollection(transaction, collection);
             }

--- a/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/EmbeddedBinariesTest.java
+++ b/extensions/modules/file/src/test/java/org/exist/xquery/modules/file/EmbeddedBinariesTest.java
@@ -31,8 +31,9 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.lock.ManagedCollectionLock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
-import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.CompiledXQuery;
 import org.exist.xquery.XQuery;
@@ -41,7 +42,6 @@ import org.exist.xquery.value.*;
 import org.junit.ClassRule;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Optional;
 
 /**
@@ -60,13 +60,10 @@ public class EmbeddedBinariesTest extends AbstractBinariesTest<Sequence, Item, I
 
             try(final ManagedCollectionLock collectionLock = brokerPool.getLockManager().acquireCollectionWriteLock(filePath.removeLastSegment())) {
                 final Collection collection = broker.getOrCreateCollection(transaction, filePath.removeLastSegment());
-                try(final InputStream is = new UnsynchronizedByteArrayInputStream(content)) {
 
-                    collection.addBinaryResource(transaction, broker, filePath.lastSegment(), is, "application/octet-stream", content.length);
+                collection.storeDocument(transaction, broker, filePath.lastSegment(), new StringInputSource(content), MimeType.BINARY_TYPE);
 
-                    broker.saveCollection(transaction, collection);
-
-                }
+                broker.saveCollection(transaction, collection);
             }
 
             transaction.commit();

--- a/extensions/modules/image/src/main/java/org/exist/xquery/modules/image/GetThumbnailsFunction.java
+++ b/extensions/modules/image/src/main/java/org/exist/xquery/modules/image/GetThumbnailsFunction.java
@@ -51,6 +51,8 @@ import org.exist.storage.txn.Txn;
 import org.exist.util.FileUtils;
 import org.exist.util.LockException;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.BasicFunction;
 import org.exist.xquery.Cardinality;
@@ -231,7 +233,6 @@ public class GetThumbnailsFunction extends BasicFunction {
             DocumentImpl docImage = null;
             BinaryDocument binImage = null;
             @SuppressWarnings("unused")
-            BinaryDocument doc = null;
             BufferedImage bImage = null;
             @SuppressWarnings("unused")
             byte[] imgData = null;
@@ -275,13 +276,12 @@ public class GetThumbnailsFunction extends BasicFunction {
                                     } catch (Exception e) {
                                         throw new XPathException(this, e.getMessage());
                                     }
-                                    try {
-                                        doc = thumbCollection.addBinaryResource(
+                                    try (final StringInputSource sis = new StringInputSource(os.toByteArray())) {
+                                        thumbCollection.storeDocument(
                                                 transaction, dbbroker,
                                                 XmldbURI.create(prefix
-                                                        + docImage.getFileURI()), os
-                                                        .toByteArray(), "image/jpeg");
-                                    } catch (Exception e) {
+                                                        + docImage.getFileURI()), sis, new MimeType("image/jpeg", MimeType.BINARY));
+                                    } catch (final Exception e) {
                                         throw new XPathException(this, e.getMessage());
                                     }
                                     // result.add(new

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java
@@ -135,7 +135,7 @@ public class ConnectionIT {
 
             // store module
             try (final Collection collection = broker.openCollection(XmldbURI.create("/db"), Lock.LockMode.WRITE_LOCK)) {
-                collection.storeDocument(transaction, broker, XmldbURI.create("mymodule.xqm"), new StringInputSource(moduleQuery.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("mymodule.xqm"), new StringInputSource(moduleQuery.getBytes(UTF_8)), MimeType.XQUERY_TYPE, collection);
             }
 
             final Tuple2<XQueryContext, ModuleContext> escapedContexts = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java
@@ -35,7 +35,6 @@ package org.exist.xquery.modules.sql;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.source.Source;
 import org.exist.source.StringSource;
@@ -45,6 +44,8 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.modules.ModuleUtils;
@@ -53,13 +54,14 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.Type;
 import org.junit.Rule;
 import org.junit.Test;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.xquery.modules.sql.Util.executeQuery;
 import static org.exist.xquery.modules.sql.Util.withCompiledQuery;
 import static org.junit.Assert.*;
@@ -114,14 +116,13 @@ public class ConnectionIT {
     }
 
     @Test
-    public void getConnectionFromModuleIsAutomaticallyClosed() throws EXistException, XPathException, PermissionDeniedException, IOException, LockException, TriggerException {
+    public void getConnectionFromModuleIsAutomaticallyClosed() throws EXistException, XPathException, PermissionDeniedException, IOException, LockException, SAXException {
         final String moduleQuery =
                 "module namespace mymodule = \"http://mymodule.com\";\n" +
                 "import module namespace sql = \"http://exist-db.org/xquery/sql\";\n" +
                 "declare function mymodule:get-handle() {\n" +
                 "    sql:get-connection(\"" + h2Database.getDriverClass().getName() + "\", \"" + h2Database.getUrl() + "\", \"" + h2Database.getUser() + "\", \"" + h2Database.getPassword() + "\")\n" +
                 "};\n";
-        final Source moduleQuerySource = new StringSource(moduleQuery);
 
         final String mainQuery =
                 "import module namespace mymodule = \"http://mymodule.com\" at \"xmldb:exist:///db/mymodule.xqm\";\n" +
@@ -133,10 +134,8 @@ public class ConnectionIT {
              final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // store module
-            try (final InputStream is = moduleQuerySource.getInputStream()) {
-                try (final Collection collection = broker.openCollection(XmldbURI.create("/db"), Lock.LockMode.WRITE_LOCK)) {
-                    collection.addBinaryResource(transaction, broker, XmldbURI.create("mymodule.xqm"), is, "application/xquery", -1);
-                }
+            try (final Collection collection = broker.openCollection(XmldbURI.create("/db"), Lock.LockMode.WRITE_LOCK)) {
+                collection.storeDocument(transaction, broker, XmldbURI.create("mymodule.xqm"), new StringInputSource(moduleQuery.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
             }
 
             final Tuple2<XQueryContext, ModuleContext> escapedContexts = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ImplicitConnectionCloseIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ImplicitConnectionCloseIT.java
@@ -184,7 +184,7 @@ public class ImplicitConnectionCloseIT {
 
             // store module
             try (final Collection collection = broker.openCollection(XmldbURI.create("/db"), Lock.LockMode.WRITE_LOCK)) {
-                collection.storeDocument(transaction, broker, XmldbURI.create("mymodule.xqm"), new StringInputSource(moduleQuery.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("mymodule.xqm"), new StringInputSource(moduleQuery.getBytes(UTF_8)), MimeType.XQUERY_TYPE, collection);
             }
 
             final Tuple2<XQueryContext, ModuleContext> escapedContexts = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
@@ -35,7 +35,6 @@ package org.exist.xquery.modules.sql;
 import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.triggers.TriggerException;
 import org.exist.security.PermissionDeniedException;
 import org.exist.source.Source;
 import org.exist.source.StringSource;
@@ -45,6 +44,8 @@ import org.exist.storage.lock.Lock;
 import org.exist.storage.txn.Txn;
 import org.exist.test.ExistEmbeddedServer;
 import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.modules.ModuleUtils;
@@ -58,17 +59,18 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.osjava.sj.loader.JndiLoader;
+import org.xml.sax.SAXException;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
 import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.xquery.modules.sql.Util.executeQuery;
 import static org.exist.xquery.modules.sql.Util.withCompiledQuery;
 import static org.junit.Assert.*;
@@ -148,14 +150,13 @@ public class JndiConnectionIT {
     }
 
     @Test
-    public void getJndiConnectionFromModuleIsAutomaticallyClosed() throws EXistException, XPathException, PermissionDeniedException, IOException, LockException, TriggerException {
+    public void getJndiConnectionFromModuleIsAutomaticallyClosed() throws EXistException, XPathException, PermissionDeniedException, IOException, LockException, SAXException {
         final String moduleQuery =
                 "module namespace mymodule = \"http://mymodule.com\";\n" +
                 "import module namespace sql = \"http://exist-db.org/xquery/sql\";\n" +
                 "declare function mymodule:get-handle() {\n" +
                 "    sql:get-jndi-connection(\"" + JNDI_DS_NAME + "\", \"" + h2Database.getUser() + "\", \"" + h2Database.getPassword() + "\")\n" +
                 "};\n";
-        final Source moduleQuerySource = new StringSource(moduleQuery);
 
         final String mainQuery =
                 "import module namespace mymodule = \"http://mymodule.com\" at \"xmldb:exist:///db/mymodule.xqm\";\n" +
@@ -167,10 +168,8 @@ public class JndiConnectionIT {
              final Txn transaction = pool.getTransactionManager().beginTransaction()) {
 
             // store module
-            try (final InputStream is = moduleQuerySource.getInputStream()) {
-                try (final Collection collection = broker.openCollection(XmldbURI.create("/db"), Lock.LockMode.WRITE_LOCK)) {
-                    collection.addBinaryResource(transaction, broker, XmldbURI.create("mymodule.xqm"), is, "application/xquery", -1);
-                }
+            try (final Collection collection = broker.openCollection(XmldbURI.create("/db"), Lock.LockMode.WRITE_LOCK)) {
+                collection.storeDocument(transaction, broker, XmldbURI.create("mymodule.xqm"), new StringInputSource(moduleQuery.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
             }
 
             final Tuple2<XQueryContext, ModuleContext> escapedContexts = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
@@ -169,7 +169,7 @@ public class JndiConnectionIT {
 
             // store module
             try (final Collection collection = broker.openCollection(XmldbURI.create("/db"), Lock.LockMode.WRITE_LOCK)) {
-                collection.storeDocument(transaction, broker, XmldbURI.create("mymodule.xqm"), new StringInputSource(moduleQuery.getBytes(UTF_8)), MimeType.XQUERY_TYPE);
+                broker.storeDocument(transaction, XmldbURI.create("mymodule.xqm"), new StringInputSource(moduleQuery.getBytes(UTF_8)), MimeType.XQUERY_TYPE, collection);
             }
 
             final Tuple2<XQueryContext, ModuleContext> escapedContexts = withCompiledQuery(broker, mainQuerySource, mainCompiledQuery -> {

--- a/extensions/webdav/src/main/java/org/exist/webdav/ExistCollection.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/ExistCollection.java
@@ -313,7 +313,7 @@ public class ExistCollection extends ExistResource {
                 }
 
                 // Stream into database
-                collection.storeDocument(txn, broker, newNameUri, in, mime);
+                broker.storeDocument(txn, newNameUri, in, mime, collection);
 
                 // Commit change
                 txnManager.commit(txn);

--- a/extensions/webdav/src/main/java/org/exist/webdav/ExistCollection.java
+++ b/extensions/webdav/src/main/java/org/exist/webdav/ExistCollection.java
@@ -21,10 +21,8 @@
  */
 package org.exist.webdav;
 
-import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.exist.EXistException;
 import org.exist.collections.Collection;
-import org.exist.collections.IndexInfo;
 import org.exist.collections.triggers.TriggerException;
 import org.exist.dom.persistent.DocumentImpl;
 import org.exist.security.Permission;
@@ -35,7 +33,6 @@ import org.exist.storage.lock.Lock.LockMode;
 import org.exist.storage.txn.TransactionManager;
 import org.exist.storage.txn.Txn;
 import org.exist.util.*;
-import org.exist.util.io.*;
 import org.exist.webdav.exceptions.CollectionDoesNotExistException;
 import org.exist.webdav.exceptions.CollectionExistsException;
 import org.exist.xmldb.XmldbURI;
@@ -49,8 +46,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Class for accessing the Collection class of the exist-db native API.
@@ -283,76 +278,71 @@ public class ExistCollection extends ExistResource {
         // To support LockNullResource, a 0-byte XML document can be received. Since 0-byte
         // XML documents are not supported a small file will be created.
 
-        if(mime.isXMLType() && length == 0) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Creating dummy XML file for null resource lock '{}'", newNameUri);
+        InputSource in = null;
+        try {
+            if (mime.isXMLType() && length == 0) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Creating dummy XML file for null resource lock '{}'", newNameUri);
+                }
+
+                in = new StringInputSource("<null_resource/>");
+            } else {
+                in = new InputSource(is);
             }
 
-            is = new UnsynchronizedByteArrayInputStream("<null_resource/>".getBytes(UTF_8));
-        }
+            final TransactionManager txnManager = brokerPool.getTransactionManager();
 
-        final TransactionManager txnManager = brokerPool.getTransactionManager();
+            try (final DBBroker broker = brokerPool.get(Optional.ofNullable(subject));
+                 final Txn txn = txnManager.beginTransaction();
+                 final Collection collection = broker.openCollection(xmldbUri, LockMode.WRITE_LOCK)) {
 
-        try (final DBBroker broker = brokerPool.get(Optional.ofNullable(subject));
-            final Txn txn = txnManager.beginTransaction();
-            final Collection collection = broker.openCollection(xmldbUri, LockMode.WRITE_LOCK)) {
+                // Check if collection exists. not likely to happen since availability is checked
+                // by ResourceFactory
+                if (collection == null) {
+                    LOG.debug("Collection {} does not exist", xmldbUri);
+                    txnManager.abort(txn);
+                    throw new CollectionDoesNotExistException(xmldbUri + "");
+                }
 
-            // Check if collection exists. not likely to happen since availability is checked
-            // by ResourceFactory
-            if (collection == null) {
-                LOG.debug("Collection {} does not exist", xmldbUri);
-                txnManager.abort(txn);
-                throw new CollectionDoesNotExistException(xmldbUri + "");
-            }
-
-
-            try(final FilterInputStreamCache cache = FilterInputStreamCacheFactory.getCacheInstance(() -> (String) brokerPool.getConfiguration().getProperty(Configuration.BINARY_CACHE_CLASS_PROPERTY), is);
-                    final InputStream cfis = new CachingFilterInputStream(cache)) {
-                if (mime.isXMLType()) {
-                    if (LOG.isDebugEnabled()) {
+                if (LOG.isDebugEnabled()) {
+                    if (mime.isXMLType()) {
                         LOG.debug("Inserting XML document '{}'", mime.getName());
-                    }
-
-                    // Stream into database
-                    cfis.mark(Integer.MAX_VALUE);
-                    final IndexInfo info = collection.validateXMLResource(txn, broker, newNameUri, new InputSource(cfis));
-                    final DocumentImpl doc = info.getDocument();
-                    doc.setMimeType(mime.getName());
-                    cfis.reset();
-                    collection.store(txn, broker, info, new InputSource(cfis));
-                } else {
-                    if (LOG.isDebugEnabled()) {
+                    } else {
                         LOG.debug("Inserting BINARY document '{}'", mime.getName());
                     }
+                }
 
-                    // Stream into database
-                    collection.addBinaryResource(txn, broker, newNameUri, cfis, mime.getName(), length);
+                // Stream into database
+                collection.storeDocument(txn, broker, newNameUri, in, mime);
+
+                // Commit change
+                txnManager.commit(txn);
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Document created sucessfully");
+                }
+
+
+            } catch (EXistException | SAXException e) {
+                LOG.error(e);
+                throw new IOException(e);
+
+            } catch (LockException e) {
+                LOG.error(e);
+                throw new PermissionDeniedException(xmldbUri + "");
+
+            } catch (IOException | PermissionDeniedException e) {
+                LOG.error(e);
+                throw e;
+
+            } finally {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Finished creation");
                 }
             }
-
-            // Commit change
-            txnManager.commit(txn);
-
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Document created sucessfully");
-            }
-
-
-        } catch (EXistException | SAXException e) {
-            LOG.error(e);
-            throw new IOException(e);
-
-        } catch (LockException e) {
-            LOG.error(e);
-            throw new PermissionDeniedException(xmldbUri + "");
-
-        } catch (IOException | PermissionDeniedException e) {
-            LOG.error(e);
-            throw e;
-
         } finally {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Finished creation");
+            if (in != null && in instanceof EXistInputSource) {
+                ((EXistInputSource) in).close();
             }
         }
 


### PR DESCRIPTION
This enhancement has been back-ported from FusionDB. It introduces an additional new API for storing documents which is much simpler and easier to use that what was already present.

Previously, storing an XML document involved a more complex two step procedure of calling:
1. `Collection#validateXMLResource`
2. `Collection#store`

whilst storing a Binary document involved calling:
1. `Collection#validateBinaryResource`
2. `Collection#addBinary`

This new API means that for both XML and Binary documents you can just call:
```
DBBroker#storeDocument
```

I have then applied this to the code-base, which has simplified and removed a lot of redundant code. I have left the existing APIs in-place and marked them as deprecated so that they can be removed in a future major release; these changes are 100% backwards compatible at present.

Moving the API call to `DBBroker` also has the advantage of allowing us to more easily refactor how Collections are implemented in future.