### PR TITLE
License file for exist-xqts distro needs to be excluded from license checks

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -895,6 +895,7 @@
                             <excludes>
                                 <exclude>FDB-backport-LGPL-21-ONLY-license.template.txt</exclude>
                                 <exclude>FDB-backport-LGPL-21-ONLY-license.xml.template.txt</exclude>
+                                <exclude>LGPL-21-license.txt</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>


### PR DESCRIPTION
Fixes the build, as this was inadvertently missed from https://github.com/eXist-db/exist/pull/4333