### PR TITLE
Docker enhancements for tools and debugging

### DIFF
--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -49,6 +49,7 @@
         <assemble.dir>${project.build.directory}/exist-docker-${project.version}-docker-dir</assemble.dir>
         <exist.uber.jar.filename>exist.uber.jar</exist.uber.jar.filename>
         <docker.tag>latest</docker.tag>
+        <docker.debug.tag>debug</docker.debug.tag>
     </properties>
 
     <dependencies>
@@ -208,6 +209,17 @@
                                     <tag>${docker.tag}</tag>
                                 </tags>
                                 <dockerFile>${project.build.outputDirectory}/Dockerfile</dockerFile>
+                                <contextDir>${assemble.dir}</contextDir>
+                            </build>
+                        </image>
+                        <image>
+                            <name>existdb/existdb:%v-DEBUG</name>
+                            <alias>exist-debug</alias>
+                            <build>
+                                <tags>
+                                    <tag>${docker.debug.tag}</tag>
+                                </tags>
+                                <dockerFile>${project.build.outputDirectory}/Dockerfile-DEBUG</dockerFile>
                                 <contextDir>${assemble.dir}</contextDir>
                             </build>
                         </image>

--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -202,7 +202,7 @@
                     <images>
                         <image>
                             <name>existdb/existdb:%v</name>
-                            <alias>exist-ci</alias>
+                            <alias>exist</alias>
                             <build>
                                 <tags>
                                     <tag>${docker.tag}</tag>

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -98,4 +98,5 @@ HEALTHCHECK CMD [ "java", \
     "--xpath", "system:get-version()" ]
 
 ENTRYPOINT [ "java", \
-    "org.exist.start.Main", "jetty" ]
+    "org.exist.start.Main"]
+CMD ["jetty" ]

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -1,0 +1,82 @@
+#
+# eXist-db Open Source Native XML Database
+# Copyright (C) 2001 The eXist-db Authors
+#
+# info@exist-db.org
+# http://www.exist-db.org
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+
+# Use JDK 8 in Debian Stretch (as our production image gcr.io/distroless/java:8 is based on Debian Stretch with just a JRE)
+FROM debian:stretch-slim
+RUN apt-get update && apt-get -y dist-upgrade
+RUN apt-get install -y openjdk-8-jdk-headless
+RUN apt-get install -y expat fontconfig     # Install tools required by FOP
+
+# Copy eXist-db
+COPY LICENSE /exist/LICENSE
+COPY autodeploy /exist/autodeploy
+COPY etc /exist/etc
+COPY lib /exist/lib
+COPY logs /exist/logs
+
+# Build-time metadata as defined at http://label-schema.org
+# and used by autobuilder @hooks/build
+LABEL org.label-schema.build-date=${build-tstamp} \
+      org.label-schema.description="${project.description} (DEBUG version)" \
+      org.label-schema.name="existdb-debug" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.url="${project.url}" \
+      org.label-schema.vcs-ref=${build-commit-abbrev} \
+      org.label-schema.vcs-url="${project.scm.url}" \
+      org.label-schema.vendor="existdb"
+
+EXPOSE 8080 8443 5005
+
+# make CACHE_MEM, MAX_BROKER, and JVM_MAX_RAM_PERCENTAGE available to users
+ARG CACHE_MEM
+ARG MAX_BROKER
+ARG JVM_MAX_RAM_PERCENTAGE
+
+ENV EXIST_HOME "/exist"
+ENV CLASSPATH=/exist/lib/${exist.uber.jar.filename}
+
+ENV JAVA_TOOL_OPTIONS \
+  -Dfile.encoding=UTF8 \
+  -Dsun.jnu.encoding=UTF-8 \
+  -Djava.awt.headless=true \
+  -Dorg.exist.db-connection.cacheSize=${CACHE_MEM:-256}M \
+  -Dorg.exist.db-connection.pool.max=${MAX_BROKER:-20} \
+  -Dlog4j.configurationFile=/exist/etc/log4j2.xml \
+  -Dexist.home=/exist \
+  -Dexist.configurationFile=/exist/etc/conf.xml \
+  -Djetty.home=/exist \
+  -Dexist.jetty.config=/exist/etc/jetty/standard.enabled-jetty-configs \
+  -XX:+UseG1GC \
+  -XX:+UseStringDeduplication \
+  -XX:+UseContainerSupport \
+  -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} \
+  -XX:+ExitOnOutOfMemoryError \
+  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+
+HEALTHCHECK CMD [ "java", \
+    "org.exist.start.Main", "client", \
+    "--no-gui",  \
+    "--user", "guest", "--password", "guest", \
+    "--xpath", "system:get-version()" ]
+
+CMD [ "java", \
+    "org.exist.start.Main", "jetty" ]


### PR DESCRIPTION
1. When using the production Docker image, you can now override the eXist-db tool that is started if you wish. It still defaults to Jetty (to start eXist-db server). e.g. to run the JAC CLI instead:
```
docker run -it existdb/existdb:latest client --no-gui
```

2. Adds a DEBUG image which can be used when developing/testing eXist-db. This is based on the same Debian stretch-slim that is used by our GCR production image.
**NOTE**: this *SHOULD* not be used for production environments.
This image has Bash, a full JDK, and enables Java Remote Debugging of eXist-db by default.

    1. Normal debug startup is like:

    ```
    docker run -it existdb/existdb:debug
    ```

    2. If for some reason you need Bash or another command:
    ```
    docker run -it existdb/existdb:debug bash
    ```
