### PR TITLE
[4.x.x] Change URL for two unparsed-text tests

### DIFF
--- a/exist-core/src/test/xquery/unparsed-text.xql
+++ b/exist-core/src/test/xquery/unparsed-text.xql
@@ -129,7 +129,20 @@ function upt:invalid-uri2() {
 
 declare
     %test:assertError("FOUT1170")
-function upt:non-existant() {
+function upt:non-existent() {
+    unparsed-text-lines("https://www.w3.org/fots/unparsed-text/does-not-exist.txt")
+};
+
+(:~
+ : this test will fail as the server responds with a
+ : permanent redirect that is neither followed nor
+ : treated as an error
+ : @see https://github.com/eXist-db/exist/issues/4542
+ :)
+declare
+    %test:pending
+    %test:assertError("FOUT1170")
+function upt:non-existent-redirect() {
     unparsed-text-lines("http://www.w3.org/fots/unparsed-text/does-not-exist.txt")
 };
 
@@ -208,14 +221,21 @@ function upt:unparsed-text-available-invalid-uri2() {
     unparsed-text-available(":/")
 };
 
-declare 
+declare
     %test:assertFalse
-function upt:unparsed-text-available-non-existant() {
-    unparsed-text-available("http://www.w3.org/fots/unparsed-text/does-not-exist.txt")
+function upt:unparsed-text-available-non-existent() {
+    unparsed-text-available("https://www.w3.org/fots/unparsed-text/does-not-exist.txt")
 };
 
-declare 
+(:~
+ : this test will fail as the server responds with a
+ : permanent redirect that is neither followed nor
+ : treated as an error
+ : @see https://github.com/eXist-db/exist/issues/4542
+ :)
+declare
+    %test:pending
     %test:assertFalse
-function upt:unparsed-text-available-unsupported-scheme() {
+function upt:unparsed-text-available-non-existent-redirect() {
     fn:unparsed-text-available("surely-nobody-supports-this:/path.txt")
 };

--- a/exist-core/src/test/xquery/unparsed-text.xql
+++ b/exist-core/src/test/xquery/unparsed-text.xql
@@ -128,6 +128,7 @@ function upt:invalid-uri2() {
 };
 
 declare
+    %test:assumeInternetAccess("https://www.w3.org")
     %test:assertError("FOUT1170")
 function upt:non-existent() {
     unparsed-text-lines("https://www.w3.org/fots/unparsed-text/does-not-exist.txt")
@@ -141,6 +142,7 @@ function upt:non-existent() {
  :)
 declare
     %test:pending
+    %test:assumeInternetAccess("https://www.w3.org")
     %test:assertError("FOUT1170")
 function upt:non-existent-redirect() {
     unparsed-text-lines("http://www.w3.org/fots/unparsed-text/does-not-exist.txt")
@@ -222,6 +224,7 @@ function upt:unparsed-text-available-invalid-uri2() {
 };
 
 declare
+    %test:assumeInternetAccess("https://www.w3.org")
     %test:assertFalse
 function upt:unparsed-text-available-non-existent() {
     unparsed-text-available("https://www.w3.org/fots/unparsed-text/does-not-exist.txt")
@@ -235,6 +238,7 @@ function upt:unparsed-text-available-non-existent() {
  :)
 declare
     %test:pending
+    %test:assumeInternetAccess("https://www.w3.org")
     %test:assertFalse
 function upt:unparsed-text-available-non-existent-redirect() {
     fn:unparsed-text-available("surely-nobody-supports-this:/path.txt")


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/4543