### PR TITLE
[bugfix] - namespace binding conflict errors

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/NodeImpl.java
@@ -48,7 +48,7 @@ import java.util.Iterator;
 import java.util.Properties;
 
 
-public abstract class NodeImpl<T extends NodeImpl> implements INode<DocumentImpl, T>, NodeValue {
+public abstract class NodeImpl<T extends NodeImpl<T>> implements INode<DocumentImpl, T>, NodeValue {
 
     public static final short REFERENCE_NODE = 100;
     public static final short NAMESPACE_NODE = 101;

--- a/exist-core/src/main/java/org/exist/dom/persistent/AttrImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/AttrImpl.java
@@ -40,7 +40,7 @@ import javax.xml.XMLConstants;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-public class AttrImpl extends NamedNode implements Attr {
+public class AttrImpl extends NamedNode<AttrImpl> implements Attr {
 
     public static final int LENGTH_NS_ID = 2; //sizeof short
     public static final int LENGTH_PREFIX_LENGTH = 2; //sizeof short

--- a/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
@@ -835,7 +835,7 @@ public class ElementImpl extends NamedNode<ElementImpl> implements Element {
                 for(int i = 0; i < childCount; i++) {
                     final IStoredNode next = iterator.next();
                     if (next == null) {
-                        LOG.warn("Miscounted getChildCount() index " + i + " was null of " + childCount);
+                        LOG.warn("Miscounted getChildCount() index: {} was null of: {}", i, childCount);
                         continue;
                     }
                     if(next.getNodeType() != Node.ATTRIBUTE_NODE) {
@@ -1350,7 +1350,7 @@ public class ElementImpl extends NamedNode<ElementImpl> implements Element {
     public Iterator<String> getPrefixes() {
 
         if (namespaceMappings == null) {
-            return Collections.EMPTY_SET.iterator();
+            return Collections.<String>emptySet().iterator();
         }
         return namespaceMappings.keySet().iterator();
     }

--- a/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/ElementImpl.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.exist.EXistException;
 import org.exist.Namespaces;
 import org.exist.dom.NamedNodeMapImpl;
+import org.exist.dom.NodeListImpl;
 import org.exist.dom.QName;
 import org.exist.dom.QName.IllegalQNameException;
 import org.exist.indexing.IndexController;
@@ -67,7 +68,7 @@ import static org.exist.dom.QName.Validity.ILLEGAL_FORMAT;
  *
  * @author Wolfgang Meier
  */
-public class ElementImpl extends NamedNode implements Element {
+public class ElementImpl extends NamedNode<ElementImpl> implements Element {
 
     public static final int LENGTH_ELEMENT_CHILD_COUNT = 4; //sizeof int
     public static final int LENGTH_ATTRIBUTES_COUNT = 2; //sizeof short
@@ -527,7 +528,7 @@ public class ElementImpl extends NamedNode implements Element {
         }
     }
 
-    private void appendAttributes(final Txn transaction, final NodeList attribs) throws DOMException {
+    private void appendAttributes(final Txn transaction, final NodeListImpl attribs) throws DOMException {
         final NodeList duplicateAttrs = findDupAttributes(attribs);
         removeAppendAttributes(transaction, duplicateAttrs, attribs);
     }
@@ -633,6 +634,16 @@ public class ElementImpl extends NamedNode implements Element {
         }
     }
 
+    private QName attrName(Attr attr) {
+        final String ns = attr.getNamespaceURI();
+        final String prefix = (Namespaces.XML_NS.equals(ns) ? XMLConstants.XML_NS_PREFIX : attr.getPrefix());
+        String name = attr.getLocalName();
+        if(name == null) {
+            name = attr.getName();
+        }
+        return new QName(name, ns, prefix);
+    }
+
     private Node appendChild(final Txn transaction, final NodeId newNodeId, final NodeImplRef last, final NodePath lastPath, final Node child, final StreamListener listener)
         throws DOMException {
         if(last == null || last.getNode() == null) {
@@ -725,17 +736,11 @@ public class ElementImpl extends NamedNode implements Element {
 
                 case Node.ATTRIBUTE_NODE:
                     final Attr attr = (Attr) child;
-                    final String ns = attr.getNamespaceURI();
-                    final String prefix = (Namespaces.XML_NS.equals(ns) ? XMLConstants.XML_NS_PREFIX : attr.getPrefix());
-                    String name = attr.getLocalName();
-                    if(name == null) {
-                        name = attr.getName();
-                    }
-                    final QName attrName = new QName(name, ns, prefix);
+                    final QName attrName = attrName(attr);
                     final AttrImpl attrib = new AttrImpl(getExpression(), attrName, attr.getValue(), broker.getBrokerPool().getSymbols());
                     attrib.setNodeId(newNodeId);
                     attrib.setOwnerDocument(owner);
-                    if(ns != null && attrName.compareTo(Namespaces.XML_ID_QNAME) == Constants.EQUAL) {
+                    if(attrName.getNamespaceURI() != null && attrName.compareTo(Namespaces.XML_ID_QNAME) == Constants.EQUAL) {
                         // an xml:id attribute. Normalize the attribute and set its type to ID
                         attrib.setValue(StringValue.trimWhitespace(StringValue.collapseWhitespace(attrib.getValue())));
                         attrib.setType(AttrImpl.ID);
@@ -829,6 +834,10 @@ public class ElementImpl extends NamedNode implements Element {
                 final int childCount = getChildCount();
                 for(int i = 0; i < childCount; i++) {
                     final IStoredNode next = iterator.next();
+                    if (next == null) {
+                        LOG.warn("Miscounted getChildCount() index " + i + " was null of " + childCount);
+                        continue;
+                    }
                     if(next.getNodeType() != Node.ATTRIBUTE_NODE) {
                         break;
                     }
@@ -1339,10 +1348,17 @@ public class ElementImpl extends NamedNode implements Element {
     }
 
     public Iterator<String> getPrefixes() {
+
+        if (namespaceMappings == null) {
+            return Collections.EMPTY_SET.iterator();
+        }
         return namespaceMappings.keySet().iterator();
     }
 
     public String getNamespaceForPrefix(final String prefix) {
+        if (namespaceMappings == null) {
+            return null;
+        }
         return namespaceMappings.get(prefix);
     }
 
@@ -2038,5 +2054,20 @@ public class ElementImpl extends NamedNode implements Element {
             }
         }
         return true;
+    }
+
+    @Override
+    public String lookupNamespaceURI(final String prefix) {
+
+        for (Node pathNode = this; pathNode != null; pathNode = pathNode.getParentNode()) {
+            if (pathNode instanceof ElementImpl) {
+                final String namespaceForPrefix = ((ElementImpl)pathNode).getNamespaceForPrefix(prefix);
+                if (namespaceForPrefix != null) {
+                    return namespaceForPrefix;
+                }
+            }
+        }
+
+        return XMLConstants.NULL_NS_URI;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -134,6 +134,8 @@ public class ErrorCodes {
     public static final ErrorCode XQDY0137 = new W3CErrorCode("XQDY0137", "No two keys in a map may have the same key value");
     public static final ErrorCode XQDY0138 = new W3CErrorCode("XQDY0138", "Position n does not exist in this array");
 
+    public static final ErrorCode XUDY0023 = new W3CErrorCode("XUDY0023", "It is a dynamic error if an insert, replace, or rename expression affects an element node by introducing a new namespace binding that conflicts with one of its existing namespace bindings.");
+
     /* XQuery 1.0 and XPath 2.0 Functions and Operators http://www.w3.org/TR/xpath-functions/#error-summary */
     public static final ErrorCode FOER0000 = new W3CErrorCode("FOER0000", "Unidentified error.");
     public static final ErrorCode FOAR0001 = new W3CErrorCode("FOAR0001", "Division by zero.");

--- a/exist-core/src/main/java/org/exist/xquery/update/Insert.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/Insert.java
@@ -130,10 +130,10 @@ public class Insert extends Modification {
 
             //start a transaction
             try (final Txn transaction = getTransaction()) {
-                final StoredNode[] ql = selectAndLock(transaction, inSeq);
+                final StoredNode<?>[] ql = selectAndLock(transaction, inSeq);
                 final NotificationService notifier = context.getBroker().getBrokerPool().getNotificationService();
                 final NodeList contentList = seq2nodeList(contentSeq);
-                for (final StoredNode node : ql) {
+                for (final StoredNode<?> node : ql) {
                     final DocumentImpl doc = node.getOwnerDocument();
                     if (!doc.getPermissions().validate(context.getSubject(), Permission.WRITE)) {
                         throw new PermissionDeniedException("User '" + context.getSubject().getName() + "' does not have permission to write to the document '" + doc.getDocumentURI() + "'!");
@@ -144,7 +144,7 @@ public class Insert extends Modification {
                         validateNonDefaultNamespaces(contentList, node);
                         node.appendChildren(transaction, contentList, -1);
                     } else {
-                        final NodeImpl parent = (NodeImpl) getParent(node);
+                        final NodeImpl<?> parent = (NodeImpl<?>) getParent(node);
                         validateNonDefaultNamespaces(contentList, parent);
                         switch (mode) {
                             case INSERT_BEFORE:
@@ -225,7 +225,7 @@ public class Insert extends Modification {
      * @param parent the position into which the nodes are being inserted
      * @throws XPathException if a node has a namespace conflict
      */
-    private void validateNonDefaultNamespaces(final NodeList nodeList, final NodeImpl parent) throws XPathException {
+    private <T extends NodeImpl<T>> void validateNonDefaultNamespaces(final NodeList nodeList, final NodeImpl<T> parent) throws XPathException {
         if (parent instanceof ElementImpl) {
             final ElementImpl parentAsElement = (ElementImpl) parent;
             for (int i = 0; i < nodeList.getLength(); i++) {

--- a/exist-core/src/test/xquery/xquery3/bindingConflict.xqm
+++ b/exist-core/src/test/xquery/xquery3/bindingConflict.xqm
@@ -1,0 +1,88 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace ut="http://exist-db.org/xquery/update/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace xmldb="http://exist-db.org/xquery/xmldb";
+
+declare namespace myns="http://www.foo.com";
+declare namespace myns2="http://www.foo.net";
+
+(: insert node into a ns with a conflicting ns in parent tree :)
+declare %test:assertError("XUDY0023")
+function ut:insert-child-namespaced-attr-conflicted() {
+    let $f  := xmldb:store('/db', 'xupdate.xml', <root xmlns:myns="http://www.bar.com" attr="1"><!-- foobar --><z blah="wah"/></root>)
+    let $u  := update insert <child myns:baz="qux"/> into doc($f)/root/z
+    return doc($f)
+};
+
+(: insert attr into a ns, but nothing contradictory in the tree - should add ns node :)
+declare %test:assertEquals("<z blah=""wah""><child xmlns:myns=""http://www.foo.com"" myns:baz=""qux""/></z>")
+function ut:insert-child-namespaced-attr() {
+    let $f  := xmldb:store('/db', 'xupdate.xml', <root attr="1"><!-- foobar --><z blah="wah"/></root>)
+    let $u  := update insert <child myns:baz="qux"/> into doc($f)/root/z
+    return doc($f)/root/z
+};
+
+(: insert attr into a ns, but nothing contradictory in the tree - should add ns node :)
+declare %test:assertEquals("<z blah=""wah""><myns:child xmlns:myns=""http://www.foo.com"" baz=""qux""/></z>")
+function ut:insert-namespaced-child() {
+    let $f  := xmldb:store('/db', 'xupdate.xml', <root attr="1"><!-- foobar --><z blah="wah"/></root>)
+    let $u  := update insert <myns:child baz="qux"/> into doc($f)/root/z
+    return doc($f)/root/z
+};
+
+(: We "manually" redefined xmlns:myns in <grand> -- what does the code see in <great myns:boz="chux"..>, and should we reject it ? :)
+(: Do we need to code up the added namespaces, and check conflicts, thus this would XUDY0023 :)
+(: or are we content to ignore manual redefinitions :)
+declare %test:assertEquals("<z blah=""wah""><myns:child xmlns:myns=""http://www.foo.com"" baz=""qux""><grand xmlns:myns=""http://www.fubar.com""><great xmlns:myns2=""http://www.foo.net"" myns:boz=""chux"" myns2:pip=""dickens""/></grand></myns:child></z>")
+function ut:insert-namespaced-child-deep() {
+    let $f  := xmldb:store('/db', 'xupdate.xml', <root attr="1"><!-- foobar --><z blah="wah"/></root>)
+    let $u  := update insert <myns:child baz="qux"><grand xmlns:myns="http://www.fubar.com"><great myns:boz="chux" myns2:pip="dickens"/></grand></myns:child> into doc($f)/root/z
+    return fn:serialize(doc($f)/root/z)
+};
+
+(: insert attr into a ns, but nothing contradictory in the tree - should add ns node :)
+declare %test:assertError("XUDY0023")
+function ut:insert-namespaced-child-conflicted() {
+    let $f  := xmldb:store('/db', 'xupdate.xml', <root xmlns:myns="http://www.bar.com" attr="1"><!-- foobar --><z blah="wah"/></root>)
+    let $u  := update insert <myns:child baz="qux"/> into doc($f)/root/z
+    return doc($f)/root/z
+};
+
+(: insert attr into a ns with a conflicting ns in parent tree :)
+declare %test:assertError("XUDY0023")
+function ut:insert-namespaced-attr-conflicted() {
+    let $f  := xmldb:store('/db', 'xupdate.xml', <root xmlns:myns="http://www.bar.com" attr="1"><!-- foobar --><z blah="wah"/></root>)
+    let $u  := update insert attribute myns:baz { "qux" } into doc($f)/root/z
+    return doc($f)
+};
+
+(: insert attr into a ns, but nothing contradictory in the tree - should add ns node :)
+declare %test:assertEquals("<z xmlns:myns=""http://www.foo.com"" blah=""wah"" myns:baz=""qux""/>")
+function ut:insert-namespaced-attr() {
+    let $f  := xmldb:store('/db', 'xupdate.xml', <root attr="1"><!-- foobar --><z blah="wah"/></root>)
+    let $u  := update insert attribute myns:baz { "qux" } into doc($f)/root/z
+    return doc($f)/root/z
+};


### PR DESCRIPTION
### Description:

Report an error (`XUDY0023`) when an insertion is attempted with a node or attribute name in a namespace that conflicts with one which exists in the document.

### References:

Closes https://github.com/eXist-db/exist/issues/1482

See https://www.w3.org/TR/xquery-update-30/#dt-conflict

Recursively check node/attributes inserted into a document for namespace conflicts. This change does not look at namespaces introduced in the subtrees being inserted, it appears these correctly respect the namespace in the subtree rather than the declared namespace in the XQuery context in which the insertion happens.

### Type of tests:

Added unit tests in `binidingConflict.xqm` for correct reporting of binding conflict errors
