### PR TITLE
Continue evaluation on preceding empty sequences for EnclosedExpr

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/EnclosedExpr.java
@@ -193,4 +193,8 @@ public class EnclosedExpr extends PathExpr {
         return this;
     }
 
+    @Override
+    public boolean evalNextExpressionOnEmptyContextSequence() {
+        return true;
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/PathExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/PathExpr.java
@@ -229,7 +229,8 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
             //TODO : let the parser do it ? -pb
             boolean gotAtomicResult = false;
             Expression prev = null;
-            for (final Expression step : steps) {
+            for (int stepIdx = 0; stepIdx < steps.size(); stepIdx++) {
+                final Expression step = steps.get(stepIdx);
                 prev = expr;
                 expr = step;
                 context.getWatchDog().proceed(expr);
@@ -313,7 +314,7 @@ public class PathExpr extends AbstractExpression implements CompiledXQuery,
                      * return true when {@link Expression#evalNextExpressionOnEmptyContextSequence()}
                      * is called to indicate that.
                      */
-                    if (result.isEmpty() && !step.evalNextExpressionOnEmptyContextSequence()) {
+                    if (result.isEmpty() && stepIdx < steps.size() - 1 && !step.evalNextExpressionOnEmptyContextSequence()) {
                         break;
                     }
                 }

--- a/exist-core/src/test/java/org/exist/xquery/XQueryFunctionsTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XQueryFunctionsTest.java
@@ -1030,4 +1030,29 @@ public class XQueryFunctionsTest {
         final String defaultLanguage = (String) result.getResource(0).getContent();
         assertEquals(Locale.getDefault().getLanguage(), defaultLanguage);
     }
+
+    @Test
+    public void enclosedExpression() throws XMLDBException {
+        ResourceSet result = existEmbeddedServer.executeQuery("<abc>{()}{123}</abc>");
+        assertEquals(1, result.getSize());
+        String text = (String) result.getResource(0).getContent();
+        assertEquals("<abc>123</abc>", text);
+
+        result = existEmbeddedServer.executeQuery("<abc>{(), 123}</abc>");
+        assertEquals(1, result.getSize());
+        text = (String) result.getResource(0).getContent();
+        assertEquals("<abc>123</abc>", text);
+
+        result = existEmbeddedServer.executeQuery("<abc>{()}123</abc>");
+        assertEquals(1, result.getSize());
+        text = (String) result.getResource(0).getContent();
+        assertEquals("<abc>123</abc>", text);
+
+        result = existEmbeddedServer.executeQuery("<root>{'time '}{()}{'is: '}{current-time()}</root>");
+        assertEquals(1, result.getSize());
+        text = (String) result.getResource(0).getContent();
+        assertTrue(text.startsWith("<root>time is: "));
+        assertTrue(text.length() > 35);
+        assertTrue(text.endsWith("</root>"));
+    }
 }


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/eXist-db/exist/pull/4473 whereby preceding empty sequences of `EnclosedExpr` stopped execution too early.