### PR TITLE
Fix a security privilege escalation issue with XQueryTrigger

### DIFF
--- a/exist-core/src/main/java/org/exist/security/EffectiveSubject.java
+++ b/exist-core/src/main/java/org/exist/security/EffectiveSubject.java
@@ -24,6 +24,8 @@ package org.exist.security;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import org.apache.commons.lang3.ArrayUtils;
 import org.exist.config.Configuration;
 import org.exist.config.ConfigurationException;
@@ -146,9 +148,9 @@ public class EffectiveSubject implements Subject {
     @Override
     public int[] getGroupIds() {
         if(group != null) {
-            final Set<Integer> groupIds = new HashSet<>(Arrays.asList(ArrayUtils.toObject(account.getGroupIds())));
+            final IntOpenHashSet groupIds = new IntOpenHashSet(account.getGroupIds());
             groupIds.add(group.getId());
-            return ArrayUtils.toPrimitive(groupIds.toArray(new Integer[0]));
+            return groupIds.toIntArray();
         } else {
             return account.getGroupIds();
         }

--- a/exist-core/src/main/java/org/exist/xquery/LibraryModuleRoot.java
+++ b/exist-core/src/main/java/org/exist/xquery/LibraryModuleRoot.java
@@ -1,0 +1,48 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class LibraryModuleRoot extends PathExpr {
+
+    private static final Logger LOG = LogManager.getLogger(LibraryModuleRoot.class);
+
+    public LibraryModuleRoot(final XQueryContext context) {
+        super(context);
+    }
+
+    @Override
+    public void dump(final Writer writer) {
+        final String functionNs = context.getDefaultFunctionNamespace();
+        final String functionPrefix = context.getPrefixForURI(functionNs);
+        try {
+            writer.write("module namespace " + functionPrefix + " = \"" + functionNs + "\";");
+        } catch (final IOException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerSetGidTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerSetGidTest.java
@@ -1,0 +1,229 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.collections.triggers;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.PermissionFactory;
+import org.exist.source.StringSource;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.value.Sequence;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI;
+import static org.exist.collections.CollectionConfigurationManager.CONFIG_COLLECTION_URI;
+import static org.exist.security.SecurityManager.*;
+import static org.exist.test.Util.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class XQueryTriggerSetGidTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer EXIST_EMBEDDED_SERVER = new ExistEmbeddedServer(true, true);
+
+	private final static XmldbURI TEST_COLLECTION_URI = XmldbURI.create("/db/testXQueryTriggerSetGid");
+    private final static XmldbURI TEST_TRIGGER_COLLECTION_URI = TEST_COLLECTION_URI.append("triggered");
+    private final static XmldbURI TEST_OUTPUT_COLLECTION_URI = TEST_COLLECTION_URI.append("output");
+
+    private final static XmldbURI TEST_OUTPUT_BEFORE_DOC_URI = TEST_OUTPUT_COLLECTION_URI.append("before.xml");
+    private final static XmldbURI TEST_OUTPUT_AFTER_DOC_URI = TEST_OUTPUT_COLLECTION_URI.append("after.xml");
+
+    private final static XmldbURI TRIGGER_MODULE_URI = TEST_COLLECTION_URI.append("XQueryTriggerSetGid.xqm");
+    private final static String TRIGGER_MODULE =
+            "module namespace trigger = 'http://exist-db.org/xquery/trigger';\n" +
+            "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+            "import module namespace xmldb = 'http://exist-db.org/xquery/xmldb';\n" +
+            "\n" +
+            "declare function trigger:before-create-document($uri as xs:anyURI) {\n" +
+            "  xmldb:store('" +  TEST_OUTPUT_COLLECTION_URI + "', '" + TEST_OUTPUT_BEFORE_DOC_URI.lastSegment() + "', sm:id())\n" +
+            "};\n" +
+            "\n" +
+            "declare function trigger:after-create-document($uri as xs:anyURI) {\n" +
+            "  xmldb:store('" + TEST_OUTPUT_COLLECTION_URI + "', '" + TEST_OUTPUT_AFTER_DOC_URI.lastSegment() + "', sm:id())\n" +
+            "};";
+
+    private final static String TRIGGER_COLLECTION_CONFIG =
+    	"<exist:collection xmlns:exist='http://exist-db.org/collection-config/1.0'>" +
+	    "  <exist:triggers>" +
+		"     <exist:trigger class='org.exist.collections.triggers.XQueryTrigger'>" +
+		"	     <exist:parameter " +
+		"			name='url' " +
+		"			value='" + TRIGGER_MODULE_URI + "' " +
+		"        />" +
+		"     </exist:trigger>" +
+		"  </exist:triggers>" +
+        "</exist:collection>";    
+
+    private final static XmldbURI TRIGGERING_DOCUMENT_URI = TEST_TRIGGER_COLLECTION_URI.append("test.xml");
+    
+    private final static String TRIGGERING_DOCUMENT_CONTENT =
+		  "<test/>";
+
+    @BeforeClass
+    public static void setup() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
+        final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
+        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
+                final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+
+            // store the trigger module
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI)) {
+                assertNotNull(collection);
+                final XmldbURI triggerModuleUri = storeQuery(broker, transaction, new StringInputSource(TRIGGER_MODULE.getBytes(UTF_8)), collection, TRIGGER_MODULE_URI);
+                assertEquals(TRIGGER_MODULE_URI, triggerModuleUri);
+
+                try (final LockedDocument lockedDocument = collection.getDocumentWithLock(broker, TRIGGER_MODULE_URI.lastSegment(), Lock.LockMode.WRITE_LOCK)) {
+                    assertNotNull(lockedDocument);
+                    final DocumentImpl document = lockedDocument.getDocument();
+
+                    // set the trigger module as setGid for DBA_GROUP
+                    PermissionFactory.chown(broker, document, Optional.of(DBA_USER), Optional.of(DBA_GROUP));
+                    PermissionFactory.chmod_str(broker, document, Optional.of("rw-r-sr-x"), Optional.empty());
+                }
+            }
+
+            // create the collection we will trigger on
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_TRIGGER_COLLECTION_URI)) {
+                assertNotNull(collection);
+
+                // allow any user to write to this collection
+                PermissionFactory.chmod_str(broker, collection, Optional.of("rwxrwxrwx"), Optional.empty());
+            }
+
+            // create the collection for the output of the trigger
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_OUTPUT_COLLECTION_URI)) {
+                assertNotNull(collection);
+            }
+
+            // install the collection.xconf for the collection we will trigger on
+            final XmldbURI configCollectionUri = CONFIG_COLLECTION_URI.append(TEST_TRIGGER_COLLECTION_URI);
+            try (final Collection collection = broker.getOrCreateCollection(transaction, configCollectionUri)) {
+                assertNotNull(collection);
+                broker.storeDocument(transaction, configCollectionUri.append(DEFAULT_COLLECTION_CONFIG_FILE_URI), new StringInputSource(TRIGGER_COLLECTION_CONFIG), MimeType.XML_TYPE, collection);
+            }
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void triggerSetGid() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException, XPathException {
+        final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
+        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
+             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getGuestSubject()))) {  // NOTE: "guest" user
+
+            // store a document into the "triggered" collection as the guest user, should cause the trigger to fire
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_TRIGGER_COLLECTION_URI)) {
+                assertNotNull(collection);
+                broker.storeDocument(transaction, TRIGGERING_DOCUMENT_URI, new StringInputSource(TRIGGERING_DOCUMENT_CONTENT), MimeType.XML_TYPE, collection);
+            }
+
+            transaction.commit();
+        }
+
+        // trigger should have completed by this stage... so now check the content of the documents produced by the trigger
+
+        // trigger group for "before" phase should be real=guest, effective=guest,dba...
+        final String queryBeforeRealGroup =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "doc('" + TEST_OUTPUT_BEFORE_DOC_URI + "')/sm:id/sm:real/sm:groups/sm:group/string(.)";
+        final String queryBeforeEffectiveGroup =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "doc('" + TEST_OUTPUT_BEFORE_DOC_URI + "')/sm:id/sm:effective/sm:groups/sm:group/string(.)";
+
+        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
+             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+
+            final String beforeRealGroup = withCompiledQuery(broker, new StringSource(queryBeforeRealGroup), compiledQuery -> {
+                final Sequence result = executeQuery(broker, compiledQuery);
+                assertNotNull(result);
+                assertEquals(1, result.getItemCount());
+
+                return result.itemAt(0).getStringValue();
+            });
+            assertEquals(GUEST_GROUP, beforeRealGroup);
+
+            final String beforeEffectiveGroup = withCompiledQuery(broker, new StringSource(queryBeforeEffectiveGroup), compiledQuery -> {
+                final Sequence result = executeQuery(broker, compiledQuery);
+                assertNotNull(result);
+                assertEquals(2, result.getItemCount());
+                return result.itemAt(0).getStringValue() + "," + result.itemAt(1).getStringValue();
+            });
+            assertEquals(DBA_GROUP + "," + GUEST_GROUP, beforeEffectiveGroup);
+
+            transaction.commit();
+        }
+
+        // trigger group for "after" phase should be real=guest, effective=guest,dba...
+        final String queryAfterRealGroup =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "doc('" + TEST_OUTPUT_AFTER_DOC_URI + "')/sm:id/sm:real/sm:groups/sm:group/string(.)";
+        final String queryAfterEffectiveGroup =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "doc('" + TEST_OUTPUT_AFTER_DOC_URI + "')/sm:id/sm:effective/sm:groups/sm:group/string(.)";
+
+        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
+             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+
+            final String afterRealGroup = withCompiledQuery(broker, new StringSource(queryAfterRealGroup), compiledQuery -> {
+                final Sequence result = executeQuery(broker, compiledQuery);
+                assertNotNull(result);
+                assertEquals(1, result.getItemCount());
+
+                return result.itemAt(0).getStringValue();
+            });
+            assertEquals(GUEST_GROUP, afterRealGroup);
+
+            final String afterEffectiveGroup = withCompiledQuery(broker, new StringSource(queryAfterEffectiveGroup), compiledQuery -> {
+                final Sequence result = executeQuery(broker, compiledQuery);
+                assertNotNull(result);
+                assertEquals(2, result.getItemCount());
+                return result.itemAt(0).getStringValue() + "," + result.itemAt(1).getStringValue();
+            });
+            assertEquals(DBA_GROUP + "," + GUEST_GROUP, afterEffectiveGroup);
+
+            transaction.commit();
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerSetUidTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerSetUidTest.java
@@ -1,0 +1,231 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.collections.triggers;
+
+import org.exist.EXistException;
+import org.exist.collections.Collection;
+import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.LockedDocument;
+import org.exist.security.PermissionDeniedException;
+import org.exist.security.PermissionFactory;
+import org.exist.source.StringSource;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.storage.lock.Lock;
+import org.exist.storage.txn.Txn;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.util.LockException;
+import org.exist.util.MimeType;
+import org.exist.util.StringInputSource;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.value.Sequence;
+import org.junit.*;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.exist.collections.CollectionConfiguration.DEFAULT_COLLECTION_CONFIG_FILE_URI;
+import static org.exist.collections.CollectionConfigurationManager.CONFIG_COLLECTION_URI;
+import static org.exist.security.SecurityManager.DBA_GROUP;
+import static org.exist.security.SecurityManager.DBA_USER;
+import static org.exist.security.SecurityManager.GUEST_USER;
+import static org.exist.test.Util.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class XQueryTriggerSetUidTest {
+
+    @ClassRule
+    public static final ExistEmbeddedServer EXIST_EMBEDDED_SERVER = new ExistEmbeddedServer(true, true);
+
+	private final static XmldbURI TEST_COLLECTION_URI = XmldbURI.create("/db/testXQueryTriggerSetUid");
+    private final static XmldbURI TEST_TRIGGER_COLLECTION_URI = TEST_COLLECTION_URI.append("triggered");
+    private final static XmldbURI TEST_OUTPUT_COLLECTION_URI = TEST_COLLECTION_URI.append("output");
+
+    private final static XmldbURI TEST_OUTPUT_BEFORE_DOC_URI = TEST_OUTPUT_COLLECTION_URI.append("before.xml");
+    private final static XmldbURI TEST_OUTPUT_AFTER_DOC_URI = TEST_OUTPUT_COLLECTION_URI.append("after.xml");
+
+    private final static XmldbURI TRIGGER_MODULE_URI = TEST_COLLECTION_URI.append("XQueryTriggerSetUid.xqm");
+    private final static String TRIGGER_MODULE =
+            "module namespace trigger = 'http://exist-db.org/xquery/trigger';\n" +
+            "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+            "import module namespace xmldb = 'http://exist-db.org/xquery/xmldb';\n" +
+            "\n" +
+            "declare function trigger:before-create-document($uri as xs:anyURI) {\n" +
+            "  xmldb:store('" +  TEST_OUTPUT_COLLECTION_URI + "', '" + TEST_OUTPUT_BEFORE_DOC_URI.lastSegment() + "', sm:id())\n" +
+            "};\n" +
+            "\n" +
+            "declare function trigger:after-create-document($uri as xs:anyURI) {\n" +
+            "  xmldb:store('" + TEST_OUTPUT_COLLECTION_URI + "', '" + TEST_OUTPUT_AFTER_DOC_URI.lastSegment() + "', sm:id())\n" +
+            "};";
+
+    private final static String TRIGGER_COLLECTION_CONFIG =
+    	"<exist:collection xmlns:exist='http://exist-db.org/collection-config/1.0'>" +
+	    "  <exist:triggers>" +
+		"     <exist:trigger class='org.exist.collections.triggers.XQueryTrigger'>" +
+		"	     <exist:parameter " +
+		"			name='url' " +
+		"			value='" + TRIGGER_MODULE_URI + "' " +
+		"        />" +
+		"     </exist:trigger>" +
+		"  </exist:triggers>" +
+        "</exist:collection>";    
+
+    private final static XmldbURI TRIGGERING_DOCUMENT_URI = TEST_TRIGGER_COLLECTION_URI.append("test.xml");
+    
+    private final static String TRIGGERING_DOCUMENT_CONTENT =
+		  "<test/>";
+
+    @BeforeClass
+    public static void setup() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException {
+        final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
+        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
+                final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+
+            // store the trigger module
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI)) {
+                assertNotNull(collection);
+                final XmldbURI triggerModuleUri = storeQuery(broker, transaction, new StringInputSource(TRIGGER_MODULE.getBytes(UTF_8)), collection, TRIGGER_MODULE_URI);
+                assertEquals(TRIGGER_MODULE_URI, triggerModuleUri);
+
+                try (final LockedDocument lockedDocument = collection.getDocumentWithLock(broker, TRIGGER_MODULE_URI.lastSegment(), Lock.LockMode.WRITE_LOCK)) {
+                    assertNotNull(lockedDocument);
+                    final DocumentImpl document = lockedDocument.getDocument();
+
+                    // set the trigger module as setUid for DBA_USER
+                    PermissionFactory.chown(broker, document, Optional.of(DBA_USER), Optional.of(DBA_GROUP));
+                    PermissionFactory.chmod_str(broker, document, Optional.of("rwsr-xr-x"), Optional.empty());
+                }
+            }
+
+            // create the collection we will trigger on
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_TRIGGER_COLLECTION_URI)) {
+                assertNotNull(collection);
+
+                // allow any user to write to this collection
+                PermissionFactory.chmod_str(broker, collection, Optional.of("rwxrwxrwx"), Optional.empty());
+            }
+
+            // create the collection for the output of the trigger
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_OUTPUT_COLLECTION_URI)) {
+                assertNotNull(collection);
+            }
+
+            // install the collection.xconf for the collection we will trigger on
+            final XmldbURI configCollectionUri = CONFIG_COLLECTION_URI.append(TEST_TRIGGER_COLLECTION_URI);
+            try (final Collection collection = broker.getOrCreateCollection(transaction, configCollectionUri)) {
+                assertNotNull(collection);
+                broker.storeDocument(transaction, configCollectionUri.append(DEFAULT_COLLECTION_CONFIG_FILE_URI), new StringInputSource(TRIGGER_COLLECTION_CONFIG), MimeType.XML_TYPE, collection);
+            }
+
+            transaction.commit();
+        }
+    }
+
+    @Test
+    public void triggerSetUid() throws EXistException, PermissionDeniedException, IOException, SAXException, LockException, XPathException {
+        final BrokerPool pool = EXIST_EMBEDDED_SERVER.getBrokerPool();
+        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
+             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getGuestSubject()))) {  // NOTE: "guest" user
+
+            // store a document into the "triggered" collection as the guest user, should cause the trigger to fire
+            try (final Collection collection = broker.getOrCreateCollection(transaction, TEST_TRIGGER_COLLECTION_URI)) {
+                assertNotNull(collection);
+                broker.storeDocument(transaction, TRIGGERING_DOCUMENT_URI, new StringInputSource(TRIGGERING_DOCUMENT_CONTENT), MimeType.XML_TYPE, collection);
+            }
+
+            transaction.commit();
+        }
+
+        // trigger should have completed by this stage... so now check the content of the documents produced by the trigger
+
+        // trigger user for "before" phase should be real=guest, effective=admin...
+        final String queryBeforeRealUser =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "doc('" + TEST_OUTPUT_BEFORE_DOC_URI + "')/sm:id/sm:real/sm:username";
+        final String queryBeforeEffectiveUser =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "doc('" + TEST_OUTPUT_BEFORE_DOC_URI + "')/sm:id/sm:effective/sm:username";
+
+        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
+             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+
+            final String beforeRealUser = withCompiledQuery(broker, new StringSource(queryBeforeRealUser), compiledQuery -> {
+                final Sequence result = executeQuery(broker, compiledQuery);
+                assertNotNull(result);
+                assertEquals(1, result.getItemCount());
+
+                return result.itemAt(0).getStringValue();
+            });
+            assertEquals(GUEST_USER, beforeRealUser);
+
+            final String beforeEffectiveUser = withCompiledQuery(broker, new StringSource(queryBeforeEffectiveUser), compiledQuery -> {
+                final Sequence result = executeQuery(broker, compiledQuery);
+                assertNotNull(result);
+                assertEquals(1, result.getItemCount());
+
+                return result.itemAt(0).getStringValue();
+            });
+            assertEquals(DBA_USER, beforeEffectiveUser);
+
+            transaction.commit();
+        }
+
+        // trigger user for "after" phase should be real=guest, effective=admin...
+        final String queryAfterRealUser =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "doc('" + TEST_OUTPUT_AFTER_DOC_URI + "')/sm:id/sm:real/sm:username";
+        final String queryAfterEffectiveUser =
+                "import module namespace sm = 'http://exist-db.org/xquery/securitymanager';\n" +
+                "doc('" + TEST_OUTPUT_AFTER_DOC_URI + "')/sm:id/sm:effective/sm:username";
+
+        try (final Txn transaction = pool.getTransactionManager().beginTransaction();
+             final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()))) {
+
+            final String afterRealUser = withCompiledQuery(broker, new StringSource(queryAfterRealUser), compiledQuery -> {
+                final Sequence result = executeQuery(broker, compiledQuery);
+                assertNotNull(result);
+                assertEquals(1, result.getItemCount());
+
+                return result.itemAt(0).getStringValue();
+            });
+            assertEquals(GUEST_USER, afterRealUser);
+
+            final String afterEffectiveUser = withCompiledQuery(broker, new StringSource(queryAfterEffectiveUser), compiledQuery -> {
+                final Sequence result = executeQuery(broker, compiledQuery);
+                assertNotNull(result);
+                assertEquals(1, result.getItemCount());
+
+                return result.itemAt(0).getStringValue();
+            });
+            assertEquals(DBA_USER, afterEffectiveUser);
+
+            transaction.commit();
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerTest.java
+++ b/exist-core/src/test/java/org/exist/collections/triggers/XQueryTriggerTest.java
@@ -29,7 +29,6 @@ import java.net.URISyntaxException;
 import javax.xml.transform.OutputKeys;
 
 import org.apache.commons.codec.binary.Base64;
-import org.exist.TestUtils;
 import org.exist.test.ExistXmldbEmbeddedServer;
 import org.exist.xmldb.EXistCollectionManagementService;
 import org.exist.xmldb.EXistResource;

--- a/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/IdFunctionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/securitymanager/IdFunctionTest.java
@@ -135,6 +135,8 @@ public class IdFunctionTest {
         expect(mckContext.getEffectiveUser()).andReturn(mckUser);
         expect(mckUser.getId()).andReturn(1);
 
+        expect(mckUser.getGroupIds()).andReturn(new int[] {101, 102}).times(2);
+
         replay(mckUser, mckContext);
 
         final IdFunction idFunctions = new IdFunction(mckContext, IdFunction.FNS_ID);
@@ -156,5 +158,65 @@ public class IdFunctionTest {
         assertEquals("", actualEffectiveUsername);
 
         verify(mckUser, mckContext);
+    }
+
+    /**
+     * Test of eval method, of class IdFunction.
+     * when real and effective users are have the same username/id
+     * but have different group memberships - as can happen with setGid
+     * without setUid.
+     */
+    @Test
+    public void differingByGroupRealAndEffectiveUsers() throws XPathException, XpathException {
+        final XQueryContext mckContext = createMockBuilder(XQueryContext.class)
+                .addMockedMethod("pushDocumentContext")
+                .addMockedMethod("getDocumentBuilder", new Class[0])
+                .addMockedMethod("popDocumentContext")
+                .addMockedMethod("getRealUser")
+                .addMockedMethod("getEffectiveUser")
+                .createMock();
+
+        final Subject mckRealUser = EasyMock.createMock(Subject.class);
+        final String realUsername = "user1";
+        mckContext.pushDocumentContext();
+        expectLastCall().once();
+        expect(mckContext.getDocumentBuilder()).andReturn(new MemTreeBuilder());
+        mckContext.popDocumentContext();
+        expectLastCall().once();
+        expect(mckContext.getRealUser()).andReturn(mckRealUser).times(2);
+        expect(mckRealUser.getName()).andReturn(realUsername);
+        expect(mckRealUser.getGroups()).andReturn(new String[]{"realGroup1"});
+        expect(mckRealUser.getId()).andReturn(101);
+        expect(mckRealUser.getGroupIds()).andReturn(new int[] {101});
+
+        final Subject mckEffectiveUser = EasyMock.createMock(Subject.class);
+        final String effectiveUsername = "user1";
+        expect(mckContext.getEffectiveUser()).andReturn(mckEffectiveUser).times(2);
+        expect(mckEffectiveUser.getId()).andReturn(101);
+        expect(mckEffectiveUser.getName()).andReturn(effectiveUsername);
+        expect(mckEffectiveUser.getGroups()).andReturn(new String[]{"realGroup1", "effectiveGroup1"});
+        expect(mckEffectiveUser.getGroupIds()).andReturn(new int[] {101, 102});
+
+        replay(mckEffectiveUser, mckRealUser, mckContext);
+
+        final IdFunction idFunctions = new IdFunction(mckContext, IdFunction.FNS_ID);
+        final Sequence result = idFunctions.eval(new Sequence[]{Sequence.EMPTY_SEQUENCE}, null);
+
+        assertEquals(1, result.getItemCount());
+
+        final XpathEngine xpathEngine = XMLUnit.newXpathEngine();
+        final Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("sm", "http://exist-db.org/xquery/securitymanager");
+        xpathEngine.setNamespaceContext(new SimpleNamespaceContext(namespaces));
+
+        final DocumentImpl resultDoc = (DocumentImpl)result.itemAt(0);
+
+        final String actualRealUsername = xpathEngine.evaluate("/sm:id/sm:real/sm:username", resultDoc);
+        assertEquals(realUsername, actualRealUsername);
+
+        final String actualEffectiveUsername = xpathEngine.evaluate("/sm:id/sm:effective/sm:username", resultDoc);
+        assertEquals(effectiveUsername, actualEffectiveUsername);
+
+        verify(mckEffectiveUser, mckRealUser, mckContext);
     }
 }


### PR DESCRIPTION
This fixes a security issue with XQueryTrigger, and also as a nice consequence enables setUid and setGid to be used on XQuery Triggers that are stored as modules in the database.