### PR TITLE
Fix a bug in XSuite reporting too many failures

### DIFF
--- a/exist-core/src/main/java/org/exist/test/runner/AbstractTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/AbstractTestRunner.java
@@ -41,7 +41,6 @@ import org.exist.xquery.value.Sequence;
 import org.junit.runner.Runner;
 
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -57,7 +56,6 @@ import static java.util.Objects.requireNonNull;
  * @author Adam Retter
  */
 public abstract class AbstractTestRunner extends Runner {
-    protected static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[0];
 
     protected final Path path;
     protected final boolean parallel;

--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestAssumptionFailedFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestAssumptionFailedFunction.java
@@ -22,7 +22,6 @@
 
 package org.exist.test.runner;
 
-import org.exist.xquery.Annotation;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.functions.map.MapType;
@@ -56,7 +55,7 @@ public class ExtTestAssumptionFailedFunction extends JUnitIntegrationFunction {
         final Sequence arg2 = getCurrentArguments().length == 2 ? getCurrentArguments()[1] : null;
         final MapType assumption = arg2 != null ? (MapType)arg2.itemAt(0) : null;
 
-        final Description description = Description.createTestDescription(suiteName, name, new Annotation[0]);
+        final Description description = createTestDescription(name);
 
         // notify JUnit
         try {

--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestErrorFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestErrorFunction.java
@@ -121,7 +121,7 @@ public class ExtTestErrorFunction extends JUnitIntegrationFunction {
     private static final Pattern PTN_CAUSED_BY = Pattern.compile("Caused by:\\s([a-zA-Z0-9_$\\.]+)(?::\\s(.+))?");
     private static final Pattern PTN_AT = Pattern.compile("at\\s((?:[a-zA-Z0-9_$]+)(?:\\.[a-zA-Z0-9_$]+)*)\\.((?:[a-zA-Z0-9_$-]+)|(?:<init>))\\(([a-zA-Z0-9_]+\\.java):([0-9]+)\\)");
 
-    protected StackTraceElement[] convertStackTraceElements(final Sequence seqJavaStackTrace) throws XPathException {
+    protected @Nullable StackTraceElement[] convertStackTraceElements(final Sequence seqJavaStackTrace) throws XPathException {
         StackTraceElement[] traceElements = null;
 
         final Matcher matcherAt = PTN_AT.matcher("");

--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestErrorFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestErrorFunction.java
@@ -22,7 +22,6 @@
 
 package org.exist.test.runner;
 
-import org.exist.xquery.Annotation;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
@@ -57,7 +56,7 @@ public class ExtTestErrorFunction extends JUnitIntegrationFunction {
         final Sequence arg2 = getCurrentArguments().length == 2 ? getCurrentArguments()[1] : null;
         final MapType error = arg2 != null ? (MapType)arg2.itemAt(0) : null;
 
-        final Description description = Description.createTestDescription(suiteName, name, new Annotation[0]);
+        final Description description = createTestDescription(name);
 
         // notify JUnit
         try {

--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestFailureFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestFailureFunction.java
@@ -23,7 +23,6 @@
 package org.exist.test.runner;
 
 import org.exist.util.serializer.XQuerySerializer;
-import org.exist.xquery.Annotation;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.functions.map.MapType;
@@ -67,7 +66,7 @@ public class ExtTestFailureFunction extends JUnitIntegrationFunction {
         final Sequence arg3 = getCurrentArguments()[2];
         final MapType actual = (MapType)arg3.itemAt(0);
 
-        final Description description = Description.createTestDescription(suiteName, name, new Annotation[0]);
+        final Description description = createTestDescription(name);
 
         // notify JUnit
         try {

--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestFinishedFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestFinishedFunction.java
@@ -22,7 +22,6 @@
 
 package org.exist.test.runner;
 
-import org.exist.xquery.Annotation;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.Item;
@@ -46,7 +45,8 @@ public class ExtTestFinishedFunction extends JUnitIntegrationFunction {
         final String name = arg1.itemAt(0).getStringValue();
 
         // notify JUnit
-        notifier.fireTestFinished(Description.createTestDescription(suiteName, name, new Annotation[0]));
+        final Description description = createTestDescription(name);
+        notifier.fireTestFinished(description);
 
         return Sequence.EMPTY_SEQUENCE;
     }

--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestIgnoredFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestIgnoredFunction.java
@@ -22,7 +22,6 @@
 
 package org.exist.test.runner;
 
-import org.exist.xquery.Annotation;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.Item;
@@ -46,7 +45,8 @@ public class ExtTestIgnoredFunction extends JUnitIntegrationFunction {
         final String name = arg1.itemAt(0).getStringValue();
 
         // notify JUnit
-        notifier.fireTestIgnored(Description.createTestDescription(suiteName, name, new Annotation[0]));
+        final Description description = createTestDescription(name);
+        notifier.fireTestIgnored(description);
 
         return Sequence.EMPTY_SEQUENCE;
     }

--- a/exist-core/src/main/java/org/exist/test/runner/ExtTestStartedFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/ExtTestStartedFunction.java
@@ -22,7 +22,6 @@
 
 package org.exist.test.runner;
 
-import org.exist.xquery.Annotation;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.Item;
@@ -46,7 +45,8 @@ public class ExtTestStartedFunction extends JUnitIntegrationFunction {
         final String name = arg1.itemAt(0).getStringValue();
 
         // notify JUnit
-        notifier.fireTestStarted(Description.createTestDescription(suiteName, name, new Annotation[0]));
+        final Description description = createTestDescription(name);
+        notifier.fireTestStarted(description);
 
         return Sequence.EMPTY_SEQUENCE;
     }

--- a/exist-core/src/main/java/org/exist/test/runner/JUnitIntegrationFunction.java
+++ b/exist-core/src/main/java/org/exist/test/runner/JUnitIntegrationFunction.java
@@ -27,13 +27,10 @@ import org.exist.xquery.ExpressionVisitor;
 import org.exist.xquery.UserDefinedFunction;
 import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.FunctionParameterSequenceType;
-import org.exist.xquery.value.Sequence;
+import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
 
 import javax.xml.XMLConstants;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.exist.xquery.FunctionDSL.functionSignature;
 import static org.exist.xquery.FunctionDSL.returnsNothing;
@@ -66,5 +63,16 @@ public abstract class JUnitIntegrationFunction extends UserDefinedFunction {
             return;
         }
         visited = true;
+    }
+
+    /**
+     * Create a JUnit description of the test.
+     *
+     * @param name the name of the test.
+     *
+     * @return the test description.
+     */
+    protected Description createTestDescription(final String name) {
+        return Description.createTestDescription(suiteName, name);
     }
 }

--- a/exist-core/src/main/java/org/exist/test/runner/XMLTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/XMLTestRunner.java
@@ -176,9 +176,9 @@ public class XMLTestRunner extends AbstractTestRunner {
     @Override
     public Description getDescription() {
         final String suiteName = checkDescription(info, getSuiteName());
-        final Description description = Description.createSuiteDescription(suiteName, EMPTY_ANNOTATIONS);
+        final Description description = Description.createSuiteDescription(suiteName);
         for (final String childName : info.getChildNames()) {
-            description.addChild(Description.createTestDescription(suiteName, checkDescription(info, childName), EMPTY_ANNOTATIONS));
+            description.addChild(Description.createTestDescription(suiteName, checkDescription(info, childName)));
         }
         return description;
     }

--- a/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
@@ -217,9 +217,9 @@ public class XQueryTestRunner extends AbstractTestRunner {
     @Override
     public Description getDescription() {
         final String suiteName = checkDescription(this, getSuiteName());
-        final Description description = Description.createSuiteDescription(suiteName, EMPTY_ANNOTATIONS);
+        final Description description = Description.createSuiteDescription(suiteName);
         for (final XQueryTestInfo.TestFunctionDef testFunctionDef : info.getTestFunctions()) {
-            description.addChild(Description.createTestDescription(suiteName, checkDescription(testFunctionDef, testFunctionDef.getLocalName()), EMPTY_ANNOTATIONS));
+            description.addChild(Description.createTestDescription(suiteName, checkDescription(testFunctionDef, testFunctionDef.getLocalName())));
         }
         return description;
     }

--- a/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
+++ b/exist-core/src/main/java/org/exist/test/runner/XQueryTestRunner.java
@@ -118,6 +118,7 @@ public class XQueryTestRunner extends AbstractTestRunner {
                     final FunctionSignature localFunctionSignature = localFunction.getSignature();
 
                     String testName = null;
+                    int testArity = 0;
                     boolean isTest = false;
 
                     final Annotation[] annotations = localFunctionSignature.getAnnotations();
@@ -146,6 +147,7 @@ public class XQueryTestRunner extends AbstractTestRunner {
                     if (isTest) {
                         if (testName == null) {
                             testName = localFunctionSignature.getName().getLocalPart();
+                            testArity = localFunctionSignature.getArgumentCount();
                         }
 
                         if (moduleNsPrefix == null) {
@@ -155,7 +157,7 @@ public class XQueryTestRunner extends AbstractTestRunner {
                             moduleNsUri = localFunctionSignature.getName().getNamespaceURI();
                         }
 
-                        testFunctions.add(new XQueryTestInfo.TestFunctionDef(testName));
+                        testFunctions.add(new XQueryTestInfo.TestFunctionDef(testName, testArity));
                     }
                 } // end while
 
@@ -280,13 +282,19 @@ public class XQueryTestRunner extends AbstractTestRunner {
 
         private static class TestFunctionDef {
             private final String localName;
+            private final int arity;
 
-            private TestFunctionDef(final String localName) {
+            private TestFunctionDef(final String localName, final int arity) {
                 this.localName = localName;
+                this.arity = arity;
             }
 
             public String getLocalName() {
                 return localName;
+            }
+
+            public int getArity() {
+                return arity;
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunUnparsedText.java
@@ -31,6 +31,7 @@ import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 
+import javax.annotation.Nullable;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -78,14 +79,15 @@ public class FunUnparsedText extends BasicFunction {
 
     @Override
     public Sequence eval(Sequence[] args, Sequence contextSequence) throws XPathException {
-        final String encoding = args.length == 2 ? args[1].getStringValue() : null;
+        @Nullable final String encoding = args.length == 2 ? args[1].getStringValue() : null;
         if (!args[0].isEmpty()) {
+            final String href = args[0].getStringValue();
             if (isCalledAs("unparsed-text-lines")) {
-                return readLines(args[0].getStringValue(), encoding);
+                return readLines(href, encoding);
             } else if (isCalledAs("unparsed-text-available")) {
-                return BooleanValue.valueOf(contentAvailable(args[0].getStringValue(), encoding));
+                return BooleanValue.valueOf(contentAvailable(href, encoding));
             } else {
-                return new StringValue(this, readContent(args[0].getStringValue(), encoding));
+                return new StringValue(this, readContent(href, encoding));
             }
         }
         return Sequence.EMPTY_SEQUENCE;

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -761,7 +761,7 @@
                     </dependencies>
                     <configuration>
                         <forkCount>2C</forkCount>
-                        <!--  Setting `reuseForks` to `true` greatly speeds up execution of the the test suite.
+                        <!--  Setting `reuseForks` to `true` greatly speeds up execution of the test suite.
                               However it can make it hard to diagnose problems if tests leak state; If you experience
                               such a problem you may want to set it to `false` whilst debugging -->
                         <reuseForks>true</reuseForks>


### PR DESCRIPTION
Fix an issue where XSuite tests had the wrong uniqueId; this caused one failing test to make some subequent tests also appear like they were failing

fixes https://github.com/eXist-db/exist/issues/4538