### PR TITLE
[4.x.x] Improve out-of-scope detection for binary variables

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentImpl.java
@@ -200,6 +200,10 @@ public class DocumentImpl extends NodeImpl<DocumentImpl> implements Document {
         return size;
     }
 
+    public long getDocId() {
+        return docId;
+    }
+
     public int addNode(final short kind, final short level, final QName qname) {
         if(nodeKind == null) {
             init();

--- a/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
@@ -757,6 +757,16 @@ public abstract class NodeImpl<T extends NodeImpl> implements INode<DocumentImpl
     }
 
     @Override
+    public boolean containsReference(final Item item) {
+        return this == item;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        return equals(item);
+    }
+
+    @Override
     public void destroy(final XQueryContext context, final Sequence contextSequence) {
     }
 

--- a/exist-core/src/main/java/org/exist/dom/persistent/AVLTreeNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/AVLTreeNodeSet.java
@@ -352,6 +352,48 @@ public class AVLTreeNodeSet extends AbstractNodeSet {
         return searchData(root, proxy) != null;
     }
 
+    @Override
+    public boolean containsReference(final Item item) {
+        if (root == null) {
+            return false;
+        }
+
+        return containsReference(root, item);
+    }
+
+    private boolean containsReference(@Nullable final Node node, final Item item) {
+        if (node == null) {
+            return false;
+        }
+
+        if (node.data == item) {
+            return true;
+        }
+
+        return containsReference(node.leftChild, item) || containsReference(node.rightChild, item);
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        if (root == null) {
+            return false;
+        }
+
+        return containsReference(root, item);
+    }
+
+    private boolean contains(@Nullable final Node node, final Item item) {
+        if (node == null) {
+            return false;
+        }
+
+        if (node.data.equals(item)) {
+            return true;
+        }
+
+        return containsReference(node.leftChild, item) || containsReference(node.rightChild, item);
+    }
+
     public void removeNode(final Node node) {
         --size;
         Node tempNode = node;

--- a/exist-core/src/main/java/org/exist/dom/persistent/EmptyNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/EmptyNodeSet.java
@@ -126,6 +126,16 @@ public final class EmptyNodeSet extends AbstractNodeSet {
         return other;
     }
 
+    @Override
+    public boolean containsReference(final Item item) {
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        return false;
+    }
+
     private static final class EmptyNodeSetIterator implements NodeSetIterator {
 
         @Override

--- a/exist-core/src/main/java/org/exist/dom/persistent/ExtArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ExtArrayNodeSet.java
@@ -38,8 +38,10 @@ import org.exist.xquery.XPathException;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.SequenceIterator;
 import org.exist.xquery.value.Type;
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
+import javax.annotation.Nullable;
 import java.util.*;
 
 /**
@@ -445,6 +447,52 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
     }
 
     @Override
+    public boolean containsReference(final Item item) {
+        if (item instanceof Node) {
+            for (int i = 0; i < partCount; i++) {
+                if (parts[i].containsReference(item)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        if (item instanceof Node) {
+            @Nullable final Document doc;
+            if (item instanceof Document) {
+                doc = (Document) item;
+            } else {
+                doc = ((Node) item).getOwnerDocument();
+            }
+
+            if (doc == null || !(doc instanceof DocumentImpl || doc instanceof org.exist.dom.memtree.DocumentImpl)) {
+                return false;
+            }
+
+            final int docId;
+            if (doc instanceof DocumentImpl) {
+                docId = ((DocumentImpl) doc).getDocId();
+            } else {
+                docId = (int) ((org.exist.dom.memtree.DocumentImpl) doc).getDocId();
+            }
+
+            if (ArrayUtils.binarySearch(documentIds, docId, partCount) == -1) {
+                return false;
+            }
+
+            for (int i = 0; i < partCount; i++) {
+                if (parts[i].contains(item)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
     public NodeSet docsToNodeSet() {
         final NodeSet result = new ExtArrayNodeSet(partCount);
         for (int i = 0; i < partCount; i++) {
@@ -652,6 +700,26 @@ public class ExtArrayNodeSet extends AbstractArrayNodeSet implements DocumentSet
 
         boolean contains(final NodeId nodeId) {
             return get(nodeId) != null;
+        }
+
+        boolean containsReference(final Item item) {
+            for (int i = 0; i < length; i++) {
+                final NodeProxy p = array[i];
+                if (p == item) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        boolean contains(final Item item) {
+            for (int i = 0; i < length; i++) {
+                final NodeProxy p = array[i];
+                if (p.equals(item)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         NodeProxy get(final int pos) {

--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -22,6 +22,7 @@
 package org.exist.dom.persistent;
 
 import org.exist.collections.Collection;
+import org.exist.dom.INode;
 import org.exist.numbering.NodeId;
 import org.exist.storage.DBBroker;
 import org.exist.storage.lock.Lock;
@@ -35,8 +36,10 @@ import org.exist.xquery.XPathException;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.SequenceIterator;
 import org.exist.xquery.value.Type;
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
+import javax.annotation.Nullable;
 import java.util.*;
 
 /**
@@ -212,6 +215,72 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
             return false;
         }
         return get(idx, proxy.getNodeId()) != null;
+    }
+
+    @Override
+    public boolean containsReference(final Item item) {
+        sort();
+        if (item instanceof Node) {
+            @Nullable final Document doc;
+            if (item instanceof Document) {
+                doc = (Document) item;
+            } else {
+                doc = ((Node) item).getOwnerDocument();
+            }
+
+            if (doc == null || !(doc instanceof DocumentImpl || doc instanceof org.exist.dom.memtree.DocumentImpl)) {
+                return false;
+            }
+
+            final int docId;
+            if (doc instanceof DocumentImpl) {
+                docId = ((DocumentImpl) doc).getDocId();
+            } else {
+                docId = (int) ((org.exist.dom.memtree.DocumentImpl) doc).getDocId();
+            }
+
+            final int idx = findDoc(docId);
+            if (idx < 0) {
+                return false;
+            }
+
+            return get(idx, ((INode) item).getNodeId()) == item;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        sort();
+        if (item instanceof Node) {
+            @Nullable final Document doc;
+            if (item instanceof Document) {
+                doc = (Document) item;
+            } else {
+                doc = ((Node) item).getOwnerDocument();
+            }
+
+            if (doc == null || !(doc instanceof DocumentImpl || doc instanceof org.exist.dom.memtree.DocumentImpl)) {
+                return false;
+            }
+
+            final int docId;
+            if (doc instanceof DocumentImpl) {
+                docId = ((DocumentImpl) doc).getDocId();
+            } else {
+                docId = (int) ((org.exist.dom.memtree.DocumentImpl) doc).getDocId();
+            }
+
+            final int idx = findDoc(docId);
+            if (idx < 0) {
+                return false;
+            }
+
+            return get(idx, ((INode) item).getNodeId()).equals(item);
+        }
+
+        return false;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -985,6 +985,16 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     }
 
     @Override
+    public boolean containsReference(final Item item) {
+        return this == item;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        return this.equals(item);
+    }
+
+    @Override
     public void destroy(final XQueryContext context, final Sequence contextSequence) {
         // Nothing to do
     }

--- a/exist-core/src/main/java/org/exist/dom/persistent/SortedNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/SortedNodeSet.java
@@ -143,6 +143,28 @@ public class SortedNodeSet extends AbstractNodeSet {
     }
 
     @Override
+    public boolean containsReference(final Item item) {
+        for (final Iterator<IteratorItem> i = list.iterator(); i.hasNext();) {
+            final NodeProxy p = (i.next()).proxy;
+            if (p == item) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        for (final Iterator<IteratorItem> i = list.iterator(); i.hasNext();) {
+            final NodeProxy p = (i.next()).proxy;
+            if (p.equals(item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public NodeProxy get(final int pos) {
         final IteratorItem item = (IteratorItem) list.get(pos);
         return item == null ? null : item.proxy;

--- a/exist-core/src/main/java/org/exist/dom/persistent/VirtualNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/VirtualNodeSet.java
@@ -120,10 +120,7 @@ public class VirtualNodeSet extends AbstractNodeSet {
         }
 
         final NodeProxy firstParent = getFirstParent((NodeProxy) item, null, axis == Constants.SELF_AXIS, 0);
-        if (firstParent == item) {
-            return true;
-        }
-        return false;
+        return firstParent == item;
     }
 
     @Override
@@ -133,10 +130,7 @@ public class VirtualNodeSet extends AbstractNodeSet {
         }
 
         final NodeProxy firstParent = getFirstParent((NodeProxy) item, null, axis == Constants.SELF_AXIS, 0);
-        if (firstParent.equals(item)) {
-            return true;
-        }
-        return false;
+        return firstParent.equals(item);
     }
 
     public void setInPredicate(final boolean predicate) {

--- a/exist-core/src/main/java/org/exist/dom/persistent/VirtualNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/VirtualNodeSet.java
@@ -112,6 +112,33 @@ public class VirtualNodeSet extends AbstractNodeSet {
         return false;
     }
 
+
+    @Override
+    public boolean containsReference(final Item item) {
+        if (!(item instanceof NodeProxy)) {
+            return false;
+        }
+
+        final NodeProxy firstParent = getFirstParent((NodeProxy) item, null, axis == Constants.SELF_AXIS, 0);
+        if (firstParent == item) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        if (!(item instanceof NodeProxy)) {
+            return false;
+        }
+
+        final NodeProxy firstParent = getFirstParent((NodeProxy) item, null, axis == Constants.SELF_AXIS, 0);
+        if (firstParent.equals(item)) {
+            return true;
+        }
+        return false;
+    }
+
     public void setInPredicate(final boolean predicate) {
         inPredicate = predicate;
     }

--- a/exist-core/src/main/java/org/exist/xquery/FunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionCall.java
@@ -448,7 +448,16 @@ public class FunctionCall extends Function {
                 context.popDocumentContext();
             }
         }
-        
+
+        @Override
+        public boolean containsReference(final Item item) {
+            return this == item;
+        }
+
+        @Override
+        public boolean contains(final Item item) {
+            return this.equals(item);
+        }
     }
     
     protected void setRecursive(boolean recursive) {

--- a/exist-core/src/main/java/org/exist/xquery/RangeSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/RangeSequence.java
@@ -11,6 +11,8 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceIterator;
 import org.exist.xquery.value.Type;
 
+import java.math.BigInteger;
+
 public class RangeSequence extends AbstractSequence {
 
     private final static Logger LOG = LogManager.getLogger(AbstractSequence.class);
@@ -187,7 +189,26 @@ public class RangeSequence extends AbstractSequence {
     public void removeDuplicates() {
     }
 
-	/**
+    @Override
+    public boolean containsReference(final Item item) {
+        return start == item || end == item;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        if (item instanceof IntegerValue) {
+            try {
+                final BigInteger other = item.toJavaObject(BigInteger.class);
+                return other.compareTo(start.toJavaObject(BigInteger.class)) >= 0
+                        && other.compareTo(end.toJavaObject(BigInteger.class)) <= 0;
+            } catch (final XPathException e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    /**
 	 * Generates a string representation of the Range Sequence.
 	 *
 	 * Range sequences can potentially be

--- a/exist-core/src/main/java/org/exist/xquery/RangeSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/RangeSequence.java
@@ -202,6 +202,7 @@ public class RangeSequence extends AbstractSequence {
                 return other.compareTo(start.toJavaObject(BigInteger.class)) >= 0
                         && other.compareTo(end.toJavaObject(BigInteger.class)) <= 0;
             } catch (final XPathException e) {
+                LOG.warn(e.getMessage(), e);
                 return false;
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayType.java
@@ -325,10 +325,9 @@ public class ArrayType extends FunctionReference implements Lookup.LookupSupport
     public boolean containsReference(final Item item) {
         for (int i = 0; i < vector.length(); i++) {
             final Sequence value = vector.nth(i);
-            if (value == item) {
+            if (value == item || value.containsReference(item)) {
                 return true;
             }
-            return value.containsReference(item);
         }
         return false;
     }
@@ -337,10 +336,9 @@ public class ArrayType extends FunctionReference implements Lookup.LookupSupport
     public boolean contains(final Item item) {
         for (int i = 0; i < vector.length(); i++) {
             final Sequence value = vector.nth(i);
-            if (value.equals(item)) {
+            if (value.equals(item) || value.contains(item)) {
                 return true;
             }
-            return value.contains(item);
         }
         return false;
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayType.java
@@ -321,6 +321,26 @@ public class ArrayType extends FunctionReference implements Lookup.LookupSupport
         return flatten ? flatten(input, new ValueSequence(input.getItemCount() * 2)) : input;
     }
 
+    @Override
+    public boolean containsReference(final Item item) {
+        for (int i = 0; i < vector.length(); i++) {
+            if (vector.nth(i) == item) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        for (int i = 0; i < vector.length(); i++) {
+            if (vector.nth(i).equals(item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * The accessor function which will be evaluated if the map is called
      * as a function item.

--- a/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayType.java
@@ -324,9 +324,11 @@ public class ArrayType extends FunctionReference implements Lookup.LookupSupport
     @Override
     public boolean containsReference(final Item item) {
         for (int i = 0; i < vector.length(); i++) {
-            if (vector.nth(i) == item) {
+            final Sequence value = vector.nth(i);
+            if (value == item) {
                 return true;
             }
+            return value.containsReference(item);
         }
         return false;
     }
@@ -334,9 +336,11 @@ public class ArrayType extends FunctionReference implements Lookup.LookupSupport
     @Override
     public boolean contains(final Item item) {
         for (int i = 0; i < vector.length(); i++) {
-            if (vector.nth(i).equals(item)) {
+            final Sequence value = vector.nth(i);
+            if (value.equals(item)) {
                 return true;
             }
+            return value.contains(item);
         }
         return false;
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapExpr.java
@@ -77,12 +77,21 @@ public class MapExpr extends AbstractExpression {
     @Override
     public void dump(final ExpressionDumper dumper) {
         dumper.display("map {");
-        for (final Mapping mapping : this.mappings) {
+        for (int i = 0; i < this.mappings.size(); i++) {
+            final Mapping mapping = this.mappings.get(i);
+            if (i > 0) {
+                dumper.display(", ");
+            }
             mapping.key.dump(dumper);
-            dumper.display(" := ");
+            dumper.display(" : ");
             mapping.value.dump(dumper);
         }
         dumper.display("}");
+    }
+
+    @Override
+    public String toString() {
+        return ExpressionDumper.dump(this);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
@@ -98,7 +98,10 @@ public class MapType extends AbstractMapType {
     public boolean containsReference(final Item item) {
         for (final Iterator<Map.Entry<AtomicValue, Sequence>> it = map.iterator(); it.hasNext();) {
             final Sequence value = it.next().getValue();
-            return value == item;
+            if (value == item) {
+                return true;
+            }
+            return value.containsReference(item);
         }
         return false;
     }
@@ -107,7 +110,10 @@ public class MapType extends AbstractMapType {
     public boolean contains(final Item item) {
         for (final Iterator<Map.Entry<AtomicValue, Sequence>> it = map.iterator(); it.hasNext();) {
             final Sequence value = it.next().getValue();
-            return value.equals(item);
+            if (value.equals(item)) {
+                return true;
+            }
+            return value.contains(item);
         }
         return false;
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
@@ -94,6 +94,24 @@ public class MapType extends AbstractMapType {
         return this.map.containsKey(key);
     }
 
+    @Override
+    public boolean containsReference(final Item item) {
+        for (final Iterator<Map.Entry<AtomicValue, Sequence>> it = map.iterator(); it.hasNext();) {
+            final Sequence value = it.next().getValue();
+            return value == item;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        for (final Iterator<Map.Entry<AtomicValue, Sequence>> it = map.iterator(); it.hasNext();) {
+            final Sequence value = it.next().getValue();
+            return value.equals(item);
+        }
+        return false;
+    }
+
     public Sequence keys() {
         final ValueSequence seq = new ValueSequence();
         for (final Map.Entry<AtomicValue, Sequence> entry: this.map) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
@@ -98,10 +98,9 @@ public class MapType extends AbstractMapType {
     public boolean containsReference(final Item item) {
         for (final Iterator<Map.Entry<AtomicValue, Sequence>> it = map.iterator(); it.hasNext();) {
             final Sequence value = it.next().getValue();
-            if (value == item) {
+            if (value == item || value.containsReference(item)) {
                 return true;
             }
-            return value.containsReference(item);
         }
         return false;
     }
@@ -110,10 +109,9 @@ public class MapType extends AbstractMapType {
     public boolean contains(final Item item) {
         for (final Iterator<Map.Entry<AtomicValue, Sequence>> it = map.iterator(); it.hasNext();) {
             final Sequence value = it.next().getValue();
-            if (value.equals(item)) {
+            if (value.equals(item) || value.contains(item)) {
                 return true;
             }
-            return value.contains(item);
         }
         return false;
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/AtomicValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/AtomicValue.java
@@ -348,6 +348,16 @@ public abstract class AtomicValue implements Item, Sequence, Indexable {
     }
 
     @Override
+    public boolean containsReference(final Item item) {
+        return this == item;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        return equals(item);
+    }
+
+    @Override
     public void destroy(final XQueryContext context, final Sequence contextSequence) {
         // nothing to be done by default
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromFile.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromFile.java
@@ -125,8 +125,7 @@ public class BinaryValueFromFile extends BinaryValue {
     @Override
     public void destroy(final XQueryContext context, final Sequence contextSequence) {
         // do not close if this object is part of the contextSequence
-        if (contextSequence == this ||
-                (contextSequence instanceof ValueSequence && ((ValueSequence) contextSequence).containsValue(this))) {
+        if (contextSequence == this || contextSequence.containsReference(this)) {
             return;
         }
         try {

--- a/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromInputStream.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromInputStream.java
@@ -100,8 +100,7 @@ public class BinaryValueFromInputStream extends BinaryValue {
     @Override
     public void destroy(XQueryContext context, final Sequence contextSequence) {
         // do not close if this object is part of the contextSequence
-        if (contextSequence == this
-                || (contextSequence instanceof ValueSequence && ((ValueSequence) contextSequence).containsValue(this))) {
+        if (contextSequence == this || contextSequence.containsReference(this)) {
             return;
         }
         LOG.debug("Closing input stream");

--- a/exist-core/src/main/java/org/exist/xquery/value/EmptySequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/EmptySequence.java
@@ -93,6 +93,16 @@ public class EmptySequence extends AbstractSequence {
     }
 
     @Override
+    public boolean containsReference(final Item item) {
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "()";
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/OrderedValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/OrderedValueSequence.java
@@ -290,6 +290,28 @@ public class OrderedValueSequence extends AbstractSequence {
         return true;
     }
 
+    @Override
+    public boolean containsReference(final Item item) {
+        for (final SequenceIterator it = iterate(); it.hasNext(); ) {
+            final Item i = it.nextItem();
+            if (i == item) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        for (final SequenceIterator it = iterate(); it.hasNext(); ) {
+            final Item i = it.nextItem();
+            if (i.equals(item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private class Entry implements Comparable<Entry> {
         Item item;
         AtomicValue values[];

--- a/exist-core/src/main/java/org/exist/xquery/value/PreorderedValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/PreorderedValueSequence.java
@@ -139,6 +139,28 @@ public class PreorderedValueSequence extends AbstractSequence {
         // TODO: is this ever relevant?
     }
 
+    @Override
+    public boolean containsReference(final Item item) {
+        for (final SequenceIterator it = iterate(); it.hasNext(); ) {
+            final Item i = it.nextItem();
+            if (i == item) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        for (final SequenceIterator it = iterate(); it.hasNext(); ) {
+            final Item i = it.nextItem();
+            if (i.equals(item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void sort() {
         Arrays.sort(nodes, new OrderedComparator());
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/Sequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Sequence.java
@@ -291,6 +291,24 @@ public interface Sequence {
     boolean hasChanged(int previousState);
 
     /**
+     * Returns true if the sequence contains the item.
+     *
+     * NOTE that comparison is done via reference equality.
+     *
+     * @return true if the item is within the sequence, false otherwise.
+     */
+    boolean containsReference(Item item);
+
+    /**
+     * Returns true if the sequence contains the item.
+     *
+     * NOTE that comparison is done via object equality.
+     *
+     * @return true if the item is within the sequence, false otherwise.
+     */
+    boolean contains(Item item);
+
+    /**
      * Clean up any resources used by the items in this sequence.
      */
     void destroy(XQueryContext context, Sequence contextSequence);

--- a/exist-core/src/main/java/org/exist/xquery/value/SubSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SubSequence.java
@@ -434,6 +434,7 @@ public class SubSequence extends AbstractSequence {
             }
             return false;
         } catch (final XPathException e) {
+            LOG.warn(e.getMessage(), e);
             return false;
         }
     }
@@ -449,6 +450,7 @@ public class SubSequence extends AbstractSequence {
             }
             return false;
         } catch (final XPathException e) {
+            LOG.warn(e.getMessage(), e);
             return false;
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/SubSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SubSequence.java
@@ -424,6 +424,36 @@ public class SubSequence extends AbstractSequence {
     }
 
     @Override
+    public boolean containsReference(final Item item) {
+        try {
+            for (final SequenceIterator it = iterate(); it.hasNext(); ) {
+                final Item i = it.nextItem();
+                if (i == item) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (final XPathException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        try {
+            for (final SequenceIterator it = iterate(); it.hasNext(); ) {
+                final Item i = it.nextItem();
+                if (i.equals(item)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (final XPathException e) {
+            return false;
+        }
+    }
+
+    @Override
     public void destroy(final XQueryContext context, final Sequence contextSequence) {
         sequence.destroy(context, contextSequence);
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/ValueSequence.java
@@ -382,9 +382,20 @@ public class ValueSequence extends AbstractSequence implements MemoryNodeSet {
         }
     }
 
-    public boolean containsValue(final AtomicValue value) {
+    @Override
+    public boolean containsReference(final Item item) {
         for (int i = 0; i <= size; i++) {
-            if (values[i] == value) {
+            if (values[i] == item) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean contains(final Item item) {
+        for (int i = 0; i <= size; i++) {
+            if (values[i].equals(item)) {
                 return true;
             }
         }


### PR DESCRIPTION
This PR fixes *some* cases where `xs:base64Binary` value variables within an XQuery are cleared before they should be.

# Diagnosis of the problem

If you have a function which returns a Map containing an `xs:base64Binary` (specifically the result of an EXPath HTTP Client response), and then you try and use that value in a calling function you will encounter an error where the temporary file backing the xs:base64Binary value has incorrectly already been deleted.

What is happening is:

1. The EXPath HTTP Client response constructs an `xs:base64Binary` value using `org.exist.xquery.value.BinaryValueFromFile`.
2. `BinaryValueFromFile` stores the binary data in a temporary file.
3. When the xs:base64BinaryValue is returned from the function inside a Map, eXist-db does not recognise it is inside a Map, and so incorrectly assumes it is no longer required and calls `destroy` on the variable; this is done to clean up variables that are no longer needed.
4. The destroy call on the variable, causes `BinaryValueFromFile` to delete the temporary file.
5. When we try and use the value in the Map returned by the function, the binary value cannot be read from the temporary file because it was deleted in the previous step.

# Further work in Future
Ultimately, how eXist-db determines whether a Variable is still "in-scope" or "out-of-scope" within an XQuery is far too limited and does not match the semantics of the XQuery language specifications.
The current implementation of this in eXist-db is mostly within `XQueryContext#markLocalVariables` and `XQueryContext#popLocalVariables`.

Fixing this completely would require substantiate changes to both eXist-db's XQuery Parser and Interpreter.

# Post-script
It is not possible to write a test for this with the way that eXist-db is currently structured. A test for this should be in the Core module. However, the only way I have found to easily trigger it is via the EXPath HTTP Client which is itself in Extension Modules. To introduce a dependency between Core and Extension Modules, when there is already a dependency between Extension Modules and Core would cause a cycle in the build graph (and the build would be rejected by Maven).