### PR TITLE
[fix] ignore temporary POMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ target/
 .classpath
 .project
 
+# quartz artefacts
+dependency-reduced-pom.xml
+
 # IDE specific files
 .idea/*
 !/.idea/runConfigurations
@@ -13,3 +16,4 @@ target/
 
 # OS specific files
 .DS_Store
+


### PR DESCRIPTION
closes #4694

Two POMs are created during packaging

- exist-core-jcstress/depedency-reduced-pom.xml
- exist-core-jmh/dependency-reduced-pom.xml

These files are show up as untracked afterwards and might therefore be committed in error.

