### PR TITLE
Migrate to java11

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: '8'
+          java-version: '11'
       - name: Make buildkit default
         uses: docker/setup-buildx-action@v1
         id: buildx

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -8,7 +8,7 @@ jobs:
     name: ${{ matrix.jdk }} Javadocs 
     strategy:
       matrix: 
-        jdk: ['8','11', '16']
+        jdk: ['11', '16']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        jdk: ['8', '11']
+        jdk: ['11']
         include:
           - os: ubuntu-latest
             jdk: '16'

--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -9,18 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: '8'
+          java-version: '11'
           cache: 'maven'
       - name: Maven XQTS Build
         run: mvn -V -B clean package -DskipTests -Ddependency-check.skip=true --projects exist-xqts --also-make
       - name: Run XQTS
         timeout-minutes: 60
         env:
-          JAVA_OPTS: -XX:+UseG1GC -XX:+UseStringDeduplication
+          JAVA_OPTS: -XX:+UseStringDeduplication
         run: find exist-xqts/target -name exist-xqts-runner.sh -exec {} --xqts-version HEAD --output-dir /tmp/xqts-output \;
       - name: Archive XQTS Logs
         if: always()

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -120,15 +120,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerVersion>${project.build.target}</compilerVersion>
-                    <source>${project.build.source}</source>
-                    <target>${project.build.target}</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -293,7 +293,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
             <groupId>org.apache.ws.commons.util</groupId>
             <artifactId>ws-commons-util</artifactId>
@@ -1034,9 +1034,9 @@ The BaseX Team. The original license statement is also included below.]]></pream
                         <configuration>
                             <forceAjcCompile>true</forceAjcCompile>  <!-- Required, otherwise the Aspects are not re-compiled when the src/main/java is recompiled for the test phase -->
                             <showWeaveInfo>true</showWeaveInfo>
-                            <complianceLevel>${project.build.source}</complianceLevel>
-                            <source>${project.build.source}</source>
-                            <target>${project.build.target}</target>
+                            <complianceLevel>${maven.compiler.release}</complianceLevel>
+                            <source>${maven.compiler.release}</source>
+                            <target>${maven.compiler.release}</target>
                             <!-- sources>
                                 <source>
                                     <basedir>${project.build.sourceDirectory}</basedir>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -22,7 +22,8 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -42,8 +43,8 @@
         <connection>scm:git:https://github.com/exist-db/exist.git</connection>
         <developerConnection>scm:git:https://github.com/exist-db/exist.git</developerConnection>
         <url>scm:git:https://github.com/exist-db/exist.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <dependencies>
         <dependency>
@@ -272,6 +273,12 @@
             <artifactId>xercesImpl</artifactId>
             <version>2.12.2</version>
             <classifier>xml-schema-1.1</classifier>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -286,15 +293,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
+        
         <dependency>
             <groupId>org.apache.ws.commons.util</groupId>
             <artifactId>ws-commons-util</artifactId>
             <version>1.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- xml-resolver is needed at runtime because xercesImpl declares this as optional,
