### PR TITLE
Use builtin maven-cache of setup-java action

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,12 +21,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.jdk }}
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: 'maven'
       - name: Maven Test
         timeout-minutes: 60
         run: mvn -V -B -DtrimStackTrace=false clean verify


### PR DESCRIPTION
The caching key is built hashing all pomfiles (as fileHash).
That is in line with the current strategy.

- was : `${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}`
- is  : `setup-java-${{ platform }}-${{ packageManager }}-${{ fileHash }}`

Documentation: https://github.com/actions/setup-java#caching-packages-dependencies

