### PR TITLE
[bugfix] file:sync#3 updates only changed files

### DIFF
--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/Sync.java
@@ -371,27 +371,30 @@ public class Sync extends BasicFunction {
     }
 
     private void saveFile(final Path targetFile, final DocumentImpl doc, final Date startDate, final MemTreeBuilder output) throws LockException {
+        // the resource has not changed in the selected period
+        if (startDate != null && doc.getLastModified() <= startDate.getTime()) {
+            return;
+        }
         try (final ManagedLock<MultiLock[]> lock = context.getBroker().getBrokerPool().getLockManager().acquireDocumentReadLock(doc.getURI())) {
-            if (startDate == null || (
-                    doc.getLastModified() > startDate.getTime() && (
-                            !Files.exists(targetFile) ||
-                                    Files.getLastModifiedTime(targetFile).compareTo(FileTime.fromMillis(doc.getLastModified())) >= 0
-                    ))) {
-                output.startElement(FILE_UPDATE_ELEMENT, null);
-                output.addAttribute(FILE_ATTRIBUTE, targetFile.toAbsolutePath().toString());
-                output.addAttribute(NAME_ATTRIBUTE, doc.getFileURI().toString());
-                output.addAttribute(COLLECTION_ATTRIBUTE, doc.getCollection().getURI().toString());
-                output.addAttribute(MODIFIED_ATTRIBUTE, new DateTimeValue(new Date(doc.getLastModified())).getStringValue());
+            // the file on the disk appears to be up-to-date
+            if (Files.exists(targetFile) && Files.getLastModifiedTime(targetFile).compareTo(FileTime.fromMillis(doc.getLastModified())) >= 0) {
+                return;
+            }
 
-                if (doc.getResourceType() == DocumentImpl.BINARY_FILE) {
-                    output.addAttribute(TYPE_ATTRIBUTE, "binary");
-                    output.endElement();
-                    saveBinary(targetFile, (BinaryDocument) doc, output);
-                } else {
-                    output.addAttribute(TYPE_ATTRIBUTE, "xml");
-                    output.endElement();
-                    saveXML(targetFile, doc, output);
-                }
+            output.startElement(FILE_UPDATE_ELEMENT, null);
+            output.addAttribute(FILE_ATTRIBUTE, targetFile.toAbsolutePath().toString());
+            output.addAttribute(NAME_ATTRIBUTE, doc.getFileURI().toString());
+            output.addAttribute(COLLECTION_ATTRIBUTE, doc.getCollection().getURI().toString());
+            output.addAttribute(MODIFIED_ATTRIBUTE, new DateTimeValue(new Date(doc.getLastModified())).getStringValue());
+
+            if (doc.getResourceType() == DocumentImpl.BINARY_FILE) {
+                output.addAttribute(TYPE_ATTRIBUTE, "binary");
+                output.endElement();
+                saveBinary(targetFile, (BinaryDocument) doc, output);
+            } else {
+                output.addAttribute(TYPE_ATTRIBUTE, "xml");
+                output.endElement();
+                saveXML(targetFile, doc, output);
             }
         } catch (final XPathException e) {
             reportError(output, e.getMessage());

--- a/extensions/modules/file/src/test/resources/util/fixtures.xqm
+++ b/extensions/modules/file/src/test/resources/util/fixtures.xqm
@@ -106,7 +106,7 @@ declare variable $fixtures:NL := "&#10;";
 (: modification dates :)
 
 declare variable $fixtures:now := current-dateTime();
-declare variable $fixtures:mod-date := $fixtures:now + xs:dayTimeDuration('PT1H');
+declare variable $fixtures:mod-date := $fixtures:now;
 declare variable $fixtures:mod-date-2 := $fixtures:now + xs:dayTimeDuration('PT2H');
 
 (: collections :)


### PR DESCRIPTION
### Description:

- Sync.saveFile checks for modification of resource in a more readable and
  safer way while also returning even earlier than before
- add test that runs file:sync twice and ensures nothing is written to disk
- add test with multiple exclude patterns
- fix expectation in tests that were false positives before,
  due to the issue in helper:assert-sync-result
- fix and enhance helper:assert-sync-result to
  - throw when empty sequence is expected but something was returned
  - add label to each test so that it is clear where the error occurred
- helper:create-db-resource does not set modified time (is unnecessary)
- $fixtures:mod-date is now equal to current time

### Reference:

Fixes #4321

### Type of tests:

XQSuite