### PR TITLE
[4.x.x] Prevent OutOfMemory on JDK 17 when loading EXPath Modules

### DIFF
--- a/exist-core/src/main/java/org/exist/repo/ExistRepository.java
+++ b/exist-core/src/main/java/org/exist/repo/ExistRepository.java
@@ -10,9 +10,7 @@
 package org.exist.repo;
 
 import java.io.IOException;
-import java.lang.invoke.LambdaMetafactory;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -20,8 +18,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 
@@ -44,8 +40,6 @@ import org.expath.pkg.repo.PackageException;
 import org.expath.pkg.repo.Repository;
 import org.expath.pkg.repo.URISpace;
 
-import static java.lang.invoke.MethodType.methodType;
-
 /**
  * A repository as viewed by eXist.
  *
@@ -57,7 +51,6 @@ import static java.lang.invoke.MethodType.methodType;
 public class ExistRepository extends Observable implements BrokerPoolService {
 
     private final static Logger LOG = LogManager.getLogger(ExistRepository.class);
-    private final static MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
     public final static String EXPATH_REPO_DIR = "expathrepo";
     public final static String EXPATH_REPO_DEFAULT = "webapp/WEB-INF/" + EXPATH_REPO_DIR;
 
@@ -153,25 +146,13 @@ public class ExistRepository extends Observable implements BrokerPoolService {
         try {
             try {
                 // attempt for a constructor that takes 1 argument
-                final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, methodType(void.class, Map.class));
-                final Function<Map, Module> ctor = (Function<Map, Module>)
-                        LambdaMetafactory.metafactory(
-                                LOOKUP, "apply", methodType(Function.class),
-                                methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
-                return ctor.apply(Collections.emptyMap());
+                final Constructor<Module> cstr1 = clazz.getConstructor(Map.class);
+                return cstr1.newInstance(Collections.emptyMap());
 
             } catch (final NoSuchMethodException nsme) {
                 // attempt for a constructor that takes 0 arguments
-                final MethodHandle methodHandle = LOOKUP.findConstructor(clazz, methodType(void.class, Map.class));
-                final Supplier<Module> ctor = (Supplier<Module>)
-                        LambdaMetafactory.metafactory(
-                                LOOKUP, "apply", methodType(Supplier.class),
-                                methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
-                return ctor.get();
+                return clazz.newInstance();
             }
-        } catch (final NoSuchMethodException nsme) {
-            throw new XPathException("Cannot find suitable constructor " +
-                "for module from EXPath repository: " + clazz.getName(), nsme);
         } catch (final Throwable e) {
             if (e instanceof InterruptedException) {
                 // NOTE: must set interrupted flag
@@ -179,7 +160,7 @@ public class ExistRepository extends Observable implements BrokerPoolService {
             }
 
             throw new XPathException("Unable to instantiate module from EXPath" +
-                    "repository: " + clazz.getName());
+                    "repository: " + clazz.getName(), e);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -21,9 +21,7 @@ package org.exist.xquery;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.lang.invoke.LambdaMetafactory;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -93,7 +91,7 @@ import org.exist.xquery.util.SerializerUtils;
 import org.exist.xquery.value.*;
 import org.w3c.dom.Node;
 
-import static java.lang.invoke.MethodType.methodType;
+import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE;
 import static javax.xml.XMLConstants.XML_NS_PREFIX;
 import static org.exist.Namespaces.XML_NS;
@@ -1472,13 +1470,15 @@ public class XQueryContext implements BinaryValueManager, Context {
                                      final Map<String, Map<String, List<? extends Object>>> moduleParameters) {
         Module module = null;
         try {
-            final MethodHandles.Lookup lookup = MethodHandles.lookup();
-            final MethodHandle methodHandle = lookup.findConstructor(mClazz, methodType(void.class, Map.class));
-            final java.util.function.Function<Map, Module> ctor = (java.util.function.Function<Map, Module>)
-                    LambdaMetafactory.metafactory(
-                            lookup, "apply", methodType(java.util.function.Function.class),
-                            methodHandle.type().erase(), methodHandle, methodHandle.type()).getTarget().invokeExact();
-            module = ctor.apply(moduleParameters.get(namespaceURI));
+            try {
+                // attempt for a constructor that takes 1 argument
+                final Constructor<Module> cstr1 = mClazz.getConstructor(Map.class);
+                module = cstr1.newInstance(moduleParameters.get(namespaceURI));
+
+            } catch (final NoSuchMethodException nsme) {
+                // attempt for a constructor that takes 0 arguments
+                module = mClazz.newInstance();
+            }
 
             if (namespaceURI != null && !module.getNamespaceURI().equals(namespaceURI)) {
                 LOG.warn("the module declares a different namespace URI. Expected: " + namespaceURI + " found: " + module.getNamespaceURI());


### PR DESCRIPTION
We use 4.x.x with custom `org/exist/xquery/Function`s. 
This works fine on JDK 11. 
As soon as we use JDK 17, we get OutOfMemory in the Non-heap region (Lambdas from `org/exist/xquery/Function`).
6 does not show the problem.

If we pick the commit: 

4ec61b0af9d5cec91ebcfe7c3a79bef9d1155555 
([bugfix] EXPath Repo classes must be instantiable via reflection, however LamdaMetafactory cannot cross classloader boundaries. As only EXPath Repo classes are now loaded by the EXistClassLoader everything else is loaded by a URLClassLoader (via AppAssemblerBooter), we have to use reflection instead of invokeDynamic to load EXPath Jar Modules) 

from develop, the OutOfMemory goes away.


Forensics done together with @reinhapa.