### PR TITLE
Fix default encoding and file module tests on Windows

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -97,7 +97,7 @@ public class SerializerUtils {
         CDATA_SECTION_ELEMENTS(OutputKeys.CDATA_SECTION_ELEMENTS, Type.QNAME, Cardinality.ZERO_OR_MORE, Sequence.EMPTY_SEQUENCE),
         DOCTYPE_PUBLIC(OutputKeys.DOCTYPE_PUBLIC, Type.STRING, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),   //default: () means "absent"
         DOCTYPE_SYSTEM(OutputKeys.DOCTYPE_SYSTEM, Type.STRING, Cardinality.ZERO_OR_ONE, Sequence.EMPTY_SEQUENCE),   //default: () means "absent"
-        ENCODING(OutputKeys.ENCODING, Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("utf-8")),
+        ENCODING(OutputKeys.ENCODING, Type.STRING, Cardinality.ZERO_OR_ONE, new StringValue("UTF-8")),
         ESCAPE_URI_ATTRIBUTES("escape-uri-attributes", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),
         HTML_VERSION(EXistOutputKeys.HTML_VERSION, Type.DECIMAL, Cardinality.ZERO_OR_ONE, new DecimalValue(5)),
         INCLUDE_CONTENT_TYPE("include-content-type", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, BooleanValue.TRUE),

--- a/exist-core/src/test/java/xquery/xquery3/XQuery3Tests.java
+++ b/exist-core/src/test/java/xquery/xquery3/XQuery3Tests.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(XSuite.class)
 @XSuite.XSuiteFiles({
-        "src/test/xquery/xquery3/generate-id.xqm"
+        "src/test/xquery/xquery3"
 })
 public class XQuery3Tests {
 }

--- a/exist-core/src/test/xquery/unparsed-text.xql
+++ b/exist-core/src/test/xquery/unparsed-text.xql
@@ -163,7 +163,7 @@ function upt:unsupported-scheme() {
 declare
     %test:assertError("FOUT1170")
 function upt:windows-path() {
-    unparsed-text-lines("C:\file-might-exist.txt", "utf-8")
+    unparsed-text-lines("C:\file-might-exist.txt", "UTF-8")
 };
 
 declare

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
@@ -122,6 +122,7 @@ public class Sync extends BasicFunction {
         DEFAULT_PROPERTIES.put(OutputKeys.INDENT, "yes");
         DEFAULT_PROPERTIES.put(OutputKeys.OMIT_XML_DECLARATION, "no");
         DEFAULT_PROPERTIES.put(EXistOutputKeys.EXPAND_XINCLUDES, "no");
+        DEFAULT_PROPERTIES.put(OutputKeys.ENCODING, "UTF-8");
     }
 
     private Properties outputProperties = new Properties();

--- a/extensions/modules/file/src/test/resources/util/fixtures.xqm
+++ b/extensions/modules/file/src/test/resources/util/fixtures.xqm
@@ -23,16 +23,85 @@ xquery version "3.1";
 
 module namespace fixtures="http://exist-db.org/xquery/test/util/fixtures";
 
-(: file contents :)
+(: simple xml :)
 
 declare variable $fixtures:XML := document {<foo><bar/></foo>};
+
+declare variable $fixtures:SIMPLE_XML_INDENTED :=
+"<foo>" || $fixtures:NL ||
+"    <bar/>" || $fixtures:NL ||
+"</foo>"
+;
+
+declare variable $fixtures:SIMPLE_XML_UNINDENTED := "<foo><bar/></foo>";
+
+(: more complex xml :)
+
+declare variable $fixtures:COMPLEX_XML :=
+    <root>
+        <item>This is a very long line. Certainly longer than eighty characters. It is here to see what happens to lines longer than a certain limit. Let's see.</item>
+        <empty-item></empty-item>
+        <unary />
+        <item>
+
+            MIXED CONTENT&#10;
+            <nested
+                attr = "with lots of whitespace"
+            />
+            The next word <hi>is</hi> highlighted.
+        </item>
+        <p/>
+    </root>
+;
+
+(: FIXME(JL) cannot use StringConstructor here because that will cause all comparisons to fail on Windows :)
+(: see https://github.com/eXist-db/exist/issues/4301 :)
+declare variable $fixtures:COMPLEX_XML_INDENTED :=
+"<root>" || $fixtures:NL ||
+"    <item>This is a very long line. Certainly longer than eighty characters. It is here to see what happens to lines longer than a certain limit. Let's see.</item>"  || $fixtures:NL ||
+"    <empty-item/>" || $fixtures:NL ||
+"    <unary/>" || $fixtures:NL ||
+"    <item>" || $fixtures:NL ||
+$fixtures:NL ||
+"            MIXED CONTENT" || $fixtures:NL ||
+$fixtures:NL ||
+"            <nested attr=""with lots of whitespace""/>" || $fixtures:NL ||
+"            The next word <hi>is</hi> highlighted." || $fixtures:NL ||
+"        </item>" || $fixtures:NL ||
+"    <p/>" || $fixtures:NL ||
+"</root>"
+;
+
+declare variable $fixtures:COMPLEX_XML_UNINDENTED :=
+"<root>" ||
+"<item>This is a very long line. Certainly longer than eighty characters. It is here to see what happens to lines longer than a certain limit. Let's see.</item>" ||
+"<empty-item/>" ||
+"<unary/>" ||
+"<item>" || $fixtures:NL ||
+$fixtures:NL ||
+"            MIXED CONTENT" || $fixtures:NL ||
+$fixtures:NL ||
+"            <nested attr=""with lots of whitespace""/>" || $fixtures:NL ||
+"            The next word <hi>is</hi> highlighted." || $fixtures:NL ||
+"        </item>" ||
+"<p/>" ||
+"</root>"
+;
+
+
 declare variable $fixtures:TXT :=
 ``[12 12
 This is just a Text
 ]``
 ;
+
 declare variable $fixtures:XQY := "xquery version ""3.1""; 0 to 9";
 declare variable $fixtures:BIN := "To bin or not to bin...";
+
+(: other constants :)
+
+declare variable $fixtures:XML_DECLARATION := '<?xml version="1.0" encoding="UTF-8"?>';
+declare variable $fixtures:NL := "&#10;";
 
 (: modification dates :)
 

--- a/extensions/modules/file/src/test/resources/util/helper.xqm
+++ b/extensions/modules/file/src/test/resources/util/helper.xqm
@@ -191,3 +191,21 @@ declare function helper:maybe-remove-item-at-index($sequence as xs:anyAtomicType
     )
     else $sequence (: do nothing - will be handled later :)
 };
+
+declare function helper:assert-file-contents($expected as xs:string, $path-parts as xs:string+) as xs:boolean {
+    let $path := helper:glue-path($path-parts)
+    let $actual := file:read($path)
+
+    return
+        if (
+            exists($actual) and
+            count($actual) = 1 and
+            $actual eq $expected)
+        then true()
+        else error(
+            $helper:error,
+            "File Content Assertion failed:&#10;expected file " || $path || "&#10;" ||
+             "to contain string&#10;" || "<[" || $expected || "]>" ||
+             " but was&#10;<["  || $actual || "]>"
+        )
+};


### PR DESCRIPTION
### Description:

With this PR applied the file module tests reliably pass. It also sets the correct default encoding `UTF-8` where needed and reinstates the full XQuery3 test suite.

### Reference:

CI tests fail on Windows 

### Type of tests:

XQSuite