### PR TITLE
Test Collection Rename and Move operations

### DIFF
--- a/exist-core/src/test/java/org/exist/storage/MoveCollectionTest.java
+++ b/exist-core/src/test/java/org/exist/storage/MoveCollectionTest.java
@@ -55,6 +55,9 @@ public class MoveCollectionTest {
     @Rule
     public ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
 
+    /**
+     * Test move collection /db/a/b/c/d/e/f/g/h/i/j/k to /db/z/y/x/w/v/u/k
+     */
     @Test
     public void moveDeep() throws EXistException, IOException, PermissionDeniedException, TriggerException, LockException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
@@ -85,6 +88,59 @@ public class MoveCollectionTest {
         }
     }
 
+    /**
+     * Test move collection /db/a/b/c/d/e/f/g/h/i/j/k to /db/z/y/x/w/v/u/k
+     *
+     * Note that the collection /db/a/b/c/d/e/f/g/h/i/j/k has the sub-collections (sub-1 and sub-2),
+     * this test checks that the sub-collections are correctly preserved.
+     */
+    @Test
+    public void moveDeepWithSubCollections() throws EXistException, IOException, PermissionDeniedException, TriggerException, LockException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = transact.beginTransaction()) {
+
+            final XmldbURI srcUri = XmldbURI.create("/db/a/b/c/d/e/f/g/h/i/j/k");
+            final XmldbURI srcSubCol1Uri = srcUri.append("sub-1");
+            final XmldbURI srcSubCol2Uri = srcUri.append("sub-2");
+            final XmldbURI destUri = XmldbURI.create("/db/z/y/x/w/v/u");
+
+            // create src collection
+            try (final Collection src = broker.getOrCreateCollection(transaction, srcUri)) {
+                assertNotNull(src);
+                broker.saveCollection(transaction, src);
+            }
+
+            // create src sub-collections
+            try (final Collection srcColSubCol1 = broker.getOrCreateCollection(transaction, srcSubCol1Uri)) {
+                assertNotNull(srcColSubCol1);
+                broker.saveCollection(transaction, srcColSubCol1);
+            }
+            try (final Collection srcColSubCol2 = broker.getOrCreateCollection(transaction, srcSubCol2Uri)) {
+                assertNotNull(srcColSubCol2);
+                broker.saveCollection(transaction, srcColSubCol2);
+            }
+
+            // create dst collection
+            try (final Collection dst = broker.getOrCreateCollection(transaction, destUri)) {
+                assertNotNull(dst);
+                broker.saveCollection(transaction, dst);
+            }
+
+            try (final Collection src = broker.openCollection(srcUri, Lock.LockMode.WRITE_LOCK);
+                 final Collection dst = broker.openCollection(destUri, Lock.LockMode.WRITE_LOCK)) {
+
+                broker.moveCollection(transaction, src, dst, src.getURI().lastSegment());
+            }
+
+            transact.commit(transaction);
+        }
+    }
+
+    /**
+     * Test rename collection /db/move-collection-test-rename/before to /db/move-collection-test-rename/after
+     */
     @Test
     public void rename() throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
         final BrokerPool pool = existEmbeddedServer.getBrokerPool();
@@ -104,6 +160,60 @@ public class MoveCollectionTest {
             try (final Collection srcCol = broker.getOrCreateCollection(transaction, srcColUri)) {
                 assertNotNull(srcCol);
                 broker.saveCollection(transaction, srcCol);
+            }
+
+            try (final Collection src = broker.openCollection(srcColUri, Lock.LockMode.WRITE_LOCK);
+                 final Collection testCol = broker.openCollection(testColUri, Lock.LockMode.WRITE_LOCK)) {
+
+                broker.moveCollection(transaction, src, testCol, newName);
+
+                assertFalse(testCol.hasChildCollection(broker, srcColUri.lastSegment()));
+                assertTrue(testCol.hasChildCollection(broker, newName));
+            }
+
+            transact.commit(transaction);
+        }
+    }
+
+    /**
+     * Test rename collection /db/move-collection-test-rename/before to /db/move-collection-test-rename/after
+     *
+     * Note that the collection /db/move-collection-test-rename/before has the sub-collections (sub-1 and sub-2),
+     * this test checks that the sub-collections are correctly preserved.
+     */
+    @Test
+    public void renameWithSubCollections() throws EXistException, PermissionDeniedException, IOException, TriggerException, LockException {
+        final BrokerPool pool = existEmbeddedServer.getBrokerPool();
+        final TransactionManager transact = pool.getTransactionManager();
+        try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
+             final Txn transaction = transact.beginTransaction()) {
+
+            final XmldbURI testColUri = XmldbURI.create("/db/move-collection-test-rename");
+            final XmldbURI srcColUri = testColUri.append("before");
+            final XmldbURI srcColSubCol1Uri = srcColUri.append("sub-1");
+            final XmldbURI srcColSubCol2Uri = srcColUri.append("sub-2");
+            final XmldbURI newName = XmldbURI.create("after");
+
+            // create test collection
+            try (final Collection testCol = broker.getOrCreateCollection(transaction, testColUri)) {
+                assertNotNull(testCol);
+                broker.saveCollection(transaction, testCol);
+            }
+
+            // create src collection
+            try (final Collection srcCol = broker.getOrCreateCollection(transaction, srcColUri)) {
+                assertNotNull(srcCol);
+                broker.saveCollection(transaction, srcCol);
+            }
+
+            // create src sub-collections
+            try (final Collection srcColSubCol1 = broker.getOrCreateCollection(transaction, srcColSubCol1Uri)) {
+                assertNotNull(srcColSubCol1);
+                broker.saveCollection(transaction, srcColSubCol1);
+            }
+            try (final Collection srcColSubCol2 = broker.getOrCreateCollection(transaction, srcColSubCol2Uri)) {
+                assertNotNull(srcColSubCol2);
+                broker.saveCollection(transaction, srcColSubCol2);
             }
 
             try (final Collection src = broker.openCollection(srcColUri, Lock.LockMode.WRITE_LOCK);


### PR DESCRIPTION
This is a forward port of the eXist-db 4.x.x tests in https://github.com/eXist-db/exist/pull/4201 to show that the Rename and Move operations identified in eXist-db 4.x.x do not impact 5.x.x.