### PR TITLE
Notarize macOS DMG

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
-            <version>2.4.0</version>
+            <version>${jansi.version}</version>
             <!--
                 Optionally used by jline at runtime on Linux and macOS,
                 and required by jline at runtime on Windows.

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -1250,6 +1250,31 @@
                                     </arguments>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>mac-notarize-dmg</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <useMavenLogger>true</useMavenLogger>
+                                    <executable>/usr/bin/xcrun</executable>
+                                    <arguments>
+                                        <argument>altool</argument>
+                                        <argument>--notarize-app</argument>
+                                        <argument>--verbose</argument>
+                                        <argument>--primary-bundle-id</argument>
+                                        <argument>org.exist-db</argument>
+                                        <argument>--username</argument>
+                                        <argument>${existdb.release.notarize.username}</argument>
+                                        <argument>--password</argument>
+                                        <argument>${existdb.release.notarize.password}</argument>
+                                        <argument>--file</argument>
+                                        <argument>${mac.dmg}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+
                         </executions>
                     </plugin>
                 </plugins>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -52,6 +52,7 @@
         <expath.pkg.dir>${project.build.directory}/expath-pkgs</expath.pkg.dir>
         <mac.bundle.dir>${project.build.directory}/${project.artifactId}-${project.version}.app</mac.bundle.dir>
         <mac.bundle.resources.dir>${mac.bundle.dir}/Contents/Resources</mac.bundle.resources.dir>
+        <mac.bundle.java.dir>${mac.bundle.dir}/Contents/Java</mac.bundle.java.dir>
         <mac.dmg>${project.build.directory}/eXist-db-${project.version}.dmg</mac.dmg>
         <mac.codesign.identity>Developer ID Application: Evolved Binary Ltd</mac.codesign.identity>
     </properties>
@@ -332,9 +333,11 @@
                             <header>${project.parent.relativePath}/LGPL-21-license.template.txt</header>
                             <excludes>
                                 <exclude>LGPL-21-license.txt</exclude>
