### PR TITLE
Support for Count Expressions

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -802,12 +802,19 @@ initialClause throws XPathException
 
 intermediateClause throws XPathException
 :
-    ( initialClause | whereClause | groupByClause | orderByClause )
+    ( initialClause | whereClause | groupByClause | orderByClause | countClause )
     ;
 
 whereClause throws XPathException
 :
 	"where"^ exprSingle
+	;
+
+countClause throws XPathException
+{ String varName; }
+:
+	"count"^ DOLLAR! varName=varName!
+	{ #countClause = #(#countClause, #[VARIABLE_BINDING, varName]); }
 	;
 
 forClause throws XPathException
@@ -2222,6 +2229,8 @@ reservedKeywords returns [String name]
 	"map" { name = "map"; }
 	|
 	"array" { name = "array"; }
+	|
+	"count" { name = "count"; }
 	|
 	"copy-namespaces" { name = "copy-namespaces"; }
 	|

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -103,6 +103,10 @@ options {
 		return buf.toString();
 	}
 
+	public Exception getLastException() {
+		return (Exception) exceptions.get(exceptions.size() - 1);
+	}
+
 	public String getXQDoc() {
 		return lexer.getXQDoc();
 	}

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -1752,9 +1752,22 @@ throws PermissionDeniedException, EXistException, XPathException
                     clauses.add(clause);
                 }
             )
-        )+
-        step=expr [(PathExpr) action]
-        {
+            |
+            #(
+            	co:"count"
+            	countVarName:VARIABLE_BINDING
+                {
+                    ForLetClause clause = new ForLetClause();
+                    clause.ast = co;
+                    clause.varName = countVarName.getText();
+                    clause.type = FLWORClause.ClauseType.COUNT;
+                    clause.inputSequence = null;
+                    clauses.add(clause);
+                }
+            )
+		)+
+		step=expr [(PathExpr) action]
+		{
             for (int i= clauses.size() - 1; i >= 0; i--) {
                 ForLetClause clause= (ForLetClause) clauses.get(i);
                 FLWORClause expr;

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -128,9 +128,9 @@ options {
 
     private static class ForLetClause {
         XQueryAST ast;
-        String varName;
+        QName varName;
         SequenceType sequenceType= null;
-        String posVar= null;
+        QName posVar = null;
         Expression inputSequence;
         Expression action;
         FLWORClause.ClauseType type = FLWORClause.ClauseType.FOR;
@@ -1398,7 +1398,11 @@ throws PermissionDeniedException, EXistException, XPathException
                 )?
                 step=expr[inputSequence]
                 {
-                    clause.varName= someVarName.getText();
+                    try {
+                        clause.varName = QName.parse(staticContext, someVarName.getText(), null);
+                    } catch (final IllegalQNameException iqe) {
+                        throw new XPathException(someVarName.getLine(), someVarName.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + someVarName.getText());
+                    }
                     clause.inputSequence= inputSequence;
                     clauses.add(clause);
                 }
@@ -1449,7 +1453,11 @@ throws PermissionDeniedException, EXistException, XPathException
                 )?
                 step=expr[inputSequence]
                 {
-                    clause.varName= everyVarName.getText();
+                    try {
+                        clause.varName = QName.parse(staticContext, everyVarName.getText(), null);
+                    } catch (final IllegalQNameException iqe) {
+                        throw new XPathException(everyVarName.getLine(), everyVarName.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + everyVarName.getText());
+                    }
                     clause.inputSequence= inputSequence;
                     clauses.add(clause);
                 }
@@ -1585,11 +1593,21 @@ throws PermissionDeniedException, EXistException, XPathException
                         )?
                         (
                             posVar:POSITIONAL_VAR
-                            { clause.posVar= posVar.getText(); }
+                            {
+                                try {
+                                    clause.posVar = QName.parse(staticContext, posVar.getText(), null);
+                                } catch (final IllegalQNameException iqe) {
+                                    throw new XPathException(posVar.getLine(), posVar.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + posVar.getText());
+                                }
+                            }
                         )?
                         step=expr [inputSequence]
                         {
-                            clause.varName= varName.getText();
+                            try {
+                                clause.varName = QName.parse(staticContext, varName.getText(), null);
+                            } catch (final IllegalQNameException iqe) {
+                                throw new XPathException(varName.getLine(), varName.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + varName.getText());
+                            }
                             clause.inputSequence= inputSequence;
                             clauses.add(clause);
                         }
@@ -1618,7 +1636,11 @@ throws PermissionDeniedException, EXistException, XPathException
                         )?
                         step=expr [inputSequence]
                         {
-                            clause.varName= letVarName.getText();
+                            try {
+                                clause.varName = QName.parse(staticContext, letVarName.getText(), null);
+                            } catch (final IllegalQNameException iqe) {
+                                throw new XPathException(letVarName.getLine(), letVarName.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + letVarName.getText());
+                            }
                             clause.inputSequence= inputSequence;
                             clauses.add(clause);
                         }
