### PR TITLE
[bugfix] Install current eXist binaries before javadoc

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -19,12 +19,6 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.jdk }}
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Maven Javadoc
-        run: mvn -V -B -q -T 2C javadoc:javadoc
+        run: mvn -V -B -q -T 2C install javadoc:javadoc -DskipTests -Ddependency-check.skip=true --projects '!exist-distribution,!exist-installer' --also-make
         


### PR DESCRIPTION
### Description:
Javadoc fails due to a unkown SNAPSHOT version used.