### PR TITLE
Lazy loading model for module imports

### DIFF
--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -472,13 +472,16 @@ public class Configuration implements ErrorHandler
                         final Class<?> moduleClass = lookupModuleClass(uri, clazz);
 
                         // Store class if the module class actually exists
-                        if(moduleClass != null && (load == null || BUILT_IN_MODULE_LOAD_ATTRIBUTE_VALUE_EAGER.equals(load))) {
-                            eagerModuleClassMap.put(uri, moduleClass);
-                        } else if(moduleClass != null) {
-                            lazyModuleClassMap.put(uri, moduleClass);
-                        }
-                        if(LOG.isDebugEnabled()) {
-                            LOG.debug("Configured module '{}' implemented in '{}'", uri, clazz);
+                        if (moduleClass != null) {
+                            if (XQueryContext.BUILT_IN_MODULE_LOAD_ATTRIBUTE_VALUE_LAZY.equals(load)) {
+                                lazyModuleClassMap.put(uri, moduleClass);
+                            } else {
+                                eagerModuleClassMap.put(uri, moduleClass);
+                            }
+
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("Configured module '{}' implemented in '{}'", uri, clazz);
+                            }
                         }
                     }
 

--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -452,8 +452,8 @@ public class Configuration implements ErrorHandler
                         throw(new DatabaseConfigurationException("element 'module' requires either an attribute " + "'class' or 'src'" ));
                     }
 
