### PR TITLE
bugfix: use correct implementation for slf4j 2.0.0

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -263,7 +263,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>slf4j-impl</artifactId>
             <scope>runtime</scope>
         </dependency>
 
@@ -921,7 +921,7 @@ The BaseX Team. The original license statement is also included below.]]></pream
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core:jar:${log4j.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-jcl:jar:${log4j.version}</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl:jar:${log4j.version}</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:slf4j-impl:jar:${log4j.slf4j.impl.version}</ignoredUnusedDeclaredDependency>
 
                                 <ignoredUnusedDeclaredDependency>org.glassfish.jaxb:jaxb-runtime:jar:${jaxb.impl.version}</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.fusesource.jansi:jansi:jar:2.4.0</ignoredUnusedDeclaredDependency>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -114,6 +114,7 @@
         <jaxb.impl.version>3.0.2</jaxb.impl.version>
         <jetty.version>9.4.48.v20220622</jetty.version>
         <log4j.version>2.18.0</log4j.version>
+        <log4j.slf4j.impl.version>2.0-alpha2</log4j.slf4j.impl.version>
         <lucene.version>4.10.4</lucene.version>
         <milton.version>1.8.1.3</milton.version>
         <saxon.version>9.9.1-8</saxon.version>
@@ -249,8 +250,8 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
-                <version>${log4j.version}</version>
+                <artifactId>slf4j-impl</artifactId>
+                <version>${log4j.slf4j.impl.version}</version>
                 <scope>runtime</scope>
             </dependency>
 


### PR DESCRIPTION
Fixes warnings of missing SLF4J provider implementation. This dependency will change again as soon there is a final version of Log4j available later.