### PR TITLE
Bugfix/serialization item separator

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -42,7 +42,7 @@ import static org.exist.Namespaces.XSLT_XQUERY_SERIALIZATION_NS;
 
 public class FunSerialize extends BasicFunction {
 
-    private final static String DEFAULT_ITEM_SEPARATOR = "\n";
+    private final static String DEFAULT_ITEM_SEPARATOR = " ";
 
     public final static FunctionSignature[] signatures = {
         new FunctionSignature(

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -148,7 +148,11 @@ public class FunSerialize extends BasicFunction {
                 if (next.getType() == Type.ATTRIBUTE || next.getType() == Type.NAMESPACE || next.getType() == Type.FUNCTION_REFERENCE)
                     {throw new XPathException(callingExpr, FnModule.SENR0001,
                         "It is an error if an item in the sequence to serialize is an attribute node or a namespace node.");}
-                temp.add(next);
+                if (itemSeparator != null && itemSeparator.length() > 0 && !temp.isEmpty()) {
+                    temp.add(new StringValue(itemSeparator + next.getStringValue()));
+                } else {
+                    temp.add(next);
+                }
             } else {
                 // atomic value
                 Item last = null;

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
@@ -404,7 +404,7 @@ public class Eval extends BasicFunction {
 
                         final Sequence seq;
                         if (xqSerializer.normalize()) {
-                            seq = FunSerialize.normalize(this, context, result);
+                            seq = FunSerialize.normalize(this, context, result, null);
                         } else {
                             seq = result;
                         }

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -774,3 +774,31 @@ function ser:item-separator-text-method() {
     let $data := (1, 2)
     return ser:serialize-with-item-separator($data, "text")
 };
+
+declare
+    %test:assertEquals("1--2")
+function ser:item-separator-html-method() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "html")
+};
+
+declare
+    %test:assertEquals("1--2")
+function ser:item-separator-xhtml-method() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "xhtml")
+};
+
+declare
+    %test:assertEquals("1--2")
+function ser:item-separator-xml-method() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "xml")
+};
+
+declare
+    %test:assertEquals("1--2")
+function ser:item-separator-adaptive-method() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "adaptive")
+};

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -214,8 +214,7 @@ function ser:serialize-empty-params() {
 };
 
 declare
