### PR TITLE
[4.x.x] Limit the number of hardware threads to a max of 16 in some tests

### DIFF
--- a/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/ConcurrencyTest.java
+++ b/extensions/indexes/lucene/src/test/java/org/exist/indexing/lucene/ConcurrencyTest.java
@@ -61,7 +61,7 @@ public class ConcurrencyTest {
     @ClassRule
     public static final ExistXmldbEmbeddedServer existEmbeddedServer = new ExistXmldbEmbeddedServer(false, true, true);
 
-    private static int CONCURRENT_THREADS = Runtime.getRuntime().availableProcessors() * 3;
+    private static int CONCURRENT_THREADS = Math.min(16, Runtime.getRuntime().availableProcessors() * 3);
 
     private static Collection test;
 


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/4369