### PR TITLE
remove exist-serialize option

### DIFF
--- a/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
+++ b/exist-core/src/main/java/org/exist/storage/serializers/Serializer.java
@@ -469,25 +469,9 @@ public abstract class Serializer implements XMLReader {
                 throw new SAXException(e.getMessage(), e);
             }
         }
-		if (templates != null)
-			{applyXSLHandler(writer);}
-		else {
-			//looking for serializer properties in <?exist-serialize?> 
-	    	final NodeList children = doc.getChildNodes();
-	    	for (int i = 0; i < children.getLength(); i++) {
-	    		final StoredNode node = (StoredNode) children.item(i);
-	    		if (node.getNodeType() == Node.PROCESSING_INSTRUCTION_NODE 
-	    				&& "exist-serialize".equals(node.getNodeName())) {
-
-	                final String params[] = ((ProcessingInstructionImpl)node).getData().split(" ");
-	                for(final String param : params) {
-	                    final String opt[] = Option.parseKeyValuePair(param);
-	                    if (opt != null)
-	                    	{outputProperties.setProperty(opt[0], opt[1]);}
-	                }
-	    		}
-	    	}
-
+		if (templates != null) {
+			applyXSLHandler(writer);
+		} else {
 			setPrettyPrinter(writer, "no".equals(outputProperties.getProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")),
                     null, true); //setPrettyPrinter(writer, false);
 		}


### PR DESCRIPTION
Closes https://github.com/eXist-db/documentation/issues/265 and Closes https://github.com/eXist-db/exist/issues/3233
this feature was added in https://github.com/eXist-db/exist/commit/0cda7b6387aa4fb8ff82e6bb14a4de81bb210f74 and it was both `undocumented` and `untested` when trying to provide documentation for it we tried testing it, it didn't work as intended.
this feature is better removed as it doesn't work.