### PR TITLE
Improve XSLT errors

### DIFF
--- a/exist-core/src/main/java/org/exist/http/servlets/XSLTServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/XSLTServlet.java
@@ -89,7 +89,7 @@ public class XSLTServlet extends HttpServlet {
         new XSLTErrorsListener<ServletException>(true, false) {
 
             @Override
-            protected void raiseError(String error, Exception ex) throws ServletException {
+            protected void raiseError(final String error, final TransformerException ex) throws ServletException {
                 throw new ServletException(error, ex);
             }
         };

--- a/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
@@ -188,7 +188,7 @@ public class Transform extends BasicFunction {
         final XSLTErrorsListener<XPathException> errorListener =
             new XSLTErrorsListener<XPathException>(stopOnError, stopOnWarn) {
                 @Override
-                protected void raiseError(String error, Exception ex) throws XPathException {
+                protected void raiseError(final String error, final TransformerException ex) throws XPathException {
                     throw new XPathException(Transform.this, error, ex);
                 }
             };

--- a/exist-core/src/main/java/org/exist/xslt/XSLTErrorsListener.java
+++ b/exist-core/src/main/java/org/exist/xslt/XSLTErrorsListener.java
@@ -42,14 +42,14 @@ public abstract class XSLTErrorsListener<E extends Exception> implements ErrorLi
   private final boolean stopOnWarn;
 
   @Nullable private ErrorType errorType;
-  @Nullable private Exception exception;
+  @Nullable private TransformerException exception;
 
   public XSLTErrorsListener(final boolean stopOnError, final boolean stopOnWarn) {
     this.stopOnError = stopOnError;
     this.stopOnWarn = stopOnWarn;
   }
 
-  protected abstract void raiseError(String error, Exception ex) throws E;
+  protected abstract void raiseError(String error, TransformerException ex) throws E;
 
   public void checkForErrors() throws E {
     if (errorType == null) {
@@ -59,16 +59,16 @@ public abstract class XSLTErrorsListener<E extends Exception> implements ErrorLi
     switch (errorType) {
       case WARNING:
         if (stopOnWarn) {
-          raiseError("XSL transform reported warning: " + exception.getMessage(), exception);
+          raiseError("XSL transform reported warning: " + exception.getMessageAndLocation(), exception);
         }
         break;
       case ERROR:
         if (stopOnError) {
-          raiseError("XSL transform reported error: " + exception.getMessage(), exception);
+          raiseError("XSL transform reported error: " + exception.getMessageAndLocation(), exception);
         }
         break;
       case FATAL:
-        raiseError("XSL transform reported error: " + exception.getMessage(), exception);
+        raiseError("XSL transform reported error: " + exception.getMessageAndLocation(), exception);
     }
   }
 


### PR DESCRIPTION
Previously errors that could be raised in XSLT transformations (by Saxon) and appear in eXist-db's log file did not include information about where the error occurred. This PR simply includes the location information provided by the `TransformerException`.