### PR TITLE
[5.x.x] Jetty dtd references must now use https instead of http

### DIFF
--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-annotations.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-annotations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
     <!-- =========================================================== -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-bytebufferpool.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-bytebufferpool.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 <Configure>
   <New id="byteBufferPool" class="org.eclipse.jetty.io.ArrayByteBufferPool">
     <Arg type="int"><Property name="jetty.byteBufferPool.minCapacity" default="0"/></Arg>

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-deploy.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-deploy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Create the deployment manager                                   -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-gzip.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-gzip.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Mixin the GZIP Handler                                          -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-http.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-https.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-https.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure an HTTPS connector.                                  -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-jaas.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-jaas.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-jmx.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-jmx.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
 

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-logging.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-logging.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure stderr and stdout to a Jetty rollover log file        -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-requestlog.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-requestlog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Configure the Jetty Request Log                                 -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl-context.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- SSL ContextFactory configuration                              -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Base SSL configuration                                        -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-threadpool.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty-threadpool.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<?xml version="1.0"?><!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure>
   <!-- =========================================================== -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Documentation of this file format can be found at:              -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-deploy.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-deploy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Create the deployment manager                                   -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-http.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Configure the Jetty Server instance with an ID "Server"       -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-ssl.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty-ssl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- ============================================================= -->
 <!-- Base SSL configuration                                        -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-jetty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <!-- =============================================================== -->
 <!-- Documentation of this file format can be found at:              -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-webapps/exist-webapp-context.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/standalone-webapps/exist-webapp-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure id="exist-webapp-context" class="org.exist.jetty.WebAppContext">
     <!-- contextPath can be set to either '/exist' or '/' -->

--- a/exist-jetty-config/src/main/resources/org/exist/jetty/etc/webapps/exist-webapp-context.xml
+++ b/exist-jetty-config/src/main/resources/org/exist/jetty/etc/webapps/exist-webapp-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://www.eclipse.org/jetty/configure_9_3.dtd">
 
 <Configure id="exist-webapp-context" class="org.exist.jetty.WebAppContext">
     <!-- contextPath can be set to either '/exist' or '/' -->


### PR DESCRIPTION
Backport of #4616
