### PR TITLE
add lowercase-expended-terms option documentation 

### DIFF
--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -88,6 +88,7 @@ public class Query extends Function implements Optimizable {
                         "   <phrase-slop>number</phrase-slop>\n" +
                         "   <leading-wildcard>yes|no</leading-wildcard>\n" +
                         "   <filter-rewrite>yes|no</filter-rewrite>\n" +
+                        "   <lowercase-expanded-terms>yes|no</lowercase-expanded-terms>\n" +
                         "</options>")
             },
             new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,


### PR DESCRIPTION
Linked to https://github.com/eXist-db/documentation/pull/837
this adds `lowercase-expended-terms` docs in function docs