### PR TITLE
Don't allow xs:string to be cast as xs:QName

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/value/StringValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/StringValue.java
@@ -512,8 +512,6 @@ public class StringValue extends AtomicValue {
                 return new GMonthDayValue(value);
             case Type.UNTYPED_ATOMIC:
                 return new UntypedAtomicValue(getStringValue());
-            case Type.QNAME:
-                return new QNameValue(null, new QName(value, XMLConstants.NULL_NS_URI));
             default:
                 throw new XPathException(ErrorCodes.FORG0001, "cannot cast '" +
                         Type.getTypeName(this.getItemType()) + "(\"" + getStringValue() + "\")' to " +

--- a/exist-core/src/test/xquery/xquery3/castable.xqm
+++ b/exist-core/src/test/xquery/xquery3/castable.xqm
@@ -1,3 +1,27 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+ (:~
+  : @see https://github.com/eXist-db/exist/issues/3390
+  :)
 xquery version "3.1";
 
 module namespace t="http://exist-db.org/xquery/test";

--- a/exist-core/src/test/xquery/xquery3/castable.xqm
+++ b/exist-core/src/test/xquery/xquery3/castable.xqm
@@ -1,0 +1,11 @@
+xquery version "3.1";
+
+module namespace t="http://exist-db.org/xquery/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:assertFalse
+function t:castable-test() {
+    "0" castable as xs:QName
+};


### PR DESCRIPTION
Fix #3390

This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/