### PR TITLE
Fix issues with document-node lookups on various axis

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -467,7 +467,8 @@ public class LocationStep extends Step {
                 if (nodeTestType == null) {
                     nodeTestType = test.getType();
                 }
-                if (nodeTestType != Type.NODE
+                if (nodeTestType != Type.DOCUMENT
+                        && nodeTestType != Type.NODE
                         && nodeTestType != Type.ELEMENT
                         && nodeTestType != Type.PROCESSING_INSTRUCTION) {
                     if (context.getProfiler().isEnabled()) {
@@ -1054,10 +1055,9 @@ public class LocationStep extends Step {
 
                 NodeId parentID = current.getNodeId().getParentId();
                 while (parentID != null) {
-                    ancestor = new NodeProxy(this, current.getOwnerDocument(), parentID, Node.ELEMENT_NODE);
+                    ancestor = new NodeProxy(this, current.getOwnerDocument(), parentID, parentID == NodeId.DOCUMENT_NODE ? Node.DOCUMENT_NODE : Node.ELEMENT_NODE);
                     // Filter out the temporary nodes wrapper element
-                    if (parentID != NodeId.DOCUMENT_NODE
-                            && !(parentID.getTreeLevel() == 1 && current.getOwnerDocument().getCollection().isTempCollection())) {
+                    if (!(parentID.getTreeLevel() == 1 && current.getOwnerDocument().getCollection().isTempCollection())) {
                         if (test.matches(ancestor)) {
                             final NodeProxy t = result.get(ancestor);
                             if (t == null) {

--- a/exist-core/src/test/xquery/document-nodes.xq
+++ b/exist-core/src/test/xquery/document-nodes.xq
@@ -115,3 +115,75 @@ declare
 function dn:memtree-document-node-element-wrong-name() {
     document { element template {} } instance of document-node(element(wrong))
 };
+
+declare
+    %test:assertEmpty
+function dn:persistent-document-node-from-collection() {
+    collection($dn:TEST_COLLECTION)[1]/document-node()
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-doc() {
+    collection($dn:TEST_COLLECTION)[1]/doc(document-uri(.))
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-self-axis() {
+    collection($dn:TEST_COLLECTION)[1]/self::document-node()
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-ancestor-of-self-axis() {
+    collection($dn:TEST_COLLECTION)[1]/ancestor-or-self::document-node()
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-parent-axis-node() {
+    (collection($dn:TEST_COLLECTION)/template)[1]/parent::node()
+};
+
+declare
+    %test:assertEmpty
+function dn:persistent-document-node-from-collection-via-parent-axis-wildcard() {
+    (collection($dn:TEST_COLLECTION)/template)[1]/parent::*
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-parent-axis-document-node() {
+    (collection($dn:TEST_COLLECTION)/template)[1]/parent::document-node()
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-parent-axis-document-element() {
+    (collection($dn:TEST_COLLECTION)/template)[1]/parent::document-node(element(template))
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-ancestor-axis-document-node() {
+    (collection($dn:TEST_COLLECTION)/template)[1]/ancestor::document-node()
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-ancestor-axis-document-element() {
+    (collection($dn:TEST_COLLECTION)/template)[1]/ancestor::document-node(element(template))
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-ancestor-or-self-axis-document-node() {
+    (collection($dn:TEST_COLLECTION)/template)[1]/ancestor-or-self::document-node()
+};
+
+declare
+    %test:assertExists
+function dn:persistent-document-node-from-collection-via-ancestor-or-self-axis-document-element() {
+    (collection($dn:TEST_COLLECTION)/template)[1]/ancestor-or-self::document-node(element(template))
+};


### PR DESCRIPTION
Appears to have been caused by over zealous optimisations.
The fixes should not impact general performance at all.

Closes https://github.com/eXist-db/exist/issues/4546