### PR TITLE
Fix numerous bugs in numeric operations

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/ValueComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/ValueComparison.java
@@ -76,7 +76,7 @@ public class ValueComparison extends GeneralComparison {
 			final AtomicValue rv = rs.itemAt(0).atomize();
             final Collator collator = getCollator(contextSequence);
 			return BooleanValue.valueOf(compareAtomic(collator, lv, rv, StringTruncationOperator.NONE, relation));
-		} 
+		}
         throw new XPathException(this, ErrorCodes.XPTY0004, "Type error: sequence with more than one item is not allowed here");
 	}
 

--- a/exist-core/src/main/java/org/exist/xquery/value/DecimalValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DecimalValue.java
@@ -283,7 +283,8 @@ public class DecimalValue extends NumericValue {
         } else if (other instanceof DoubleValue) {
             comparison = () -> value.compareTo(BigDecimal.valueOf(((DoubleValue)other).value));
         } else if (other instanceof FloatValue) {
-            comparison = () -> value.compareTo(BigDecimal.valueOf(((FloatValue)other).value));
+            final BigDecimal otherPromoted = new BigDecimal(Float.toString(((FloatValue)other).value));
+            comparison = () -> value.compareTo(otherPromoted);
         } else {
             return null;
         }
@@ -361,10 +362,8 @@ public class DecimalValue extends NumericValue {
         return round(precision, DecimalValue.DEFAULT_ROUNDING_MODE);
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.value.NumericValue#minus(org.exist.xquery.value.NumericValue)
-     */
-    public ComputableValue minus(ComputableValue other) throws XPathException {
+    @Override
+    public ComputableValue minus(final ComputableValue other) throws XPathException {
         switch (other.getType()) {
             case Type.DECIMAL:
                 return new DecimalValue(value.subtract(((DecimalValue) other).value));
@@ -375,10 +374,8 @@ public class DecimalValue extends NumericValue {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.value.NumericValue#plus(org.exist.xquery.value.NumericValue)
-     */
-    public ComputableValue plus(ComputableValue other) throws XPathException {
+    @Override
+    public ComputableValue plus(final ComputableValue other) throws XPathException {
         switch (other.getType()) {
             case Type.DECIMAL:
                 return new DecimalValue(value.add(((DecimalValue) other).value));

--- a/exist-core/src/test/java/xquery/numericOp/NumericOpTests.java
+++ b/exist-core/src/test/java/xquery/numericOp/NumericOpTests.java
@@ -1,0 +1,32 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package xquery.numericOp;
+
+import org.exist.test.runner.XSuite;
+import org.junit.runner.RunWith;
+
+@RunWith(XSuite.class)
+@XSuite.XSuiteFiles({
+    "src/test/xquery/numericOp"
+})
+public class NumericOpTests {
+}

--- a/exist-core/src/test/xquery/numericOp/numeric-add.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-add.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the op:numeric-add operator.
+ :)
+module namespace ona = "http://exist-db.org/test/op-numeric-add";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("2.2599999952316283")
+function ona:numeric-add-float-double($f as xs:float, $d as xs:double) {
+    $f + $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("2.2599999952316283")
+function ona:numeric-add-double-float($d as xs:double, $f as xs:float) {
+    $d + $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("2.26")
+function ona:numeric-add-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d + $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("2.26")
+function ona:numeric-add-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec + $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("2.26")
+function ona:numeric-add-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec + $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("2.26")
+function ona:numeric-add-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f + $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-divide.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-divide.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the op:numeric-divide operator.
+ :)
+module namespace ond = "http://exist-db.org/test/op-numeric-divide";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0.9999999957802023")
+function ond:numeric-divide-float-double($f as xs:float, $d as xs:double) {
+    $f div $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1.0000000042197978")
+function ond:numeric-divide-double-float($d as xs:double, $f as xs:float) {
+    $d div $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1")
+function ond:numeric-divide-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d div $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1")
+function ond:numeric-divide-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec div $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1")
+function ond:numeric-divide-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec div $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1")
+function ond:numeric-divide-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f div $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-equal.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-equal.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the op:numeric-equal operator.
+ :)
+module namespace one = "http://exist-db.org/test/op-numeric-equal";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function one:numeric-equal-float-double($f as xs:float, $d as xs:double) {
+    $f eq $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function one:numeric-equal-double-float($d as xs:double, $f as xs:float) {
+    $d eq $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function one:numeric-equal-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d eq $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function one:numeric-equal-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec eq $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function one:numeric-equal-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec eq $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function one:numeric-equal-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f eq $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-greater-than-or-equal.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-greater-than-or-equal.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the "ge" operator.
+ :)
+module namespace onge = "http://exist-db.org/test/op-numeric-greater-than-or-equal";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onge:numeric-greater-than-or-equal-float-double($f as xs:float, $d as xs:double) {
+    $f ge $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onge:numeric-greater-than-or-equal-double-float($d as xs:double, $f as xs:float) {
+    $d ge $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onge:numeric-greater-than-or-equal-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d ge $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onge:numeric-greater-than-or-equal-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec ge $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onge:numeric-greater-than-or-equal-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec ge $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onge:numeric-greater-than-or-equal-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f ge $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-greater-than.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-greater-than.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the op:numeric-greater-than operator.
+ :)
+module namespace ongt = "http://exist-db.org/test/op-numeric-greater-than";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function ongt:numeric-greater-than-float-double($f as xs:float, $d as xs:double) {
+    $f gt $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function ongt:numeric-greater-than-double-float($d as xs:double, $f as xs:float) {
+    $d gt $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function ongt:numeric-greater-than-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d gt $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function ongt:numeric-greater-than-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec gt $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function ongt:numeric-greater-than-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec gt $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function ongt:numeric-greater-than-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f gt $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-integer-divide.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-integer-divide.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the op:numeric-integer-divide operator.
+ :)
+module namespace onid = "http://exist-db.org/test/op-numeric-integer-divide";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0")
+function onid:numeric-integer-divide-float-double($f as xs:float, $d as xs:double) {
+    $f idiv $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1")
+function onid:numeric-integer-divide-double-float($d as xs:double, $f as xs:float) {
+    $d idiv $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1")
+function onid:numeric-integer-divide-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d idiv $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1")
+function onid:numeric-integer-divide-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec idiv $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1")
+function onid:numeric-integer-divide-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec idiv $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1")
+function onid:numeric-integer-divide-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f idiv $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-less-than-or-equal.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-less-than-or-equal.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the "le" operator.
+ :)
+module namespace onle = "http://exist-db.org/test/op-numeric-less-than-or-equal";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onle:numeric-less-than-or-equal-float-double($f as xs:float, $d as xs:double) {
+    $f le $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onle:numeric-less-than-or-equal-double-float($d as xs:double, $f as xs:float) {
+    $d le $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onle:numeric-less-than-or-equal-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d le $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onle:numeric-less-than-or-equal-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec le $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onle:numeric-less-than-or-equal-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec le $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onle:numeric-less-than-or-equal-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f le $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-less-than.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-less-than.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the op:numeric-less-than operator.
+ :)
+module namespace onlt = "http://exist-db.org/test/op-numeric-less-than";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onlt:numeric-less-than-float-double($f as xs:float, $d as xs:double) {
+    $f lt $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onlt:numeric-less-than-double-float($d as xs:double, $f as xs:float) {
+    $d lt $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onlt:numeric-less-than-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d lt $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onlt:numeric-less-than-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec lt $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onlt:numeric-less-than-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec lt $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onlt:numeric-less-than-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f lt $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-mod.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-mod.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the op:numeric-multiply operator.
+ :)
+module namespace onmod = "http://exist-db.org/test/op-numeric-mod";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1.1299999952316284")
+function onmod:numeric-mod-float-double($f as xs:float, $d as xs:double) {
+    $f mod $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("4.76837147544984E-9")
+function onmod:numeric-mod-double-float($d as xs:double, $f as xs:float) {
+    $d mod $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0")
+function onmod:numeric-mod-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d mod $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0")
+function onmod:numeric-mod-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec mod $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0")
+function onmod:numeric-mod-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec mod $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0")
+function onmod:numeric-mod-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f mod $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-multiply.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-multiply.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the op:numeric-multiply operator.
+ :)
+module namespace onm = "http://exist-db.org/test/op-numeric-multiply";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1.27689999461174")
+function onm:numeric-multiply-float-double($f as xs:float, $d as xs:double) {
+    $f * $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1.27689999461174")
+function onm:numeric-multiply-double-float($d as xs:double, $f as xs:float) {
+    $d * $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1.2768999999999997")
+function onm:numeric-multiply-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d * $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1.2768999999999997")
+function onm:numeric-multiply-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec * $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1.2768999")
+function onm:numeric-multiply-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec * $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("1.2768999")
+function onm:numeric-multiply-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f * $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-not-equal.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-not-equal.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the "ne" operator.
+ :)
+module namespace onne = "http://exist-db.org/test/op-numeric-not-equal";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onne:numeric-not-equal-float-double($f as xs:float, $d as xs:double) {
+    $f ne $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertTrue
+function onne:numeric-not-equal-double-float($d as xs:double, $f as xs:float) {
+    $d ne $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onne:numeric-not-equal-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d ne $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onne:numeric-not-equal-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec ne $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onne:numeric-not-equal-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec ne $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertFalse
+function onne:numeric-not-equal-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f ne $dec
+};

--- a/exist-core/src/test/xquery/numericOp/numeric-subtract.xqm
+++ b/exist-core/src/test/xquery/numericOp/numeric-subtract.xqm
@@ -1,0 +1,71 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Tests for the op:numeric-subtract operator.
+ :)
+module namespace ons = "http://exist-db.org/test/op-numeric-subtract";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("-4.76837147544984E-9")
+function ons:numeric-subtract-float-double($f as xs:float, $d as xs:double) {
+    $f - $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("4.76837147544984E-9")
+function ons:numeric-subtract-double-float($d as xs:double, $f as xs:float) {
+    $d - $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0")
+function ons:numeric-subtract-double-decimal($d as xs:double, $dec as xs:decimal) {
+    $d - $dec
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0")
+function ons:numeric-subtract-decimal-double($dec as xs:decimal, $d as xs:double) {
+    $dec - $d
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0")
+function ons:numeric-subtract-decimal-float($dec as xs:decimal, $f as xs:float) {
+    $dec - $f
+};
+
+declare
+    %test:args("1.13", "1.13")
+    %test:assertEquals("0")
+function ons:numeric-subtract-float-decimal($f as xs:float, $dec as xs:decimal) {
+    $f - $dec
+};


### PR DESCRIPTION
It seems eXist-db had quite a lot of bugs in its numeric operations, most of these were around missing type promotions. This PR adds 72 tests and a bunch of fixes.

This was previously leading to false negatives in seemingly unrelated XQTS tests.
Closes https://github.com/eXist-db/exist-xqts-runner/issues/23

https://i.pinimg.com/originals/9f/7d/89/9f7d89ea2c67cb6cb0daf85fa7e52e0a.png