### PR TITLE
Fix mail:send-email via Java API in Docker

### DIFF
--- a/exist-docker/pom.xml
+++ b/exist-docker/pom.xml
@@ -186,7 +186,13 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
                                     <addHeader>false</addHeader>
-                                </transformer>&gt;
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/mailcap</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/mailcap.default</resource>
+                                </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
                         </configuration>


### PR DESCRIPTION
Concatenate the mailcap files from bcmail and jakarta.mail together when shading the Uber Jar for Docker, previously one would overwrite the other.

Closes https://github.com/eXist-db/exist/issues/4600