@@ -304,12 +313,24 @@
             <artifactId>xml-resolver</artifactId>
             <version>1.2</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.xmlresolver</groupId>
             <artifactId>xmlresolver</artifactId>
             <version>${xmlresolver.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -318,6 +339,12 @@
             <version>${xmlresolver.version}</version>
             <classifier>data</classifier>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- xpath2 and java-cup are needed at runtime because xercesImpl declares this as optional,
@@ -339,6 +366,12 @@
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
             <version>2.7.2</version> <!-- needed an compile time for various dependencies -->
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -20,59 +20,29 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-# Install latest JRE 8 in Debian Stretch (which is the base of gcr.io/distroless/java:8)
-FROM debian:stretch-slim as updated-jre
-RUN apt-get update && apt-get -y dist-upgrade
-RUN apt-get install -y openjdk-8-jre-headless
-RUN apt-get install -y expat fontconfig     # Install tools required by FOP
+ARG DISTRO_TAG=latest
+FROM gcr.io/distroless/java11-debian11:${DISTRO_TAG}
 
-FROM gcr.io/distroless/java:8
-
-# Copy over updated JRE from Debian Stretch
-COPY --from=updated-jre /etc/java-8-openjdk /etc/java-8-openjdk
-COPY --from=updated-jre /usr/lib/jvm/java-8-openjdk-amd64 /usr/lib/jvm/java-8-openjdk-amd64
-COPY --from=updated-jre /usr/share/gdb/auto-load/usr/lib/jvm/java-8-openjdk-amd64 /usr/share/gdb/auto-load/usr/lib/jvm/java-8-openjdk-amd64
-
-# Copy over dependencies for Apache FOP, missing from GCR's JRE
-COPY --from=updated-jre /usr/lib/x86_64-linux-gnu/libfreetype.so.6 /usr/lib/x86_64-linux-gnu/libfreetype.so.6
-COPY --from=updated-jre /usr/lib/x86_64-linux-gnu/liblcms2.so.2 /usr/lib/x86_64-linux-gnu/liblcms2.so.2
-COPY --from=updated-jre /usr/lib/x86_64-linux-gnu/libpng16.so.16 /usr/lib/x86_64-linux-gnu/libpng16.so.16
-COPY --from=updated-jre /usr/lib/x86_64-linux-gnu/libfontconfig.so.1 /usr/lib/x86_64-linux-gnu/libfontconfig.so.1
-
-# Copy dependencies for Apache Batik (used by Apache FOP to handle SVG rendering)
-COPY --from=updated-jre /etc/fonts /etc/fonts
-COPY --from=updated-jre /lib/x86_64-linux-gnu/libexpat.so.1 /lib/x86_64-linux-gnu/libexpat.so.1
-COPY --from=updated-jre /usr/share/fontconfig /usr/share/fontconfig
-COPY --from=updated-jre /usr/share/fonts/truetype/dejavu /usr/share/fonts/truetype/dejavu
+ARG USR=root
 
 # Copy eXist-db
-COPY LICENSE /exist/LICENSE
-COPY autodeploy /exist/autodeploy
-COPY etc /exist/etc
-COPY lib /exist/lib
-COPY logs /exist/logs
+COPY --chown=${USR} dump/exist-distribution-*/LICENSE /exist/LICENSE
+COPY --chown=${USR} dump/exist-distribution-*/autodeploy /exist/autodeploy
+COPY --chown=${USR} dump/exist-distribution-*/etc /exist/etc
+COPY --chown=${USR} dump/exist-distribution-*/lib /exist/lib
+COPY --chown=${USR} log4j2.xml /exist/etc
 
-
-# Build-time metadata as defined at http://label-schema.org
-# and used by autobuilder @hooks/build
-LABEL org.label-schema.build-date=${build-tstamp} \
-      org.label-schema.description="${project.description}" \
-      org.label-schema.name="existdb" \
-      org.label-schema.schema-version="1.0" \
-      org.label-schema.url="${project.url}" \
-      org.label-schema.vcs-ref=${build-commit-abbrev} \
-      org.label-schema.vcs-url="${project.scm.url}" \
-      org.label-schema.vendor="existdb"
 
 EXPOSE 8080 8443
 
-# make CACHE_MEM, MAX_BROKER, and JVM_MAX_RAM_PERCENTAGE available to users
+# make CACHE_MEM and MAX_BROKER available to users
 ARG CACHE_MEM
 ARG MAX_BROKER
 ARG JVM_MAX_RAM_PERCENTAGE
 
 ENV EXIST_HOME "/exist"
-ENV CLASSPATH=/exist/lib/${exist.uber.jar.filename}
+ENV CLASSPATH=/exist/lib/*
+
 
 ENV JAVA_TOOL_OPTIONS \
   -Dfile.encoding=UTF8 \
@@ -85,11 +55,12 @@ ENV JAVA_TOOL_OPTIONS \
   -Dexist.configurationFile=/exist/etc/conf.xml \
   -Djetty.home=/exist \
   -Dexist.jetty.config=/exist/etc/jetty/standard.enabled-jetty-configs \
-  -XX:+UseG1GC \
   -XX:+UseStringDeduplication \
-  -XX:+UseContainerSupport \
   -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} \
+  -XX:MinRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} \
   -XX:+ExitOnOutOfMemoryError
+
+USER ${USR}
 
 HEALTHCHECK CMD [ "java", \
     "org.exist.start.Main", "client", \
@@ -98,5 +69,4 @@ HEALTHCHECK CMD [ "java", \
     "--xpath", "system:get-version()" ]
 
 ENTRYPOINT [ "java", \
-    "org.exist.start.Main"]
-CMD ["jetty" ]
+    "org.exist.start.Main", "jetty" ]

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -92,8 +92,7 @@
     </mailingLists>
 
     <properties>
-        <project.build.source>11</project.build.source>
-        <project.build.target>11</project.build.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <project.copyright.name>The eXist-db Authors</project.copyright.name>
@@ -624,8 +623,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.10.1</version>
                     <configuration>
-                        <source>${project.build.source}</source>
-                        <target>${project.build.target}</target>
+                        <release>${maven.compiler.release}</release>
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
                 </plugin>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -1150,32 +1150,7 @@
     </distributionManagement>
 
     <profiles>
-        <profile>
-            <id>java8-runtime-compatibility</id>
-            <!--
-                By default, this sets the `-release 8` flag to javac
-                on JDK 9+, so that the produced class files
-                are runtime compatible with Java 8.
 
-                See - https://github.com/eclipse/jetty.project/issues/3244
-
-                You can disable at build time, by using the mvn
-                args: `-P !java8-runtime-compatibility`
-            -->
-            <activation>
-                <jdk>[1.9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <release>8</release>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
 
         <profile>
             <!-- NOTE: this is used from the maven-release-plugin -->

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -760,7 +760,7 @@
                               However it can make it hard to diagnose problems if tests leak state; If you experience
                               such a problem you may want to set it to `false` whilst debugging -->
                         <reuseForks>true</reuseForks>
-                        <argLine>@{jacocoArgLine} -XX:+IgnoreUnrecognizedVMOptions --illegal-access=debug --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.ref=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED -XX:StartFlightRecording=maxsize=5g,disk=true,dumponexit=true,settings=default,filename=${project.build.directory}/ -Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                        <argLine>@{jacocoArgLine} -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.ref=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED -XX:StartFlightRecording=maxsize=5g,disk=true,dumponexit=true,settings=default,filename=${project.build.directory}/ -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                         <systemPropertyVariables>
                             <user.country>UK</user.country>
                             <user.language>en</user.language>

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -92,8 +92,8 @@
     </mailingLists>
 
     <properties>
-        <project.build.source>1.8</project.build.source>
-        <project.build.target>1.8</project.build.target>
+        <project.build.source>11</project.build.source>
+        <project.build.target>11</project.build.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <project.copyright.name>The eXist-db Authors</project.copyright.name>

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ConnectionIT.java
@@ -48,6 +48,7 @@ import org.exist.util.MimeType;
 import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
+import org.exist.xquery.Module;
 import org.exist.xquery.modules.ModuleUtils;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.Sequence;

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ImplicitConnectionCloseIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/ImplicitConnectionCloseIT.java
@@ -48,6 +48,7 @@ import org.exist.util.MimeType;
 import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
+import org.exist.xquery.Module;
 import org.exist.xquery.modules.ModuleUtils;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.Sequence;

--- a/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
+++ b/extensions/modules/sql/src/test/java/org/exist/xquery/modules/sql/JndiConnectionIT.java
@@ -48,6 +48,7 @@ import org.exist.util.MimeType;
 import org.exist.util.StringInputSource;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
+import org.exist.xquery.Module;
 import org.exist.xquery.modules.ModuleUtils;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.Sequence;


### PR DESCRIPTION
In an ambition to default to Java11 for eXist-db, changes are made in the build system.

According to @reinhapa  eg due to much more efficient String handling, performance could increase significantly.

this PR is (now) to test GHA.

Java8 tests are expected to fail.... or should not run at all?