### PR TITLE
Do not override Bearer Authentication with Basic Authentication

### DIFF
--- a/exist-core/src/main/java/org/exist/http/servlets/AbstractExistHttpServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/AbstractExistHttpServlet.java
@@ -246,9 +246,9 @@ public abstract class AbstractExistHttpServlet extends HttpServlet {
 	        }
         }
 
-        // Secondly try basic authentication
+        // Secondly try basic authentication if there is no Authorization header or the Authorization header does not indicate Basic auth
         final String auth = request.getHeader("Authorization");
-        if (auth == null && getDefaultUser() != null) {
+        if ((auth == null || !auth.startsWith("Basic ")) && getDefaultUser() != null) {
             return getDefaultUser();
         }
         return getAuthenticator().authenticate(request, response, true);

--- a/exist-core/src/main/java/org/exist/http/servlets/AbstractExistHttpServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/AbstractExistHttpServlet.java
@@ -248,7 +248,7 @@ public abstract class AbstractExistHttpServlet extends HttpServlet {
 
         // Secondly try basic authentication if there is no Authorization header or the Authorization header does not indicate Basic auth
         final String auth = request.getHeader("Authorization");
-        if ((auth == null || !auth.startsWith("Basic ")) && getDefaultUser() != null) {
+        if ((auth == null || !auth.toLowerCase().startsWith("basic ")) && getDefaultUser() != null) {
             return getDefaultUser();
         }
         return getAuthenticator().authenticate(request, response, true);

--- a/exist-core/src/main/java/org/exist/http/servlets/BasicAuthenticator.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/BasicAuthenticator.java
@@ -61,8 +61,8 @@ public class BasicAuthenticator implements Authenticator {
 		String password = null;
 
 		try {
-			if (credentials != null && credentials.startsWith("Basic")) {
-				final byte[] c = Base64.decodeBase64(credentials.substring("Basic ".length()));
+			if (credentials != null && credentials.toLowerCase().startsWith("basic ")) {
+				final byte[] c = Base64.decodeBase64(credentials.substring("basic ".length()));
 				final String s = new String(c, UTF_8);
 				// LOG.debug("BASIC auth credentials: "+s);
 				final int p = s.indexOf(':');
@@ -70,7 +70,7 @@ public class BasicAuthenticator implements Authenticator {
 				password = p < 0 ? null : s.substring(p + 1);
 			}
 		} catch(final IllegalArgumentException iae) {
-			LOG.warn("Invalid BASIC authentication header received: {}", iae.getMessage(), iae);
+			LOG.warn("Invalid Basic Authentication header received: {}", iae.getMessage(), iae);
 			credentials = null;
 		}
 

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -179,7 +179,7 @@ public class XQueryURLRewrite extends HttpServlet {
         } else {
             // Secondly try basic authentication
             final String auth = request.getHeader("Authorization");
-            if (auth != null && auth.startsWith("Basic ")) {
+            if (auth != null && auth.toLowerCase().startsWith("basic ")) {
                 requestUser = authenticator.authenticate(request, response, sendChallenge);
                 if (requestUser != null) {
                     user = requestUser;

--- a/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
+++ b/exist-core/src/main/java/org/exist/http/urlrewrite/XQueryURLRewrite.java
@@ -179,7 +179,7 @@ public class XQueryURLRewrite extends HttpServlet {
         } else {
             // Secondly try basic authentication
             final String auth = request.getHeader("Authorization");
-            if (auth != null) {
+            if (auth != null && auth.startsWith("Basic ")) {
                 requestUser = authenticator.authenticate(request, response, sendChallenge);
                 if (requestUser != null) {
                     user = requestUser;

--- a/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
@@ -709,6 +709,9 @@ try {
     public void execQueryWithNoAuth() throws IOException {
         doPut(AUTH_QUERY, "auth.xq", HttpStatus.CREATED_201);
 
+        // allow query to be executed only by owner
+        chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r--");
+
         // call the auth.xq
         final String uri = getCollectionUri() + "/auth.xq";
         final HttpURLConnection connect = getConnection(uri);
@@ -729,26 +732,11 @@ try {
         doPut(AUTH_QUERY, "auth.xq", HttpStatus.CREATED_201);
 
         // allow query to be executed by guest
-        String uri = getCollectionUri() +"?_query=" + URLEncoder.encode(
-                "sm:chmod(xs:anyURI('" + XmldbURI.ROOT_COLLECTION + "/test/auth.xq'), 'rwxr--r-x')",
-                UTF_8.displayName());
-        HttpURLConnection connect = getConnection(uri);
-        try {
-            connect.setRequestMethod("GET");
-            connect.setRequestProperty("Authorization", "Basic " + credentials);
-            connect.connect();
-
-            final int r = connect.getResponseCode();
-            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
-
-            readResponse(connect.getInputStream());
-        } finally {
-            connect.disconnect();
-        }
+        chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r-x");
 
         // call the auth.xq
-        uri = getCollectionUri() + "/auth.xq";
-        connect = getConnection(uri);
+        final String uri = getCollectionUri() + "/auth.xq";
+        final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -787,6 +775,9 @@ try {
     @Test
     public void execQueryWithBasicAuth() throws IOException {
         doPut(AUTH_QUERY, "auth.xq", HttpStatus.CREATED_201);
+
+        // allow query to be executed only by owner
+        chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r--");
 
         // call the auth.xq
         final String uri = getCollectionUri() + "/auth.xq";
@@ -831,27 +822,12 @@ try {
     public void execSetUidQueryWithNoAuth() throws IOException {
         doPut(AUTH_QUERY, "auth.xq", HttpStatus.CREATED_201);
 
-        // allow query to be executed by guest
-        String uri = getCollectionUri() +"?_query=" + URLEncoder.encode(
-                "sm:chmod(xs:anyURI('" + XmldbURI.ROOT_COLLECTION + "/test/auth.xq'), 'rwsr--r-x')",
-                UTF_8.displayName());
-        HttpURLConnection connect = getConnection(uri);
-        try {
-            connect.setRequestMethod("GET");
-            connect.setRequestProperty("Authorization", "Basic " + credentials);
-            connect.connect();
-
-            final int r = connect.getResponseCode();
-            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
-
-            readResponse(connect.getInputStream());
-        } finally {
-            connect.disconnect();
-        }
+        // allow query to be executed setUid as admin by guest
+        chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwsr--r-x");
 
         // call the auth.xq
-        uri = getCollectionUri() + "/auth.xq";
-        connect = getConnection(uri);
+        final String uri = getCollectionUri() + "/auth.xq";
+        final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -897,27 +873,12 @@ try {
     public void execSetUidQueryWithBasicAuth() throws IOException {
         doPut(AUTH_QUERY, "auth.xq", HttpStatus.CREATED_201);
 
-        // allow query to be executed by guest
-        String uri = getCollectionUri() +"?_query=" + URLEncoder.encode(
-                "sm:chmod(xs:anyURI('" + XmldbURI.ROOT_COLLECTION + "/test/auth.xq'), 'rwsr--r-x')",
-                UTF_8.displayName());
-        HttpURLConnection connect = getConnection(uri);
-        try {
-            connect.setRequestMethod("GET");
-            connect.setRequestProperty("Authorization", "Basic " + credentials);
-            connect.connect();
-
-            final int r = connect.getResponseCode();
-            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
-
-            readResponse(connect.getInputStream());
-        } finally {
-            connect.disconnect();
-        }
+        // allow query to be executed setUid as admin by guest
+        chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwsr--r-x");
 
         // call the auth.xq
-        uri = getCollectionUri() + "/auth.xq";
-        connect = getConnection(uri);
+        final String uri = getCollectionUri() + "/auth.xq";
+        final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
             connect.setRequestProperty("Authorization", "Basic " + credentials);
@@ -958,6 +919,9 @@ try {
     public void execQueryWithBearerAuth() throws IOException {
         doPut(AUTH_QUERY, "auth.xq", HttpStatus.CREATED_201);
 
+        // allow query to be executed only by owner
+        chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r--");
+
         // call the auth.xq
         final String uri = getCollectionUri() + "/auth.xq";
         final HttpURLConnection connect = getConnection(uri);
@@ -978,27 +942,12 @@ try {
     public void execSetUidQueryWithBearerAuth() throws IOException {
         doPut(AUTH_QUERY, "auth.xq", HttpStatus.CREATED_201);
 
-        // allow query to be executed by guest
-        String uri = getCollectionUri() +"?_query=" + URLEncoder.encode(
-                "sm:chmod(xs:anyURI('" + XmldbURI.ROOT_COLLECTION + "/test/auth.xq'), 'rwsr--r-x')",
-                UTF_8.displayName());
-        HttpURLConnection connect = getConnection(uri);
-        try {
-            connect.setRequestMethod("GET");
-            connect.setRequestProperty("Authorization", "Basic " + credentials);
-            connect.connect();
-
-            final int r = connect.getResponseCode();
-            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
-
-            readResponse(connect.getInputStream());
-        } finally {
-            connect.disconnect();
-        }
+        // allow query to be executed setUid as admin by guest
+        chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwsr--r-x");
 
         // call the auth.xq
-        uri = getCollectionUri() + "/auth.xq";
-        connect = getConnection(uri);
+        final String uri = getCollectionUri() + "/auth.xq";
+        final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
             connect.setRequestProperty("Authorization", "Bearer some-token");
@@ -1036,6 +985,23 @@ try {
 
             assertFalse(diff.toString(), diff.hasDifferences());
 
+        } finally {
+            connect.disconnect();
+        }
+    }
+
+    private void chmod(final String resourcePath, final String mode) throws IOException {
+        final String uri = getCollectionUri() +"?_query=" + URLEncoder.encode(
+                "sm:chmod(xs:anyURI('" + resourcePath + "'), '" + mode + "')",
+                UTF_8.displayName());
+        final HttpURLConnection connect = getConnection(uri);
+        try {
+            connect.setRequestMethod("GET");
+            connect.setRequestProperty("Authorization", "Basic " + credentials);
+            connect.connect();
+
+            final int responseCode = connect.getResponseCode();
+            assertEquals("Server returned response code " + responseCode, HttpStatus.OK_200, responseCode);
         } finally {
             connect.disconnect();
         }


### PR DESCRIPTION
Previously Bearer Authentication was incorrectly intercepted by the `AbstractExistHttpServlet` and/or XQuery Controller (`XQueryURLRewrite`), which made custom handling of Bearer Authentication (e.g. OAuth, JWT, etc.) impossible from XQuery.

It is now possible to work with Bearer Authentication tokens directly in XQuery, so you may implement your own authentication schemes in XQuery if you wish.