### PR TITLE
[hotfix] fn:serialize issues

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -156,13 +156,6 @@ public class FunSerialize extends BasicFunction {
                     throw new XPathException(callingExpr, FnModule.SENR0001,
                         "It is an error if an item in the sequence to serialize is an attribute node or a namespace node.");
                 }
-//                if (itemType == Type.TEXT || itemType == Type.COMMENT) {
-//                    final StringValue stringRepresentation = new StringValue(callingExpr, next.getStringValue());
-//                    if (stringRepresentation.getStringValue().isEmpty()) {
-//                        continue;
-//                    }
-//                    temp.add(stringRepresentation);
-//                }
                 temp.add(next);
             } else {
                 // atomic value
@@ -189,7 +182,7 @@ public class FunSerialize extends BasicFunction {
                     final String stringValue = next.getStringValue();
                     receiver.characters(stringValue);
                 }
-                // add itemSeparator if there is a next item and the current item is not an empty string
+                // add itemSeparator if there is a next item
                 if (i.hasNext()) {
                     receiver.characters(itemSeparator);
                 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -186,6 +186,7 @@ public class FunSerialize extends BasicFunction {
         try {
             final MemTreeBuilder builder = context.getDocumentBuilder();
             final DocumentBuilderReceiver receiver = new DocumentBuilderReceiver(callingExpr, builder, true);
+            final String safeItemSeparator = itemSeparator == null ? "" : itemSeparator;
             for (final SequenceIterator i = step2.iterate(); i.hasNext(); ) {
                 final Item next = i.nextItem();
                 if (Type.subTypeOf(next.getType(), Type.NODE)) {
@@ -196,7 +197,7 @@ public class FunSerialize extends BasicFunction {
                 }
                 // add itemSeparator if there is a next item
                 if (i.hasNext()) {
-                    receiver.characters(itemSeparator);
+                    receiver.characters(safeItemSeparator);
                 }
             }
             return (DocumentImpl)receiver.getDocument();

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -163,9 +163,6 @@ public class FunSerialize extends BasicFunction {
                 // casting it to an xs:string and copy the string representation to the new sequence;"
                 final StringValue stringRepresentation = new StringValue(callingExpr, next.getStringValue());
                 // skip values that evaluate to an empty string
-                if (stringRepresentation.getStringValue().isEmpty()) {
-                    continue;
-                }
                 temp.add(stringRepresentation);
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -144,6 +144,7 @@ public class FunSerialize extends BasicFunction {
         if (input.isEmpty())
             // "If the sequence that is input to serialization is empty, create a sequence S1 that consists of a zero-length string."
             {return StringValue.EMPTY_STRING;}
+        final String _separator = itemSeparator == null ? DEFAULT_ITEM_SEPARATOR : itemSeparator;
         final ValueSequence temp = new ValueSequence(input.getItemCount());
         for (final SequenceIterator i = input.iterate(); i.hasNext(); ) {
             final Item next = i.nextItem();
@@ -151,25 +152,12 @@ public class FunSerialize extends BasicFunction {
                 if (next.getType() == Type.ATTRIBUTE || next.getType() == Type.NAMESPACE || next.getType() == Type.FUNCTION_REFERENCE)
                     {throw new XPathException(callingExpr, FnModule.SENR0001,
                         "It is an error if an item in the sequence to serialize is an attribute node or a namespace node.");}
-                if (itemSeparator != null && itemSeparator.length() > 0 && !temp.isEmpty()) {
-                    temp.add(new StringValue(itemSeparator + next.getStringValue()));
-                } else {
-                    temp.add(next);
-                }
+                temp.add(next);
             } else {
                 // atomic value
-                Item last = null;
-                if (!temp.isEmpty())
-                    {last = temp.itemAt(temp.getItemCount() - 1);}
-                if (last != null && last.getType() == Type.STRING)
-                    // "For each subsequence of adjacent strings in S2, copy a single string to the new sequence
-                    // equal to the values of the strings in the subsequence concatenated in order, each separated
-                    // by a single space."
-                    {((StringValue)last).append((itemSeparator == null ? " " : itemSeparator) + next.getStringValue());}
-                else
-                    // "For each item in S1, if the item is atomic, obtain the lexical representation of the item by
-                    // casting it to an xs:string and copy the string representation to the new sequence;"
-                    {temp.add(new StringValue(callingExpr, next.getStringValue()));}
+                // "For each item in S1, if the item is atomic, obtain the lexical representation of the item by
+                // casting it to an xs:string and copy the string representation to the new sequence;"
+                temp.add(new StringValue(callingExpr, next.getStringValue()));
             }
         }
 
@@ -183,6 +171,9 @@ public class FunSerialize extends BasicFunction {
                     next.copyTo(context.getBroker(), receiver);
                 } else {
                     receiver.characters(next.getStringValue());
+                }
+                if (i.hasNext()) {
+                    receiver.characters(_separator);
                 }
             }
             return (DocumentImpl)receiver.getDocument();

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -153,16 +153,13 @@ public class FunSerialize extends BasicFunction {
         final ValueSequence step1 = new ValueSequence();
         for (final SequenceIterator i = input.iterate(); i.hasNext(); ) {
             final Item next = i.nextItem();
-            if (next.getType() != Type.ARRAY) {
+            if (next.getType() == Type.ARRAY) {
+                final Sequence sequence = ArrayType.flatten(next);
+                for (final SequenceIterator si = sequence.iterate(); si.hasNext(); ) {
+                    step1.add(si.nextItem());
+                }
+            } else {
                 step1.add(next);
-                continue;
-            }
-            final Sequence sequence = ArrayType.flatten(next);
-            if (sequence.isEmpty()) {
-                continue;
-            }
-            for (final SequenceIterator si = sequence.iterate(); si.hasNext(); ) {
-                step1.add(si.nextItem());
             }
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunSerialize.java
@@ -28,6 +28,7 @@ import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.storage.serializers.EXistOutputKeys;
 import org.exist.util.serializer.XQuerySerializer;
 import org.exist.xquery.*;
+import org.exist.xquery.functions.array.ArrayType;
 import org.exist.xquery.functions.map.AbstractMapType;
 import org.exist.xquery.util.SerializerUtils;
 import org.exist.xquery.value.*;
@@ -157,6 +158,12 @@ public class FunSerialize extends BasicFunction {
                         "It is an error if an item in the sequence to serialize is an attribute node or a namespace node.");
                 }
                 temp.add(next);
+            } else if (itemType == Type.ARRAY) {
+                 final Sequence sequence = ArrayType.flatten(next);
+                 if (sequence.isEmpty()) {
+                     continue;
+                 }
+                 temp.add(new StringValue(callingExpr, sequence.getStringValue()));
             } else {
                 // atomic value
                 // "For each item in S1, if the item is atomic, obtain the lexical representation of the item by

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
@@ -404,7 +404,8 @@ public class Eval extends BasicFunction {
 
                         final Sequence seq;
                         if (xqSerializer.normalize()) {
-                            seq = FunSerialize.normalize(this, context, result, "");
+                            // TODO(JL): should this not be changed to DEFAULT_ITEM_SEPARATOR
+                            seq = FunSerialize.normalize(this, context, result, null);
                         } else {
                             seq = result;
                         }

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Eval.java
@@ -404,7 +404,7 @@ public class Eval extends BasicFunction {
 
                         final Sequence seq;
                         if (xqSerializer.normalize()) {
-                            seq = FunSerialize.normalize(this, context, result, null);
+                            seq = FunSerialize.normalize(this, context, result, "");
                         } else {
                             seq = result;
                         }

--- a/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
+++ b/exist-core/src/main/java/org/exist/xquery/util/SerializerUtils.java
@@ -450,7 +450,12 @@ public class SerializerUtils {
         final Sequence providedParameterValue = entries.get(parameterConventionEntryKey);
 
         // should we use the default value
-        if (providedParameterValue == null || providedParameterValue.isEmpty() || (parameterConvention.getType() == Type.STRING && isEmptyStringValue(providedParameterValue))) {
+        if (providedParameterValue == null || providedParameterValue.isEmpty() || (
+                parameterConvention.getType() == Type.STRING && isEmptyStringValue(providedParameterValue) &&
+                        // allow empty separator #4704
+                        parameterConvention.getParameterName() != EXistOutputKeys.ITEM_SEPARATOR
+        )
+        ) {
             // use default value
 
             if (W3CParameterConvention.MEDIA_TYPE == parameterConvention) {

--- a/exist-core/src/test/java/xquery/xquery3/XQuery3Tests.java
+++ b/exist-core/src/test/java/xquery/xquery3/XQuery3Tests.java
@@ -28,7 +28,8 @@ import org.junit.runner.RunWith;
 @XSuite.XSuiteFiles({
         "src/test/xquery/xquery3",
         "src/test/xquery/xquery3/transform",
-        //Reminder - add an individual test like this - "src/test/xquery/xquery3/transform/<test-file>.xqm",
+        // To add an individual test or only run a specific set of tests -
+//         "src/test/xquery/xquery3/serialize.xql",
 })
 public class XQuery3Tests {
 }

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -993,3 +993,9 @@ declare
 function ser:sequence-of-empty-arrays-serializes-to-empty-string() {
     serialize(([],[]), map{"item-separator": "|"})
 };
+
+declare
+    %test:assertEquals("1|2")
+function ser:item-separator-applies-to-array-members() {
+    serialize(([1,2]), map{"item-separator":"|"})
+};

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -927,3 +927,11 @@ function ser:serialize-html-5-needs-escape-elements() {
         => serialize($params)
         => normalize-space()
 };
+
+(: test for https://github.com/eXist-db/exist/issues/4702 :)
+declare
+    %test:assertEquals("<a>foo</a> <b>bar</b>")
+function ser:sequence-of-nodes() {
+    (<a>foo</a>, <b>bar</b>) => serialize()
+};
+

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -224,6 +224,26 @@ function ser:serialize-atomic() {
         fn:serialize($nodes)
 };
 
+(: test for https://github.com/eXist-db/exist/issues/4704 :)
+declare
+    %test:assertEquals("aaabbb")
+function ser:serialize-atomic-empty-separator() {
+    fn:serialize(("aaa", "bbb"), map {"item-separator": ""})
+};
+
+(: test for https://github.com/eXist-db/exist/issues/4704 :)
+declare
+    %test:assertEquals("aaabbb")
+function ser:serialize-atomic-empty-separator-xml-options() {
+    fn:serialize(("aaa", "bbb"),
+      <output:serialization-parameters
+           xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
+        <output:item-separator value=""/>
+      </output:serialization-parameters>
+    )
+};
+
+
 declare
     %test:assertEquals("")
 function ser:serialize-empty-sequence() {
@@ -935,3 +955,27 @@ function ser:sequence-of-nodes() {
     (<a>foo</a>, <b>bar</b>) => serialize()
 };
 
+
+declare
+    %test:assertEquals("foo")
+function ser:skip-empty-no-separator() {
+    (<a>foo</a>, <b></b>)/text() => serialize(map{"item-separator": "!"})
+};
+
+declare
+    %test:assertEquals("")
+function ser:empty-array-serializes-to-empty-string() {
+    [] => serialize()
+};
+
+declare
+    %test:assertEquals("")
+function ser:array-with-members-serializes-to-empty-string() {
+    ["", ()] => serialize()
+};
+
+declare
+    %test:assertEquals("")
+function ser:sequence-of-empty-arrays-serializes-to-empty-string() {
+    ([],[]) => serialize()
+};

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -958,31 +958,38 @@ function ser:sequence-of-nodes() {
 declare
     %test:assertEquals("[|]")
 function ser:sequence-skip-empty-text-node() {
-    fn:serialize((<a>[</a>, <a>
-    </a>, <a>]</a>)/text(), map {"item-separator": "|"})
+    (<a>[</a>, <a>
+        </a>, <a>]</a>)/text()
+    => serialize(map {"item-separator": "|"})
 };
 
+declare
+    %test:assertEquals("||")
+function ser:sequence-dont-skip-empty-string() {
+    serialize(("", "", ""), map {"item-separator": "|"})
+};
 
 declare
     %test:assertEquals("foo")
 function ser:skip-empty-no-separator() {
-    (<a>foo</a>, <b></b>)/text() => serialize(map{"item-separator": "!"})
+    (<a>foo</a>, <b></b>)/text()
+    => serialize(map{"item-separator": "!"})
 };
 
 declare
     %test:assertEquals("")
 function ser:empty-array-serializes-to-empty-string() {
-    [] => serialize()
+    serialize([])
 };
 
 declare
     %test:assertEquals("")
 function ser:array-with-members-serializes-to-empty-string() {
-    ["", ()] => serialize()
+    serialize(["", ()])
 };
 
 declare
-    %test:assertEquals("")
+    %test:assertEquals("|")
 function ser:sequence-of-empty-arrays-serializes-to-empty-string() {
-    ([],[]) => serialize()
+    serialize(([],[]), map{"item-separator": "|"})
 };

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -955,6 +955,13 @@ function ser:sequence-of-nodes() {
     (<a>foo</a>, <b>bar</b>) => serialize()
 };
 
+declare
+    %test:assertEquals("[|]")
+function ser:sequence-skip-empty-text-node() {
+    fn:serialize((<a>[</a>, <a>
+    </a>, <a>]</a>)/text(), map {"item-separator": "|"})
+};
+
 
 declare
     %test:assertEquals("foo")

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -989,7 +989,7 @@ function ser:array-with-members-serializes-to-empty-string() {
 };
 
 declare
-    %test:assertEquals("|")
+    %test:assertEquals("")
 function ser:sequence-of-empty-arrays-serializes-to-empty-string() {
     serialize(([],[]), map{"item-separator": "|"})
 };


### PR DESCRIPTION
### Description:

- apply item separator _after_ string normalisation: fixes #4702
- allow empty item separator: fixes #4704
- skip empty values: fixes #4705
- item-separator applies to array members: fixes #4706 

Note:
The provided test cases by @peterstadler had an expected value of `"<a>foo</a><b>bar</b>"`
This had to be changed to `"<a>foo</a> <b>bar</b>"` because of the _changed_ default item separator. 

### Reference:

https://www.w3.org/TR/xslt-xquery-serialization-31/#serdm

### Type of tests:

XQSuite tests