### PR TITLE
Preserve XML Declaration

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -679,6 +679,7 @@
                                 <!--
                                     Already under LGPL 2.1, but with a different Copyright
                                 -->
+                                <exclude>src/main/java/org/exist/dom/persistent/XMLDeclarationImpl.java</exclude>
                                 <exclude>src/main/java/org/exist/resolver/ResolverFactory.java</exclude>
                                 <exclude>src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java</exclude>
                                 <exclude>src/main/java/org/exist/util/UTF8.java</exclude>
@@ -831,6 +832,7 @@ The original license statement is also included below.]]></preamble>
                             -->
                             <header>${project.parent.relativePath}/FDB-backport-LGPL-21-ONLY-license.template.txt</header>
                             <includes>
+                                <include>src/main/java/org/exist/dom/persistent/XMLDeclarationImpl.java</include>
                                 <include>src/main/java/org/exist/resolver/ResolverFactory.java</include>
                                 <include>src/main/java/org/exist/resolver/XercesXmlResolverAdapter.java</include>
                                 <include>src/test/java/org/exist/storage/MoveCollectionTest.java</include>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -271,7 +271,7 @@
             <groupId>org.exist-db.thirdparty.xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>2.12.2</version>
-            <classifier>xml-schema-1.1</classifier>
+            <classifier>jdk14-xml-schema-1.1</classifier>
             <exclusions>
                 <exclusion> <!-- conflicts with Java 17's javax.xml module -->
                     <groupId>xml-apis</groupId>

--- a/exist-core/src/main/java/org/exist/Indexer.java
+++ b/exist-core/src/main/java/org/exist/Indexer.java
@@ -26,6 +26,7 @@ import java.util.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.collections.CollectionConfiguration;
+import org.exist.dom.QName;
 import org.exist.dom.persistent.AttrImpl;
 import org.exist.dom.persistent.CDATASectionImpl;
 import org.exist.dom.persistent.CommentImpl;
@@ -34,9 +35,9 @@ import org.exist.dom.persistent.DocumentTypeImpl;
 import org.exist.dom.persistent.ElementImpl;
 import org.exist.dom.persistent.NodeHandle;
 import org.exist.dom.persistent.ProcessingInstructionImpl;
-import org.exist.dom.QName;
 import org.exist.dom.persistent.StoredNode;
 import org.exist.dom.persistent.TextImpl;
+import org.exist.dom.persistent.XMLDeclarationImpl;
 import org.exist.indexing.StreamListener;
 import org.exist.indexing.StreamListener.ReindexMode;
 import org.exist.storage.DBBroker;
@@ -61,6 +62,8 @@ import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.ext.LexicalHandler;
+
+import javax.annotation.Nullable;
 
 /**
  * Parses a given input document via SAX, stores it to the database and handles
@@ -540,6 +543,12 @@ public class Indexer implements ContentHandler, LexicalHandler, ErrorHandler {
          * considers the Document to be the first node with an id.
          */
         nodeFactoryInstanceCnt = 1;
