### PR TITLE
(5.x.x) Restore libraries required for Monex's Remote Console pane

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -551,6 +551,14 @@
             <version>1.4</version>
         </dependency>
         <dependency>
+            <!--
+                 NOTE(AR) This is needed to enable loading of Servlets etc
+                          that use Java Annotations for configuration.
+                          This is less than ideal as it allows any extension to
+                          serve arbitary Web requests, and should ultimately be
+                          removed. Unfortunately, at this time, it is required for
+                          Monex's Remote Console to function.
+            -->
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-annotations</artifactId>
         </dependency>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -552,6 +552,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
         </dependency>
         <dependency>
@@ -910,6 +914,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                                 <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-jaas:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-deploy:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-jmx:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.eclipse.jetty:jetty-annotations:jar:${jetty.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>${project.groupId}:exist-jetty-config:jar:${project.version}</ignoredUnusedDeclaredDependency>
 
                                 <ignoredUnusedDeclaredDependency>org.junit.vintage:junit-vintage-engine:jar:${junit.vintage.version}</ignoredUnusedDeclaredDependency>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-annotations.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-annotations.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <!-- =========================================================== -->
+    <!-- Add annotation Configuring classes to all webapps for this Server -->
+    <!-- =========================================================== -->
+    <Call class="org.eclipse.jetty.webapp.Configuration$ClassList" name="setServerDefault">
+        <Arg><Ref refid="Server" /></Arg>
+        <Call name="addBefore">
+            <Arg name="beforeClass">org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Arg>
+            <Arg>
+                <Array type="String">
+                    <Item>org.eclipse.jetty.annotations.AnnotationConfiguration</Item>
+                </Array>
+            </Arg>
+        </Call>
+    </Call>
+    
+</Configure>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone.enabled-jetty-configs
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone.enabled-jetty-configs
@@ -43,3 +43,7 @@ jetty-https.xml
 
 ### Webapp deployment
 standalone-jetty-deploy.xml
+
+
+### Annotation support 
+jetty-annotations.xml

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standard.enabled-jetty-configs
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standard.enabled-jetty-configs
@@ -43,3 +43,7 @@ jetty-https.xml
 
 ### Webapp deployment
 jetty-deploy.xml
+
+
+### Annotation support 
+jetty-annotations.xml


### PR DESCRIPTION
### Description:

Port #4215 to 5.x.x

### Reference:

#4215

### Type of tests:

As mentioned in #4215:

> None included, but I tested by opening http://localhost:8080/exist/apps/monex/console.html and confirming that Monex's Remote Console now displays, "Connected" - whereas previously it could never connect and instead displayed "Disconnected."