### PR TITLE
[BUG] HTML5 serializer should escape contents of title and textarea elements

### DIFF
--- a/exist-core/src/main/java/org/exist/util/serializer/HTML5Writer.java
+++ b/exist-core/src/main/java/org/exist/util/serializer/HTML5Writer.java
@@ -141,8 +141,6 @@ public class HTML5Writer extends XHTML5Writer {
     static {
         RAW_TEXT_ELEMENTS.add("script");
         RAW_TEXT_ELEMENTS.add("style");
-        RAW_TEXT_ELEMENTS.add("textarea");
-        RAW_TEXT_ELEMENTS.add("title");
     }
 
     public HTML5Writer() {

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -865,3 +865,65 @@ function ser:serialize-xml-134() {
     }
     return serialize((1 to 4)!text{.}, $params)
 };
+
+declare
+    %test:assertEquals('<!DOCTYPE html> <option selected></option>')
+function ser:serialize-html-5-boolean-attribute-names() {
+    let $params := map {
+        "method" : "html",
+        "html-version": 5.0
+    }
+    return
+        <option selected="selected"/>
+        => serialize($params)
+        => normalize-space()
+};
+
+declare
+    %test:assertEquals('<!DOCTYPE html> <br>')
+function ser:serialize-html-5-empty-tags() {
+    let $params := map {
+        "method" : "html",
+        "html-version": 5.0
+    }
+    return
+        <br/>
+        => serialize($params)
+        => normalize-space()
+};
+
+declare
+    %test:assertEquals('<!DOCTYPE html> <foo><style>ul > li { color:red; }</style><script>if (a < b) foo()</script></foo>')
+function ser:serialize-html-5-raw-text-elements() {
+    let $params := map {
+        "method" : "html",
+        "html-version": 5.0
+    }
+    return
+        <foo>
+            <style>{``[ul > li { 
+                color:red; 
+            }]``}</style>
+            <script>{``[if (a < b) foo()]``}</script>
+        </foo>
+        => serialize($params)
+        => normalize-space()
+};
+
+declare
+    %test:assertEquals('<!DOCTYPE html> <foo><title>ul &amp;gt; li { color:red; }</title><textarea>if (a &amp;lt; b) foo()</textarea></foo>')
+function ser:serialize-html-5-needs-escape-elements() {
+    let $params := map {
+        "method" : "html",
+        "html-version": 5.0
+    }
+    return
+        <foo>
+            <title>{``[ul > li { 
+                color:red; 
+            }]``}</title>
+            <textarea>{``[if (a < b) foo()]``}</textarea>
+        </foo>
+        => serialize($params)
+        => normalize-space()
+};


### PR DESCRIPTION
### Description:

According to the XSLT and XQuery Serialization 3.1 spec, in the HTML Output Method, the text node descendants of all elements are to be escaped, except two: `<script>` and `<style>`:

> The HTML output method **MUST NOT** perform escaping for any text node descendant, nor for any attribute of an element node descendant, of a `script` or `style` element.

eXist's HTML 5 serializer extended this behavior to 2 additional elements: `<textarea>` and `<title>`. As a result their text node descendants are serialized in an unescaped form.

This PR fixes the error by removing `<textarea>` and `<title>` from this list and limiting this behavior to the two elements prescribed in the spec: `<script>` and `<style>`.

### Reference:

https://www.w3.org/TR/xslt-xquery-serialization-31/#html-output

### Type of tests:

XQSuite
