### PR TITLE
fix Rest client file encoding 

### DIFF
--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -393,7 +393,7 @@ public class RESTServer {
         // Process the request
         LockedDocument lockedDocument = null;
         DocumentImpl resource = null;
-        final XmldbURI pathUri = XmldbURI.createInternal(path);
+        final XmldbURI pathUri = XmldbURI.create(path);
         try {
             // check if path leads to an XQuery resource
             final String xquery_mime_type = MimeType.XQUERY_TYPE.getName();
@@ -545,7 +545,7 @@ public class RESTServer {
             throws BadRequestException, PermissionDeniedException,
             NotFoundException, IOException {
 
-        final XmldbURI pathUri = XmldbURI.createInternal(path);
+        final XmldbURI pathUri = XmldbURI.create(path);
         if (checkForXQueryTarget(broker, transaction, pathUri, request, response)) {
             return;
         }
@@ -623,7 +623,7 @@ public class RESTServer {
         }
 
         final Properties outputProperties = new Properties(defaultOutputKeysProperties);
-        final XmldbURI pathUri = XmldbURI.createInternal(path);
+        final XmldbURI pathUri = XmldbURI.create(path);
         LockedDocument lockedDocument = null;
         DocumentImpl resource = null;
 
@@ -1134,7 +1134,7 @@ public class RESTServer {
 
     public void doDelete(final DBBroker broker, final Txn transaction, final String path, final HttpServletRequest request, final HttpServletResponse response)
             throws PermissionDeniedException, NotFoundException, IOException, BadRequestException {
-        final XmldbURI pathURI = XmldbURI.createInternal(path);
+        final XmldbURI pathURI = XmldbURI.create(path);
         if (checkForXQueryTarget(broker, transaction, pathURI, request, response)) {
             return;
         }
@@ -1322,7 +1322,7 @@ public class RESTServer {
             }
         }
 
-        final XmldbURI pathUri = XmldbURI.createInternal(path);
+        final XmldbURI pathUri = XmldbURI.create(path);
         final Source source = new StringSource(query);
         final XQueryPool pool = broker.getBrokerPool().getXQueryPool();
         CompiledXQuery compiled = null;

--- a/exist-core/src/main/java/org/exist/http/servlets/EXistServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/EXistServlet.java
@@ -135,7 +135,7 @@ public class EXistServlet extends AbstractExistHttpServlet {
         try (final DBBroker broker = getPool().get(Optional.of(user));
              final Txn transaction = getPool().getTransactionManager().beginTransaction()) {
 
-            final XmldbURI dbpath = XmldbURI.createInternal(path);
+            final XmldbURI dbpath = XmldbURI.create(path);
             try (final Collection collection = broker.getCollection(dbpath)) {
                 if (collection != null) {
                     transaction.abort();

--- a/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
@@ -1087,7 +1087,7 @@ try {
             String response = readResponse(connect.getInputStream());
 
             //readResponse is appending \r\n to each line that's why its added the expected content
-            assertEquals("Server returned document content " + response,"<foo/>\r\n",response);
+            assertEquals("Server returned document content " + response,"<foobar/>\r\n",response);
         } finally {
             connect.disconnect();
         }

--- a/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
@@ -254,7 +254,6 @@ public class RESTServiceTest {
         credentials = Base64.encodeBase64String("admin:".getBytes(UTF_8));
         badCredentials = Base64.encodeBase64String("johndoe:this pw should fail".getBytes(UTF_8));
 
-        //TODO create collection /db/AéB and store doc AéB.xml
         final XmldbURI TEST_XML_DOC_URI = XmldbURI.create("AéB.xml");
         final XmldbURI TEST_COLLECTION_URI = XmldbURI.create("/db/AéB");
         final String TEST_XML_DOC = "<foo/>";


### PR DESCRIPTION
this Fixes: https://github.com/eXist-db/exist/issues/4458
as mentioned in the issue above the rest client was unable to handle filenames with special characters. This fixes that for all HTTP request GET,POST,PUT,DELETE
now storing resource like 
```xquery
xquery version "3.1";

xmldb:create-collection("/db","AéB"),
xmldb:store(xmldb:encode("/db/AéB"), xmldb:encode("AéB.xml"), <foo/>)
```
and performing operations on it from the rest client works fine eg:
GET: http://localhost:8080/exist/rest/db/A%C3%A9B/A%C3%A9B.xml