### PR TITLE
Log xsl:fo render errors to exist.log

### DIFF
--- a/extensions/modules/xslfo/src/main/java/org/exist/xquery/modules/xslfo/RenderFunction.java
+++ b/extensions/modules/xslfo/src/main/java/org/exist/xquery/modules/xslfo/RenderFunction.java
@@ -136,6 +136,7 @@ public class RenderFunction extends BasicFunction {
             // return the result
             return BinaryValueFromInputStream.getInstance(context, new Base64BinaryValueType(), new ByteArrayInputStream(baos.toByteArray()));
         } catch (final IOException | SAXException se) {
+            LOG.error(se.getMessage(), se);
             throw new XPathException(this, se.getMessage(), se);
         } finally {
             if (adapter != null) {


### PR DESCRIPTION
Without this it can be very hard to diagnose when your XSL:FO processor is misconfigured.