### PR TITLE
Optimise URI Encoding of Path Components

### DIFF
--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -64,6 +64,40 @@
 
     <build>
         <plugins>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <licenseSets>
+
+                        <licenseSet>
+                            <!--
+                                eXist-db's License
+                            -->
+                            <header>${project.parent.relativePath}/LGPL-21-license.template.txt</header>
+                            <excludes>
+                                <exclude>src/main/java/org/exist/storage/lock/LockTableBenchmark.java</exclude>
+                                <exclude>src/main/java/org/exist/xquery/utils/URIUtilsBenchmark.java</exclude>
+                            </excludes>
+                        </licenseSet>
+
+                        <licenseSet>
+                            <!--
+                                FDB backport to LGPL 2.1-only licensed code
+                            -->
+                            <header>${project.parent.relativePath}/FDB-backport-LGPL-21-ONLY-license.template.txt</header>
+                            <includes>
+                                <include>src/main/java/org/exist/storage/lock/LockTableBenchmark.java</include>
+                                <include>src/main/java/org/exist/xquery/utils/URIUtilsBenchmark.java</include>
+                            </includes>
+
+                        </licenseSet>
+
+                    </licenseSets>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -39,7 +39,7 @@
     <description>JMH Benchmarks for exist-core</description>
 
     <properties>
-        <jmh.version>1.34</jmh.version>
+        <jmh.version>1.35</jmh.version>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>
 

