### PR TITLE
Corrects issues with fn:local-name and unnecessary evaluation of path steps on empty sequences

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/AbstractExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/AbstractExpression.java
@@ -183,4 +183,9 @@ public abstract class AbstractExpression implements Expression {
     public Expression getParent() {
         return null;
     }
+
+    @Override
+    public boolean evalNextExpressionOnEmptyContextSequence() {
+        return false;
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/DebuggableExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/DebuggableExpression.java
@@ -194,4 +194,9 @@ public class DebuggableExpression implements Expression, RewritableExpression {
     public Expression getParent() {
         return null;
     }
+
+    @Override
+    public boolean evalNextExpressionOnEmptyContextSequence() {
+        return false;
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/Expression.java
+++ b/exist-core/src/main/java/org/exist/xquery/Expression.java
@@ -255,4 +255,13 @@ public interface Expression {
     public boolean allowMixedNodesInReturn();
 
     public Expression getParent();
+
+    /**
+     * Return true only if the next expression within a path expression
+     * should be evaluated even when this expression returns an
+     * empty sequence.
+     *
+     * @return true if the next expression should be evaluated, false otherwise.
+     */
+    boolean evalNextExpressionOnEmptyContextSequence();
 }

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -229,7 +229,7 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
             //TODO : let the parser do it ? -pb
             boolean gotAtomicResult = false;
             Expression prev = null;
-            for (Expression step : steps) {
+            for (final Expression step : steps) {
                 prev = expr;
                 expr = step;
                 context.getWatchDog().proceed(expr);
@@ -299,7 +299,22 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                         // expression with more than one step
                         result.removeDuplicates();
                     }
+
+                    /**
+                     * If the result is an Empty Sequence, we don't need to process
+                     * any more steps as there is no Context Item for the next step!
+                     *
+                     * There is one exception to this rule, which is a TextConstructor,
+                     * that only contains whitespace but has been configured
+                     * to strip-whitespace. In this instance the TextConstructor will
+                     * return an {@link Sequence.EMPTY_SEQUENCE_VALID} to indicate
+                     * that.
+                     */
+                    if (result != Sequence.EMPTY_SEQUENCE_VALID && result.isEmpty()) {
+                        break;
+                    }
                 }
+
                 if (!staticContext) {
                     currentContext = result;
                 }

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -302,15 +302,15 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
 
                     /**
                      * If the result is an Empty Sequence, we don't need to process
-                     * any more steps as there is no Context Item for the next step!
+                     * any more steps as there is no Context Sequence for the next step!
                      *
-                     * There is one exception to this rule, which is a TextConstructor,
-                     * that only contains whitespace but has been configured
+                     * There is one exception to this rule, which is a TextConstructor
+                     * expression that only contains whitespace but has been configured
                      * to strip-whitespace. In this instance the TextConstructor will
-                     * return an {@link Sequence.EMPTY_SEQUENCE_VALID} to indicate
-                     * that.
+                     * return true when {@link Expression#evalNextExpressionOnEmptyContextSequence()}
+                     * is called to indicate that.
                      */
-                    if (result != Sequence.EMPTY_SEQUENCE_VALID && result.isEmpty()) {
+                    if (result.isEmpty() && !step.evalNextExpressionOnEmptyContextSequence()) {
                         break;
                     }
                 }

--- a/exist-core/src/main/java/org/exist/xquery/TextConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/TextConstructor.java
@@ -54,7 +54,7 @@ public class TextConstructor extends NodeConstructor {
      */
     public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
         if (isWhitespaceOnly && context.stripWhitespace())
-            {return Sequence.EMPTY_SEQUENCE_VALID;}
+            {return Sequence.EMPTY_SEQUENCE;}
         if (newDocumentContext)
             {context.pushDocumentContext();}
         try {
@@ -95,5 +95,14 @@ public class TextConstructor extends NodeConstructor {
     @Override
     public boolean allowMixedNodesInReturn() {
         return true;
+    }
+
+    @Override
+    public boolean evalNextExpressionOnEmptyContextSequence() {
+        /*
+        When this TextConstructor only contains whitespace but has been configured
+        to strip-whitespace, return true so that the next expression is processed correctly.
+         */
+        return isWhitespaceOnly && context.stripWhitespace();
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/TextConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/TextConstructor.java
@@ -54,7 +54,7 @@ public class TextConstructor extends NodeConstructor {
      */
     public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
         if (isWhitespaceOnly && context.stripWhitespace())
-            {return Sequence.EMPTY_SEQUENCE;}
+            {return Sequence.EMPTY_SEQUENCE_VALID;}
         if (newDocumentContext)
             {context.pushDocumentContext();}
         try {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLocalName.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunLocalName.java
@@ -39,6 +39,7 @@ import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.StringValue;
 import org.exist.xquery.value.Type;
 import org.w3c.dom.Node;
+import org.w3c.dom.ProcessingInstruction;
 
 /**
  * Built-in function fn:local-name().
@@ -126,8 +127,14 @@ public class FunLocalName extends Function {
             }
 
             //TODO : how to improve performance ?
+            final String localName;
             final Node n = ((NodeValue) item).getNode();
-            final String localName = n.getLocalName();
+            if (n.getNodeType() == Node.PROCESSING_INSTRUCTION_NODE) {
+                localName = ((ProcessingInstruction) n).getTarget();
+            } else {
+                localName = n.getLocalName();
+            }
+
             if (localName != null) {
                 result = new StringValue(localName);
             } else {

--- a/exist-core/src/main/java/org/exist/xquery/value/Sequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Sequence.java
@@ -54,6 +54,8 @@ public interface Sequence {
      */
     Sequence EMPTY_SEQUENCE = new EmptySequence();
 
+    Sequence EMPTY_SEQUENCE_VALID = new EmptySequence();
+
     /**
      * The purpose of ordered and unordered flag is to set the ordering mode
      * in the static context to ordered or unordered for a certain region in a query.

--- a/exist-core/src/main/java/org/exist/xquery/value/Sequence.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/Sequence.java
@@ -54,8 +54,6 @@ public interface Sequence {
      */
     Sequence EMPTY_SEQUENCE = new EmptySequence();
 
-    Sequence EMPTY_SEQUENCE_VALID = new EmptySequence();
-
     /**
      * The purpose of ordered and unordered flag is to set the ordering mode
      * in the static context to ordered or unordered for a certain region in a query.

--- a/exist-core/src/test/java/org/exist/xquery/XQueryFunctionsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryFunctionsTest.java
@@ -606,8 +606,7 @@ public class XQueryFunctionsTest {
         final ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $a := <a><b/></a>" +
                         "return $a/b/c/fn:local-name()");
-        final String r = (String) result.getResource(0).getContent();
-        assertEquals("", r);
+        assertEquals(0, result.getSize());
     }
 
     @Test
@@ -657,8 +656,7 @@ public class XQueryFunctionsTest {
         final ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $a := <a><b/></a>" +
                         "return $a/b/c/fn:name()");
-        final String r = (String) result.getResource(0).getContent();
-        assertEquals("", r);
+        assertEquals(0, result.getSize());
     }
 
     @Test
@@ -762,12 +760,11 @@ public class XQueryFunctionsTest {
     }
 
     @Test
-    public void namespaceURI_contextItem_empty() throws XPathException, XMLDBException {
+    public void namespaceURI_contextItem_empty() throws XMLDBException {
         final ResourceSet result = existEmbeddedServer.executeQuery(
                 "let $a := <a><b/></a>" +
                         "return $a/exist:b/c/fn:namespace-uri()");
-        final String r = (String) result.getResource(0).getContent();
-        assertEquals("", r);
+        assertEquals(0, result.getSize());
     }
 
     @Test

--- a/exist-core/src/test/xquery/fn.xql
+++ b/exist-core/src/test/xquery/fn.xql
@@ -145,7 +145,7 @@ function fnt:document-uri0_context() {
 };
 
 declare
-    %test:assertError("err:XPDY0002")
+    %test:assertEmpty
 function fnt:document-uri0_context_empty() {
      root(collection('/db/fn-test')//bookies)/document-uri()
 };


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/4466

Previously eXist-db was doing more work than it needed, i.e. it was evaluating path steps on empty sequences. This led to both incorrect results and sub-optimal performance. eXist-db also has some tests for this previous behaviour which were incorrect, these tests have also been corrected.