### PR TITLE
Field perf revised

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/ValueIndexFactory.java
+++ b/exist-core/src/main/java/org/exist/storage/ValueIndexFactory.java
@@ -127,6 +127,7 @@ public class ValueIndexFactory {
         return serialize(value, offset, true);
     }
 
+    // TODO(AR) switch implementation to various serialize methods in the AtomicValues (requires major version bump)
     public final static byte[] serialize(final Indexable value, final int offset, final boolean caseSensitive) throws EXistException {
         /* xs:string */
         if (Type.subTypeOf(value.getType(), Type.STRING)) {

--- a/exist-core/src/main/java/org/exist/util/ByteConversion.java
+++ b/exist-core/src/main/java/org/exist/util/ByteConversion.java
@@ -21,6 +21,8 @@
  */
 package org.exist.util;
 
+import java.nio.ByteBuffer;
+
 /**
  * A collection of static methods to write integer values from/to a
  * byte array.
@@ -65,6 +67,27 @@ public class ByteConversion {
     }
 
     /**
+     * Read an integer value from the specified byte buffer.
+     *
+     * This version of the method reads the highest byte first.
+     *
+     * @param buf the byte buffer to read from
+     *
+     * @return the integer
+     */
+    public final static int byteToIntH(final ByteBuffer buf) {
+        final byte b0 = buf.get();
+        final byte b1 = buf.get();
+        final byte b2 = buf.get();
+        final byte b3 = buf.get();
+
+        return (b3 & 0xff) |
+                ((b2 & 0xff) << 8) |
+                ((b1 & 0xff) << 16) |
+                ((b0 & 0xff) << 24);
+    }
+
+    /**
      *  Read a long value from the specified byte array, starting at start.
      *
      * @param data the input data
@@ -81,6 +104,33 @@ public class ByteConversion {
             ( ( ( (long) data[start + 5] ) & 0xffL ) << 16 ) |
             ( ( ( (long) data[start + 6] ) & 0xffL ) << 8 ) |
             ( ( (long) data[start + 7] ) & 0xffL );
+    }
+
+    /**
+     *  Read a long value from the specified byte buffer.
+     *
+     * @param buf the byte buffer to read from
+     *
+     * @return the long integer
+     */
+    public final static long byteToLong(final ByteBuffer buf) {
+        final byte b0 = buf.get();
+        final byte b1 = buf.get();
+        final byte b2 = buf.get();
+        final byte b3 = buf.get();
+        final byte b4 = buf.get();
+        final byte b5 = buf.get();
+        final byte b6 = buf.get();
+        final byte b7 = buf.get();
+
+        return ((((long) b0) & 0xffL) << 56) |
+                ((((long) b1) & 0xffL) << 48) |
+                ((((long) b2) & 0xffL) << 40) |
+                ((((long) b3) & 0xffL) << 32) |
+                ((((long) b4) & 0xffL) << 24) |
+                ((((long) b5) & 0xffL) << 16) |
+                ((((long) b6) & 0xffL) << 8) |
+                (((long) b7) & 0xffL);
     }
 
     /**
@@ -115,6 +165,21 @@ public class ByteConversion {
     }
 
     /**
+     * Read a short value from the specified byte array, starting at start.
+     *
+     * This version of the method reads the highest byte first.
+     *
+     * @param buf the byte buffer to read from
+     *
+     * @return the short integer
+     */
+    public final static short byteToShortH(final ByteBuffer buf) {
+        final byte b0 = buf.get();
+        final byte b1 = buf.get();
+        return (short) (((b0 & 0xff) << 8) | (b1 & 0xff));
+    }
+
+    /**
      * Write an int value to the specified byte array. The first byte is written
      * into the location specified by start.
      *
@@ -134,7 +199,22 @@ public class ByteConversion {
     }
 
     /**
-     * Write an int value to the specified byte array. The first byte is written
+     * Write an int value to the specified byte array.
+     *
+     * This version of the method writes the highest byte first.
+     *
+     * @param v the value
+     * @param buf the byte buffer to write into
+     */
+    public final static void intToByteH(final int v, final ByteBuffer buf) {
+        buf.put((byte) ((v >>> 24) & 0xff));
+        buf.put((byte) ((v >>> 16) & 0xff));
+        buf.put((byte) ((v >>> 8) & 0xff));
+        buf.put((byte) ((v >>> 0) & 0xff));
+    }
+
+    /**
+     * Write an int value to the specified byte buffer. The first byte is written
      * into the location specified by start.
      *
      * This version of the method writes the highest byte first.
@@ -173,6 +253,22 @@ public class ByteConversion {
         return data;
     }
 
+    /**
+     * Write a long value to the specified byte buffer.
+     *
+     * @param v the value
+     * @param buf the byte buffer to write into
+     */
+    public final static void longToByte(final long v, final ByteBuffer buf) {
+        buf.put((byte) ((v >>> 56) & 0xff));
+        buf.put((byte) ((v >>> 48) & 0xff));
+        buf.put((byte) ((v >>> 40) & 0xff));
+        buf.put((byte) ((v >>> 32) & 0xff));
+        buf.put((byte) ((v >>> 24) & 0xff));
+        buf.put((byte) ((v >>> 16) & 0xff));
+        buf.put((byte) ((v >>> 8) & 0xff));
+        buf.put((byte) ((v >>> 0) & 0xff));
+    }
 
     /**
      * Write an int value to a newly allocated byte array.
@@ -227,6 +323,20 @@ public class ByteConversion {
         data[start + 1] = (byte) ( ( v >>> 0 ) & 0xff );
         data[start] = (byte) ( ( v >>> 8 ) & 0xff );
         return data;
+    }
+
+    /**
+     * Write a short value to the specified byte array.
+     *
+     * This version writes the highest byte first.
+     *
+     * @param v the value
+     * @param buf the byte buffer to write into
+     */
+    public final static void shortToByteH(final short v, final ByteBuffer buf) {
+        buf.put( (byte) ((v >>> 8) & 0xff));
+        buf.put((byte) ((v >>> 0) & 0xff));
+
     }
 }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.util.ByteConversion;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
 import org.exist.xquery.XPathException;
@@ -28,6 +29,7 @@ import org.exist.xquery.XPathException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
+import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
@@ -38,6 +40,8 @@ import java.util.GregorianCalendar;
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>
  */
 public class DateTimeValue extends AbstractDateTimeValue {
+
+    public static final int SERIALIZED_SIZE = 13;
 
     public DateTimeValue() throws XPathException {
         super(null, TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar()));
@@ -184,4 +188,64 @@ public class DateTimeValue extends AbstractDateTimeValue {
         return calendar.toGregorianCalendar().getTime();
     }
 
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target == byte[].class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf.array();
+        } else if (target == ByteBuffer.class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf;
+        } else {
+            return super.toJavaObject(target);
+        }
+    }
+
+    /**
+     * Serializes to a ByteBuffer.
+     *
+     * 13 bytes where: [0-3 (Year), 4 (Month), 5 (Day), 6 (Hour), 7 (Minute), 8 (Second), 9-10 (Milliseconds), 11-12 (Timezone)]
+     *
+     * @param buf the ByteBuffer to serialize to.
+     */
+    public void serialize(final ByteBuffer buf) {
+        ByteConversion.intToByteH(calendar.getYear(), buf);
+        buf.put((byte) calendar.getMonth());
+        buf.put((byte) calendar.getDay());
+        buf.put((byte) calendar.getHour());
+        buf.put((byte) calendar.getMinute());
+        buf.put((byte) calendar.getSecond());
+
+        final int ms = calendar.getMillisecond();
+        if (ms == DatatypeConstants.FIELD_UNDEFINED) {
+            buf.putShort((short) 0);
+        } else {
+            ByteConversion.shortToByteH((short) ms, buf);
+        }
+
+        // values for timezone range from -14*60 to 14*60, so we can use a short, but
+        // need to choose a different value for FIELD_UNDEFINED, which is not the same as 0 (= UTC)
+        final int timezone = calendar.getTimezone();
+        ByteConversion.shortToByteH((short) (timezone == DatatypeConstants.FIELD_UNDEFINED ? Short.MAX_VALUE : timezone), buf);
+    }
+
+    public static AtomicValue deserialize(final ByteBuffer buf) {
+        final int year = ByteConversion.byteToIntH(buf);
+        final int month = buf.get();
+        final int day = buf.get();
+        final int hour = buf.get();
+        final int minute = buf.get();
+        final int second = buf.get();
+
+        final int ms = ByteConversion.byteToShortH(buf);
+
+        int timezone = ByteConversion.byteToShortH(buf);
+        if (timezone == Short.MAX_VALUE) {
+            timezone = DatatypeConstants.FIELD_UNDEFINED;
+        }
+
+        return new DateTimeValue(year, month, day, hour, minute, second, ms, timezone);
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
@@ -67,7 +67,7 @@ public class DateTimeValue extends AbstractDateTimeValue {
         normalize();
     }
 
-    public DateTimeValue(int year, int month, int day, int hour, int minute, int second, int millisecond, int timezone) {
+    public DateTimeValue(final int year, final int month, final int day, final int hour, final int minute, final int second, final int millisecond, final int timezone) {
         super(TimeUtils.getInstance().newXMLGregorianCalendar(year, month, day, hour, minute, second, millisecond, timezone));
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateTimeValue.java
@@ -67,6 +67,10 @@ public class DateTimeValue extends AbstractDateTimeValue {
         normalize();
     }
 
+    public DateTimeValue(int year, int month, int day, int hour, int minute, int second, int millisecond, int timezone) {
+        super(TimeUtils.getInstance().newXMLGregorianCalendar(year, month, day, hour, minute, second, millisecond, timezone));
+    }
+
     public DateTimeValue(String dateTime) throws XPathException {
         this(null, dateTime);
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.util.ByteConversion;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
 import org.exist.xquery.XPathException;
@@ -28,6 +29,7 @@ import org.exist.xquery.XPathException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
+import java.nio.ByteBuffer;
 import java.util.GregorianCalendar;
 
 /**
@@ -35,6 +37,8 @@ import java.util.GregorianCalendar;
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>
  */
 public class DateValue extends AbstractDateTimeValue {
+
+    public static final int SERIALIZED_SIZE = 8;
 
     public DateValue() throws XPathException {
         super(null, stripCalendar(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar())));
@@ -137,5 +141,51 @@ public class DateValue extends AbstractDateTimeValue {
                         "Operand to minus should be of type xdt:yearMonthDuration or xdt:dayTimeDuration; got: "
                                 + Type.getTypeName(other.getType()));
         }
+    }
+
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target == byte[].class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf.array();
+        } else if (target == ByteBuffer.class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf;
+        } else {
+            return super.toJavaObject(target);
+        }
+    }
+
+    /**
+     * Serializes to a ByteBuffer.
+     *
+     * 8 bytes where: [0-3 (Year), 4 (Month), 5 (Day), 6-7 (Timezone)]
+     *
+     * @param buf the ByteBuffer to serialize to.
+     */
+    public void serialize(final ByteBuffer buf) {
+        ByteConversion.intToByteH(calendar.getYear(), buf);
+        buf.put((byte) calendar.getMonth());
+        buf.put((byte) calendar.getDay());
+
+        // values for timezone range from -14*60 to 14*60, so we can use a short, but
+        // need to choose a different value for FIELD_UNDEFINED, which is not the same as 0 (= UTC)
+        final int timezone = calendar.getTimezone();
+        ByteConversion.shortToByteH((short) (timezone == DatatypeConstants.FIELD_UNDEFINED ? Short.MAX_VALUE : timezone), buf);
+    }
+
+    public static AtomicValue deserialize(final ByteBuffer buf) {
+        final int year = ByteConversion.byteToIntH(buf);
+        final int month = buf.get();
+        final int day = buf.get();
+
+        int timezone = ByteConversion.byteToShortH(buf);
+        if (timezone == Short.MAX_VALUE) {
+            timezone = DatatypeConstants.FIELD_UNDEFINED;
+        }
+
+        return new DateValue(year, month, day, timezone);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
@@ -67,6 +67,10 @@ public class DateValue extends AbstractDateTimeValue {
         super(expression, stripCalendar(cloneXMLGregorianCalendar(calendar)));
     }
 
+    public DateValue(int year, int month, int day, int timezone) {
+        super(TimeUtils.getInstance().newXMLGregorianCalendarDate(year, month, day, timezone));
+    }
+    
     private static XMLGregorianCalendar stripCalendar(XMLGregorianCalendar calendar) {
         calendar.setHour(DatatypeConstants.FIELD_UNDEFINED);
         calendar.setMinute(DatatypeConstants.FIELD_UNDEFINED);

--- a/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
@@ -72,6 +72,7 @@ public class DateValue extends AbstractDateTimeValue {
         calendar.setMinute(DatatypeConstants.FIELD_UNDEFINED);
         calendar.setSecond(DatatypeConstants.FIELD_UNDEFINED);
         calendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
+        calendar.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
         return calendar;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
@@ -67,7 +67,7 @@ public class DateValue extends AbstractDateTimeValue {
         super(expression, stripCalendar(cloneXMLGregorianCalendar(calendar)));
     }
 
-    public DateValue(int year, int month, int day, int timezone) {
+    public DateValue(final int year, final int month, final int day, final int timezone) {
         super(TimeUtils.getInstance().newXMLGregorianCalendarDate(year, month, day, timezone));
     }
     

--- a/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DateValue.java
@@ -76,7 +76,6 @@ public class DateValue extends AbstractDateTimeValue {
         calendar.setMinute(DatatypeConstants.FIELD_UNDEFINED);
         calendar.setSecond(DatatypeConstants.FIELD_UNDEFINED);
         calendar.setMillisecond(DatatypeConstants.FIELD_UNDEFINED);
-        calendar.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
         return calendar;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/DecimalValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/DecimalValue.java
@@ -22,6 +22,7 @@
 package org.exist.xquery.value;
 
 import com.ibm.icu.text.Collator;
+import org.exist.util.ByteConversion;
 import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
@@ -33,6 +34,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.util.function.IntSupplier;
 import java.util.regex.Pattern;
 
@@ -40,6 +42,9 @@ import java.util.regex.Pattern;
  * @author wolf
  */
 public class DecimalValue extends NumericValue {
+
+    public static final int SERIALIZED_SIZE = 8;
+
     public static final BigInteger BIG_INTEGER_TEN = BigInteger.valueOf(10);
     // i × 10^-n where i, n = integers  and n >= 0
     // All ·minimally conforming· processors ·must· support decimal numbers
@@ -588,6 +593,14 @@ public class DecimalValue extends NumericValue {
         } else if (target == Byte.class || target == byte.class) {
             final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
             return (T) Byte.valueOf((byte) v.getValue());
+        } else if (target == byte[].class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf.array();
+        } else if (target == ByteBuffer.class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf;
         } else if (target == String.class) {
             return (T) getStringValue();
         } else if (target == Boolean.class) {
@@ -601,4 +614,22 @@ public class DecimalValue extends NumericValue {
                         + target.getName());
     }
     //End of copy
+
+    /**
+     * Serializes to a ByteBuffer.
+     *
+     * 8 bytes.
+     *
+     * @param buf the ByteBuffer to serialize to.
+     */
+    public void serialize(final ByteBuffer buf) {
+        final long ddBits = Double.doubleToLongBits(value.doubleValue()) ^ 0x8000000000000000L;
+        ByteConversion.longToByte(ddBits, buf);
+    }
+
+    public static DecimalValue deserialize(final ByteBuffer buf) {
+        final long dBits = ByteConversion.byteToLong(buf) ^ 0x8000000000000000L;
+        final double d = Double.longBitsToDouble(dBits);
+        return new DecimalValue(d);
+    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/FloatValue.java
@@ -24,6 +24,7 @@ package org.exist.xquery.value;
 import com.ibm.icu.text.Collator;
 import net.sf.saxon.tree.util.FastStringBuffer;
 import net.sf.saxon.value.FloatingPointConverter;
+import org.exist.util.ByteConversion;
 import org.exist.xquery.Constants;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
@@ -32,12 +33,16 @@ import org.exist.xquery.XPathException;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.util.function.IntSupplier;
 
 /**
  * @author wolf
  */
 public class FloatValue extends NumericValue {
+
+    public static final int SERIALIZED_SIZE = 4;
+
     // m × 2^e, where m is an integer whose absolute value is less than 2^24, 
     // and e is an integer between -149 and 104, inclusive.
     // In addition also -INF, +INF and NaN.
@@ -484,6 +489,14 @@ public class FloatValue extends NumericValue {
         } else if (target == Byte.class || target == byte.class) {
             final IntegerValue v = (IntegerValue) convertTo(Type.BYTE);
             return (T) Byte.valueOf((byte) v.getValue());
+        } else if (target == byte[].class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf.array();
+        } else if (target == ByteBuffer.class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf;
         } else if (target == String.class) {
             return (T) getStringValue();
         } else if (target == Boolean.class) {
@@ -512,5 +525,23 @@ public class FloatValue extends NumericValue {
     @Override
     public int hashCode() {
         return Float.valueOf(value).hashCode();
+    }
+
+    /**
+     * Serializes to a ByteBuffer.
+     *
+     * 4 bytes.
+     *
+     * @param buf the ByteBuffer to serialize to.
+     */
+    public void serialize(final ByteBuffer buf) {
+        final int fBits = Float.floatToIntBits(value) ^ 0x80000000;
+        ByteConversion.intToByteH(fBits, buf);
+    }
+
+    public static FloatValue deserialize(final ByteBuffer buf) {
+        final int fBits = ByteConversion.byteToIntH(buf) ^ 0x80000000;
+        final float f = Float.intBitsToFloat(fBits);
+        return new FloatValue(f);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/TimeUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/TimeUtils.java
@@ -76,7 +76,7 @@ public class TimeUtils {
      *
      * @param millis the timezone offset in milliseconds, positive or negative
      */
-    public void overrideLocalTimezoneOffset(int millis) {
+    public void overrideLocalTimezoneOffset(final int millis) {
         timezoneOffset = millis;
         timezoneOverriden = true;
     }

--- a/exist-core/src/main/java/org/exist/xquery/value/TimeUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/TimeUtils.java
@@ -76,7 +76,7 @@ public class TimeUtils {
      *
      * @param millis the timezone offset in milliseconds, positive or negative
      */
-    public void overrideLocalTimezoneOffset(final int millis) {
+    void overrideLocalTimezoneOffset(final int millis) {
         timezoneOffset = millis;
         timezoneOverriden = true;
     }
@@ -87,7 +87,7 @@ public class TimeUtils {
      * NOTE calling this method is not thread-safe and has a global impact
      * it should only be used for test cases.
      */
-    public void resetLocalTimezoneOffset() {
+    void resetLocalTimezoneOffset() {
         timezoneOverriden = false;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
@@ -67,6 +67,9 @@ public class TimeValue extends AbstractDateTimeValue {
         }
     }
 
+    public TimeValue(int hour, int minute, int second, int millisecond, int timezone) {
+        super(TimeUtils.getInstance().newXMLGregorianCalendarTime(hour, minute, second, millisecond, timezone));
+    }
     private static XMLGregorianCalendar stripCalendar(XMLGregorianCalendar calendar) {
         calendar = (XMLGregorianCalendar) calendar.clone();
         calendar.setYear(DatatypeConstants.FIELD_UNDEFINED);

--- a/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
@@ -67,7 +67,7 @@ public class TimeValue extends AbstractDateTimeValue {
         }
     }
 
-    public TimeValue(int hour, int minute, int second, int millisecond, int timezone) {
+    public TimeValue(final int hour, final int minute, final int second, final int millisecond, final int timezone) {
         super(TimeUtils.getInstance().newXMLGregorianCalendarTime(hour, minute, second, millisecond, timezone));
     }
     private static XMLGregorianCalendar stripCalendar(XMLGregorianCalendar calendar) {

--- a/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/TimeValue.java
@@ -21,6 +21,7 @@
  */
 package org.exist.xquery.value;
 
+import org.exist.util.ByteConversion;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.Expression;
 import org.exist.xquery.XPathException;
@@ -28,6 +29,8 @@ import org.exist.xquery.XPathException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
 import java.util.GregorianCalendar;
 
 /**
@@ -35,6 +38,8 @@ import java.util.GregorianCalendar;
  * @author <a href="mailto:piotr@ideanest.com">Piotr Kaminski</a>
  */
 public class TimeValue extends AbstractDateTimeValue {
+
+    public static final int SERIALIZED_SIZE = 7;
 
     public TimeValue() throws XPathException {
         super(null, stripCalendar(TimeUtils.getInstance().newXMLGregorianCalendar(new GregorianCalendar())));
@@ -131,4 +136,58 @@ public class TimeValue extends AbstractDateTimeValue {
                         + Type.getTypeName(other.getType()));
     }
 
+    @Override
+    public <T> T toJavaObject(final Class<T> target) throws XPathException {
+        if (target == byte[].class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf.array();
+        } else if (target == ByteBuffer.class) {
+            final ByteBuffer buf = ByteBuffer.allocate(SERIALIZED_SIZE);
+            serialize(buf);
+            return (T) buf;
+        } else {
+            return super.toJavaObject(target);
+        }
+    }
+
+    /**
+     * Serializes to a ByteBuffer.
+     *
+     * 7 bytes where: [0 (Hour), 1 (Minute), 2 (Second), 3-4 (Milliseconds), 5-6 (Timezone)]
+     *
+     * @param buf the ByteBuffer to serialize to.
+     */
+    public void serialize(final ByteBuffer buf) {
+        buf.put((byte) calendar.getHour());
+        buf.put((byte) calendar.getMinute());
+        buf.put((byte) calendar.getSecond());
+
+        final int ms = calendar.getMillisecond();
+        if (ms == DatatypeConstants.FIELD_UNDEFINED) {
+            buf.putShort((short) 0);
+        } else {
+            ByteConversion.shortToByteH((short) ms, buf);
+        }
+
+        // values for timezone range from -14*60 to 14*60, so we can use a short, but
+        // need to choose a different value for FIELD_UNDEFINED, which is not the same as 0 (= UTC)
+        final int timezone = calendar.getTimezone();
+        ByteConversion.shortToByteH((short) (timezone == DatatypeConstants.FIELD_UNDEFINED ? Short.MAX_VALUE : timezone), buf);
+    }
+
+    public static TimeValue deserialize(final ByteBuffer buf) {
+        final int hour = buf.get();
+        final int minute = buf.get();
+        final int second = buf.get();
+
+        final int ms = ByteConversion.byteToShortH(buf);
+
+        int timezone = ByteConversion.byteToShortH(buf);
+        if (timezone == Short.MAX_VALUE) {
+            timezone = DatatypeConstants.FIELD_UNDEFINED;
+        }
+
+        return new TimeValue(hour, minute, second, ms, timezone);
+    }
 }

--- a/extensions/indexes/lucene/pom.xml
+++ b/extensions/indexes/lucene/pom.xml
@@ -115,6 +115,11 @@
         </dependency>
 
         <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>net.sf.xmldb-org</groupId>
             <artifactId>xmldb-api</artifactId>
         </dependency>

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -61,12 +61,12 @@ import java.util.Optional;
  */
 public class LuceneFieldConfig extends AbstractFieldConfig {
 
-    private final static String ATTR_FIELD_NAME = "name";
-    private final static String ATTR_TYPE = "type";
-    private final static String ATTR_BINARY = "binary";
-    private final static String ATTR_STORE = "store";
-    private final static String ATTR_ANALYZER = "analyzer";
-    private final static String ATTR_IF = "if";
+    private static final String ATTR_FIELD_NAME = "name";
+    private static final String ATTR_TYPE = "type";
+    private static final String ATTR_BINARY = "binary";
+    private static final String ATTR_STORE = "store";
+    private static final String ATTR_ANALYZER = "analyzer";
+    private static final String ATTR_IF = "if";
 
     protected String fieldName;
     protected int type = Type.STRING;

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -171,12 +171,7 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
     protected void processResult(Sequence result, Document luceneDoc) throws XPathException {
         for (SequenceIterator i = result.unorderedIterator(); i.hasNext(); ) {
             final String text = i.nextItem().getStringValue();
-            final Field field;
-            if (binary) {
-                field = convertToDocValue(text);
-            } else {
-                field = convertToField(text);
-            }
+            final Field field = binary ? convertToDocValue(text) : convertToField(text);
             if (field != null) {
                 luceneDoc.add(field);
             }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -242,41 +242,50 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
     private Field convertToDocValue(String content) {
         try {
             final byte[] data;
-            final XMLGregorianCalendar normalizedCalendar;
+            final XMLGregorianCalendar calendar;
             final int ms;
+            final int timezone;
             switch(type) {
                 case Type.TIME:
                     final TimeValue tv = new TimeValue(content);
-                    normalizedCalendar = tv.calendar.normalize();
-                    data = new byte[5]; // allocate an appropriately sized
-                    data[0] = (byte) normalizedCalendar.getHour();
-                    data[1] = (byte) normalizedCalendar.getMinute();
-                    data[2] = (byte) normalizedCalendar.getSecond();
-                    ms = normalizedCalendar.getMillisecond();
+                    calendar = tv.calendar;
+                    data = new byte[7]; // allocate an appropriately sized
+                    data[0] = (byte) calendar.getHour();
+                    data[1] = (byte) calendar.getMinute();
+                    data[2] = (byte) calendar.getSecond();
+                    ms = calendar.getMillisecond();
                     ByteConversion.shortToByteH((short) (ms == DatatypeConstants.FIELD_UNDEFINED ? 0 : ms),
                             data, 3);
+                    // values for timezone range from -14*60 to 14*60, so we can use a short, but
+                    // need to choose a different value for FIELD_UNDEFINED, which is not the same as 0 (= UTC)
+                    timezone = calendar.getTimezone();
+                    ByteConversion.shortToByteH((short) (timezone == DatatypeConstants.FIELD_UNDEFINED ? Short.MAX_VALUE : timezone), data, 5);
                     return new BinaryDocValuesField(fieldName, new BytesRef(data));
                 case Type.DATE_TIME:
                     final DateTimeValue dtv = new DateTimeValue(content);
-                    normalizedCalendar = dtv.calendar.normalize();
-                    data = new byte[11]; // allocate an appropriately sized
-                    ByteConversion.intToByteH(normalizedCalendar.getYear(), data, 0);
-                    data[4] = (byte) normalizedCalendar.getMonth();
-                    data[5] = (byte) normalizedCalendar.getDay();
-                    data[6] = (byte) normalizedCalendar.getHour();
-                    data[7] = (byte) normalizedCalendar.getMinute();
-                    data[8] = (byte) normalizedCalendar.getSecond();
-                    ms = normalizedCalendar.getMillisecond();
+                    calendar = dtv.calendar;
+                    data = new byte[13]; // allocate an appropriately sized
+                    ByteConversion.intToByteH(calendar.getYear(), data, 0);
+                    data[4] = (byte) calendar.getMonth();
+                    data[5] = (byte) calendar.getDay();
+                    data[6] = (byte) calendar.getHour();
+                    data[7] = (byte) calendar.getMinute();
+                    data[8] = (byte) calendar.getSecond();
+                    ms = calendar.getMillisecond();
                     ByteConversion.shortToByteH((short) (ms == DatatypeConstants.FIELD_UNDEFINED ? 0 : ms),
                             data, 9);
+                    timezone = calendar.getTimezone();
+                    ByteConversion.shortToByteH((short) (timezone == DatatypeConstants.FIELD_UNDEFINED ? Short.MAX_VALUE : timezone), data, 11);
                     return new BinaryDocValuesField(fieldName, new BytesRef(data));
                 case Type.DATE:
                     final DateValue dv = new DateValue(content);
-                    normalizedCalendar = dv.calendar.normalize();
-                    data = new byte[6]; // allocate an appropriately sized
-                    ByteConversion.intToByteH(normalizedCalendar.getYear(), data, 0);
-                    data[4] = (byte) normalizedCalendar.getMonth();
-                    data[5] = (byte) normalizedCalendar.getDay();
+                    calendar = dv.calendar;
+                    data = new byte[8]; // allocate an appropriately sized
+                    ByteConversion.intToByteH(calendar.getYear(), data, 0);
+                    data[4] = (byte) calendar.getMonth();
+                    data[5] = (byte) calendar.getDay();
+                    timezone = calendar.getTimezone();
+                    ByteConversion.shortToByteH((short) (timezone == DatatypeConstants.FIELD_UNDEFINED ? Short.MAX_VALUE : timezone), data, 6);
                     return new BinaryDocValuesField(fieldName, new BytesRef(data));
                 case Type.INTEGER:
                 case Type.LONG:

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -306,6 +306,12 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
                     final int fBits = Float.floatToIntBits(fv.getValue()) ^ 0x80000000;
                     ByteConversion.intToByteH(fBits, data, 0);
                     return new BinaryDocValuesField(fieldName, new BytesRef(data));
+                case Type.DECIMAL:
+                    final DecimalValue ddbv = new DecimalValue(content);
+                    data = new byte[8];
+                    final long ddBits = Double.doubleToLongBits(ddbv.getDouble()) ^ 0x8000000000000000L;
+                    ByteConversion.longToByte(ddBits, data, 0);
+                    return new BinaryDocValuesField(fieldName, new BytesRef(data));
                 // everything else treated as string
                 default:
                     return new BinaryDocValuesField(fieldName, new BytesRef(content.getBytes(StandardCharsets.UTF_8)));

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneFieldConfig.java
@@ -234,7 +234,7 @@ public class LuceneFieldConfig extends AbstractFieldConfig {
         return null;
     }
 
-    private Field convertToDocValue(String content) {
+    private Field convertToDocValue(final String content) {
         try {
             final byte[] data;
             final XMLGregorianCalendar calendar;

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -881,70 +881,12 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
     }
 
     public IndexableField[] getField(final int docId, final NodeId nodeId, final String field) throws IOException, XPathException {
-//        final byte[] refdata = LuceneUtil.createId(docId, nodeId);
-//        final Term rterm = new Term("docNodeId", new BytesRef(refdata));
-
         Set<String> fields = new HashSet<>();
         fields.add(field);
         return index.withReader(reader -> {
-//            List<AtomicReaderContext> leaves = reader.leaves();
-//            for (AtomicReaderContext context : leaves) {
-//                BinaryDocValues values = context.reader().getBinaryDocValues(field);
-//                if (values != null && docId < context.reader().numDocs()) {
-//                    BytesRef bytes = values.get(docId);
-//                    if (bytes != null && bytes.length > 0) {
-//                        return bytes;
-//                    }
-//                }
-//            }
             Document doc = reader.document(docId, fields);
             return doc.getFields(field);
-//            Terms terms = reader.getTermVector(docId, field);
-//            if (terms != null) {
-//                TermsEnum termsEnum = terms.iterator((TermsEnum)null);
-//                BytesRef data;
-//                if ((data = termsEnum.next()) != null) {
-//
-//                }
-//            }
-//            List<AtomicReaderContext> leaves = reader.leaves();
-//            for (AtomicReaderContext context : leaves) {
-//                    Terms terms = context.reader().getTermVector(docId, field);
-//                    if (terms != null) {
-//                        TermsEnum termsEnum = terms.iterator((TermsEnum)null);
-//                        BytesRef data;
-//                        if ((data = termsEnum.next()) != null) {
-//
-//                        }
-//                    }
-//            }
-//            return null;
         });
-//        final BytesRefBuilder bytes = new BytesRefBuilder();
-//        NumericUtils.intToPrefixCoded(docId, 0, bytes);
-//        Term dt = new Term(FIELD_DOC_ID, bytes.toBytesRef());
-//        TermQuery tq = new TermQuery(dt);
-//
-//        int nodeIdLen = nodeId.size();
-//        byte[] data = new byte[nodeIdLen + 2];
-//        ByteConversion.shortToByte((short) nodeId.units(), data, 0);
-//        nodeId.serialize(data, 2);
-//
-//        Term it = new Term(LuceneUtil.FIELD_NODE_ID, new BytesRef(data));
-//
-//        TermQuery iq = new TermQuery(it);
-//        BooleanQuery q = new BooleanQuery();
-//        q.add(tq, BooleanClause.Occur.MUST);
-//        q.add(iq, BooleanClause.Occur.MUST);
-//
-//        Set<String> fields = new HashSet<>();
-//        fields.add(field);
-//        return index.withSearcher(searcher -> {
-//            TopDocs docs = searcher.searcher.search(q, 1);
-//            ScoreDoc scoreDoc = docs.scoreDocs[0];
-//            Document doc = searcher.searcher.doc(scoreDoc.doc);
-//            return doc.getField(field);
-//        });
     }
 
     public boolean hasIndex(int docId) throws IOException {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -454,7 +454,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                     query = drilldown(facets.get(), query, config);
                 }
                 searchAndProcess(contextId, qname, docs, contextSet, resultSet,
-                        returnAncestor, searcher, query, options.getFields(), config);
+                        returnAncestor, searcher, query, config);
             }
             return resultSet;
         });
@@ -498,7 +498,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 }
                 if (query != null) {
                     searchAndProcess(contextId, qname, docs, contextSet, resultSet,
-                            returnAncestor, searcher, query, options.getFields(), config);
+                            returnAncestor, searcher, query, config);
                 }
             }
             return resultSet;
@@ -516,7 +516,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             final Query query = queryTranslator.parse(field, queryRoot, analyzer, options);
             if (query != null) {
                 searchAndProcess(contextId, null, docs, contextSet, resultSet,
-                        returnAncestor, searcher, query, null, config);
+                        returnAncestor, searcher, query, config);
             }
             return resultSet;
         });
@@ -534,10 +534,10 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
     private void searchAndProcess(int contextId, QName qname, DocumentSet docs,
                                   NodeSet contextSet, NodeSet resultSet, boolean returnAncestor,
                                   SearcherTaxonomyManager.SearcherAndTaxonomy searcher, Query query,
-                                  @Nullable Set<String> fields, LuceneConfig config) throws IOException {
+                                  LuceneConfig config) throws IOException {
         final LuceneFacets facets = new LuceneFacets();
         final FacetsCollector facetsCollector = new FacetsCollector();
-        final LuceneHitCollector collector = new LuceneHitCollector(qname, query, docs, contextSet, resultSet, returnAncestor, contextId, facets, facetsCollector, fields);
+        final LuceneHitCollector collector = new LuceneHitCollector(qname, query, docs, contextSet, resultSet, returnAncestor, contextId, facets, facetsCollector);
         searcher.searcher.search(query, collector);
 
         // compute facets
@@ -599,7 +599,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             options.configureParser(parser.getConfiguration());
             Query query = parser.parse(queryString);
             searchAndProcess(contextId, null, docs, contextSet, resultSet,
-                    returnAncestor, searcher, query, null, config);
+                    returnAncestor, searcher, query, config);
             return resultSet;
         });
     }
@@ -955,7 +955,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         private final LuceneFacets facets;
         private final FacetsCollector chainedCollector;
 
-        private LuceneHitCollector(QName qname, Query query, DocumentSet docs, NodeSet contextSet, NodeSet resultSet, boolean returnAncestor, int contextId, LuceneFacets facets, FacetsCollector nextCollector, @Nullable Set<String> fields) {
+        private LuceneHitCollector(QName qname, Query query, DocumentSet docs, NodeSet contextSet, NodeSet resultSet, boolean returnAncestor, int contextId, LuceneFacets facets, FacetsCollector nextCollector) {
             this.qname = qname;
             this.docs = docs;
             this.contextSet = contextSet;

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -869,12 +869,11 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
                 final int id = docId - context.docBase;
                 if (id >= 0 && id < context.reader().numDocs()) {
                     final BinaryDocValues values = context.reader().getBinaryDocValues(field);
-                    if (values == null) {
-                        continue;
-                    }
-                    final BytesRef bytes = values.get(id);
-                    if (bytes != null && bytes.length > 0) {
-                        return bytes;
+                    if (values != null) {
+                        final BytesRef bytes = values.get(id);
+                        if (bytes != null && bytes.length > 0) {
+                            return bytes;
+                        }
                     }
                 }
             }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -531,10 +531,10 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         return drillDownQuery;
     }
 
-    private void searchAndProcess(int contextId, QName qname, DocumentSet docs,
-                                  NodeSet contextSet, NodeSet resultSet, boolean returnAncestor,
-                                  SearcherTaxonomyManager.SearcherAndTaxonomy searcher, Query query,
-                                  LuceneConfig config) throws IOException {
+    private void searchAndProcess(final int contextId, final QName qname, final DocumentSet docs,
+                                  final NodeSet contextSet, final NodeSet resultSet, final boolean returnAncestor,
+                                  final SearcherTaxonomyManager.SearcherAndTaxonomy searcher, final Query query,
+                                  final LuceneConfig config) throws IOException {
         final LuceneFacets facets = new LuceneFacets();
         final FacetsCollector facetsCollector = new FacetsCollector();
         final LuceneHitCollector collector = new LuceneHitCollector(qname, query, docs, contextSet, resultSet, returnAncestor, contextId, facets, facetsCollector);
@@ -885,7 +885,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         Set<String> fields = new HashSet<>();
         fields.add(field);
         return index.withReader(reader -> {
-            Document doc = reader.document(docId, fields);
+            final Document doc = reader.document(docId, fields);
             return doc.getFields(field);
         });
     }
@@ -955,7 +955,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
         private final LuceneFacets facets;
         private final FacetsCollector chainedCollector;
 
-        private LuceneHitCollector(QName qname, Query query, DocumentSet docs, NodeSet contextSet, NodeSet resultSet, boolean returnAncestor, int contextId, LuceneFacets facets, FacetsCollector nextCollector) {
+        private LuceneHitCollector(final QName qname, final Query query, final DocumentSet docs, final NodeSet contextSet, final NodeSet resultSet, final boolean returnAncestor, final int contextId, final LuceneFacets facets, final FacetsCollector nextCollector) {
             this.qname = qname;
             this.docs = docs;
             this.contextSet = contextSet;
@@ -1038,7 +1038,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
             }
         }
 
-        private LuceneMatch createMatch(int docId, float score, NodeId nodeId) {
+        private LuceneMatch createMatch(final int docId, final float score, final NodeId nodeId) {
             final LuceneMatch match = new LuceneMatch(contextId, docId + docBase, nodeId, query, facets);
             match.setScore(score);
             return match;

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndexWorker.java
@@ -21,6 +21,7 @@
  */
 package org.exist.indexing.lucene;
 
+import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
@@ -882,8 +883,7 @@ public class LuceneIndexWorker implements OrderedValuesIndex, QNamedKeysIndex {
     }
 
     public IndexableField[] getField(final int docId, final String field) throws IOException {
-        Set<String> fields = new HashSet<>();
-        fields.add(field);
+        final Set<String> fields = ObjectArraySet.of(field);
         return index.withReader(reader -> {
             final Document doc = reader.document(docId, fields);
             return doc.getFields(field);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -22,19 +22,16 @@
 package org.exist.indexing.lucene;
 
 import org.apache.lucene.facet.Facets;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
 import org.exist.dom.persistent.Match;
 import org.exist.numbering.NodeId;
-import org.exist.storage.Indexable;
 import org.exist.xquery.XPathException;
-import org.exist.xquery.modules.lucene.LuceneModule;
-import org.exist.xquery.value.*;
+import org.exist.xquery.value.AtomicValue;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.ValueSequence;
 
 import javax.annotation.Nullable;
-import javax.xml.datatype.XMLGregorianCalendar;
-import java.util.*;
+import java.util.Map;
 
 /**
  * Match class containing the score of a match and a reference to

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -24,9 +24,10 @@ package org.exist.indexing.lucene;
 import org.apache.lucene.facet.Facets;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
 import org.exist.dom.persistent.Match;
 import org.exist.numbering.NodeId;
-import org.exist.xquery.Expression;
+import org.exist.storage.Indexable;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.modules.lucene.LuceneModule;
 import org.exist.xquery.value.*;
@@ -41,6 +42,7 @@ import java.util.*;
  */
 public class LuceneMatch extends Match {
 
+    private int luceneDocId = -1;
     private float score = 0.0f;
     private final Query query;
 
@@ -48,12 +50,9 @@ public class LuceneMatch extends Match {
 
     private Map<String, FieldValue[]> fields = null;
 
-    private LuceneMatch(int contextId, NodeId nodeId, Query query) {
-        this(contextId, nodeId, query, null);
-    }
-
-    LuceneMatch(int contextId, NodeId nodeId, Query query, LuceneIndexWorker.LuceneFacets facets) {
+    LuceneMatch(int contextId, int luceneDocId, NodeId nodeId, Query query, LuceneIndexWorker.LuceneFacets facets) {
         super(contextId, nodeId, null);
+        this.luceneDocId = luceneDocId;
         this.query = query;
         this.facets = facets;
     }
@@ -61,6 +60,7 @@ public class LuceneMatch extends Match {
     private LuceneMatch(LuceneMatch copy) {
         super(copy);
         this.score = copy.score;
+        this.luceneDocId = copy.luceneDocId;
         this.query = copy.query;
         this.facets = copy.facets;
         this.fields = copy.fields;
@@ -71,8 +71,8 @@ public class LuceneMatch extends Match {
         return null;
     }
 
-    public Match createInstance(int contextId, NodeId nodeId, Query query) {
-        return new LuceneMatch(contextId, nodeId, query);
+    public int getLuceneDocId() {
+        return luceneDocId;
     }
 
     @Override
@@ -99,22 +99,6 @@ public class LuceneMatch extends Match {
 
     public Facets getFacets() {
         return this.facets.getFacets();
-    }
-
-    protected void addField(String name, IndexableField[] values) {
-        if (fields == null) {
-            fields = new HashMap<>();
-        }
-        final FieldValue[] v = new FieldValue[values.length];
-        int i = 0;
-        for (IndexableField value : values) {
-            if (value.numericValue() != null) {
-                v[i++] = new NumericField(value.numericValue());
-            } else {
-                v[i++] = new StringField(value.stringValue());
-            }
-        }
-        fields.put(name, v);
     }
 
     public @Nullable
@@ -154,85 +138,4 @@ public class LuceneMatch extends Match {
         AtomicValue getValue(int type) throws XPathException;
     }
 
-    private static class StringField implements FieldValue {
-
-        private final String value;
-
-        StringField(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public AtomicValue getValue(int type) throws XPathException {
-            switch(type) {
-                case Type.TIME:
-                    return new TimeValue(value);
-                case Type.DATE_TIME:
-                    return new DateTimeValue(value);
-                case Type.DATE:
-                    return new DateValue(value);
-                case Type.FLOAT:
-                    return new FloatValue(value);
-                case Type.DOUBLE:
-                    return new DoubleValue(value);
-                case Type.DECIMAL:
-                    return new DecimalValue(value);
-                case Type.INTEGER:
-                case Type.INT:
-                case Type.UNSIGNED_INT:
-                case Type.LONG:
-                case Type.UNSIGNED_LONG:
-                    return new IntegerValue(value);
-                default:
-                    return new StringValue(value);
-            }
-        }
-    }
-
-    private static class NumericField implements FieldValue {
-
-        private final Number value;
-
-        NumericField(Number value) {
-            this.value = value;
-        }
-
-        @Override
-        public AtomicValue getValue(int type) throws XPathException {
-            switch(type) {
-                case Type.TIME:
-                    final Date time = new Date(value.longValue());
-                    final GregorianCalendar gregorianCalendar = new GregorianCalendar();
-                    gregorianCalendar.setTime(time);
-                    final XMLGregorianCalendar calendar = TimeUtils.getInstance().newXMLGregorianCalendar(gregorianCalendar);
-                    return new TimeValue(calendar);
-                case Type.DATE_TIME:
-                    throw new XPathException((Expression) null, LuceneModule.EXXQDYFT0004, "Cannot convert numeric field to xs:dateTime");
-                case Type.DATE:
-                    final long dl = value.longValue();
-                    final int year = (int)(dl >> 16) & 0xFFFF;
-                    final int month = (int)(dl >> 8) & 0xFF;
-                    final int day = (int)(dl & 0xFF);
-                    final DateValue date = new DateValue();
-                    date.calendar.setYear(year);
-                    date.calendar.setMonth(month);
-                    date.calendar.setDay(day);
-                    return date;
-                case Type.FLOAT:
-                    return new FloatValue(value.floatValue());
-                case Type.DOUBLE:
-                    return new DoubleValue(value.floatValue());
-                case Type.DECIMAL:
-                    return new DecimalValue(value.doubleValue());
-                case Type.INTEGER:
-                case Type.INT:
-                case Type.UNSIGNED_INT:
-                case Type.LONG:
-                case Type.UNSIGNED_LONG:
-                    return new IntegerValue(value.longValue());
-                default:
-                    return new StringValue(value.toString());
-            }
-        }
-    }
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -47,7 +47,7 @@ public class LuceneMatch extends Match {
 
     private Map<String, FieldValue[]> fields = null;
 
-    LuceneMatch(int contextId, int luceneDocId, NodeId nodeId, Query query, LuceneIndexWorker.LuceneFacets facets) {
+    LuceneMatch(final int contextId, final int luceneDocId, final NodeId nodeId, final Query query, final LuceneIndexWorker.LuceneFacets facets) {
         super(contextId, nodeId, null);
         this.luceneDocId = luceneDocId;
         this.query = query;

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -293,16 +293,19 @@ public class Field extends BasicFunction {
 
     static AtomicValue bytesToAtomic(BytesRef field, int type) throws XPathException {
         final byte[] data = field.bytes;
+        final int timezone;
         switch(type) {
             case Type.TIME:
+                timezone = ByteConversion.byteToShortH(data, 5);
                 return new TimeValue(
                         data[0],
                         data[1],
                         data[2],
                         ByteConversion.byteToShortH(data, 3),
-                        DatatypeConstants.FIELD_UNDEFINED
+                        timezone == Short.MAX_VALUE ? DatatypeConstants.FIELD_UNDEFINED : timezone
                 );
             case Type.DATE_TIME:
+                timezone = ByteConversion.byteToShortH(data, 11);
                 return new DateTimeValue(
                     ByteConversion.byteToIntH(data, 0),
                     data[4],
@@ -311,14 +314,16 @@ public class Field extends BasicFunction {
                     data[7],
                     data[8],
                     ByteConversion.byteToShortH(data, 9),
-                    DatatypeConstants.FIELD_UNDEFINED
+                    timezone == Short.MAX_VALUE ? DatatypeConstants.FIELD_UNDEFINED : timezone
                 );
             case Type.DATE:
+                timezone = ByteConversion.byteToShortH(data, 6);
                 return new DateValue(
                     ByteConversion.byteToIntH(data, 0),
                     data[4],
                     data[5],
-                    DatatypeConstants.FIELD_UNDEFINED);
+                    timezone == Short.MAX_VALUE ? DatatypeConstants.FIELD_UNDEFINED : timezone
+                );
             case Type.DOUBLE:
                 final long bits = ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L;
                 final double d = Double.longBitsToDouble(bits);

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -54,55 +54,62 @@ import java.util.Map;
 
 public class Field extends BasicFunction {
 
-    public final static FunctionSignature[] signatures = {
+    public static final String FN_FIELD = "field";
+    public static final String FN_BINARY_FIELD = "binary-field";
+    public static final String FN_HIGHLIGHT_FIELD_MATCHES = "highlight-field-matches";
+
+    public static final FunctionParameterSequenceType CONTEXT_NODE_PARAMETER =
+            new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
+                    "the context node to check for attached fields");
+
+    public static final FunctionParameterSequenceType FIELD_NAME_PARAMETER =
+            new FunctionParameterSequenceType("field", Type.STRING, Cardinality.EXACTLY_ONE,
+                    "name of the field");
+    public static final FunctionParameterSequenceType TYPE_CAST_PARAMETER =
+            new FunctionParameterSequenceType("type", Type.STRING, Cardinality.EXACTLY_ONE,
+                "intended target type to cast the field value to. Casting may fail with a dynamic error.");
+
+    public static final FunctionSignature[] signatures = {
             new FunctionSignature(
-                new QName("field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+                new QName(FN_FIELD, LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
                 "Returns the value of a field attached to a particular node obtained via a full text search.",
                 new SequenceType[]{
-                        new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
-                                "the context node to check for attached fields"),
-                        new FunctionParameterSequenceType("field", Type.STRING, Cardinality.EXACTLY_ONE,
-                                "name of the field")
+                        CONTEXT_NODE_PARAMETER,
+                        FIELD_NAME_PARAMETER
                 },
                 new FunctionReturnSequenceType(Type.STRING, Cardinality.ZERO_OR_MORE,
                         "One or more string values corresponding to the values of the field attached")
             ),
             new FunctionSignature(
-                    new QName("field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+                    new QName(FN_FIELD, LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
                     "Returns the value of a field attached to a particular node obtained via a full text search." +
                             "Accepts an additional parameter to name the target type into which the field " +
                             "value should be cast. This is mainly relevant for fields having a different type than xs:string. " +
                             "As lucene does not record type information, numbers or dates would be returned as strings by default.",
                     new SequenceType[]{
-                            new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
-                                    "the context node to check for attached fields"),
-                            new FunctionParameterSequenceType("field", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "name of the field"),
-                            new FunctionParameterSequenceType("type", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "intended target type to cast the field value to. Casting may fail with a dynamic error.")
+                            CONTEXT_NODE_PARAMETER,
+                            FIELD_NAME_PARAMETER,
+                            TYPE_CAST_PARAMETER
                     },
                     new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
                             "Sequence corresponding to the values of the field attached, cast to the desired target type")
             ),
             new FunctionSignature(
-                    new QName("binary-field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+                    new QName(FN_BINARY_FIELD, LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
                     "Returns the value of a binary field attached to a particular node obtained via a full text search." +
                             "Accepts an additional parameter to name the target type into which the field " +
                             "value should be cast. This is mainly relevant for fields having a different type than xs:string. " +
                             "As lucene does not record type information, numbers or dates would be returned as strings by default.",
                     new SequenceType[]{
-                            new FunctionParameterSequenceType("node", Type.NODE, Cardinality.EXACTLY_ONE,
-                                    "the context node to check for attached fields"),
-                            new FunctionParameterSequenceType("field", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "name of the field"),
-                            new FunctionParameterSequenceType("type", Type.STRING, Cardinality.EXACTLY_ONE,
-                                    "intended target type to cast the field value to. Casting may fail with a dynamic error.")
+                            CONTEXT_NODE_PARAMETER,
+                            FIELD_NAME_PARAMETER,
+                            TYPE_CAST_PARAMETER
                     },
                     new FunctionReturnSequenceType(Type.ITEM, Cardinality.ZERO_OR_MORE,
                             "Sequence corresponding to the values of the field attached, cast to the desired target type")
             ),
             new FunctionSignature(
-                    new QName("highlight-field-matches", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+                    new QName(FN_HIGHLIGHT_FIELD_MATCHES, LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
                     "Highlights matches for the last executed lucene query within the value of a field " +
                     "attached to a particular node obtained via a full text search. Only fields listed in the 'fields' option of ft:query will be " +
                     "available to highlighting.",
@@ -146,7 +153,7 @@ public class Field extends BasicFunction {
         final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
         try {
             Sequence result;
-            if (isCalledAs("field") || isCalledAs("highlight-field-matches")) {
+            if (isCalledAs(FN_FIELD) || isCalledAs(FN_HIGHLIGHT_FIELD_MATCHES)) {
                 // field is a normal lucene field
                 final IndexableField[] fields = index.getField(match.getLuceneDocId(), fieldName);
                 result = new ValueSequence(fields.length);
@@ -165,7 +172,7 @@ public class Field extends BasicFunction {
                 }
                 result = bytesToAtomic(fieldValue, type);
             }
-            if (isCalledAs("highlight-field-matches")) {
+            if (isCalledAs(FN_HIGHLIGHT_FIELD_MATCHES)) {
                 return highlightMatches(fieldName, proxy, match, result);
             }
             return result;

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -169,7 +169,7 @@ public class Field extends BasicFunction {
         }
     }
 
-    private Sequence getBinaryFieldValue(final String fieldName, final int type, final LuceneMatch match, final LuceneIndexWorker index) throws IOException, XPathException {
+    private Sequence getBinaryFieldValue(final String fieldName, final int type, final LuceneMatch match, final LuceneIndexWorker index) throws IOException {
         final BytesRef fieldValue = index.getBinaryField(match.getLuceneDocId(), fieldName);
         if (fieldValue == null) {
             return Sequence.EMPTY_SEQUENCE;

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -148,7 +148,7 @@ public class Field extends BasicFunction {
             Sequence result;
             if (isCalledAs("field") || isCalledAs("highlight-field-matches")) {
                 // field is a normal lucene field
-                final IndexableField[] fields = index.getField(match.getLuceneDocId(), match.getNodeId(), fieldName);
+                final IndexableField[] fields = index.getField(match.getLuceneDocId(), fieldName);
                 result = new ValueSequence(fields.length);
                 for (final IndexableField field : fields) {
                     if (field.numericValue() != null) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -43,9 +43,7 @@ import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 
 import javax.annotation.Nullable;
-import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.io.IOException;
 import java.io.Reader;
@@ -297,41 +295,30 @@ public class Field extends BasicFunction {
         final byte[] data = field.bytes;
         switch(type) {
             case Type.TIME:
-                final TimeValue value = new TimeValue();
-                final XMLGregorianCalendar utccal = value.calendar;
-                utccal.setHour(data[0]);
-                utccal.setMinute(data[1]);
-                utccal.setSecond(data[2]);
-                utccal.setMillisecond(ByteConversion.byteToShortH(data, 3));
-                return value;
+                return new TimeValue(
+                        data[0],
+                        data[1],
+                        data[2],
+                        ByteConversion.byteToShortH(data, 3),
+                        DatatypeConstants.FIELD_UNDEFINED
+                );
             case Type.DATE_TIME:
-                try {
-                    final XMLGregorianCalendar xmlutccal =
-                            DatatypeFactory.newInstance().newXMLGregorianCalendar(
-                                    ByteConversion.byteToIntH(data, 0),
-                                    data[4],
-                                    data[5],
-                                    data[6],
-                                    data[7],
-                                    data[8],
-                                    ByteConversion.byteToShortH(data, 9),
-                                    0);
-                    return new DateTimeValue(xmlutccal);
-                } catch (final DatatypeConfigurationException dtce) {
-                    throw new XPathException(LuceneModule.EXXQDYFT0004, "Cannot convert binary field value to xs:dateTime");
-                }
+                return new DateTimeValue(
+                    ByteConversion.byteToIntH(data, 0),
+                    data[4],
+                    data[5],
+                    data[6],
+                    data[7],
+                    data[8],
+                    ByteConversion.byteToShortH(data, 9),
+                    DatatypeConstants.FIELD_UNDEFINED
+                );
             case Type.DATE:
-                try {
-                    final XMLGregorianCalendar xmlutccal =
-                            DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
-                                    ByteConversion.byteToIntH(data, 0),
-                                    data[4],
-                                    data[5],
-                                    DatatypeConstants.FIELD_UNDEFINED);
-                    return new DateValue(xmlutccal);
-                } catch (final DatatypeConfigurationException e) {
-                    throw new XPathException(LuceneModule.EXXQDYFT0004, "Cannot convert binary field value to xs:date");
-                }
+                return new DateValue(
+                    ByteConversion.byteToIntH(data, 0),
+                    data[4],
+                    data[5],
+                    DatatypeConstants.FIELD_UNDEFINED);
             case Type.DOUBLE:
                 final long bits = ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L;
                 final double d = Double.longBitsToDouble(bits);

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -44,6 +44,7 @@ import org.exist.xquery.value.*;
 
 import javax.annotation.Nullable;
 import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.io.IOException;
@@ -301,7 +302,7 @@ public class Field extends BasicFunction {
                                 ByteConversion.byteToIntH(data, 0),
                                 data[4],
                                 data[5],
-                                0);
+                                DatatypeConstants.FIELD_UNDEFINED);
                 return new DateValue(xmlutccal);
             } catch (final DatatypeConfigurationException e) {
                 throw new XPathException(LuceneModule.EXXQDYFT0004, "Cannot convert binary field value to xs:date");

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -69,7 +69,7 @@ public class Field extends BasicFunction {
             new FunctionParameterSequenceType("type", Type.STRING, Cardinality.EXACTLY_ONE,
                 "intended target type to cast the field value to. Casting may fail with a dynamic error.");
 
-    public static final FunctionSignature[] signatures = {
+    protected static final FunctionSignature[] signatures = {
             new FunctionSignature(
                 new QName(FN_FIELD, LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
                 "Returns the value of a field attached to a particular node obtained via a full text search.",
@@ -308,7 +308,7 @@ public class Field extends BasicFunction {
         return null;
     }
 
-    static AtomicValue bytesToAtomic(BytesRef field, int type) throws XPathException {
+    static AtomicValue bytesToAtomic(BytesRef field, int type) {
         final byte[] data = field.bytes;
         final int timezone;
         switch(type) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -333,6 +333,11 @@ public class Field extends BasicFunction {
                 final long dBits = ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L;
                 final double d = Double.longBitsToDouble(dBits);
                 return new DoubleValue(d);
+            case Type.FLOAT:
+                final int fBits = ByteConversion.byteToIntH(data, 0) ^ 0x80000000;
+                final float f = Float.intBitsToFloat(fBits);
+                return new FloatValue(f);
+
             default:
                 return new StringValue(field.utf8ToString());
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -125,13 +125,13 @@ public class Field extends BasicFunction {
             )
     };
 
-    public Field(XQueryContext context, FunctionSignature signature) {
+    public Field(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
     @Override
-    public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-        NodeValue nodeValue = (NodeValue) args[0].itemAt(0);
+    public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
+        final NodeValue nodeValue = (NodeValue) args[0].itemAt(0);
         if (nodeValue.getImplementationType() != NodeValue.PERSISTENT_NODE) {
             return Sequence.EMPTY_SEQUENCE;
         }
@@ -164,7 +164,7 @@ public class Field extends BasicFunction {
                 default:
                     throw new XPathException(this, ErrorCodes.FOER0000, "Unknown function: " + getName());
             }
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new XPathException(this, LuceneModule.EXXQDYFT0002, "Error retrieving field: " + e.getMessage());
         }
     }
@@ -178,9 +178,8 @@ public class Field extends BasicFunction {
     }
 
     private Sequence getFieldValues(final String fieldName, final int type, final LuceneMatch match, final LuceneIndexWorker index) throws IOException, XPathException {
-        Sequence result;
         final IndexableField[] fields = index.getField(match.getLuceneDocId(), fieldName);
-        result = new ValueSequence(fields.length);
+        final Sequence result = new ValueSequence(fields.length);
         for (final IndexableField field : fields) {
             if (field.numericValue() != null) {
                 result.add(numberToAtomic(type, field.numericValue()));
@@ -308,7 +307,7 @@ public class Field extends BasicFunction {
         return null;
     }
 
-    static AtomicValue bytesToAtomic(BytesRef field, int type) {
+    static AtomicValue bytesToAtomic(final BytesRef field, final int type) {
         final byte[] data = field.bytes;
         final int timezone;
         switch(type) {
@@ -356,7 +355,7 @@ public class Field extends BasicFunction {
         }
     }
 
-    static AtomicValue stringToAtomic(int type, String value) throws XPathException {
+    static AtomicValue stringToAtomic(final int type, final String value) throws XPathException {
         switch(type) {
             case Type.TIME:
                 return new TimeValue(value);
@@ -381,7 +380,7 @@ public class Field extends BasicFunction {
         }
     }
 
-    static AtomicValue numberToAtomic(int type, Number value) throws XPathException {
+    static AtomicValue numberToAtomic(final int type, final Number value) throws XPathException {
         switch(type) {
             case Type.TIME:
                 final Date time = new Date(value.longValue());

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -399,7 +399,7 @@ public class Field extends BasicFunction {
             case Type.UNSIGNED_SHORT:
                 return new IntegerValue(value.longValue());
             case Type.DOUBLE:
-                return new DoubleValue(value.floatValue());
+                return new DoubleValue(value.doubleValue());
             case Type.FLOAT:
                 return new FloatValue(value.floatValue());
             case Type.DECIMAL:

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -332,7 +332,7 @@ public class Field extends BasicFunction {
             case Type.UNSIGNED_LONG:
                 return new IntegerValue(ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L);
             default:
-                return new StringValue(new String(field.bytes));
+                return new StringValue(field.utf8ToString());
         }
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -326,6 +326,8 @@ public class Field extends BasicFunction {
             case Type.UNSIGNED_LONG:
             case Type.INT:
             case Type.UNSIGNED_INT:
+            case Type.SHORT:
+            case Type.UNSIGNED_SHORT:
                 return new IntegerValue(ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L);
             case Type.DOUBLE:
                 final long dBits = ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L;
@@ -349,6 +351,8 @@ public class Field extends BasicFunction {
             case Type.UNSIGNED_LONG:
             case Type.INT:
             case Type.UNSIGNED_INT:
+            case Type.SHORT:
+            case Type.UNSIGNED_SHORT:
                 return new IntegerValue(value);
             case Type.DOUBLE:
                 return new DoubleValue(value);
@@ -386,6 +390,8 @@ public class Field extends BasicFunction {
             case Type.UNSIGNED_LONG:
             case Type.INT:
             case Type.UNSIGNED_INT:
+            case Type.SHORT:
+            case Type.UNSIGNED_SHORT:
                 return new IntegerValue(value.longValue());
             case Type.DOUBLE:
                 return new DoubleValue(value.floatValue());

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -337,7 +337,10 @@ public class Field extends BasicFunction {
                 final int fBits = ByteConversion.byteToIntH(data, 0) ^ 0x80000000;
                 final float f = Float.intBitsToFloat(fBits);
                 return new FloatValue(f);
-
+            case Type.DECIMAL:
+                final long ddBits = ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L;
+                final double dd = Double.longBitsToDouble(ddBits);
+                return new DecimalValue(dd);
             default:
                 return new StringValue(field.utf8ToString());
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Field.java
@@ -321,16 +321,16 @@ public class Field extends BasicFunction {
                     data[5],
                     timezone == Short.MAX_VALUE ? DatatypeConstants.FIELD_UNDEFINED : timezone
                 );
-            case Type.DOUBLE:
-                final long bits = ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L;
-                final double d = Double.longBitsToDouble(bits);
-                return new DoubleValue(d);
             case Type.INTEGER:
-            case Type.INT:
-            case Type.UNSIGNED_INT:
             case Type.LONG:
             case Type.UNSIGNED_LONG:
+            case Type.INT:
+            case Type.UNSIGNED_INT:
                 return new IntegerValue(ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L);
+            case Type.DOUBLE:
+                final long dBits = ByteConversion.byteToLong(data, 0) ^ 0x8000000000000000L;
+                final double d = Double.longBitsToDouble(dBits);
+                return new DoubleValue(d);
             default:
                 return new StringValue(field.utf8ToString());
         }
@@ -344,18 +344,18 @@ public class Field extends BasicFunction {
                 return new DateTimeValue(value);
             case Type.DATE:
                 return new DateValue(value);
-            case Type.FLOAT:
-                return new FloatValue(value);
-            case Type.DOUBLE:
-                return new DoubleValue(value);
-            case Type.DECIMAL:
-                return new DecimalValue(value);
             case Type.INTEGER:
-            case Type.INT:
-            case Type.UNSIGNED_INT:
             case Type.LONG:
             case Type.UNSIGNED_LONG:
+            case Type.INT:
+            case Type.UNSIGNED_INT:
                 return new IntegerValue(value);
+            case Type.DOUBLE:
+                return new DoubleValue(value);
+            case Type.FLOAT:
+                return new FloatValue(value);
+            case Type.DECIMAL:
+                return new DecimalValue(value);
             default:
                 return new StringValue(value);
         }
@@ -381,18 +381,18 @@ public class Field extends BasicFunction {
                 date.calendar.setMonth(month);
                 date.calendar.setDay(day);
                 return date;
-            case Type.FLOAT:
-                return new FloatValue(value.floatValue());
-            case Type.DOUBLE:
-                return new DoubleValue(value.floatValue());
-            case Type.DECIMAL:
-                return new DecimalValue(value.doubleValue());
             case Type.INTEGER:
-            case Type.INT:
-            case Type.UNSIGNED_INT:
             case Type.LONG:
             case Type.UNSIGNED_LONG:
+            case Type.INT:
+            case Type.UNSIGNED_INT:
                 return new IntegerValue(value.longValue());
+            case Type.DOUBLE:
+                return new DoubleValue(value.floatValue());
+            case Type.FLOAT:
+                return new FloatValue(value.floatValue());
+            case Type.DECIMAL:
+                return new DecimalValue(value.doubleValue());
             default:
                 return new StringValue(value.toString());
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
@@ -71,6 +71,7 @@ public class LuceneModule extends AbstractInternalModule {
         new FunctionDef(Field.signatures[0], Field.class),
         new FunctionDef(Field.signatures[1], Field.class),
         new FunctionDef(Field.signatures[2], Field.class),
+        new FunctionDef(Field.signatures[3], Field.class),
         new FunctionDef(LuceneIndexKeys.signatures[0], LuceneIndexKeys.class)
     };
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/LuceneModule.java
@@ -27,7 +27,11 @@ import java.util.Map;
 import org.exist.dom.QName;
 import org.exist.xquery.AbstractInternalModule;
 import org.exist.xquery.ErrorCodes.ErrorCode;
+import org.exist.xquery.FunctionDSL;
 import org.exist.xquery.FunctionDef;
+import org.exist.xquery.FunctionSignature;
+import org.exist.xquery.value.FunctionParameterSequenceType;
+import org.exist.xquery.value.FunctionReturnSequenceType;
 
 /**
  * Module function definitions for Lucene-based full text indexed searching.
@@ -68,10 +72,10 @@ public class LuceneModule extends AbstractInternalModule {
         new FunctionDef(Facets.signatures[0], Facets.class),
         new FunctionDef(Facets.signatures[1], Facets.class),
         new FunctionDef(Facets.signatures[2], Facets.class),
-        new FunctionDef(Field.signatures[0], Field.class),
-        new FunctionDef(Field.signatures[1], Field.class),
-        new FunctionDef(Field.signatures[2], Field.class),
-        new FunctionDef(Field.signatures[3], Field.class),
+        new FunctionDef(Field.FS_FIELD[0], Field.class),
+        new FunctionDef(Field.FS_FIELD[1], Field.class),
+        new FunctionDef(Field.FS_BINARY_FIELD, Field.class),
+        new FunctionDef(Field.FS_HIGHLIGHT_FIELD_MATCHES, Field.class),
         new FunctionDef(LuceneIndexKeys.signatures[0], LuceneIndexKeys.class)
     };
 
@@ -97,6 +101,14 @@ public class LuceneModule extends AbstractInternalModule {
     @Override
     public String getReleaseVersion() {
         return RELEASED_IN_VERSION;
+    }
+
+    static FunctionSignature functionSignature(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType... paramTypes) {
+        return FunctionDSL.functionSignature(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, paramTypes);
+    }
+
+    static FunctionSignature[] functionSignatures(final String name, final String description, final FunctionReturnSequenceType returnType, final FunctionParameterSequenceType[][] variableParamTypes) {
+        return FunctionDSL.functionSignatures(new QName(name, NAMESPACE_URI, PREFIX), description, returnType, variableParamTypes);
     }
 
     protected final static class LuceneErrorCode extends ErrorCode {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
@@ -53,7 +53,6 @@ public class QueryOptions {
     public static final String DEFAULT_OPERATOR_OR = "or";
     public static final String OPTION_LOWERCASE_EXPANDED_TERMS = "lowercase-expanded-terms";
     public static final String OPTION_FACETS = "facets";
-    public static final String OPTION_FIELDS = "fields";
     public static final String OPTION_QUERY_ANALYZER_ID = "query-analyzer-id";
 
     protected enum DefaultOperator {
@@ -102,12 +101,7 @@ public class QueryOptions {
     public QueryOptions(AbstractMapType map) throws XPathException {
         for (final IEntry<AtomicValue, Sequence> entry: map) {
             final String key = entry.key().getStringValue();
-            if (key.equals(OPTION_FIELDS) && !entry.value().isEmpty()) {
-                fields = new HashSet<>();
-                for (SequenceIterator i = entry.value().unorderedIterator(); i.hasNext(); ) {
-                    fields.add(i.nextItem().getStringValue());
-                }
-            } else if (key.equals(OPTION_FACETS) && entry.value().hasOne() && entry.value().getItemType() == Type.MAP) {
+            if (key.equals(OPTION_FACETS) && entry.value().hasOne() && entry.value().getItemType() == Type.MAP) {
                 // map to hold the facet values for each dimension
                 final Map<String, FacetQuery> tf = new HashMap<>();
                 // iterate over each dimension and collect its values into a FacetQuery

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
@@ -102,10 +102,14 @@ public class QueryOptions {
         for (final IEntry<AtomicValue, Sequence> entry: map) {
             final String key = entry.key().getStringValue();
             if (key.equals(OPTION_FACETS) && entry.value().hasOne() && entry.value().getItemType() == Type.MAP) {
-                // map to hold the facet values for each dimension
-                final Map<String, FacetQuery> tf = new HashMap<>();
+
                 // iterate over each dimension and collect its values into a FacetQuery
-                for (final IEntry<AtomicValue, Sequence> facet: (AbstractMapType) entry.value().itemAt(0)) {
+                final AbstractMapType subMap = (AbstractMapType) entry.value().itemAt(0);
+
+                // map to hold the facet values for each dimension
+                final Map<String, FacetQuery> tf = new HashMap<>(subMap.size());
+
+                for (final IEntry<AtomicValue, Sequence> facet : subMap) {
                     final Sequence value = facet.value();
                     final FacetQuery values;
                     if (value.hasOne() && value.getItemType() == Type.ARRAY) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryOptions.java
@@ -98,7 +98,7 @@ public class QueryOptions {
         }
     }
 
-    public QueryOptions(AbstractMapType map) throws XPathException {
+    public QueryOptions(final AbstractMapType map) throws XPathException {
         for (final IEntry<AtomicValue, Sequence> entry: map) {
             final String key = entry.key().getStringValue();
             if (key.equals(OPTION_FACETS) && entry.value().hasOne() && entry.value().getItemType() == Type.MAP) {
@@ -107,7 +107,7 @@ public class QueryOptions {
                 // iterate over each dimension and collect its values into a FacetQuery
                 for (final IEntry<AtomicValue, Sequence> facet: (AbstractMapType) entry.value().itemAt(0)) {
                     final Sequence value = facet.value();
-                    FacetQuery values;
+                    final FacetQuery values;
                     if (value.hasOne() && value.getItemType() == Type.ARRAY) {
                         values = new FacetQuery((ArrayType) facet.value().itemAt(0));
                     } else {

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -32,7 +32,9 @@ declare variable $facet:XML :=
             <to>Egon</to>
             <place>Berlin</place>
             <date>2019-03-14</date>
+            <received>2019-03-14</received>
             <time>14:22:19.329+01:00</time>
+            <dateTime>1972-06-08T10:00:00-05:00</dateTime>
             <likes>9</likes>
             <score>6.0</score>
             <subject>art</subject>
@@ -43,7 +45,9 @@ declare variable $facet:XML :=
             <to>Egon</to>
             <place>Berlin</place>
             <date>2017-03-13</date>
+            <received>2017-03-20</received>
             <time>15:22:19.329+01:00</time>
+            <dateTime>1970-07-03T00:00:00-05:00</dateTime>
             <likes>19</likes>
             <score>8.25</score>
             <subject>history</subject>
@@ -53,6 +57,7 @@ declare variable $facet:XML :=
             <to>Hans</to>
             <place>Hamburg</place>
             <date>2019-04-01</date>
+            <received>2019-04-03</received>
             <likes>29</likes>
             <score>16.5</score>
             <subject>engineering</subject>
@@ -63,6 +68,7 @@ declare variable $facet:XML :=
             <to>Babsi Müller</to>
             <place></place>
             <date>2017-03-11</date>
+            <received>2017-04-01</received>
             <likes>1</likes>
             <score>14.25</score>
             <subject>history</subject>
@@ -72,6 +78,7 @@ declare variable $facet:XML :=
             <to>Basia Müller</to>
             <place>Wrocław</place>
             <date>2015-06-22</date>
+            <received>2018-06-24</received>
             <likes>5</likes>
             <score>29.50</score>
             <subject>history</subject>
@@ -81,6 +88,7 @@ declare variable $facet:XML :=
             <to>Basia Kowalska</to>
             <place>Wrocław</place>
             <date>2013-06-22</date>
+            <received>2013-08-01</received>
             <likes>3</likes>
             <subject>history</subject>
             <score>16.0</score>
@@ -221,10 +229,16 @@ declare variable $facet:XCONF1 :=
                     <field name="place" expression="place" analyzer="nodiacritics"/>
                     <field name="from" expression="from" store="no"/>
                     <field name="to" expression="to"/>
+                    <field name="to-binary" expression="to" binary="true"/>
                     <field name="date" expression="date" type="xs:date"/>
+                    <field name="received" expression="received" type="xs:date" binary="true"/>
                     <field name="likes" expression="likes" type="xs:int"/>
+                    <field name="likes-binary" expression="likes" type="xs:int" binary="true"/>
                     <field name="score" expression="score" type="xs:double"/>
+                    <field name="score-binary" expression="score" type="xs:double" binary="true"/>
                     <field name="time" expression="time" type="xs:time"/>
+                    <field name="time-binary" expression="time" type="xs:time" binary="true"/>
+                    <field name="dateTime-binary" expression="dateTime" type="xs:dateTime" binary="true"/>
                 </text>
                 <text qname="document">
                     <field name="title" expression="title"/>
@@ -573,7 +587,7 @@ function facet:query-field($query as xs:string) {
 declare
     %test:assertEquals("Babsi Müller", "Basia Kowalska", "Basia Müller")
 function facet:query-and-sort() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz", map { "fields": "to" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz")]
     order by ft:field($letter, "to")
     return
         $letter/to/text()
@@ -582,7 +596,7 @@ function facet:query-and-sort() {
 declare
     %test:assertEquals("Basia Kowalska", "Basia Müller", "Babsi Müller")
 function facet:query-and-sort-by-date() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz", map { "fields": "date" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz")]
     order by ft:field($letter, "date", "xs:date")
     return
         $letter/to/text()
@@ -591,7 +605,7 @@ function facet:query-and-sort-by-date() {
 declare
     %test:assertEquals("Hans", "Rudi")
 function facet:query-and-sort-by-time() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., "place:berlin", map { "fields": "time" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "place:berlin")]
     order by ft:field($letter, "time", "xs:time")
     return
         $letter/from/text()
@@ -603,7 +617,7 @@ declare
     %test:args("score", "xs:float")
     %test:assertEquals(6, 8.25, 14.25, 16, 16.5, 29.5)
 function facet:query-and-sort-by-numeric($field as xs:string, $type as xs:string) {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., (), map { "fields": $field })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
     let $likes := ft:field($letter, $field, $type)
     order by $likes
     return
@@ -613,7 +627,7 @@ function facet:query-and-sort-by-numeric($field as xs:string, $type as xs:string
 declare
     %test:assertEmpty
 function facet:retrieve-non-existant-field() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., (), map { "fields": "foo" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
     return
         ft:field($letter, "foo")
 };
@@ -621,7 +635,7 @@ function facet:retrieve-non-existant-field() {
 declare
     %test:assertEmpty
 function facet:retrieve-not-stored() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., (), map { "fields": "from" })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
     return
         ft:field($letter, "from")
 };
@@ -629,7 +643,7 @@ function facet:retrieve-not-stored() {
 declare
     %test:assertEquals("Egon", "Berlin")
 function facet:retrieve-multiple-fields() {
-    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:rudi", map { "fields": ("to", "place") })]
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:rudi")]
     return
         (ft:field($letter, "to"), ft:field($letter, "place"))
 };
@@ -637,7 +651,7 @@ function facet:retrieve-multiple-fields() {
 declare
     %test:assertEquals("2017-03-13", 19, 8.25)
 function facet:test-field-type() {
-    let $letter := collection("/db/lucenetest")//letter[ft:query(., "from:rudi", map { "fields": ("date", "likes", "score") })]
+    let $letter := collection("/db/lucenetest")//letter[ft:query(., "from:rudi")]
     return (
         ft:field($letter, "date", "xs:date"),
         ft:field($letter, "likes", "xs:integer"),
@@ -801,7 +815,67 @@ declare
     %test:args('title:"Streiten und Hoffen"', "title")
     %test:assertEquals("<exist:field xmlns:exist='http://exist.sourceforge.net/NS/exist'><exist:match>Streiten und Hoffen</exist:match></exist:field>")
 function facet:query-field-expand-matches($query as xs:string, $field as xs:string) {
-    let $result := doc("/db/lucenetest/documents.xml")//document[ft:query(., $query, map { "fields": $field })]
+    let $result := doc("/db/lucenetest/documents.xml")//document[ft:query(., $query)]
     return
         ft:highlight-field-matches($result, $field)[.//exist:match]
+};
+
+declare
+    %test:assertEquals("Basia Kowalska", "Babsi Müller", "Basia Müller")
+function facet:query-and-sort-by-binary-date() {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz")]
+    order by ft:binary-field($letter, "received", "xs:date")
+    return
+        $letter/to/text()
+};
+
+declare
+    %test:assertEquals("2017", "20")
+function facet:retrieve-binary-date-field() {
+    let $letter := collection("/db/lucenetest")//letter[ft:query(., "from:rudi")]
+    let $date := ft:binary-field($letter, "received", "xs:date")
+    return (
+        year-from-date($date),
+        day-from-date($date)
+    )
+};
+
+declare
+    %test:assertEquals("Babsi Müller", "Basia Kowalska", "Basia Müller")
+function facet:query-and-sort-by-binary-string() {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "from:heinz")]
+    order by ft:binary-field($letter, "to-binary", "xs:string") empty least
+    return
+        $letter/to/text()
+};
+
+declare
+    %test:args("likes-binary", "xs:int")
+    %test:assertEquals(1, 3, 5, 9, 19, 29)
+    %test:args("score-binary", "xs:double")
+    %test:assertEquals(6, 8.25, 14.25, 16, 16.5, 29.5)
+function facet:query-and-sort-by-binary-numeric($field as xs:string, $type as xs:string) {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
+    let $likes := ft:binary-field($letter, $field, $type)
+    order by $likes
+    return
+        $likes
+};
+
+declare
+    %test:assertEquals("Hans", "Rudi")
+function facet:query-and-sort-by-binary-time() {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "to:Egon")]
+    order by ft:binary-field($letter, "time-binary", "xs:time")
+    return
+        $letter/from/text()
+};
+
+declare
+    %test:assertEquals("Rudi", "Hans")
+function facet:query-and-sort-by-binary-dateTime() {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., "place:berlin")]
+    order by ft:binary-field($letter, "dateTime-binary", "xs:dateTime")
+    return
+        $letter/from/text()
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -864,7 +864,7 @@ function facet:query-and-sort-by-binary-numeric($field as xs:string, $type as xs
 
 declare
     %test:args("time-binary", "xs:time")
-    %test:assertEquals("13:22:19.329+01:00", "14:22:19.329+01:00")
+    %test:assertEquals("14:22:19.329+01:00", "15:22:19.329+01:00")
     %test:args("date-binary", "xs:date")
     %test:assertEquals("2013-06-22", "2015-06-22", "2017-03-11", "2017-03-13", "2019-03-14", "2019-04-01")
 function facet:query-and-sort-by-binary-dates-and-times($field as xs:string, $type as xs:string) {
@@ -876,7 +876,7 @@ function facet:query-and-sort-by-binary-dates-and-times($field as xs:string, $ty
 
 declare
     %test:args("dateTime-binary", "xs:dateTime")
-    %test:assertEquals("1970-07-03T05:00:00", "1972-06-08T15:00:00")
+    %test:assertEquals("1970-07-03T00:00:00-05:00", "1972-06-08T10:00:00-05:00")
 function facet:query-and-sort-by-binary-dateTime($field as xs:string, $type as xs:string) {
     for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
     let $field-value := ft:binary-field($letter, $field, $type)

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -876,7 +876,7 @@ function facet:query-and-sort-by-binary-dates-and-times($field as xs:string, $ty
 
 declare
     %test:args("dateTime-binary", "xs:dateTime")
-    %test:assertEquals("1970-07-03T00:00:00-05:00", "1972-06-08T10:00:00-05:00")
+    %test:assertEquals("1970-07-03T05:00:00", "1972-06-08T15:00:00")
 function facet:query-and-sort-by-binary-dateTime($field as xs:string, $type as xs:string) {
     for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
     let $field-value := ft:binary-field($letter, $field, $type)

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -238,6 +238,7 @@ declare variable $facet:XCONF1 :=
                     <field name="score-binary" expression="score" type="xs:double" binary="true"/>
                     <field name="time" expression="time" type="xs:time"/>
                     <field name="time-binary" expression="time" type="xs:time" binary="true"/>
+                    <field name="date-binary" expression="date" type="xs:date" binary="true"/>
                     <field name="dateTime-binary" expression="dateTime" type="xs:dateTime" binary="true"/>
                 </text>
                 <text qname="document">
@@ -856,10 +857,31 @@ declare
     %test:assertEquals(6, 8.25, 14.25, 16, 16.5, 29.5)
 function facet:query-and-sort-by-binary-numeric($field as xs:string, $type as xs:string) {
     for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
-    let $likes := ft:binary-field($letter, $field, $type)
-    order by $likes
-    return
-        $likes
+    let $field-value := ft:binary-field($letter, $field, $type)
+    order by $field-value
+    return $field-value
+};
+
+declare
+    %test:args("time-binary", "xs:time")
+    %test:assertEquals("13:22:19.329+01:00", "14:22:19.329+01:00")
+    %test:args("date-binary", "xs:date")
+    %test:assertEquals("2013-06-22", "2015-06-22", "2017-03-11", "2017-03-13", "2019-03-14", "2019-04-01")
+function facet:query-and-sort-by-binary-dates-and-times($field as xs:string, $type as xs:string) {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
+    let $field-value := ft:binary-field($letter, $field, $type)
+    order by $field-value
+    return $field-value
+};
+
+declare
+    %test:args("dateTime-binary", "xs:dateTime")
+    %test:assertEquals("1970-07-03T00:00:00-05:00", "1972-06-08T10:00:00-05:00")
+function facet:query-and-sort-by-binary-dateTime($field as xs:string, $type as xs:string) {
+    for $letter in collection("/db/lucenetest")//letter[ft:query(., ())]
+    let $field-value := ft:binary-field($letter, $field, $type)
+    order by $field-value
+    return $field-value
 };
 
 declare


### PR DESCRIPTION
revised version of #4253

This PR will address 3 problems when using Lucene fields for sorting or iterating large node sets (> 100.000 elements):

1. eXist-db quickly runs out of memory: this happens as `ft:query` retrieves the fields for the entire result set at once and keeps them attached to each item in the set, no matter if the fields content is in fact accessed or not
2. Because fields are retrieved at query time, users have to know in advance which fields will be required later and list them in the `ft:query` options
3. Fixing 1 and 2 will further slow down field-based sort operations on large node sets. In general, those operations were already slow, but performance will degrade even more if we do not preload the fields.

The PR effectively fixes 1 by not preloading any fields. Instead, the loading will be deferred until `ft:field` is called. As a consequence, users no longer need to specify the fields to retrieve at query time, so 2 is solved as well (this doesn't change the API: you can still define fields in ft:query options, though the setting is unnecessary and will be ignored).

To address 3, an additional configuration attribute is introduced to field definitions in `collection.xconf`: adding `binary="yes"` will result in the field to be stored as a `BinaryDocValue`, which guarantees the fastest possible access in Lucene. This follows the example of other Lucene-based implementations (e.g. elastic search), which provide a similar option. Binary fields can only be retrieved, but not queried like other fields.

~~For strings and simple numeric types,~~ performance should be outstanding. ~~A bottleneck remains for complex data types though, in particular xs:date and xs:dateTime. Here the overhead to cast the stored binary field into a proper XQuery xs:date is always considerable, though not to be avoided. We're still trying to find a way to address this.~~

Connected documentation PR: https://github.com/eXist-db/documentation/pull/760

This PR adds some missing atomic types to typed lucene fields (`xs:decimal`, `xs:float`, `xs:short` and more).
Additional xqsuite tests would be reasonable to add to test for these new types (see also #4537).