-                    if(load != null && !("always".equals(load) || "lazily".equals(load))) {
-                        throw(new DatabaseConfigurationException("parameter 'load' on module can contains only 'always' and 'lazily' values"));
+                    if (load != null && !(XQueryContext.BUILT_IN_MODULE_LOAD_ATTRIBUTE_VALUE_EAGER.equals(load) || XQueryContext.BUILT_IN_MODULE_LOAD_ATTRIBUTE_VALUE_LAZY.equals(load))) {
+                        throw new DatabaseConfigurationException(String.format("parameter '{}' on module can only contain the value: '{}' or '{}'", XQueryContext.BUILT_IN_MODULE_LOAD_ATTRIBUTE, XQueryContext.BUILT_IN_MODULE_LOAD_ATTRIBUTE_VALUE_EAGER, XQueryContext.BUILT_IN_MODULE_LOAD_ATTRIBUTE_VALUE_LAZY));
                     }
 
                     if(source != null) {
@@ -472,7 +472,7 @@ public class Configuration implements ErrorHandler
                         final Class<?> moduleClass = lookupModuleClass(uri, clazz);
 
                         // Store class if the module class actually exists
-                        if(moduleClass != null && (load == null || "always".equals(load))) {
+                        if(moduleClass != null && (load == null || BUILT_IN_MODULE_LOAD_ATTRIBUTE_VALUE_EAGER.equals(load))) {
                             eagerModuleClassMap.put(uri, moduleClass);
                         } else if(moduleClass != null) {
                             lazyModuleClassMap.put(uri, moduleClass);

--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -471,10 +471,10 @@ public class Configuration implements ErrorHandler
                         // Get class of module
                         final Class<?> moduleClass = lookupModuleClass(uri, clazz);
 
-                        // Store class if thw module class actually exists
-                        if( moduleClass != null && (load == null || "always".equals(load))) {
+                        // Store class if the module class actually exists
+                        if(moduleClass != null && (load == null || "always".equals(load))) {
                             eagerModuleClassMap.put(uri, moduleClass);
-                        }else if(moduleClass != null) {
+                        } else if(moduleClass != null) {
                             lazyModuleClassMap.put(uri, moduleClass);
                         }
                         if(LOG.isDebugEnabled()) {

--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -393,11 +393,13 @@ public class Configuration implements ErrorHandler
         config.put( PerformanceStats.CONFIG_PROPERTY_TRACE, trace );
 
         // built-in-modules
-        final Map<String, Class<?>> classMap      = new HashMap<>();
-        final Map<String, String>   knownMappings = new HashMap<>();
+        final Map<String, Class<?>> eagerModuleClassMap = new HashMap<>();
+        final Map<String, Class<?>> lazyModuleClassMap  = new HashMap<>();
+        final Map<String, String>   knownMappings       = new HashMap<>();
         final Map<String, Map<String, List<? extends Object>>> moduleParameters = new HashMap<>();
-        loadModuleClasses(xquery, classMap, knownMappings, moduleParameters);
-        config.put( XQueryContext.PROPERTY_BUILT_IN_MODULES, classMap);
+        loadModuleClasses(xquery, eagerModuleClassMap, lazyModuleClassMap, knownMappings, moduleParameters);
+        config.put( XQueryContext.PROPERTY_BUILT_IN_MODULES, eagerModuleClassMap);
+        config.put( XQueryContext.PROPERTY_BUILT_IN_LAZY_MODULES, lazyModuleClassMap);
         config.put( XQueryContext.PROPERTY_STATIC_MODULE_MAP, knownMappings);
         config.put( XQueryContext.PROPERTY_MODULE_PARAMETERS, moduleParameters);
     }
@@ -407,14 +409,15 @@ public class Configuration implements ErrorHandler
      * that the specified module class exists and is a subclass of {@link org.exist.xquery.Module}.
      *
      * @param   xquery            configuration root
-     * @param   modulesClassMap   map containing all classes of modules
-     * @param   modulesSourceMap  map containing all source uris to external resources
+     * @param   eagerModuleClassMap map containing all classes of modules which are always loaded to XQueryContext
+     * @param   lazyModuleClassMap  map containing all classes of modules which are lazy loaded to XQueryContext only if they are explicitly imported
+     * @param   modulesSourceMap    map containing all source uris to external resources
      *
      * @throws  DatabaseConfigurationException
      */
-    private void loadModuleClasses( Element xquery, Map<String, Class<?>> modulesClassMap, Map<String, String> modulesSourceMap, Map<String, Map<String, List<? extends Object>>> moduleParameters) throws DatabaseConfigurationException {
+    private void loadModuleClasses( Element xquery, Map<String, Class<?>> eagerModuleClassMap, Map<String, Class<?>> lazyModuleClassMap, Map<String, String> modulesSourceMap, Map<String, Map<String, List<? extends Object>>> moduleParameters) throws DatabaseConfigurationException {
         // add the standard function module
-        modulesClassMap.put(Namespaces.XPATH_FUNCTIONS_NS, org.exist.xquery.functions.fn.FnModule.class);
+        eagerModuleClassMap.put(Namespaces.XPATH_FUNCTIONS_NS, org.exist.xquery.functions.fn.FnModule.class);
 
         // add other modules specified in configuration
         final NodeList builtins = xquery.getElementsByTagName(XQUERY_BUILTIN_MODULES_CONFIGURATION_MODULES_ELEMENT_NAME);
@@ -436,6 +439,8 @@ public class Configuration implements ErrorHandler
                     final String uri    = elem.getAttribute(XQueryContext.BUILT_IN_MODULE_URI_ATTRIBUTE);
                     final String clazz  = elem.getAttribute(XQueryContext.BUILT_IN_MODULE_CLASS_ATTRIBUTE);
                     final String source = elem.getAttribute(XQueryContext.BUILT_IN_MODULE_SOURCE_ATTRIBUTE);
+                    final String load   = elem.getAttribute(XQueryContext.BUILT_IN_MODULE_LOAD_ATTRIBUTE);
+
 
                     // uri attribute is the identifier and is always required
                     if(uri == null) {
@@ -445,6 +450,10 @@ public class Configuration implements ErrorHandler
                     // either class or source attribute must be present
                     if((clazz == null) && (source == null)) {
                         throw(new DatabaseConfigurationException("element 'module' requires either an attribute " + "'class' or 'src'" ));
+                    }
+
+                    if(load != null && !("always".equals(load) || "lazily".equals(load))) {
+                        throw(new DatabaseConfigurationException("parameter 'load' on module can contains only 'always' and 'lazily' values"));
                     }
 
                     if(source != null) {
@@ -463,10 +472,11 @@ public class Configuration implements ErrorHandler
                         final Class<?> moduleClass = lookupModuleClass(uri, clazz);
 
                         // Store class if thw module class actually exists
-                        if( moduleClass != null) {
-                            modulesClassMap.put(uri, moduleClass);
+                        if( moduleClass != null && (load == null || "always".equals(load))) {
+                            eagerModuleClassMap.put(uri, moduleClass);
+                        }else if(moduleClass != null) {
+                            lazyModuleClassMap.put(uri, moduleClass);
                         }
-
                         if(LOG.isDebugEnabled()) {
                             LOG.debug("Configured module '{}' implemented in '{}'", uri, clazz);
                         }

--- a/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
@@ -209,6 +209,11 @@ public class ModuleContext extends XQueryContext {
     }
 
     @Override
+    public void addModule(String namespaceURI, Module module) {
+        parentContext.addModule(namespaceURI, module);
+    }
+
+    @Override
     protected void setRootModules(final String namespaceURI, final Module[] modules) {
         parentContext.setRootModules(namespaceURI, modules);
     }

--- a/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
@@ -209,11 +209,6 @@ public class ModuleContext extends XQueryContext {
     }
 
     @Override
-    public void addModule(String namespaceURI, Module module) {
-        parentContext.addModule(namespaceURI, module);
-    }
-
-    @Override
     protected void setRootModules(final String namespaceURI, final Module[] modules) {
         parentContext.setRootModules(namespaceURI, modules);
     }

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -127,6 +127,8 @@ public class XQueryContext implements BinaryValueManager, Context {
     public static final String BUILT_IN_MODULE_CLASS_ATTRIBUTE = "class";
     public static final String BUILT_IN_MODULE_SOURCE_ATTRIBUTE = "src";
     public static final String BUILT_IN_MODULE_LOAD_ATTRIBUTE = "load";
+    public static final String BUILT_IN_MODULE_LOAD_ATTRIBUTE_VALUE_EAGER = "eager";
+    public static final String BUILT_IN_MODULE_LOAD_ATTRIBUTE_VALUE_LAZY = "lazy";
 
 
     public static final String PROPERTY_XQUERY_BACKWARD_COMPATIBLE = "xquery.backwardCompatible";

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -126,6 +126,8 @@ public class XQueryContext implements BinaryValueManager, Context {
     public static final String BUILT_IN_MODULE_URI_ATTRIBUTE = "uri";
     public static final String BUILT_IN_MODULE_CLASS_ATTRIBUTE = "class";
     public static final String BUILT_IN_MODULE_SOURCE_ATTRIBUTE = "src";
+    public static final String BUILT_IN_MODULE_LOAD_ATTRIBUTE = "load";
+
 
     public static final String PROPERTY_XQUERY_BACKWARD_COMPATIBLE = "xquery.backwardCompatible";
     public static final String PROPERTY_ENABLE_QUERY_REWRITING = "xquery.enable-query-rewriting";
@@ -134,7 +136,8 @@ public class XQueryContext implements BinaryValueManager, Context {
     public static final String PROPERTY_ENFORCE_INDEX_USE = "xquery.enforce-index-use";
 
     //TODO : move elsewhere ?
-    public static final String PROPERTY_BUILT_IN_MODULES = "xquery.modules";
+    public static final String PROPERTY_BUILT_IN_MODULES      = "xquery.modules";
+    public static final String PROPERTY_BUILT_IN_LAZY_MODULES = "xquery.modules.lazy";
     public static final String PROPERTY_STATIC_MODULE_MAP = "xquery.modules.static";
     public static final String PROPERTY_MODULE_PARAMETERS = "xquery.modules.parameters";
 
@@ -2512,6 +2515,19 @@ public class XQueryContext implements BinaryValueManager, Context {
 
         if (namespaceURI != null) {
             modules = getRootModules(namespaceURI);
+
+            //Lazy load modules
+            if (modules == null) {
+                final Class<Module> moduleClass = (Class<Module>) ((Map) getConfiguration()
+                        .getProperty(PROPERTY_BUILT_IN_LAZY_MODULES))
+                        .get(namespaceURI);
+                if(moduleClass != null) {
+                    instantiateModule(namespaceURI, moduleClass ,
+                            (Map<String, Map<String, List<? extends Object>>>) getConfiguration().getProperty(PROPERTY_MODULE_PARAMETERS));
+
+                    modules = getRootModules(namespaceURI);
+                }
+            }
         }
 
         if (isNotEmpty(modules)) {

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -1763,8 +1763,8 @@ public class XQueryContext implements BinaryValueManager, Context {
                 declareNamespace(module.getDefaultPrefix(), module.getNamespaceURI());
             }
 
-            modules.compute(module.getNamespaceURI(), addToMapValueArray(module));
-            allModules.compute(module.getNamespaceURI(), addToMapValueArray(module));
+            this.addModule(module.getNamespaceURI(), module);
+            this.addRootModule(module.getNamespaceURI(), module);
 
             if (module instanceof InternalModule) {
                 ((InternalModule) module).prepare(this);

--- a/exist-core/src/main/resources/org/exist/test/runner/xquery-test-runner.xq
+++ b/exist-core/src/main/resources/org/exist/test/runner/xquery-test-runner.xq
@@ -24,6 +24,8 @@ xquery version "3.1";
 import module namespace test = "http://exist-db.org/xquery/xqsuite"
     at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
 
+import module namespace inspect = "http://exist-db.org/xquery/inspection";
+
 declare variable $test-module-uri as xs:anyURI external;
 
 (: hooks for sending external notifications about test events :)

--- a/exist-core/src/test/java/org/exist/validation/CollectionConfigurationValidationModeTest.java
+++ b/exist-core/src/test/java/org/exist/validation/CollectionConfigurationValidationModeTest.java
@@ -55,12 +55,18 @@ public class CollectionConfigurationValidationModeTest {
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        existEmbeddedServer.executeQuery("validation:clear-grammar-cache()");
+        existEmbeddedServer.executeQuery(
+                "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:clear-grammar-cache()"
+        );
     }
 
     @Before
     public void setUp() throws Exception {
-        existEmbeddedServer.executeQuery("validation:clear-grammar-cache()");
+        existEmbeddedServer.executeQuery(
+                "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:clear-grammar-cache()"
+        );
     }
 
     private void createCollection(final String collection) throws XMLDBException {

--- a/exist-core/src/test/java/org/exist/xquery/ForwardReferenceTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/ForwardReferenceTest.java
@@ -141,6 +141,7 @@ public class ForwardReferenceTest {
                 "\n" +
                 "import module namespace xqsuite = \"http://exist-db.org/xquery/xqsuite\"\n" +
                 "    at \"resource:org/exist/xquery/lib/xqsuite/xqsuite.xql\";\n" +
+                "import module namespace inspect = \"http://exist-db.org/xquery/inspection\";" +
                 "\n" +
                 "xqsuite:suite((\n" +
                 "    inspect:module-functions(xs:anyURI(\"xmldb:exist://" + TEST_PAGES_MODULE_URI + "\"))\n" +

--- a/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryTest.java
@@ -922,7 +922,7 @@ public class XQueryTest {
 
         String query =
                 "xquery version \"1.0\";\n" +
-                "declare namespace transform=\"http://exist-db.org/xquery/transform\";\n" +
+                "import module namespace transform=\"http://exist-db.org/xquery/transform\";\n" +
                 "declare variable $xml {\n" +
                 "	<node>text</node>\n" +
                 "};\n" +

--- a/exist-core/src/test/java/org/exist/xquery/functions/transform/TransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/transform/TransformTest.java
@@ -132,6 +132,7 @@ public class TransformTest {
             "xquery version \"3.0\";\n" +
             "\n" +
             "(:Read document with xsl:for-each and look for key in the dictionary document :)\n" +
+            "import module namespace transform = \"http://exist-db.org/xquery/transform\";\n" +
             "declare variable $xsltPath as xs:string := '" + TEST_IDS_COLLECTION.getCollectionPath() + "';\n" +
             "declare variable $listOpsFileUri as xs:string := '" + TEST_IDS_COLLECTION.getCollectionPath()+ "/listOpsErr.xml';\n" +
             "declare variable $inputFileUri as xs:string := '" + TEST_IDS_COLLECTION.getCollectionPath() + "/inputListOps.xml';\n" +

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/AdditionalJingXsdRngTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/AdditionalJingXsdRngTest.java
@@ -43,7 +43,8 @@ public class AdditionalJingXsdRngTest {
 
     @Test
     public void testValidateXSDwithJing() throws XMLDBException {
-        final String query = "let $v := <doc>\n" +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "let $v := <doc>\n" +
                 "\t<title>Title</title>\n" +
                 "\t<p>Some paragraph.</p>\n" +
                 "      </doc>\n" +
@@ -71,7 +72,8 @@ public class AdditionalJingXsdRngTest {
 
     @Test
     public void testValidateXSDwithJing_invalid() throws XMLDBException {
-        final String query = "let $v := <doc>\n" +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "let $v := <doc>\n" +
                 "\t<title1>Title</title1>\n" +
                 "\t<p>Some paragraph.</p>\n" +
                 "      </doc>\n" +
@@ -99,7 +101,8 @@ public class AdditionalJingXsdRngTest {
 
     @Test
     public void testValidateRNGwithJing() throws XPathException, XMLDBException {
-        final String query = "let $v := <doc>\n" +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "let $v := <doc>\n" +
                 "\t<title>Title</title>\n" +
                 "\t<p>Some paragraph.</p>\n" +
                 "      </doc>\n" +
@@ -139,7 +142,8 @@ public class AdditionalJingXsdRngTest {
 
     @Test
     public void testValidateRNGwithJing_invalid() throws XMLDBException {
-        final String query = "let $v := <doc>\n" +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "let $v := <doc>\n" +
                 "\t<title1>Title</title1>\n" +
                 "\t<p>Some paragraph.</p>\n" +
                 "      </doc>\n" +

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpDtdCatalogTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpDtdCatalogTest.java
@@ -118,7 +118,9 @@ public class JaxpDtdCatalogTest {
 
     @Before
     public void clearGrammarCache() throws XMLDBException {
-        final ResourceSet results = existEmbeddedServer.executeQuery("validation:clear-grammar-cache()");
+        final ResourceSet results = existEmbeddedServer.executeQuery(
+                "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:clear-grammar-cache()");
         results.getResource(0).getContent();
     }
 
@@ -127,7 +129,8 @@ public class JaxpDtdCatalogTest {
      */
     @Test
     public void dtd_stored_catalog_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/parse/instance/valid-dtd.xml'), false()," +
                 "doc('/db/parse/catalog.xml') )";
         executeAndEvaluate(query,"valid");
@@ -135,7 +138,8 @@ public class JaxpDtdCatalogTest {
 
     @Test
     public void dtd_stored_catalog_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/parse/instance/invalid-dtd.xml'), false()," +
                 "doc('/db/parse/catalog.xml') )";
         executeAndEvaluate(query,"invalid");
@@ -143,7 +147,8 @@ public class JaxpDtdCatalogTest {
 
     @Test
     public void dtd_anyURI_catalog_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/parse/instance/valid-dtd.xml'), false()," +
                 "xs:anyURI('/db/parse/catalog.xml') )";
         executeAndEvaluate(query,"valid");
@@ -151,7 +156,8 @@ public class JaxpDtdCatalogTest {
 
     @Test
     public void dtd_anyURI_catalog_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/parse/instance/invalid-dtd.xml'), false()," +
                 "xs:anyURI('/db/parse/catalog.xml') )";
        executeAndEvaluate(query,"invalid");
@@ -165,7 +171,8 @@ public class JaxpDtdCatalogTest {
      */
     @Test
     public void dtd_searched_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/parse/instance/valid-dtd.xml'), false()," +
                 "xs:anyURI('/db/parse/') )";
         executeAndEvaluate(query,"valid");
@@ -173,7 +180,8 @@ public class JaxpDtdCatalogTest {
 
     @Test
     public void dtd_searched_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/parse/instance/invalid-dtd.xml'), false()," +
                 "xs:anyURI('/db/parse/') )";
         executeAndEvaluate(query,"invalid");

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpParseTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpParseTest.java
@@ -90,17 +90,21 @@ public class JaxpParseTest {
 
     @Before
     public void clearGrammarCache() throws XMLDBException {
-        final ResourceSet results = existEmbeddedServer.executeQuery("validation:clear-grammar-cache()");
+        final ResourceSet results = existEmbeddedServer.executeQuery(
+                "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:clear-grammar-cache()");
         results.getResource(0).getContent();
     }
 
     @Test
     public void parse_and_fill_defaults() throws XMLDBException, IOException, SAXException {
-        String query = "validation:pre-parse-grammar(xs:anyURI('/db/parse_validate/defaultValue.xsd'))";
+        String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:pre-parse-grammar(xs:anyURI('/db/parse_validate/defaultValue.xsd'))";
         String result = execute(query);
         assertEquals(result, "defaultTest");
 
-        query = "declare option exist:serialize 'indent=no'; " +
+        query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "declare option exist:serialize 'indent=no'; " +
                 "validation:jaxp-parse(xs:anyURI('/db/parse_validate/defaultValue.xml'), true(), ())";
         result = execute(query);
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxpXsdCatalogTest.java
@@ -124,13 +124,16 @@ public class JaxpXsdCatalogTest {
 
     @Before
     public void clearGrammarCache() throws XMLDBException {
-        final ResourceSet results = existEmbeddedServer.executeQuery("validation:clear-grammar-cache()");
+        final ResourceSet results = existEmbeddedServer.executeQuery(
+                "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:clear-grammar-cache()");
         results.getResource(0).getContent();
     }
 
     @Test
     public void xsd_stored_catalog_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "doc('/db/parse/instance/valid.xml'), false()," +
                 "doc('/db/parse/catalog.xml') )";
         executeAndEvaluate(query,"valid");
@@ -138,7 +141,8 @@ public class JaxpXsdCatalogTest {
 
     @Test
     public void xsd_stored_catalog_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "doc('/db/parse/instance/invalid.xml'), false()," +
                 "doc('/db/parse/catalog.xml') )";
         executeAndEvaluate(query,"invalid");
@@ -146,7 +150,8 @@ public class JaxpXsdCatalogTest {
 
     @Test
     public void xsd_anyURI_catalog_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/parse/instance/valid.xml'), false()," +
                 "xs:anyURI('/db/parse/catalog.xml') )";
         executeAndEvaluate(query,"valid");
@@ -154,7 +159,8 @@ public class JaxpXsdCatalogTest {
 
     @Test
     public void xsd_anyURI_catalog_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/parse/instance/invalid.xml'), false()," +
                 "xs:anyURI('/db/parse/catalog.xml') )";
         executeAndEvaluate(query,"invalid");
@@ -162,7 +168,8 @@ public class JaxpXsdCatalogTest {
 
     @Test
     public void xsd_searched_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "doc('/db/parse/instance/valid.xml'), false()," +
                 "xs:anyURI('/db/parse/') )";
         executeAndEvaluate(query,"valid");
@@ -170,7 +177,8 @@ public class JaxpXsdCatalogTest {
 
     @Test
     public void xsd_searched_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "doc('/db/parse/instance/invalid.xml'), false()," +
                 "xs:anyURI('/db/parse/') )";
         executeAndEvaluate(query,"invalid");
@@ -179,7 +187,8 @@ public class JaxpXsdCatalogTest {
     // test boolean function
     @Test
     public void xsd_searched_valid_boolean() throws XMLDBException {
-        final String query = "validation:jaxp( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp( " +
                 "doc('/db/parse/instance/valid.xml'), false()," +
                 "xs:anyURI('/db/parse/') )";
         assertEquals("true", existEmbeddedServer.executeOneValue(query));
@@ -188,7 +197,8 @@ public class JaxpXsdCatalogTest {
     // test boolean function
     @Test
     public void xsd_searched_invalid_boolean() throws XMLDBException {
-        final String query = "validation:jaxp( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp( " +
                 "doc('/db/parse/instance/invalid.xml'), false()," +
                 "xs:anyURI('/db/parse/') )";
         assertEquals("false", existEmbeddedServer.executeOneValue(query));
@@ -197,7 +207,8 @@ public class JaxpXsdCatalogTest {
     // test parse function
     @Test
     public void xsd_searched_parse_valid() throws SAXException, IOException, XpathException, XMLDBException {
-        final String query = "validation:jaxp-parse( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-parse( " +
                 "doc('/db/parse/instance/valid.xml'), false()," +
                 "xs:anyURI('/db/parse/') )";
         final String r = existEmbeddedServer.executeOneValue(query);
@@ -207,7 +218,8 @@ public class JaxpXsdCatalogTest {
     // test parse function
     @Test
     public void xsd_searched_parse_invalid() throws SAXException, IOException, XpathException, XMLDBException {
-        final String query = "validation:jaxp-parse( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-parse( " +
                 "doc('/db/parse/instance/invalid.xml'), false()," +
                 "xs:anyURI('/db/parse/') )";
         final String r = existEmbeddedServer.executeOneValue(query);

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxvTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JaxvTest.java
@@ -89,7 +89,8 @@ public class JaxvTest {
 
     @Test
     public void xsd_stored_valid() throws XMLDBException {
-        final String query = "validation:jaxv( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxv( " +
                 "doc('/db/personal/personal-valid.xml'), " +
                 "doc('/db/personal/personal.xsd') )";
 
@@ -101,7 +102,8 @@ public class JaxvTest {
 
     @Test
     public void xsd_stored_report_valid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxv-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxv-report( " +
                 "doc('/db/personal/personal-valid.xml'), " +
                 "doc('/db/personal/personal.xsd') )";
 
@@ -114,7 +116,8 @@ public class JaxvTest {
 
     @Test
     public void xsd_stored_invalid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxv-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxv-report( " +
                 "doc('/db/personal/personal-invalid.xml'), " +
                 "doc('/db/personal/personal.xsd') )";
 
@@ -127,7 +130,8 @@ public class JaxvTest {
 
     @Test
     public void xsd_anyuri_valid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxv-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxv-report( " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal-valid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal.xsd') )";
 
@@ -140,7 +144,8 @@ public class JaxvTest {
 
     @Test
     public void xsd_anyuri_invalid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxv-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxv-report( " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal-invalid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal.xsd') )";
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JingOnvdlTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JingOnvdlTest.java
@@ -96,7 +96,8 @@ public class JingOnvdlTest {
 
     @Test
     public void onvdl_valid() throws XPathException, IOException, XpathException, SAXException, XMLDBException {
-        final String query = "let $a := " + XML_DATA1 +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "let $a := " + XML_DATA1 +
                 "let $b := xs:anyURI('/db/validate-test/test.nvdl')" +
                 "return " +
                 "validation:jing-report($a,$b)";
@@ -105,7 +106,8 @@ public class JingOnvdlTest {
 
     @Test
     public void onvdl_invalid() throws XPathException, IOException, XpathException, SAXException, XMLDBException {
-        final String query = "let $a := <test/>" +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "let $a := <test/>" +
                     "let $b := xs:anyURI('/db/validate-test/test.nvdl')" +
                     "return " +
                     "validation:jing-report($a,$b)";
@@ -115,7 +117,8 @@ public class JingOnvdlTest {
 
     @Test
     public void onvdl_stored_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/validate-test/valid.xml'), " +
                 "doc('/db/validate-test/test.nvdl') )";
         executeAndEvaluate(query,"valid");
@@ -123,7 +126,8 @@ public class JingOnvdlTest {
 
     @Test
     public void onvdl_stored_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/validate-test/invalid.xml'), " +
                 "doc('/db/validate-test/test.nvdl') )";
         executeAndEvaluate(query,"invalid");
@@ -131,7 +135,8 @@ public class JingOnvdlTest {
 
     @Test
     public void onvdl_anyuri_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "xs:anyURI('xmldb:exist:///db/validate-test/valid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/validate-test/test.nvdl') )";
         executeAndEvaluate(query,"valid");
@@ -139,7 +144,8 @@ public class JingOnvdlTest {
 
     @Test
     public void onvdl_anyuri_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "xs:anyURI('xmldb:exist:///db/validate-test/invalid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/validate-test/test.nvdl') )";
         executeAndEvaluate(query,"invalid");
@@ -147,7 +153,8 @@ public class JingOnvdlTest {
 
     @Test
     public void onvdl_anyuri_valid_boolean() throws XMLDBException {
-        final String query = "validation:jing( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing( " +
                 "xs:anyURI('xmldb:exist:///db/validate-test/valid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/validate-test/test.nvdl') )";
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JingRelaxNgTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JingRelaxNgTest.java
@@ -88,7 +88,8 @@ public class JingRelaxNgTest {
 
     @Test
     public void rng_stored_valid_boolean() throws XMLDBException {
-        final String query = "validation:jing( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing( " +
                 "doc('/db/personal/personal-valid.xml'), " +
                 "doc('/db/personal/personal.rng') )";
         final ResourceSet results = existEmbeddedServer.executeQuery(query);
@@ -99,7 +100,8 @@ public class JingRelaxNgTest {
     
     @Test
     public void rng_stored_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/personal/personal-valid.xml'), " +
                 "doc('/db/personal/personal.rng') )";
         executeAndEvaluate(query,"valid");
@@ -107,7 +109,8 @@ public class JingRelaxNgTest {
 
     @Test
     public void rng_stored_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/personal/personal-invalid.xml'), " +
                 "doc('/db/personal/personal.rng') )";
         executeAndEvaluate(query,"invalid");
@@ -115,7 +118,8 @@ public class JingRelaxNgTest {
 
     @Test
     public void rng_anyuri_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal-valid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal.rng') )";
         executeAndEvaluate(query,"valid");
@@ -123,7 +127,8 @@ public class JingRelaxNgTest {
 
     @Test
     public void rng_anyuri_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal-invalid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal.rng') )";
         executeAndEvaluate(query,"invalid");
@@ -131,7 +136,8 @@ public class JingRelaxNgTest {
 
     @Test
     public void rnc_stored_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/personal/personal-valid.xml'), " +
                 "util:binary-doc('/db/personal/personal.rnc') )";
         executeAndEvaluate(query,"valid");
@@ -139,7 +145,8 @@ public class JingRelaxNgTest {
 
     @Test
     public void rnc_stored_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/personal/personal-invalid.xml'), " +
                 "util:binary-doc('/db/personal/personal.rnc') )";
         executeAndEvaluate(query,"invalid");
@@ -147,14 +154,16 @@ public class JingRelaxNgTest {
 
     @Test
     public void rnc_anyuri_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( xs:anyURI('xmldb:exist:///db/personal/personal-valid.xml'), " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( xs:anyURI('xmldb:exist:///db/personal/personal-valid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal.rnc') )";
         executeAndEvaluate(query,"valid");
     }
 
     @Test
     public void rnc_anyuri_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( xs:anyURI('xmldb:exist:///db/personal/personal-invalid.xml'), " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( xs:anyURI('xmldb:exist:///db/personal/personal-invalid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal.rnc') )";
         executeAndEvaluate(query,"invalid");
     }

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JingSchematronTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JingSchematronTest.java
@@ -90,7 +90,8 @@ public class JingSchematronTest {
 
     @Test
     public void sch_15_stored_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        String query = "validation:jing-report( " +
+        String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/tournament/1.5/Tournament-valid.xml'), " +
                 "doc('/db/tournament/1.5/tournament-schema.sch') )";
 
@@ -99,7 +100,8 @@ public class JingSchematronTest {
 
     @Test
     public void sch_15_stored_valid_boolean() throws XMLDBException {
-        final String query = "validation:jing( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing( " +
                 "doc('/db/tournament/1.5/Tournament-valid.xml'), " +
                 "doc('/db/tournament/1.5/tournament-schema.sch') )";
 
@@ -113,7 +115,8 @@ public class JingSchematronTest {
     @Test
 
     public void sch_15_stored_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/tournament/1.5/Tournament-invalid.xml'), " +
                 "doc('/db/tournament/1.5/tournament-schema.sch') )";
         executeAndEvaluate(query,"invalid");
@@ -121,7 +124,8 @@ public class JingSchematronTest {
 
     @Test
     public void sch_15_anyuri_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "xs:anyURI('xmldb:exist:///db/tournament/1.5/Tournament-valid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/tournament/1.5/tournament-schema.sch') )";
         executeAndEvaluate(query,"valid");
@@ -129,7 +133,8 @@ public class JingSchematronTest {
 
     @Test
     public void sch_15_anyuri_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "xs:anyURI('xmldb:exist:///db/tournament/1.5/Tournament-invalid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/tournament/1.5/tournament-schema.sch') )";
         executeAndEvaluate(query,"invalid");

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/JingXsdTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/JingXsdTest.java
@@ -91,7 +91,8 @@ public class JingXsdTest {
 
     @Test
     public void xsd_stored_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/personal/personal-valid.xml'), " +
                 "doc('/db/personal/personal.xsd') )";
         executeAndEvaluate(query,"valid");
@@ -99,7 +100,8 @@ public class JingXsdTest {
 
     @Test
     public void xsd_stored_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "doc('/db/personal/personal-invalid.xml'), " +
                 "doc('/db/personal/personal.xsd') )";
         executeAndEvaluate(query,"invalid");
@@ -107,7 +109,8 @@ public class JingXsdTest {
 
     @Test
     public void xsd_anyuri_valid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal-valid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal.xsd') )";
         executeAndEvaluate(query, "valid");
@@ -115,7 +118,8 @@ public class JingXsdTest {
 
     @Test
     public void xsd_anyuri_invalid() throws XMLDBException, SAXException, XpathException, IOException {
-        final String query = "validation:jing-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jing-report( " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal-invalid.xml'), " +
                 "xs:anyURI('xmldb:exist:///db/personal/personal.xsd') )";
         executeAndEvaluate(query,"invalid");

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseDtdTestNOK.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseDtdTestNOK.java
@@ -101,7 +101,8 @@ public class ParseDtdTestNOK {
 
     @Test
     public void xsd_stored_valid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "doc('/db/hamlet/hamlet_valid.xml'), " +
                 "xs:anyURI('/db/hamlet/dtd/hamlet.dtd'), () )";
 
@@ -114,7 +115,8 @@ public class ParseDtdTestNOK {
 
     @Test
     public void xsd_stored_invalid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxp-report(doc('/db/hamlet/hamlet_invalid.xml'), " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report(doc('/db/hamlet/hamlet_invalid.xml'), " +
                 "xs:anyURI('/db/hamlet/dtd/hamlet.dtd'), () )";
 
         final ResourceSet results = existEmbeddedServer.executeQuery(query);
@@ -126,7 +128,8 @@ public class ParseDtdTestNOK {
 
     @Test
     public void xsd_anyuri_valid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/hamlet/hamlet_valid.xml'), " +
                 "xs:anyURI('/db/hamlet/dtd/hamlet.dtd'), () )";
 
@@ -139,7 +142,8 @@ public class ParseDtdTestNOK {
 
     @Test
     public void xsd_anyuri_invalid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "xs:anyURI('/db/hamlet/hamlet_invalid.xml'), " +
                 "xs:anyURI('/db/hamlet/dtd/hamlet.dtd'), () )";
 

--- a/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseXsdTestNOK.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/validate/ParseXsdTestNOK.java
@@ -89,7 +89,8 @@ public class ParseXsdTestNOK {
 
     @Test
     public void xsd_stored_valid() throws XMLDBException, SAXException, IOException, XpathException {
-        final String query = "validation:jaxp-report( " +
+        final String query = "import module namespace validation = \"http://exist-db.org/xquery/validation\";\n" +
+                "validation:jaxp-report( " +
                 "doc('/db/addressbook/addressbook_valid.xml'), " +
                 "xs:anyURI('/db/addressbook/addressbook.xsd'), () )";
 

--- a/exist-core/src/test/resources-filtered/conf.xml
+++ b/exist-core/src/test/resources-filtered/conf.xml
@@ -896,18 +896,18 @@
             <module uri="http://www.w3.org/2005/xpath-functions/math" class="org.exist.xquery.functions.math.MathModule" />
             <module uri="http://www.w3.org/2005/xpath-functions/array" class="org.exist.xquery.functions.array.ArrayModule" />
 
-            <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule" load="lazy"/>
             <module uri="http://exist-db.org/xquery/request"    class="org.exist.xquery.functions.request.RequestModule" />
             <module uri="http://exist-db.org/xquery/response"   class="org.exist.xquery.functions.response.ResponseModule" />
             <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule" />
             <module uri="http://exist-db.org/xquery/session"    class="org.exist.xquery.functions.session.SessionModule" />
             <module uri="http://exist-db.org/xquery/system"     class="org.exist.xquery.functions.system.SystemModule"/>
-            <module uri="http://exist-db.org/xquery/transform"  class="org.exist.xquery.functions.transform.TransformModule" load="lazily" />
+            <module uri="http://exist-db.org/xquery/transform"  class="org.exist.xquery.functions.transform.TransformModule" load="lazy" />
             <module uri="http://exist-db.org/xquery/util"       class="org.exist.xquery.functions.util.UtilModule">
                 <!-- set to true to disable the util:eval functions -->
                 <parameter name="evalDisabled" value="false"/>
             </module>
-            <module uri="http://exist-db.org/xquery/validation" class="org.exist.xquery.functions.validation.ValidationModule" load="lazily" />
+            <module uri="http://exist-db.org/xquery/validation" class="org.exist.xquery.functions.validation.ValidationModule" load="lazy" />
             <module uri="http://exist-db.org/xquery/xmldb"      class="org.exist.xquery.functions.xmldb.XMLDBModule" />
 
         </builtin-modules>

--- a/exist-core/src/test/resources-filtered/conf.xml
+++ b/exist-core/src/test/resources-filtered/conf.xml
@@ -899,9 +899,9 @@
             <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule" load="lazily"/>
             <module uri="http://exist-db.org/xquery/request"    class="org.exist.xquery.functions.request.RequestModule" />
             <module uri="http://exist-db.org/xquery/response"   class="org.exist.xquery.functions.response.ResponseModule" />
-            <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule" />
             <module uri="http://exist-db.org/xquery/session"    class="org.exist.xquery.functions.session.SessionModule" />
-            <module uri="http://exist-db.org/xquery/system"     class="org.exist.xquery.functions.system.SystemModule"  load="lazily"/>
+            <module uri="http://exist-db.org/xquery/system"     class="org.exist.xquery.functions.system.SystemModule"/>
             <module uri="http://exist-db.org/xquery/transform"  class="org.exist.xquery.functions.transform.TransformModule" load="lazily" />
             <module uri="http://exist-db.org/xquery/util"       class="org.exist.xquery.functions.util.UtilModule">
                 <!-- set to true to disable the util:eval functions -->

--- a/exist-core/src/test/resources-filtered/conf.xml
+++ b/exist-core/src/test/resources-filtered/conf.xml
@@ -896,18 +896,18 @@
             <module uri="http://www.w3.org/2005/xpath-functions/math" class="org.exist.xquery.functions.math.MathModule" />
             <module uri="http://www.w3.org/2005/xpath-functions/array" class="org.exist.xquery.functions.array.ArrayModule" />
 
-            <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule"/>
+            <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule" load="lazily"/>
             <module uri="http://exist-db.org/xquery/request"    class="org.exist.xquery.functions.request.RequestModule" />
             <module uri="http://exist-db.org/xquery/response"   class="org.exist.xquery.functions.response.ResponseModule" />
-            <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule"/>
+            <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule" load="lazily"/>
             <module uri="http://exist-db.org/xquery/session"    class="org.exist.xquery.functions.session.SessionModule" />
-            <module uri="http://exist-db.org/xquery/system"     class="org.exist.xquery.functions.system.SystemModule" />
-            <module uri="http://exist-db.org/xquery/transform"  class="org.exist.xquery.functions.transform.TransformModule" />
+            <module uri="http://exist-db.org/xquery/system"     class="org.exist.xquery.functions.system.SystemModule"  load="lazily"/>
+            <module uri="http://exist-db.org/xquery/transform"  class="org.exist.xquery.functions.transform.TransformModule" load="lazily" />
             <module uri="http://exist-db.org/xquery/util"       class="org.exist.xquery.functions.util.UtilModule">
                 <!-- set to true to disable the util:eval functions -->
                 <parameter name="evalDisabled" value="false"/>
             </module>
-            <module uri="http://exist-db.org/xquery/validation" class="org.exist.xquery.functions.validation.ValidationModule" />
+            <module uri="http://exist-db.org/xquery/validation" class="org.exist.xquery.functions.validation.ValidationModule" load="lazily" />
             <module uri="http://exist-db.org/xquery/xmldb"      class="org.exist.xquery.functions.xmldb.XMLDBModule" />
 
         </builtin-modules>

--- a/exist-core/src/test/xquery/securitymanager/account.xqm
+++ b/exist-core/src/test/xquery/securitymanager/account.xqm
@@ -24,7 +24,7 @@ xquery version "3.1";
 module namespace account = "http://exist-db.org/test/securitymanager/account";
 
 declare namespace test = "http://exist-db.org/xquery/xqsuite";
-declare namespace sm = "http://exist-db.org/xquery/securitymanager";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
 
 declare
     %test:assertFalse

--- a/exist-core/src/test/xquery/securitymanager/id.xqm
+++ b/exist-core/src/test/xquery/securitymanager/id.xqm
@@ -25,7 +25,8 @@ module namespace id = "http://exist-db.org/test/securitymanager/id";
 
 declare namespace test = "http://exist-db.org/xquery/xqsuite";
 declare namespace mod1 = "http://module1";
-declare namespace sm = "http://exist-db.org/xquery/securitymanager";
+import module namespace inspect = "http://exist-db.org/xquery/inspection";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
 
 declare variable $id:TEST_COLLECTION_NAME := "test-id";
 declare variable $id:TEST_COLLECTION_PATH := "/db/test-id";
@@ -38,6 +39,7 @@ function id:setup() {
     xmldb:store($id:TEST_COLLECTION_PATH, $id:TEST_MODULE_NAME, 'xquery version "3.0";
 
 module namespace mod1 = "http://module1";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
 
 declare function mod1:function1() {
     <mod1>{sm:id()}</mod1>

--- a/exist-core/src/test/xquery/serialization.xml
+++ b/exist-core/src/test/xquery/serialization.xml
@@ -45,7 +45,7 @@ some value
         <task>comments and xsl</task>
         <code><![CDATA[
 xquery version "1.0" encoding "UTF-8";
-
+import module namespace transform = "http://exist-db.org/xquery/transform";
 let $doc as document-node() := document {
   <Root>
     <!-- Comment 1 -->

--- a/exist-core/src/test/xquery/validation/jaxv.xql
+++ b/exist-core/src/test/xquery/validation/jaxv.xql
@@ -25,6 +25,8 @@ module namespace val ="http://exist-db.org/xquery/test/validation";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
+import module namespace validation = "http://exist-db.org/xquery/validation";
+
 declare variable $val:XML := <root>
                                 <value1>20</value1>
                                 <value2>30</value2>

--- a/exist-core/src/test/xquery/xinclude/xinclude.xml
+++ b/exist-core/src/test/xquery/xinclude/xinclude.xml
@@ -175,6 +175,7 @@
     <test output="text">
         <task>XInclude applied before XSLT step</task>
         <code><![CDATA[
+            import module namespace transform = "http://exist-db.org/xquery/transform";
             let $stylesheet := doc("/db/test/test.xsl")
             return
                 transform:transform(doc('/db/test/test1.xml'), $stylesheet, (), (),
@@ -185,6 +186,7 @@
     <test output="text">
         <task>XInclude applied before XSLT step 2</task>
         <code><![CDATA[
+            import module namespace transform = "http://exist-db.org/xquery/transform";
             let $stylesheet := doc("/db/test/test.xsl")
             return
                 transform:transform(doc('/db/test/test1.xml'), $stylesheet, ())

--- a/exist-core/src/test/xquery/xmldb/copy-tests.xql
+++ b/exist-core/src/test/xquery/xmldb/copy-tests.xql
@@ -25,6 +25,8 @@ module namespace t="http://exist-db.org/testsuite/copy";
 
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
 
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
+
 declare variable $t:collection-name := "copy-test";
 declare variable $t:collection := "/db/" || $t:collection-name;
 declare variable $t:target-collection-name := "copy-target";

--- a/exist-core/src/test/xquery/xmldb/permission-tests.xql
+++ b/exist-core/src/test/xquery/xmldb/permission-tests.xql
@@ -24,6 +24,7 @@ xquery version "3.0";
 module namespace t="http://exist-db.org/testsuite/permissions";
 
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
+import module namespace sm = "http://exist-db.org/xquery/securitymanager";
 
 declare variable $t:collection-name := "permission-test";
 declare variable $t:collection := "/db/" || $t:collection-name;

--- a/exist-distribution/src/main/config/conf.xml
+++ b/exist-distribution/src/main/config/conf.xml
@@ -948,21 +948,21 @@
             <module uri="http://www.w3.org/2005/xpath-functions/map"  class="org.exist.xquery.functions.map.MapModule"/>
             <module uri="http://www.w3.org/2005/xpath-functions/math" class="org.exist.xquery.functions.math.MathModule"/>
             <module uri="http://www.w3.org/2005/xpath-functions/array" class="org.exist.xquery.functions.array.ArrayModule"/>
-            <module uri="http://exist-db.org/xquery/backups" class="org.exist.backup.xquery.BackupModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/backups" class="org.exist.backup.xquery.BackupModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule" load="lazy"/>
             <module uri="http://exist-db.org/xquery/kwic" src="resource:org/exist/xquery/lib/kwic.xql"/>
             <module uri="http://exist-db.org/xquery/request" class="org.exist.xquery.functions.request.RequestModule"/>
             <module uri="http://exist-db.org/xquery/response" class="org.exist.xquery.functions.response.ResponseModule"/>
-            <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule" load="lazy"/>
             <module uri="http://exist-db.org/xquery/session" class="org.exist.xquery.functions.session.SessionModule"/>
-            <module uri="http://exist-db.org/xquery/system" class="org.exist.xquery.functions.system.SystemModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/system" class="org.exist.xquery.functions.system.SystemModule" load="lazy"/>
             <module uri="http://exist-db.org/xquery/testing" src="resource:org/exist/xquery/lib/test.xq"/>
-            <module uri="http://exist-db.org/xquery/transform" class="org.exist.xquery.functions.transform.TransformModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/transform" class="org.exist.xquery.functions.transform.TransformModule" load="lazy"/>
             <module uri="http://exist-db.org/xquery/util" class="org.exist.xquery.functions.util.UtilModule">
                 <!-- set to true to disable the util:eval functions -->
                 <parameter name="evalDisabled" value="false"/>
             </module>
-            <module uri="http://exist-db.org/xquery/validation" class="org.exist.xquery.functions.validation.ValidationModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/validation" class="org.exist.xquery.functions.validation.ValidationModule" load="lazy"/>
             <module uri="http://exist-db.org/xquery/xmldb" class="org.exist.xquery.functions.xmldb.XMLDBModule">
                 <!-- set to false to disable the use of xs:anyURI as a $contents value for xmldb:store and xmldb:store-as-binary function -->
                 <parameter name="allowAnyUri" value="false"/>
@@ -972,10 +972,10 @@
             <!-- 
                 Extension Indexes
             -->
-            <module uri="http://exist-db.org/xquery/lucene" class="org.exist.xquery.modules.lucene.LuceneModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/ngram"  class="org.exist.xquery.modules.ngram.NGramModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/range"  class="org.exist.xquery.modules.range.RangeIndexModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/sort"   class="org.exist.xquery.modules.sort.SortModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/lucene" class="org.exist.xquery.modules.lucene.LuceneModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/ngram"  class="org.exist.xquery.modules.ngram.NGramModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/range"  class="org.exist.xquery.modules.range.RangeIndexModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/sort"   class="org.exist.xquery.modules.sort.SortModule" load="lazy"/>
             <!--
             <module uri="http://exist-db.org/xquery/spatial" class="org.exist.xquery.modules.spatial.SpatialModule"/>
             -->
@@ -984,23 +984,23 @@
             <!--
                 Extensions
             -->
-            <module uri="http://exist-db.org/xquery/contentextraction"  class="org.exist.contentextraction.xquery.ContentExtractionModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/contentextraction"  class="org.exist.contentextraction.xquery.ContentExtractionModule" load="lazy"/>
             <!-- module uri="http://exist-db.org/xquery/exiftool"  class="org.exist.exiftool.xquery.ExiftoolModule">
                 <parameter name="perl-path" value="/usr/bin/perl" description="file system path to the perl executable"/>
                 <parameter name="exiftool-path" value="/usr/bin/exiftool" description="file system path to the exiftool perl script"/>
             </module -->
-            <module uri="http://expath.org/ns/http-client" class="org.expath.exist.HttpClientModule" load="lazily"/>
-            <module uri="http://expath.org/ns/zip" class="org.expath.exist.ZipModule" load="lazily"/>
-            <module uri="http://exquery.org/ns/request" class="org.exist.extensions.exquery.modules.request.RequestModule" load="lazily"/>
-            <module uri="http://exquery.org/ns/restxq" class="org.exist.extensions.exquery.restxq.impl.xquery.RestXqModule" load="lazily"/>
-            <module uri="http://exquery.org/ns/restxq/exist" class="org.exist.extensions.exquery.restxq.impl.xquery.exist.ExistRestXqModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/xqdoc" class="org.exist.xqdoc.xquery.XQDocModule" load="lazily"/>
+            <module uri="http://expath.org/ns/http-client" class="org.expath.exist.HttpClientModule" load="lazy"/>
+            <module uri="http://expath.org/ns/zip" class="org.expath.exist.ZipModule" load="lazy"/>
+            <module uri="http://exquery.org/ns/request" class="org.exist.extensions.exquery.modules.request.RequestModule" load="lazy"/>
+            <module uri="http://exquery.org/ns/restxq" class="org.exist.extensions.exquery.restxq.impl.xquery.RestXqModule" load="lazy"/>
+            <module uri="http://exquery.org/ns/restxq/exist" class="org.exist.extensions.exquery.restxq.impl.xquery.exist.ExistRestXqModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/xqdoc" class="org.exist.xqdoc.xquery.XQDocModule" load="lazy"/>
 
 
             <!--
                 Extension Modules
             -->
-            <module uri="http://exist-db.org/xquery/cache" class="org.exist.xquery.modules.cache.CacheModule" load="lazily">
+            <module uri="http://exist-db.org/xquery/cache" class="org.exist.xquery.modules.cache.CacheModule" load="lazy">
                 <!--
                 If a named Cache does not exist it can be created lazily on-demand
                 when an operation is first performed upon it.
@@ -1025,21 +1025,21 @@
                 <parameter name="enableLazyCreation" value="true"/>
                 <parameter name="lazy.maximumSize" value="128"/>
             </module>
-            <module uri="http://exist-db.org/xquery/compression" class="org.exist.xquery.modules.compression.CompressionModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/counter" class="org.exist.xquery.modules.counter.CounterModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/cqlparser" class="org.exist.xquery.modules.cqlparser.CQLParserModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/compression" class="org.exist.xquery.modules.compression.CompressionModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/counter" class="org.exist.xquery.modules.counter.CounterModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/cqlparser" class="org.exist.xquery.modules.cqlparser.CQLParserModule" load="lazy"/>
             <!-- module uri="http://exist-db.org/xquery/exi" class="org.exist.xquery.modules.exi.ExiModule"/ -->
-            <module uri="http://exist-db.org/xquery/repo" class="org.exist.xquery.modules.expathrepo.ExpathPackageModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/file" class="org.exist.xquery.modules.file.FileModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/image" class="org.exist.xquery.modules.image.ImageModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/jndi" class="org.exist.xquery.modules.jndi.JNDIModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/mail" class="org.exist.xquery.modules.mail.MailModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/repo" class="org.exist.xquery.modules.expathrepo.ExpathPackageModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/file" class="org.exist.xquery.modules.file.FileModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/image" class="org.exist.xquery.modules.image.ImageModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/jndi" class="org.exist.xquery.modules.jndi.JNDIModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/mail" class="org.exist.xquery.modules.mail.MailModule" load="lazy"/>
             <!-- module uri="http://exist-db.org/xquery/oracle" class="org.exist.xquery.modules.oracle.OracleModule"/ -->
-            <module uri="http://exist-db.org/xquery/persistentlogin" class="org.exist.xquery.modules.persistentlogin.PersistentLoginModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/process" class="org.exist.xquery.modules.process.ProcessModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/scheduler" class="org.exist.xquery.modules.scheduler.SchedulerModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/simple-ql" class="org.exist.xquery.modules.simpleql.SimpleQLModule" load="lazily"/>
-            <module uri="http://exist-db.org/xquery/sql" class="org.exist.xquery.modules.sql.SQLModule" load="lazily">
+            <module uri="http://exist-db.org/xquery/persistentlogin" class="org.exist.xquery.modules.persistentlogin.PersistentLoginModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/process" class="org.exist.xquery.modules.process.ProcessModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/scheduler" class="org.exist.xquery.modules.scheduler.SchedulerModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/simple-ql" class="org.exist.xquery.modules.simpleql.SimpleQLModule" load="lazy"/>
+            <module uri="http://exist-db.org/xquery/sql" class="org.exist.xquery.modules.sql.SQLModule" load="lazy">
 
                 <!--
                 Connection Pools can be setup for SQL connections, for use with sql:get-connection-from-pool($pool-name)
@@ -1071,7 +1071,7 @@
                 <parameter name="pool.2.properties.registerMbeans" value="false"/>
                 -->
             </module>
-            <module uri="http://exist-db.org/xquery/xmldiff" class="org.exist.xquery.modules.xmldiff.XmlDiffModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/xmldiff" class="org.exist.xquery.modules.xmldiff.XmlDiffModule" load="lazy"/>
             <!--
                 XSL:FO Transformation Module
                     Valid processor adapters are:
@@ -1079,7 +1079,7 @@
                         - org.exist.xquery.modules.xslfo.RenderXXepProcessorAdapter for RenderX's XEP
                         - org.exist.xquery.modules.xslfo.AntennaHouseProcessorAdapter for AntennaHouse Formatter
             -->
-            <module uri="http://exist-db.org/xquery/xslfo" class="org.exist.xquery.modules.xslfo.XSLFOModule" load="lazily">
+            <module uri="http://exist-db.org/xquery/xslfo" class="org.exist.xquery.modules.xslfo.XSLFOModule" load="lazy">
                 <parameter name="processorAdapter" value="org.exist.xquery.modules.xslfo.ApacheFopProcessorAdapter"/>
             </module>
 

--- a/exist-distribution/src/main/config/conf.xml
+++ b/exist-distribution/src/main/config/conf.xml
@@ -948,21 +948,21 @@
             <module uri="http://www.w3.org/2005/xpath-functions/map"  class="org.exist.xquery.functions.map.MapModule"/>
             <module uri="http://www.w3.org/2005/xpath-functions/math" class="org.exist.xquery.functions.math.MathModule"/>
             <module uri="http://www.w3.org/2005/xpath-functions/array" class="org.exist.xquery.functions.array.ArrayModule"/>
-            <module uri="http://exist-db.org/xquery/backups" class="org.exist.backup.xquery.BackupModule"/>
-            <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule"/>
+            <module uri="http://exist-db.org/xquery/backups" class="org.exist.backup.xquery.BackupModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/inspection" class="org.exist.xquery.functions.inspect.InspectionModule" load="lazily"/>
             <module uri="http://exist-db.org/xquery/kwic" src="resource:org/exist/xquery/lib/kwic.xql"/>
             <module uri="http://exist-db.org/xquery/request" class="org.exist.xquery.functions.request.RequestModule"/>
             <module uri="http://exist-db.org/xquery/response" class="org.exist.xquery.functions.response.ResponseModule"/>
-            <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule"/>
+            <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule" load="lazily"/>
             <module uri="http://exist-db.org/xquery/session" class="org.exist.xquery.functions.session.SessionModule"/>
-            <module uri="http://exist-db.org/xquery/system" class="org.exist.xquery.functions.system.SystemModule"/>
+            <module uri="http://exist-db.org/xquery/system" class="org.exist.xquery.functions.system.SystemModule" load="lazily"/>
             <module uri="http://exist-db.org/xquery/testing" src="resource:org/exist/xquery/lib/test.xq"/>
-            <module uri="http://exist-db.org/xquery/transform" class="org.exist.xquery.functions.transform.TransformModule"/>
+            <module uri="http://exist-db.org/xquery/transform" class="org.exist.xquery.functions.transform.TransformModule" load="lazily"/>
             <module uri="http://exist-db.org/xquery/util" class="org.exist.xquery.functions.util.UtilModule">
                 <!-- set to true to disable the util:eval functions -->
                 <parameter name="evalDisabled" value="false"/>
             </module>
-            <module uri="http://exist-db.org/xquery/validation" class="org.exist.xquery.functions.validation.ValidationModule"/>
+            <module uri="http://exist-db.org/xquery/validation" class="org.exist.xquery.functions.validation.ValidationModule" load="lazily"/>
             <module uri="http://exist-db.org/xquery/xmldb" class="org.exist.xquery.functions.xmldb.XMLDBModule">
                 <!-- set to false to disable the use of xs:anyURI as a $contents value for xmldb:store and xmldb:store-as-binary function -->
                 <parameter name="allowAnyUri" value="false"/>
@@ -972,10 +972,10 @@
             <!-- 
                 Extension Indexes
             -->
-            <module uri="http://exist-db.org/xquery/lucene" class="org.exist.xquery.modules.lucene.LuceneModule"/>
-            <module uri="http://exist-db.org/xquery/ngram"  class="org.exist.xquery.modules.ngram.NGramModule"/>
-            <module uri="http://exist-db.org/xquery/range"  class="org.exist.xquery.modules.range.RangeIndexModule"/>
-            <module uri="http://exist-db.org/xquery/sort"   class="org.exist.xquery.modules.sort.SortModule"/>
+            <module uri="http://exist-db.org/xquery/lucene" class="org.exist.xquery.modules.lucene.LuceneModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/ngram"  class="org.exist.xquery.modules.ngram.NGramModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/range"  class="org.exist.xquery.modules.range.RangeIndexModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/sort"   class="org.exist.xquery.modules.sort.SortModule" load="lazily"/>
             <!--
             <module uri="http://exist-db.org/xquery/spatial" class="org.exist.xquery.modules.spatial.SpatialModule"/>
             -->
@@ -984,23 +984,23 @@
             <!--
                 Extensions
             -->
-            <module uri="http://exist-db.org/xquery/contentextraction"  class="org.exist.contentextraction.xquery.ContentExtractionModule"/>
+            <module uri="http://exist-db.org/xquery/contentextraction"  class="org.exist.contentextraction.xquery.ContentExtractionModule" load="lazily"/>
             <!-- module uri="http://exist-db.org/xquery/exiftool"  class="org.exist.exiftool.xquery.ExiftoolModule">
                 <parameter name="perl-path" value="/usr/bin/perl" description="file system path to the perl executable"/>
                 <parameter name="exiftool-path" value="/usr/bin/exiftool" description="file system path to the exiftool perl script"/>
             </module -->
-            <module uri="http://expath.org/ns/http-client" class="org.expath.exist.HttpClientModule"/>
-            <module uri="http://expath.org/ns/zip" class="org.expath.exist.ZipModule"/>
-            <module uri="http://exquery.org/ns/request" class="org.exist.extensions.exquery.modules.request.RequestModule"/>
-            <module uri="http://exquery.org/ns/restxq" class="org.exist.extensions.exquery.restxq.impl.xquery.RestXqModule"/>
-            <module uri="http://exquery.org/ns/restxq/exist" class="org.exist.extensions.exquery.restxq.impl.xquery.exist.ExistRestXqModule"/>
-            <module uri="http://exist-db.org/xquery/xqdoc" class="org.exist.xqdoc.xquery.XQDocModule"/>
+            <module uri="http://expath.org/ns/http-client" class="org.expath.exist.HttpClientModule" load="lazily"/>
+            <module uri="http://expath.org/ns/zip" class="org.expath.exist.ZipModule" load="lazily"/>
+            <module uri="http://exquery.org/ns/request" class="org.exist.extensions.exquery.modules.request.RequestModule" load="lazily"/>
+            <module uri="http://exquery.org/ns/restxq" class="org.exist.extensions.exquery.restxq.impl.xquery.RestXqModule" load="lazily"/>
+            <module uri="http://exquery.org/ns/restxq/exist" class="org.exist.extensions.exquery.restxq.impl.xquery.exist.ExistRestXqModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/xqdoc" class="org.exist.xqdoc.xquery.XQDocModule" load="lazily"/>
 
 
             <!--
                 Extension Modules
             -->
-            <module uri="http://exist-db.org/xquery/cache" class="org.exist.xquery.modules.cache.CacheModule">
+            <module uri="http://exist-db.org/xquery/cache" class="org.exist.xquery.modules.cache.CacheModule" load="lazily">
                 <!--
                 If a named Cache does not exist it can be created lazily on-demand
                 when an operation is first performed upon it.
@@ -1025,21 +1025,21 @@
                 <parameter name="enableLazyCreation" value="true"/>
                 <parameter name="lazy.maximumSize" value="128"/>
             </module>
-            <module uri="http://exist-db.org/xquery/compression" class="org.exist.xquery.modules.compression.CompressionModule"/>
-            <module uri="http://exist-db.org/xquery/counter" class="org.exist.xquery.modules.counter.CounterModule"/>
-            <module uri="http://exist-db.org/xquery/cqlparser" class="org.exist.xquery.modules.cqlparser.CQLParserModule"/>
+            <module uri="http://exist-db.org/xquery/compression" class="org.exist.xquery.modules.compression.CompressionModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/counter" class="org.exist.xquery.modules.counter.CounterModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/cqlparser" class="org.exist.xquery.modules.cqlparser.CQLParserModule" load="lazily"/>
             <!-- module uri="http://exist-db.org/xquery/exi" class="org.exist.xquery.modules.exi.ExiModule"/ -->
-            <module uri="http://exist-db.org/xquery/repo" class="org.exist.xquery.modules.expathrepo.ExpathPackageModule"/>
-            <module uri="http://exist-db.org/xquery/file" class="org.exist.xquery.modules.file.FileModule"/>
-            <module uri="http://exist-db.org/xquery/image" class="org.exist.xquery.modules.image.ImageModule"/>
-            <module uri="http://exist-db.org/xquery/jndi" class="org.exist.xquery.modules.jndi.JNDIModule"/>
-            <module uri="http://exist-db.org/xquery/mail" class="org.exist.xquery.modules.mail.MailModule"/>
+            <module uri="http://exist-db.org/xquery/repo" class="org.exist.xquery.modules.expathrepo.ExpathPackageModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/file" class="org.exist.xquery.modules.file.FileModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/image" class="org.exist.xquery.modules.image.ImageModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/jndi" class="org.exist.xquery.modules.jndi.JNDIModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/mail" class="org.exist.xquery.modules.mail.MailModule" load="lazily"/>
             <!-- module uri="http://exist-db.org/xquery/oracle" class="org.exist.xquery.modules.oracle.OracleModule"/ -->
-            <module uri="http://exist-db.org/xquery/persistentlogin" class="org.exist.xquery.modules.persistentlogin.PersistentLoginModule"/>
-            <module uri="http://exist-db.org/xquery/process" class="org.exist.xquery.modules.process.ProcessModule"/>
-            <module uri="http://exist-db.org/xquery/scheduler" class="org.exist.xquery.modules.scheduler.SchedulerModule"/>
-            <module uri="http://exist-db.org/xquery/simple-ql" class="org.exist.xquery.modules.simpleql.SimpleQLModule"/>
-            <module uri="http://exist-db.org/xquery/sql" class="org.exist.xquery.modules.sql.SQLModule">
+            <module uri="http://exist-db.org/xquery/persistentlogin" class="org.exist.xquery.modules.persistentlogin.PersistentLoginModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/process" class="org.exist.xquery.modules.process.ProcessModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/scheduler" class="org.exist.xquery.modules.scheduler.SchedulerModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/simple-ql" class="org.exist.xquery.modules.simpleql.SimpleQLModule" load="lazily"/>
+            <module uri="http://exist-db.org/xquery/sql" class="org.exist.xquery.modules.sql.SQLModule" load="lazily">
 
                 <!--
                 Connection Pools can be setup for SQL connections, for use with sql:get-connection-from-pool($pool-name)
@@ -1071,7 +1071,7 @@
                 <parameter name="pool.2.properties.registerMbeans" value="false"/>
                 -->
             </module>
-            <module uri="http://exist-db.org/xquery/xmldiff" class="org.exist.xquery.modules.xmldiff.XmlDiffModule"/>
+            <module uri="http://exist-db.org/xquery/xmldiff" class="org.exist.xquery.modules.xmldiff.XmlDiffModule" load="lazily"/>
             <!--
                 XSL:FO Transformation Module
                     Valid processor adapters are:
@@ -1079,7 +1079,7 @@
                         - org.exist.xquery.modules.xslfo.RenderXXepProcessorAdapter for RenderX's XEP
                         - org.exist.xquery.modules.xslfo.AntennaHouseProcessorAdapter for AntennaHouse Formatter
             -->
-            <module uri="http://exist-db.org/xquery/xslfo" class="org.exist.xquery.modules.xslfo.XSLFOModule">
+            <module uri="http://exist-db.org/xquery/xslfo" class="org.exist.xquery.modules.xslfo.XSLFOModule" load="lazily">
                 <parameter name="processorAdapter" value="org.exist.xquery.modules.xslfo.ApacheFopProcessorAdapter"/>
             </module>
 

--- a/schema/conf.xsd
+++ b/schema/conf.xsd
@@ -373,8 +373,8 @@
                                                 <xs:attribute name="load" default="always">
                                                     <xs:simpleType>
                                                         <xs:restriction base="xs:string">
-                                                            <xs:enumeration value="always" />
-                                                            <xs:enumeration value="lazily" />
+                                                            <xs:enumeration value="eager" />
+                                                            <xs:enumeration value="lazy" />
                                                         </xs:restriction>
                                                     </xs:simpleType>
                                                 </xs:attribute>

--- a/schema/conf.xsd
+++ b/schema/conf.xsd
@@ -370,6 +370,14 @@
                                                 <xs:attribute name="class" type="xs:string"/>
                                                 <xs:attribute name="uri" type="xs:anyURI"/>
                                                 <xs:attribute name="src" type="xs:string"/>
+                                                <xs:attribute name="load" default="always">
+                                                    <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                            <xs:enumeration value="always" />
+                                                            <xs:enumeration value="lazily" />
+                                                        </xs:restriction>
+                                                    </xs:simpleType>
+                                                </xs:attribute>
                                             </xs:complexType>
                                         </xs:element>
                                     </xs:sequence>


### PR DESCRIPTION
This PR fixes #1848 by allowing the user to configure which modules should be loaded lazily.

It adds a new attribute `load` on the `module` element of `conf.xml`. If unspecified, modules are loaded automatically (i.e. eagerly) to maintain backwards compatibility with the previous eXist-db mode of operation.

The `exist-distribution` config file was updated to take advantage of this new feature. Only those modules that are deemed as required by eXist-db's XQSuite tests and Apps are loaded by default. Other modules can be loaded with `import module namespace`, for example:

```xquery
import module namespace validation = "http://exist-db.org/xquery/validation";
```

----
This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.
