### PR TITLE
Relax eXist functions that require parameter of type xs:anyURI to accept xs:string

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/response/RedirectTo.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/RedirectTo.java
@@ -48,7 +48,7 @@ public class RedirectTo extends StrictResponseFunction {
 		new FunctionSignature(
 			new QName("redirect-to", ResponseModule.NAMESPACE_URI, ResponseModule.PREFIX),
 			"Sends a HTTP redirect response (302) to the client.",
-			new SequenceType[] { new FunctionParameterSequenceType("uri", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The URI to redirect the client to") },
+			new SequenceType[] { new FunctionParameterSequenceType("uri", Type.STRING, Cardinality.EXACTLY_ONE, "The URI to redirect the client to") },
 			new SequenceType(Type.EMPTY_SEQUENCE, Cardinality.EMPTY_SEQUENCE));
 
     public RedirectTo(final XQueryContext context)


### PR DESCRIPTION
### Description:

As discussed on yesterday's community call, this is a new branch focusing first on a single function. 

### Reference:

https://github.com/eXist-db/exist/issues/4632

### Type of tests:

No new tests yet