### PR TITLE
Use Saxon for fn:matches regular expression handling.

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTokenize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTokenize.java
@@ -21,8 +21,6 @@
  */
 package org.exist.xquery.functions.fn;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.exist.dom.QName;

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTokenize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunTokenize.java
@@ -21,6 +21,8 @@
  */
 package org.exist.xquery.functions.fn;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.exist.dom.QName;

--- a/exist-core/src/test/xquery/regex.xml
+++ b/exist-core/src/test/xquery/regex.xml
@@ -50,6 +50,16 @@
         <expected>true</expected>
     </test>
     <test output="text">
+        <task>fn:matches-using-hyphen-postfix</task>
+        <code>fn:matches('aww he--', '[l-]')</code>
+        <expected>true</expected>
+    </test>
+    <test output="text">
+        <task>fn:matches-using-hyphen-prefix</task>
+        <code>fn:matches('aww he--', '[-l]')</code>
+        <expected>true</expected>
+    </test>
+    <test output="text">
         <task>fn:matches-xflag-1</task>
         <code>fn:matches('helloworld', 'hello world', 'x')</code>
         <expected>true</expected>
@@ -77,6 +87,12 @@
     <test output="text">
         <task>fn:matches-iqflags-1</task>
         <code>fn:matches("Mr. B. Obama", "B. OBAMA", "iq")</code>
+        <expected>true</expected>
+    </test>
+
+    <test output="text">
+        <task>fn:matches-jflags-1</task>
+        <code>fn:matches("(", "\p{javaMirrored}", ";j")</code>
         <expected>true</expected>
     </test>
 


### PR DESCRIPTION
Replace java Regex with Saxon  for `fn:matches`
#3633 

This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.