### PR TITLE
Fix Memory leaks caused by XQuery context and update listener leaks

### DIFF
--- a/exist-core/src/main/java/org/exist/collections/triggers/XQueryTrigger.java
+++ b/exist-core/src/main/java/org/exist/collections/triggers/XQueryTrigger.java
@@ -257,6 +257,8 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
         } catch (final XPathException | PermissionDeniedException e) {
 			TriggerStatePerThread.clear();
         	throw new TriggerException(PREPARE_EXCEPTION_MESSAGE, e);
+        } finally {
+        	context.runCleanupTasks();
         }
     }
     
@@ -299,6 +301,8 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
         } catch (final PermissionDeniedException e) {
         	//Should never be reached
         	LOG.error(e);
+        } finally {
+        	context.runCleanupTasks();
         }
 
 		TriggerStatePerThread.clearIfFinished(TriggerPhase.AFTER);
@@ -455,6 +459,7 @@ public class XQueryTrigger extends SAXTrigger implements DocumentTrigger, Collec
         	throw new TriggerException(PREPARE_EXCEPTION_MESSAGE, e);
         } finally {
     		compiledQuery.reset();
+        	context.runCleanupTasks();
         }
 
 		TriggerStatePerThread.clearIfFinished(phase);

--- a/exist-core/src/main/java/org/exist/dom/persistent/SortedNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/SortedNodeSet.java
@@ -288,6 +288,9 @@ public class SortedNodeSet extends AbstractNodeSet {
                 value = buf.toString();
             } catch(final XPathException e) {
                 LOG.warn(e.getMessage(), e); //TODO : throw exception ! -pb
+            } finally {
+                expr.getContext().runCleanupTasks();
+                expr.getContext().reset();
             }
         }
 

--- a/exist-core/src/main/java/org/exist/repo/Deployment.java
+++ b/exist-core/src/main/java/org/exist/repo/Deployment.java
@@ -697,6 +697,8 @@ public class Deployment {
             return xqs.execute(broker, compiled, null);
         } catch (final PermissionDeniedException e) {
             throw new PackageException(e.getMessage(), e);
+        } finally {
+            ctx.runCleanupTasks();
         }
     }
 

--- a/exist-core/src/main/java/org/exist/security/internal/SMEvents.java
+++ b/exist-core/src/main/java/org/exist/security/internal/SMEvents.java
@@ -142,6 +142,7 @@ public class SMEvents implements Configurable {
             		pm.queryCompleted(context.getWatchDog());
             	}
             	compiled.reset();
+				context.runCleanupTasks();
         		context.reset();
             }
             

--- a/exist-core/src/main/java/org/exist/storage/NotificationService.java
+++ b/exist-core/src/main/java/org/exist/storage/NotificationService.java
@@ -77,8 +77,8 @@ public class NotificationService implements BrokerPoolService {
      * Notify all subscribers that a document has been updated/removed or
      * a new document has been added.
      *
-     * @param document subscribers are listining to
-     * @param event that triggers the notify
+     * @param document subscribers are listening to
+     * @param event the event that triggers the notification
      */
     public synchronized void notifyUpdate(final DocumentImpl document, final int event) {
         listeners.keySet().forEach(listener -> listener.documentUpdated(document, event));

--- a/exist-core/src/main/java/org/exist/storage/NotificationService.java
+++ b/exist-core/src/main/java/org/exist/storage/NotificationService.java
@@ -100,4 +100,12 @@ public class NotificationService implements BrokerPoolService {
         }
         listeners.keySet().forEach(UpdateListener::debug);
     }
+
+    @Override
+    public void shutdown() {
+        synchronized (this) {
+            LOG.warn("Expected 0 listeners at shutdown, but {} listeners are still registered", listeners.size());
+        }
+        BrokerPoolService.super.shutdown();
+    }
 }

