### PR TITLE
[build] add missing dependency to copy-maven-plugin

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -715,6 +715,18 @@
                 <configuration>
                     <showfiles>true</showfiles>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                        <version>2.11.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-utils</artifactId>
+                        <version>1.1</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>autodeploy-expath-pkgs-for-appassembler</id>


### PR DESCRIPTION
### Description:

The [copy maven plugin](https://github.com/Antibrumm/copy-maven-plugin/tree/copy-maven-plugin-1.0.0)
did not run without specifying additional dependencies

- override `commons-io` version to the one used by existdb (2.4.0-> 2.11.0)
- add dependency on `org.codehaus.plexus` 1.1 (also used by appassembler)

### Reference:

fixes #4749 

### Type of tests:

none