### PR TITLE
[sec] add run configuration for local jetty server

### DIFF
--- a/.idea/runConfigurations/Local_Jetty_Server.xml
+++ b/.idea/runConfigurations/Local_Jetty_Server.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Local Jetty Server" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="1.8" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="MAIN_CLASS_NAME" value="org.exist.start.Main" />
+    <module name="exist-distribution" />
+    <option name="PROGRAM_PARAMETERS" value="jetty $MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/conf.xml" />
+    <option name="VM_PARAMETERS" value="-Djetty.host=127.0.0.1 -Dexist.home=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir -Dexist.configurationFile=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/conf.xml -Dlog4j.configurationFile=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/log4j2.xml -Dorg.exist.db-connection.files=$MODULE_DIR$/target/data -Dorg.exist.db-connection.recovery.journal-dir=$MODULE_DIR$/target/data -Dexist.jetty.config=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir/etc/jetty/standard.enabled-jetty-configs -Djetty.home=$MODULE_DIR$/target/exist-distribution-6.1.0-SNAPSHOT-dir -Dexist.ensurelocking.disabled=true -Dfile.encoding=UTF-8" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
The run configuration to start the jetty server within the IDEA IDE that ships with eXist-db exposes the server to the local network (by binding to 0.0.0.0).
A new configuration named "Local Jetty Server" is added which only binds to the host IP `127.0.0.1` aka localhost.
This was made possible by #4196, which adds recognition of the option `jetty.host`.

It is absolutely unnecessary to expose a development instance running inside an IDE to the internet in most cases.