-    %test:assertEquals("aaa
-bbb")
+    %test:assertEquals("aaa bbb")
 function ser:serialize-atomic() {
     let $nodes := ("aaa", "bbb")
     return
@@ -774,32 +773,4 @@ declare
 function ser:item-separator-text-method() {
     let $data := (1, 2)
     return ser:serialize-with-item-separator($data, "text")
-};
-
-declare
-    %test:assertEquals("1--2")
-function ser:item-separator-html-method() {
-    let $data := (1, 2)
-    return ser:serialize-with-item-separator($data, "html")
-};
-
-declare
-    %test:assertEquals("1--2")
-function ser:item-separator-xhtml-method() {
-    let $data := (1, 2)
-    return ser:serialize-with-item-separator($data, "xhtml")
-};
-
-declare
-    %test:assertEquals("1--2")
-function ser:item-separator-xml-method() {
-    let $data := (1, 2)
-    return ser:serialize-with-item-separator($data, "xml")
-};
-
-declare
-    %test:assertEquals("1--2")
-function ser:item-separator-adaptive-method() {
-    let $data := (1, 2)
-    return ser:serialize-with-item-separator($data, "adaptive")
 };

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -61,6 +61,18 @@ declare %private function ser:adaptive-map-params($data) {
     ser:adaptive-map-params($data, ())
 };
 
+declare %private function ser:serialize-with-item-separator($data as item()*, $method as xs:string) {
+    let $options :=
+        <output:serialization-parameters
+            xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
+            <output:method value="{$method}"/>
+            <output:indent>no</output:indent>
+            <output:item-separator>--</output:item-separator>
+        </output:serialization-parameters>
+    return
+        fn:serialize($data, $options)
+};
+
 declare variable $ser:atomic :=
     <atomic:root xmlns:atomic="http://www.w3.org/XQueryTest" xmlns:foo="http://www.example.com/foo"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -202,7 +214,8 @@ function ser:serialize-empty-params() {
 };
 
 declare
-    %test:assertEquals("aaa bbb")
+    %test:assertEquals("aaa
+bbb")
 function ser:serialize-atomic() {
     let $nodes := ("aaa", "bbb")
     return
@@ -754,4 +767,46 @@ declare
 function ser:exist-process-xsl-pi-false() {
     let $doc := doc($ser:collection || "/test-xsl.xml")
     return fn:serialize($doc, map {xs:QName("exist:process-xsl-pi"): false()})
+};
+
+declare
+    %test:assertEquals("1--2")
+function ser:item-separator-text-method() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "text")
+};
+
+declare
+    %test:assertEquals("1--2")
+function ser:item-separator-html-method() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "html")
+};
+
+declare
+    %test:assertEquals("1--2")
+function ser:item-separator-xhtml-method() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "xhtml")
+};
+
+declare
+    %test:assertEquals("1--2")
+function ser:item-separator-xml-method() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "xml")
+};
+
+declare
+    %test:assertEquals("1--2")
+function ser:item-separator-adaptive-method() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "adaptive")
+};
+
+declare
+    %test:assertEquals("1--2")
+function ser:test() {
+    let $data := (1, 2)
+    return ser:serialize-with-item-separator($data, "xml")
 };

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -803,10 +803,3 @@ function ser:item-separator-adaptive-method() {
     let $data := (1, 2)
     return ser:serialize-with-item-separator($data, "adaptive")
 };
-
-declare
-    %test:assertEquals("1--2")
-function ser:test() {
-    let $data := (1, 2)
-    return ser:serialize-with-item-separator($data, "xml")
-};

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -802,3 +802,47 @@ function ser:item-separator-adaptive-method() {
     let $data := (1, 2)
     return ser:serialize-with-item-separator($data, "adaptive")
 };
+
+declare
+    %test:assertEquals("1|2|3|4|5|6|7|8|9|10")
+function ser:serialize-xml-033() {
+    let $params :=
+        <output:serialization-parameters xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
+            <output:method value="xml"/>
+            <output:item-separator value="|"/>
+        </output:serialization-parameters>
+    return serialize(1 to 10, $params)
+};
+
+declare
+    %test:assertEquals("1==2==3==4")
+function ser:serialize-xml-034() {
+    let $params :=
+        <output:serialization-parameters xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
+            <output:method value="xml"/>
+            <output:omit-xml-declaration value="yes"/>
+            <output:item-separator value="=="/>
+        </output:serialization-parameters>
+    return serialize(1 to 4, $params)
+};
+
+declare
+    %test:assertEquals("1|2|3|4|5|6|7|8|9|10")
+function ser:serialize-xml-133() {
+    let $params := map {
+        "method" : "xml",
+        "item-separator" : "|"
+    }
+    return serialize(1 to 10, $params)
+};
+
+declare
+    %test:assertEquals("1==2==3==4")
+function ser:serialize-xml-134() {
+    let $params := map {
+        "method" : "xml",
+        "omit-xml-declaration" : true(),
+        "item-separator" : "=="
+    }
+    return serialize((1 to 4)!text{.}, $params)
+};


### PR DESCRIPTION
### Description

The item separator was not appearing for some serialization methods.

### Reference

https://github.com/eXist-db/exist/issues/1483

### Type of Tests

Added the following tests to `exist-core/src/test/xquery/xquery3/serialize.xql`:

- `ser:item-separator-text-method`
- `ser:item-separator-html-method`
- `ser:item-separator-xhtml-method`
- `ser:item-separator-xml-method`
- `ser:item-separator-adaptive-method`

---

This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.