### PR TITLE
[bugfix] corrects version number on missed POMs

### DIFF
--- a/exist-core-jcstress/pom.xml
+++ b/exist-core-jcstress/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.2.0-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 

--- a/exist-core-jmh/pom.xml
+++ b/exist-core-jmh/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.2.0-SNAPSHOT</version>
         <relativePath>../exist-parent</relativePath>
     </parent>
 


### PR DESCRIPTION
### Description:
Fixes the version numbers in missed POM files after the last release.
