### PR TITLE
fix resource leak (and file lock)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromFile.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BinaryValueFromFile.java
@@ -49,6 +49,7 @@ import java.util.function.BiConsumer;
 public class BinaryValueFromFile extends BinaryValue {
 
     private final Path file;
+    private final RandomAccessFile fileHandle;
     private final FileChannel channel;
     private final MappedByteBuffer buf;
     private final Optional<BiConsumer<Boolean, Path>> closeListener;
@@ -61,7 +62,8 @@ public class BinaryValueFromFile extends BinaryValue {
         super(expression, manager, binaryValueType);
         try {
             this.file = file;
-            this.channel = new RandomAccessFile(file.toFile(), "r").getChannel();
+            this.fileHandle = new RandomAccessFile(file.toFile(), "r");
+            this.channel = fileHandle.getChannel();
             this.buf = channel.map(MapMode.READ_ONLY, 0, channel.size());
             this.closeListener = closeListener;
         } catch (final IOException ioe) {
@@ -129,6 +131,7 @@ public class BinaryValueFromFile extends BinaryValue {
         boolean closed = false;
         try {
             channel.close();
+            fileHandle.close();
             closed = true;
         } finally {
             final boolean finalClosed = closed;


### PR DESCRIPTION
This PR fixes a resource leak, which kept file handles around until they are garbage collected. This results in an incorrect file lock in Windows.

### Description:

This fixes a resource leak in `org.exist.xquery.value.BinaryValueFromFile`, which causes file handles to hang around.
Under Windows, this means that most editors cannot save such a file, once the handle has been created, because they consider the file locked. Under Linux, vi (and apparently, nano) have no problem. However, the resource leak still exists.

The problem occurs in line 64 of `BinaryValueFromFile.java`:

```
this.channel = new RandomAccessFile(file.toFile(), "r").getChannel();
```

The creation of the `RandomAccessFile` object creates the file handle. Because the `RandomAccessFile` object is not kept, its close() method can never be called.
