### PR TITLE
[4.x.x] Ensure that spaces in Windows paths for startup.sh and server.sh are correctly quoted

### DIFF
--- a/bin/server.sh
+++ b/bin/server.sh
@@ -52,6 +52,6 @@ if [ $PIDFILE ]; then
     echo $$ > $PIDFILE
 fi
 
-${JAVA_RUN} $JAVA_OPTIONS $OPTIONS -jar "$EXIST_HOME/start.jar" standalone "${JAVA_OPTS[@]}"
+"${JAVA_RUN}" $JAVA_OPTIONS $OPTIONS -jar "$EXIST_HOME/start.jar" standalone "${JAVA_OPTS[@]}"
 
 restore_locale_lang;

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -59,7 +59,7 @@ if [ $PIDFILE ]; then
     echo $$ > $PIDFILE
 fi
 
-${JAVA_RUN} ${JAVA_OPTIONS} ${OPTIONS} \
+"${JAVA_RUN}" ${JAVA_OPTIONS} ${OPTIONS} \
 	${DEBUG_OPTS} -jar "$EXIST_HOME/start.jar" \
 	jetty ${JAVA_OPTS[@]}
 


### PR DESCRIPTION
It appears that these were correctly handled previously in all `bin/*.sh` scripts but not the `startup.sh` and `server.sh` scripts. This PR now causes these to correctly handle Windows paths that have spaces in them.