--- a/exist-core/src/main/java/org/exist/test/runner/AbstractTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/AbstractTestRunner.java
@@ -73,8 +73,8 @@ public abstract class AbstractTestRunner extends Runner {
             final XQueryPool queryPool = brokerPool.getXQueryPool();
             CompiledXQuery compiledQuery = queryPool.borrowCompiledXQuery(broker, query);
 
+            XQueryContext context = null;
             try {
-                XQueryContext context;
                 if (compiledQuery == null) {
                     context = new XQueryContext(broker.getBrokerPool());
                 } else {
@@ -112,6 +112,10 @@ public abstract class AbstractTestRunner extends Runner {
                 return xqueryService.execute(broker, compiledQuery, null);
 
             } finally {
+                if (context != null) {
+                    context.runCleanupTasks();
+                }
+
                 queryPool.returnCompiledXQuery(query, compiledQuery);
             }
         }

--- a/exist-core/src/main/java/org/exist/validation/internal/DatabaseResources.java
+++ b/exist-core/src/main/java/org/exist/validation/internal/DatabaseResources.java
@@ -132,10 +132,10 @@ public class DatabaseResources {
         }
 
         Sequence result= null;
+        final XQueryContext context = new XQueryContext(brokerPool);
         try(final DBBroker broker = brokerPool.get(Optional.ofNullable(user))) {
 
             final XQuery xquery = brokerPool.getXQueryService();
-            final XQueryContext context = new XQueryContext(brokerPool);
             
             if(collection!=null){
                 context.declareVariable(COLLECTION, collection);
@@ -160,6 +160,7 @@ public class DatabaseResources {
         } catch (final EXistException | XPathException | IOException | PermissionDeniedException ex) {
             logger.error("Problem executing xquery", ex);
             result= null;
+            context.runCleanupTasks();
             
         }
         return result;

--- a/exist-core/src/main/java/org/exist/xquery/FunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionCall.java
@@ -329,7 +329,7 @@ public class FunctionCall extends Function {
     @Override
     public void resetState(boolean postOptimization) {
         super.resetState(postOptimization);
-        if(expression.needsReset() || postOptimization) {
+        if(expression != null && (expression.needsReset() || postOptimization)) {
             expression.resetState(postOptimization);
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/ModuleContext.java
@@ -485,6 +485,11 @@ public class ModuleContext extends XQueryContext {
     }
 
     @Override
+    public void addImportedContext(final XQueryContext importedContext) {
+        parentContext.addImportedContext(importedContext);
+    }
+
+    @Override
     public void registerUpdateListener(final UpdateListener listener) {
         parentContext.registerUpdateListener(listener);
     }

--- a/exist-core/src/main/java/org/exist/xquery/XQuery.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQuery.java
@@ -481,11 +481,23 @@ public class XQuery {
         final XQueryContext context = new XQueryContext(broker.getBrokerPool());
         final CompiledXQuery compiled = compile(context, expression);
         return execute(broker, compiled, contextSequence);
+        // NOTE(AR) we might consider the below cleanup, but what if a binary value is needed from the result sequence?
+//        try {
+//            return execute(broker, compiled, contextSequence);
+//        } finally {
+//            context.runCleanupTasks();
+//        }
     }
 	
     public Sequence execute(final DBBroker broker, File file, Sequence contextSequence) throws XPathException, IOException, PermissionDeniedException {
         final XQueryContext context = new XQueryContext(broker.getBrokerPool());
         final CompiledXQuery compiled = compile(context, new FileSource(file.toPath(), true));
         return execute(broker, compiled, contextSequence);
+        // NOTE(AR) we might consider the below cleanup, but what if a binary value is needed from the result sequence?
+//        try {
+//            return execute(broker, compiled, contextSequence);
+//        } finally {
+//            context.runCleanupTasks();
+//        }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -34,6 +34,7 @@ import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
@@ -427,6 +428,26 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     // Only used for testing, e.g. {@link org.exist.test.runner.XQueryTestRunner}.
     private Optional<ExistRepository> testRepository = Optional.empty();
+
+    /**
+     * Holds a list of any new XQuery Contexts that
+     * were created by the XQuery (owning this XQuery Context)
+     * dynamically importing, compiling, and/or evaluating modules.
+     *
+     * NOTE(AR) - This is needed to ensure that these "imported contexts" are
+     * also correctly reset and cleaned up when this XQuery is finished.
+     */
+    private Set<XQueryContext> importedContexts = null;
+
+    /**
+     * Holds a list of the {@link #runCleanupTasks(Predicate)} functions
+     * of the {@link #importedContexts}.
+     *
+     * NOTE(AR) - This is needed to ensure that these the user call
+     * {@link #reset()} or {@link #runCleanupTasks(Predicate)}
+     * in any order.
+     */
+    private List<Consumer<Predicate<Object>>> importedContextsCleanupTasksFns = null;
 
     public XQueryContext() {
         this(null, null, null);
@@ -1409,6 +1430,13 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     @Override
     public void reset(final boolean keepGlobals) {
+        if (importedContexts != null) {
+            for (final XQueryContext importedContext : importedContexts) {
+                importedContext.reset(keepGlobals);
+            }
+            importedContexts = null;
+        }
+
         setRealUser(null);
 
         if (this.pushedUserFromHttpSession) {
@@ -2848,6 +2876,25 @@ public class XQueryContext implements BinaryValueManager, Context {
     }
 
     /**
+     * Add a reference to an additional XQuery Context that
+     * was created by the XQuery (owning this XQuery Context)
+     * dynamically importing, compiling, and/or evaluating modules.
+     *
+     * NOTE(AR) - This is needed to ensure that these "imported contexts" are
+     * also correctly reset and cleaned up when this XQuery is finished.
+     *
+     * @param importedContext the dynamically created content for importing a module.
+     */
+    public void addImportedContext(final XQueryContext importedContext) {
+        if (importedContexts == null) {
+            importedContexts = new HashSet<>();
+            importedContextsCleanupTasksFns = new ArrayList<>();
+        }
+        importedContexts.add(importedContext);
+        importedContextsCleanupTasksFns.add(importedContext::runCleanupTasks);
+    }
+
+    /**
      * Save state
      */
     private class SavedState {
@@ -3448,6 +3495,13 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     @Override
     public void runCleanupTasks(final Predicate<Object> predicate) {
+        if (importedContextsCleanupTasksFns != null) {
+            for (final Consumer<Predicate<Object>> importedContextsCleanupTasksFn : importedContextsCleanupTasksFns) {
+                importedContextsCleanupTasksFn.accept(predicate);
+            }
+            importedContextsCleanupTasksFns = null;
+        }
+
         for (final CleanupTask cleanupTask : cleanupTasks) {
             try {
                 cleanupTask.cleanup(this, predicate);

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -3233,8 +3233,8 @@ public class XQueryContext implements BinaryValueManager, Context {
         if (updateListener != null) {
             final DBBroker broker = getBroker();
             broker.getBrokerPool().getNotificationService().unsubscribe(updateListener);
+            updateListener = null;
         }
-        updateListener = null;
     }
 
     @Override
@@ -3461,7 +3461,8 @@ public class XQueryContext implements BinaryValueManager, Context {
         @Override
         public void unsubscribe() {
             List<UpdateListener> prev = listeners.get();
-            while (!listeners.compareAndSet(prev, new CopyOnWriteArrayList<>())) {
+            final List<UpdateListener> next = new CopyOnWriteArrayList<>();
+            while (!listeners.compareAndSet(prev, next)) {
                 prev = listeners.get();
             }
 

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -3443,7 +3443,7 @@ public class XQueryContext implements BinaryValueManager, Context {
          *
          * The AtomicReference enables us to quickly clear the listeners
          * in #unsubscribe() and maintain happens-before integrity whilst
-         * unsubcribing them. The CopyOnWriteArrayList allows
+         * unsubscribing them. The CopyOnWriteArrayList allows
          * us to add listeners whilst iterating over a snapshot
          * of existing iterators in other methods.
          */

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
@@ -69,77 +69,81 @@ public class InspectModule extends BasicFunction {
     public Sequence eval(final Sequence[] args, final Sequence contextSequence) throws XPathException {
 
         final XQueryContext tempContext = new XQueryContext(context.getBroker().getBrokerPool());
-        tempContext.setModuleLoadPath(context.getModuleLoadPath());
-        final Module[] modules;
-        if (isCalledAs(FN_INSPECT_MODULE_NAME)) {
-            modules = tempContext.importModule(null, null, new AnyURIValue[] { (AnyURIValue) args[0].itemAt(0) });
-        } else {
-            modules = tempContext.importModule(args[0].getStringValue(), null, null);
-        }
-
-        if (modules == null || modules.length == 0) {
-            return Sequence.EMPTY_SEQUENCE;
-        }
-
-        // this function only supports working with a singular module for a namespace!
-        final Module module = modules[0];
-
         try {
-            context.pushDocumentContext();
-            final MemTreeBuilder builder = context.getDocumentBuilder();
-            final AttributesImpl attribs = new AttributesImpl();
-            attribs.addAttribute("", "uri", "uri", "CDATA", module.getNamespaceURI());
-            attribs.addAttribute("", "prefix", "prefix", "CDATA", module.getDefaultPrefix());
-            if (module.isInternalModule()) {
-                attribs.addAttribute("", "location", "location", "CDATA", "java:" + module.getClass().getName());
-            } else if (isCalledAs("inspect-module")) {
-                attribs.addAttribute("", "location", "location", "CDATA", args[0].getStringValue());
+            tempContext.setModuleLoadPath(context.getModuleLoadPath());
+            final Module[] modules;
+            if (isCalledAs(FN_INSPECT_MODULE_NAME)) {
+                modules = tempContext.importModule(null, null, new AnyURIValue[]{(AnyURIValue) args[0].itemAt(0)});
+            } else {
+                modules = tempContext.importModule(args[0].getStringValue(), null, null);
             }
-            final int nodeNr = builder.startElement(MODULE_QNAME, attribs);
-            if (!module.isInternalModule()) {
-                XQDocHelper.parse((ExternalModule) module);
+
+            if (modules == null || modules.length == 0) {
+                return Sequence.EMPTY_SEQUENCE;
             }
-            if (module.getDescription() != null) {
-                builder.startElement(InspectFunctionHelper.DESCRIPTION_QNAME, null);
-                builder.characters(module.getDescription());
-                builder.endElement();
-            }
-            if (!module.isInternalModule()) {
-                final ExternalModule externalModule = (ExternalModule) module;
-                if (externalModule.getMetadata() != null) {
-                    for (final Map.Entry<String, String> entry : externalModule.getMetadata().entrySet()) {
-                        builder.startElement(new QName(entry.getKey(), XMLConstants.NULL_NS_URI), null);
-                        builder.characters(entry.getValue());
+
+            // this function only supports working with a singular module for a namespace!
+            final Module module = modules[0];
+
+            try {
+                context.pushDocumentContext();
+                final MemTreeBuilder builder = context.getDocumentBuilder();
+                final AttributesImpl attribs = new AttributesImpl();
+                attribs.addAttribute("", "uri", "uri", "CDATA", module.getNamespaceURI());
+                attribs.addAttribute("", "prefix", "prefix", "CDATA", module.getDefaultPrefix());
+                if (module.isInternalModule()) {
+                    attribs.addAttribute("", "location", "location", "CDATA", "java:" + module.getClass().getName());
+                } else if (isCalledAs("inspect-module")) {
+                    attribs.addAttribute("", "location", "location", "CDATA", args[0].getStringValue());
+                }
+                final int nodeNr = builder.startElement(MODULE_QNAME, attribs);
+                if (!module.isInternalModule()) {
+                    XQDocHelper.parse((ExternalModule) module);
+                }
+                if (module.getDescription() != null) {
+                    builder.startElement(InspectFunctionHelper.DESCRIPTION_QNAME, null);
+                    builder.characters(module.getDescription());
+                    builder.endElement();
+                }
+                if (!module.isInternalModule()) {
+                    final ExternalModule externalModule = (ExternalModule) module;
+                    if (externalModule.getMetadata() != null) {
+                        for (final Map.Entry<String, String> entry : externalModule.getMetadata().entrySet()) {
+                            builder.startElement(new QName(entry.getKey(), XMLConstants.NULL_NS_URI), null);
+                            builder.characters(entry.getValue());
+                            builder.endElement();
+                        }
+                    }
+                    // variables
+                    for (final VariableDeclaration var : externalModule.getVariableDeclarations()) {
+                        attribs.clear();
+                        attribs.addAttribute("", "name", "name", "CDATA", var.getName().toString());
+                        final SequenceType type = var.getSequenceType();
+                        if (type != null) {
+                            attribs.addAttribute("", "type", "type", "CDATA", Type.getTypeName(type.getPrimaryType()));
+                            attribs.addAttribute("", "cardinality", "cardinality", "CDATA", type.getCardinality().getHumanDescription());
+                        }
+                        builder.startElement(VARIABLE_QNAME, attribs);
                         builder.endElement();
                     }
                 }
-                // variables
-                for (final VariableDeclaration var : externalModule.getVariableDeclarations()) {
-                    attribs.clear();
-                    attribs.addAttribute("", "name", "name", "CDATA", var.getName().toString());
-                    final SequenceType type = var.getSequenceType();
-                    if (type != null) {
-                        attribs.addAttribute("", "type", "type", "CDATA", Type.getTypeName(type.getPrimaryType()));
-                        attribs.addAttribute("", "cardinality", "cardinality", "CDATA", type.getCardinality().getHumanDescription());
+                // functions
+                for (final FunctionSignature sig : module.listFunctions()) {
+                    if (!sig.isPrivate()) {
+                        UserDefinedFunction func = null;
+                        if (!module.isInternalModule()) {
+                            func = ((ExternalModule) module).getFunction(sig.getName(), sig.getArgumentCount(), null);
+                        }
+                        InspectFunctionHelper.generateDocs(sig, func, builder);
                     }
-                    builder.startElement(VARIABLE_QNAME, attribs);
-                    builder.endElement();
                 }
+                builder.endElement();
+                return builder.getDocument().getNode(nodeNr);
+            } finally {
+                context.popDocumentContext();
             }
-            // functions
-            for (final FunctionSignature sig : module.listFunctions()) {
-                if (!sig.isPrivate()) {
-                    UserDefinedFunction func = null;
-                    if (!module.isInternalModule()) {
-                        func = ((ExternalModule) module).getFunction(sig.getName(), sig.getArgumentCount(), null);
-                    }
-                    InspectFunctionHelper.generateDocs(sig, func, builder);
-                }
-            }
-            builder.endElement();
-            return builder.getDocument().getNode(nodeNr);
         } finally {
-            context.popDocumentContext();
+            context.addImportedContext(tempContext);
         }
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
@@ -438,7 +438,7 @@ public class Eval extends BasicFunction {
     private void cleanup(final XQueryContext evalContext, final XQueryContext innerContext, final DocumentSet oldDocs,
             final LocalVariable mark, final Item expr, final Sequence resultSequence) {
         if (innerContext != evalContext) {
-            innerContext.reset(true);
+            evalContext.addImportedContext(innerContext);
         }
 
         if (oldDocs != null) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/ModuleInfo.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/ModuleInfo.java
@@ -223,14 +223,19 @@ public class ModuleInfo extends BasicFunction {
 		} else {
 			final ValueSequence resultSeq = new ValueSequence();
             final XQueryContext tempContext = new XQueryContext(context.getBroker().getBrokerPool());
-			for(final Iterator<Module> i = tempContext.getRootModules(); i.hasNext(); ) {
-				final Module module = i.next();
-				resultSeq.add(new StringValue(this, module.getNamespaceURI()));
-			}
-			if (tempContext.getRepository().isPresent()) {
-			    for (final URI uri : tempContext.getRepository().get().getJavaModules()) {
-				resultSeq.add(new StringValue(this, uri.toString()));
-			    }
+			try {
+				for (final Iterator<Module> i = tempContext.getRootModules(); i.hasNext(); ) {
+					final Module module = i.next();
+					resultSeq.add(new StringValue(this, module.getNamespaceURI()));
+				}
+				if (tempContext.getRepository().isPresent()) {
+					for (final URI uri : tempContext.getRepository().get().getJavaModules()) {
+						resultSeq.add(new StringValue(this, uri.toString()));
+					}
+				}
+			} finally {
+				tempContext.reset();
+				tempContext.runCleanupTasks();
 			}
 			return resultSeq;
 		}

--- a/exist-core/src/main/java/org/exist/xupdate/XUpdateProcessor.java
+++ b/exist-core/src/main/java/org/exist/xupdate/XUpdateProcessor.java
@@ -786,8 +786,10 @@ public class XUpdateProcessor implements ContentHandler, LexicalHandler {
 		} catch (final XPathException e) {
 			throw new SAXException(e);
 		} finally {
-            if (context != null)
-                {context.reset(false);}
+            if (context != null) {
+				context.reset(false);
+				context.runCleanupTasks();
+			}
         }
 	}
 


### PR DESCRIPTION
This PR fixes a memory leak in eXist-db that can quickly cause all available memory to be consumed.

This came about due to Listeners subscribing to events produced by a running XQuery never being reset between executions of the query. Thus the list of listeners per-query grew indefinitely. 

The cause of this was due to several XQuery expressions not being reset and cleaned up after the query was executed. In particular these XQuery functions were incorrectly implemented and therefore failed to clean up after themselves and could contribute to the memory leak:

* `inspect:module-functions`
* `inspect:module-functions-by-uri`
* `inspect:inspect-module`
* `inspect:inspect-module-uri`
* `util:eval`
* `util:compile`
* `util:module-info`
* `fn:load-xquery-module`


----
Thanks to @PieterLamers for reporting to me, and testing this in production at [John Benjamins Publishing](https://benjamins.com/content/home). Also thanks to @nverwer for his work investigating and testing this.