### PR TITLE
Fix Journal Bugs

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/blob/BlobStoreImpl.java
+++ b/exist-core/src/main/java/org/exist/storage/blob/BlobStoreImpl.java
@@ -156,7 +156,7 @@ import static org.exist.util.ThreadUtils.newInstanceSubThreadGroup;
  *
  *      On crash recovery, firstly:
  *          the StoreBlobFile will either be:
- *              1. undone, which copies the blob file from the blob store to to the staging area,
+ *              1. undone, which copies the blob file from the blob store to the staging area,
  *              2. redone, which copies the blob file from the staging area to the blob store,
  *              3. or both undone and redone.
  *          This is possible because the blob file in the staging area is ONLY deleted after

--- a/exist-core/src/main/java/org/exist/storage/journal/Journal.java
+++ b/exist-core/src/main/java/org/exist/storage/journal/Journal.java
@@ -605,7 +605,8 @@ public final class Journal implements Closeable {
     public static int findLastFile(final Stream<Path> files) {
         return files
                 .map(Journal::journalFileNum)
-                .max(Integer::max)
+                .mapToInt(v -> v)
+                .max()
                 .orElse(-1);
     }
 

--- a/exist-core/src/main/java/org/exist/storage/journal/Journal.java
+++ b/exist-core/src/main/java/org/exist/storage/journal/Journal.java
@@ -207,9 +207,9 @@ public final class Journal implements Closeable {
     private FileLock fileLock;
 
     /**
-     * the current file number
+     * the current journal file number
      */
-    private int currentFile = -1;
+    private int currentJournalFileNumber = -1;
 
     /**
      * temp buffer
@@ -337,14 +337,14 @@ public final class Journal implements Closeable {
         }
 
         try {
-            if (currentFile > Short.MAX_VALUE) {
+            if (currentJournalFileNumber > Short.MAX_VALUE) {
                 throw new JournalException("Journal can only support " + Short.MAX_VALUE + " log files");
             }
 
             // TODO(AR) this is needed as the journal is initialised by starting a transaction for loading the SymbolTable... before recovery! which is likely wrong!!! as Recovery Cannot run if the Journal file has been switched!
             final long pos = channel != null ? channel.position() : 0;
 
-            currentLsn = new Lsn((short)currentFile, pos + currentBuffer.position() + 1);
+            currentLsn = new Lsn((short) currentJournalFileNumber, pos + currentBuffer.position() + 1);
         } catch (final IOException e) {
             throw new JournalException("Unable to create LSN for: " + entry.dump());
         }
@@ -479,7 +479,7 @@ public final class Journal implements Closeable {
         }
         try {
             if (switchLogFiles && channel != null && channel.position() > journalSizeMin) {
-                final Path oldFile = getFile(currentFile);
+                final Path oldFile = getFile(currentJournalFileNumber);
                 final RemoveRunnable removeRunnable = new RemoveRunnable(channel, oldFile);
                 try {
                     switchFiles();
@@ -496,12 +496,12 @@ public final class Journal implements Closeable {
     }
 
     /**
-     * Set the file number of the last file used.
+     * Set the file number of the current journal file.
      *
-     * @param fileNum the log file number
+     * @param currentJournalFileNumber the current journal file number
      */
-    public void setCurrentFileNum(final int fileNum) {
-        currentFile = fileNum;
+    public void setCurrentJournalFileNumber(final int currentJournalFileNumber) {
+        this.currentJournalFileNumber = currentJournalFileNumber;
     }
 
     /**
@@ -511,39 +511,44 @@ public final class Journal implements Closeable {
      * @throws LogException if the journal files could not be switched
      */
     public void switchFiles() throws LogException {
-        ++currentFile;
-        final String fname = getFileName(currentFile);
-        final Path file = dir.resolve(fname);
-        if (Files.exists(file)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Journal file {} already exists. Moving it to a backup file.", file.toAbsolutePath());
-            }
+        ++currentJournalFileNumber;
+        final String newJournalFileName = getFileName(currentFile);
+        final Path newJournalFile = dir.resolve(newJournalFileName);
+
+        /**
+         * If a file already exists in the same path as where we
+         * wish to write our new journal file, then we try and rename
+         * the existing file to give it a .bak file extension.
+         */
+        if (Files.exists(newJournalFile)) {
+            final Path backupFile = newJournalFile.resolveSibling(FileUtils.fileName(newJournalFile) + BAK_FILE_SUFFIX);
+            LOG.warn("Journal file: {} already exists. Moving it to a backup file: {}", newJournalFile.toAbsolutePath(), backupFile.toAbsolutePath());
 
             try {
-                final Path renamed = Files.move(file, file.resolveSibling(FileUtils.fileName(file) + BAK_FILE_SUFFIX), StandardCopyOption.ATOMIC_MOVE);
+                final Path backedUpJournalFile = Files.move(newJournalFile, backupFile, StandardCopyOption.ATOMIC_MOVE);
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Old Journal file renamed from '{}' to '{}'", file.toAbsolutePath().toString(), renamed.toAbsolutePath().toString());
+                    LOG.debug("Old Journal file renamed from '{}' to '{}'", newJournalFile.toAbsolutePath().toString(), backedUpJournalFile.toAbsolutePath().toString());
                 }
             } catch (final IOException ioe) {
-                LOG.warn(ioe); //TODO(AR) should probably be an LogException but wasn't previously!
+                LOG.warn(ioe); //TODO(AR) should probably throw a LogException!
             }
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Creating new journal: {}", file.toAbsolutePath().toString());
+            LOG.debug("Creating new journal: {}", newJournalFile.toAbsolutePath().toString());
         }
 
         synchronized (latch) {
             try {
-                // close current file
+                // close current journal file
                 close();
 
-                // open new file
-                channel = (FileChannel) Files.newByteChannel(file, CREATE_NEW, WRITE);
+                // open new journal file
+                channel = (FileChannel) Files.newByteChannel(newJournalFile, CREATE_NEW, WRITE);
                 writeJournalHeader(channel);
                 initialised = true;
             } catch (final IOException e) {
-                throw new LogException("Failed to open new journal: " + file.toAbsolutePath().toString(), e);
+                throw new LogException("Failed to open new journal: " + newJournalFile.toAbsolutePath().toString(), e);
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/storage/journal/Journal.java
+++ b/exist-core/src/main/java/org/exist/storage/journal/Journal.java
@@ -209,7 +209,7 @@ public final class Journal implements Closeable {
     /**
      * the current file number
      */
-    private int currentFile = 0;
+    private int currentFile = -1;
 
     /**
      * temp buffer
@@ -592,7 +592,11 @@ public final class Journal implements Closeable {
         final String fileName = FileUtils.fileName(path);
         final int p = fileName.indexOf('.');
         final String baseName = fileName.substring(0, p);
-        return Integer.parseInt(baseName, 16);
+        final int fileNum = Integer.parseInt(baseName, 16);
+        if (fileNum < 0 || fileNum > Short.MAX_VALUE) {
+            throw new IllegalArgumentException("Path: " + fileNum + " has a file number that is out of range (0-" + Short.MAX_VALUE + ")");
+        }
+        return fileNum;
     }
 
     /**
@@ -723,11 +727,14 @@ public final class Journal implements Closeable {
      * @param fileNum the journal file number
      *
      * @return The file name
+     *
+     * @throws IllegalArgumentException if the file number is out of range
      */
-    static String getFileName(final int fileNum) {
-        String hex = Integer.toHexString(fileNum);
-        hex = "0000000000".substring(hex.length()) + hex;
-        return hex + '.' + LOG_FILE_SUFFIX;
+    static String getFileName(final int fileNum) throws IllegalArgumentException {
+        if (fileNum < 0 || fileNum > Short.MAX_VALUE) {
+            throw new IllegalArgumentException("File Number: " + fileNum + " is out of range (0-" + Short.MAX_VALUE + ")");
+        }
+        return String.format("%010x", fileNum) + '.' + LOG_FILE_SUFFIX;
     }
 
     private static class RemoveRunnable implements Runnable {

--- a/exist-core/src/main/java/org/exist/storage/journal/JournalManager.java
+++ b/exist-core/src/main/java/org/exist/storage/journal/JournalManager.java
@@ -32,6 +32,8 @@
  */
 package org.exist.storage.journal;
 
+import net.jcip.annotations.GuardedBy;
+import net.jcip.annotations.ThreadSafe;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.EXistException;
@@ -53,19 +55,20 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
+@ThreadSafe
 public class JournalManager implements BrokerPoolService {
     private static final Logger LOG = LogManager.getLogger(JournalManager.class);
 
-    private Path journalDir;
-    private boolean groupCommits;
-    private Journal journal;
-    private boolean journallingDisabled = false;
-    private boolean initialized = false;
+    @GuardedBy("this") private Path journalDir;
+    @GuardedBy("this") private boolean groupCommits;
+    @GuardedBy("this") private Journal journal;
+    @GuardedBy("this") private boolean journallingDisabled = false;
+    @GuardedBy("this") private boolean initialized = false;
 
     private final List<JournalListener> journalListeners = new CopyOnWriteArrayList<>();
 
     @Override
-    public void configure(final Configuration configuration) {
+    public synchronized void configure(final Configuration configuration) {
         this.journalDir = (Path) Optional.ofNullable(configuration.getProperty(Journal.PROPERTY_RECOVERY_JOURNAL_DIR))
                 .orElse(configuration.getProperty(BrokerPool.PROPERTY_DATA_DIR));
         this.groupCommits = configuration.getProperty(BrokerPool.PROPERTY_RECOVERY_GROUP_COMMIT, false);
@@ -75,8 +78,8 @@ public class JournalManager implements BrokerPoolService {
     }
 
     @Override
-    public void prepare(final BrokerPool pool) throws BrokerPoolServiceException {
-        if(!journallingDisabled) {
+    public synchronized void prepare(final BrokerPool pool) throws BrokerPoolServiceException {
+        if (!journallingDisabled) {
             try {
                 this.journal = new Journal(pool, journalDir);
                 this.journal.initialize();
@@ -87,7 +90,7 @@ public class JournalManager implements BrokerPoolService {
         }
     }
 
-    public void disableJournalling() {
+    public synchronized void disableJournalling() {
         this.journallingDisabled = true;
     }
 
@@ -101,7 +104,7 @@ public class JournalManager implements BrokerPoolService {
      * @throws JournalException of the journal entry cannot be written
      */
     public synchronized void journal(final Loggable loggable) throws JournalException {
-        if(!journallingDisabled) {
+        if (!journallingDisabled) {
             journal.writeToLog(loggable);
         }
     }
@@ -117,7 +120,7 @@ public class JournalManager implements BrokerPoolService {
      * @throws JournalException of the journal group cannot be written
      */
     public synchronized void journalGroup(final Loggable loggable) throws JournalException {
-        if(!journallingDisabled) {
+        if (!journallingDisabled) {
             journal.writeToLog(loggable);
             if (!groupCommits) {
                 journal.flushToLog(true);
@@ -142,7 +145,7 @@ public class JournalManager implements BrokerPoolService {
      * @throws JournalException of the journal checkpoint cannot be written
      */
     public synchronized void checkpoint(final long transactionId, final boolean switchFiles) throws JournalException {
-        if(!journallingDisabled) {
+        if (!journallingDisabled) {
             journal.checkpoint(transactionId, switchFiles);
 
             // notify each listener, de-registering those who want no further events
@@ -188,7 +191,7 @@ public class JournalManager implements BrokerPoolService {
      *
      * @return the last written LSN
      */
-    public Lsn lastWrittenLsn() {
+    public synchronized Lsn lastWrittenLsn() {
         return journal.lastWrittenLsn();
     }
 

--- a/exist-core/src/main/java/org/exist/storage/journal/JournalManager.java
+++ b/exist-core/src/main/java/org/exist/storage/journal/JournalManager.java
@@ -197,7 +197,7 @@ public class JournalManager implements BrokerPoolService {
     public RecoveryManager.JournalRecoveryAccessor getRecoveryAccessor(final RecoveryManager recoveryManager) {
         return recoveryManager.new JournalRecoveryAccessor(
                 journal::setInRecovery, journal::getFiles, journal::getFile, journal::setCurrentFileNum,
-                () -> { journal.switchFiles(); return null; }, () -> { journal.clearBackupFiles(); return null; });
+                () -> { journal.switchFiles(); return null; });
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/journal/JournalManager.java
+++ b/exist-core/src/main/java/org/exist/storage/journal/JournalManager.java
@@ -196,7 +196,7 @@ public class JournalManager implements BrokerPoolService {
 
     public RecoveryManager.JournalRecoveryAccessor getRecoveryAccessor(final RecoveryManager recoveryManager) {
         return recoveryManager.new JournalRecoveryAccessor(
-                journal::setInRecovery, journal::getFiles, journal::getFile, journal::setCurrentFileNum,
+                journal::setInRecovery, journal::getFiles, journal::getFile, journal::setCurrentJournalFileNumber,
                 () -> { journal.switchFiles(); return null; });
     }
 

--- a/exist-core/src/main/java/org/exist/storage/journal/JournalReader.java
+++ b/exist-core/src/main/java/org/exist/storage/journal/JournalReader.java
@@ -50,7 +50,7 @@ public class JournalReader implements AutoCloseable {
     private static final Logger LOG = LogManager.getLogger(JournalReader.class);
 
     private final DBBroker broker;
-    private final int fileNumber;
+    private final short fileNumber;
     private final ByteBuffer header = ByteBuffer.allocateDirect(LOG_ENTRY_HEADER_LEN);
     private ByteBuffer payload = ByteBuffer.allocateDirect(8192);  // 8 KB
     @Nullable
@@ -66,7 +66,7 @@ public class JournalReader implements AutoCloseable {
      * @param fileNumber the number of the journal file
      * @throws LogException if the journal cannot be opened
      */
-    public JournalReader(final DBBroker broker, final Path file, final int fileNumber) throws LogException {
+    public JournalReader(final DBBroker broker, final Path file, final short fileNumber) throws LogException {
         this.broker = broker;
         this.fileNumber = fileNumber;
         try {
@@ -192,11 +192,7 @@ public class JournalReader implements AutoCloseable {
     private @Nullable
     Loggable readEntry() throws LogException {
         try {
-            if (fileNumber > Short.MAX_VALUE) {
-                throw new LogException("Journal can only support " + Short.MAX_VALUE + " log files");
-            }
-
-            final Lsn lsn = new Lsn((short)fileNumber, fc.position() + 1);
+            final Lsn lsn = new Lsn(fileNumber, fc.position() + 1);
 
             // read the entry header
             header.clear();

--- a/exist-core/src/main/java/org/exist/storage/recovery/RecoveryManager.java
+++ b/exist-core/src/main/java/org/exist/storage/recovery/RecoveryManager.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -204,7 +203,6 @@ public class RecoveryManager {
 		}
         journalRecovery.setCurrentFileNum.accept(lastNum);
         journalRecovery.switchFiles.get();
-        journalRecovery.clearBackupFiles.get();
 
         return recoveryRun;
 	}
@@ -215,19 +213,16 @@ public class RecoveryManager {
         final Function<Integer, Path> getFile;
         final Consumer<Integer> setCurrentFileNum;
         final SupplierE<Void, LogException> switchFiles;
-        final Supplier<Void> clearBackupFiles;
 
 
         public JournalRecoveryAccessor(final Consumer<Boolean> setInRecovery,
                 final SupplierE<Stream<Path>, IOException> getFiles, final Function<Integer, Path> getFile,
-                final Consumer<Integer> setCurrentFileNum, final SupplierE<Void, LogException> switchFiles,
-                final Supplier<Void> clearBackupFiles) {
+                final Consumer<Integer> setCurrentFileNum, final SupplierE<Void, LogException> switchFiles) {
             this.setInRecovery = setInRecovery;
             this.getFiles = getFiles;
             this.getFile = getFile;
             this.setCurrentFileNum = setCurrentFileNum;
             this.switchFiles = switchFiles;
-            this.clearBackupFiles = clearBackupFiles;
         }
     }
 

--- a/exist-core/src/main/java/org/exist/storage/recovery/RecoveryManager.java
+++ b/exist-core/src/main/java/org/exist/storage/recovery/RecoveryManager.java
@@ -86,7 +86,7 @@ public class RecoveryManager {
             throw new LogException("Unable to find journal files in data dir", ioe);
         }
         // find the last log file in the data directory
-		final int lastNum = Journal.findLastFile(files.stream());
+		final short lastNum = Journal.findLastFile(files.stream());
 		if (-1 < lastNum) {
             // load the last log file
 			final Path last = journalRecovery.getFile.apply(lastNum);
@@ -210,14 +210,14 @@ public class RecoveryManager {
     public class JournalRecoveryAccessor {
         final Consumer<Boolean> setInRecovery;
         final SupplierE<Stream<Path>, IOException> getFiles;
-        final Function<Integer, Path> getFile;
-        final Consumer<Integer> setCurrentFileNum;
+        final Function<Short, Path> getFile;
+        final Consumer<Short> setCurrentFileNum;
         final SupplierE<Void, LogException> switchFiles;
 
 
         public JournalRecoveryAccessor(final Consumer<Boolean> setInRecovery,
-                final SupplierE<Stream<Path>, IOException> getFiles, final Function<Integer, Path> getFile,
-                final Consumer<Integer> setCurrentFileNum, final SupplierE<Void, LogException> switchFiles) {
+                final SupplierE<Stream<Path>, IOException> getFiles, final Function<Short, Path> getFile,
+                final Consumer<Short> setCurrentFileNum, final SupplierE<Void, LogException> switchFiles) {
             this.setInRecovery = setInRecovery;
             this.getFiles = getFiles;
             this.getFile = getFile;

--- a/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
@@ -214,16 +214,18 @@ public class XQueryTestRunner extends AbstractTestRunner {
             final Source query = new ClassLoaderSource(pkgName + "/xquery-test-runner.xq");
             final URI testModuleUri = path.toAbsolutePath().toUri();
 
+            final String suiteName = getSuiteName();
+
             final List<java.util.function.Function<XQueryContext, Tuple2<String, Object>>> externalVariableDeclarations = Arrays.asList(
                     context -> new Tuple2<>("test-module-uri", new AnyURIValue(testModuleUri)),
 
                     // set callback functions for notifying junit!
-                    context -> new Tuple2<>("test-ignored-function", new FunctionReference(new FunctionCall(context, new ExtTestIgnoredFunction(context, getSuiteName(), notifier)))),
-                    context -> new Tuple2<>("test-started-function", new FunctionReference(new FunctionCall(context, new ExtTestStartedFunction(context, getSuiteName(), notifier)))),
-                    context -> new Tuple2<>("test-failure-function", new FunctionReference(new FunctionCall(context, new ExtTestFailureFunction(context, getSuiteName(), notifier)))),
-                    context -> new Tuple2<>("test-assumption-failed-function", new FunctionReference(new FunctionCall(context, new ExtTestAssumptionFailedFunction(context, getSuiteName(), notifier)))),
-                    context -> new Tuple2<>("test-error-function", new FunctionReference(new FunctionCall(context, new ExtTestErrorFunction(context, getSuiteName(), notifier)))),
-                    context -> new Tuple2<>("test-finished-function", new FunctionReference(new FunctionCall(context, new ExtTestFinishedFunction(context, getSuiteName(), notifier))))
+                    context -> new Tuple2<>("test-ignored-function", new FunctionReference(new FunctionCall(context, new ExtTestIgnoredFunction(context, suiteName, notifier)))),
+                    context -> new Tuple2<>("test-started-function", new FunctionReference(new FunctionCall(context, new ExtTestStartedFunction(context, suiteName, notifier)))),
+                    context -> new Tuple2<>("test-failure-function", new FunctionReference(new FunctionCall(context, new ExtTestFailureFunction(context, suiteName, notifier)))),
+                    context -> new Tuple2<>("test-assumption-failed-function", new FunctionReference(new FunctionCall(context, new ExtTestAssumptionFailedFunction(context, suiteName, notifier)))),
+                    context -> new Tuple2<>("test-error-function", new FunctionReference(new FunctionCall(context, new ExtTestErrorFunction(context, suiteName, notifier)))),
+                    context -> new Tuple2<>("test-finished-function", new FunctionReference(new FunctionCall(context, new ExtTestFinishedFunction(context, suiteName, notifier))))
             );
 
             // NOTE: at this stage EXIST_EMBEDDED_SERVER_CLASS_INSTANCE in XSuite will be usable

--- a/exist-core/src/test/java/org/exist/storage/journal/AbstractJournalTest.java
+++ b/exist-core/src/test/java/org/exist/storage/journal/AbstractJournalTest.java
@@ -1443,7 +1443,7 @@ public abstract class AbstractJournalTest<T> {
         final Path journalDir = (Path) Optional.ofNullable(configuration.getProperty(Journal.PROPERTY_RECOVERY_JOURNAL_DIR))
                 .orElse(configuration.getProperty(BrokerPool.PROPERTY_DATA_DIR));
 
-        final int lastNum;
+        final short lastNum;
         try (final Stream<Path> files = Files.list(journalDir).filter(f -> f.getFileName().toString().endsWith("." + Journal.LOG_FILE_SUFFIX))) {
             lastNum = Journal.findLastFile(files);
         }

--- a/exist-core/src/test/java/org/exist/storage/journal/JournalTest.java
+++ b/exist-core/src/test/java/org/exist/storage/journal/JournalTest.java
@@ -58,17 +58,17 @@ public class JournalTest {
 
     @Test
     public void getFileName() {
-        assertEquals("0000000000.log", Journal.getFileName(0));
-        assertEquals("0000000001.log", Journal.getFileName(1));
-        assertEquals("0000000002.log", Journal.getFileName(2));
-        assertEquals("000000000a.log", Journal.getFileName(10));
-        assertEquals("000000000b.log", Journal.getFileName(11));
-        assertEquals("0000000014.log", Journal.getFileName(20));
-        assertEquals("0000000015.log", Journal.getFileName(21));
-        assertEquals("000000001e.log", Journal.getFileName(30));
-        assertEquals("000000001f.log", Journal.getFileName(31));
+        assertEquals("0000000000.log", Journal.getFileName((short)0));
+        assertEquals("0000000001.log", Journal.getFileName((short)1));
+        assertEquals("0000000002.log", Journal.getFileName((short)2));
+        assertEquals("000000000a.log", Journal.getFileName((short)10));
+        assertEquals("000000000b.log", Journal.getFileName((short)11));
+        assertEquals("0000000014.log", Journal.getFileName((short)20));
+        assertEquals("0000000015.log", Journal.getFileName((short)21));
+        assertEquals("000000001e.log", Journal.getFileName((short)30));
+        assertEquals("000000001f.log", Journal.getFileName((short)31));
 
-        assertEquals("0000007ffe.log", Journal.getFileName(Short.MAX_VALUE - 1));
+        assertEquals("0000007ffe.log", Journal.getFileName((short)(Short.MAX_VALUE - 1)));
         assertEquals("0000007fff.log", Journal.getFileName(Short.MAX_VALUE));
     }
 
@@ -79,7 +79,7 @@ public class JournalTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void getFileNameWithFileNumMinusOneRaisesException() {
-        Journal.getFileName(-1);
+        Journal.getFileName((short)-1);
     }
 
     @Test
@@ -113,51 +113,51 @@ public class JournalTest {
     @Test
     public void findLastFile() {
         try (final Stream<Path> paths = Stream.of(
-                Paths.get(Journal.getFileName(1)),
-                Paths.get(Journal.getFileName(31)),
-                Paths.get(Journal.getFileName(11)),
-                Paths.get(Journal.getFileName(10)),
-                Paths.get(Journal.getFileName(2)),
+                Paths.get(Journal.getFileName((short)1)),
+                Paths.get(Journal.getFileName((short)31)),
+                Paths.get(Journal.getFileName((short)11)),
+                Paths.get(Journal.getFileName((short)10)),
+                Paths.get(Journal.getFileName((short)2)),
                 Paths.get(Journal.getFileName(Short.MAX_VALUE)),
-                Paths.get(Journal.getFileName(20)),
-                Paths.get(Journal.getFileName(Short.MAX_VALUE - 1)),
-                Paths.get(Journal.getFileName(21)),
-                Paths.get(Journal.getFileName(30))
+                Paths.get(Journal.getFileName((short)20)),
+                Paths.get(Journal.getFileName((short)(Short.MAX_VALUE - 1))),
+                Paths.get(Journal.getFileName((short)21)),
+                Paths.get(Journal.getFileName((short)30))
         )) {
             assertEquals(Short.MAX_VALUE, Journal.findLastFile(paths));
         }
 
         try (final Stream<Path> paths = Stream.of(
-                Paths.get(Journal.getFileName(1)),
-                Paths.get(Journal.getFileName(31)),
-                Paths.get(Journal.getFileName(11)),
-                Paths.get(Journal.getFileName(10)),
-                Paths.get(Journal.getFileName(2)),
-                Paths.get(Journal.getFileName(20)),
-                Paths.get(Journal.getFileName(Short.MAX_VALUE - 1)),
-                Paths.get(Journal.getFileName(21)),
-                Paths.get(Journal.getFileName(30))
+                Paths.get(Journal.getFileName((short)1)),
+                Paths.get(Journal.getFileName((short)31)),
+                Paths.get(Journal.getFileName((short)11)),
+                Paths.get(Journal.getFileName((short)10)),
+                Paths.get(Journal.getFileName((short)2)),
+                Paths.get(Journal.getFileName((short)20)),
+                Paths.get(Journal.getFileName((short)(Short.MAX_VALUE - 1))),
+                Paths.get(Journal.getFileName((short)21)),
+                Paths.get(Journal.getFileName((short)30))
         )) {
             assertEquals(Short.MAX_VALUE - 1, Journal.findLastFile(paths));
         }
 
         try (final Stream<Path> paths = Stream.of(
-                Paths.get(Journal.getFileName(1)),
-                Paths.get(Journal.getFileName(11)),
-                Paths.get(Journal.getFileName(2))
+                Paths.get(Journal.getFileName((short)1)),
+                Paths.get(Journal.getFileName((short)11)),
+                Paths.get(Journal.getFileName((short)2))
         )) {
             assertEquals(11, Journal.findLastFile(paths));
         }
 
         try (final Stream<Path> paths = Stream.of(
-                Paths.get(Journal.getFileName(1))
+                Paths.get(Journal.getFileName((short)1))
         )) {
             assertEquals(1, Journal.findLastFile(paths));
         }
 
         try (final Stream<Path> paths = Stream.of(
-                Paths.get(Journal.getFileName(111)),
-                Paths.get(Journal.getFileName(1))
+                Paths.get(Journal.getFileName((short)111)),
+                Paths.get(Journal.getFileName((short)1))
         )) {
             assertEquals(111, Journal.findLastFile(paths));
         }
@@ -192,27 +192,27 @@ public class JournalTest {
         List<String> input = Arrays.asList(new String[]{ "0000000001.log" });
         Path mockJournalDir = createTempDirWithFiles(input);
 
-        Path journalFile = Journal.getFile(mockJournalDir, 0);
+        Path journalFile = Journal.getFile(mockJournalDir, (short)0);
         assertFalse(Files.exists(journalFile));  // no such file!
         assertEquals("0000000000.log", FileUtils.fileName(journalFile));
 
-        journalFile = Journal.getFile(mockJournalDir, 1);
+        journalFile = Journal.getFile(mockJournalDir, (short)1);
         assertTrue(Files.exists(journalFile));
         assertEquals(input.get(0), FileUtils.fileName(journalFile));
 
-        journalFile = Journal.getFile(mockJournalDir, 2);
+        journalFile = Journal.getFile(mockJournalDir, (short)2);
         assertFalse(Files.exists(journalFile));  // no such file!
         assertEquals("0000000002.log", FileUtils.fileName(journalFile));
 
-        journalFile = Journal.getFile(mockJournalDir, 30);
+        journalFile = Journal.getFile(mockJournalDir, (short)30);
         assertFalse(Files.exists(journalFile));  // no such file!
         assertEquals("000000001e.log", FileUtils.fileName(journalFile));
 
-        journalFile = Journal.getFile(mockJournalDir, 31);
+        journalFile = Journal.getFile(mockJournalDir, (short)31);
         assertFalse(Files.exists(journalFile));  // no such file!
         assertEquals("000000001f.log", FileUtils.fileName(journalFile));
 
-        journalFile = Journal.getFile(mockJournalDir, Short.MAX_VALUE - 1);
+        journalFile = Journal.getFile(mockJournalDir, (short)(Short.MAX_VALUE - 1));
         assertFalse(Files.exists(journalFile));  // no such file!
         assertEquals("0000007ffe.log", FileUtils.fileName(journalFile));
 
@@ -223,19 +223,19 @@ public class JournalTest {
         input = Arrays.asList(new String[]{ "0000000001.log", "00000000af.log", "000000000a.log", "000000000f.log" });
         mockJournalDir = createTempDirWithFiles(input);
 
-        journalFile = Journal.getFile(mockJournalDir, 1);
+        journalFile = Journal.getFile(mockJournalDir, (short)1);
         assertTrue(Files.exists(journalFile));
         assertEquals(input.get(0), FileUtils.fileName(journalFile));
 
-        journalFile = Journal.getFile(mockJournalDir, 175);
+        journalFile = Journal.getFile(mockJournalDir, (short)175);
         assertTrue(Files.exists(journalFile));
         assertEquals(input.get(1), FileUtils.fileName(journalFile));
 
-        journalFile = Journal.getFile(mockJournalDir, 10);
+        journalFile = Journal.getFile(mockJournalDir, (short)10);
         assertTrue(Files.exists(journalFile));
         assertEquals(input.get(2), FileUtils.fileName(journalFile));
 
-        journalFile = Journal.getFile(mockJournalDir, 15);
+        journalFile = Journal.getFile(mockJournalDir, (short)15);
         assertTrue(Files.exists(journalFile));
         assertEquals(input.get(3), FileUtils.fileName(journalFile));
     }
@@ -247,7 +247,7 @@ public class JournalTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void getFileWithFileNumMinusOneRaisesException() throws IOException {
-        Journal.getFile(TEMPORARY_FOLDER.newFolder().toPath(), -1);
+        Journal.getFile(TEMPORARY_FOLDER.newFolder().toPath(), (short)-1);
     }
 
 
@@ -303,7 +303,7 @@ public class JournalTest {
         // start the journal by calling switch files
         journal.switchFiles();
 
-        int currentJournalFileNumber = journal.getCurrentJournalFileNumber();
+        short currentJournalFileNumber = journal.getCurrentJournalFileNumber();
         assertEquals(0, currentJournalFileNumber);
         final Path journalFile0 = journal.getFile(currentJournalFileNumber);
         assertNotNull(journalFile0);
@@ -345,13 +345,13 @@ public class JournalTest {
         assertEquals(-1, journal.getCurrentJournalFileNumber());  // journal is not yet operating!
 
         // create an existing (old) journal file first
-        final Path existingJournalFile = Files.createFile(tempJournalDir.resolve(Journal.getFileName(0)));
+        final Path existingJournalFile = Files.createFile(tempJournalDir.resolve(Journal.getFileName((short)0)));
         assertTrue(Files.exists(existingJournalFile));
 
         // start the journal by calling switch files
         journal.switchFiles();
 
-        int currentJournalFileNumber = journal.getCurrentJournalFileNumber();
+        short currentJournalFileNumber = journal.getCurrentJournalFileNumber();
         assertEquals(0, currentJournalFileNumber);
         final Path journalFile0 = journal.getFile(currentJournalFileNumber);
         assertNotNull(journalFile0);
@@ -387,8 +387,8 @@ public class JournalTest {
         assertEquals(-1, journal.getCurrentJournalFileNumber());  // journal is not yet operating!
 
         // set the current journal file number to one less than the maximum
-        journal.setCurrentJournalFileNumber(Short.MAX_VALUE - 1);
-        int currentJournalFileNumber = journal.getCurrentJournalFileNumber();
+        journal.setCurrentJournalFileNumber((short)(Short.MAX_VALUE - 1));
+        short currentJournalFileNumber = journal.getCurrentJournalFileNumber();
         assertEquals(Short.MAX_VALUE - 1, currentJournalFileNumber);  // journal is not yet operating!
 
         // start the journal by calling switch files

--- a/exist-core/src/test/java/org/exist/storage/journal/JournalTest.java
+++ b/exist-core/src/test/java/org/exist/storage/journal/JournalTest.java
@@ -40,6 +40,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -176,6 +177,8 @@ public class JournalTest {
         input = Arrays.asList(new String[]{ "0000000001.log", "0000000002.log", "000000000a.log" });
         mockJournalDir = createTempDirWithFiles(input);
         actual = Journal.getFiles(mockJournalDir).map(FileUtils::fileName).collect(Collectors.toList());
+        Collections.sort(input);
+        Collections.sort(actual);
         assertEquals(input, actual);
 
         input = Arrays.asList(new String[]{ "0000000001.log", "0000000001.log" + Journal.BAK_FILE_SUFFIX, "0000000001_index.log", "journal.lck" });

--- a/exist-core/src/test/java/org/exist/storage/journal/JournalTest.java
+++ b/exist-core/src/test/java/org/exist/storage/journal/JournalTest.java
@@ -1,0 +1,281 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage.journal;
+
+import edu.emory.mathcs.backport.java.util.Arrays;
+import org.easymock.Capture;
+import org.easymock.CaptureType;
+import org.exist.util.FileUtils;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class JournalTest {
+
+    @ClassRule
+    public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    @Test
+    public void getFileName() {
+        assertEquals("0000000000.log", Journal.getFileName(0));
+        assertEquals("0000000001.log", Journal.getFileName(1));
+        assertEquals("0000000002.log", Journal.getFileName(2));
+        assertEquals("000000000a.log", Journal.getFileName(10));
+        assertEquals("000000000b.log", Journal.getFileName(11));
+        assertEquals("0000000014.log", Journal.getFileName(20));
+        assertEquals("0000000015.log", Journal.getFileName(21));
+        assertEquals("000000001e.log", Journal.getFileName(30));
+        assertEquals("000000001f.log", Journal.getFileName(31));
+
+        assertEquals("0000007ffe.log", Journal.getFileName(Short.MAX_VALUE - 1));
+        assertEquals("0000007fff.log", Journal.getFileName(Short.MAX_VALUE));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getFileNameWithFileNumShortMinValueRaisesException() {
+        Journal.getFileName(Short.MIN_VALUE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getFileNameWithFileNumMinusOneRaisesException() {
+        Journal.getFileName(-1);
+    }
+
+    @Test
+    public void journalFileNum() {
+        assertEquals(0, Journal.journalFileNum(Paths.get("0000000000.log")));
+        assertEquals(1, Journal.journalFileNum(Paths.get("0000000001.log")));
+        assertEquals(2, Journal.journalFileNum(Paths.get("0000000002.log")));
+        assertEquals(10, Journal.journalFileNum(Paths.get("000000000a.log")));
+        assertEquals(11, Journal.journalFileNum(Paths.get("000000000b.log")));
+        assertEquals(20, Journal.journalFileNum(Paths.get("0000000014.log")));
+        assertEquals(21, Journal.journalFileNum(Paths.get("0000000015.log")));
+        assertEquals(30, Journal.journalFileNum(Paths.get("000000001e.log")));
+        assertEquals(31, Journal.journalFileNum(Paths.get("000000001f.log")));
+
+        assertEquals(Short.MAX_VALUE - 1, Journal.journalFileNum(Paths.get("0000007ffe.log")));
+        assertEquals(Short.MAX_VALUE, Journal.journalFileNum(Paths.get("0000007fff.log")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void journalFileNumWithPathShortMinValueRaisesException() {
+        final String fileName = String.format("%010x", Short.MIN_VALUE) + '.' + Journal.LOG_FILE_SUFFIX;
+        Journal.journalFileNum(Paths.get(fileName));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void journalFileNumWithPathMinusOneRaisesException() {
+        final String fileName = String.format("%010x", -1) + '.' + Journal.LOG_FILE_SUFFIX;
+        Journal.journalFileNum(Paths.get(fileName));
+    }
+
+    @Test
+    public void findLastFile() {
+        try (final Stream<Path> paths = Stream.of(
+                Paths.get(Journal.getFileName(1)),
+                Paths.get(Journal.getFileName(31)),
+                Paths.get(Journal.getFileName(11)),
+                Paths.get(Journal.getFileName(10)),
+                Paths.get(Journal.getFileName(2)),
+                Paths.get(Journal.getFileName(Short.MAX_VALUE)),
+                Paths.get(Journal.getFileName(20)),
+                Paths.get(Journal.getFileName(Short.MAX_VALUE - 1)),
+                Paths.get(Journal.getFileName(21)),
+                Paths.get(Journal.getFileName(30))
+        )) {
+            assertEquals(Short.MAX_VALUE, Journal.findLastFile(paths));
+        }
+
+        try (final Stream<Path> paths = Stream.of(
+                Paths.get(Journal.getFileName(1)),
+                Paths.get(Journal.getFileName(31)),
+                Paths.get(Journal.getFileName(11)),
+                Paths.get(Journal.getFileName(10)),
+                Paths.get(Journal.getFileName(2)),
+                Paths.get(Journal.getFileName(20)),
+                Paths.get(Journal.getFileName(Short.MAX_VALUE - 1)),
+                Paths.get(Journal.getFileName(21)),
+                Paths.get(Journal.getFileName(30))
+        )) {
+            assertEquals(Short.MAX_VALUE - 1, Journal.findLastFile(paths));
+        }
+
+        try (final Stream<Path> paths = Stream.of(
+                Paths.get(Journal.getFileName(1)),
+                Paths.get(Journal.getFileName(11)),
+                Paths.get(Journal.getFileName(2))
+        )) {
+            assertEquals(11, Journal.findLastFile(paths));
+        }
+
+        try (final Stream<Path> paths = Stream.of(
+                Paths.get(Journal.getFileName(1))
+        )) {
+            assertEquals(1, Journal.findLastFile(paths));
+        }
+
+        try (final Stream<Path> paths = Stream.of(
+                Paths.get(Journal.getFileName(111)),
+                Paths.get(Journal.getFileName(1))
+        )) {
+            assertEquals(111, Journal.findLastFile(paths));
+        }
+
+        try (final Stream<Path> paths = Stream.empty()) {
+            assertEquals(-1, Journal.findLastFile(paths));
+        }
+    }
+
+    @Test
+    public void getFiles() throws IOException {
+        List<String> input = Arrays.asList(new String[]{ "0000000001.log" });
+        Path mockJournalDir = createTempDirWithFiles(input);
+        List<String> actual = Journal.getFiles(mockJournalDir).map(FileUtils::fileName).collect(Collectors.toList());
+        assertEquals(input, actual);
+
+        input = Arrays.asList(new String[]{ "0000000001.log", "0000000002.log", "000000000a.log" });
+        mockJournalDir = createTempDirWithFiles(input);
+        actual = Journal.getFiles(mockJournalDir).map(FileUtils::fileName).collect(Collectors.toList());
+        assertEquals(input, actual);
+
+        input = Arrays.asList(new String[]{ "0000000001.log", "0000000001.log" + Journal.BAK_FILE_SUFFIX, "0000000001_index.log", "journal.lck" });
+        mockJournalDir = createTempDirWithFiles(input);
+        actual = Journal.getFiles(mockJournalDir).map(FileUtils::fileName).collect(Collectors.toList());
+        assertEquals(Arrays.asList(new String[] { "0000000001.log" }), actual);
+    }
+
+    @Test
+    public void getFile() throws IOException {
+        List<String> input = Arrays.asList(new String[]{ "0000000001.log" });
+        Path mockJournalDir = createTempDirWithFiles(input);
+
+        Path journalFile = Journal.getFile(mockJournalDir, 0);
+        assertFalse(Files.exists(journalFile));  // no such file!
+        assertEquals("0000000000.log", FileUtils.fileName(journalFile));
+
+        journalFile = Journal.getFile(mockJournalDir, 1);
+        assertTrue(Files.exists(journalFile));
+        assertEquals(input.get(0), FileUtils.fileName(journalFile));
+
+        journalFile = Journal.getFile(mockJournalDir, 2);
+        assertFalse(Files.exists(journalFile));  // no such file!
+        assertEquals("0000000002.log", FileUtils.fileName(journalFile));
+
+        journalFile = Journal.getFile(mockJournalDir, 30);
+        assertFalse(Files.exists(journalFile));  // no such file!
+        assertEquals("000000001e.log", FileUtils.fileName(journalFile));
+
+        journalFile = Journal.getFile(mockJournalDir, 31);
+        assertFalse(Files.exists(journalFile));  // no such file!
+        assertEquals("000000001f.log", FileUtils.fileName(journalFile));
+
+        journalFile = Journal.getFile(mockJournalDir, Short.MAX_VALUE - 1);
+        assertFalse(Files.exists(journalFile));  // no such file!
+        assertEquals("0000007ffe.log", FileUtils.fileName(journalFile));
+
+        journalFile = Journal.getFile(mockJournalDir, Short.MAX_VALUE);
+        assertFalse(Files.exists(journalFile));  // no such file!
+        assertEquals("0000007fff.log", FileUtils.fileName(journalFile));
+
+        input = Arrays.asList(new String[]{ "0000000001.log", "00000000af.log", "000000000a.log", "000000000f.log" });
+        mockJournalDir = createTempDirWithFiles(input);
+
+        journalFile = Journal.getFile(mockJournalDir, 1);
+        assertTrue(Files.exists(journalFile));
+        assertEquals(input.get(0), FileUtils.fileName(journalFile));
+
+        journalFile = Journal.getFile(mockJournalDir, 175);
+        assertTrue(Files.exists(journalFile));
+        assertEquals(input.get(1), FileUtils.fileName(journalFile));
+
+        journalFile = Journal.getFile(mockJournalDir, 10);
+        assertTrue(Files.exists(journalFile));
+        assertEquals(input.get(2), FileUtils.fileName(journalFile));
+
+        journalFile = Journal.getFile(mockJournalDir, 15);
+        assertTrue(Files.exists(journalFile));
+        assertEquals(input.get(3), FileUtils.fileName(journalFile));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getFileWithFileNumShortMinValueRaisesException() throws IOException {
+        Journal.getFile(TEMPORARY_FOLDER.newFolder().toPath(), Short.MIN_VALUE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getFileWithFileNumMinusOneRaisesException() throws IOException {
+        Journal.getFile(TEMPORARY_FOLDER.newFolder().toPath(), -1);
+    }
+
+
+    @Test
+    public void writeJournalHeader() throws IOException {
+        final SeekableByteChannel mockSeekableByteChannel = mock(SeekableByteChannel.class);
+        final Capture<ByteBuffer> captureByteBuffer = newCapture(CaptureType.FIRST);
+        expect(mockSeekableByteChannel.write(capture(captureByteBuffer))).andReturn(Journal.JOURNAL_HEADER_LEN);
+
+        replay(mockSeekableByteChannel);
+
+        // call the operation
+        Journal.writeJournalHeader(mockSeekableByteChannel);
+
+        final ByteBuffer writtenJournalHeader = captureByteBuffer.getValue();
+        assertNotNull(writtenJournalHeader);
+        assertEquals(0, writtenJournalHeader.position());
+        assertEquals(Journal.JOURNAL_HEADER_LEN, writtenJournalHeader.limit());
+        final byte[] bufMagic = new byte[Journal.JOURNAL_MAGIC_NUMBER.length];
+        writtenJournalHeader.get(bufMagic);
+        assertArrayEquals(Journal.JOURNAL_MAGIC_NUMBER, bufMagic);
+        final byte[] bufVersion = new byte[Journal.JOURNAL_HEADER_LEN - Journal.JOURNAL_MAGIC_NUMBER.length];
+        writtenJournalHeader.get(bufVersion);
+        assertArrayEquals(new byte[] {0, Journal.JOURNAL_VERSION}, bufVersion);
+
+        // verify the mocks
+        verify(mockSeekableByteChannel);
+    }
+
+    private static Path createTempDirWithFiles(final List<String> fileNames) throws IOException {
+        final Path tempFolder = TEMPORARY_FOLDER.newFolder().toPath();
+        Files.createDirectories(tempFolder);
+        for (final String fileName : fileNames) {
+            final Path file = Files.createFile(tempFolder.resolve(fileName));
+            assertTrue(Files.exists(file));
+        }
+        return tempFolder;
+    }
+}

--- a/exist-core/src/test/java/org/exist/storage/journal/JournalTest.java
+++ b/exist-core/src/test/java/org/exist/storage/journal/JournalTest.java
@@ -21,7 +21,6 @@
  */
 package org.exist.storage.journal;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.exist.EXistException;
@@ -40,6 +39,7 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/4189

Addresses the following bugs:

1. Previously `Journal#findLastFile(Stream)` would incorrectly find the first file instead of the last file, it now correctly finds the last file.

2. Each Journal file is assigned an increasing number. Previously, if you reached the maximum number of `32767` then eXist-db would throw an exception and stop in an in-consistent state with no ability to move forward. As there is typically only one or two journal files in existence simultaneously, we now simply wrap around to `0` when we exceed `32767`.

3. The Journal and JournalManager had insufficient synchronisation for concurrent operations. This means that eXist-db could potentially produce a corrupt journal. Should a crash occur, eXist-db would either not be able to recover using a corrupt journal, or worse yet might corrupt the database further when applying its recovery strategy based on the corrupt journal.