### PR TITLE
Capture xs:anyURI error details in XMLDB Module

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticate.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBAuthenticate.java
@@ -143,7 +143,7 @@ public class XMLDBAuthenticate extends UserSwitchingBasicFunction {
                 return BooleanValue.FALSE;
             }
 
-            final Collection root = XMLDBAbstractCollectionManipulator.getCollection(context, uri, Optional.of(userName), Optional.of(password));
+            final Collection root = XMLDBAbstractCollectionManipulator.getCollection(this, context, uri, Optional.of(userName), Optional.of(password));
 
             if (root == null) {
                 logger.error("Unable to authenticate user: target collection {} does not exist {}", uri, getLocation());

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBCopy.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBCopy.java
@@ -38,6 +38,7 @@ import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.XMLDBException;
 
 import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
 import static org.exist.xquery.functions.xmldb.XMLDBModule.functionSignatures;
 
 /**
@@ -101,8 +102,8 @@ public class XMLDBCopy extends XMLDBAbstractCollectionManipulator {
             final Sequence contextSequence) throws XPathException {
 
         if (isCalledAs(FS_COPY_RESOURCE_NAME)) {
-            final XmldbURI destination = new AnyURIValue(args[2].itemAt(0).getStringValue()).toXmldbURI();
-            final XmldbURI doc = new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI();
+            final XmldbURI destination = execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[2].itemAt(0).getStringValue()).toXmldbURI());
+            final XmldbURI doc = execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI());
             try {
                 final Resource resource = collection.getResource(doc.toString());
                 if (resource == null) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBGetMimeType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBGetMimeType.java
@@ -43,6 +43,8 @@ import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.StringValue;
 import org.exist.xquery.value.Type;
 
+import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
+
 /**
  * @author <a href="mailto:adam.retter@devon.gov.uk">Adam Retter</a>
  */
@@ -67,7 +69,7 @@ public class XMLDBGetMimeType extends BasicFunction {
 	public Sequence eval(Sequence[] args, Sequence contextSequence)
         throws XPathException {
 
-		final String path = new AnyURIValue(args[0].itemAt(0).getStringValue()).toString();
+		final String path = execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[0].itemAt(0).getStringValue()).toString());
 		
 		if(path.matches("^[a-z]+://.*")) {
 			//external

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBHasLock.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBHasLock.java
@@ -41,6 +41,8 @@ import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.XMLDBException;
 
+import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
+
 /**
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  *
@@ -83,7 +85,7 @@ public class XMLDBHasLock extends XMLDBAbstractCollectionManipulator {
 
 		try {
 			final UserManagementService ums = (UserManagementService) collection.getService("UserManagementService", "1.0");
-			final Resource res = collection.getResource(new AnyURIValue(args[1].getStringValue()).toXmldbURI().toString());
+			final Resource res = collection.getResource(execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[1].getStringValue()).toXmldbURI().toString()));
 			if (res != null) {
 				final String lockUser = ums.hasUserLock(res);
 				if (lockUser != null && isCalledAs("clear-lock")) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBMove.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBMove.java
@@ -41,6 +41,8 @@ import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.XMLDBException;
 
+import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
+
 /**
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  *
@@ -81,9 +83,9 @@ public class XMLDBMove extends XMLDBAbstractCollectionManipulator {
     public Sequence evalWithCollection(Collection collection, Sequence[] args, Sequence contextSequence)
         throws XPathException {
 
-        final XmldbURI destination = new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI();
+        final XmldbURI destination = execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI());
         if (getSignature().getArgumentCount() == 3) {
-            final XmldbURI doc = new AnyURIValue(args[2].itemAt(0).getStringValue()).toXmldbURI();
+            final XmldbURI doc = execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[2].itemAt(0).getStringValue()).toXmldbURI());
             try {
                 final Resource resource = collection.getResource(doc.toString());
                 if (resource == null) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRemove.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRemove.java
@@ -38,6 +38,8 @@ import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.XMLDBException;
 import org.xmldb.api.modules.CollectionManagementService;
 
+import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
+
 /**
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  *
@@ -74,7 +76,7 @@ public class XMLDBRemove extends XMLDBAbstractCollectionManipulator {
 	public Sequence evalWithCollection(Collection collection, Sequence[] args, Sequence contextSequence)
 		throws XPathException {
 		if(getSignature().getArgumentCount() == 2) {
-			final String doc = new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI().toString();
+			final String doc = execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI().toString());
 			try {
 				final Resource resource = collection.getResource(doc);
 				if (resource == null) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRename.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRename.java
@@ -41,6 +41,8 @@ import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.XMLDBException;
 
+import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
+
 /**
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  *
@@ -80,7 +82,7 @@ public class XMLDBRename extends XMLDBAbstractCollectionManipulator {
         throws XPathException {
 
 		if(getSignature().getArgumentCount() == 3) {
-			final XmldbURI doc = new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI();
+			final XmldbURI doc = execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[1].itemAt(0).getStringValue()).toXmldbURI());
 			try {
 				final Resource resource = collection.getResource(doc.toString());
 				if (resource == null) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBSetMimeType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBSetMimeType.java
@@ -46,6 +46,8 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
 
+import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
+
 /**
  * @author <a href="mailto:dannes@exist-db.org">Dannes Wessels</a>
  */
@@ -74,7 +76,7 @@ public class XMLDBSetMimeType extends BasicFunction {
         final MimeTable mimeTable = MimeTable.getInstance();
 
         // Get first parameter
-        final String pathParameter = new AnyURIValue(args[0].itemAt(0).getStringValue()).toString();
+        final String pathParameter = execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[0].itemAt(0).getStringValue()).toString());
 
         if (pathParameter.matches("^[a-z]+://.*")) {
             throw new XPathException("Can not set mime-type for resources outside the database.");

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBSize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBSize.java
@@ -41,6 +41,8 @@ import org.xmldb.api.base.Collection;
 import org.xmldb.api.base.Resource;
 import org.xmldb.api.base.XMLDBException;
 
+import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
+
 /**
  * @author wolf
  */
@@ -69,7 +71,7 @@ public class XMLDBSize extends XMLDBAbstractCollectionManipulator {
 	protected Sequence evalWithCollection(final Collection collection, final Sequence[] args,
 			final Sequence contextSequence) throws XPathException {
         try {
-			final Resource resource = collection.getResource(new AnyURIValue(args[1].getStringValue()).toXmldbURI().toString());
+			final Resource resource = collection.getResource(execAndAddErrorIfMissing(this, () -> new AnyURIValue(args[1].getStringValue()).toXmldbURI().toString()));
 			return new IntegerValue(((EXistResource)resource).getContentLength(), Type.LONG);
 		} catch (final XMLDBException e) {
 			logger.error("Failed to retrieve size: {}", e.getMessage());

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBStore.java
@@ -63,6 +63,7 @@ import org.xmldb.api.modules.BinaryResource;
 import org.xmldb.api.modules.XMLResource;
 
 import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.XPathException.execAndAddErrorIfMissing;
 import static org.exist.xquery.functions.xmldb.XMLDBModule.functionSignature;
 import static org.exist.xquery.functions.xmldb.XMLDBModule.functionSignatures;
 
@@ -131,7 +132,8 @@ public class XMLDBStore extends XMLDBAbstractCollectionManipulator {
         if (docName != null && docName.isEmpty()) {
             docName = null;
         } else if (docName != null) {
-            docName = new AnyURIValue(docName).toXmldbURI().toString();
+            final String localDocName = docName;
+            docName = execAndAddErrorIfMissing(this, () -> new AnyURIValue(localDocName).toXmldbURI().toString());
         }
 
         final Item item = args[2].itemAt(0);


### PR DESCRIPTION
Various functions in the xmldb XQuery extension module internally construct xs:anyURI. Previously, if this construction failed, the error raised in your XQuery would not contain the line-number, column-number, or source. This PR fixes that by capturing the location information and setting it on the XPathException (which is behind the XQuery Error).