### PR TITLE
util:expand must handle Document and Attribute Nodes correctly

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/memtree/MemTreeBuilder.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/MemTreeBuilder.java
@@ -26,11 +26,13 @@ import org.exist.Namespaces;
 import org.exist.dom.QName;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.xquery.Constants;
+import org.exist.xquery.XQuery;
 import org.exist.xquery.XQueryContext;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 import org.xml.sax.Attributes;
 
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 import java.util.Arrays;
 
@@ -42,7 +44,7 @@ import java.util.Arrays;
  */
 public class MemTreeBuilder {
 
-    private final XQueryContext context;
+    private XQueryContext context;
     private DocumentImpl doc;
     private short level = 1;
     private int[] prevNodeInLevel;
@@ -54,11 +56,20 @@ public class MemTreeBuilder {
 
 
     public MemTreeBuilder(final XQueryContext context) {
-        super();
         this.context = context;
         prevNodeInLevel = new int[15];
         Arrays.fill(prevNodeInLevel, -1);
         prevNodeInLevel[0] = 0;
+    }
+
+    public void reset(@Nullable final XQueryContext context) {
+        this.context = context;
+        doc = null;
+        level = 1;
+        prevNodeInLevel = new int[15];
+        Arrays.fill(prevNodeInLevel, -1);
+        prevNodeInLevel[0] = 0;
+        defaultNamespaceURI = XMLConstants.NULL_NS_URI;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xmldb/LocalXMLResource.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalXMLResource.java
@@ -485,9 +485,9 @@ public class LocalXMLResource extends AbstractEXistResource implements XMLResour
 
     @Override
     public void setContentAsDOM(final Node root) throws XMLDBException {
-        if (root instanceof AttrImpl) {
-            throw new XMLDBException(ErrorCodes.WRONG_CONTENT_TYPE, "SENR0001: can not serialize a standalone attribute");
-        }
+//        if (root instanceof AttrImpl) {
+//            throw new XMLDBException(ErrorCodes.WRONG_CONTENT_TYPE, "SENR0001: can not serialize a standalone attribute");
+//        }
 
         content = null;
         file = null;

--- a/exist-core/src/test/java/org/exist/xquery/functions/util/ExpandTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/util/ExpandTest.java
@@ -41,11 +41,8 @@ import org.xmldb.api.modules.XMLResource;
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class ExpandTest {
-
-    private static final String EOL = System.getProperty("line.separator");
-
     private static final String DOC1_CONTENT = "<doc1>doc1</doc1>";
-    private static final String DOC2_CONTENT = "<!-- comment 1 before --><!-- comment 2 before -->" + EOL + "<doc2>doc2</doc2>";
+    private static final String DOC2_CONTENT = "<!-- comment 1 before --><!-- comment 2 before -->\n<doc2>doc2</doc2>";
     private static final String DOC3_CONTENT = "<doc3 foo=\"bar\">doc3</doc3>";
     private static final String DOC4_CONTENT = "<doc4 xmlns:x=\"http://x\" x:foo=\"bar\">doc4</doc4>";
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/util/ExpandTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/util/ExpandTest.java
@@ -28,9 +28,12 @@ import org.exist.test.ExistXmldbEmbeddedServer;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.w3c.dom.Node;
 import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.XMLResource;
 
 /**
  * @author Casey Jordan
@@ -43,6 +46,8 @@ public class ExpandTest {
 
     private static final String DOC1_CONTENT = "<doc1>doc1</doc1>";
     private static final String DOC2_CONTENT = "<!-- comment 1 before --><!-- comment 2 before -->" + EOL + "<doc2>doc2</doc2>";
+    private static final String DOC3_CONTENT = "<doc3 foo=\"bar\">doc3</doc3>";
+    private static final String DOC4_CONTENT = "<doc4 xmlns:x=\"http://x\" x:foo=\"bar\">doc4</doc4>";
 
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
@@ -52,6 +57,8 @@ public class ExpandTest {
         final Collection expandTestCol = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "expand-test");
         ExistXmldbEmbeddedServer.storeResource(expandTestCol, "doc1.xml", DOC1_CONTENT.getBytes(UTF_8));
         ExistXmldbEmbeddedServer.storeResource(expandTestCol, "doc2.xml", DOC2_CONTENT.getBytes(UTF_8));
+        ExistXmldbEmbeddedServer.storeResource(expandTestCol, "doc3.xml", DOC3_CONTENT.getBytes(UTF_8));
+        ExistXmldbEmbeddedServer.storeResource(expandTestCol, "doc4.xml", DOC4_CONTENT.getBytes(UTF_8));
     }
 
     @Test
@@ -95,5 +102,34 @@ public class ExpandTest {
         final ResourceSet result = existEmbeddedServer.executeQuery(query);
         final String r = (String) result.getResource(0).getContent();
         assertEquals(DOC2_CONTENT, r);
+    }
+
+    @Test
+    public void expandPersistentDomAttr() throws XMLDBException {
+        final String query = "util:expand(doc('/db/expand-test/doc3.xml')/doc3/@foo)";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final Resource res = result.getResource(0);
+        assertEquals(XMLResource.RESOURCE_TYPE, res.getResourceType());
+        final XMLResource xmlRes = (XMLResource) res;
+        final Node node = xmlRes.getContentAsDOM();
+        assertEquals(Node.ATTRIBUTE_NODE, node.getNodeType());
+        assertNull(node.getNamespaceURI());
+        assertEquals("foo", node.getNodeName());
+        assertEquals("bar", node.getNodeValue());
+    }
+
+    @Test
+    public void expandPersistentDomAttrNs() throws XMLDBException {
+        final String query = "declare namespace x = \"http://x\";\n" +
+                "util:expand(doc('/db/expand-test/doc4.xml')/doc4/@x:foo)";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final Resource res = result.getResource(0);
+        assertEquals(XMLResource.RESOURCE_TYPE, res.getResourceType());
+        final XMLResource xmlRes = (XMLResource) res;
+        final Node node = xmlRes.getContentAsDOM();
+        assertEquals(Node.ATTRIBUTE_NODE, node.getNodeType());
+        assertEquals("http://x", node.getNamespaceURI());
+        assertEquals("foo", node.getNodeName());
+        assertEquals("bar", node.getNodeValue());
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/util/ExpandTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/util/ExpandTest.java
@@ -21,27 +21,41 @@
  */
 package org.exist.xquery.functions.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 
 import org.exist.test.ExistXmldbEmbeddedServer;
-import org.exist.xquery.XPathException;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.ResourceSet;
 import org.xmldb.api.base.XMLDBException;
 
 /**
  * @author Casey Jordan
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
- *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
 public class ExpandTest {
+
+    private static final String EOL = System.getProperty("line.separator");
+
+    private static final String DOC1_CONTENT = "<doc1>doc1</doc1>";
+    private static final String DOC2_CONTENT = "<!-- comment 1 before --><!-- comment 2 before -->" + EOL + "<doc2>doc2</doc2>";
 
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
 
+    @BeforeClass
+    public static void setup() throws XMLDBException {
+        final Collection expandTestCol = existEmbeddedServer.createCollection(existEmbeddedServer.getRoot(), "expand-test");
+        ExistXmldbEmbeddedServer.storeResource(expandTestCol, "doc1.xml", DOC1_CONTENT.getBytes(UTF_8));
+        ExistXmldbEmbeddedServer.storeResource(expandTestCol, "doc2.xml", DOC2_CONTENT.getBytes(UTF_8));
+    }
+
     @Test
-    public void testExpandWithDefaultNS() throws XPathException, XMLDBException {
+    public void expandWithDefaultNS() throws XMLDBException {
     	final String expected = "<ok xmlns=\"some\">\n    <concept xmlns=\"\"/>\n</ok>";
 
         String query = "" +
@@ -65,5 +79,21 @@ public class ExpandTest {
         result = existEmbeddedServer.executeQuery(query);
         r = (String) result.getResource(0).getContent();
         assertEquals(expected, r);
+    }
+
+    @Test
+    public void expandPersistentDom() throws XMLDBException {
+        final String query = "util:expand(doc('/db/expand-test/doc1.xml'))";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertEquals(DOC1_CONTENT, r);
+    }
+
+    @Test
+    public void expandPersistentDomCommentsFirst() throws XMLDBException {
+        final String query = "util:expand(doc('/db/expand-test/doc2.xml'))";
+        final ResourceSet result = existEmbeddedServer.executeQuery(query);
+        final String r = (String) result.getResource(0).getContent();
+        assertEquals(DOC2_CONTENT, r);
     }
 }

--- a/exist-core/src/test/xquery/serialization.xml
+++ b/exist-core/src/test/xquery/serialization.xml
@@ -83,10 +83,11 @@ declare boundary-space preserve;
 
 let $doc := doc('/db/mycollection/sample.xml')
 let $uri := xmldb:store('/db/mycollection', 'tample.xml', $doc, "text/xml")
-return doc($uri)
+return doc($uri)/test
         ]]></code>
         <expected>
 <test>
+<!-- this is a test comment -->
 <test1>
 some value
 </test1>

--- a/exist-core/src/test/xquery/util/expand.xqm
+++ b/exist-core/src/test/xquery/util/expand.xqm
@@ -1,0 +1,103 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.0";
+
+module namespace ue = "http://exist-db.org/xquery/test/util/expand";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+declare namespace util = "http://exist-db.org/xquery/util";
+
+declare
+    %test:assertEquals("true", "true", "bar")
+function ue:attribute() as item()+ {
+   let $attr := util:expand( attribute foo { "bar" } )
+   return
+       (
+               $attr instance of attribute(),
+               node-name($attr) eq xs:QName("foo"),
+               string($attr)
+       )
+};
+
+declare
+    %test:assertEquals("true", "true", "bar")
+function ue:attributeNs() as item()+ {
+    let $attr := util:expand( attribute ue:foo { "bar" } )
+    return
+        (
+                $attr instance of attribute(),
+                node-name($attr) eq xs:QName("ue:foo"),
+                string($attr)
+        )
+};
+
+declare
+    %test:assertTrue
+function ue:comment() as xs:boolean {
+    util:expand( comment { "foo" } ) instance of comment()
+};
+
+declare
+    %test:assertTrue
+function ue:document() as xs:boolean {
+    util:expand( document { element foo {()} } ) instance of document-node()
+};
+
+declare
+    %test:assertTrue
+function ue:documentNs() as xs:boolean {
+    util:expand( document { element ue:foo {()} } ) instance of document-node()
+};
+
+declare
+    %test:assertEquals("true", "true")
+function ue:element() as xs:boolean+ {
+    let $elem := util:expand( element foo {()} )
+    return
+        (
+                $elem instance of element(),
+                node-name($elem) eq xs:QName("foo")
+        )
+};
+
+declare
+    %test:assertEquals("true", "true")
+function ue:elementNs() as xs:boolean+ {
+    let $elem := util:expand( element ue:foo {()} )
+    return
+        (
+                $elem instance of element(),
+                node-name($elem) eq xs:QName("ue:foo")
+        )
+};
+
+declare
+    %test:assertTrue
+function ue:pi() as xs:boolean {
+    util:expand( processing-instruction foo { "" } ) instance of processing-instruction()
+};
+
+declare
+    %test:assertTrue
+function ue:text() as xs:boolean {
+    util:expand( text { "foo" } ) instance of text()
+};


### PR DESCRIPTION
Previously `util:expand` did not handle Document or AttributeNodes correctly.

Closes https://github.com/eXist-db/exist/issues/1562
Closes https://github.com/eXist-db/exist/issues/1486

For Document Nodes instead it would just return the first node from the document. If the first node was an element, you likely would not have noticed a problem (as it is a container of child nodes), however if the first node was a comment, text node, or processing instruction, then you would not see any of the other descendant nodes of the document.

For example, previously:
```xquery
let $doc1 := document { <!-- comment 1 before --><!-- comment 2 before --><doc2>doc2</doc2> }
let $doc1-uri := xmldb:store("/db", "doc1.xml", $doc1, "application/xml")
return
  util:expand(doc($doc1-uri))
```
would incorrectly return only the first node in the document, i.e.:
```xml
<!-- comment 1 before -->
```

After this fix, it now correctly returns:
```xml
<!-- comment 1 before --><!-- comment 2 before --><doc2>doc2</doc2>
```

For Attribute Nodes, it would previously incorrectly return a Text Node holding the value of the Attribute.