+                                <exclude>src/app/entitlements.plist</exclude>
                                 <exclude>src/appbundler/**</exclude>
                                 <exclude>src/dmg/**</exclude>
                                 <exclude>src/main/config/**</exclude>  <!-- config files shipped with eXist-db don't need copyright headers -->
+                                <exclude>src/main/scripts/codesign-jansi-mac.sh</exclude>
                                 <exclude>src/main/xslt/configure_9_3.dtd</exclude>
                                 <exclude>src/main/xslt/web-app_3_1.xsd</exclude>
                                 <exclude>src/main/xslt/javaee_web_services_client_1_4.xsd</exclude>
@@ -344,6 +347,18 @@
                                 <exclude>src/main/xslt/javaee_7.xsd</exclude>
                             </excludes>
                         </licenseSet>
+
+                        <licenseSet>
+                            <!--
+                                FDB backport to LGPL 2.1-only licensed code
+                            -->
+                            <header>${project.parent.relativePath}/FDB-backport-LGPL-21-ONLY-license.template.txt</header>
+                            <includes>
+                                <include>src/app/entitlements.plist</include>
+                                <include>src/main/scripts/codesign-jansi-mac.sh</include>
+                            </includes>
+                        </licenseSet>
+
                     </licenseSets>
                 </configuration>
             </plugin>
@@ -1103,6 +1118,26 @@
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
                         <executions>
+                            <execution>
+                                <!--
+                                    Signs the jansi native binaries
+                                -->
+                                <id>mac-codesign-jansi-native</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <useMavenLogger>true</useMavenLogger>
+                                    <executable>${project.basedir}/src/main/scripts/codesign-jansi-mac.sh</executable>
+                                    <arguments>
+                                        <argument>${mac.bundle.java.dir}</argument>
+                                        <argument>${jansi.version}</argument>
+                                        <argument>${project.build.directory}/jansi-native</argument>
+                                        <argument>${mac.codesign.identity}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
                             <execution>
                                 <id>mac-codesign-app</id>
                                 <phase>package</phase>

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -1113,6 +1113,10 @@
                                     <executable>/usr/bin/codesign</executable>
                                     <arguments>
                                         <argument>--force</argument>
+                                        <argument>--options</argument>
+                                        <argument>runtime</argument>
+                                        <argument>--entitlements</argument>
+                                        <argument>${project.basedir}/src/app/entitlements.plist</argument>
                                         <argument>--sign</argument>
                                         <argument>${mac.codesign.identity}</argument>
                                         <argument>${mac.bundle.dir}</argument>

--- a/exist-distribution/src/app/entitlements.plist
+++ b/exist-distribution/src/app/entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.cs.disable-executable-page-protection</key>
+        <true/>
+        <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+    </dict>
+</plist>

--- a/exist-distribution/src/app/entitlements.plist
+++ b/exist-distribution/src/app/entitlements.plist
@@ -12,5 +12,7 @@
         <true/>
         <key>com.apple.security.cs.disable-library-validation</key>
         <true/>
+        <key>com.apple.security.automation.apple-events</key>
+        <true/>
     </dict>
 </plist>

--- a/exist-distribution/src/app/entitlements.plist
+++ b/exist-distribution/src/app/entitlements.plist
@@ -1,4 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2014, Evolved Binary Ltd
+
+    This file was originally ported from FusionDB to eXist-db by
+    Evolved Binary, for the benefit of the eXist-db Open Source community.
+    Only the ported code as it appears in this file, at the time that
+    it was contributed to eXist-db, was re-licensed under The GNU
+    Lesser General Public License v2.1 only for use in eXist-db.
+
+    This license grant applies only to a snapshot of the code as it
+    appeared when ported, it does not offer or infer any rights to either
+    updates of this source code or access to the original source code.
+
+    The GNU Lesser General Public License v2.1 only license follows.
+
+    ---------------------------------------------------------------------
+
+    Copyright (C) 2014, Evolved Binary Ltd
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; version 2.1.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+-->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>

--- a/exist-distribution/src/main/scripts/codesign-jansi-mac.sh
+++ b/exist-distribution/src/main/scripts/codesign-jansi-mac.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2014, Evolved Binary Ltd
+#
+# This file was originally ported from FusionDB to eXist-db by
+# Evolved Binary, for the benefit of the eXist-db Open Source community.
+# Only the ported code as it appears in this file, at the time that
+# it was contributed to eXist-db, was re-licensed under The GNU
+# Lesser General Public License v2.1 only for use in eXist-db.
+#
+# This license grant applies only to a snapshot of the code as it
+# appeared when ported, it does not offer or infer any rights to either
+# updates of this source code or access to the original source code.
+#
+# The GNU Lesser General Public License v2.1 only license follows.
+#
+# ---------------------------------------------------------------------
+#
+# Copyright (C) 2014, Evolved Binary Ltd
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; version 2.1.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+
+# $1 is .app/Contents/Java dir
+# $2 is the jansi version
+# $3 is temp work directory
+# $4 the mac codesign identity
+
+
+set -e
+#set -x  ## enable to help debug
+
+# ensure a clean temp work directory
+if [ -d "${3}/org" ]
+then
+  rm -rf "${3}/org"
+fi
+
+# for each native arch
+archs=('arm64' 'x86' 'x86_64')
+for arch in ${archs[@]}
+do
+  # create the temp output dirs
+  mkdir -p "${3}/org/fusesource/jansi/internal/native/Mac/${arch}"
+
+  # switch to temp output dir
+  pushd "${3}"
+
+  # extract the native files
+  jar -xf "${1}/jansi-${2}.jar" "org/fusesource/jansi/internal/native/Mac/${arch}/libjansi.jnilib"
+
+  # test if the file is unsigned, and sign if needed
+  /usr/bin/codesign --verbose --test-requirement="=anchor trusted" --verify "org/fusesource/jansi/internal/native/Mac/${arch}/libjansi.jnilib" || /usr/bin/codesign --verbose --force --timestamp --sign "${4}" "org/fusesource/jansi/internal/native/Mac/${arch}/libjansi.jnilib"
+
+  # overwrite the file in the jar
+  jar -uf "${1}/jansi-${2}.jar" "org/fusesource/jansi/internal/native/Mac/${arch}/libjansi.jnilib"
+
+  # switch back from temp output dir
+  popd
+
+done

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -108,6 +108,7 @@
         <exquery.distribution.version>0.2.0</exquery.distribution.version>
         <icu.version>59.1</icu.version>
         <izpack.version>5.1.3</izpack.version>
+        <jansi.version>2.4.0</jansi.version>
         <jaxb.api.version>3.0.1</jaxb.api.version>
         <jaxb.impl.version>3.0.2</jaxb.impl.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
@@ -877,6 +878,7 @@
                         <form>XML_STYLE</form>
                         <g>SLASHSTAR_STYLE</g>
                         <java>SLASHSTAR_STYLE</java>
+                        <plist>XML_STYLE</plist>
                         <xconf>XML_STYLE</xconf>
                         <xconf.init>XML_STYLE</xconf.init>
                         <xq>XQUERY_STYLE</xq>

--- a/exist-versioning-release.md
+++ b/exist-versioning-release.md
@@ -156,7 +156,7 @@ You will require a system with:
     </settings>
     ```
 
-2. You will need your GPG Key and Java KeyStore credentials for signing the release artifacts in the `<activeProfiles`> section on your machine in your local `~/.m2/settings.xml` file, e.g.:
+2. You will need your GPG Key, Java KeyStore, and Apple Notarization API credentials for signing the release artifacts in the `<activeProfiles`> section on your machine in your local `~/.m2/settings.xml` file, e.g.:
     ```xml
     <profiles>
    
@@ -172,6 +172,9 @@ You will require a system with:
                <existdb.release.keystore.pass>your-keystore-password</existdb.release.keystore.pass>
                <existdb.release.keystore.key.alias>your-alias</existdb.release.keystore.key.alias>
                <existdb.release.keystore.key.pass>your-key-password</existdb.release.keystore.key.pass>
+   
+                <existdb.release.notarize.username>your-apple-developer-email@your-dom.ain</existdb.release.notarize.username>
+                <existdb.release.notarize.password>your-apple-notarize-api-password</existdb.release.notarize.password>
            </properties>
        </profile>
    


### PR DESCRIPTION
At the request of @joewiz I have backported from FusionDB to eXist-db the functionality for notarizing the Apple macOS DMG.
Closes https://github.com/eXist-db/exist/issues/3961