### PR TITLE
[4.x.x] Canonical source of apps

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -27,7 +27,8 @@ keystore.password = secret
 keystore.file = key.store
 keystore.validity = 100000
 
-autodeploy=dashboard,shared,eXide,monex,functx,usermanager
+autodeploy.dir=autodeploy
+autodeploy=shared,dashboard,functx,usermanager,eXide,monex,doc,fundocs,markdown
 autodeploy.repo=http://demo.exist-db.org/exist/apps/public-repo
 use.autodeploy.feature=true
 

--- a/build/scripts/installer.xml
+++ b/build/scripts/installer.xml
@@ -22,8 +22,6 @@
     <property name="installer.scripts" value="installer/scripts"/>
     <property name="installer.mac.icon" value="${installer.scripts}/icon.icns"/>
 
-    <property file="installer/apps.properties"/>
-
 	<target name="commandline-installer">
     </target>
 
@@ -78,31 +76,16 @@
     <target name="download-xars" description="Download xars to include in installer"  depends="clean-installer-xars-dir">
         <mkdir dir="${apps.dir}"/>
         <echo message="Downloading xar packages to include in installer ..."/>
-        <foreach list="${apps}" target="download-xar" param="xar"></foreach>
 
-        <move todir="${apps.dir}">
-            <fileset dir="${apps.dir}">
-                <include name="shared*.xar"/>
+        <ant antfile="build/scripts/setup.xml" dir="." inheritall="false"/>
+
+        <!-- copy the xars to the location for the installer -->
+        <copy todir="${apps.dir}">
+            <fileset dir="${autodeploy.dir}">
+                <include name="*.xar"/>
             </fileset>
-            <mapper type="glob" from="*" to="00*"/>
-        </move>
-    </target>
+        </copy>
 
-    <target name="download-xar">
-        <!-- get dest="${apps.dir}" src="${apps.repo}/find?abbrev=${xar}&amp;processor=${project.version}"
-             verbose="on" maxtime="180" usetimestamp="true" tryGzipEncoding="true"/ -->
-
-        <taskdef name="fetch" classname="nl.ow.dilemma.ant.fetch.FetchTask">
-            <classpath>
-                <pathelement location="${asocat-exist.jar}"/>
-            </classpath>
-        </taskdef>
-        <fetch dest="${apps.dir}" url="${apps.repo}/find?abbrev=${xar}&amp;processor=${project.version}&amp;zip=yes"
-               failonerror="true" maxtime="180">
-            <patternset>
-                <include name="**/*.xar"/>
-            </patternset>
-        </fetch>
     </target>
 
     <target name="xars" depends="download-xars" description="Scan apps directory and include all .xar files into installer">

--- a/build/scripts/setup.xml
+++ b/build/scripts/setup.xml
@@ -21,15 +21,13 @@
 
   <property file="build.properties"/>
 
-  <property name="autostart-dir" value="autodeploy"/>
-
   <target name="prepare">
-    <mkdir dir="${autostart-dir}"/>
+    <mkdir dir="${autodeploy.dir}"/>
     <!--  Automatically download standard xar packages from public repository
         if autostart directory is empty.
   -->
     <path id="autostart-files">
-      <fileset dir="${autostart-dir}">
+      <fileset dir="${autodeploy.dir}">
         <include name="*.xar"/>
       </fileset>
     </path>
@@ -47,15 +45,24 @@
   <target name="setup" depends="prepare" description="Download standard xar packages.">
     <echo message="Downloading xar packages: ${autodeploy}..."/>
     <foreach list="${autodeploy}" target="download" param="xar"></foreach>
+
+    <!-- rename the shared-resources xar -->
+    <move todir="${autodeploy.dir}">
+      <fileset dir="${autodeploy.dir}">
+        <include name="shared*.xar"/>
+      </fileset>
+      <mapper type="glob" from="*" to="00*"/>
+    </move>
+
   </target>
 
   <target name="download">
     <pathconvert property="xar-installed" setonempty="false">
-        <fileset dir="${autostart-dir}">
+        <fileset dir="${autodeploy.dir}">
             <include name="${xar}-*.xar"/>
         </fileset>
     </pathconvert>
-    <condition property="xar-found-status" value="Existing copy of ${xar} found at ${xar-installed}. Download will be skipped." else="No copy of ${xar} found in ${autostart-dir}. Download will be attempted.">
+    <condition property="xar-found-status" value="Existing copy of ${xar} found at ${xar-installed}. Download will be skipped." else="No copy of ${xar} found in ${autodeploy.dir}. Download will be attempted.">
       <isset property="xar-installed"/>
     </condition>
     <echo message="${xar-found-status}"/>
@@ -63,7 +70,7 @@
   </target>
 
   <target name="download-xar" unless="xar-installed">
-    <!-- get dest="${autostart-dir}" src="${autodeploy.repo}/find?abbrev=${xar}&amp;processor=${project.version}"
+    <!-- get dest="${autodeploy.dir}" src="${autodeploy.repo}/find?abbrev=${xar}&amp;processor=${project.version}"
          verbose="on" maxtime="180" usetimestamp="true" tryGzipEncoding="true"/ -->
 
     <taskdef name="fetch" classname="nl.ow.dilemma.ant.fetch.FetchTask">
@@ -71,7 +78,7 @@
         <pathelement location="${asocat-exist.jar}"/>
       </classpath>
     </taskdef>
-    <fetch dest="${autostart-dir}" url="${autodeploy.repo}/find?abbrev=${xar}&amp;processor=${project.version}&amp;zip=yes"
+    <fetch dest="${autodeploy.dir}" url="${autodeploy.repo}/find?abbrev=${xar}&amp;processor=${project.version}&amp;zip=yes"
         failonerror="true" failonzeroextracted="true" maxtime="180">
       <patternset>
         <include name="**/*.xar"/>

--- a/installer/apps.properties
+++ b/installer/apps.properties
@@ -1,2 +1,0 @@
-apps.repo=http://demo.exist-db.org/exist/apps/public-repo
-apps=shared,dashboard,functx,usermanager,eXide,monex,doc,fundocs,markdown


### PR DESCRIPTION
Previously a different set of apps was provided in the DMG and Installer, to that in the dist archives. This was because there were two list of apps present, this consolidates on a single list of the apps to ship.