### PR TITLE
Fix issues with binary files being closed whilst they are still needed

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -721,6 +721,7 @@
                                 <exclude>src/main/java/org/exist/xquery/value/SubSequence.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/value/SubSequenceRangeTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/value/SubSequenceTest.java</exclude>
+                                <exclude>src/test/xquery/binary-value.xqm</exclude>
 
                                 <!--
                                     Derivative work licensed under dbXML 1.0 and LGPL 2.1
@@ -870,6 +871,7 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/main/java/org/exist/xquery/value/SubSequence.java</include>
                                 <include>src/test/java/org/exist/xquery/value/SubSequenceRangeTest.java</include>
                                 <include>src/test/java/org/exist/xquery/value/SubSequenceTest.java</include>
+                                <include>src/test/xquery/binary-value.xqm</include>
                             </includes>
 
                         </licenseSet>

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -1168,11 +1168,11 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     @Override
     public NodeSet getParents(final int contextId) {
         final NodeId pid = nodeId.getParentId();
-        if(pid == null || pid == NodeId.DOCUMENT_NODE) {
+        if (pid == null) {
             return NodeSet.EMPTY_SET;
         }
 
-        final NodeProxy parent = new NodeProxy(expression, doc, pid, Node.ELEMENT_NODE);
+        final NodeProxy parent = new NodeProxy(expression, doc, pid, pid == NodeId.DOCUMENT_NODE ? Node.DOCUMENT_NODE : Node.ELEMENT_NODE);
         if(contextId != Expression.NO_CONTEXT_ID) {
             parent.addContextNode(contextId, this);
         } else {

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -37,6 +37,7 @@ import org.exist.xquery.value.SequenceIterator;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -164,7 +165,7 @@ public class Predicate extends PathExpr {
 
             final Tuple2<ExecutionMode, Sequence> recomputed = recomputeExecutionMode(contextSequence, inner);
             final ExecutionMode recomputedExecutionMode = recomputed._1;
-            Sequence innerSeq = recomputed._2;
+            @Nullable Sequence innerSeq = recomputed._2;
 
             switch (recomputedExecutionMode) {
                 case NODE:

--- a/exist-core/src/main/java/org/exist/xquery/Predicate.java
+++ b/exist-core/src/main/java/org/exist/xquery/Predicate.java
@@ -565,23 +565,55 @@ public class Predicate extends PathExpr {
                     Type.NODE) && (mode == Constants.ANCESTOR_AXIS ||
                     mode == Constants.ANCESTOR_SELF_AXIS || mode == Constants.PARENT_AXIS ||
                     mode == Constants.PRECEDING_AXIS || mode == Constants.PRECEDING_SIBLING_AXIS);
-            final Set<NumericValue> set = new TreeSet<>();
-            final ValueSequence result = new ValueSequence();
-            for (final SequenceIterator i = innerSeq.iterate(); i.hasNext(); ) {
-                final NumericValue v = (NumericValue) i.nextItem();
+
+            Sequence result = Sequence.EMPTY_SEQUENCE;
+            if (innerSeq.hasOne()) {
+                // optimise for single position lookup
+                final NumericValue v = (NumericValue) innerSeq.itemAt(0);
                 // Non integers return... nothing, not even an error !
-                if (!v.hasFractionalPart() && !v.isZero()) {
-                    final int pos = (reverseAxis ? contextSequence.getItemCount()
-                            - v.getInt() : v.getInt() - 1);
+                if (isNonZeroInteger(v)) {
+                    final int pos = calculatePos(reverseAxis, contextSequence, v);
                     // Other positions are ignored
-                    if (pos >= 0 && pos < contextSequence.getItemCount() && !set.contains(v)) {
-                        result.add(contextSequence.itemAt(pos));
-                        set.add(v);
+                    if (withinBounds(contextSequence, pos)) {
+                        result = (Sequence) contextSequence.itemAt(pos);
+                    }
+                }
+            } else {
+                // multi-position lookup
+                Set<NumericValue> set = null;
+                for (final SequenceIterator i = innerSeq.iterate(); i.hasNext(); ) {
+                    final NumericValue v = (NumericValue) i.nextItem();
+                    // Non integers return... nothing, not even an error !
+                    if (isNonZeroInteger(v)) {
+                        final int pos = calculatePos(reverseAxis, contextSequence, v);
+                        // Other positions are ignored
+                        if (withinBounds(contextSequence, pos) && (set == null || !set.contains(v))) {
+                            if (result == Sequence.EMPTY_SEQUENCE) {
+                                result = new ValueSequence();
+                            }
+                            result.add(contextSequence.itemAt(pos));
+                            if (set == null) {
+                                set = new TreeSet<>();
+                            }
+                            set.add(v);
+                        }
                     }
                 }
             }
             return result;
         }
+    }
+
+    private static boolean isNonZeroInteger(final NumericValue v) {
+        return !v.hasFractionalPart() && !v.isZero();
+    }
+
+    private static int calculatePos(final boolean reverseAxis, final Sequence contextSequence, final NumericValue v) throws XPathException {
+        return (reverseAxis ? contextSequence.getItemCount() - v.getInt() : v.getInt() - 1);
+    }
+
+    private static boolean withinBounds(final Sequence contextSequence, final int pos) {
+        return pos >= 0 && pos < contextSequence.getItemCount();
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/array/ArrayType.java
@@ -421,6 +421,27 @@ public class ArrayType extends FunctionReference implements Lookup.LookupSupport
         return false;
     }
 
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append('[');
+        if (vector.length() > 0) {
+            builder.append(' ');
+        }
+        for (int i = 0; i < vector.length(); i++) {
+            final Sequence value = vector.nth(i);
+            builder.append(value.toString());
+            if (i < vector.length() - 1) {
+                builder.append(", ");
+            }
+        }
+        if (vector.length() > 0) {
+            builder.append(' ');
+        }
+        builder.append(']');
+        return builder.toString();
+    }
+
     /**
      * The accessor function which will be evaluated if the map is called
      * as a function item.

--- a/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/map/MapType.java
@@ -283,7 +283,7 @@ public class MapType extends AbstractMapType {
     public boolean containsReference(final Item item) {
         for (final Iterator<Sequence> it = map.values().iterator(); it.hasNext();) {
             final Sequence value = it.next();
-            if (value == item) {
+            if (value == item || value.containsReference(item)) {
                 return true;
             }
         }
@@ -294,7 +294,7 @@ public class MapType extends AbstractMapType {
     public boolean contains(final Item item) {
         for (final Iterator<Sequence> it = map.values().iterator(); it.hasNext();) {
             final Sequence value = it.next();
-            if (value.equals(item)) {
+            if (value.equals(item) || value.contains(item)) {
                 return true;
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/value/BinaryValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/BinaryValue.java
@@ -155,8 +155,8 @@ public abstract class BinaryValue extends AtomicValue implements Closeable {
                 return (T) baos.toByteArray();
             } catch (final IOException ioe) {
                 LOG.error("Unable to Stream BinaryValue to byte[]: {}", ioe.getMessage(), ioe);
+                throw new XPathException(getExpression(), "Unable to Stream BinaryValue to byte[]: " + ioe.getMessage(), ioe);
             }
-
         }
 
         throw new XPathException(getExpression(), "Cannot convert value of type " + Type.getTypeName(getType()) + " to Java object of type " + target.getName());

--- a/exist-core/src/test/xquery/binary-value.xqm
+++ b/exist-core/src/test/xquery/binary-value.xqm
@@ -1,0 +1,256 @@
+(:
+ : Copyright (C) 2014, Evolved Binary Ltd
+ :
+ : This file was originally ported from FusionDB to eXist-db by
+ : Evolved Binary, for the benefit of the eXist-db Open Source community.
+ : Only the ported code as it appears in this file, at the time that
+ : it was contributed to eXist-db, was re-licensed under The GNU
+ : Lesser General Public License v2.1 only for use in eXist-db.
+ :
+ : This license grant applies only to a snapshot of the code as it
+ : appeared when ported, it does not offer or infer any rights to either
+ : updates of this source code or access to the original source code.
+ :
+ : The GNU Lesser General Public License v2.1 only license follows.
+ :
+ : ---------------------------------------------------------------------
+ :
+ : Copyright (C) 2014, Evolved Binary Ltd
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+(:~
+ : Test for binary value lifetimes.
+ : This also checks that the escape analysis is correct for LetExpr calling XQueryContext#popLocalVariables.
+ :
+ : @author Adam Retter
+ :)
+module namespace bv = "http://exist-db.org/xquery/test/binary-value";
+
+import module namespace test = "http://exist-db.org/xquery/xqsuite";
+import module namespace util ="http://exist-db.org/xquery/util";
+import module namespace xmldb ="http://exist-db.org/xquery/xmldb";
+
+declare variable $bv:db := "/db";
+declare variable $bv:src-collection-name := "test-binary-value-src";
+declare variable $bv:dst-collection-name := "test-binary-value-dst";
+declare variable $bv:doc1 := "doc1.bin";
+declare variable $bv:doc2 := "doc2.bin";
+declare variable $bv:doc3 := "doc3.bin";
+declare variable $bv:doc4 := "doc4.bin";
+declare variable $bv:doc5 := "doc5.bin";
+declare variable $bv:doc6 := "doc6.bin";
+declare variable $bv:doc7 := "doc7.bin";
+declare variable $bv:doc8 := "doc8.bin";
+declare variable $bv:doc9 := "doc9.bin";
+declare variable $bv:doc10 := "doc10.bin";
+declare variable $bv:bin := fn:current-dateTime() cast as xs:string;
+
+declare
+    %test:setUp
+function bv:setup() {
+  let $src-collection := xmldb:create-collection($bv:db, $bv:src-collection-name)
+  let $_ := xmldb:create-collection($bv:db, $bv:dst-collection-name)
+  for $doc-name in ($bv:doc1, $bv:doc2, $bv:doc3, $bv:doc4, $bv:doc5, $bv:doc6, $bv:doc7, $bv:doc8, $bv:doc9, $bv:doc10)
+  return
+    xmldb:store($src-collection, $doc-name, $bv:bin, "application/octet-stream")
+};
+
+declare
+    %test:tearDown
+function bv:teardown() {
+  xmldb:remove($bv:db || "/" || $bv:src-collection-name)
+};
+
+declare
+  %private
+function bv:internal-escape-item-in-map() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc1)
+  let $m := map { "content": $b }
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc1.bin")
+function bv:escape-item-in-map() {
+  let $m := bv:internal-escape-item-in-map()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc1, $m?content, "application/octet-stream")
+};
+
+declare
+  %private
+function bv:internal-escape-filtered-item-in-map() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc2)
+  let $m := map { "content": $b[1] }
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc2.bin")
+function bv:escape-filtered-item-in-map() {
+  let $m := bv:internal-escape-filtered-item-in-map()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc2, $m?content, "application/octet-stream")
+};
+
+declare
+  %private
+function bv:internal-escape-sequence-item-in-map() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc3)
+  let $m := map { "content": ($b, fn:true()) }
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc3.bin")
+function bv:escape-sequence-item-in-map() {
+  let $m := bv:internal-escape-sequence-item-in-map()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc3, $m?content[1], "application/octet-stream")
+};
+
+declare
+  %private
+function bv:internal-escape-map-item-in-map() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc4)
+  let $m := map { "content": map { "content": $b } }
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc4.bin")
+function bv:escape-map-item-in-map() {
+  let $m := bv:internal-escape-map-item-in-map()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc4, $m?content?content, "application/octet-stream")
+};
+
+declare
+  %private
+function bv:internal-escape-array-item-in-map() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc5)
+  let $m := map { "content": [ $b ] }
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc5.bin")
+function bv:escape-array-item-in-map() {
+  let $m := bv:internal-escape-array-item-in-map()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc5, $m?content?1, "application/octet-stream")
+};
+
+declare
+  %private
+function bv:internal-escape-array-item-in-array() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc6)
+  let $m := [ [ $b ] ]
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc6.bin")
+function bv:escape-array-item-in-array() {
+  let $m := bv:internal-escape-array-item-in-array()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc6, $m?1?1, "application/octet-stream")
+};
+
+declare
+  %private
+function bv:internal-escape-map-item-in-array() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc7)
+  let $m := [ map { "content": $b } ]
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc7.bin")
+function bv:escape-map-item-in-array() {
+  let $m := bv:internal-escape-map-item-in-array()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc7, $m?1?content, "application/octet-stream")
+};
+
+declare
+  %private
+function bv:internal-escape-item-in-array() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc8)
+  let $m := [ $b ]
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc8.bin")
+function bv:escape-item-in-array() {
+  let $m := bv:internal-escape-item-in-array()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc8, $m?1, "application/octet-stream")
+};
+
+declare
+  %private
+function bv:internal-escape-filtered-item-in-array() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc9)
+  let $m := [ $b[1] ]
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc9.bin")
+function bv:escape-filtered-item-in-array() {
+  let $m := bv:internal-escape-filtered-item-in-array()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc9, $m?1, "application/octet-stream")
+};
+
+declare
+  %private
+function bv:internal-escape-sequence-in-array() {
+  let $b := util:binary-doc($bv:db || "/" || $bv:src-collection-name || "/" || $bv:doc10)
+  let $m := [ ($b, fn:true()) ]
+  return
+    $m
+};
+
+declare
+  %test:assertEquals("/db/test-binary-value-dst/doc10.bin")
+function bv:escape-sequence-in-array() {
+  let $m := bv:internal-escape-sequence-in-array()
+  let $dst-collection := $bv:db || "/" || $bv:dst-collection-name
+  return
+    xmldb:store($dst-collection, $bv:doc10, $m?1[1], "application/octet-stream")
+};

--- a/exist-core/src/test/xquery/pathExpression_operators.xml
+++ b/exist-core/src/test/xquery/pathExpression_operators.xml
@@ -45,9 +45,10 @@
         <task>union operator: should select context node (not its child nodes)</task>
         <code><![CDATA[
           let $a := collection('/db/coll')/test
-          return $a/(.|..)
+          return
+            <result>{$a/(.|..)}</result>
         ]]></code>
-        <expected><test>this is text with an <el>embedded element</el></test></expected>
+        <expected><result><test>this is text with an <el>embedded element</el></test><test>this is text with an <el>embedded element</el></test></result></expected>
     </test>
     <test output="xml" ignore="yes">
         <task>comma operator: should remove duplicates (due to '/' operator)</task>


### PR DESCRIPTION
Previously if an `xs:base64Binary` or `xs:hexBinary` value was constructed dynamically in XQuery and bound to a variable (e.g. from `util:binary-doc`, `http:send-request, etc.) and that value was then returned within a Map or Array, the variable binding (and therefore the value) would be destroyed prematurely as the XQuery engine believed that the variable binding was no longer needed.

This caused numerous issues with error messages such as "The underlying InputStream has been closed" when trying to work with binary values.

Fixing this also revealed a further issue with retrieving parent document-nodes of NodeProxy objects (stored nodes), and an invalid Union Operator test in the test suite, which I have also corrected.