### PR TITLE
allow all options in map:merge#2

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/map/AbstractMapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/AbstractMapType.java
@@ -31,6 +31,7 @@ import org.exist.xquery.value.*;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.function.BinaryOperator;
 
 /**
  * Abstract base class for map types. A map item is also a function item. This class thus extends
@@ -70,11 +71,11 @@ public abstract class AbstractMapType extends FunctionReference
 
     protected XQueryContext context;
 
-    protected AbstractMapType(XQueryContext context) {
+    protected AbstractMapType(final XQueryContext context) {
         this(null, context);
     }
 
-    protected AbstractMapType(final Expression expression, XQueryContext context) {
+    protected AbstractMapType(final Expression expression, final XQueryContext context) {
         super(expression, null);
         this.context = context;
     }
@@ -85,12 +86,15 @@ public abstract class AbstractMapType extends FunctionReference
 
     public abstract AbstractMapType merge(Iterable<AbstractMapType> others);
 
+    public abstract AbstractMapType merge(Iterable<AbstractMapType> others, BinaryOperator<Sequence> mergeFn);
+
     public abstract boolean contains(AtomicValue key);
 
     public abstract Sequence keys();
 
     public abstract AbstractMapType remove(AtomicValue[] keysAtomicValues) throws XPathException;
 
+    @SuppressWarnings("unused")
     public abstract int getKeyType();
 
     public abstract int size();
@@ -106,12 +110,12 @@ public abstract class AbstractMapType extends FunctionReference
     }
 
     @Override
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         getAccessorFunc().analyze(contextInfo);
     }
 
     @Override
-    public Sequence eval(Sequence contextSequence) throws XPathException {
+    public Sequence eval(final Sequence contextSequence) throws XPathException {
         return getAccessorFunc().eval(contextSequence);
     }
 
@@ -127,12 +131,12 @@ public abstract class AbstractMapType extends FunctionReference
     }
 
     @Override
-    public void setArguments(List<Expression> arguments) throws XPathException {
+    public void setArguments(final List<Expression> arguments) throws XPathException {
         getAccessorFunc().setArguments(arguments);
     }
 
     @Override
-    public void resetState(boolean postOptimization) {
+    public void resetState(final boolean postOptimization) {
         getAccessorFunc().resetState(postOptimization);
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapFunction.java
@@ -250,8 +250,10 @@ public class MapFunction extends BasicFunction {
 
         final MergeDuplicates mergeDuplicates;
         if (args.length == 2) {
-            final Sequence mapValue = ((MapType) args[1]).get(new StringValue(this, "duplicates"));
-            if (mapValue != null) {
+            final MapType map = (MapType) args[1];
+            final StringValue key = new StringValue(this, "duplicates");
+            if (map.contains(key)) {
+                final Sequence mapValue = map.get(key);
                 mergeDuplicates = MergeDuplicates.fromDuplicatesValue(mapValue.getStringValue());
                 if (mergeDuplicates == null) {
                     throw new XPathException(this, ErrorCodes.FOJS0005, "value for duplicates key was not recognised: " + mapValue.getStringValue());

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/SingleKeyMapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/SingleKeyMapType.java
@@ -82,8 +82,9 @@ public class SingleKeyMapType extends AbstractMapType {
 
     @Override
     public AbstractMapType merge(final Iterable<AbstractMapType> others, final BinaryOperator<Sequence> mergeFn) {
-        final MapType map = new MapType(context, collator, key, value);
-        return map.merge(others, mergeFn);
+        try (final MapType map = new MapType(context, collator, key, value)) {
+            return map.merge(others, mergeFn);
+        }
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/SingleKeyMapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/SingleKeyMapType.java
@@ -33,6 +33,7 @@ import org.exist.xquery.value.Sequence;
 
 import javax.annotation.Nullable;
 import java.util.Iterator;
+import java.util.function.BinaryOperator;
 
 import static org.exist.xquery.functions.map.MapType.newLinearMap;
 
@@ -44,9 +45,9 @@ import static org.exist.xquery.functions.map.MapType.newLinearMap;
  */
 public class SingleKeyMapType extends AbstractMapType {
 
-    private AtomicValue key;
-    private Sequence value;
-    private @Nullable Collator collator;
+    private final AtomicValue key;
+    private final Sequence value;
+    private final @Nullable Collator collator;
 
     public SingleKeyMapType(final XQueryContext context, final @Nullable Collator collator, final AtomicValue key, final Sequence value) {
         this(null, context, collator, key, value);
@@ -77,6 +78,12 @@ public class SingleKeyMapType extends AbstractMapType {
         try (final MapType map = new MapType(getExpression(), context, collator, key, value)) {
             return map.merge(others);
         }
+    }
+
+    @Override
+    public AbstractMapType merge(final Iterable<AbstractMapType> others, final BinaryOperator<Sequence> mergeFn) {
+        final MapType map = new MapType(context, collator, key, value);
+        return map.merge(others, mergeFn);
     }
 
     @Override

--- a/exist-core/src/test/xquery/maps/maps.xqm
+++ b/exist-core/src/test/xquery/maps/maps.xqm
@@ -976,3 +976,16 @@ function mt:immutable-merge-duplicates-then-merge() {
             $expected ne $result($mt:test-key-one)
         )
 };
+
+(:~
+ : ensure that empty options map is allowed and behaves like
+ : map:merge#1
+ :)
+declare
+    %test:assertTrue
+function mt:map-merge-2-empty-options-map() {
+    let $maps := (mt:getMapFixture(), map { "Su": "Sunnuntai" })
+    let $expected := map:merge($maps)
+    let $actual := map:merge($maps, map {})
+    return $expected?Su eq $actual?Su
+};

--- a/exist-core/src/test/xquery/maps/maps.xqm
+++ b/exist-core/src/test/xquery/maps/maps.xqm
@@ -251,6 +251,78 @@ function mt:merge-duplicate-keys-use-last-explicit-2() {
 };
 
 declare
+    %test:assertError("err:FOJS0003")
+function mt:merge-duplicate-keys-reject-has-duplicates() {
+    let $specialWeek := map:merge((map { 7 : "Caturday" }, $mt:integerKeys), map { "duplicates": "reject" })
+    return
+        ($specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Saturday", "Saturday", "Caturday")
+function mt:merge-duplicate-keys-reject-no-duplicates() {
+    let $specialWeek := map:merge((map { 8 : "Caturday" }, $mt:integerKeys), map { "duplicates": "reject" })
+    return
+        ($mt:integerKeys(7), $specialWeek(7), $specialWeek(8))
+};
+
+declare
+    %test:assertEquals("Caturday","Maturday","Saturday")
+function mt:merge-duplicate-keys-combine-has-duplicates-sequence() {
+    let $specialWeek := map:merge((map { 7 : ("Caturday","Maturday") }, $mt:integerKeys), map { "duplicates": "combine" })
+    return
+        ($specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Saturday","Caturday","Maturday")
+function mt:merge-duplicate-keys-combine-has-duplicates-sequence-order() {
+    let $specialWeek := map:merge(($mt:integerKeys, map { 7 : ("Caturday","Maturday") }), map { "duplicates": "combine" })
+    return
+        ($specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Saturday","Caturday","Maturday", "Caturday", "Zaturday")
+function mt:merge-duplicate-keys-combine-3-has-duplicates-sequence-order() {
+    let $specialWeek := map:merge(($mt:integerKeys, map { 7 : ("Caturday","Maturday") }, map { 7 : ("Caturday","Zaturday") }), map { "duplicates": "combine" })
+    return
+        ($specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Caturday","Saturday")
+function mt:merge-duplicate-keys-combine-has-duplicates-atomic() {
+    let $specialWeek := map:merge((map { 7 : ("Caturday") }, $mt:integerKeys), map { "duplicates": "combine" })
+    return
+        ($specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Caturday","Saturday", "Maturday")
+function mt:merge-duplicate-keys-combine-has-duplicates-three() {
+    let $specialWeek := map:merge((map { 7 : ("Caturday") }, $mt:integerKeys, map { 7: ("Maturday")}), map { "duplicates": "combine" })
+    return
+        ($specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Saturday", "Caturday", "Maturday", "Waturday")
+function mt:merge-duplicate-keys-combine-has-duplicates-four() {
+    let $specialWeek := map:merge((map { 7 : () }, $mt:integerKeys, map { 7: ("Caturday", "Maturday", "Waturday")}), map { "duplicates": "combine" })
+    return
+        ($specialWeek(7))
+};
+
+declare
+    %test:assertEquals("Caturday","Saturday")
+function mt:merge-duplicate-keys-combine-has-duplicates-empty-third() {
+    let $specialWeek := map:merge((map { 7 : ("Caturday") }, $mt:integerKeys, map { 7: ()}), map { "duplicates": "combine" })
+    return
+        ($specialWeek(7))
+};
+
+declare
     %test:assertEmpty
 function mt:mapEmptyValue() {
     let $map := $mt:mapOfSequences


### PR DESCRIPTION
- support options `map{ "duplicates": "combine" }` and `map{ "duplicates": "reject" }`
  Cherry-picked 3 commits from #3738 and squashed them 
  These enhancements are non-breaking and can be merged in to develop before the next major release. 
- allow an empty options map passed to map:merge#2 - fixes #4620 