### PR TITLE
[4.x.x] Remove GeoSpatial Index from IntelliJ project

### DIFF
--- a/eXist-db.iml
+++ b/eXist-db.iml
@@ -80,8 +80,6 @@
       <sourceFolder url="file://$MODULE_DIR$/extensions/indexes/range/src/test/xquery" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/extensions/indexes/sort/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/extensions/indexes/sort/src/test/xquery" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/extensions/indexes/spatial/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/extensions/indexes/spatial/src/test/java" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/extensions/security/activedirectory/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/extensions/security/iprange/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/extensions/security/ldap/src/test/java" isTestSource="true" />


### PR DESCRIPTION
As 4.x.x uses Ant, unless we remove the GeoSpatial index from the IntelliJ project file, it is not possible to compile eXist-db 4.x.x in IntelliJ after a fresh clone of the code.

