### PR TITLE
[fix] IDEA runconfiguration

### DIFF
--- a/.idea/runConfigurations/Java_Admin_Client.xml
+++ b/.idea/runConfigurations/Java_Admin_Client.xml
@@ -5,7 +5,7 @@
     <option name="MAIN_CLASS_NAME" value="org.exist.start.Main" />
     <module name="exist-distribution" />
     <option name="PROGRAM_PARAMETERS" value="client" />
-    <option name="VM_PARAMETERS" value="-Dexist.home=$MODULE_DIR$/target/exist-distribution-5.4.0-SNAPSHOT-dir -Dexist.configurationFile=$MODULE_DIR$/target/exist-distribution-5.4.0-SNAPSHOT-dir/etc/conf.xml -Dlog4j.configurationFile=$MODULE_DIR$/target/exist-distribution-5.4.0-SNAPSHOT-dir/etc/log4j2.xml -Dorg.exist.db-connection.files=$MODULE_DIR$/target/data -Dorg.exist.db-connection.recovery.journal-dir=$MODULE_DIR$/target/data -Dexist.ensurelocking.disabled=true -Dfile.encoding=UTF-8" />
+    <option name="VM_PARAMETERS" value="-Dexist.home=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir -Dexist.configurationFile=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/conf.xml -Dlog4j.configurationFile=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/log4j2.xml -Dorg.exist.db-connection.files=$MODULE_DIR$/target/data -Dorg.exist.db-connection.recovery.journal-dir=$MODULE_DIR$/target/data -Dexist.ensurelocking.disabled=true -Dfile.encoding=UTF-8" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Jetty_Server.xml
+++ b/.idea/runConfigurations/Jetty_Server.xml
@@ -4,8 +4,8 @@
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="org.exist.start.Main" />
     <module name="exist-distribution" />
-    <option name="PROGRAM_PARAMETERS" value="jetty $MODULE_DIR$/target/exist-distribution-5.4.0-SNAPSHOT-dir/etc/conf.xml" />
-    <option name="VM_PARAMETERS" value="-Dexist.home=$MODULE_DIR$/target/exist-distribution-5.4.0-SNAPSHOT-dir -Dexist.configurationFile=$MODULE_DIR$/target/exist-distribution-5.4.0-SNAPSHOT-dir/etc/conf.xml -Dlog4j.configurationFile=$MODULE_DIR$/target/exist-distribution-5.4.0-SNAPSHOT-dir/etc/log4j2.xml -Dorg.exist.db-connection.files=$MODULE_DIR$/target/data -Dorg.exist.db-connection.recovery.journal-dir=$MODULE_DIR$/target/data -Dexist.jetty.config=$MODULE_DIR$/target/exist-distribution-5.4.0-SNAPSHOT-dir/etc/jetty/standard.enabled-jetty-configs -Djetty.home=$MODULE_DIR$/target/exist-distribution-5.4.0-SNAPSHOT-dir -Dexist.ensurelocking.disabled=true -Dfile.encoding=UTF-8" />
+    <option name="PROGRAM_PARAMETERS" value="jetty $MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/conf.xml" />
+    <option name="VM_PARAMETERS" value="-Dexist.home=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir -Dexist.configurationFile=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/conf.xml -Dlog4j.configurationFile=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/log4j2.xml -Dorg.exist.db-connection.files=$MODULE_DIR$/target/data -Dorg.exist.db-connection.recovery.journal-dir=$MODULE_DIR$/target/data -Dexist.jetty.config=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/jetty/standard.enabled-jetty-configs -Djetty.home=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir -Dexist.ensurelocking.disabled=true -Dfile.encoding=UTF-8" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>


### PR DESCRIPTION
Allows to run Jetty Server and Admin Client from Intellij IDEA

Otherwise it fails with a non-descriptive Error:
```
StatusLogger Reconfiguration failed: No configuration found for '18b4aac2' at 'null' in 'null'
19:09:26.711 [main] ERROR org.exist.jetty.JettyStart - Unable to find configuration file on classpath!

Process finished with exit code 0
```