### PR TITLE
[5.x.x] Fix catalog uris when using Windows Paths

### DIFF
--- a/exist-core/src/main/java/org/exist/resolver/ResolverFactory.java
+++ b/exist-core/src/main/java/org/exist/resolver/ResolverFactory.java
@@ -40,6 +40,7 @@ import org.xmlresolver.XMLResolverConfiguration;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -71,14 +72,33 @@ public interface ResolverFactory {
         resolverConfiguration.setFeature(ResolverFeature.URI_FOR_SYSTEM, true);
 
         for (final Tuple2<String, Optional<InputSource>> catalog : catalogs) {
+            String strCatalogUri = catalog._1;
+            strCatalogUri = sanitizeCatalogUri(strCatalogUri);
             if (catalog._2.isPresent()) {
-                resolverConfiguration.addCatalog(new URI(catalog._1), catalog._2.get());
+                resolverConfiguration.addCatalog(new URI(strCatalogUri), catalog._2.get());
             } else {
-                resolverConfiguration.addCatalog(catalog._1);
+                resolverConfiguration.addCatalog(strCatalogUri);
             }
         }
 
         return new Resolver(resolverConfiguration);
+    }
+
+    /**
+     * Sanitize the Catalog URI.
+     *
+     * Mainly deals with converting Windows file paths to URI.
+     *
+     * @param strCatalogUri The Catalog URI string
+     *
+     * @return The sanitized Catalog URI string
+     */
+    static String sanitizeCatalogUri(String strCatalogUri) {
+        if (strCatalogUri.indexOf('\\') > -1) {
+            // convert from Windows file path
+            strCatalogUri = Paths.get(strCatalogUri).toUri().toString();
+        }
+        return strCatalogUri;
     }
 
     /**


### PR DESCRIPTION
This was missing from https://github.com/eXist-db/exist/pull/4329 and fixes the Windows test failures.