### PR TITLE
[hotfix] change URL for two unparsed-text tests

### DIFF
--- a/exist-core/src/test/xquery/unparsed-text.xql
+++ b/exist-core/src/test/xquery/unparsed-text.xql
@@ -150,7 +150,20 @@ function upt:invalid-uri2() {
 
 declare
     %test:assertError("FOUT1170")
-function upt:non-existant() {
+function upt:non-existent() {
+    unparsed-text-lines("https://www.w3.org/fots/unparsed-text/does-not-exist.txt")
+};
+
+(:~
+ : this test will fail as the server responds with a
+ : permanent redirect that is neither followed nor
+ : treated as an error
+ : @see https://github.com/eXist-db/exist/issues/4542
+ :)
+declare
+    %test:pending
+    %test:assertError("FOUT1170")
+function upt:non-existent-redirect() {
     unparsed-text-lines("http://www.w3.org/fots/unparsed-text/does-not-exist.txt")
 };
 
@@ -229,9 +242,22 @@ function upt:unparsed-text-available-invalid-uri2() {
     unparsed-text-available(":/")
 };
 
-declare 
+declare
     %test:assertFalse
-function upt:unparsed-text-available-non-existant() {
+function upt:unparsed-text-available-non-existent() {
+    unparsed-text-available("https://www.w3.org/fots/unparsed-text/does-not-exist.txt")
+};
+
+(:~
+ : this test will fail as the server responds with a
+ : permanent redirect that is neither followed nor
+ : treated as an error
+ : @see https://github.com/eXist-db/exist/issues/4542
+ :)
+declare
+    %test:pending
+    %test:assertFalse
+function upt:unparsed-text-available-non-existent-redirect() {
     unparsed-text-available("http://www.w3.org/fots/unparsed-text/does-not-exist.txt")
 };
 

--- a/exist-core/src/test/xquery/unparsed-text.xql
+++ b/exist-core/src/test/xquery/unparsed-text.xql
@@ -149,6 +149,7 @@ function upt:invalid-uri2() {
 };
 
 declare
+    %test:assumeInternetAccess("https://www.w3.org")
     %test:assertError("FOUT1170")
 function upt:non-existent() {
     unparsed-text-lines("https://www.w3.org/fots/unparsed-text/does-not-exist.txt")
@@ -162,6 +163,7 @@ function upt:non-existent() {
  :)
 declare
     %test:pending
+    %test:assumeInternetAccess("https://www.w3.org")
     %test:assertError("FOUT1170")
 function upt:non-existent-redirect() {
     unparsed-text-lines("http://www.w3.org/fots/unparsed-text/does-not-exist.txt")
@@ -243,6 +245,7 @@ function upt:unparsed-text-available-invalid-uri2() {
 };
 
 declare
+    %test:assumeInternetAccess("https://www.w3.org")
     %test:assertFalse
 function upt:unparsed-text-available-non-existent() {
     unparsed-text-available("https://www.w3.org/fots/unparsed-text/does-not-exist.txt")
@@ -256,6 +259,7 @@ function upt:unparsed-text-available-non-existent() {
  :)
 declare
     %test:pending
+    %test:assumeInternetAccess("https://www.w3.org")
     %test:assertFalse
 function upt:unparsed-text-available-non-existent-redirect() {
     unparsed-text-available("http://www.w3.org/fots/unparsed-text/does-not-exist.txt")


### PR DESCRIPTION
refs #4542

This is just a quick patch!

Two pending tests were added `upt:non-existent-redirect` and `upt:unparsed-text-available-non-existent-redirect` which will pass when the redirect is followed _or_ an HTTP status code in the 3XX range is treated as an error. 