### PR TITLE
CI: test xqts workflow

### DIFF
--- a/.github/workflows/ci-xqts.yml
+++ b/.github/workflows/ci-xqts.yml
@@ -22,8 +22,9 @@ jobs:
         env:
           JAVA_OPTS: -XX:+UseG1GC -XX:+UseStringDeduplication
         run: find exist-xqts/target -name exist-xqts-runner.sh -exec {} --xqts-version HEAD --output-dir /tmp/xqts-output \;
+      - name: Check XQTS Logs
+        run: ls /tmp/xqts-output 
       - name: Archive XQTS Logs
-        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: xqts-logs


### PR DESCRIPTION
closes #4707
By adding a new step into the XQTS workflow that checks for the existence of the temporary folder
the workflow now signals failure if no output was created.
This approach was discussed and agreed on the community call on 6.2.2023 