### PR TITLE
[5.x.x] override resource type from backup metadata

### DIFF
--- a/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
+++ b/exist-core/src/main/java/org/exist/backup/restore/RestoreHandler.java
@@ -304,11 +304,16 @@ public class RestoreHandler extends DefaultHandler {
         }
 
         MimeType mimeType = null;
-        if (mimeTypeStr != null) {
+        if (xmlType) {
+            mimeType = MimeType.XML_TYPE;
+        } else if (mimeTypeStr != null) {
             mimeType = MimeTable.getInstance().getContentType(mimeTypeStr);
-        }
-        if (mimeType == null) {
-            mimeType = xmlType ? MimeType.XML_TYPE : MimeType.BINARY_TYPE;
+            if (mimeType == null) {
+                mimeType = MimeType.BINARY_TYPE;
+            } else if (mimeType.isXMLType() !=  xmlType) {
+                listener.warn("Calculated mime type " + mimeType + " type differs from the one specified in the backup, adjusting it");
+                mimeType = new MimeType(mimeType.getName(), xmlType ? MimeType.XML : MimeType.BINARY);
+            }
         }
 
         Date dateCreated = null;


### PR DESCRIPTION
### Description:
Fixes #4368 by using the resource type defined by the backup meta data if it differs the one defined on the mime type definition.

The current implementation does always calculate the resource type (`XMLResource`/`BinaryResource`) based on the bakcup meta data content type using the `MimeTable` instance. In the failing case the resulting resource type will be set to `XMLResource` using the currently defined type for `text/html` within the `mime-types.xml` instead of the resource type `BinaryResource` that is defined in the backup meta data. This leads to the fact that the restore task will change the resource type to a different one as has being wrote to the backup.