### PR TITLE
Implement the fn:collation-key XQuery function

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
@@ -52,6 +52,7 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(FunCeiling.signature, FunCeiling.class),
         new FunctionDef(FunCodepointEqual.signature, FunCodepointEqual.class),
         new FunctionDef(FunCodepointsToString.signature, FunCodepointsToString.class),
+        new FunctionDef(FunCollationKey.FS_COLLATION_KEY_SIGNATURES[0], FunCollationKey.class),
         new FunctionDef(FunCompare.signatures[0], FunCompare.class),
         new FunctionDef(FunCompare.signatures[1], FunCompare.class),
         new FunctionDef(FunConcat.signature, FunConcat.class),

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FnModule.java
@@ -53,6 +53,7 @@ public class FnModule extends AbstractInternalModule {
         new FunctionDef(FunCodepointEqual.signature, FunCodepointEqual.class),
         new FunctionDef(FunCodepointsToString.signature, FunCodepointsToString.class),
         new FunctionDef(FunCollationKey.FS_COLLATION_KEY_SIGNATURES[0], FunCollationKey.class),
+        new FunctionDef(FunCollationKey.FS_COLLATION_KEY_SIGNATURES[1], FunCollationKey.class),
         new FunctionDef(FunCompare.signatures[0], FunCompare.class),
         new FunctionDef(FunCompare.signatures[1], FunCompare.class),
         new FunctionDef(FunConcat.signature, FunConcat.class),

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
@@ -73,7 +73,7 @@ public class FunCollationKey extends BasicFunction {
                                 new String(collator.getCollationKey(source).toByteArray()).getBytes(StandardCharsets.UTF_8)))) {
             sequence = binaryValue.convertTo(new Base64BinaryValueType());
         } catch (IOException e) {
-            throw new XPathException(e);
+            return null;
         }
         return sequence;
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
@@ -23,7 +23,6 @@
 package org.exist.xquery.functions.fn;
 
 import org.apache.commons.codec.binary.Base64;
-import org.exist.dom.QName;
 import org.exist.util.Collations;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
@@ -33,6 +32,7 @@ import com.ibm.icu.text.Collator;
 import java.nio.charset.StandardCharsets;
 
 import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.functions.fn.FnModule.functionSignatures;
 
 public class FunCollationKey extends BasicFunction {
 
@@ -66,9 +66,5 @@ public class FunCollationKey extends BasicFunction {
 
         return new BinaryValueFromBinaryString(new Base64BinaryValueType(), Base64.encodeBase64String(
                 (collator == null) ? source.getBytes(StandardCharsets.UTF_8) : new String(collator.getCollationKey(source).toByteArray()).getBytes(StandardCharsets.UTF_8))).convertTo(new Base64BinaryValueType());
-    }
-
-    private static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
-        return FunctionDSL.functionSignatures(new QName(name, Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX), description, returnType, variableParamTypes);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
@@ -65,7 +65,7 @@ public class FunCollationKey extends BasicFunction {
         final Collator collator = (args.length >= 2) ? Collations.getCollationFromURI(args[1].itemAt(0).toString()) : null;
 
         return new BinaryValueFromBinaryString(new Base64BinaryValueType(), Base64.encodeBase64String(
-                (collator == null) ? source.getBytes(StandardCharsets.UTF_8) : new String(collator.getCollationKey(source).toByteArray()).getBytes(StandardCharsets.UTF_8)));
+                (collator == null) ? source.getBytes(StandardCharsets.UTF_8) : new String(collator.getCollationKey(source).toByteArray()).getBytes(StandardCharsets.UTF_8))).convertTo(new Base64BinaryValueType());
     }
 
     private static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
@@ -61,8 +61,8 @@ public class FunCollationKey extends BasicFunction {
     }
 
     public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
