### PR TITLE
Import jetty Properties from SystemProperties

### DIFF
--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-http.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-http.xml
@@ -34,8 +34,8 @@
             </Item>
           </Array>
         </Arg>
-        <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port"><Default><SystemProperty name="jetty.port" default="8080"/></Default></Property></Set>
+        <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host"><Default><SystemProperty name="jetty.http.host" deprecated="jetty.host"/></Default></Property></Set>
+        <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port"><Default><SystemProperty name="jetty.http.port" deprecated="jetty.port" default="8080"/></Default></Property></Set>
         <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl.xml
@@ -26,7 +26,7 @@
           </Array>
         </Arg>
 
-        <Set name="host"><Property name="jetty.ssl.host" deprecated="jetty.host" /></Set>
+        <Set name="host"><Property name="jetty.ssl.host" deprecated="jetty.host"><Default><SystemProperty name="jetty.ssl.host" deprecated="jetty.host"/></Default></Property></Set>
         <Set name="port"><Property name="jetty.ssl.port" deprecated="ssl.port"><Default><SystemProperty name="jetty.ssl.port" deprecated="ssl.port" default="8443"/></Default></Property></Set>
         <Set name="idleTimeout"><Property name="jetty.ssl.idleTimeout" deprecated="ssl.timeout" default="30000"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.ssl.acceptorPriorityDelta" deprecated="ssl.acceptorPriorityDelta" default="0"/></Set>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-http.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-http.xml
@@ -34,8 +34,8 @@
             </Item>
           </Array>
         </Arg>
-        <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host" /></Set>
-        <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port"><Default><SystemProperty name="jetty.port" default="8088"/></Default></Property></Set>
+        <Set name="host"><Property name="jetty.http.host" deprecated="jetty.host"><Default><SystemProperty name="jetty.http.host" deprecated="jetty.host"/></Default></Property></Set>
+        <Set name="port"><Property name="jetty.http.port" deprecated="jetty.port"><Default><SystemProperty name="jetty.http.port" deprecated="jetty.port" default="8088"/></Default></Property></Set>
         <Set name="idleTimeout"><Property name="jetty.http.idleTimeout" deprecated="http.timeout" default="30000"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.http.acceptorPriorityDelta" deprecated="http.acceptorPriorityDelta" default="0"/></Set>
         <Set name="acceptQueueSize"><Property name="jetty.http.acceptQueueSize" deprecated="http.acceptQueueSize" default="0"/></Set>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-ssl.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-ssl.xml
@@ -26,7 +26,7 @@
           </Array>
         </Arg>
 
-        <Set name="host"><Property name="jetty.ssl.host" deprecated="jetty.host" /></Set>
+        <Set name="host"><Property name="jetty.ssl.host" deprecated="jetty.host"><Default><SystemProperty name="jetty.ssl.host" deprecated="jetty.host"/></Default></Property></Set>
         <Set name="port"><Property name="jetty.ssl.port" deprecated="ssl.port"><Default><SystemProperty name="jetty.ssl.port" deprecated="ssl.port" default="8451"/></Default></Property></Set>
         <Set name="idleTimeout"><Property name="jetty.ssl.idleTimeout" deprecated="ssl.timeout" default="30000"/></Set>
         <Set name="acceptorPriorityDelta"><Property name="jetty.ssl.acceptorPriorityDelta" deprecated="ssl.acceptorPriorityDelta" default="0"/></Set>


### PR DESCRIPTION
This unifies handling of jetty variables set via JAVA_OPTS environment variable.
The following jetty Properties can now be set via JAVA_OPTS: [jetty.host, jetty.port, ssl.port, jetty.http.host, jetty.http.port, jetty.ssl.host, jetty.ssl.port].

to clarify: the PR enables e.g. the following inside an existdb home directory
```
$ JAVA_OPTS='-Djetty.host=127.0.0.2 -Djetty.http.port=9999' ./bin/startup.sh
```
or putting the options directly on the java command
```
$ /usr/bin/java ... \
   -Djetty.host=127.0.0.2 \
   -Djetty.http.port=9999 \
   ... org.codehaus.mojo.appassembler.booter.AppassemblerBooter
```