@@ -1759,7 +1781,11 @@ throws PermissionDeniedException, EXistException, XPathException
                 {
                     ForLetClause clause = new ForLetClause();
                     clause.ast = co;
-                    clause.varName = countVarName.getText();
+                    try {
+                        clause.varName = QName.parse(staticContext, countVarName.getText(), null);
+                    } catch (final IllegalQNameException iqe) {
+                        throw new XPathException(countVarName.getLine(), countVarName.getColumn(), ErrorCodes.XPST0081, "No namespace defined for prefix " + countVarName.getText());
+                    }
                     clause.type = FLWORClause.ClauseType.COUNT;
                     clause.inputSequence = null;
                     clauses.add(clause);

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -1773,21 +1773,24 @@ throws PermissionDeniedException, EXistException, XPathException
                 FLWORClause expr;
                 switch (clause.type) {
                     case LET:
-                        expr= new LetExpr(context);
+                        expr = new LetExpr(context);
                         expr.setASTNode(expr_AST_in);
                         break;
                     case GROUPBY:
-                expr = new GroupByClause(context);
-                break;
-            case ORDERBY:
-                expr = new OrderByClause(context, clause.orderSpecs);
-                break;
-                        case WHERE:
-                                expr = new WhereClause(context, new DebuggableExpression(clause.inputSequence));
-                                break;
-            default:
-                expr= new ForExpr(context, clause.allowEmpty);
-                break;
+                        expr = new GroupByClause(context);
+                        break;
+                    case ORDERBY:
+                        expr = new OrderByClause(context, clause.orderSpecs);
+                        break;
+                    case WHERE:
+                        expr = new WhereClause(context, new DebuggableExpression(clause.inputSequence));
+                        break;
+                    case COUNT:
+                        expr = new CountClause(context, clause.varName);
+                        break;
+                    default:
+                        expr = new ForExpr(context, clause.allowEmpty);
+                        break;
                 }
                 expr.setASTNode(clause.ast);
                 if (clause.type == FLWORClause.ClauseType.FOR || clause.type == FLWORClause.ClauseType.LET) {

--- a/exist-core/src/main/java/org/exist/xquery/AbstractFLWORClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/AbstractFLWORClause.java
@@ -41,14 +41,10 @@ public abstract class AbstractFLWORClause extends AbstractExpression implements 
     }
 
     @Override
-    public LocalVariable createVariable(final String name) throws XPathException {
-        try {
-            final LocalVariable var = new LocalVariable(QName.parse(context, name, null));
-            firstVar = var;
-            return var;
-        } catch (final IllegalQNameException e) {
-            throw new XPathException(this, ErrorCodes.XPST0081, "No namespace defined for prefix " + name);
-        }
+    public LocalVariable createVariable(final QName name) throws XPathException {
+        final LocalVariable var = new LocalVariable(name);
+        firstVar = var;
+        return var;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/BasicExpressionVisitor.java
+++ b/exist-core/src/main/java/org/exist/xquery/BasicExpressionVisitor.java
@@ -181,6 +181,11 @@ public class BasicExpressionVisitor implements ExpressionVisitor {
     }
 
     @Override
+    public void visitCountClause(final CountClause count) {
+        // Nothing to do
+    }
+
+    @Override
     public void visitGroupByClause(final GroupByClause groupBy) {
         // Nothing to do
     }

--- a/exist-core/src/main/java/org/exist/xquery/BindingExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/BindingExpression.java
@@ -30,7 +30,7 @@ import org.exist.storage.UpdateListener;
 import org.exist.xquery.value.*;
 
 /**
- * Abstract superclass for the variable binding expressions "for" and "let".
+ * Abstract superclass for the variable binding expressions "for", "let", and "count".
  * 
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  */
@@ -45,11 +45,9 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
 	protected QName varName;
 	protected SequenceType sequenceType = null;
 	protected Expression inputSequence;
-
 	private ExprUpdateListener listener;
 
-
-    public BindingExpression(XQueryContext context) {
+    public BindingExpression(final XQueryContext context) {
 		super(context);
 	}
 
@@ -78,10 +76,8 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
         return this.inputSequence;
     }
 
-    /* (non-Javadoc)
-             * @see org.exist.xquery.Expression#analyze(org.exist.xquery.Expression, int)
-             */
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         unordered = (contextInfo.getFlags() & UNORDERED) > 0;
     }
 
@@ -93,37 +89,32 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
         return super.postEval(seq);
     }
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.Expression#preselect(org.exist.dom.persistent.DocumentSet, org.exist.xquery.StaticContext)
-	 */
-	public DocumentSet preselect(DocumentSet in_docs) throws XPathException {
-		return in_docs;
+	public DocumentSet preselect(final DocumentSet docs) throws XPathException {
+		return docs;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.exist.xquery.AbstractExpression#resetState()
-	 */
-	public void resetState(boolean postOptimization) {
+	@Override
+	public void resetState(final boolean postOptimization) {
 		super.resetState(postOptimization);
 		inputSequence.resetState(postOptimization);
 		returnExpr.resetState(postOptimization);
 	}
 	
-	public final static void setContext(int contextId, Sequence seq) throws XPathException {
+	public static void setContext(final int contextId, final Sequence seq) throws XPathException {
 		if (seq instanceof VirtualNodeSet) {
 			((VirtualNodeSet)seq).setInPredicate(true);
             ((VirtualNodeSet)seq).setSelfIsContext();
 		} else {
-			Item next;
-			for (final SequenceIterator i = seq.unorderedIterator(); i.hasNext();) {
-				next = i.nextItem(); 
-				if (next instanceof NodeProxy)
-					 {((NodeProxy) next).addContextNode(contextId, (NodeProxy) next);}
+			for (final SequenceIterator i = seq.unorderedIterator(); i.hasNext(); ) {
+				final Item next = i.nextItem();
+				if (next instanceof NodeProxy) {
+					((NodeProxy) next).addContextNode(contextId, (NodeProxy) next);
+				}
 			}
 		}
 	}
 	
-	public final static void clearContext(int contextId, Sequence seq) throws XPathException {
+	public final static void clearContext(final int contextId, final Sequence seq) throws XPathException {
 		if (seq != null && !(seq instanceof VirtualNodeSet)) {
             seq.clearContext(contextId);
 		}
@@ -133,27 +124,28 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
         if (listener == null) {
             listener = new ExprUpdateListener(sequence);
             context.registerUpdateListener(listener);
-        } else
-            {listener.setSequence(sequence);}
+        } else {
+			listener.setSequence(sequence);
+		}
     }
 
     private class ExprUpdateListener implements UpdateListener {
         private Sequence sequence;
 
-        public ExprUpdateListener(Sequence sequence) {
+        public ExprUpdateListener(final Sequence sequence) {
             this.sequence = sequence;
         }
 
-        public void setSequence(Sequence sequence) {
+        public void setSequence(final Sequence sequence) {
             this.sequence = sequence;
         }
         
         @Override
-        public void documentUpdated(DocumentImpl document, int event) {
+        public void documentUpdated(final DocumentImpl document, final int event) {
         }
 
         @Override
-        public void nodeMoved(NodeId oldNodeId, NodeHandle newNode) {
+        public void nodeMoved(final NodeId oldNodeId, final NodeHandle newNode) {
             sequence.nodeMoved(oldNodeId, newNode);
         }
 
@@ -179,11 +171,12 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
 	/* RewritableExpression API */
 	
 	@Override
-	public void replace(Expression oldExpr, Expression newExpr) {
-		if (inputSequence == oldExpr)
-			{inputSequence = newExpr;}
-		else if (returnExpr == oldExpr)
-			{returnExpr = newExpr;}
+	public void replace(final Expression oldExpr, final Expression newExpr) {
+		if (inputSequence == oldExpr) {
+			inputSequence = newExpr;
+		} else if (returnExpr == oldExpr) {
+			returnExpr = newExpr;
+		}
 	}
 	
 	@Override
@@ -197,7 +190,7 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
 	}
 	
 	@Override
-	public void remove(Expression oldExpr) throws XPathException {
+	public void remove(final Expression oldExpr) throws XPathException {
 	}
 	
 	/* END RewritableExpression API */

--- a/exist-core/src/main/java/org/exist/xquery/BindingExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/BindingExpression.java
@@ -23,6 +23,7 @@ package org.exist.xquery;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.exist.dom.QName;
 import org.exist.dom.persistent.*;
 import org.exist.numbering.NodeId;
 import org.exist.storage.UpdateListener;
@@ -41,7 +42,7 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
     protected final static SequenceType POSITIONAL_VAR_TYPE = 
         new SequenceType(Type.INTEGER, Cardinality.EXACTLY_ONE);
     
-	protected String varName;
+	protected QName varName;
 	protected SequenceType sequenceType = null;
 	protected Expression inputSequence;
 
@@ -52,11 +53,11 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
 		super(context);
 	}
 
-	public void setVariable(String qname) {
-		varName = qname;
+	public void setVariable(final QName varName) {
+		this.varName = varName;
 	}
 
-    public String getVariable() {
+    public QName getVariable() {
         return this.varName;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/BindingExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/BindingExpression.java
@@ -142,6 +142,7 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
         
         @Override
         public void documentUpdated(final DocumentImpl document, final int event) {
+			// no-op
         }
 
         @Override
@@ -156,6 +157,7 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
 
         @Override
         public void debug() {
+			// no-op
         }
     }
 
@@ -191,6 +193,7 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
 	
 	@Override
 	public void remove(final Expression oldExpr) throws XPathException {
+		// no-op
 	}
 	
 	/* END RewritableExpression API */

--- a/exist-core/src/main/java/org/exist/xquery/BindingExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/BindingExpression.java
@@ -83,8 +83,8 @@ public abstract class BindingExpression extends AbstractFLWORClause implements R
 
     @Override
     public Sequence postEval(Sequence seq) throws XPathException {
-        if (returnExpr instanceof FLWORClause) {
-            seq = ((FLWORClause)returnExpr).postEval(seq);
+        if (returnExpr instanceof FLWORClause flworClause) {
+            seq = flworClause.postEval(seq);
         }
         return super.postEval(seq);
     }

--- a/exist-core/src/main/java/org/exist/xquery/CountClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/CountClause.java
@@ -1,0 +1,69 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+
+/**
+ * Implements a count clause inside a FLWOR expressions.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ * @author <a href="mailto:gabriele@strumenta.com">Gabriele Tomassetti</a>
+ */
+public class CountClause extends AbstractFLWORClause {
+
+    final String varName;
+
+    public CountClause(final XQueryContext context, final String countName) {
+        super(context);
+        this.varName = countName;
+    }
+
+    @Override
+    public ClauseType getType() {
+        return ClauseType.COUNT;
+    }
+
+    public String getVarName() {
+        return varName;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        return null;
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("count", this.getLine());
+        dumper.startIndent();
+        dumper.display(this.varName);
+        dumper.endIndent().nl();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/CountClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/CountClause.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery;
 
+import org.exist.dom.QName;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
@@ -33,11 +34,11 @@ import org.exist.xquery.value.Sequence;
  */
 public class CountClause extends AbstractFLWORClause {
 
-    final String varName;
+    final QName varName;
 
-    public CountClause(final XQueryContext context, final String countName) {
+    public CountClause(final XQueryContext context, final QName varName) {
         super(context);
-        this.varName = countName;
+        this.varName = varName;
     }
 
     @Override
@@ -45,7 +46,7 @@ public class CountClause extends AbstractFLWORClause {
         return ClauseType.COUNT;
     }
 
-    public String getVarName() {
+    public QName getVarName() {
         return varName;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/CountClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/CountClause.java
@@ -111,8 +111,8 @@ public class CountClause extends AbstractFLWORClause {
                 case ORDERBY -> {
                     return isDescending(((OrderByClause) prev).getOrderSpecs());
                 }
+                default -> prev = prev.getPreviousClause();
             }
-            prev = prev.getPreviousClause();
         }
         return true;
     }
@@ -183,8 +183,8 @@ public class CountClause extends AbstractFLWORClause {
 
     @Override
     public Sequence postEval(Sequence seq) throws XPathException {
-        if (returnExpr instanceof FLWORClause) {
-            seq = ((FLWORClause)returnExpr).postEval(seq);
+        if (returnExpr instanceof FLWORClause flworClause) {
+            seq = flworClause.postEval(seq);
         }
         return super.postEval(seq);
     }

--- a/exist-core/src/main/java/org/exist/xquery/CountClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/CountClause.java
@@ -105,12 +105,12 @@ public class CountClause extends AbstractFLWORClause {
         FLWORClause prev = getPreviousClause();
         while (prev != null) {
             switch (prev.getType()) {
-                case LET:
-                case GROUPBY:
-                case FOR:
+                case LET, GROUPBY, FOR -> {
                     return false;
-                case ORDERBY:
-                   return isDescending(((OrderByClause) prev).getOrderSpecs());
+                }
+                case ORDERBY -> {
+                    return isDescending(((OrderByClause) prev).getOrderSpecs());
+                }
             }
             prev = prev.getPreviousClause();
         }

--- a/exist-core/src/main/java/org/exist/xquery/CountClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/CountClause.java
@@ -197,6 +197,13 @@ public class CountClause extends AbstractFLWORClause {
         dumper.endIndent().nl();
     }
 
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("count ");
+        result.append("$").append(this.varName);
+        return result.toString();
+    }
+
     @Override
     public void accept(final ExpressionVisitor visitor) {
         visitor.visitCountClause(this);

--- a/exist-core/src/main/java/org/exist/xquery/ExpressionVisitor.java
+++ b/exist-core/src/main/java/org/exist/xquery/ExpressionVisitor.java
@@ -74,6 +74,8 @@ public interface ExpressionVisitor {
 
     void visitLetExpression(LetExpr letExpr);
 
+    void visitCountClause(CountClause count);
+
     void visitOrderByClause(OrderByClause orderBy);
 
     void visitGroupByClause(GroupByClause groupBy);

--- a/exist-core/src/main/java/org/exist/xquery/FLWORClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/FLWORClause.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery;
 
+import org.exist.dom.QName;
 import org.exist.xquery.value.Sequence;
 
 /**
@@ -102,7 +103,7 @@ public interface FLWORClause extends Expression {
      * @return a new local variable, registered in the context
      * @throws XPathException if an error occurs whilst creating the variable
      */
-    LocalVariable createVariable(String name) throws XPathException;
+    LocalVariable createVariable(QName name) throws XPathException;
 
     /**
      * Returns the first variable created by this FLWOR clause for reference

--- a/exist-core/src/main/java/org/exist/xquery/FLWORClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/FLWORClause.java
@@ -31,7 +31,7 @@ import org.exist.xquery.value.Sequence;
 public interface FLWORClause extends Expression {
 
     enum ClauseType {
-        FOR, LET, GROUPBY, ORDERBY, WHERE, SOME, EVERY
+        FOR, LET, GROUPBY, ORDERBY, WHERE, SOME, EVERY, COUNT
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/ForExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/ForExpr.java
@@ -33,7 +33,7 @@ import org.exist.xquery.value.*;
  */
 public class ForExpr extends BindingExpression {
 
-    private String positionalVariable = null;
+    private QName positionalVariable = null;
     private boolean allowEmpty = false;
     private boolean isOuterFor = true;
 
@@ -53,7 +53,7 @@ public class ForExpr extends BindingExpression {
      * 
      * @param var the name of the variable to set
      */
-    public void setPositionalVariable(String var) {
+    public void setPositionalVariable(final QName var) {
         positionalVariable = var;
     }
 
@@ -69,7 +69,7 @@ public class ForExpr extends BindingExpression {
             final AnalyzeContextInfo varContextInfo = new AnalyzeContextInfo(contextInfo);
             inputSequence.analyze(varContextInfo);
             // Declare the iteration variable
-            final LocalVariable inVar = new LocalVariable(QName.parse(context, varName, null));
+            final LocalVariable inVar = new LocalVariable(varName);
             inVar.setSequenceType(sequenceType);
             inVar.setStaticType(varContextInfo.getStaticReturnType());
             context.declareVariableBinding(inVar);
@@ -80,7 +80,7 @@ public class ForExpr extends BindingExpression {
                     throw new XPathException(this, ErrorCodes.XQST0089,
                             "bound variable and positional variable have the same name");
                 }
-                final LocalVariable posVar = new LocalVariable(QName.parse(context, positionalVariable, null));
+                final LocalVariable posVar = new LocalVariable(positionalVariable);
                 posVar.setSequenceType(POSITIONAL_VAR_TYPE);
                 posVar.setStaticType(Type.INTEGER);
                 context.declareVariableBinding(posVar);
@@ -89,8 +89,6 @@ public class ForExpr extends BindingExpression {
             final AnalyzeContextInfo newContextInfo = new AnalyzeContextInfo(contextInfo);
             newContextInfo.addFlag(SINGLE_STEP_EXECUTION);
             returnExpr.analyze(newContextInfo);
-        } catch (final QName.IllegalQNameException e) {
-            throw new XPathException(this, ErrorCodes.XPST0081, "No namespace defined for prefix");
         } finally {
             // restore the local variable stack
             context.popLocalVariables(mark);
@@ -135,7 +133,7 @@ public class ForExpr extends BindingExpression {
             // Declare positional variable
             LocalVariable at = null;
             if (positionalVariable != null) {
-                at = new LocalVariable(QName.parse(context, positionalVariable, null));
+                at = new LocalVariable(positionalVariable);
                 at.setSequenceType(POSITIONAL_VAR_TYPE);
                 context.declareVariableBinding(at);
             }
@@ -187,8 +185,6 @@ public class ForExpr extends BindingExpression {
                     processItem(var, i.nextItem(), in, resultSequence, at, p);
                 }
             }
-        } catch (final QName.IllegalQNameException e) {
-            throw new XPathException(this, ErrorCodes.XPST0081, "No namespace defined for prefix " + positionalVariable);
         } finally {
             // restore the local variable stack 
             context.popLocalVariables(mark, resultSequence);

--- a/exist-core/src/main/java/org/exist/xquery/GroupByClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/GroupByClause.java
@@ -172,8 +172,8 @@ public class GroupByClause extends AbstractFLWORClause {
                 context.popLocalVariables(mark, result);
             }
 
-            if (returnExpr instanceof FLWORClause) {
-                result = ((FLWORClause) returnExpr).postEval(result);
+            if (returnExpr instanceof FLWORClause flworClause) {
+                result = flworClause.postEval(result);
             }
             result = super.postEval(result);
             return result;

--- a/exist-core/src/main/java/org/exist/xquery/LetExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/LetExpr.java
@@ -53,7 +53,7 @@ public class LetExpr extends BindingExpression {
             final AnalyzeContextInfo varContextInfo = new AnalyzeContextInfo(contextInfo);
             inputSequence.analyze(varContextInfo);
             //Declare the iteration variable
-            final LocalVariable inVar = new LocalVariable(QName.parse(context, varName, null));
+            final LocalVariable inVar = new LocalVariable(varName);
             inVar.setSequenceType(sequenceType);
             inVar.setStaticType(varContextInfo.getStaticReturnType());
             context.declareVariableBinding(inVar);
@@ -61,8 +61,6 @@ public class LetExpr extends BindingExpression {
             context.setContextSequencePosition(0, null);
 
             returnExpr.analyze(contextInfo);
-        } catch (final QName.IllegalQNameException e) {
-            throw new XPathException(this, ErrorCodes.XPST0081, "No namespace defined for prefix " + varName);
         } finally {
             // restore the local variable stack
             context.popLocalVariables(mark);

--- a/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
@@ -113,6 +113,19 @@ public class OrderByClause extends AbstractFLWORClause {
     }
 
     @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("order by ");
+        for (int i = 0; i < orderSpecs.length; i++) {
+            if (i > 0) {
+                builder.append(", ");
+            }
+            builder.append(orderSpecs[i]);
+        }
+        return builder.toString();
+    }
+
+    @Override
     public void accept(ExpressionVisitor visitor) {
         visitor.visitOrderByClause(this);
     }

--- a/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/OrderByClause.java
@@ -95,8 +95,8 @@ public class OrderByClause extends AbstractFLWORClause {
         orderedResult.sort();
         Sequence result = orderedResult;
 
-        if (getReturnExpression() instanceof FLWORClause) {
-            result = ((FLWORClause) getReturnExpression()).postEval(result);
+        if (getReturnExpression() instanceof FLWORClause flworClause) {
+            result = flworClause.postEval(result);
         }
         return super.postEval(result);
     }

--- a/exist-core/src/main/java/org/exist/xquery/QuantifiedExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/QuantifiedExpression.java
@@ -21,7 +21,6 @@
  */
 package org.exist.xquery;
 
-import org.exist.dom.QName;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.BooleanValue;
 import org.exist.xquery.value.Item;
@@ -63,13 +62,11 @@ public class QuantifiedExpression extends BindingExpression {
 	public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
 		final LocalVariable mark = context.markLocalVariables(false);
 		try {
-			context.declareVariableBinding(new LocalVariable(QName.parse(context, varName, null)));
+			context.declareVariableBinding(new LocalVariable(varName));
 
 			contextInfo.setParent(this);
 			inputSequence.analyze(contextInfo);
 			returnExpr.analyze(contextInfo);
-		} catch (final QName.IllegalQNameException e) {
-			throw new XPathException(this, ErrorCodes.XPST0081, "No namespace defined for prefix " + varName);
 		} finally {
 			context.popLocalVariables(mark);
 		}
@@ -87,12 +84,7 @@ public class QuantifiedExpression extends BindingExpression {
                 {context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT ITEM", contextItem.toSequence());}
         }        
         
-		final LocalVariable var;
-        try {
-			var = new LocalVariable(QName.parse(context, varName, null));
-		} catch (final QName.IllegalQNameException e) {
-			throw new XPathException(this, ErrorCodes.XPST0081, "No namespace defined for prefix " + varName);
-		}
+		final LocalVariable var = new LocalVariable(varName);
         
 		final Sequence inSeq = inputSequence.eval(contextSequence, contextItem);
         if (sequenceType != null) {

--- a/exist-core/src/main/java/org/exist/xquery/WhereClause.java
+++ b/exist-core/src/main/java/org/exist/xquery/WhereClause.java
@@ -133,8 +133,8 @@ public class WhereClause extends AbstractFLWORClause {
     @Override
     public Sequence postEval(Sequence seq) throws XPathException {
         fastTrack = false;
-        if (returnExpr instanceof FLWORClause) {
-            seq = ((FLWORClause) returnExpr).postEval(seq);
+        if (returnExpr instanceof FLWORClause flworClause) {
+            seq = flworClause.postEval(seq);
         }
         return super.postEval(seq);
     }

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -224,10 +224,18 @@ public class XQuery {
             } else {
                 parser.xpath();
             }
-            
-            if(parser.foundErrors()) {
-            	LOG.debug(parser.getErrorMessage());
-            	throw new StaticXQueryException(context.getRootExpression(), parser.getErrorMessage());
+
+            if (parser.foundErrors()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(parser.getErrorMessage());
+                }
+                final Exception lastException = parser.getLastException();
+                if (lastException != null && lastException instanceof XPathException) {
+                    final XPathException xpe = (XPathException) lastException;
+                    throw new StaticXQueryException(xpe.getColumn(), xpe.getLine(), parser.getErrorMessage(), xpe);
+                } else {
+                    throw new StaticXQueryException(context.getRootExpression(), parser.getErrorMessage());
+                }
             }
 
             final AST ast = parser.getAST();

--- a/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
@@ -147,7 +147,11 @@ public class DoubleValue extends NumericValue {
     @Override
     protected @Nullable IntSupplier createComparisonWith(final NumericValue other) {
         final IntSupplier comparison;
-        if (isInfinite() && other.isInfinite() && isPositive() == other.isPositive()) {
+        if (isNaN()) {
+            comparison = () -> Constants.INFERIOR;
+        } else if (other.isNaN()) {
+            comparison = () -> Constants.SUPERIOR;
+        } else if (isInfinite() && other.isInfinite() && isPositive() == other.isPositive()) {
             comparison = () -> Constants.EQUAL;
         } else if (other instanceof IntegerValue) {
             comparison = () -> BigDecimal.valueOf(value).compareTo(new BigDecimal(((IntegerValue) other).value));

--- a/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
@@ -153,14 +153,14 @@ public class DoubleValue extends NumericValue {
             comparison = () -> Constants.SUPERIOR;
         } else if (isInfinite() && other.isInfinite() && isPositive() == other.isPositive()) {
             comparison = () -> Constants.EQUAL;
-        } else if (other instanceof IntegerValue) {
-            comparison = () -> BigDecimal.valueOf(value).compareTo(new BigDecimal(((IntegerValue) other).value));
-        } else if (other instanceof DecimalValue) {
-            comparison = () -> BigDecimal.valueOf(value).compareTo(((DecimalValue) other).value);
-        } else if (other instanceof DoubleValue) {
-            comparison = () -> Double.compare(value, ((DoubleValue) other).value);
-        } else if (other instanceof FloatValue) {
-            comparison = () -> Double.compare(value, ((FloatValue) other).value);
+        } else if (other instanceof IntegerValue iv) {
+            comparison = () -> BigDecimal.valueOf(value).compareTo(new BigDecimal(iv.value));
+        } else if (other instanceof DecimalValue dv) {
+            comparison = () -> BigDecimal.valueOf(value).compareTo(dv.value);
+        } else if (other instanceof DoubleValue dv) {
+            comparison = () -> Double.compare(value, dv.value);
+        } else if (other instanceof FloatValue fv) {
+            comparison = () -> Double.compare(value, fv.value);
         } else {
             comparison = null;
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DoubleValue.java
@@ -146,19 +146,21 @@ public class DoubleValue extends NumericValue {
 
     @Override
     protected @Nullable IntSupplier createComparisonWith(final NumericValue other) {
-        if (other instanceof IntegerValue) {
-            return () -> BigDecimal.valueOf(value).compareTo(new BigDecimal(((IntegerValue) other).value));
+        final IntSupplier comparison;
+        if (isInfinite() && other.isInfinite() && isPositive() == other.isPositive()) {
+            comparison = () -> Constants.EQUAL;
+        } else if (other instanceof IntegerValue) {
+            comparison = () -> BigDecimal.valueOf(value).compareTo(new BigDecimal(((IntegerValue) other).value));
+        } else if (other instanceof DecimalValue) {
+            comparison = () -> BigDecimal.valueOf(value).compareTo(((DecimalValue) other).value);
+        } else if (other instanceof DoubleValue) {
+            comparison = () -> Double.compare(value, ((DoubleValue) other).value);
+        } else if (other instanceof FloatValue) {
+            comparison = () -> Double.compare(value, ((FloatValue) other).value);
+        } else {
+            comparison = null;
         }
-        if (other instanceof DecimalValue) {
-            return () -> BigDecimal.valueOf(value).compareTo(((DecimalValue) other).value);
-        }
-        if (other instanceof DoubleValue) {
-            return () -> Double.compare(value, ((DoubleValue) other).value);
-        }
-        if (other instanceof FloatValue) {
-            return () -> Double.compare(value, ((FloatValue) other).value);
-        }
-        return null;
+        return comparison;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
@@ -150,7 +150,10 @@ public class FloatValue extends NumericValue {
     @Override
     protected @Nullable IntSupplier createComparisonWith(final NumericValue other) {
         final IntSupplier comparison;
-        if (other instanceof IntegerValue) {
+
+        if (isInfinite() && other.isInfinite() && isPositive() == other.isPositive()) {
+            comparison = () -> Constants.EQUAL;
+        } else if (other instanceof IntegerValue) {
             comparison = () -> BigDecimal.valueOf(value).compareTo(new BigDecimal(((IntegerValue)other).value));
         } else if (other instanceof DecimalValue) {
             final BigDecimal promoted = new BigDecimal(Float.toString(value));

--- a/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
@@ -150,8 +150,11 @@ public class FloatValue extends NumericValue {
     @Override
     protected @Nullable IntSupplier createComparisonWith(final NumericValue other) {
         final IntSupplier comparison;
-
-        if (isInfinite() && other.isInfinite() && isPositive() == other.isPositive()) {
+        if (isNaN()) {
+            comparison = () -> Constants.INFERIOR;
+        } else if (other.isNaN()) {
+            comparison = () -> Constants.SUPERIOR;
+        } else if (isInfinite() && other.isInfinite() && isPositive() == other.isPositive()) {
             comparison = () -> Constants.EQUAL;
         } else if (other instanceof IntegerValue) {
             comparison = () -> BigDecimal.valueOf(value).compareTo(new BigDecimal(((IntegerValue)other).value));

--- a/exist-core/src/test/java/org/exist/xquery/CountExpressionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/CountExpressionTest.java
@@ -73,8 +73,8 @@ public class CountExpressionTest {
         }
 
         // count keyword
-        assertEquals(143, ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getType());
+        assertEquals(XQueryParser.LITERAL_count, ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getType());
         // rank variable binding
-        assertEquals(20, ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getFirstChild().getType());
+        assertEquals(XQueryParser.VARIABLE_BINDING, ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getFirstChild().getType());
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/CountExpressionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/CountExpressionTest.java
@@ -23,6 +23,7 @@ package org.exist.xquery;
 
 import antlr.RecognitionException;
 import antlr.TokenStreamException;
+import org.exist.dom.QName;
 import org.exist.xquery.parser.XQueryAST;
 import org.exist.xquery.parser.XQueryLexer;
 import org.exist.xquery.parser.XQueryParser;
@@ -42,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class CountExpressionTest {
 
     @Test
-    public void countTest() throws RecognitionException, XPathException, TokenStreamException {
+    public void countTest() throws RecognitionException, XPathException, TokenStreamException, QName.IllegalQNameException {
         final String query = "xquery version \"3.1\";\n" +
                 "for $p in $products\n" +
                 "order by $p/sales descending\n" +
@@ -79,6 +80,6 @@ public class CountExpressionTest {
         assertEquals(XQueryParser.VARIABLE_BINDING, ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getFirstChild().getType());
         assertTrue(((ForExpr)expr.getFirst()).returnExpr instanceof OrderByClause);
         assertTrue(((OrderByClause)(((ForExpr)expr.getFirst()).returnExpr)).returnExpr instanceof CountClause);
-        assertEquals("rank", ((CountClause)((OrderByClause)(((ForExpr)expr.getFirst()).returnExpr)).returnExpr).varName);
+        assertEquals(new QName("rank"), ((CountClause)((OrderByClause)(((ForExpr)expr.getFirst()).returnExpr)).returnExpr).varName);
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/CountExpressionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/CountExpressionTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.io.StringReader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -76,5 +77,8 @@ public class CountExpressionTest {
         assertEquals(XQueryParser.LITERAL_count, ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getType());
         // rank variable binding
         assertEquals(XQueryParser.VARIABLE_BINDING, ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getFirstChild().getType());
+        assertTrue(((ForExpr)expr.getFirst()).returnExpr instanceof OrderByClause);
+        assertTrue(((OrderByClause)(((ForExpr)expr.getFirst()).returnExpr)).returnExpr instanceof CountClause);
+        assertEquals("rank", ((CountClause)((OrderByClause)(((ForExpr)expr.getFirst()).returnExpr)).returnExpr).varName);
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/CountExpressionTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/CountExpressionTest.java
@@ -1,0 +1,80 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery;
+
+import antlr.RecognitionException;
+import antlr.TokenStreamException;
+import org.exist.xquery.parser.XQueryAST;
+import org.exist.xquery.parser.XQueryLexer;
+import org.exist.xquery.parser.XQueryParser;
+import org.exist.xquery.parser.XQueryTreeParser;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ * @author <a href="mailto:gabriele@strumenta.com">Gabriele Tomassetti</a>
+ */
+public class CountExpressionTest {
+
+    @Test
+    public void countTest() throws RecognitionException, XPathException, TokenStreamException {
+        final String query = "xquery version \"3.1\";\n" +
+                "for $p in $products\n" +
+                "order by $p/sales descending\n" +
+                "count $rank\n" +
+                "where $rank <= 3\n" +
+                "return\n" +
+                "   <product rank=\"{$rank}\">\n" +
+                "      {$p/name, $p/sales}\n" +
+                "   </product>";
+
+        // parse the query into the internal syntax tree
+        final XQueryContext context = new XQueryContext();
+        final XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+        final XQueryParser xparser = new XQueryParser(lexer);
+        xparser.xpath();
+        if (xparser.foundErrors()) {
+            fail(xparser.getErrorMessage());
+            return;
+        }
+
+        final XQueryAST ast = (XQueryAST) xparser.getAST();
+
+        final XQueryTreeParser treeParser = new XQueryTreeParser(context);
+        final PathExpr expr = new PathExpr(context);
+        treeParser.xpath(ast, expr);
+        if (treeParser.foundErrors()) {
+            fail(treeParser.getErrorMessage());
+            return;
+        }
+
+        // count keyword
+        assertEquals(143, ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getType());
+        // rank variable binding
+        assertEquals(20, ast.getNextSibling().getFirstChild().getNextSibling().getNextSibling().getFirstChild().getType());
+    }
+}

--- a/exist-core/src/test/xquery/count.xql
+++ b/exist-core/src/test/xquery/count.xql
@@ -22,43 +22,43 @@
 xquery version "3.0";
 
 (:~ Additional tests for the fn:count function :)
-module namespace count="http://exist-db.org/xquery/test/count";
+module namespace cnt="http://exist-db.org/xquery/test/count";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
 import module namespace xmldb="http://exist-db.org/xquery/xmldb";
 
-declare variable $count:TEST_COLLECTION_NAME := "test-count";
-declare variable $count:TEST_COLLECTION := "/db/" || $count:TEST_COLLECTION_NAME;
-declare variable $count:COLLECTION1_NAME := "test-count-1";
-declare variable $count:COLLECTION2_NAME := "test-count-2";
-declare variable $count:COLLECTION1 := $count:TEST_COLLECTION || "/" || $count:COLLECTION1_NAME;
-declare variable $count:COLLECTION2 := $count:TEST_COLLECTION || "/" || $count:COLLECTION2_NAME;
+declare variable $cnt:TEST_COLLECTION_NAME := "test-count";
+declare variable $cnt:TEST_COLLECTION := "/db/" || $cnt:TEST_COLLECTION_NAME;
+declare variable $cnt:COLLECTION1_NAME := "test-count-1";
+declare variable $cnt:COLLECTION2_NAME := "test-count-2";
+declare variable $cnt:COLLECTION1 := $cnt:TEST_COLLECTION || "/" || $cnt:COLLECTION1_NAME;
+declare variable $cnt:COLLECTION2 := $cnt:TEST_COLLECTION || "/" || $cnt:COLLECTION2_NAME;
 
 declare
     %test:setUp
-function count:setup() {
-    xmldb:create-collection("/db", $count:TEST_COLLECTION_NAME),
-    xmldb:create-collection($count:TEST_COLLECTION, $count:COLLECTION1_NAME),
-    xmldb:store($count:COLLECTION1, "test1.xml", <test/>),
-    xmldb:create-collection($count:TEST_COLLECTION, $count:COLLECTION2_NAME),
-    xmldb:store($count:COLLECTION2, "test2xml", <test/>)
+function cnt:setup() {
+    xmldb:create-collection("/db", $cnt:TEST_COLLECTION_NAME),
+    xmldb:create-collection($cnt:TEST_COLLECTION, $cnt:COLLECTION1_NAME),
+    xmldb:store($cnt:COLLECTION1, "test1.xml", <test/>),
+    xmldb:create-collection($cnt:TEST_COLLECTION, $cnt:COLLECTION2_NAME),
+    xmldb:store($cnt:COLLECTION2, "test2xml", <test/>)
 };
 
 declare 
     %test:tearDown
-function count:cleanup() {
-    xmldb:remove($count:TEST_COLLECTION)
+function cnt:cleanup() {
+    xmldb:remove($cnt:TEST_COLLECTION)
 };
 
 declare 
     %test:assertEquals(1, 1)
-function count:arg-self-on-stored() {
-    (collection($count:COLLECTION1)/*, collection($count:COLLECTION2)/*)/count(.)
+function cnt:arg-self-on-stored() {
+    (collection($cnt:COLLECTION1)/*, collection($cnt:COLLECTION2)/*)/count(.)
 };
 
 declare 
     %test:assertEquals(1, 1, 1)
-function count:arg-self-on-constructed() {
+function cnt:arg-self-on-constructed() {
     (<a/>, <b/>, <c/>)/count(.)
 };

--- a/exist-core/src/test/xquery/xquery3/count.xqm
+++ b/exist-core/src/test/xquery/xquery3/count.xqm
@@ -101,6 +101,21 @@ function ct:order-descending-index1-after() {
 };
 
 declare
+%test:assertEquals(
+        '<x index1="2" index2="1">b</x>',
+        '<x index1="1" index2="2">a</x>'
+    )
+function ct:order-alpha-ascending-indexes() {
+  for $x in ('a', 'b')
+  count $index1
+  let $remainder := $index1 mod 2
+  order by $remainder, $index1
+  count $index2
+  return
+    <x index1="{$index1}" index2="{$index2}">{$x}</x>
+};
+
+declare
     %test:assertEquals(
         '<x index1="1" index2="1">1</x>',
         '<x index1="2" index2="2">2</x>',

--- a/exist-core/src/test/xquery/xquery3/count.xqm
+++ b/exist-core/src/test/xquery/xquery3/count.xqm
@@ -1,0 +1,240 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.0";
+
+module namespace ct = "http://exist-db.org/xquery/test/count";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+
+declare
+    %test:assertEquals(
+        '<x index1="1">1</x>',
+        '<x index1="2">2</x>',
+        '<x index1="3">3</x>',
+        '<x index1="4">4</x>'
+    )
+function ct:simple() {
+  for $x in 1 to 4
+  count $index1
+  return
+    <x index1="{$index1}">{$x}</x>
+};
+
+declare
+    %test:assertEquals(
+        '<x index1="1">1</x>',
+        '<x index1="2">2</x>',
+        '<x index1="3">3</x>',
+        '<x index1="4">4</x>'
+    )
+function ct:order-ascending-index1-before() {
+  for $x in 1 to 4
+  order by $x ascending
+  count $index1
+  return
+    <x index1="{$index1}">{$x}</x>
+};
+
+declare
+    %test:assertEquals(
+        '<x index1="1">1</x>',
+        '<x index1="2">2</x>',
+        '<x index1="3">3</x>',
+        '<x index1="4">4</x>'
+    )
+function ct:order-ascending-index1-after() {
+  for $x in 1 to 4
+  count $index1
+  order by $x ascending
+  return
+    <x index1="{$index1}">{$x}</x>
+};
+
+declare
+    %test:assertEquals(
+        '<x index1="1">4</x>',
+        '<x index1="2">3</x>',
+        '<x index1="3">2</x>',
+        '<x index1="4">1</x>'
+    )
+function ct:order-descending-index1-before() {
+  for $x in 1 to 4
+  order by $x descending
+  count $index1
+  return
+    <x index1="{$index1}">{$x}</x>
+};
+
+declare
+    %test:assertEquals(
+        '<x index1="4">4</x>',
+        '<x index1="3">3</x>',
+        '<x index1="2">2</x>',
+        '<x index1="1">1</x>'
+    )
+function ct:order-descending-index1-after() {
+  for $x in 1 to 4
+  count $index1
+  order by $x descending
+  return
+    <x index1="{$index1}">{$x}</x>
+};
+
+declare
+    %test:assertEquals(
+        '<x index1="1" index2="1">1</x>',
+        '<x index1="2" index2="2">2</x>',
+        '<x index1="3" index2="3">3</x>',
+        '<x index1="4" index2="4">4</x>'
+    )
+function ct:order-ascending-indexes() {
+  for $x in 1 to 4
+  count $index1
+  order by $x ascending
+  count $index2
+  return
+    <x index1="{$index1}" index2="{$index2}">{$x}</x>
+};
+
+declare
+    %test:assertEquals(
+        '<x index1="4" index2="1">4</x>',
+        '<x index1="3" index2="2">3</x>',
+        '<x index1="2" index2="3">2</x>',
+        '<x index1="1" index2="4">1</x>'
+    )
+function ct:order-descending-indexes() {
+  for $x in 1 to 4
+  count $index1
+  order by $x descending
+  count $index2
+  return
+    <x index1="{$index1}" index2="{$index2}">{$x}</x>
+};
+
+declare
+    %test:assertEquals(
+        '<item index1="3" remainder="0" index2="1"><x>3</x></item>',
+        '<item index1="1" remainder="1" index2="2"><x>1</x></item>',
+        '<item index1="4" remainder="1" index2="3"><x>4</x></item>',
+        '<item index1="2" remainder="2" index2="4"><x>2</x></item>'
+    )
+function ct:order-non-linear-ascending-indexes() {
+  for $x in 1 to 4
+  count $index1
+  let $remainder := $index1 mod 3
+  order by $remainder ascending
+  count $index2
+  return
+    <item index1="{$index1}" remainder="{$remainder}" index2="{$index2}"><x>{$x}</x></item>
+};
+
+declare
+    %test:assertEquals(
+        '<item index1="2" remainder="2" index2="1"><x>2</x></item>',
+        '<item index1="1" remainder="1" index2="2"><x>1</x></item>',
+        '<item index1="4" remainder="1" index2="3"><x>4</x></item>',
+        '<item index1="3" remainder="0" index2="4"><x>3</x></item>'
+    )
+function ct:order-non-linear-descending-indexes() {
+  for $x in 1 to 4
+  count $index1
+  let $remainder := $index1 mod 3
+  order by $remainder descending
+  count $index2
+  return
+    <item index1="{$index1}" remainder="{$remainder}" index2="{$index2}"><x>{$x}</x></item>
+};
+
+declare
+    %test:assertEquals(
+        '<item index1="3" remainder="0" index2="1"><x>2</x><y>1</y></item>',
+        '<item index1="1" remainder="1" index2="2"><x>1</x><y>1</y></item>',
+        '<item index1="4" remainder="1" index2="3"><x>2</x><y>2</y></item>',
+        '<item index1="2" remainder="2" index2="4"><x>1</x><y>2</y></item>'
+    )
+function ct:order-ascending-indexes-two-keys() {
+  for $x in 1 to 2
+  for $y in 1 to 2
+  count $index1
+  let $remainder := $index1 mod 3
+  order by $remainder, $index1
+  count $index2
+  return
+    <item index1="{$index1}" remainder="{$remainder}" index2="{$index2}"><x>{$x}</x><y>{$y}</y></item>
+};
+
+declare
+    %test:assertEquals(
+        '<item index1="2" remainder="2" index2="1"><x>1</x><y>2</y></item>',
+        '<item index1="4" remainder="1" index2="2"><x>2</x><y>2</y></item>',
+        '<item index1="1" remainder="1" index2="3"><x>1</x><y>1</y></item>',
+        '<item index1="3" remainder="0" index2="4"><x>2</x><y>1</y></item>'
+    )
+function ct:order-descending-indexes-two-keys() {
+  for $x in 1 to 2
+  for $y in 1 to 2
+  count $index1
+  let $remainder := $index1 mod 3
+  order by $remainder descending, $index1 descending
+  count $index2
+  return
+    <item index1="{$index1}" remainder="{$remainder}" index2="{$index2}"><x>{$x}</x><y>{$y}</y></item>
+};
+
+declare
+    %test:assertEquals(
+        '<item index1="3" remainder="0" index2="1"><x>2</x><y>1</y></item>',
+        '<item index1="4" remainder="1" index2="2"><x>2</x><y>2</y></item>',
+        '<item index1="1" remainder="1" index2="3"><x>1</x><y>1</y></item>',
+        '<item index1="2" remainder="2" index2="4"><x>1</x><y>2</y></item>'
+    )
+function ct:order-ascending-descending-indexes-two-keys() {
+  for $x in 1 to 2
+  for $y in 1 to 2
+  count $index1
+  let $remainder := $index1 mod 3
+  order by $remainder ascending, $index1 descending
+  count $index2
+  return
+    <item index1="{$index1}" remainder="{$remainder}" index2="{$index2}"><x>{$x}</x><y>{$y}</y></item>
+};
+
+
+declare
+    %test:assertEquals(
+        '<item index1="2" remainder="2" index2="1"><x>1</x><y>2</y></item>',
+        '<item index1="1" remainder="1" index2="2"><x>1</x><y>1</y></item>',
+        '<item index1="4" remainder="1" index2="3"><x>2</x><y>2</y></item>',
+        '<item index1="3" remainder="0" index2="4"><x>2</x><y>1</y></item>'
+    )
+function ct:order-descending-ascending-indexes-two-keys() {
+  for $x in 1 to 2
+  for $y in 1 to 2
+  count $index1
+  let $remainder := $index1 mod 3
+  order by $remainder descending, $index1 ascending
+  count $index2
+  return
+    <item index1="{$index1}" remainder="{$remainder}" index2="{$index2}"><x>{$x}</x><y>{$y}</y></item>
+};

--- a/exist-core/src/test/xquery/xquery3/count.xqm
+++ b/exist-core/src/test/xquery/xquery3/count.xqm
@@ -101,6 +101,7 @@ function ct:order-descending-index1-after() {
 };
 
 declare
+%test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
 %test:assertEquals(
         '<x index1="2" index2="1">b</x>',
         '<x index1="1" index2="2">a</x>'
@@ -148,6 +149,7 @@ function ct:order-descending-indexes() {
 };
 
 declare
+    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="3" remainder="0" index2="1"><x>3</x></item>',
         '<item index1="1" remainder="1" index2="2"><x>1</x></item>',
@@ -165,6 +167,7 @@ function ct:order-non-linear-ascending-indexes() {
 };
 
 declare
+    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="2" remainder="2" index2="1"><x>2</x></item>',
         '<item index1="1" remainder="1" index2="2"><x>1</x></item>',
@@ -182,6 +185,7 @@ function ct:order-non-linear-descending-indexes() {
 };
 
 declare
+    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="3" remainder="0" index2="1"><x>2</x><y>1</y></item>',
         '<item index1="1" remainder="1" index2="2"><x>1</x><y>1</y></item>',
@@ -200,6 +204,7 @@ function ct:order-ascending-indexes-two-keys() {
 };
 
 declare
+    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="2" remainder="2" index2="1"><x>1</x><y>2</y></item>',
         '<item index1="4" remainder="1" index2="2"><x>2</x><y>2</y></item>',
@@ -218,6 +223,7 @@ function ct:order-descending-indexes-two-keys() {
 };
 
 declare
+    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="3" remainder="0" index2="1"><x>2</x><y>1</y></item>',
         '<item index1="4" remainder="1" index2="2"><x>2</x><y>2</y></item>',
@@ -237,6 +243,7 @@ function ct:order-ascending-descending-indexes-two-keys() {
 
 
 declare
+    %test:pending('Related to failing XQTS test prod-CountClause/count-009, see: https://github.com/eXist-db/exist/pull/4530#issue-1356325345')
     %test:assertEquals(
         '<item index1="2" remainder="2" index2="1"><x>1</x><y>2</y></item>',
         '<item index1="1" remainder="1" index2="2"><x>1</x><y>1</y></item>',


### PR DESCRIPTION
This is currently passing 12 out of 13 XQTS tests. The 1 failing test is: `prod-CountClause/count-009`. 

<img width="1328" alt="Screenshot 2023-06-06 at 23 20 43" src="https://github.com/eXist-db/exist/assets/1264057/980eb4c1-df2e-4532-b333-628d347c6052">

## <a name="acceptance" id="acceptance">Acceptance of Failing XQTS Test</a>
The 1 failing test occurs due to the existing design and implementation of FLWOR expressions in eXist-db.

Specifically, eXist-db's implementation of the XQuery `order by` clause does not follow the W3C specification. The W3C XQuery 3.1 [Order By Clause](https://www.w3.org/TR/xquery-31/#id-order-by-clause) specification states:

> The purpose of an order by clause is to impose a value-based ordering on the tuples in the tuple stream. The output tuple stream of the order by clause contains the same tuples as its input tuple stream, but the tuples may be in a different order.

This means that any tuples in a tuple stream after an Order By Clause should be in the order defined by the order by clause. In the eXist-db implementation that is not the case. In eXist-db any expressions/clauses within a FLWOR expression that occur after the order by clause, but before the return clause, will not see an ordered tuple stream; instead they see the tuple stream prior to the order by clause. The reason for this is that in eXist-db the operation of executing the `sort` for the Order By clause is always deferred until just before the return clause of the FLWOR expression. In eXist-db this is known as a `postEval` phase, see:
1. [`FLWORClause#postEval(Sequence)`](https://github.com/eXist-db/exist/blob/eXist-6.2.0/exist-core/src/main/java/org/exist/xquery/FLWORClause.java#L95)
2. [`ForExpr#eval(Sequence, Item)`](https://github.com/eXist-db/exist/blob/eXist-6.2.0/exist-core/src/main/java/org/exist/xquery/ForExpr.java#L224)
3. [`OrderByClause#postEval(Sequence)`](https://github.com/eXist-db/exist/blob/eXist-6.2.0/exist-core/src/main/java/org/exist/xquery/OrderByClause.java#L90)

Unfortunately at this time it appears that modifying eXist-db to correctly implement the `Order By Clause` semantics would be a huge undertaking, and may require a rewrite of all FLWOR expressions. Therefore we consider it out of scope for this PR.

On an tangentially related note, we suspect there may be other problems with all other FLWOR expressions in eXist-db that implement `postEval` with regards to compliance with W3C XQuery 3.1.

----
### In Further Detail

Given the XQuery:
```xquery
for $x in ('a', 'b')

  count $index1
  
  let $remainder := $index1 mod 2
  order by $remainder, $index1
  
  count $index2

return
    <x index1="{$index1}" index2="{$index2}">{$x}</x>
```

The result should be computed as:
```xml
<x index1="2" index2="1">b</x>
<x index1="1" index2="2">a</x>
```

However eXist-db produces the *incorrect* result due to its incorrect implementation of the `order by` clause:
```xml
<x index1="2" index2="2">b</x>
<x index1="1" index2="1">a</x>
```

This occurs because eXist-db evaluates the query by effectively executing the following steps:
1. Bind `$x := 'a'`
2. Bind `$index1 := 1`
3. Bind `$remainder := 1`
4. Bind `$index2 := 1`
5. Add `<x index1="1" index2="1">a</x>` to the result sequence.
6. Bind `$x := 'b'`
7. Bind `$index1 := 2`
8. Bind `$remainder := 0`
9. Bind `$index2 := 2`
10. Add `<x index1="2" index2="2">b</x>` to the result sequence.
11. Sort the result sequence based by `$remainder ascending` and then `$index1 ascending`
12. Return the sorted result sequence.

The problem is that eXist-db applies the sorting (i.e. the `order by` clause) after the fact.

I have created a detailed UML Sequence Diagram of the above XQuery execution in eXist-db that shows the exact problem:
![eXist-db Count and Order By - UML Sequence Diagram](https://github.com/eXist-db/exist/assets/1264057/9ed46d4c-13cc-46ca-b895-8ae8e1d642c0)

In case it is helpful for anyone else, the code for the UML Sequence Diagram:
```uml
participant user as "User"
participant xquery as "XQuery"
participant pathexpr as "PathExpr"
participant x as "$x: ForExpr"
participant index1 as "$index1: CountExpr"
participant remainder as "$remainder: LetExpr"
participant orderby as "OrderByClause"
participant index2 as "$index2: CountExpr"
participant element as "ElementConstructor"

activate user

'XQuery Compilation Phase
note over user: XQuery Compilation phase starts here
activate xquery
user -> xquery: compile(...)
xquery -> xquery: analyzeAndOptimizeIfModulesChanged(...)
activate pathexpr
xquery -> pathexpr: analyze(...)
activate x
pathexpr -> x: analyze(...)
activate index1
x -> index1: analyze(...)
activate remainder
index1 -> remainder: analyze(...)
activate orderby
remainder -> orderby: analyze(...)
activate index2
orderby -> index2: analyze(...)
activate element
index2 -> element: analyze(...)
element -> index2
deactivate element
index2 -> orderby
deactivate index2
orderby -> remainder
deactivate orderby
remainder -> index1
deactivate remainder
index1 -> x
deactivate index1
x -> pathexpr
deactivate x
pathexpr -> xquery
deactivate pathexpr
xquery -> user
deactivate xquery

'XQuery Execution Phase
note over user: XQuery Execution phase starts here
activate xquery
user -> xquery: execute(...)
activate pathexpr
xquery -> pathexpr: eval(null)
activate x
pathexpr -> x: eval(null)
x -> x: isOuterFor == true
x -> x: $index1 is FLWORClause == true
activate index1
x -> index1: preEval(('a', 'b'))
index1 -> index1: hasPreviousOrderByDescending() == false
index1 -> index1: calcStartPosition == 0
activate remainder
index1 --> remainder: preEval(('a', 'b'))
activate orderby
remainder --> orderby: preEval(('a', 'b')) 
activate index2
orderby -> index2: preEval(('a', 'b')) 
index2 -> index2: hasPreviousOrderByDescending() == false
index2 -> index2: calcStartPosition == 0
index2 -> orderby
orderby --> remainder
remainder --> index1
index1 -> x

'Process first Item 'a'
x -> x: processItem('a')
x -> index1: eval(null, null)
index1 -> index1: increment/decrement count == 1
index1 -> remainder: eval(null, null)
remainder -> orderby: eval(null, null)
note over orderby, index2, element: Error: No ordering of the Tuple Stream as been performed by `order by` before\n the `count $index2` is evaluated and subsequently used by the `x` Element Constructor
orderby -> index2: eval(null, null)
index2 -> index2: increment/decrement count == 1
activate element
index2 -> element: eval(null, null)
element-> index2: (index1=1 index2=1 x='a')
index2-> orderby: (index1=1 index2=1 x='a')
orderby -> orderby: orderedResult == \n  [\n    (index1=1 index2=1 x='a')\n  ]
note over orderby: orderedResult is not yet sorted!
orderby -> remainder: (index1=1 index2=1 x='a')
remainder -> index1: (index1=1 index2=1 x='a')
index1 -> x: (index1=1 index2=1 x='a')

'Process second Item 'b'
x -> x: processItem('b')
x -> index1: eval(null, null)
index1 -> index1: increment/decrement count == 2
index1 -> remainder: eval(null, null)
note over orderby, index2, element: Error: No ordering of the Tuple Stream as been performed by `order by` before\n the `count $index2` is evaluated and subsequently used by the `x` Element Constructor
remainder -> orderby: eval(null, null)
orderby -> index2: eval(null, null)
index2 -> index2: increment/decrement count == 2
index2 -> element: eval(null, null)
element-> index2: (index1=2 index2=2 x='b')
deactivate element
index2-> orderby: (index1=2 index2=2 x='b')
orderby -> orderby: orderedResult == \n  [\n    (index1=1 index2=1 x='a')\n    (index1=2 index2=2 x='b')\n  ]
note over orderby: orderedResult is not yet sorted!
orderby -> remainder: (index1=2 index2=2 x='b')
remainder -> index1: (index1=2 index2=2 x='b')
index1 -> x: (index1=2 index2=2 x='b')

'Post Eval phase
x -> x: callPostEval == true
note over x: Post Eval Phase starts here...
x --> index1: postEval([\n    (index1=1 index2=1 x='a')\n    (index1=2 index2=2 x='b')\n  ])
index1 --> remainder: postEval([\n    (index1=1 index2=1 x='a')\n    (index1=2 index2=2 x='b')\n  ])
remainder --> orderby: postEval([\n    (index1=1 index2=1 x='a')\n    (index1=2 index2=2 x='b')\n  ])
orderby -> orderby: orderedResult.sort
orderby -> orderby: orderedResult == \n  [\n    (index1=2 index2=2 x='b')\n    (index1=1 index2=1 x='a')\n  ]
note over orderby: orderedResult is now sorted!
note over orderby: Error: The Tuple Stream was sorted after the `count $index2`,\n it should have been sorted before!
orderby -> index2: postEval([\n    (index1=2 index2=2 x='b')\n    (index1=1 index2=1 x='a')\n  ])
index2 -> orderby: [\n    (index1=2 index2=2 x='b')\n    (index1=1 index2=1 x='a')\n  ]
deactivate index2
orderby --> remainder: [\n    (index1=2 index2=2 x='b')\n    (index1=1 index2=1 x='a')\n  ]
deactivate orderby
remainder --> index1: [\n    (index1=2 index2=2 x='b')\n    (index1=1 index2=1 x='a')\n  ]
deactivate remainder
index1 --> x: [\n    (index1=2 index2=2 x='b')\n    (index1=1 index2=1 x='a')\n  ]
deactivate index1
x -> pathexpr: [\n    (index1=2 index2=2 x='b')\n    (index1=1 index2=1 x='a')\n  ]
deactivate x
pathexpr -> xquery: [\n    (index1=2 index2=2 x='b')\n    (index1=1 index2=1 x='a')\n  ]
deactivate pathexpr
note over user: The orderedResult overwrites the result sequence,\n and is returned to the User
xquery -> user: [\n    (index1=2 index2=2 x='b')\n    (index1=1 index2=1 x='a')\n  ]
deactivate xquery

deactivate user
```


----
This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.