### PR TITLE
[bugfix] NPE on qname of CDATA section

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/QName.java
+++ b/exist-core/src/main/java/org/exist/dom/QName.java
@@ -47,7 +47,7 @@ public class QName implements Comparable<QName> {
     public static final QName TEXT_QNAME = EMPTY_QNAME;
     public static final QName COMMENT_QNAME = EMPTY_QNAME;
     public static final QName DOCTYPE_QNAME = EMPTY_QNAME;
-
+    public static final QName CDATA_SECTION_QNAME = EMPTY_QNAME;
 
     private final String localPart;
     private final String namespaceURI;

--- a/exist-core/src/main/java/org/exist/dom/persistent/StoredNode.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/StoredNode.java
@@ -214,6 +214,8 @@ public abstract class StoredNode<T extends StoredNode> extends NodeImpl<T> imple
                 return QName.COMMENT_QNAME;
             case Node.DOCUMENT_TYPE_NODE:
                 return QName.DOCTYPE_QNAME;
+            case Node.CDATA_SECTION_NODE:
+                return QName.CDATA_SECTION_QNAME;
             default:
                 LOG.error("Unknown node type: {}", getNodeType());
                 return null;

--- a/exist-core/src/test/java/org/exist/xquery/AbstractDescendantOrSelfNodeKindTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/AbstractDescendantOrSelfNodeKindTest.java
@@ -47,6 +47,7 @@ public abstract class AbstractDescendantOrSelfNodeKindTest {
         "            <d xmlns=\"x\" y=\"2\" z=\"3\">text</d>\n"+
         "            </c>\n"+
         "    </a>\n"+
+        "    <d><![CDATA[ & ]]></d>\n"+
         "</doc>";
 
 
@@ -63,21 +64,21 @@ public abstract class AbstractDescendantOrSelfNodeKindTest {
     public void nodeCount() throws XMLDBException {
         final ResourceSet result = executeQueryOnDoc("count($doc//node())");
         assertEquals(1, result.getSize());
-        assertEquals(23, Integer.parseInt((String)result.getResource(0).getContent()));
+        assertEquals(26, Integer.parseInt((String)result.getResource(0).getContent()));
     }
 
     @Test
     public void elementCount() throws XMLDBException {
         final ResourceSet result = executeQueryOnDoc("count($doc//element())");
         assertEquals(1, result.getSize());
-        assertEquals(7, Integer.parseInt((String)result.getResource(0).getContent()));
+        assertEquals(8, Integer.parseInt((String)result.getResource(0).getContent()));
     }
 
     @Test
     public void textCount() throws XMLDBException {
         final ResourceSet result = executeQueryOnDoc("count($doc//text())");
         assertEquals(1, result.getSize());
-        assertEquals(14, Integer.parseInt((String)result.getResource(0).getContent()));
+        assertEquals(16, Integer.parseInt((String)result.getResource(0).getContent()));
     }
 
     @Test
@@ -99,5 +100,12 @@ public abstract class AbstractDescendantOrSelfNodeKindTest {
         final ResourceSet result = executeQueryOnDoc("count($doc//processing-instruction())");
         assertEquals(1, result.getSize());
         assertEquals(1, Integer.parseInt((String)result.getResource(0).getContent()));
+    }
+
+    @Test
+    public void qnameTest() throws XMLDBException {
+        final ResourceSet result = executeQueryOnDoc("name($doc//d/node())");
+        assertEquals(1, result.getSize());
+        assertEquals("", result.getResource(0).getContent());
     }
 }


### PR DESCRIPTION
fixes #4740

Do not log an error each time typeswitch is called on a CDATA section.

This also fixes an NPE when trying to get the name of a stored CDATA section

```xquery
doc('has-cdata.html')//script/node()/name()
```

With an in-memory CDATA section this returns an empty xs:string

```xquery
<a><![CDATA[ a ]]></a>/node()/name()
```

When this PR is merged an empty xs:string is also returned for stored CDATA sections.