### PR TITLE
[bugfix] fn:transform stylesheet document crash

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/TreeUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/TreeUtils.java
@@ -24,6 +24,7 @@ package org.exist.xquery.functions.fn.transform;
 
 import net.sf.saxon.s9api.XdmNode;
 import org.exist.xquery.value.NodeValue;
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 import java.util.ArrayList;
@@ -36,6 +37,10 @@ public class TreeUtils {
     }
 
     static StringBuilder pathTo(final Node node) {
+        if (node instanceof Document) {
+            final Document document = (Document) node;
+            return new StringBuilder().append(document.getDocumentURI());
+        }
         final List<Node> priors = new ArrayList<>();
         Node prev = node;
         while (prev != null) {
@@ -44,7 +49,7 @@ public class TreeUtils {
         }
         final Node parent = priors.get(0).getParentNode();
         final StringBuilder sb;
-        if (parent == null) {
+        if (parent == null || parent instanceof Document) {
             sb = new StringBuilder();
         } else {
             sb = pathTo(parent).append('/');

--- a/exist-core/src/test/xquery/xquery3/transform/fnTransformRegression1.xqm
+++ b/exist-core/src/test/xquery/xquery3/transform/fnTransformRegression1.xqm
@@ -1,0 +1,60 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace testTransform="http://exist-db.org/xquery/test/function_transform";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $testTransform:stylesheet := <xsl:stylesheet version='1.0' xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
+    <xsl:param name='v'/>
+    <xsl:template match='/'>
+        <v><xsl:value-of select='$v'/></v>
+    </xsl:template>
+</xsl:stylesheet>;
+
+declare
+    %test:setUp
+function testTransform:setup() {
+    let $coll := xmldb:create-collection("/db", "regression-test-1")
+    return (
+        xmldb:store($coll, "stylesheet.xsl", $testTransform:stylesheet, "application/xslt+xml")
+    )
+};
+
+declare
+    %test:tearDown
+function testTransform:cleanup() {
+    xmldb:remove("/db/regression-test-1")
+};
+
+declare
+    %test:assertEquals("<v>2</v>")
+function testTransform:regression-test-1() {
+    let $in := parse-xml("<dummy/>")
+    let $result := ( fn:transform(map{
+        "source-node":$in,
+        "stylesheet-node":doc("/db/regression-test-1/stylesheet.xsl"),
+        "stylesheet-params": map { QName("","v"): "2" } } ) )?output
+    return $result
+};
+


### PR DESCRIPTION
### Description

The fn:transform code to find the path to the node within the document, for hashing the stylesheet cache, didn’t expect a document. Test for that case explicitly, and in the case of a document the URI of the document can serve as the path.

### Issue

Passing an eXist stored document as the stylesheet node to `fn:transform` fails with a ClassCastException.
`{ ... "stylesheet-node":doc("/db/regression-test-1/stylesheet.xsl") ... }`

### Tests

An XSuite regression unit test is included in this checkin.