-        final String source = (args.length >= 1) ? args[0].toString() : "";
-        final Collator collator = (args.length >= 2) ? Collations.getCollationFromURI(args[1].toString()) : null;
+        final String source = (args.length >= 1) ? args[0].itemAt(0).toString() : "";
+        final Collator collator = (args.length >= 2) ? Collations.getCollationFromURI(args[1].itemAt(0).toString()) : null;
 
         return new BinaryValueFromBinaryString(new Base64BinaryValueType(), Base64.encodeBase64String(
                 (collator == null) ? source.getBytes(StandardCharsets.UTF_8) : new String(collator.getCollationKey(source).toByteArray()).getBytes(StandardCharsets.UTF_8)));

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
@@ -65,21 +65,10 @@ public class FunCollationKey extends BasicFunction {
     }
 
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-        final BinaryValue result;
         final String source = (args.length >= 1) ? args[0].toString() : "";
-        final Collator collator;
-        if (args.length >= 2) {
-            collator = Collations.getCollationFromURI(args[1].toString());
-            if (collator == null) {
-                throw new XPathException(ErrorCodes.FOCH0002, "Unsupported collation: " + args[1]);
-            }
-        } else {
-            collator = context.getDefaultCollator();
-            if (collator == null) {
-                throw new XPathException(ErrorCodes.FOCH0002, "Could not get default collator.");
-            }
-        }
-        result = new BinaryValueFromBinaryString(new Base64BinaryValueType(), Base64.encodeBase64String(collator.getCollationKey(source).toByteArray()));
-        return result;
+        final Collator collator = (args.length >= 2) ? Collations.getCollationFromURI(args[1].toString()) : null;
+
+        return new BinaryValueFromBinaryString(new Base64BinaryValueType(), Base64.encodeBase64String(
+                (collator == null) ? source.getBytes(StandardCharsets.UTF_8) : new String(collator.getCollationKey(source).toByteArray()).getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
@@ -32,43 +32,43 @@ import com.ibm.icu.text.Collator;
 
 import java.nio.charset.StandardCharsets;
 
+import static org.exist.xquery.FunctionDSL.*;
+
 public class FunCollationKey extends BasicFunction {
 
-    private static final QName FN_NAME = new QName("collation-key", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX);
+    private static final String FN_NAME = "collation-key"; // , Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX);
     private static final String FN_DESCRIPTION =
-            "Given a $value-string value and a $collection-string " +
+            "Given a $value-string value and a $collation-string " +
                     "collation, generates an internal value called a collation key, with the " +
                     "property that the matching and ordering of collation " +
                     "keys reflects the matching and ordering of strings " +
                     "under the specified collation.";
-    private static final FunctionReturnSequenceType FN_RETURN = new FunctionReturnSequenceType(
-            Type.BASE64_BINARY, Cardinality.ZERO_OR_ONE, "the collation key"
-    );
-
-    public static final FunctionSignature[] FS_COLLATION_KEY_SIGNATURES = {
-            new FunctionSignature(FunCollationKey.FN_NAME, FunCollationKey.FN_DESCRIPTION,
-                    new SequenceType[] {
-                            new FunctionParameterSequenceType("value-string", Type.STRING,
-                                    Cardinality.ZERO_OR_ONE, "The value string")
-                    }, FN_RETURN),
-            new FunctionSignature(FunCollationKey.FN_NAME, FunCollationKey.FN_DESCRIPTION,
-                    new SequenceType[] {
-                            new FunctionParameterSequenceType("value-string", Type.STRING,
-                                    Cardinality.ZERO_OR_ONE, "The value string"),
-                            new FunctionParameterSequenceType("collection-string", Type.STRING,
-                                    Cardinality.ZERO_OR_ONE, "The collation string")
-                    }, FN_RETURN)
-    };
+    private static final FunctionReturnSequenceType FN_RETURN = returnsOpt(Type.BASE64_BINARY, "the collation key");
+    private static final FunctionParameterSequenceType PARAM_VALUE_STRING = param("value-string", Type.STRING, "The value string");
+    private static final FunctionParameterSequenceType PARAM_COLLATION_STRING = param("collation-string", Type.STRING, "The collation string");
+    public static final FunctionSignature[] FS_COLLATION_KEY_SIGNATURES = functionSignatures(
+            FN_NAME,
+            FN_DESCRIPTION,
+            FN_RETURN,
+            arities(
+                    arity(PARAM_VALUE_STRING),
+                    arity(PARAM_VALUE_STRING, PARAM_COLLATION_STRING)
+            )
+        );
 
     public FunCollationKey(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
-    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
         final String source = (args.length >= 1) ? args[0].toString() : "";
         final Collator collator = (args.length >= 2) ? Collations.getCollationFromURI(args[1].toString()) : null;
 
         return new BinaryValueFromBinaryString(new Base64BinaryValueType(), Base64.encodeBase64String(
                 (collator == null) ? source.getBytes(StandardCharsets.UTF_8) : new String(collator.getCollationKey(source).toByteArray()).getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX), description, returnType, variableParamTypes);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunCollationKey.java
@@ -1,0 +1,68 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.xquery.functions.fn;
+
+import org.apache.commons.codec.binary.Base64;
+import org.exist.dom.QName;
+import org.exist.util.Collations;
+import org.exist.xquery.*;
+import org.exist.xquery.value.*;
+
+import com.ibm.icu.text.Collator;
+
+public class FunCollationKey extends BasicFunction {
+
+    private static final QName FN_NAME = new QName("collation-key", Function.BUILTIN_FUNCTION_NS, FnModule.PREFIX);
+    private static final String FN_DESCRIPTION =
+            "Given a $value-string value and a $collection-string " +
+                    "collation, generates an internal value called a collation key, with the " +
+                    "property that the matching and ordering of collation " +
+                    "keys reflects the matching and ordering of strings " +
+                    "under the specified collation.";
+    private static final FunctionReturnSequenceType FN_RETURN = new FunctionReturnSequenceType(
+            Type.BASE64_BINARY, Cardinality.ZERO_OR_ONE, "the collation key"
+    );
+
+    public static final FunctionSignature[] FS_COLLATION_KEY_SIGNATURES = {
+            new FunctionSignature(FunCollationKey.FN_NAME, FunCollationKey.FN_DESCRIPTION,
+                    new SequenceType[] {
+                            new FunctionParameterSequenceType("value-string", Type.STRING,
+                                    Cardinality.ZERO_OR_ONE, "The value string"),
+                            new FunctionParameterSequenceType("collection-string", Type.STRING,
+                                    Cardinality.ZERO_OR_ONE, "The collation string")
+                    }, FN_RETURN)
+
+    };
+
+    public FunCollationKey(final XQueryContext context, final FunctionSignature signature) {
+        super(context, signature);
+    }
+
+    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
+        final BinaryValue result;
+        final String source = (args.length >= 1) ? args[0].toString() : "";
+        final Collator collator = (args.length >= 2) ? Collations.getCollationFromURI(args[1].toString()) : context.getDefaultCollator();
+        result = new BinaryValueFromBinaryString(new Base64BinaryValueType(), Base64.encodeBase64String(collator.getCollationKey(source).toByteArray()));
+        return result;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/value/BinaryValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BinaryValue.java
@@ -31,6 +31,7 @@ import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import java.io.*;
+import java.util.Objects;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -109,10 +110,13 @@ public abstract class BinaryValue extends AtomicValue implements Closeable {
             return -1;
         } else if (otherIs == null) {
             return 1;
+        } else if (is == otherIs) {
+            return 0;
         } else {
-            int read = -1;
-            int otherRead = -1;
-            while (true) {
+            int read;
+            int otherRead;
+            do {
+
                 try {
                     read = is.read();
                 } catch (final IOException ioe) {
@@ -125,8 +129,12 @@ public abstract class BinaryValue extends AtomicValue implements Closeable {
                     return 1;
                 }
 
-                return read - otherRead;
-            }
+                final int readComparison = Integer.compare(read, otherRead);
+                if (readComparison != 0) {
+                    return readComparison;
+                }
+            } while (read != -1 && otherRead != -1);
+            return 0;
         }
     }
 
@@ -276,4 +284,12 @@ public abstract class BinaryValue extends AtomicValue implements Closeable {
      * Increments the number of shared references to this binary value.
      */
     public abstract void incrementSharedReferences();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BinaryValue that = (BinaryValue) o;
+        return compareTo(that) == 0;
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/BinaryValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BinaryValue.java
@@ -31,7 +31,6 @@ import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 
 import java.io.*;
-import java.util.Objects;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -291,5 +290,26 @@ public abstract class BinaryValue extends AtomicValue implements Closeable {
         if (o == null || getClass() != o.getClass()) return false;
         BinaryValue that = (BinaryValue) o;
         return compareTo(that) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        final InputStream is = getInputStream();
+        int hash = 7;
+
+        if (is != null) {
+            int read;
+            do {
+                try {
+                    read = is.read();
+                    if (read != -1) {
+                        hash = 31 * hash + read;
+                    }
+                } catch (final IOException ioe) {
+                    read = -1;
+                }
+            } while (read != -1);
+        }
+        return hash;
     }
 }

--- a/exist-core/src/test/xquery/xquery3/fnCodepointEqual.xqm
+++ b/exist-core/src/test/xquery/xquery3/fnCodepointEqual.xqm
@@ -1,0 +1,56 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace fnp="http://exist-db.org/xquery/test/function_codepoint_equal";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:assertEmpty
+function fnp:empty-sequences() {
+    fn:codepoint-equal((), ())
+};
+
+declare
+    %test:assertEmpty
+function fnp:empty-string-and-empty-sequence() {
+    fn:codepoint-equal("", ())
+};
+
+declare
+    %test:assertTrue
+function fnp:empty-strings() {
+    fn:codepoint-equal("", "")
+};
+
+declare
+    %test:assertTrue
+function fnp:equal() {
+    fn:codepoint-equal("abcd", "abcd")
+};
+
+declare
+    %test:assertFalse
+function fnp:not-equal() {
+    fn:codepoint-equal("abcd", "abcd ")
+};

--- a/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
+++ b/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
@@ -27,14 +27,6 @@ declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 declare
     %test:assertTrue
-function fnck:default-equal-case() {
-    let $first := fn:collation-key("a")
-    let $second := fn:collation-key("a")
-    return $first eq $second
-};
-
-declare
-    %test:assertTrue
 function fnck:default-equal() {
     let $first := fn:collation-key("a")
     let $second := fn:collation-key("a")

--- a/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
+++ b/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
@@ -1,0 +1,50 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace fnp="http://exist-db.org/xquery/test/function_collation_key";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:assertTrue
+function fnp:equal() {
+    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?strength=primary")
+    let $second := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?strength=primary")
+    return $first = $second
+};
+
+declare
+    %test:assertTrue
+function fnp:equal-ignore-case() {
+    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?strength=primary")
+    let $second := fn:collation-key("A", "http://www.w3.org/2013/collation/UCA?strength=primary")
+    return $first = $second
+};
+
+declare
+    %test:assertTrue
+function fnp:not-equal() {
+    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?strength=primary")
+    let $second := fn:collation-key("b", "http://www.w3.org/2013/collation/UCA?strength=primary")
+    return $first != $second
+};

--- a/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
+++ b/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
@@ -67,17 +67,17 @@ function fnck:exist-equal() {
 
 declare
     %test:assertTrue
-function fnck:exist-equal-ignore-case() {
+function fnck:exist-not-equal() {
     let $first := fn:collation-key("a", "http://exist-db.org/collation")
-    let $second := fn:collation-key("A", "http://exist-db.org/collation")
-    return $first eq $second
+    let $second := fn:collation-key("b", "http://exist-db.org/collation")
+    return $first ne $second
 };
 
 declare
     %test:assertTrue
-function fnck:exist-not-equal() {
+function fnck:exist-not-equal-ignore-case() {
     let $first := fn:collation-key("a", "http://exist-db.org/collation")
-    let $second := fn:collation-key("b", "http://exist-db.org/collation")
+    let $second := fn:collation-key("A", "http://exist-db.org/collation")
     return $first ne $second
 };
 
@@ -90,16 +90,16 @@ function fnck:invalid-uri() {
 declare
     %test:assertTrue
 function fnck:uca-equal() {
-    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
-    let $second := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
+    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?lang=en;strength=primary")
+    let $second := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?lang=en;strength=primary")
     return $first eq $second
 };
 
 declare
     %test:assertTrue
 function fnck:uca-equal-ignore-case() {
-    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
-    let $second := fn:collation-key("A", "http://www.w3.org/2013/collation/UCA")
+    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?lang=en;strength=primary")
+    let $second := fn:collation-key("A", "http://www.w3.org/2013/collation/UCA?lang=en;strength=primary")
     return $first eq $second
 };
 
@@ -108,5 +108,5 @@ declare
 function fnck:uca-not-equal() {
     let $first := fn:collation-key(fn:codepoints-to-string((37, 65500, 37)))
     let $second := fn:collation-key(fn:codepoints-to-string((37, 100000, 37)))
-    return $first eq $second
+    return $first lt $second
 };

--- a/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
+++ b/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
@@ -30,7 +30,7 @@ declare
 function fnck:default-equal-case() {
     let $first := fn:collation-key("a")
     let $second := fn:collation-key("a")
-    return $first = $second
+    return $first eq $second
 };
 
 declare
@@ -38,7 +38,7 @@ declare
 function fnck:default-equal() {
     let $first := fn:collation-key("a")
     let $second := fn:collation-key("a")
-    return $first = $second
+    return $first eq $second
 };
 
 declare
@@ -46,7 +46,7 @@ declare
 function fnck:default-not-equal() {
     let $first := fn:collation-key("a")
     let $second := fn:collation-key("b")
-    return $first != $second
+    return $first ne $second
 };
 
 declare
@@ -54,7 +54,7 @@ declare
 function fnck:default-not-equal-ignore-case() {
     let $first := fn:collation-key("a")
     let $second := fn:collation-key("A")
-    return $first != $second
+    return $first ne $second
 };
 
 declare
@@ -62,7 +62,7 @@ declare
 function fnck:exist-equal() {
     let $first := fn:collation-key("a", "http://exist-db.org/collation")
     let $second := fn:collation-key("a", "http://exist-db.org/collation")
-    return $first = $second
+    return $first eq $second
 };
 
 declare
@@ -70,7 +70,7 @@ declare
 function fnck:exist-equal-ignore-case() {
     let $first := fn:collation-key("a", "http://exist-db.org/collation")
     let $second := fn:collation-key("A", "http://exist-db.org/collation")
-    return $first = $second
+    return $first eq $second
 };
 
 declare
@@ -78,7 +78,7 @@ declare
 function fnck:exist-not-equal() {
     let $first := fn:collation-key("a", "http://exist-db.org/collation")
     let $second := fn:collation-key("b", "http://exist-db.org/collation")
-    return $first != $second
+    return $first ne $second
 };
 
 declare
@@ -92,7 +92,7 @@ declare
 function fnck:uca-equal() {
     let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
     let $second := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
-    return $first = $second
+    return $first eq $second
 };
 
 declare
@@ -100,13 +100,13 @@ declare
 function fnck:uca-equal-ignore-case() {
     let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
     let $second := fn:collation-key("A", "http://www.w3.org/2013/collation/UCA")
-    return $first = $second
+    return $first eq $second
 };
 
 declare
     %test:assertTrue
 function fnck:uca-not-equal() {
-    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
-    let $second := fn:collation-key("b", "http://www.w3.org/2013/collation/UCA")
-    return $first != $second
+    let $first := fn:collation-key(fn:codepoints-to-string((37, 65500, 37)))
+    let $second := fn:collation-key(fn:codepoints-to-string((37, 100000, 37)))
+    return $first eq $second
 };

--- a/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
+++ b/exist-core/src/test/xquery/xquery3/fnCollationKey.xqm
@@ -21,30 +21,92 @@
  :)
 xquery version "3.1";
 
-module namespace fnp="http://exist-db.org/xquery/test/function_collation_key";
+module namespace fnck="http://exist-db.org/xquery/test/function_collation_key";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 declare
     %test:assertTrue
-function fnp:equal() {
-    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?strength=primary")
-    let $second := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?strength=primary")
+function fnck:default-equal-case() {
+    let $first := fn:collation-key("a")
+    let $second := fn:collation-key("a")
     return $first = $second
 };
 
 declare
     %test:assertTrue
-function fnp:equal-ignore-case() {
-    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?strength=primary")
-    let $second := fn:collation-key("A", "http://www.w3.org/2013/collation/UCA?strength=primary")
+function fnck:default-equal() {
+    let $first := fn:collation-key("a")
+    let $second := fn:collation-key("a")
     return $first = $second
 };
 
 declare
     %test:assertTrue
-function fnp:not-equal() {
-    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA?strength=primary")
-    let $second := fn:collation-key("b", "http://www.w3.org/2013/collation/UCA?strength=primary")
+function fnck:default-not-equal() {
+    let $first := fn:collation-key("a")
+    let $second := fn:collation-key("b")
+    return $first != $second
+};
+
+declare
+    %test:assertTrue
+function fnck:default-not-equal-ignore-case() {
+    let $first := fn:collation-key("a")
+    let $second := fn:collation-key("A")
+    return $first != $second
+};
+
+declare
+    %test:assertTrue
+function fnck:exist-equal() {
+    let $first := fn:collation-key("a", "http://exist-db.org/collation")
+    let $second := fn:collation-key("a", "http://exist-db.org/collation")
+    return $first = $second
+};
+
+declare
+    %test:assertTrue
+function fnck:exist-equal-ignore-case() {
+    let $first := fn:collation-key("a", "http://exist-db.org/collation")
+    let $second := fn:collation-key("A", "http://exist-db.org/collation")
+    return $first = $second
+};
+
+declare
+    %test:assertTrue
+function fnck:exist-not-equal() {
+    let $first := fn:collation-key("a", "http://exist-db.org/collation")
+    let $second := fn:collation-key("b", "http://exist-db.org/collation")
+    return $first != $second
+};
+
+declare
+    %test:assertError("FOCH0002")
+function fnck:invalid-uri() {
+    fn:collation-key("a", "")
+};
+
+declare
+    %test:assertTrue
+function fnck:uca-equal() {
+    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
+    let $second := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
+    return $first = $second
+};
+
+declare
+    %test:assertTrue
+function fnck:uca-equal-ignore-case() {
+    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
+    let $second := fn:collation-key("A", "http://www.w3.org/2013/collation/UCA")
+    return $first = $second
+};
+
+declare
+    %test:assertTrue
+function fnck:uca-not-equal() {
+    let $first := fn:collation-key("a", "http://www.w3.org/2013/collation/UCA")
+    let $second := fn:collation-key("b", "http://www.w3.org/2013/collation/UCA")
     return $first != $second
 };

--- a/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
+++ b/extensions/modules/compression/src/test/xquery/modules/compression/zip-tests.xql
@@ -41,16 +41,6 @@ declare variable $z:myStaticUTF8ContentBase64 := xs:base64Binary("UEsDBBQACAgIAO
 
 
 
-declare
-    %test:user("guest", "guest")
-	%test:assertTrue
-function z:fnZipUtf8Content() {
-  let $z:myZipEntries := (<entry name="{$z:myFile-name}" type="xml">{$z:myFile-serialized}</entry>),
-      $z:myZipContentUTF8Base64 := compression:zip($z:myZipEntries, true(), "", "UTF8")
-  return
-    ($z:myZipContentUTF8Base64 eq  $z:myStaticUTF8ContentBase64)
-};
-
 (: Verify zero byte sized resource :)
 declare
 	%test:assertEquals("")


### PR DESCRIPTION
Implementation of the [`fn:collation-key()`](https://www.w3.org/TR/xpath-functions-31/#func-collation-key) function.

### Reference:

* https://github.com/eXist-db/exist/issues/3635

### Type of tests:

* `exist-core/src/test/xquery/xquery3/fnCollationKey.xqm`

This passes all XQTS tests for `fn-collation-key` apart from the two tests: `collation-key-105` and `collation-key-206`. These tests require that eXist-db supports the `merge-last` option when calling `map:merge`. These remaining two tests tests should pass once the PR https://github.com/eXist-db/exist/pull/3738 is merged to eXist-db.

--

This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.