### PR TITLE
Fix div operator error when arg is a variable.

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/OpNumeric.java
+++ b/exist-core/src/main/java/org/exist/xquery/OpNumeric.java
@@ -78,7 +78,11 @@ public class OpNumeric extends BinaryOp {
             } else if (ltype == Type.NUMBER || rtype == Type.NUMBER) {
                 // if one of both operands returns a number, we can safely assume
                 // the return type of the whole expression will be a number
-                returnType = Type.NUMBER;
+                if(operator == ArithmeticOperator.DIVISION) {
+                    returnType = Type.DECIMAL;
+                }else {
+                    returnType = Type.NUMBER;
+                }
             }
         }
         add(left);

--- a/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
@@ -2510,6 +2510,41 @@ public class XQueryTest {
         assertEquals(query, "INF",
                 result.getResource(0).getContent().toString());
     }
+
+    /**
+     * @see https://github.com/eXist-db/exist/issues/3441
+     */
+    @Test
+    public void divErrorArgVariable() throws XMLDBException {
+        String query = "let $x := 2 " +
+                "return 1 div $x * 4";
+
+        XPathQueryService service = (XPathQueryService) getTestCollection().getService("XPathQueryService", "1.0");
+        ResourceSet result = service.query(query);
+
+        assertEquals(1, result.getSize());
+
+        assertEquals(query, "2", result.getResource(0).getContent().toString());
+
+    }
+
+    /**
+            * @see https://github.com/eXist-db/exist/issues/3441
+            */
+    @Test
+    public void divErrorArgVariable2() throws XMLDBException {
+        String query = "let $x := 2 \n" +
+                "let $y := 1 div $x * 4\n" +
+                "return $y";
+
+        XPathQueryService service = (XPathQueryService) getTestCollection().getService("XPathQueryService", "1.0");
+        ResourceSet result = service.query(query);
+
+        assertEquals(1, result.getSize());
+
+        assertEquals(query, "2", result.getResource(0).getContent().toString());
+
+    }
     
     /**
      * @see http://sourceforge.net/support/tracker.php?aid=1841635


### PR DESCRIPTION
Fix #3441.

This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/