--- a/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/storage/lock/LockTableBenchmark.java
@@ -1,14 +1,25 @@
 /*
- * eXist-db Open Source Native XML Database
- * Copyright (C) 2001 The eXist-db Authors
+ * Copyright (C) 2014, Evolved Binary Ltd
  *
- * info@exist-db.org
- * http://www.exist-db.org
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; version 2.1.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -25,6 +36,9 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
 public class LockTableBenchmark {
 
     private static final int DATA_SUB_COLLECTIONS = 13;

--- a/exist-core-jmh/src/main/java/org/exist/xquery/utils/URIUtilsBenchmark.java
+++ b/exist-core-jmh/src/main/java/org/exist/xquery/utils/URIUtilsBenchmark.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.utils;
+
+import org.exist.xquery.util.URIUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+@State(Scope.Thread)
+public class URIUtilsBenchmark {
+
+    private String uri = "/db/some/?strange/!name++";
+
+    @Benchmark
+    public String encodeForURI() {
+        return URIUtils.encodeForURI(uri);
+    }
+
+    public static void main(final String args[]) {
+        // NOTE: just for running with the java debugger
+        final URIUtilsBenchmark uriUtilsBenchmark = new URIUtilsBenchmark();
+//        uriUtilsBenchmark.encodeForURI();
+        uriUtilsBenchmark.encodeForURI();
+    }
+}

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -687,6 +687,7 @@
                                 <exclude>src/test/java/org/exist/xquery/functions/session/AttributeTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticateTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/functions/util/Eval.java</exclude>
+                                <exclude>src/test/java/org/exist/xquery/util/URIUtilsTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/value/BifurcanMapTest.java</exclude>
                                 <exclude>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</exclude>
@@ -832,6 +833,7 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/test/java/org/exist/xquery/functions/session/AttributeTest.java</include>
                                 <include>src/test/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticateTest.java</include>
                                 <include>src/main/java/org/exist/xquery/functions/util/Eval.java</include>
+                                <include>src/test/java/org/exist/xquery/util/URIUtilsTest.java</include>
                                 <include>src/main/java/org/exist/xquery/value/ArrayListValueSequence.java</include>
                                 <include>src/test/java/org/exist/xquery/value/BifurcanMapTest.java</include>
                                 <include>src/main/java/org/exist/xquery/value/AtomicValueComparator.java</include>

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -75,10 +75,146 @@ public class URIUtils {
 			buf[count+2] = c2;
 			count = newcount;
 		}
+
+		public void append(final char[] cc) {
+			final int newcount = count + cc.length;
+			if (newcount > buf.length) {
+				buf = Arrays.copyOf(buf, Math.max(buf.length << 1, newcount));
+			}
+			System.arraycopy(cc, 0, buf, count, cc.length);
+			count = newcount;
+		}
 	}
 
-	private static final char[][] table = new char[][] {
-		new char[] { 'a' }
+	private static final char[][] ASCII_TABLE_URI_PATH_COMPONENT_ENCODED = new char[][] {
+			new char[] { '%', '0', '0' },  //NUL
+			new char[] { '%', '0', '1' },  //SOH
+			new char[] { '%', '0', '2' },  //STX
+			new char[] { '%', '0', '3' },  //ETX
+			new char[] { '%', '0', '4' },  //EOT
+			new char[] { '%', '0', '5' },  //ENQ
+			new char[] { '%', '0', '6' },  //ACK
+			new char[] { '%', '0', '7' },  //BEL
+			new char[] { '%', '0', '8' },  //BS
+			new char[] { '%', '0', '9' },  //HT
+			new char[] { '%', '0', 'A' },  //LF
+			new char[] { '%', '0', 'B' },  //VT
+			new char[] { '%', '0', 'C' },  //FF
+			new char[] { '%', '0', 'D' },  //CR
+			new char[] { '%', '0', 'E' },  //SO
+			new char[] { '%', '0', 'F' },  //SI
+			new char[] { '%', '1', '0' },  //DLE
+			new char[] { '%', '1', '1' },  //DC1
+			new char[] { '%', '1', '2' },  //DC2
+			new char[] { '%', '1', '3' },  //DC3
+			new char[] { '%', '1', '4' },  //DC4
+			new char[] { '%', '1', '5' },  //NAK
+			new char[] { '%', '1', '6' },  //SYN
+			new char[] { '%', '1', '7' },  //ETB
+			new char[] { '%', '1', '8' },  //CAN
+			new char[] { '%', '1', '9' },  //EM
+			new char[] { '%', '1', 'A' },  //SUB
+			new char[] { '%', '1', 'B' },  //ESC
+			new char[] { '%', '1', 'C' },  //FS
+			new char[] { '%', '1', 'D' },  //GS
+			new char[] { '%', '1', 'E' },  //RS
+			new char[] { '%', '1', 'F' },  //US
+			new char[] { '%', '2', '0' },  //space
+			new char[] { '%', '2', '1' },  //!
+			new char[] { '%', '2', '2' },  //"
+			new char[] { '%', '2', '3' },  //#
+			new char[] { '%', '2', '4' },  //$
+			new char[] { '%', '2', '5' },  //%
+			new char[] { '%', '2', '6' },  //&
+			new char[] { '%', '2', '7' },  //'
+			new char[] { '%', '2', '8' },  //(
+			new char[] { '%', '2', '9' },  //)
+			new char[] { '%', '2', 'A' },  //*
+			new char[] { '%', '2', 'B' },  //+
+			new char[] { '%', '2', 'C' },  //,
+			new char[] { '-' },  //-
+			new char[] { '.' },  //.
+			new char[] { '%', '2', 'F' },  ///
+			new char[] { '0' },  //0
+			new char[] { '1' },  //1
+			new char[] { '2' },  //2
+			new char[] { '3' },  //3
+			new char[] { '4' },  //4
+			new char[] { '5' },  //5
+			new char[] { '6' },  //6
+			new char[] { '7' },  //7
+			new char[] { '8' },  //8
+			new char[] { '9' },  //9
+			new char[] { '%', '3', 'A' },  //:
+			new char[] { '%', '3', 'B' },  //;
+			new char[] { '%', '3', 'C' },  //<
+			new char[] { '%', '3', 'D' },  //=
+			new char[] { '%', '3', 'E' },  //>
+			new char[] { '%', '3', 'F' },  //?
+			new char[] { '%', '4', '0' },  //@
+			new char[] { 'A' },  //A
+			new char[] { 'B' },  //B
+			new char[] { 'C' },  //C
+			new char[] { 'D' },  //D
+			new char[] { 'E' },  //E
+			new char[] { 'F' },  //F
+			new char[] { 'G' },  //G
+			new char[] { 'H' },  //H
+			new char[] { 'I' },  //I
+			new char[] { 'J' },  //J
+			new char[] { 'K' },  //K
+			new char[] { 'L' },  //L
+			new char[] { 'M' },  //M
+			new char[] { 'N' },  //N
+			new char[] { 'O' },  //O
+			new char[] { 'P' },  //P
+			new char[] { 'Q' },  //Q
+			new char[] { 'R' },  //R
+			new char[] { 'S' },  //S
+			new char[] { 'T' },  //T
+			new char[] { 'U' },  //U
+			new char[] { 'V' },  //V
+			new char[] { 'W' },  //W
+			new char[] { 'X' },  //X
+			new char[] { 'Y' },  //Y
+			new char[] { 'Z' },  //Z
+			new char[] { '%', '5', 'B' },  //[
+			new char[] { '%', '5', 'C' },  //\
+			new char[] { '%', '5', 'D' },  //]
+			new char[] { '%', '5', 'E' },  //^
+			new char[] { '_' },  //_
+			new char[] { '%', '6', '0' },  //`
+			new char[] { 'a' },  //a
+			new char[] { 'b' },  //b
+			new char[] { 'c' },  //c
+			new char[] { 'd' },  //d
+			new char[] { 'e' },  //e
+			new char[] { 'f' },  //f
+			new char[] { 'g' },  //g
+			new char[] { 'h' },  //h
+			new char[] { 'i' },  //i
+			new char[] { 'j' },  //j
+			new char[] { 'k' },  //k
+			new char[] { 'l' },  //l
+			new char[] { 'm' },  //m
+			new char[] { 'n' },  //n
+			new char[] { 'o' },  //o
+			new char[] { 'p' },  //p
+			new char[] { 'q' },  //q
+			new char[] { 'r' },  //r
+			new char[] { 's' },  //s
+			new char[] { 't' },  //t
+			new char[] { 'u' },  //u
+			new char[] { 'v' },  //v
+			new char[] { 'w' },  //w
+			new char[] { 'x' },  //x
+			new char[] { 'y' },  //y
+			new char[] { 'z' },  //z
+			new char[] { '%', '7', 'B' },  //{
+			new char[] { '%', '7', 'C' },  //|
+			new char[] { '%', '7', 'D' },  //}
+			new char[] { '~' },  //~
+			new char[] { '%', '7', 'F' }   //DEL
 	};
 
 	private static final char[] HEX_TABLE = { '0','1','2','3','4','5','6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
@@ -105,61 +241,53 @@ public class URIUtils {
 
 		for (int i = 0; i < codePoints.length(); i++) {
 			final int c = codePoints.codePointAt(i);
-			if (c== '-' || c == '.'
-					|| (c >= '0' && c <= '9')
-					|| (c >= 'A' && c <= 'Z')
-					|| c == '_'
-					|| (c >= 'a' && c <= 'z')
-					|| c == '~') {
-				buf.append((char)c);
 
-			} else {
+			if (c <= 0x7F) {
+				buf.append(ASCII_TABLE_URI_PATH_COMPONENT_ENCODED[c]);
+
+			} else if (c <= 0x7FF) {
 				buf.append('%');
+				final int c1 = 0xC0 | c >> 6;
+				buf.append(HEX_TABLE[c1 >> 4], HEX_TABLE[c1 & 0xF]);
 
-				if (c <= 0x7F) {
-					buf.append(HEX_TABLE[c >> 4], HEX_TABLE[c & 0xF]);
+				buf.append('%');
+				final int c2 = 0x80 | (c & 0x3F);
+				buf.append(HEX_TABLE[c2 >> 4], HEX_TABLE[c2 & 0xF]);
 
-				} else if (c <= 0x7FF) {
-					final int c1 = 0xC0 | c >> 6;
-					buf.append(HEX_TABLE[c1 >> 4], HEX_TABLE[c1 & 0xF]);
-
-					buf.append('%');
-					final int c2 = 0x80 | (c & 0x3F);
-					buf.append(HEX_TABLE[c2 >> 4], HEX_TABLE[c2 & 0xF]);
-
-					// unicode code point to utf8
+				// unicode code point to utf8
 //					u8 = 0xC000 | ((c >> 6) << 8);
 //					u8 |= 0x80 | (c & 0x3F);
 
-				} else if (c <= 0xFFFF) {
-					final int c1 = 0xE0 | c >> 12;
-					buf.append(HEX_TABLE[c1 >> 4], HEX_TABLE[c1 & 0xF]);
+			} else if (c <= 0xFFFF) {
+				buf.append('%');
+				final int c1 = 0xE0 | c >> 12;
+				buf.append(HEX_TABLE[c1 >> 4], HEX_TABLE[c1 & 0xF]);
 
-					buf.append('%');
-					final int c2 = 0x80 | ((c >> 6) & 0x3F);
-					buf.append(HEX_TABLE[c2 >> 4], HEX_TABLE[c2 & 0xF]);
+				buf.append('%');
+				final int c2 = 0x80 | ((c >> 6) & 0x3F);
+				buf.append(HEX_TABLE[c2 >> 4], HEX_TABLE[c2 & 0xF]);
 
-					buf.append('%');
-					final int c3 = 0x80 | (c & 0x3F);
-					buf.append(HEX_TABLE[c3 >> 4], HEX_TABLE[c3 & 0xF]);
+				buf.append('%');
+				final int c3 = 0x80 | (c & 0x3F);
+				buf.append(HEX_TABLE[c3 >> 4], HEX_TABLE[c3 & 0xF]);
 
-				} else {
-					final int c1 = 0xF0 | c >> 18;
-					buf.append(HEX_TABLE[c1 >> 4], HEX_TABLE[c1 & 0xF]);
+			} else {
+				buf.append('%');
+				final int c1 = 0xF0 | c >> 18;
+				buf.append(HEX_TABLE[c1 >> 4], HEX_TABLE[c1 & 0xF]);
 
-					buf.append('%');
+				buf.append('%');
 
-					final int c2 = 0x80 | ((c >> 12) & 0x3F);
-					buf.append(HEX_TABLE[c2 >> 4], HEX_TABLE[c2 & 0xF]);
+				final int c2 = 0x80 | ((c >> 12) & 0x3F);
+				buf.append(HEX_TABLE[c2 >> 4], HEX_TABLE[c2 & 0xF]);
 
-					buf.append('%');
-					final int c3 = 0x80 | ((c >> 6) & 0x3F);
-					buf.append(HEX_TABLE[c3 >> 4], HEX_TABLE[c3 & 0xF]);
+				buf.append('%');
+				final int c3 = 0x80 | ((c >> 6) & 0x3F);
+				buf.append(HEX_TABLE[c3 >> 4], HEX_TABLE[c3 & 0xF]);
 
-					buf.append('%');
-					final int c4 = 0x80 | (c & 0x3F);
-					buf.append(HEX_TABLE[c4 >> 4], HEX_TABLE[c4 & 0xF]);
-				}
+				buf.append('%');
+				final int c4 = 0x80 | (c & 0x3F);
+				buf.append(HEX_TABLE[c4 >> 4], HEX_TABLE[c4 & 0xF]);
 			}
 		}
 

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -117,77 +117,57 @@ public class URIUtils {
 		for (int i = 0; i < src.length(); i++) {
 			final char c = src.charAt(i);
 
-			switch (c) {
-				case '%':
-					if (i + 2 < src.length()) {
-						final char c1 = src.charAt(i+1);
-						final char c2 = src.charAt(i+2);
+			if (c == '%') {
+				if (i + 2 < src.length()) {
+					final char c1 = src.charAt(i + 1);
+					final char c2 = src.charAt(i + 2);
 
-						switch (c1) {
-							case '2':
-								switch (c2) {
-									case 'D':
-										result.append('-');
-										i+=2;
-										break;
-									case 'E':
-										result.append('.');
-										i+=2;
-										break;
-									default:
-										result.append(c, c1);
-										i++;
-										break;
-								}
-								break;
-
-							case '5':
-								switch (c2) {
-									case 'F':
-										result.append('_');
-										i+=2;
-										break;
-									default:
-										result.append(c, c1);
-										i++;
-										break;
-								}
-								break;
-
-							case '7':
-								switch (c2) {
-									case 'E':
-										result.append('~');
-										i+=2;
-										break;
-									default:
-										result.append(c, c1);
-										i++;
-										break;
-								}
-								break;
-
-							default:
-								result.append(c); //TODO(AR) should this be % encoded
-								break;
+					if (c1 =='2') {
+						if (c2 == 'D') {
+							result.append('-');
+							i += 2;
+						} else if (c2 == 'E') {
+							result.append('.');
+							i += 2;
+						} else {
+							result.append(c, c1);
+							i++;
 						}
+
+					} else if (c1 == '5') {
+						if (c2 == 'F') {
+							result.append('_');
+							i += 2;
+						} else {
+							result.append(c, c1);
+							i++;
+						}
+
+					} else if (c1 == '7') {
+						if (c2 == 'E') {
+							result.append('~');
+							i += 2;
+						} else {
+							result.append(c, c1);
+							i++;
+						}
+
 					} else {
-						result.append(c);
+						result.append(c); //TODO(AR) should this be % encoded
 					}
-					break;
-
-				case '*':
-					result.append(ENCODED_ASTERISK);
-					break;
-
-				case '+':
-					result.append(ENCODED_PLUS);
-					break;
-
-				default:
+				} else {
 					result.append(c);
-			}
+				}
 
+			} else if (c == '*') {
+				result.append(ENCODED_ASTERISK);
+
+			} else if (c == '+') {
+				result.append(ENCODED_PLUS);
+
+			} else {
+				result.append(c);
+			}
 		}
 
 		return new String(result.buf, 0, result.count);

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -32,7 +32,8 @@ import org.exist.xmldb.XmldbURI;
 
 /**
  * Utilities for URI related functions
- * 
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  * @author <a href="mailto:pierrick.brihaye@free.fr">Pierrick Brihaye</a>
  */
 public class URIUtils {
@@ -235,6 +236,8 @@ public class URIUtils {
 	 * @param pathComponent the path component to URI encode.
 	 *
 	 * @return the URI encoded path component.
+	 *
+	 * Author: <a href="adam@evolvedbinary.com">Adam Retter</a>
 	 */
 	public static String encodeForURI(final String pathComponent) {
 
@@ -255,10 +258,6 @@ public class URIUtils {
 				buf.append('%');
 				final int c2 = 0x80 | (c & 0x3F);
 				buf.append(HEX_TABLE[c2 >> 4], HEX_TABLE[c2 & 0xF]);
-
-				// unicode code point to utf8
-//					u8 = 0xC000 | ((c >> 6) << 8);
-//					u8 |= 0x80 | (c & 0x3F);
 
 			} else if (c <= 0xFFFF) {
 				buf.append('%');

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -37,9 +37,6 @@ import org.exist.xmldb.XmldbURI;
 
 public class URIUtils {
 
-	private static final char[] ENCODED_ASTERISK = new char[]{'%', '2', 'A'};
-	private static final char[] ENCODED_PLUS = new char[]{'%', '2', '0'};
-
 	private final static class CharArray {
 		char[] buf;
 		int count;
@@ -75,15 +72,6 @@ public class URIUtils {
 			buf[count] = c;
 			buf[count+1] = c1;
 			buf[count+2] = c2;
-			count = newcount;
-		}
-
-		public void append(final char[] cc) {
-			final int newcount = count + cc.length;
-			if (newcount > buf.length) {
-				buf = Arrays.copyOf(buf, Math.max(buf.length << 1, newcount));
-			}
-			System.arraycopy(cc, 0, buf, count, cc.length);
 			count = newcount;
 		}
 	}
@@ -160,10 +148,10 @@ public class URIUtils {
 				}
 
 			} else if (c == '*') {
-				result.append(ENCODED_ASTERISK);
+				result.append('%', '2', 'A');
 
 			} else if (c == '+') {
-				result.append(ENCODED_PLUS);
+				result.append('%', '2', '0');
 
 			} else {
 				result.append(c);

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -38,57 +38,6 @@ import org.exist.xmldb.XmldbURI;
  */
 public class URIUtils {
 
-	private final static class CharArray {
-		char[] buf;
-		int count;
-
-		public CharArray(final int initalSize) {
-			buf = new char[initalSize];
-		}
-
-		void append(final char c) {
-			final int newcount = count + 1;
-			if (newcount > buf.length) {
-				buf = Arrays.copyOf(buf, Math.max(buf.length << 1, newcount));
-			}
-			buf[count] = c;
-			count = newcount;
-		}
-
-		public void append(final char c, final char c1) {
-			final int newcount = count + 2;
-			if (newcount > buf.length) {
-				buf = Arrays.copyOf(buf, Math.max(buf.length << 1, newcount));
-			}
-			buf[count] = c;
-			buf[count+1] = c1;
-			count = newcount;
-		}
-
-		public void append(final char c, final char c1, final char c2) {
-			final int newcount = count + 3;
-			if (newcount > buf.length) {
-				buf = Arrays.copyOf(buf, Math.max(buf.length << 1, newcount));
-			}
-			buf[count] = c;
-			buf[count+1] = c1;
-			buf[count+2] = c2;
-			count = newcount;
-		}
-
-		public void append(final char[] cc) {
-			if (cc.length > 2) {
-				append(cc[0], cc[1], cc[2]);
-			} else if (cc.length > 1) {
-				append(cc[0], cc[1]);
-			} else if (cc.length == 1) {
-				append(cc[0]);
-			} else {
-				throw new UnsupportedOperationException("Only supported upto array size 3");
-			}
-		}
-	}
-
 	private static final char[][] ASCII_TABLE_URI_PATH_COMPONENT_ENCODED = new char[][] {
 			new char[] { '%', '0', '0' },  //NUL
 			new char[] { '%', '0', '1' },  //SOH
@@ -469,4 +418,54 @@ public class URIUtils {
 		return XmldbURI.xmldbUriFor(URIUtils.urlEncodePartsUtf8(path));
 	}
 
+	private static final class CharArray {
+		char[] buf;
+		int count;
+
+		public CharArray(final int initalSize) {
+			buf = new char[initalSize];
+		}
+
+		void append(final char c) {
+			final int newcount = count + 1;
+			if (newcount > buf.length) {
+				buf = Arrays.copyOf(buf, Math.max(buf.length << 1, newcount));
+			}
+			buf[count] = c;
+			count = newcount;
+		}
+
+		public void append(final char c, final char c1) {
+			final int newcount = count + 2;
+			if (newcount > buf.length) {
+				buf = Arrays.copyOf(buf, Math.max(buf.length << 1, newcount));
+			}
+			buf[count] = c;
+			buf[count+1] = c1;
+			count = newcount;
+		}
+
+		public void append(final char c, final char c1, final char c2) {
+			final int newcount = count + 3;
+			if (newcount > buf.length) {
+				buf = Arrays.copyOf(buf, Math.max(buf.length << 1, newcount));
+			}
+			buf[count] = c;
+			buf[count+1] = c1;
+			buf[count+2] = c2;
+			count = newcount;
+		}
+
+		public void append(final char[] cc) {
+			if (cc.length > 2) {
+				append(cc[0], cc[1], cc[2]);
+			} else if (cc.length > 1) {
+				append(cc[0], cc[1]);
+			} else if (cc.length == 1) {
+				append(cc[0]);
+			} else {
+				throw new UnsupportedOperationException("Only supported upto array size 3");
+			}
+		}
+	}
 }

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -35,7 +35,6 @@ import org.exist.xmldb.XmldbURI;
  * 
  * @author <a href="mailto:pierrick.brihaye@free.fr">Pierrick Brihaye</a>
  */
-
 public class URIUtils {
 
 	private final static class CharArray {
@@ -77,12 +76,15 @@ public class URIUtils {
 		}
 
 		public void append(final char[] cc) {
-			final int newcount = count + cc.length;
-			if (newcount > buf.length) {
-				buf = Arrays.copyOf(buf, Math.max(buf.length << 1, newcount));
+			if (cc.length > 2) {
+				append(cc[0], cc[1], cc[2]);
+			} else if (cc.length > 1) {
+				append(cc[0], cc[1]);
+			} else if (cc.length == 1) {
+				append(cc[0]);
+			} else {
+				throw new UnsupportedOperationException("Only supported upto array size 3");
 			}
-			System.arraycopy(cc, 0, buf, count, cc.length);
-			count = newcount;
 		}
 	}
 

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -35,9 +35,24 @@ import org.exist.xmldb.XmldbURI;
  */
 
 public class URIUtils {
-	
-	public static String encodeForURI(String uriPart) {
-		String result = urlEncodeUtf8(uriPart);
+
+	/**
+	 * Encodes reserved characters in a string that is intended to be used in the path segment of a URI.
+	 *
+	 * This function applies the URI escaping rules defined in <a href="https://www.ietf.org/rfc/rfc3986.html#section-2">RFC 3986 Section 2</a>.
+	 * The effect of the function is to escape reserved characters.
+	 * Each such character in the string is replaced with its percent-encoded form as described in RFC 3986.
+	 *
+	 * Since RFC 3986 recommends that, for consistency, URI producers and normalizers should use uppercase
+	 * hexadecimal digits for all percent-encodings, this function must always generate hexadecimal values
+	 * using the upper-case letters A-F.
+	 *
+	 * @param pathComponent the path component to URI encode.
+	 *
+	 * @return the URI encoded path component.
+	 */
+	public static String encodeForURI(String pathComponent) {
+		String result = urlEncodeUtf8(pathComponent);
 		result = result.replaceAll("\\+", "%20");
 		//result = result.replaceAll("%23", "#");		
 		result = result.replaceAll("%2D", "-");

--- a/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/URIUtils.java
@@ -104,7 +104,13 @@ public class URIUtils {
 	 * @return the URI encoded path component.
 	 */
 	public static String encodeForURI(final String pathComponent) {
-		final String src = urlEncodeUtf8(pathComponent);
+		final String src;
+		try {
+			src = URLEncoder.encode(pathComponent, "UTF-8");
+		} catch(final UnsupportedEncodingException e) {
+			//wrap with a runtime Exception
+			throw new RuntimeException(e);
+		}
 
 		final CharArray result = new CharArray(src.length());
 

--- a/exist-core/src/test/java/org/exist/xquery/util/URIUtilsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/util/URIUtilsTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class URIUtilsTest {
+
+    /**
+     * Unreserved Characters from <a href="https://www.ietf.org/rfc/rfc3986.html#section-2.3">RFC 3986 Section 2.3</a>.
+     */
+    @Test
+    public void encodeForURIPathComponentUnreserved() {
+        // alpha
+        String encoded = URIUtils.encodeForURI("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+        assertEquals("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", encoded);
+
+        // digit
+        encoded = URIUtils.encodeForURI("0123456789");
+        assertEquals("0123456789", encoded);
+
+        // hyphen
+        encoded = URIUtils.encodeForURI("dash-case");
+        assertEquals("dash-case", encoded);
+
+        // full-stop
+        encoded = URIUtils.encodeForURI("file.ext");
+        assertEquals("file.ext", encoded);
+
+        // underscore
+        encoded = URIUtils.encodeForURI("snake_case");
+        assertEquals("snake_case", encoded);
+
+        // tilde
+        encoded = URIUtils.encodeForURI("~home");
+        assertEquals("~home", encoded);
+    }
+
+    /**
+     * General Delimiters from <a href="https://www.ietf.org/rfc/rfc3986.html#section-2.2">RFC 3986 Section 2.2</a>.
+     */
+    @Test
+    public void encodeForURIPathComponentGeneralDelimiter() {
+        // colon
+        String encoded = URIUtils.encodeForURI("a:b");
+        assertEquals("a%3Ab", encoded);
+
+        // forward slash
+        encoded = URIUtils.encodeForURI("x/y");
+        assertEquals("x%2Fy", encoded);
+
+        // question mark
+        encoded = URIUtils.encodeForURI("Goodbye?");
+        assertEquals("Goodbye%3F", encoded);
+
+        // hash
+        encoded = URIUtils.encodeForURI("#comment");
+        assertEquals("%23comment", encoded);
+
+        // opening square bracket
+        encoded = URIUtils.encodeForURI("[predicate");
+        assertEquals("%5Bpredicate", encoded);
+
+        // closing square bracket
+        encoded = URIUtils.encodeForURI("predicate]");
+        assertEquals("predicate%5D", encoded);
+
+        // at symbol
+        encoded = URIUtils.encodeForURI("adam@work");
+        assertEquals("adam%40work", encoded);
+    }
+
+    /**
+     * Sub Delimiters from <a href="https://www.ietf.org/rfc/rfc3986.html#section-2.2">RFC 3986 Section 2.2</a>.
+     */
+    @Test
+    public void encodeForURIPathComponentSubDelimiter() {
+        // exclamation mark
+        String encoded = URIUtils.encodeForURI("Hello!");
+        assertEquals("Hello%21", encoded);
+
+        // dollar sign
+        encoded = URIUtils.encodeForURI("$100");
+        assertEquals("%24100", encoded);
+
+        // ampersand
+        encoded = URIUtils.encodeForURI("Jack&Jill");
+        assertEquals("Jack%26Jill", encoded);
+
+        // single quote
+        encoded = URIUtils.encodeForURI("it's");
+        assertEquals("it%27s", encoded);
+
+        // opening bracket
+        encoded = URIUtils.encodeForURI("(comment");
+        assertEquals("%28comment", encoded);
+
+        // closing bracket
+        encoded = URIUtils.encodeForURI("comment)");
+        assertEquals("comment%29", encoded);
+
+        // asterisk
+        encoded = URIUtils.encodeForURI("1*2");
+        assertEquals("1%2A2", encoded);
+
+        // plus sign
+        encoded = URIUtils.encodeForURI("1+2");
+        assertEquals("1%2B2", encoded);
+
+        // comma
+        encoded = URIUtils.encodeForURI("x,y");
+        assertEquals("x%2Cy", encoded);
+
+        // semi-colon
+        encoded = URIUtils.encodeForURI("a;b");
+        assertEquals("a%3Bb", encoded);
+
+        // equals sign
+        encoded = URIUtils.encodeForURI("n=1");
+        assertEquals("n%3D1", encoded);
+    }
+
+    @Test
+    public void encodeForURIPathComponent() {
+        // path
+        String encoded = URIUtils.encodeForURI("/db/a/b/c");
+        assertEquals("%2Fdb%2Fa%2Fb%2Fc", encoded);
+
+        // space
+        encoded = URIUtils.encodeForURI("hello world");
+        assertEquals("hello%20world", encoded);
+
+        // percent sign
+        encoded = URIUtils.encodeForURI("99%");
+        assertEquals("99%25", encoded);
+
+        // percent sign
+        encoded = URIUtils.encodeForURI("%2F");
+        assertEquals("%252F", encoded);
+
+        // double percent sign
+        encoded = URIUtils.encodeForURI("99%%100");
+        assertEquals("99%25%25100", encoded);
+    }
+
+    @Test
+    public void encodeForURIPathComponentUtf8() {
+        // 2 byte character - yen sign
+        String encoded = URIUtils.encodeForURI("¥");
+        assertEquals("%C2%A5", encoded);
+
+        // 3 byte character - samaritan letter tsasdiy
+        encoded = URIUtils.encodeForURI("ࠑ");
+        assertEquals("%E0%A0%91", encoded);
+
+        // 4 byte character - phoenician letter het
+        encoded = URIUtils.encodeForURI("\uD802\uDD07");
+        assertEquals("%F0%90%A4%87", encoded);
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/util/URIUtilsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/util/URIUtilsTest.java
@@ -39,13 +39,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
-public class URIUtilsTest {
+class URIUtilsTest {
 
     /**
      * Unreserved Characters from <a href="https://www.ietf.org/rfc/rfc3986.html#section-2.3">RFC 3986 Section 2.3</a>.
      */
     @Test
-    public void encodeForURIPathComponentUnreserved() {
+    void encodeForURIPathComponentUnreserved() {
         // alpha
         String encoded = URIUtils.encodeForURI("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
         assertEquals("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", encoded);
@@ -75,7 +75,7 @@ public class URIUtilsTest {
      * General Delimiters from <a href="https://www.ietf.org/rfc/rfc3986.html#section-2.2">RFC 3986 Section 2.2</a>.
      */
     @Test
-    public void encodeForURIPathComponentGeneralDelimiter() {
+    void encodeForURIPathComponentGeneralDelimiter() {
         // colon
         String encoded = URIUtils.encodeForURI("a:b");
         assertEquals("a%3Ab", encoded);
@@ -109,7 +109,7 @@ public class URIUtilsTest {
      * Sub Delimiters from <a href="https://www.ietf.org/rfc/rfc3986.html#section-2.2">RFC 3986 Section 2.2</a>.
      */
     @Test
-    public void encodeForURIPathComponentSubDelimiter() {
+    void encodeForURIPathComponentSubDelimiter() {
         // exclamation mark
         String encoded = URIUtils.encodeForURI("Hello!");
         assertEquals("Hello%21", encoded);
@@ -156,7 +156,7 @@ public class URIUtilsTest {
     }
 
     @Test
-    public void encodeForURIPathComponent() {
+    void encodeForURIPathComponent() {
         // path
         String encoded = URIUtils.encodeForURI("/db/a/b/c");
         assertEquals("%2Fdb%2Fa%2Fb%2Fc", encoded);
@@ -179,7 +179,7 @@ public class URIUtilsTest {
     }
 
     @Test
-    public void encodeForURIPathComponentUtf8() {
+    void encodeForURIPathComponentUtf8() {
         // 2 byte character - yen sign
         String encoded = URIUtils.encodeForURI("¥");
         assertEquals("%C2%A5", encoded);

--- a/exist-core/src/test/java/org/exist/xquery/util/URIUtilsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/util/URIUtilsTest.java
@@ -32,9 +32,9 @@
  */
 package org.exist.xquery.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>


### PR DESCRIPTION
This optimises the URI Encoding of Path Components in eXist-db, and specifically affects `fn:encode-for-uri`.

Through using the YourKit Java Profiler, we found that a great deal of time in a specific XQuery was unexpectedly taken up by the `fn:encode-for-uri` XQuery function. A quick examination of the code found it to be correct, yet definetly sub-optimal.

By adding JMH Tests for this in `URIUtilsBenchmark.java` we are able to confidently show that before this PR, the throughput of `URIUtils#encodeForURI(String)` (which is used by `fn:encode-for-uri`) was:

```
293623.937 ± 16251.838  ops/s
```

This PR increases the throughput to:
```
2056617.057 ± 56774.934  ops/s
``` 

Overall performance is increased by a factor of `~7x` (or `~600%` if you prefer)!

Such techniques could be applied to other URI/URL/IRI encoding/decoding methods within eXist-db in future if desired.