### PR TITLE
Limit the number of hardware threads to a max of 16 in some tests

### DIFF
--- a/exist-core/src/test/java/org/exist/collections/ConcurrencyTest.java
+++ b/exist-core/src/test/java/org/exist/collections/ConcurrencyTest.java
@@ -53,7 +53,7 @@ public class ConcurrencyTest {
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
 
-    private static int CONCURRENT_THREADS = Runtime.getRuntime().availableProcessors() * 3;
+    private static int CONCURRENT_THREADS = Math.min(16, Runtime.getRuntime().availableProcessors() * 3);
     private static final int DOC_COUNT = CONCURRENT_THREADS * 10;
 
     private static final int QUERY_COUNT = 20;

--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/ConcurrencyTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/ConcurrencyTest.java
@@ -64,7 +64,7 @@ public class ConcurrencyTest {
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
 
-    private static int CONCURRENT_THREADS = Runtime.getRuntime().availableProcessors() * 3;
+    private static int CONCURRENT_THREADS = Math.min(16, Runtime.getRuntime().availableProcessors() * 3);
 
     private static Collection test;
 


### PR DESCRIPTION
In these tests I have observed deadlocks on my machine which has 128 hardware threads. We should revisit this later...