### PR TITLE
Fix empty array constructor

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayConstructor.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayConstructor.java
@@ -74,7 +74,7 @@ public class ArrayConstructor extends AbstractExpression {
                 }
                 return new ArrayType(this, context, items);
             default:
-                final Sequence result = arguments.get(0).eval(contextSequence, contextItem);
+                final Sequence result =  arguments.isEmpty() ? Sequence.EMPTY_SEQUENCE : arguments.get(0).eval(contextSequence, contextItem);
                 return new ArrayType(this, context, result);
         }
     }

--- a/exist-core/src/test/xquery/arrays/arrays.xql
+++ b/exist-core/src/test/xquery/arrays/arrays.xql
@@ -236,6 +236,13 @@ function arr:curly-constructor2($pos as xs:int) {
 };
 
 declare
+    %test:assertEmpty
+function arr:curly-constructor3() {
+    let $a := array {}
+    return $a?*
+};
+
+declare
     %test:assertTrue
 function arr:deep-equal1() {
     deep-equal([1, <node/>, "a", ["b", "c"]], [1, <node/>, "a", ["b", "c"]])


### PR DESCRIPTION
Fixes #3472
 the expression `array {}` was returning `Index 0 out of bounds for length 0`
 now with this fix it returns `[]` as it should
 
 
This open source contribution to the [exist](https://github.com/eXist-db/exist) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.