+    }
+
+    @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
+        final XMLDeclarationImpl xmlDecl = new XMLDeclarationImpl(version, encoding, standalone);
+        document.setXmlDeclaration(xmlDecl);
     }
 
     final boolean hasNormAttribute(final Attributes attributes) {

--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -89,6 +89,8 @@ import org.xmldb.api.modules.XUpdateQueryService;
 import se.softhouse.jargo.ArgumentException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
+import static org.exist.storage.serializers.EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION;
 import static org.exist.storage.serializers.EXistOutputKeys.OUTPUT_DOCTYPE;
 import static org.xmldb.api.base.ResourceType.XML_RESOURCE;
 
@@ -143,6 +145,8 @@ public class InteractiveClient {
         DEFAULT_PROPERTIES.setProperty(USER, USER_DEFAULT);
         DEFAULT_PROPERTIES.setProperty(EDITOR, EDIT_CMD);
         DEFAULT_PROPERTIES.setProperty(INDENT, "true");
+        DEFAULT_PROPERTIES.setProperty(OMIT_XML_DECLARATION, "no");
+        DEFAULT_PROPERTIES.setProperty(OMIT_ORIGINAL_XML_DECLARATION, "no");
         DEFAULT_PROPERTIES.setProperty(OUTPUT_DOCTYPE, "true");
         DEFAULT_PROPERTIES.setProperty(ENCODING, ENCODING_DEFAULT.name());
         DEFAULT_PROPERTIES.setProperty(COLORS, "false");

--- a/exist-core/src/main/java/org/exist/collections/triggers/DocumentTriggers.java
+++ b/exist-core/src/main/java/org/exist/collections/triggers/DocumentTriggers.java
@@ -29,7 +29,6 @@ import org.exist.Indexer;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfiguration;
 import org.exist.dom.persistent.DocumentImpl;
-import org.exist.dom.persistent.XMLDeclarationImpl;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.Txn;
 import org.exist.xmldb.XmldbURI;

--- a/exist-core/src/main/java/org/exist/collections/triggers/DocumentTriggers.java
+++ b/exist-core/src/main/java/org/exist/collections/triggers/DocumentTriggers.java
@@ -29,6 +29,7 @@ import org.exist.Indexer;
 import org.exist.collections.Collection;
 import org.exist.collections.CollectionConfiguration;
 import org.exist.dom.persistent.DocumentImpl;
+import org.exist.dom.persistent.XMLDeclarationImpl;
 import org.exist.storage.DBBroker;
 import org.exist.storage.txn.Txn;
 import org.exist.xmldb.XmldbURI;
@@ -39,6 +40,8 @@ import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.ext.LexicalHandler;
+
+import javax.annotation.Nullable;
 
 /**
  * @author <a href="mailto:shabanovd@gmail.com">Dmitriy Shabanov</a>
@@ -142,6 +145,11 @@ public class DocumentTriggers implements DocumentTrigger, ContentHandler, Lexica
     @Override
     public void startDocument() throws SAXException {
         contentHandler.startDocument();
+    }
+
+    @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
+        contentHandler.declaration(version, encoding, standalone);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/collections/triggers/SAXTrigger.java
+++ b/exist-core/src/main/java/org/exist/collections/triggers/SAXTrigger.java
@@ -36,6 +36,8 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.ext.LexicalHandler;
 
+import javax.annotation.Nullable;
+
 /**
  * Abstract default implementation of a Trigger. This implementation just
  * forwards all SAX events to the output content handler.
@@ -87,6 +89,13 @@ public abstract class SAXTrigger implements DocumentTrigger, ContentHandler, Lex
     public void startDocument() throws SAXException {
         if (nextContentHandler != null)
             nextContentHandler.startDocument();
+    }
+
+    @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
+        if (nextContentHandler != null) {
+            nextContentHandler.declaration(version, encoding, standalone);
+        }
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/dom/memtree/DocumentBuilderReceiver.java
+++ b/exist-core/src/main/java/org/exist/dom/memtree/DocumentBuilderReceiver.java
@@ -123,6 +123,11 @@ public class DocumentBuilderReceiver implements ContentHandler, LexicalHandler, 
     }
 
     @Override
+    public void declaration(final String version, final String encoding, final String standalone) throws SAXException {
+        // NOTE(AR) in-memory documents do not support XML Declaration
+    }
+
+    @Override
     public void startPrefixMapping(final String prefix, final String namespaceURI) throws SAXException {
         if(prefix == null || prefix.length() == 0) {
             builder.setDefaultNamespace(namespaceURI);

--- a/exist-core/src/main/java/org/exist/dom/persistent/XMLDeclarationImpl.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/XMLDeclarationImpl.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.dom.persistent;
+
+import org.exist.storage.io.VariableByteInput;
+import org.exist.storage.io.VariableByteOutputStream;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+/**
+ * XML Declaration of an XML document
+ * available with SAX in Java 14+.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class XMLDeclarationImpl {
+
+    @Nullable private final String version;
+    @Nullable private final String encoding;
+    @Nullable private final String standalone;
+
+    public XMLDeclarationImpl(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) {
+        this.version = version;
+        this.encoding = encoding;
+        this.standalone = standalone;
+    }
+
+    /**
+     * Get the version from the XML Declaration.
+     *
+     * @return the version (if present), or null.
+     */
+    @Nullable
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Get the encoding from the XML Declaration.
+     *
+     * @return the encoding (if present), or null.
+     */
+    @Nullable
+    public String getEncoding() {
+        return encoding;
+    }
+
+    /**
+     * Get the standalone from the XML Declaration.
+     *
+     * @return the standalone (if present), or null.
+     */
+    @Nullable
+    public String getStandalone() {
+        return standalone;
+    }
+
+    /**
+     * Write the XML Declaration to the output stream.
+     *
+     * @param ostream the output stream.
+     *
+     * @throws IOException if an error occurs whilst writing to the output stream.
+     */
+    public void write(final VariableByteOutputStream ostream) throws IOException {
+        ostream.writeUTF(version != null ? version : "");
+        ostream.writeUTF(encoding != null ? encoding : "");
+        ostream.writeUTF(standalone != null ? standalone : "");
+    }
+
+    /**
+     * Read an XML Declaration from the input stream.
+     *
+     * @param istream the input stream.
+     *
+     * @throws IOException if an error occurs whilst reading from the input stream.
+     */
+    public static XMLDeclarationImpl read(final VariableByteInput istream) throws IOException {
+        String version = istream.readUTF();
+        if(version.length() == 0) {
+            version = null;
+        }
+        String encoding = istream.readUTF();
+        if(encoding.length() == 0) {
+            encoding = null;
+        }
+        String standalone = istream.readUTF();
+        if(standalone.length() == 0) {
+            standalone = null;
+        }
+
+        return new XMLDeclarationImpl(version, encoding, standalone);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+
+        builder.append("<?xml");
+
+        if (version != null) {
+            builder.append(" version=\"").append(version).append("\"");
+        }
+
+        if (encoding != null) {
+            builder.append(" encoding=\"").append(encoding).append("\"");
+        }
+
+        if (standalone != null) {
+            builder.append(" standalone=\"").append(standalone).append("\"");
+        }
+
+        builder.append("?>");
+
+        return builder.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -498,6 +498,11 @@ public class RESTServer {
             // found an XQuery or XProc resource, fixup request values
             final String pathInfo = pathUri.trimFromBeginning(servletPath).toString();
 
+            // reset any output-doctype, omit-xml-declaration, or omit-original-xml-declaration properties, as these can conflict with others set via XQuery Serialization settings
+            outputProperties.setProperty(EXistOutputKeys.OUTPUT_DOCTYPE, "no");
+            outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            outputProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "yes");
+
             // Should we display the source of the XQuery or XProc or execute it
             final Descriptor descriptor = Descriptor.getDescriptorSingleton();
             if (source) {

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -360,6 +360,22 @@ public class RESTServer {
             final String outputDocType = broker.getConfiguration().getProperty(Serializer.PROPERTY_OUTPUT_DOCTYPE, "yes");
             outputProperties.setProperty(EXistOutputKeys.OUTPUT_DOCTYPE, outputDocType);
         }
+        if ((option = getParameter(request, Omit_Xml_Declaration)) != null) {
+            // take user query-string specified omit-xml-declaration setting
+            outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, option);
+        } else {
+            // set omit-xml-declaration by configuration
+            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.PROPERTY_OMIT_XML_DECLARATION, "yes");
+            outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, omitXmlDeclaration);
+        }
+        if ((option = getParameter(request, Omit_Original_Xml_Declaration)) != null) {
+            // take user query-string specified omit-original-xml-declaration setting
+            outputProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, option);
+        } else {
+            // set omit-original-xml-declaration by configuration
+            final String omitOriginalXmlDeclaration = broker.getConfiguration().getProperty(Serializer.PROPERTY_OMIT_ORIGINAL_XML_DECLARATION, "yes");
+            outputProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, omitOriginalXmlDeclaration);
+        }
         if ((option = getParameter(request, Source)) != null && !safeMode) {
             source = "yes".equals(option);
         }

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -365,7 +365,7 @@ public class RESTServer {
             outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, option);
         } else {
             // set omit-xml-declaration by configuration
-            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.PROPERTY_OMIT_XML_DECLARATION, "yes");
+            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.PROPERTY_OMIT_XML_DECLARATION, "no");
             outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, omitXmlDeclaration);
         }
         if ((option = getParameter(request, Omit_Original_Xml_Declaration)) != null) {
@@ -373,7 +373,7 @@ public class RESTServer {
             outputProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, option);
         } else {
             // set omit-original-xml-declaration by configuration
-            final String omitOriginalXmlDeclaration = broker.getConfiguration().getProperty(Serializer.PROPERTY_OMIT_ORIGINAL_XML_DECLARATION, "yes");
+            final String omitOriginalXmlDeclaration = broker.getConfiguration().getProperty(Serializer.PROPERTY_OMIT_ORIGINAL_XML_DECLARATION, "no");
             outputProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, omitOriginalXmlDeclaration);
         }
         if ((option = getParameter(request, Source)) != null && !safeMode) {

--- a/exist-core/src/main/java/org/exist/http/RESTServer.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServer.java
@@ -129,7 +129,7 @@ public class RESTServer {
 
     static {
         defaultOutputKeysProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "no");
-        defaultOutputKeysProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        defaultOutputKeysProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
         defaultOutputKeysProperties.setProperty(OutputKeys.INDENT, "yes");
         defaultOutputKeysProperties.setProperty(OutputKeys.MEDIA_TYPE,
                 MimeType.XML_TYPE.getName());
@@ -365,7 +365,7 @@ public class RESTServer {
             outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, option);
         } else {
             // set omit-xml-declaration by configuration
-            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.PROPERTY_OMIT_XML_DECLARATION, "no");
+            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.PROPERTY_OMIT_XML_DECLARATION, "yes");
             outputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, omitXmlDeclaration);
         }
         if ((option = getParameter(request, Omit_Original_Xml_Declaration)) != null) {

--- a/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
+++ b/exist-core/src/main/java/org/exist/http/RESTServerParameter.java
@@ -357,7 +357,29 @@ enum RESTServerParameter {
      *
      * The value of the parameter should be either "yes" or "no".
      */
-    Output_Doctype;
+    Output_Doctype,
+
+    /**
+     * Can be used in the Query String of a GET request
+     * to indicate that the XML Declaration of an XML document should not
+     * be serialized if present.
+     *
+     * Contexts: GET
+     *
+     * The value of the parameter should be either "yes" or "no".
+     */
+    Omit_Xml_Declaration,
+
+    /**
+     * Can be used in the Query String of a GET request
+     * to indicate that the original persisted XML Declaration of an XML document should not
+     * be serialized if present.
+     *
+     * Contexts: GET
+     *
+     * The value of the parameter should be either "yes" or "no".
+     */
+    Omit_Original_Xml_Declaration;
 
     /**
      * Get the parameter key that is

--- a/exist-core/src/main/java/org/exist/indexing/AbstractMatchListener.java
+++ b/exist-core/src/main/java/org/exist/indexing/AbstractMatchListener.java
@@ -28,6 +28,8 @@ import org.exist.util.serializer.Receiver;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
+import javax.annotation.Nullable;
+
 /**
  * Utility implementation of interface {@link org.exist.indexing.MatchListener} which forwards all
  * events to a second receiver. Subclass this class and overwrite the methods you are interested in.
@@ -86,6 +88,13 @@ public class AbstractMatchListener implements MatchListener {
     @Override
     public void endDocument() throws SAXException {
         if (nextListener != null) {nextListener.endDocument();}
+    }
+
+    @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
+        if (nextListener != null) {
+            nextListener.declaration(version, encoding, standalone);
+        }
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/storage/index/CollectionStore.java
+++ b/exist-core/src/main/java/org/exist/storage/index/CollectionStore.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
  */
 public class CollectionStore extends BFile {
 
-    public static final short FILE_FORMAT_VERSION_ID = 16;
+    public static final short FILE_FORMAT_VERSION_ID = 17;
 
     public static final String FILE_NAME = "collections.dbx";
     public static final String  FILE_KEY_IN_CONFIG = "db-connection.collections";

--- a/exist-core/src/main/java/org/exist/storage/serializers/AbstractChainOfReceivers.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/AbstractChainOfReceivers.java
@@ -28,6 +28,8 @@ import org.exist.util.serializer.Receiver;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
+import javax.annotation.Nullable;
+
 /**
  * Utility implementation of interface {@link ChainOfReceivers} which forwards all
  * events to a second receiver. Subclass this class and overwrite the methods you are interested in.
@@ -88,6 +90,13 @@ public class AbstractChainOfReceivers implements ChainOfReceivers {
     public void endDocument() throws SAXException {
         if (next != null) {
             next.endDocument();
+        }
+    }
+
+    @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
+        if (next != null) {
+            next.declaration(version, encoding, standalone);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/storage/serializers/EXistOutputKeys.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/EXistOutputKeys.java
@@ -28,7 +28,9 @@ public class EXistOutputKeys {
      */
     public static final String ITEM_SEPARATOR = "item-separator";
 
-	public static final String OUTPUT_DOCTYPE = "output-doctype";
+    public static final String OMIT_ORIGINAL_XML_DECLARATION = "omit-original-xml-declaration";
+
+    public static final String OUTPUT_DOCTYPE = "output-doctype";
 	 
 	public static final String EXPAND_XINCLUDES = "expand-xincludes";
 	

--- a/exist-core/src/main/java/org/exist/storage/serializers/NativeSerializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/NativeSerializer.java
@@ -22,6 +22,7 @@
 package org.exist.storage.serializers;
 
 import org.exist.Namespaces;
+import org.exist.dom.QName;
 import org.exist.dom.persistent.AttrImpl;
 import org.exist.dom.persistent.CDATASectionImpl;
 import org.exist.dom.persistent.CommentImpl;
@@ -32,8 +33,8 @@ import org.exist.dom.persistent.IStoredNode;
 import org.exist.dom.persistent.Match;
 import org.exist.dom.persistent.NodeProxy;
 import org.exist.dom.persistent.ProcessingInstructionImpl;
-import org.exist.dom.QName;
 import org.exist.dom.persistent.TextImpl;
+import org.exist.dom.persistent.XMLDeclarationImpl;
 import org.exist.numbering.NodeId;
 import org.exist.storage.DBBroker;
 import org.exist.util.Configuration;
@@ -116,7 +117,14 @@ public class NativeSerializer extends Serializer {
             documentStarted = true;
         }
 
-        if (doc.getDoctype() != null){
+        if (doc.getXmlDeclaration() != null){
+            if ("no".equals(getProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "no"))) {
+                final XMLDeclarationImpl xmlDecl = doc.getXmlDeclaration();
+                receiver.declaration(xmlDecl.getVersion(), xmlDecl.getEncoding(), xmlDecl.getStandalone());
+            }
+        }
+
+        if (doc.getDoctype() != null) {
             if ("yes".equals(getProperty(EXistOutputKeys.OUTPUT_DOCTYPE, "no"))) {
                 final DocumentTypeImpl docType = (DocumentTypeImpl)doc.getDoctype();
                 serializeToReceiver(docType, null, docType.getOwnerDocument(), true, null, new TreeSet<>());

--- a/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
@@ -107,6 +107,10 @@ public abstract class Serializer implements XMLReader {
     protected static final Logger LOG = LogManager.getLogger(Serializer.class);
 
     public static final String CONFIGURATION_ELEMENT_NAME = "serializer";
+    public static final String OMIT_XML_DECLARATION_ATTRIBUTE = "omit-xml-declaration";
+    public static final String PROPERTY_OMIT_XML_DECLARATION = "serialization.omit-xml-declaration";
+    public static final String OMIT_ORIGINAL_XML_DECLARATION_ATTRIBUTE = "omit-original-xml-declaration";
+    public static final String PROPERTY_OMIT_ORIGINAL_XML_DECLARATION = "serialization.omit-original-xml-declaration";
     public static final String OUTPUT_DOCTYPE_ATTRIBUTE = "output-doctype";
     public static final String PROPERTY_OUTPUT_DOCTYPE = "serialization.output-doctype";
     public static final String ENABLE_XINCLUDE_ATTRIBUTE = "enable-xinclude";

--- a/exist-core/src/main/java/org/exist/storage/serializers/XIncludeFilter.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/XIncludeFilter.java
@@ -219,6 +219,11 @@ public class XIncludeFilter implements Receiver {
     }
 
     @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
+        receiver.declaration(version, encoding, standalone);
+    }
+
+    @Override
     public void attribute(final QName qname, final String value) throws SAXException {
         if (!inFallback || error != null) {
             receiver.attribute(qname, value);

--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -652,6 +652,18 @@ public class Configuration implements ErrorHandler
      */
     private void configureSerializer( Element serializer )
     {
+        final String omitXmlDeclaration = getConfigAttributeValue( serializer, Serializer.OMIT_XML_DECLARATION_ATTRIBUTE );
+        if (omitXmlDeclaration != null) {
+            config.put(Serializer.PROPERTY_OMIT_XML_DECLARATION, omitXmlDeclaration);
+            LOG.debug(Serializer.PROPERTY_OMIT_XML_DECLARATION + ": {}", config.get(Serializer.PROPERTY_OMIT_XML_DECLARATION));
+        }
+
+        final String omitOriginalXmlDeclaration = getConfigAttributeValue( serializer, Serializer.OMIT_ORIGINAL_XML_DECLARATION_ATTRIBUTE );
+        if (omitOriginalXmlDeclaration != null) {
+            config.put(Serializer.PROPERTY_OMIT_ORIGINAL_XML_DECLARATION, omitOriginalXmlDeclaration);
+            LOG.debug(Serializer.PROPERTY_OMIT_ORIGINAL_XML_DECLARATION + ": {}", config.get(Serializer.PROPERTY_OMIT_ORIGINAL_XML_DECLARATION));
+        }
+
         final String outputDocType = getConfigAttributeValue( serializer, Serializer.OUTPUT_DOCTYPE_ATTRIBUTE );
         if (outputDocType != null) {
             config.put(Serializer.PROPERTY_OUTPUT_DOCTYPE, outputDocType);

--- a/exist-core/src/main/java/org/exist/util/serializer/AbstractSerializer.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/AbstractSerializer.java
@@ -63,7 +63,7 @@ public abstract class AbstractSerializer {
 
     static {
         defaultProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "no");
-        defaultProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        defaultProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
         defaultProperties.setProperty(EXistOutputKeys.XDM_SERIALIZATION, "no");
     }
 

--- a/exist-core/src/main/java/org/exist/util/serializer/AbstractSerializer.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/AbstractSerializer.java
@@ -62,8 +62,9 @@ public abstract class AbstractSerializer {
     protected static final Properties defaultProperties = new Properties();
 
     static {
-        defaultProperties.setProperty(OutputKeys.ENCODING, UTF_8.name());
-        defaultProperties.setProperty(OutputKeys.INDENT, "false");
+        defaultProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "no");
+        defaultProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        defaultProperties.setProperty(EXistOutputKeys.XDM_SERIALIZATION, "no");
     }
 
     protected Properties outputProperties;

--- a/exist-core/src/main/java/org/exist/util/serializer/CharacterMappingWriter.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/CharacterMappingWriter.java
@@ -87,6 +87,11 @@ public class CharacterMappingWriter implements SerializerWriter {
     }
 
     @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws TransformerException {
+        wrappedSerializerWriter.declaration(version, encoding, standalone);
+    }
+
+    @Override
     public void startElement(final String namespaceUri, final String localName, final String qname) throws TransformerException {
         wrappedSerializerWriter.startElement(namespaceUri, localName, qname);
     }

--- a/exist-core/src/main/java/org/exist/util/serializer/EXISerializer.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/EXISerializer.java
@@ -41,6 +41,8 @@ import com.siemens.ct.exi.exceptions.EXIException;
 import com.siemens.ct.exi.grammars.Grammars;
 import com.siemens.ct.exi.helpers.DefaultEXIFactory;
 
+import javax.annotation.Nullable;
+
 public class EXISerializer implements ContentHandler, Receiver {
 	
 	static final String UNKNOWN_TYPE = "";
@@ -68,6 +70,11 @@ public class EXISerializer implements ContentHandler, Receiver {
 
 	public void endDocument() throws SAXException {
 		encoder.endDocument();
+	}
+
+	@Override
+	public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
+		encoder.declaration(version, encoding, standalone);
 	}
 
 	@Override

--- a/exist-core/src/main/java/org/exist/util/serializer/MicroXmlWriter.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/MicroXmlWriter.java
@@ -22,6 +22,7 @@
 package org.exist.util.serializer;
 
 import org.exist.dom.QName;
+import org.exist.storage.serializers.EXistOutputKeys;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
@@ -168,7 +169,8 @@ public class MicroXmlWriter extends IndentingXMLWriter {
 
     @Override
     public void setOutputProperties(final Properties properties) {
+        properties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "yes");
         properties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-        super.setOutputProperties(properties);    //To change body of overridden methods use File | Settings | File Templates.
+        super.setOutputProperties(properties);
     }
 }

--- a/exist-core/src/main/java/org/exist/util/serializer/Receiver.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/Receiver.java
@@ -27,6 +27,8 @@ import org.exist.dom.QName;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
+import javax.annotation.Nullable;
+
 /**
  * A receiver is similar to the SAX content handler and lexical handler interfaces, but
  * uses some higher level types as arguments. For example, element names are internally
@@ -43,6 +45,8 @@ public interface Receiver<T extends INodeHandle> {
     void startDocument() throws SAXException;
 
 	void endDocument() throws SAXException;
+
+	void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException;
 
 	void startPrefixMapping(String prefix, String namespaceURI) throws SAXException;
 	

--- a/exist-core/src/main/java/org/exist/util/serializer/ReceiverToSAX.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/ReceiverToSAX.java
@@ -29,6 +29,8 @@ import org.xml.sax.SAXException;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
+import javax.annotation.Nullable;
+
 /**
  * A wrapper class that forwards the method calls defined in the
  * {@link org.exist.util.serializer.Receiver} interface to a
@@ -79,6 +81,11 @@ public class ReceiverToSAX implements Receiver {
     @Override
     public void endDocument() throws SAXException {
         contentHandler.endDocument();
+    }
+
+    @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
+        contentHandler.declaration(version, encoding, standalone);
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/util/serializer/SAXSerializer.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/SAXSerializer.java
@@ -34,6 +34,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.NamespaceSupport;
 
+import javax.annotation.Nullable;
 import javax.xml.XMLConstants;
 import javax.xml.transform.TransformerException;
 import java.io.Writer;
@@ -100,6 +101,15 @@ public class SAXSerializer extends AbstractSerializer implements ContentHandler,
     public void endDocument() throws SAXException {
         try {
             receiver.endDocument();
+        } catch (final TransformerException e) {
+            throw new SAXException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
+        try {
+            receiver.declaration(version, encoding, standalone);
         } catch (final TransformerException e) {
             throw new SAXException(e.getMessage(), e);
         }

--- a/exist-core/src/main/java/org/exist/util/serializer/SerializerWriter.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/SerializerWriter.java
@@ -24,6 +24,7 @@ package org.exist.util.serializer;
 
 import org.exist.dom.QName;
 
+import javax.annotation.Nullable;
 import javax.xml.transform.TransformerException;
 import java.io.Writer;
 import java.util.Properties;
@@ -43,6 +44,8 @@ public interface SerializerWriter {
     void startDocument() throws TransformerException;
 
     void endDocument() throws TransformerException;
+
+    void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws TransformerException;
 
     void startElement(final String namespaceUri, final String localName, final String qname) throws TransformerException;
 

--- a/exist-core/src/main/java/org/exist/util/serializer/XMLWriter.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/XMLWriter.java
@@ -24,6 +24,7 @@ package org.exist.util.serializer;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.*;
+import javax.annotation.Nullable;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerException;
 
@@ -105,6 +106,8 @@ public class XMLWriter implements SerializerWriter {
         attrSpecialChars['"'] = true;
     }
 
+    @Nullable private XMLDeclaration originalXmlDecl;
+
     public XMLWriter() {
         charSet = CharacterSet.getCharacterSet(UTF_8.name());
         if(charSet == null) {
@@ -160,6 +163,7 @@ public class XMLWriter implements SerializerWriter {
         tagIsOpen = false;
         tagIsEmpty = true;
         declarationWritten = false;
+        originalXmlDecl = null;
         doctypeWritten = false;
         defaultNamespace = "";
         cdataSectionElements = new LazyVal<>(this::parseCdataSectionElementNames);
@@ -189,6 +193,11 @@ public class XMLWriter implements SerializerWriter {
 	
     public void startDocument() throws TransformerException {
         resetObjectState();
+    }
+
+    @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws TransformerException {
+        this.originalXmlDecl = new XMLDeclaration(version, encoding, standalone);
     }
 
     public void endDocument() throws TransformerException {
@@ -642,5 +651,17 @@ public class XMLWriter implements SerializerWriter {
         }
         charref[o++] = ';';
         writer.write(charref, 0, o);
+    }
+
+    private static class XMLDeclaration {
+        @Nullable final String version;
+        @Nullable final String encoding;
+        @Nullable final String standalone;
+
+        private XMLDeclaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) {
+            this.version = version;
+            this.encoding = encoding;
+            this.standalone = standalone;
+        }
     }
 }

--- a/exist-core/src/main/java/org/exist/xmldb/LocalCollection.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalCollection.java
@@ -94,7 +94,7 @@ public class LocalCollection extends AbstractLocal implements EXistCollection {
         defaultProperties.setProperty(EXistOutputKeys.EXPAND_XINCLUDES, "yes");
         defaultProperties.setProperty(EXistOutputKeys.PROCESS_XSL_PI, "no");
         defaultProperties.setProperty(NORMALIZE_HTML, "no");
-        defaultProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        defaultProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
         defaultProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "no");
         defaultProperties.setProperty(EXistOutputKeys.OUTPUT_DOCTYPE, "yes");
     }

--- a/exist-core/src/main/java/org/exist/xmldb/LocalCollection.java
+++ b/exist-core/src/main/java/org/exist/xmldb/LocalCollection.java
@@ -90,11 +90,12 @@ public class LocalCollection extends AbstractLocal implements EXistCollection {
 
     private final static Properties defaultProperties = new Properties();
     static {
-        defaultProperties.setProperty(OutputKeys.ENCODING, UTF_8.name());
         defaultProperties.setProperty(OutputKeys.INDENT, "yes");
         defaultProperties.setProperty(EXistOutputKeys.EXPAND_XINCLUDES, "yes");
         defaultProperties.setProperty(EXistOutputKeys.PROCESS_XSL_PI, "no");
         defaultProperties.setProperty(NORMALIZE_HTML, "no");
+        defaultProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        defaultProperties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "no");
         defaultProperties.setProperty(EXistOutputKeys.OUTPUT_DOCTYPE, "yes");
     }
 

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -664,12 +664,12 @@ public class RpcConnection implements RpcAPI {
 
     private void serialize(final DBBroker broker, final Properties properties, final ConsumerE<Serializer, SAXException> toSaxFunction, final Writer writer) throws SAXException, IOException {
         if (!properties.containsKey(OutputKeys.OMIT_XML_DECLARATION)) {
-            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.OMIT_XML_DECLARATION_ATTRIBUTE, "yes");
+            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.OMIT_XML_DECLARATION_ATTRIBUTE, "no");
             properties.setProperty(OutputKeys.OMIT_XML_DECLARATION, omitXmlDeclaration);
         }
 
         if (!properties.containsKey(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION)) {
-            final String omitOriginalXmlDeclaration = broker.getConfiguration().getProperty(Serializer.OMIT_ORIGINAL_XML_DECLARATION_ATTRIBUTE, "yes");
+            final String omitOriginalXmlDeclaration = broker.getConfiguration().getProperty(Serializer.OMIT_ORIGINAL_XML_DECLARATION_ATTRIBUTE, "no");
             properties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, omitOriginalXmlDeclaration);
         }
 

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -663,6 +663,16 @@ public class RpcConnection implements RpcAPI {
     }
 
     private void serialize(final DBBroker broker, final Properties properties, final ConsumerE<Serializer, SAXException> toSaxFunction, final Writer writer) throws SAXException, IOException {
+        if (!properties.containsKey(OutputKeys.OMIT_XML_DECLARATION)) {
+            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.OMIT_XML_DECLARATION_ATTRIBUTE, "yes");
+            properties.setProperty(OutputKeys.OMIT_XML_DECLARATION, omitXmlDeclaration);
+        }
+
+        if (!properties.containsKey(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION)) {
+            final String omitOriginalXmlDeclaration = broker.getConfiguration().getProperty(Serializer.OMIT_ORIGINAL_XML_DECLARATION_ATTRIBUTE, "yes");
+            properties.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, omitOriginalXmlDeclaration);
+        }
+
         if (!properties.containsKey(EXistOutputKeys.OUTPUT_DOCTYPE)) {
             final String outputDocType = broker.getConfiguration().getProperty(Serializer.PROPERTY_OUTPUT_DOCTYPE, "yes");
             properties.setProperty(EXistOutputKeys.OUTPUT_DOCTYPE, outputDocType);

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcConnection.java
@@ -664,7 +664,7 @@ public class RpcConnection implements RpcAPI {
 
     private void serialize(final DBBroker broker, final Properties properties, final ConsumerE<Serializer, SAXException> toSaxFunction, final Writer writer) throws SAXException, IOException {
         if (!properties.containsKey(OutputKeys.OMIT_XML_DECLARATION)) {
-            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.OMIT_XML_DECLARATION_ATTRIBUTE, "no");
+            final String omitXmlDeclaration = broker.getConfiguration().getProperty(Serializer.OMIT_XML_DECLARATION_ATTRIBUTE, "yes");
             properties.setProperty(OutputKeys.OMIT_XML_DECLARATION, omitXmlDeclaration);
         }
 

--- a/exist-core/src/test/java/org/exist/backup/XMLDBBackupTest.java
+++ b/exist-core/src/test/java/org/exist/backup/XMLDBBackupTest.java
@@ -119,7 +119,12 @@ public class XMLDBBackupTest {
 
         final Resource doc1 = testCollection.getResource(DOC1_NAME);
         assertNotNull(doc1);
-        final Source expected = Input.fromString(doc1Content).build();
+
+        // NOTE(AR) that org.exist.backup.Backup calls defaultOutputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        // NOTE(AR) that org.exist.backup.SystemExport also calls defaultOutputProperties.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        // TODO(AR) consider whether the backup/export should be injecting a XML Declaration that was not previously present, or should default to EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION
+        final Source expected = Input.fromString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + doc1Content).build();
+
         final Source actual = Input.fromString(doc1.getContent().toString()).build();
         final Diff diff = DiffBuilder.compare(expected)
                 .withTest(actual)

--- a/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
@@ -234,7 +234,7 @@ public class RESTServiceTest {
     }
 
     private static String getResourceWithDocTypeUri() {
-        return getServerUri() + TEST_DOCTYPE_COLLECTION_URI.append(TEST_XML_DOC_WITH_DOCTYPE_URI);
+        return getServerUri() + TEST_DOCTYPE_COLLECTION_URI.append(TEST_XML_DOC_WITH_DOCTYPE_URI) + "?_omit-xml-declaration=yes";
     }
 
     private static String getResourceWithXmlDeclUri() {
@@ -757,7 +757,7 @@ try {
 
         /* execute the stored xquery a few times */
         for (int i = 0; i < 5; i++) {
-            final HttpURLConnection connect = getConnection(getCollectionUri() + "/requestparameter.xql?doc=somedoc" + i);
+            final HttpURLConnection connect = getConnection(getCollectionUri() + "/requestparameter.xql?doc=somedoc" + i + "&_omit-xml-declaration=yes");
             try {
                 connect.setRequestProperty("Authorization", "Basic " + credentials);
                 connect.setRequestMethod("GET");
@@ -831,7 +831,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r-x");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq";
+        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
@@ -876,7 +876,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r--");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq";
+        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestProperty("Authorization", "Basic " + credentials);
@@ -922,7 +922,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r--");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq";
+        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestProperty("Authorization", "bAsiC " + credentials);  // NOTE(AR): Intentional use of 'bAsiC' to test case-insensitive scheme matching
@@ -968,7 +968,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwsr--r-x");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq";
+        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
@@ -1019,7 +1019,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwsr--r-x");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq";
+        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
@@ -1088,7 +1088,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwsr--r-x");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq";
+        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
@@ -1136,7 +1136,7 @@ try {
     // all the tests with EncodedPath in function declaration aim to test rest server ability to handle special characters
     @Test
     public void doGetEncodedPath() throws IOException {
-        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml";
+        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml?_omit-xml-declaration=yes";
         final HttpURLConnection connect = getConnection(DOC_URI);
         try {
             connect.setRequestMethod("GET");
@@ -1177,7 +1177,7 @@ try {
 
     @Test
     public void doPutEncodedPath() throws IOException {
-        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml";
+        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml?_omit-xml-declaration=yes";
         final HttpURLConnection connect = getConnection(DOC_URI);
         final HttpURLConnection getConnect = getConnection(DOC_URI);
         String data = "<foobar/>";
@@ -1305,7 +1305,7 @@ try {
 
     @Test
     public void getDocTypeNo() throws IOException {
-        final HttpURLConnection connect = getConnection(getResourceWithDocTypeUri() + "?_output-doctype=no");
+        final HttpURLConnection connect = getConnection(getResourceWithDocTypeUri() + "&_output-doctype=no");
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -1330,7 +1330,7 @@ try {
 
     @Test
     public void getDocTypeYes() throws IOException {
-        final HttpURLConnection connect = getConnection(getResourceWithDocTypeUri() + "?_output-doctype=yes");
+        final HttpURLConnection connect = getConnection(getResourceWithDocTypeUri() + "&_output-doctype=yes");
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -1419,7 +1419,8 @@ try {
 
             final String response = readResponse(connect.getInputStream());
 
-            assertEquals("<bookmap id=\"bookmap-2\"/>\r\n", response);
+            assertEquals("<?xml version=\"1.1\" encoding=\"ISO-8859-1\" standalone=\"yes\"?>\r\n" +
+                    "<bookmap id=\"bookmap-2\"/>\r\n", response);
 
         } finally {
             connect.disconnect();
@@ -1515,7 +1516,7 @@ try {
 
     private void doStoredQuery(final boolean cacheHeader, final boolean wrap) throws IOException {
 
-        String uri = getCollectionUri() + "/test.xq?p=Hello";
+        String uri = getCollectionUri() + "/test.xq?p=Hello&&_omit-xml-declaration=yes";
         if(wrap) {
             uri += "&_wrap=yes";
         }

--- a/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
@@ -213,6 +213,15 @@ public class RESTServiceTest {
     private static String credentials;
     private static String badCredentials;
 
+    private static final String TEST_ENCODED_XML_DOC_CONTENT = "<foo/>";
+    private static final String ENCODED_NAME = "AéB";
+    private static final XmldbURI GET_METHOD_ENCODED_COLLECTION_URI = XmldbURI.ROOT_COLLECTION_URI.append("test-get-method-encoded").append(ENCODED_NAME);
+    private static final XmldbURI GET_METHOD_ENCODED_DOC_URI = GET_METHOD_ENCODED_COLLECTION_URI.append(ENCODED_NAME + ".xml");
+    private static final XmldbURI PUT_METHOD_ENCODED_COLLECTION_URI = XmldbURI.ROOT_COLLECTION_URI.append("test-put-method-encoded").append(ENCODED_NAME);
+    private static final XmldbURI PUT_METHOD_ENCODED_DOC_URI = PUT_METHOD_ENCODED_COLLECTION_URI.append(ENCODED_NAME + ".xml");
+    private static final XmldbURI DELETE_METHOD_ENCODED_COLLECTION_URI = XmldbURI.ROOT_COLLECTION_URI.append("test-delete-method-encoded").append(ENCODED_NAME);
+    private static final XmldbURI DELETE_METHOD_ENCODED_DOC_URI = DELETE_METHOD_ENCODED_COLLECTION_URI.append(ENCODED_NAME + ".xml");
+
     private static String getServerUri() {
         return "http://localhost:" + existWebServer.getPort() + "/rest";
     }
@@ -306,15 +315,17 @@ public class RESTServiceTest {
         credentials = Base64.encodeBase64String("admin:".getBytes(UTF_8));
         badCredentials = Base64.encodeBase64String("johndoe:this pw should fail".getBytes(UTF_8));
 
-        final XmldbURI TEST_XML_DOC_URI = XmldbURI.create("AéB.xml");
-        final XmldbURI TEST_COLLECTION_URI = XmldbURI.create("/db/AéB");
-        final String TEST_XML_DOC = "<foo/>";
-
         final BrokerPool pool =  existEmbeddedServer.getBrokerPool();
         try (final DBBroker broker = pool.get(Optional.of(pool.getSecurityManager().getSystemSubject()));
              final Txn transaction = pool.getTransactionManager().beginTransaction()) {
-            try (final Collection col = broker.getOrCreateCollection(transaction, TEST_COLLECTION_URI)) {
-                broker.storeDocument(transaction, TEST_XML_DOC_URI, new StringInputSource(TEST_XML_DOC), MimeType.XML_TYPE, col);
+
+            try (final Collection col = broker.getOrCreateCollection(transaction, GET_METHOD_ENCODED_COLLECTION_URI)) {
+                broker.storeDocument(transaction, GET_METHOD_ENCODED_DOC_URI.lastSegment(), new StringInputSource(TEST_ENCODED_XML_DOC_CONTENT), MimeType.XML_TYPE, col);
+                broker.saveCollection(transaction, col);
+            }
+
+            try (final Collection col = broker.getOrCreateCollection(transaction, DELETE_METHOD_ENCODED_COLLECTION_URI)) {
+                broker.storeDocument(transaction, DELETE_METHOD_ENCODED_DOC_URI.lastSegment(), new StringInputSource(TEST_ENCODED_XML_DOC_CONTENT), MimeType.XML_TYPE, col);
                 broker.saveCollection(transaction, col);
             }
 
@@ -1132,12 +1143,12 @@ try {
         }
     }
 
-    //test rest server ability to handle encoded characters
+    // test rest server ability to handle encoded characters
     // all the tests with EncodedPath in function declaration aim to test rest server ability to handle special characters
     @Test
     public void doGetEncodedPath() throws IOException {
-        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml";
-        final HttpURLConnection connect = getConnection(DOC_URI);
+        final String docUri = getServerUri() + GET_METHOD_ENCODED_DOC_URI.getCollectionPath();
+        final HttpURLConnection connect = getConnection(docUri);
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -1151,10 +1162,10 @@ try {
             }
             assertEquals("Server returned content type " + contentType, "application/xml", contentType);
 
-            String response = readResponse(connect.getInputStream());
+            final String response = readResponse(connect.getInputStream());
 
             //readResponse is appending \r\n to each line that's why its added the expected content
-            assertEquals("Server returned document content " + response,"<foobar/>\r\n",response);
+            assertEquals("Server returned document content " + response,TEST_ENCODED_XML_DOC_CONTENT + "\r\n",response);
         } finally {
             connect.disconnect();
         }
@@ -1162,8 +1173,8 @@ try {
 
     @Test
     public void doHeadEncodedPath() throws IOException {
-        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml";
-        final HttpURLConnection connect = getConnection(DOC_URI);
+        final String docUri = getServerUri() + GET_METHOD_ENCODED_DOC_URI.getCollectionPath();
+        final HttpURLConnection connect = getConnection(docUri);
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -1177,10 +1188,10 @@ try {
 
     @Test
     public void doPutEncodedPath() throws IOException {
-        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml";
-        final HttpURLConnection connect = getConnection(DOC_URI);
-        final HttpURLConnection getConnect = getConnection(DOC_URI);
-        String data = "<foobar/>";
+        final String docUri = getServerUri() + PUT_METHOD_ENCODED_DOC_URI.getCollectionPath();
+        final HttpURLConnection connect = getConnection(docUri);
+        final HttpURLConnection getConnect = getConnection(docUri);
+        final String data = "<foobar/>";
         try {
             connect.setRequestProperty("Authorization", "Basic " + credentials);
             connect.setRequestMethod("PUT");
@@ -1201,10 +1212,10 @@ try {
             final int res_code = getConnect.getResponseCode();
             assertEquals("Server returned response code " + res_code, HttpStatus.OK_200, res_code);
 
-            String response = readResponse(getConnect.getInputStream());
+            final String response = readResponse(getConnect.getInputStream());
 
             //readResponse is appending \r\n to each line that's why its added the expected content
-            assertEquals("Server returned document content " + response,"<foobar/>\r\n",response);
+            assertEquals("Server returned document content " + response,data + "\r\n",response);
 
         } finally {
             connect.disconnect();
@@ -1214,10 +1225,10 @@ try {
 
     @Test
     public void doPostEncodedPath() throws IOException {
-        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml";
-        final HttpURLConnection connect = getConnection(DOC_URI);
+        final String docUri = getServerUri() + GET_METHOD_ENCODED_COLLECTION_URI.getCollectionPath();
+        final HttpURLConnection connect = getConnection(docUri);
 
-        String data = "<query xmlns=\"http://exist.sourceforge.net/NS/exist\">\n" +
+        final String data = "<query xmlns=\"http://exist.sourceforge.net/NS/exist\">\n" +
                 "    <text>\n" +
                 "        //foo\n" +
                 "    </text>\n" +
@@ -1235,7 +1246,7 @@ try {
             final int r = connect.getResponseCode();
             assertEquals("doPut: Server returned response code " + r, HttpStatus.OK_200, r);
 
-            String response = readResponse(connect.getInputStream());
+            final String response = readResponse(connect.getInputStream());
 
             //readResponse is appending \r\n to each line that's why its added the expected content
             assertTrue("Server returned " + response,response.contains("exist:hits=\"1\""));
@@ -1247,9 +1258,9 @@ try {
 
     @Test
     public void doDeleteEncodedPath() throws IOException {
-        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml";
-        final HttpURLConnection connect = getConnection(DOC_URI);
-        final HttpURLConnection getConnect = getConnection(DOC_URI);
+        final String docUri = getServerUri() + DELETE_METHOD_ENCODED_DOC_URI.getCollectionPath();
+        final HttpURLConnection connect = getConnection(docUri);
+        final HttpURLConnection getConnect = getConnection(docUri);
 
         try {
             connect.setRequestProperty("Authorization", "Basic " + credentials);

--- a/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
@@ -203,6 +203,12 @@ public class RESTServiceTest {
 
     private static final XmldbURI TEST_XML_DOC_WITH_XSLPI_URI = XmldbURI.create("test-with-xslpi.xml");
 
+    private static final String XML_WITH_XMLDECL =
+            "<?xml version=\"1.1\" encoding=\"ISO-8859-1\" standalone=\"yes\"?>\n" +
+            "<bookmap id=\"bookmap-2\"/>";
+
+    private static final XmldbURI TEST_XMLDECL_COLLECTION_URI = XmldbURI.ROOT_COLLECTION_URI.append("rest-test-xmldecl");
+    private static final XmldbURI TEST_XML_DOC_WITH_XMLDECL_URI = XmldbURI.create("test-with-xmldecl.xml");
 
     private static String credentials;
     private static String badCredentials;
@@ -229,6 +235,10 @@ public class RESTServiceTest {
 
     private static String getResourceWithDocTypeUri() {
         return getServerUri() + TEST_DOCTYPE_COLLECTION_URI.append(TEST_XML_DOC_WITH_DOCTYPE_URI);
+    }
+
+    private static String getResourceWithXmlDeclUri() {
+        return getServerUri() + TEST_XMLDECL_COLLECTION_URI.append(TEST_XML_DOC_WITH_XMLDECL_URI);
     }
 
     /* About path components of URIs:
@@ -316,6 +326,11 @@ public class RESTServiceTest {
             try (final Collection col = broker.getOrCreateCollection(transaction, TEST_XSLPI_COLLECTION_URI)) {
                 broker.storeDocument(transaction, TEST_XSLT_DOC_WITH_XSLPI_URI, new StringInputSource(XSLT_WITH_XSLPI), MimeType.XML_TYPE, col);
                 broker.storeDocument(transaction, TEST_XML_DOC_WITH_XSLPI_URI, new StringInputSource(XML_WITH_XSLPI), MimeType.XML_TYPE, col);
+                broker.saveCollection(transaction, col);
+            }
+
+            try (final Collection col = broker.getOrCreateCollection(transaction, TEST_XMLDECL_COLLECTION_URI)) {
+                broker.storeDocument(transaction, TEST_XML_DOC_WITH_XMLDECL_URI, new StringInputSource(XML_WITH_XMLDECL), MimeType.XML_TYPE, col);
                 broker.saveCollection(transaction, col);
             }
 
@@ -1384,6 +1399,82 @@ try {
         // NOTE(AR) doing this twice revealed an issue with the Serializer not being correctly reset
         getDocWithXslPi();
         getDocWithXslPi();
+    }
+
+    @Test
+    public void getXmlDeclDefault() throws IOException {
+        final HttpURLConnection connect = getConnection(getResourceWithXmlDeclUri());
+        try {
+            connect.setRequestMethod("GET");
+            connect.connect();
+
+            final int r = connect.getResponseCode();
+            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
+            String contentType = connect.getContentType();
+            final int semicolon = contentType.indexOf(';');
+            if (semicolon > 0) {
+                contentType = contentType.substring(0, semicolon).trim();
+            }
+            assertEquals("Server returned content type " + contentType, "application/xml", contentType);
+
+            final String response = readResponse(connect.getInputStream());
+
+            assertEquals("<bookmap id=\"bookmap-2\"/>\r\n", response);
+
+        } finally {
+            connect.disconnect();
+        }
+    }
+
+    @Test
+    public void getXmlDeclNo() throws IOException {
+        final HttpURLConnection connect = getConnection(getResourceWithXmlDeclUri() + "?_omit-xml-declaration=no&_omit-original-xml-declaration=no");
+        try {
+            connect.setRequestMethod("GET");
+            connect.connect();
+
+            final int r = connect.getResponseCode();
+            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
+            String contentType = connect.getContentType();
+            final int semicolon = contentType.indexOf(';');
+            if (semicolon > 0) {
+                contentType = contentType.substring(0, semicolon).trim();
+            }
+            assertEquals("Server returned content type " + contentType, "application/xml", contentType);
+
+            final String response = readResponse(connect.getInputStream());
+
+            assertEquals("<?xml version=\"1.1\" encoding=\"ISO-8859-1\" standalone=\"yes\"?>\r\n" +
+                    "<bookmap id=\"bookmap-2\"/>\r\n", response);
+
+        } finally {
+            connect.disconnect();
+        }
+    }
+
+    @Test
+    public void getXmlDeclYes() throws IOException {
+        final HttpURLConnection connect = getConnection(getResourceWithXmlDeclUri() + "?_omit-xml-declaration=yes&_omit-original-xml-declaration=yes");
+        try {
+            connect.setRequestMethod("GET");
+            connect.connect();
+
+            final int r = connect.getResponseCode();
+            assertEquals("Server returned response code " + r, HttpStatus.OK_200, r);
+            String contentType = connect.getContentType();
+            final int semicolon = contentType.indexOf(';');
+            if (semicolon > 0) {
+                contentType = contentType.substring(0, semicolon).trim();
+            }
+            assertEquals("Server returned content type " + contentType, "application/xml", contentType);
+
+            final String response = readResponse(connect.getInputStream());
+
+            assertEquals("<bookmap id=\"bookmap-2\"/>\r\n", response);
+
+        } finally {
+            connect.disconnect();
+        }
     }
 
     private void chmod(final String resourcePath, final String mode) throws IOException {

--- a/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
+++ b/exist-core/src/test/java/org/exist/http/RESTServiceTest.java
@@ -234,7 +234,7 @@ public class RESTServiceTest {
     }
 
     private static String getResourceWithDocTypeUri() {
-        return getServerUri() + TEST_DOCTYPE_COLLECTION_URI.append(TEST_XML_DOC_WITH_DOCTYPE_URI) + "?_omit-xml-declaration=yes";
+        return getServerUri() + TEST_DOCTYPE_COLLECTION_URI.append(TEST_XML_DOC_WITH_DOCTYPE_URI);
     }
 
     private static String getResourceWithXmlDeclUri() {
@@ -757,7 +757,7 @@ try {
 
         /* execute the stored xquery a few times */
         for (int i = 0; i < 5; i++) {
-            final HttpURLConnection connect = getConnection(getCollectionUri() + "/requestparameter.xql?doc=somedoc" + i + "&_omit-xml-declaration=yes");
+            final HttpURLConnection connect = getConnection(getCollectionUri() + "/requestparameter.xql?doc=somedoc" + i);
             try {
                 connect.setRequestProperty("Authorization", "Basic " + credentials);
                 connect.setRequestMethod("GET");
@@ -831,7 +831,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r-x");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
+        final String uri = getCollectionUri() + "/auth.xq";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
@@ -876,7 +876,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r--");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
+        final String uri = getCollectionUri() + "/auth.xq";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestProperty("Authorization", "Basic " + credentials);
@@ -922,7 +922,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwxrw-r--");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
+        final String uri = getCollectionUri() + "/auth.xq";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestProperty("Authorization", "bAsiC " + credentials);  // NOTE(AR): Intentional use of 'bAsiC' to test case-insensitive scheme matching
@@ -968,7 +968,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwsr--r-x");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
+        final String uri = getCollectionUri() + "/auth.xq";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
@@ -1019,7 +1019,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwsr--r-x");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
+        final String uri = getCollectionUri() + "/auth.xq";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
@@ -1088,7 +1088,7 @@ try {
         chmod(XmldbURI.ROOT_COLLECTION + "/test/auth.xq", "rwsr--r-x");
 
         // call the auth.xq
-        final String uri = getCollectionUri() + "/auth.xq?_omit-xml-declaration=yes";
+        final String uri = getCollectionUri() + "/auth.xq";
         final HttpURLConnection connect = getConnection(uri);
         try {
             connect.setRequestMethod("GET");
@@ -1136,7 +1136,7 @@ try {
     // all the tests with EncodedPath in function declaration aim to test rest server ability to handle special characters
     @Test
     public void doGetEncodedPath() throws IOException {
-        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml?_omit-xml-declaration=yes";
+        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml";
         final HttpURLConnection connect = getConnection(DOC_URI);
         try {
             connect.setRequestMethod("GET");
@@ -1177,7 +1177,7 @@ try {
 
     @Test
     public void doPutEncodedPath() throws IOException {
-        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml?_omit-xml-declaration=yes";
+        String DOC_URI = getServerUri() + XmldbURI.ROOT_COLLECTION + "/AéB/AéB.xml";
         final HttpURLConnection connect = getConnection(DOC_URI);
         final HttpURLConnection getConnect = getConnection(DOC_URI);
         String data = "<foobar/>";
@@ -1305,7 +1305,7 @@ try {
 
     @Test
     public void getDocTypeNo() throws IOException {
-        final HttpURLConnection connect = getConnection(getResourceWithDocTypeUri() + "&_output-doctype=no");
+        final HttpURLConnection connect = getConnection(getResourceWithDocTypeUri() + "?_output-doctype=no");
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -1330,7 +1330,7 @@ try {
 
     @Test
     public void getDocTypeYes() throws IOException {
-        final HttpURLConnection connect = getConnection(getResourceWithDocTypeUri() + "&_output-doctype=yes");
+        final HttpURLConnection connect = getConnection(getResourceWithDocTypeUri() + "?_output-doctype=yes");
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -1429,7 +1429,7 @@ try {
 
     @Test
     public void getXmlDeclNo() throws IOException {
-        final HttpURLConnection connect = getConnection(getResourceWithXmlDeclUri() + "?_omit-xml-declaration=no&_omit-original-xml-declaration=no");
+        final HttpURLConnection connect = getConnection(getResourceWithXmlDeclUri() + "?_omit-original-xml-declaration=no");
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -1455,7 +1455,7 @@ try {
 
     @Test
     public void getXmlDeclYes() throws IOException {
-        final HttpURLConnection connect = getConnection(getResourceWithXmlDeclUri() + "?_omit-xml-declaration=yes&_omit-original-xml-declaration=yes");
+        final HttpURLConnection connect = getConnection(getResourceWithXmlDeclUri() + "?_omit-original-xml-declaration=yes");
         try {
             connect.setRequestMethod("GET");
             connect.connect();
@@ -1516,7 +1516,7 @@ try {
 
     private void doStoredQuery(final boolean cacheHeader, final boolean wrap) throws IOException {
 
-        String uri = getCollectionUri() + "/test.xq?p=Hello&&_omit-xml-declaration=yes";
+        String uri = getCollectionUri() + "/test.xq?p=Hello";
         if(wrap) {
             uri += "&_wrap=yes";
         }

--- a/exist-core/src/test/java/org/exist/util/serializer/HTML5WriterTest.java
+++ b/exist-core/src/test/java/org/exist/util/serializer/HTML5WriterTest.java
@@ -42,7 +42,7 @@ public class HTML5WriterTest {
 
     @Test
     public void testAttributeWithBooleanValue() throws Exception {
-        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<input checked>";
+        final String expected = "<!DOCTYPE html>\n<input checked>";
         final QName elQName = new QName("input");
         writer.startElement(elQName);
         writer.attribute("checked", "checked");
@@ -54,7 +54,7 @@ public class HTML5WriterTest {
 
     @Test
     public void testAttributeWithNonBooleanValue() throws Exception {
-        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<input name=\"name\">";
+        final String expected = "<!DOCTYPE html>\n<input name=\"name\">";
         final QName elQName = new QName("input");
         writer.startElement(elQName);
         writer.attribute("name", "name");
@@ -66,7 +66,7 @@ public class HTML5WriterTest {
 
     @Test
     public void testAttributeQNameWithBooleanValue() throws Exception {
-        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<input checked>";
+        final String expected = "<!DOCTYPE html>\n<input checked>";
         final QName elQName = new QName("input");
         final QName attrQName = new QName("checked");
         writer.startElement(elQName);
@@ -79,7 +79,7 @@ public class HTML5WriterTest {
 
     @Test
     public void testAttributeQNameWithNonBooleanValue() throws Exception {
-        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html>\n<input name=\"name\">";
+        final String expected = "<!DOCTYPE html>\n<input name=\"name\">";
         final QName elQName = new QName("input");
         final QName attrQName = new QName("name");
         writer.startElement(elQName);

--- a/exist-core/src/test/java/org/exist/xmldb/SerializationTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/SerializationTest.java
@@ -58,24 +58,6 @@ public class SerializationTest {
 	public static final ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
 	private static final String PORT_PLACEHOLDER = "${PORT}";
 
-	@Parameterized.Parameters(name = "{0}")
-	public static java.util.Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] {
-				{ "local", "xmldb:exist://" },
-				{ "remote", "xmldb:exist://localhost:" + PORT_PLACEHOLDER + "/xmlrpc" }
-		});
-	}
-
-	@Parameterized.Parameter
-	public String apiName;
-
-	@Parameterized.Parameter(value = 1)
-	public String baseUri;
-
-	private final String getBaseUri() {
-		return baseUri.replace(PORT_PLACEHOLDER, Integer.toString(existWebServer.getPort()));
-	}
-
 	private static final String EOL = System.getProperty("line.separator");
 
 	private static final String TEST_COLLECTION_NAME = "xmlrpc-serialization-test";
@@ -120,7 +102,25 @@ public class SerializationTest {
 			"<?xml version=\"1.1\" encoding=\"ISO-8859-1\" standalone=\"yes\"?>\n" +
 			"<bookmap id=\"bookmap-2\"/>";
 
+	@Parameterized.Parameters(name = "{0}")
+	public static java.util.Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{ "local", "xmldb:exist://" },
+				{ "remote", "xmldb:exist://localhost:" + PORT_PLACEHOLDER + "/xmlrpc" }
+		});
+	}
+
+	@Parameterized.Parameter
+	public String apiName;
+
+	@Parameterized.Parameter(value = 1)
+	public String baseUri;
+
 	private Collection testCollection;
+
+	private final String getBaseUri() {
+		return baseUri.replace(PORT_PLACEHOLDER, Integer.toString(existWebServer.getPort()));
+	}
 
 	@Test
 	public void wrappedNsTest1() throws XMLDBException {

--- a/exist-core/src/test/java/org/exist/xmldb/SerializationTest.java
+++ b/exist-core/src/test/java/org/exist/xmldb/SerializationTest.java
@@ -43,7 +43,6 @@ import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.Diff;
 
-import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 
 import java.util.Arrays;
@@ -177,31 +176,18 @@ public class SerializationTest {
 
 	@Test
 	public void getDocTypeDefault() throws XMLDBException {
-		final String prevOutputOmitXmlDecl = testCollection.getProperty(OutputKeys.OMIT_XML_DECLARATION);
-		try {
-			final Resource res = testCollection.getResource(TEST_XML_DOC_WITH_DOCTYPE_URI.lastSegmentString());
-			testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-			assertEquals(XML_WITH_DOCTYPE, res.getContent());
-		} finally {
-			if (prevOutputOmitXmlDecl != null) {
-				testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, prevOutputOmitXmlDecl);
-			}
-		}
+		final Resource res = testCollection.getResource(TEST_XML_DOC_WITH_DOCTYPE_URI.lastSegmentString());
+		assertEquals(XML_WITH_DOCTYPE, res.getContent());
 	}
 
 	@Test
 	public void getDocTypeNo() throws XMLDBException {
-		final String prevOutputOmitXmlDecl = testCollection.getProperty(OutputKeys.OMIT_XML_DECLARATION);
 		final String prevOutputDocType = testCollection.getProperty(EXistOutputKeys.OUTPUT_DOCTYPE);
 		try {
 			final Resource res = testCollection.getResource(TEST_XML_DOC_WITH_DOCTYPE_URI.lastSegmentString());
-			testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			testCollection.setProperty(EXistOutputKeys.OUTPUT_DOCTYPE, "no");
 			assertEquals("<bookmap id=\"bookmap-1\"/>", res.getContent());
 		} finally {
-			if (prevOutputOmitXmlDecl != null) {
-				testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, prevOutputOmitXmlDecl);
-			}
 			if (prevOutputDocType != null) {
 				testCollection.setProperty(EXistOutputKeys.OUTPUT_DOCTYPE, prevOutputDocType);
 			}
@@ -210,17 +196,12 @@ public class SerializationTest {
 
 	@Test
 	public void getDocTypeYes() throws XMLDBException {
-		final String prevOutputOmitXmlDecl = testCollection.getProperty(OutputKeys.OMIT_XML_DECLARATION);
 		final String prevOutputDocType = testCollection.getProperty(EXistOutputKeys.OUTPUT_DOCTYPE);
 		try {
 			final Resource res = testCollection.getResource(TEST_XML_DOC_WITH_DOCTYPE_URI.lastSegmentString());
-			testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			testCollection.setProperty(EXistOutputKeys.OUTPUT_DOCTYPE, "yes");
 			assertEquals(XML_WITH_DOCTYPE, res.getContent());
 		} finally {
-			if (prevOutputOmitXmlDecl != null) {
-				testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, prevOutputOmitXmlDecl);
-			}
 			if (prevOutputDocType != null) {
 				testCollection.setProperty(EXistOutputKeys.OUTPUT_DOCTYPE, prevOutputDocType);
 			}
@@ -235,17 +216,12 @@ public class SerializationTest {
 
 	@Test
 	public void getXmlDeclNo() throws XMLDBException {
-		final String prevOmitXmlDecl = testCollection.getProperty(OutputKeys.OMIT_XML_DECLARATION);
 		final String prevOmitOriginalXmlDecl = testCollection.getProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION);
 		try {
 			final Resource res = testCollection.getResource(TEST_XML_DOC_WITH_XMLDECL_URI.lastSegmentString());
-			testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
 			testCollection.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "no");
 			assertEquals(XML_WITH_XMLDECL, res.getContent());
 		} finally {
-			if (prevOmitXmlDecl != null) {
-				testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, prevOmitXmlDecl);
-			}
 			if (prevOmitOriginalXmlDecl != null) {
 				testCollection.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, prevOmitOriginalXmlDecl);
 			}
@@ -254,17 +230,12 @@ public class SerializationTest {
 
 	@Test
 	public void getXmlDeclYes() throws XMLDBException {
-		final String prevOmitXmlDecl = testCollection.getProperty(OutputKeys.OMIT_XML_DECLARATION);
 		final String prevOmitOriginalXmlDecl = testCollection.getProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION);
 		try {
 			final Resource res = testCollection.getResource(TEST_XML_DOC_WITH_XMLDECL_URI.lastSegmentString());
-			testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			testCollection.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, "yes");
 			assertEquals("<bookmap id=\"bookmap-2\"/>", res.getContent());
 		} finally {
-			if (prevOmitXmlDecl != null) {
-				testCollection.setProperty(OutputKeys.OMIT_XML_DECLARATION, prevOmitXmlDecl);
-			}
 			if (prevOmitOriginalXmlDecl != null) {
 				testCollection.setProperty(EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION, prevOmitOriginalXmlDecl);
 			}

--- a/exist-core/src/test/java/org/exist/xquery/TransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/TransformTest.java
@@ -61,14 +61,14 @@ public class TransformTest {
             "let $xsl := 'xmldb:exist:///db/"+TEST_COLLECTION_NAME+"/xsl1/1.xsl'\n" +
             "return transform:transform($xml, $xsl, ())";
         String result = execQuery(query);
-        assertEquals(result, "<doc>" +
+        assertEquals("<doc>" +
                 "<p>Start Template 1</p>" +
                 "<p>Start Template 2</p>" +
                 "<p>Template 3</p>" +
                 "<p>End Template 2</p>" +
                 "<p>Template 3</p>" +
                 "<p>End Template 1</p>" +
-                "</doc>");
+                "</doc>", result);
     }
     
     

--- a/exist-distribution/src/main/config/client.properties
+++ b/exist-distribution/src/main/config/client.properties
@@ -51,3 +51,7 @@ highlight-matches=none
 
 ## output the doctype of documents
 output-doctype=yes
+
+## output the XML Declaration of documents, and then preferably the persisted XML Declaration
+omit-xml-declaration=no
+omit-original-xml-declaration=no

--- a/exist-distribution/src/main/config/conf.xml
+++ b/exist-distribution/src/main/config/conf.xml
@@ -787,6 +787,14 @@
            service.setProperty("compress-output", "yes");
            to uncompress the retrieved result in the client too.
 
+        - omit-xml-declaration:
+            should the XML Declaration for a document be serialized
+            if it is present?
+
+        - omit-original-xml-declaration:
+            should the original persisted XML Declaration for a document be serialized
+            if it is present? Requires omit-xml-declaration to also be set tp 'no'.
+
         - output-doctype:
             should the Doctype Declaration for a document be serialized
             if it is present?
@@ -815,8 +823,10 @@
             Set the parameter to "yes" to enable this feature.
 
     -->
-    <serializer add-exist-id="none" compress-output="no" output-doctype="yes" enable-xinclude="yes"
-                enable-xsl="no" indent="yes" match-tagging-attributes="no" 
+    <serializer add-exist-id="none" compress-output="no"
+                omit-xml-declaration="yes" omit-original-xml-declaration="yes"
+                output-doctype="yes" enable-xinclude="yes"
+                enable-xsl="no" indent="yes" match-tagging-attributes="no"
                 match-tagging-elements="no">
         <!--
             You may add as many custom-filters as you want, they will be executed

--- a/exist-distribution/src/main/config/conf.xml
+++ b/exist-distribution/src/main/config/conf.xml
@@ -793,7 +793,7 @@
 
         - omit-original-xml-declaration:
             should the original persisted XML Declaration for a document be serialized
-            if it is present? Requires omit-xml-declaration to also be set tp 'no'.
+            if it is present?
 
         - output-doctype:
             should the Doctype Declaration for a document be serialized
@@ -824,7 +824,7 @@
 
     -->
     <serializer add-exist-id="none" compress-output="no"
-                omit-xml-declaration="no" omit-original-xml-declaration="no"
+                omit-xml-declaration="yes" omit-original-xml-declaration="no"
                 output-doctype="yes" enable-xinclude="yes"
                 enable-xsl="no" indent="yes" match-tagging-attributes="no"
                 match-tagging-elements="no">

--- a/exist-distribution/src/main/config/conf.xml
+++ b/exist-distribution/src/main/config/conf.xml
@@ -824,7 +824,7 @@
 
     -->
     <serializer add-exist-id="none" compress-output="no"
-                omit-xml-declaration="yes" omit-original-xml-declaration="yes"
+                omit-xml-declaration="no" omit-original-xml-declaration="no"
                 output-doctype="yes" enable-xinclude="yes"
                 enable-xsl="no" indent="yes" match-tagging-attributes="no"
                 match-tagging-elements="no">

--- a/exist-distribution/src/main/config/webdav.properties
+++ b/exist-distribution/src/main/config/webdav.properties
@@ -29,3 +29,5 @@
 #encoding=UTF-8
 #omit-xml-declaration=no
 #output-doctype=yes
+#omit-xml-declaration=no
+#omit-original-xml-declaration=no

--- a/exist-distribution/src/main/config/webdav.properties
+++ b/exist-distribution/src/main/config/webdav.properties
@@ -29,5 +29,5 @@
 #encoding=UTF-8
 #omit-xml-declaration=no
 #output-doctype=yes
-#omit-xml-declaration=no
+#omit-xml-declaration=yes
 #omit-original-xml-declaration=no

--- a/extensions/contentextraction/pom.xml
+++ b/extensions/contentextraction/pom.xml
@@ -80,6 +80,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
         </dependency>

--- a/extensions/contentextraction/src/main/java/org/exist/contentextraction/ContentReceiver.java
+++ b/extensions/contentextraction/src/main/java/org/exist/contentextraction/ContentReceiver.java
@@ -40,6 +40,8 @@ import org.exist.xquery.value.ValueSequence;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
+import javax.annotation.Nullable;
+
 /**
  * @author <a href="mailto:dulip.withanage@gmail.com">Dulip Withanage</a>
  * @author <a href="mailto:dannes@exist-db.org">Dannes Wessels</a>
@@ -114,6 +116,10 @@ public class ContentReceiver implements Receiver {
 
     @Override
     public void endDocument() throws SAXException {
+    }
+
+    @Override
+    public void declaration(@Nullable final String version, @Nullable final String encoding, @Nullable final String standalone) throws SAXException {
     }
 
     @Override

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -27,6 +27,6 @@
 #expand-xincludes=no
 #process-xsl-pi=no
 #encoding=UTF-8
-omit-xml-declaration=no
+omit-xml-declaration=yes
 omit-original-xml-declaration=no
 output-doctype=yes

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -27,5 +27,6 @@
 #expand-xincludes=no
 #process-xsl-pi=no
 #encoding=UTF-8
-#omit-xml-declaration=no
+omit-xml-declaration=yes
+omit-original-xml-declaration=yes
 output-doctype=yes

--- a/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
+++ b/extensions/webdav/src/main/resources/org/exist/webdav/webdav.properties
@@ -27,6 +27,6 @@
 #expand-xincludes=no
 #process-xsl-pi=no
 #encoding=UTF-8
-omit-xml-declaration=yes
-omit-original-xml-declaration=yes
+omit-xml-declaration=no
+omit-original-xml-declaration=no
 output-doctype=yes

--- a/extensions/webdav/src/test/java/org/exist/webdav/SerializationTest.java
+++ b/extensions/webdav/src/test/java/org/exist/webdav/SerializationTest.java
@@ -86,26 +86,27 @@ public class SerializationTest {
         final Host host = builder.buildHost();
 
         // workaround pre-emptive auth issues of Milton Client
-        final AbstractHttpClient httpClient = (AbstractHttpClient)host.getClient();
-        httpClient.addRequestInterceptor(new AlwaysBasicPreAuth(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD));
+        try (final AbstractHttpClient httpClient = (AbstractHttpClient)host.getClient()) {
+            httpClient.addRequestInterceptor(new AlwaysBasicPreAuth(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD));
 
-        final Folder folder = host.getFolder("/");
-        assertNotNull(folder);
+            final Folder folder = host.getFolder("/");
+            assertNotNull(folder);
 
-        // store document
-        final byte data[] = XML_WITH_DOCTYPE.getBytes(UTF_8);
-        final java.io.File tmpStoreFile = TEMP_FOLDER.newFile();
-        Files.write(tmpStoreFile.toPath(), data);
-        assertNotNull(folder.uploadFile(docName, tmpStoreFile, null));
+            // store document
+            final byte data[] = XML_WITH_DOCTYPE.getBytes(UTF_8);
+            final java.io.File tmpStoreFile = TEMP_FOLDER.newFile();
+            Files.write(tmpStoreFile.toPath(), data);
+            assertNotNull(folder.uploadFile(docName, tmpStoreFile, null));
 
-        // retrieve document
-        final Resource resource = folder.child(docName);
-        assertNotNull(resource);
-        assertTrue(resource instanceof File);
-        assertEquals("application/xml", ((File) resource).contentType);
-        final java.io.File tempRetrieveFile = TEMP_FOLDER.newFile();
-        resource.downloadTo(tempRetrieveFile, null);
-        assertEquals(XML_WITH_DOCTYPE, new String(Files.readAllBytes(tempRetrieveFile.toPath()), UTF_8));
+            // retrieve document
+            final Resource resource = folder.child(docName);
+            assertNotNull(resource);
+            assertTrue(resource instanceof File);
+            assertEquals("application/xml", ((File) resource).contentType);
+            final java.io.File tempRetrieveFile = TEMP_FOLDER.newFile();
+            resource.downloadTo(tempRetrieveFile, null);
+            assertEquals("<?xml version=\"1.1\" encoding=\"ISO-8859-1\" standalone=\"yes\"?>\n" + XML_WITH_DOCTYPE, new String(Files.readAllBytes(tempRetrieveFile.toPath()), UTF_8));
+        }
     }
 
     @Test
@@ -119,25 +120,26 @@ public class SerializationTest {
         final Host host = builder.buildHost();
 
         // workaround pre-emptive auth issues of Milton Client
-        final AbstractHttpClient httpClient = (AbstractHttpClient)host.getClient();
-        httpClient.addRequestInterceptor(new AlwaysBasicPreAuth(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD));
+        try (final AbstractHttpClient httpClient = (AbstractHttpClient)host.getClient()) {
+            httpClient.addRequestInterceptor(new AlwaysBasicPreAuth(TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD));
 
-        final Folder folder = host.getFolder("/");
-        assertNotNull(folder);
+            final Folder folder = host.getFolder("/");
+            assertNotNull(folder);
 
-        // store document
-        final byte data[] = XML_WITH_XMLDECL.getBytes(UTF_8);
-        final java.io.File tmpStoreFile = TEMP_FOLDER.newFile();
-        Files.write(tmpStoreFile.toPath(), data);
-        assertNotNull(folder.uploadFile(docName, tmpStoreFile, null));
+            // store document
+            final byte data[] = XML_WITH_XMLDECL.getBytes(UTF_8);
+            final java.io.File tmpStoreFile = TEMP_FOLDER.newFile();
+            Files.write(tmpStoreFile.toPath(), data);
+            assertNotNull(folder.uploadFile(docName, tmpStoreFile, null));
 
-        // retrieve document
-        final Resource resource = folder.child(docName);
-        assertNotNull(resource);
-        assertTrue(resource instanceof File);
-        assertEquals("application/xml", ((File) resource).contentType);
-        final java.io.File tempRetrieveFile = TEMP_FOLDER.newFile();
-        resource.downloadTo(tempRetrieveFile, null);
-        assertEquals("<bookmap id=\"bookmap-2\"/>", new String(Files.readAllBytes(tempRetrieveFile.toPath()), UTF_8));
+            // retrieve document
+            final Resource resource = folder.child(docName);
+            assertNotNull(resource);
+            assertTrue(resource instanceof File);
+            assertEquals("application/xml", ((File) resource).contentType);
+            final java.io.File tempRetrieveFile = TEMP_FOLDER.newFile();
+            resource.downloadTo(tempRetrieveFile, null);
+            assertEquals(XML_WITH_XMLDECL, new String(Files.readAllBytes(tempRetrieveFile.toPath()), UTF_8));
+        }
     }
 }

--- a/extensions/webdav/src/test/java/org/exist/webdav/SerializationTest.java
+++ b/extensions/webdav/src/test/java/org/exist/webdav/SerializationTest.java
@@ -105,7 +105,7 @@ public class SerializationTest {
             assertEquals("application/xml", ((File) resource).contentType);
             final java.io.File tempRetrieveFile = TEMP_FOLDER.newFile();
             resource.downloadTo(tempRetrieveFile, null);
-            assertEquals("<?xml version=\"1.1\" encoding=\"ISO-8859-1\" standalone=\"yes\"?>\n" + XML_WITH_DOCTYPE, new String(Files.readAllBytes(tempRetrieveFile.toPath()), UTF_8));
+            assertEquals(XML_WITH_DOCTYPE, new String(Files.readAllBytes(tempRetrieveFile.toPath()), UTF_8));
         }
     }
 

--- a/schema/conf.xsd
+++ b/schema/conf.xsd
@@ -302,6 +302,8 @@
                             </xs:simpleType>
                         </xs:attribute>
                         <xs:attribute name="compress-output" type="yes_no" default="no"/>
+                        <xs:attribute name="omit-xml-declaration" type="yes_no" default="yes"/>
+                        <xs:attribute name="omit-original-xml-declaration" type="yes_no" default="yes"/>
                         <xs:attribute name="output-doctype" type="yes_no" default="yes"/>
                         <xs:attribute name="enable-xinclude" type="yes_no" default="yes"/>
                         <xs:attribute name="enable-xsl" type="yes_no" default="no"/>

--- a/schema/conf.xsd
+++ b/schema/conf.xsd
@@ -302,8 +302,8 @@
                             </xs:simpleType>
                         </xs:attribute>
                         <xs:attribute name="compress-output" type="yes_no" default="no"/>
-                        <xs:attribute name="omit-xml-declaration" type="yes_no" default="yes"/>
-                        <xs:attribute name="omit-original-xml-declaration" type="yes_no" default="yes"/>
+                        <xs:attribute name="omit-xml-declaration" type="yes_no" default="no"/>
+                        <xs:attribute name="omit-original-xml-declaration" type="yes_no" default="no"/>
                         <xs:attribute name="output-doctype" type="yes_no" default="yes"/>
                         <xs:attribute name="enable-xinclude" type="yes_no" default="yes"/>
                         <xs:attribute name="enable-xsl" type="yes_no" default="no"/>

--- a/schema/conf.xsd
+++ b/schema/conf.xsd
@@ -302,7 +302,7 @@
                             </xs:simpleType>
                         </xs:attribute>
                         <xs:attribute name="compress-output" type="yes_no" default="no"/>
-                        <xs:attribute name="omit-xml-declaration" type="yes_no" default="no"/>
+                        <xs:attribute name="omit-xml-declaration" type="yes_no" default="yes"/>
                         <xs:attribute name="omit-original-xml-declaration" type="yes_no" default="no"/>
                         <xs:attribute name="output-doctype" type="yes_no" default="yes"/>
                         <xs:attribute name="enable-xinclude" type="yes_no" default="yes"/>


### PR DESCRIPTION
Requires Java 17 support to be merged first - https://github.com/eXist-db/exist/pull/4574 (and so at this time it contains all commits of that PR also).

This Pull Request causes an XML Declaration to be preserved if it is present. This means that it will be stored into the database if a document that is stored has an XML Declaration, and it will be retrieved at serialisation time.

This has been implemented and tested for the following APIs:
* HTTP RESTServer
* XML-RPC
* XML:DB Local and Remote
* WebDAV

As part of the document, the XML Declaration is now visible and modifiable from:
* eXist-db Java Admin Client
* Oxygen XML Editor
* eXide

This change necessitates changing the on-disk storage format of the `collections.dbx`, and so increments the file version (which is checked at startup).

* This required me to also release new versions of Apache Xerces 2 which supports the extended SAX API of Java 14+ - https://repo1.maven.org/maven2/org/exist-db/thirdparty/xerces/xercesImpl/2.12.2/ (see: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8230814)