### PR TITLE
Implement minus unary operator for xs:dateTimeStamp

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
@@ -144,6 +144,7 @@ public class DateTimeValue extends AbstractDateTimeValue {
 
     public ComputableValue minus(ComputableValue other) throws XPathException {
         switch (other.getType()) {
+            case Type.DATE_TIME_STAMP:
             case Type.DATE_TIME:
                 return new DayTimeDurationValue(getTimeInMillis() - ((DateTimeValue) other).getTimeInMillis());
             case Type.YEAR_MONTH_DURATION:

--- a/exist-core/src/test/xquery/dates/convert-dates.xqm
+++ b/exist-core/src/test/xquery/dates/convert-dates.xqm
@@ -48,6 +48,19 @@ function fd:add-test($date as xs:dateTimeStamp, $duration as xs:dayTimeDuration)
     $duration + $date
 };
 
+declare
+    %test:args("2022-08-10T12:36:51.723+02:00", "2022-07-10T12:36:51.723+02:00")
+    %test:assertEquals("P31D")
+function fd:subtract-test($date1 as xs:dateTimeStamp, $date2 as xs:dateTimeStamp) {
+    ($date1 - $date2) cast as xs:string
+};
+
+declare
+    %test:args("2022-08-10T12:36:51.723+02:00", "2022-07-10T12:36:51.723+02:00")
+    %test:assertEquals("P31D")
+function fd:subtract-from-dateTime-test($date1 as xs:dateTime, $date2 as xs:dateTimeStamp) {
+    ($date1 - $date2) cast as xs:string
+};
 
 (: verify that fn:current-dateTime() return type is xs:dateTimeStamp  :)
 declare


### PR DESCRIPTION
Fixes the calculation of:
```xquery
xs:dateTimeStamp(“2022-08-10T12:36:51.723+02:00”) - xs:dateTimeStamp(“2022-07-10T12:36:51.723+02:00")
```
and
```xquery
xs:dateTime(“2022-08-10T12:36:51.723+02:00”) - xs:dateTimeStamp(“2022-07-10T12:36:51.723+02:00")
```
This was missing from PR https://github.com/eXist-db/exist/pull/4393