### PR TITLE
[bugfix] Add missing location information in errors for functions inside element constructors (err:XQTY0105)

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -3720,7 +3720,7 @@ throws XPathException, PermissionDeniedException, EXistException
 		t:MAP
 		{
 			MapExpr expr = new MapExpr(context);
-            expr.setASTNode(mapConstr_AST_in);
+			expr.setASTNode(mapConstr_AST_in);
 			step = expr;
 		}
 		(

--- a/exist-core/src/main/java/org/exist/xquery/DynamicFunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicFunctionCall.java
@@ -23,6 +23,7 @@ package org.exist.xquery;
 
 import java.util.List;
 
+import org.exist.xquery.functions.array.ArrayType;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.FunctionReference;
 import org.exist.xquery.value.Item;
@@ -89,11 +90,16 @@ public class DynamicFunctionCall extends AbstractExpression {
         // if the call is a partial application, create a new function
         if (isPartial) {
         	try {
-	        	final FunctionCall call = ref.getCall();
-	        	call.setArguments(arguments);
-	        	final PartialFunctionApplication partialApp = new PartialFunctionApplication(context, call);
-                partialApp.analyze(new AnalyzeContextInfo(cachedContextInfo));
-	        	return partialApp.eval(contextSequence, contextItem);
+                if (ref instanceof ArrayType) {
+                    ref.setArguments(arguments);
+                    return ref;
+                } else {
+                    final FunctionCall call = ref.getCall();
+                    call.setArguments(arguments);
+                    final PartialFunctionApplication partialApp = new PartialFunctionApplication(context, call);
+                    partialApp.analyze(new AnalyzeContextInfo(cachedContextInfo));
+                    return partialApp.eval(contextSequence, contextItem);
+                }
         	} catch (final XPathException e) {
 				e.setLocation(line, column, getSource());
 				throw e;

--- a/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
@@ -98,8 +98,8 @@ public class EnclosedExpr extends PathExpr {
                 while (next != null) {
                     context.proceed(this, builder);
                     if (Type.subTypeOf(next.getType(), Type.FUNCTION_REFERENCE)) {
-                        throw new XPathException((getLine() > 0 && getColumn() > 0) ? this : next.getExpression(),
-                                ErrorCodes.XQTY0105, "Enclosed expression contains function item");
+                        final Expression expression = ((FunctionReference) next).getExpression();
+                        throw new XPathException((expression == null) ? this : expression, ErrorCodes.XQTY0105, "Enclosed expression contains function item");
 
                         // if item is an atomic value, collect the string values of all
                         // following atomic values and separate them by a space.

--- a/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
@@ -25,6 +25,7 @@ import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.TextImpl;
 import org.exist.xquery.functions.array.ArrayType;
+import org.exist.xquery.functions.map.MapType;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.*;
 import org.w3c.dom.DOMException;
@@ -100,7 +101,6 @@ public class EnclosedExpr extends PathExpr {
                     if (Type.subTypeOf(next.getType(), Type.FUNCTION_REFERENCE)) {
                         final Expression expression = ((FunctionReference) next).getExpression();
                         throw new XPathException((expression == null) ? this : expression, ErrorCodes.XQTY0105, "Enclosed expression contains function item");
-
                         // if item is an atomic value, collect the string values of all
                         // following atomic values and separate them by a space.
                     } else if (Type.subTypeOf(next.getType(), Type.ATOMIC)) {

--- a/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
@@ -25,13 +25,10 @@ import org.exist.dom.memtree.DocumentBuilderReceiver;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.dom.memtree.TextImpl;
 import org.exist.xquery.functions.array.ArrayType;
-import org.exist.xquery.functions.map.MapType;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.*;
 import org.w3c.dom.DOMException;
 import org.xml.sax.SAXException;
-
-import java.io.IOException;
 
 /**
  * Represents an enclosed expression <code>{expr}</code> inside element

--- a/exist-core/src/main/java/org/exist/xquery/value/FunctionReference.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FunctionReference.java
@@ -192,4 +192,25 @@ public class FunctionReference extends AtomicValue implements AutoCloseable {
     public String toString() {
         return "anonymous-function#" + functionCall.getArgumentCount();
     }
+
+    /** the expression from which this value derives */
+    private Expression expression = null;
+
+    /**
+     * Gets the expression from which this value derives.
+     *
+     * @return  the expression from which this value derives
+     */
+    public Expression getExpression() {
+        return expression;
+    }
+
+    /**
+     * Sets the expression from which this value derives.
+     *
+     * @param   expression  the expression to use
+     */
+    public void setExpression(Expression expression) {
+        this.expression = expression;
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/FunctionReference.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FunctionReference.java
@@ -70,6 +70,7 @@ public class FunctionReference extends AtomicValue implements AutoCloseable {
      *
      * @return  the expression from which this type derives
      */
+    @Override
     public Expression getExpression() {
         return expression;
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/FunctionReference.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FunctionReference.java
@@ -36,6 +36,9 @@ import java.util.List;
  */
 public class FunctionReference extends AtomicValue implements AutoCloseable {
 
+    /** the expression from which this type derives */
+    private Expression expression;
+
     private final static Logger LOG = LogManager.getLogger(FunctionReference.class);
 
     protected final FunctionCall functionCall;
@@ -60,6 +63,24 @@ public class FunctionReference extends AtomicValue implements AutoCloseable {
      */
     public FunctionSignature getSignature() {
         return functionCall.getSignature();
+    }
+
+    /**
+     * Gets the expression from which this type derives.
+     *
+     * @return  the expression from which this type derives
+     */
+    public Expression getExpression() {
+        return expression;
+    }
+
+    /**
+     * Sets the expression from which this type derives.
+     *
+     * @param   expression  the expression to use
+     */
+    public void setExpression(final Expression expression) {
+        this.expression = expression;
     }
 
     /**
@@ -191,26 +212,5 @@ public class FunctionReference extends AtomicValue implements AutoCloseable {
     @Override
     public String toString() {
         return "anonymous-function#" + functionCall.getArgumentCount();
-    }
-
-    /** the expression from which this value derives */
-    private Expression expression = null;
-
-    /**
-     * Gets the expression from which this value derives.
-     *
-     * @return  the expression from which this value derives
-     */
-    public Expression getExpression() {
-        return expression;
-    }
-
-    /**
-     * Sets the expression from which this value derives.
-     *
-     * @param   expression  the expression to use
-     */
-    public void setExpression(Expression expression) {
-        this.expression = expression;
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
@@ -129,7 +129,7 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
     public void arrayOfMaps() throws EXistException, PermissionDeniedException {
         final String query = "element test { [map {}] }";
         final String error = "Enclosed expression contains function item";
-        assertXQDynamicError(ErrorCodes.XQTY0105, 1, 17, error, executeQuery(query));
+        assertXQDynamicError(ErrorCodes.XQTY0105, 1, 16, error, executeQuery(query));
     };
 
     // TODO(JL): add (sub-expression) location
@@ -138,6 +138,6 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
     public void mapConstructorInSubExpression() throws EXistException, PermissionDeniedException {
         final String query = "element test { \"a\", map {} }";
         final String error = "Enclosed expression contains function item";
-        assertXQDynamicError(ErrorCodes.XQTY0105, 1, 21, error, executeQuery(query));
+        assertXQDynamicError(ErrorCodes.XQTY0105, 1, 16, error, executeQuery(query));
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/FunctionTypeInElementContentTest.java
@@ -129,7 +129,7 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
     public void arrayOfMaps() throws EXistException, PermissionDeniedException {
         final String query = "element test { [map {}] }";
         final String error = "Enclosed expression contains function item";
-        assertXQDynamicError(ErrorCodes.XQTY0105, 1, 16, error, executeQuery(query));
+        assertXQDynamicError(ErrorCodes.XQTY0105, 1, 17, error, executeQuery(query));
     };
 
     // TODO(JL): add (sub-expression) location
@@ -138,6 +138,6 @@ public class FunctionTypeInElementContentTest extends XQueryCompilationTest {
     public void mapConstructorInSubExpression() throws EXistException, PermissionDeniedException {
         final String query = "element test { \"a\", map {} }";
         final String error = "Enclosed expression contains function item";
-        assertXQDynamicError(ErrorCodes.XQTY0105, 1, 16, error, executeQuery(query));
+        assertXQDynamicError(ErrorCodes.XQTY0105, 1, 21, error, executeQuery(query));
     }
 }

--- a/exist-core/src/test/xquery/errors.xql
+++ b/exist-core/src/test/xquery/errors.xql
@@ -363,7 +363,7 @@ function et:element-enclosed-of-array-function-partial() {
     try {
         element test { ['a'](?) }
     }
-    catch * {
+    catch err:XQTY0105 {
         exists($err:line-number) and
         $err:line-number > 0 and
         exists($err:column-number) and


### PR DESCRIPTION
### Description:

Add location information to map expressions, and pass this information to the `XQTY0105` exception that occurs when an enclosed expression contains a function item

### Reference:

https://github.com/eXist-db/exist/issues/3623

### Type of tests:

`subexpression-in-enclosed-expression-evaluates-to-map` and `enclosed-expression-evaluates-to-map` in `exist-core\src\test\xquery\errors.xql`

--

This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.