### PR TITLE
[hotfix] multipart body contents in XQuery

### DIFF
--- a/exist-core/src/main/java/org/exist/http/servlets/HttpRequestWrapper.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/HttpRequestWrapper.java
@@ -188,6 +188,9 @@ public class HttpRequestWrapper implements RequestWrapper {
         // Create a factory for disk-based file items
         final DiskFileItemFactory factory = new DiskFileItemFactory();
 
+        // Ensure small attachments are readable in XQuery context
+        factory.setSizeThreshold(0);
+
         // Create a new file upload handler
         final ServletFileUpload upload = new ServletFileUpload(factory);
 


### PR DESCRIPTION
This reverts commit c22ffe0ce3daf7034ec9069d86da8b42ae366b74.

It turns out that payloads in body encoded as  multipart/form-data have to be written to disk in order to be available in XQuery context. This is the reason the DiskFileItemFactory threshhold has to be zero.

Apparently, there are no tests covering this case. It was only revealed through testing Roaster against current develop.