### PR TITLE
Don't attempt an impossible conversion in NativeValueIndex

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/NativeValueIndex.java
+++ b/exist-core/src/main/java/org/exist/storage/NativeValueIndex.java
@@ -61,6 +61,7 @@ import org.exist.util.*;
 
 import org.w3c.dom.Node;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
@@ -1033,9 +1034,13 @@ public class NativeValueIndex implements ContentLoadingObserver {
      *
      * @param xpathType The type to convert the value to
      * @param value     The value to atomize
-     * @return <code>null</null> if atomization fails or if the atomic value is not indexable
+     * @return The converted value, or <code>null</null> if atomization failed or if the atomic value is not indexable
      */
-    private AtomicValue convertToAtomic(final int xpathType, final String value) {
+    static @Nullable AtomicValue convertToAtomic(final int xpathType, @Nullable final String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+
         final AtomicValue atomic;
         if (Type.subTypeOf(xpathType, Type.STRING)) {
             try {
@@ -1048,7 +1053,7 @@ public class NativeValueIndex implements ContentLoadingObserver {
             try {
                 atomic = new StringValue(value).convertTo(xpathType);
             } catch (final XPathException e) {
-                LOG.error("Node value '{}' cannot be converted to {}", value, Type.getTypeName(xpathType));
+                LOG.warn("Node value '{}' cannot be converted to {}", value, Type.getTypeName(xpathType));
                 return null;
             }
         }

--- a/exist-core/src/test/java/org/exist/storage/NativeValueIndexTest.java
+++ b/exist-core/src/test/java/org/exist/storage/NativeValueIndexTest.java
@@ -1,0 +1,72 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage;
+
+import org.exist.xquery.XPathException;
+import org.exist.xquery.value.AtomicValue;
+import org.exist.xquery.value.Type;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(Parameterized.class)
+public class NativeValueIndexTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static java.util.Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "xs:string", Type.STRING },
+                { "xs:int", Type.INT }
+        });
+    }
+
+    @Parameterized.Parameter
+    public String typeName;
+
+    @Parameterized.Parameter(value = 1)
+    public int type;
+
+    @Test
+    public void convertToAtomicNull() {
+        final AtomicValue result = NativeValueIndex.convertToAtomic(type, null);
+        assertNull(result);
+    }
+
+    @Test
+    public void convertToAtomicEmptyString() {
+        final AtomicValue result = NativeValueIndex.convertToAtomic(type, "");
+        assertNull(result);
+    }
+
+    @Test
+    public void convertToAtomic() throws XPathException {
+        final String mockValue = "1234567890";
+        final AtomicValue result = NativeValueIndex.convertToAtomic(type, mockValue);
+        assertEquals(type, result.getType());
+        assertEquals(mockValue, result.getStringValue());
+    }
+}


### PR DESCRIPTION
Previously eXist-db would log lots of errors when indexing empty strings as integers, e.g.:
```
ERROR (NativeValueIndex.java [convertToAtomic]:1051) - Node value '' cannot be converted to xs:integer - which implies the Node was empty!
```
 
This PR changes the behaviour so that if a Node is empty, i.e. there is no value, then the NativeValueIndex will simply ignore it.
However, if the Node has a non-empty value that cannot be converted to an integer, then the error is instead now logged as a warning.

Thanks to @joewiz who reported the error to me.