### PR TITLE
Lock object optimisation

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -710,6 +710,8 @@
                                 <exclude>src/main/java/org/exist/storage/lock/LockEventJsonListener.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/lock/LockEventLogListener.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/lock/LockEventXmlListener.java</exclude>
+                                <exclude>src/main/java/org/exist/storage/lock/LockedPath.java</exclude>
+                                <exclude>src/main/java/org/exist/storage/lock/LockGroup.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/lock/LockManager.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/lock/LockTable.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/lock/LockTableUtils.java</exclude>
@@ -862,6 +864,8 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/main/java/org/exist/storage/lock/LockEventJsonListener.java</include>
                                 <include>src/main/java/org/exist/storage/lock/LockEventLogListener.java</include>
                                 <include>src/main/java/org/exist/storage/lock/LockEventXmlListener.java</include>
+                                <include>src/main/java/org/exist/storage/lock/LockedPath.java</include>
+                                <include>src/main/java/org/exist/storage/lock/LockGroup.java</include>
                                 <include>src/main/java/org/exist/storage/lock/LockManager.java</include>
                                 <include>src/main/java/org/exist/storage/lock/LockTable.java</include>
                                 <include>src/main/java/org/exist/storage/lock/LockTableUtils.java</include>

--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -718,6 +718,8 @@
                                 <exclude>src/main/java/org/exist/storage/lock/ManagedCollectionLock.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/lock/ManagedDocumentLock.java</exclude>
                                 <exclude>src/main/java/org/exist/storage/lock/ManagedLock.java</exclude>
+                                <exclude>src/main/java/org/exist/storage/lock/ManagedLockGroupDocumentLock.java</exclude>
+                                <exclude>src/main/java/org/exist/storage/lock/ManagedSingleLockDocumentLock.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/lock/CollectionLocksTest.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/lock/DocumentLocksTest.java</exclude>
                                 <exclude>src/test/java/org/exist/storage/lock/LockManagerTest.java</exclude>
@@ -872,6 +874,8 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/main/java/org/exist/storage/lock/ManagedCollectionLock.java</include>
                                 <include>src/main/java/org/exist/storage/lock/ManagedDocumentLock.java</include>
                                 <include>src/main/java/org/exist/storage/lock/ManagedLock.java</include>
+                                <include>src/main/java/org/exist/storage/lock/ManagedLockGroupDocumentLock.java</include>
+                                <include>src/main/java/org/exist/storage/lock/ManagedSingleLockDocumentLock.java</include>
                                 <include>src/test/java/org/exist/storage/lock/CollectionLocksTest.java</include>
                                 <include>src/test/java/org/exist/storage/lock/DocumentLocksTest.java</include>
                                 <include>src/test/java/org/exist/storage/lock/LockManagerTest.java</include>

--- a/exist-core/src/main/java/org/exist/collections/MutableCollection.java
+++ b/exist-core/src/main/java/org/exist/collections/MutableCollection.java
@@ -568,7 +568,7 @@ public class MutableCollection implements Collection {
 
                     case NO_LOCK:
                     default:
-                        documentLock = ManagedDocumentLock.notLocked(doc.getURI());
+                        documentLock = ManagedSingleLockDocumentLock.notLocked(doc.getURI());
                         break;
                 }
 
@@ -710,7 +710,7 @@ public class MutableCollection implements Collection {
 
                 case NO_LOCK:
                 default:
-                    documentLock = ManagedDocumentLock.notLocked(getURI().append(name.lastSegment()));
+                    documentLock = ManagedSingleLockDocumentLock.notLocked(getURI().append(name.lastSegment()));
                     unlockFn = () -> {};
             }
 

--- a/exist-core/src/main/java/org/exist/storage/lock/LockGroup.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockGroup.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage.lock;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+class LockGroup {
+    final long groupId;
+    final LockedPath[] locks;
+
+
+    LockGroup(final long groupId, final LockedPath[] locks) {
+        this.groupId = groupId;
+        this.locks = locks;
+    }
+}

--- a/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
@@ -492,7 +492,7 @@ public class LockManager {
             final LockGroup lockGroup = acquirePathReadLock(LockType.DOCUMENT, documentPath);
             return new ManagedLockGroupDocumentLock(
                     documentPath,
-                    Arrays.stream(lockGroup.locks).map(l -> l.lock).toArray(MultiLock[]::new),
+                    lockGroup,
                     () -> unlockAll(lockGroup.locks, l -> lockTable.released(lockGroup.groupId, l.path, LockType.DOCUMENT, l.mode))
             );
         } else {
@@ -531,7 +531,7 @@ public class LockManager {
             final LockGroup lockGroup = acquirePathWriteLock(LockType.DOCUMENT, documentPath, false);
             return new ManagedLockGroupDocumentLock(
                     documentPath,
-                    Arrays.stream(lockGroup.locks).map(l -> l.lock).toArray(MultiLock[]::new),
+                    lockGroup,
                     () -> unlockAll(lockGroup.locks, l -> lockTable.released(lockGroup.groupId, l.path, LockType.DOCUMENT, l.mode))
             );
         } else {

--- a/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
@@ -218,7 +218,7 @@ public class LockManager {
         final LockGroup lockGroup = acquirePathReadLock(LockType.COLLECTION, collectionPath);
         return new ManagedCollectionLock(
                 collectionPath,
-                Arrays.stream(lockGroup.locks).map(l -> l.lock).toArray(MultiLock[]::new),
+                lockGroup,
                 () -> unlockAll(lockGroup.locks, l -> lockTable.released(lockGroup.groupId, l.path, LockType.COLLECTION, l.mode))
         );
     }
@@ -369,7 +369,7 @@ public class LockManager {
         final LockGroup lockGroup = acquirePathWriteLock(LockType.COLLECTION, collectionPath, lockParent);
         return new ManagedCollectionLock(
                 collectionPath,
-                Arrays.stream(lockGroup.locks).map(l -> l.lock).toArray(MultiLock[]::new),
+                lockGroup,
                 () -> unlockAll(lockGroup.locks, l -> lockTable.released(lockGroup.groupId, l.path, LockType.COLLECTION, l.mode))
         );
     }

--- a/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
@@ -276,7 +276,7 @@ public class LockManager {
      *
      * @return true, if we were able to lock with the mode.
      */
-    private boolean lock(final MultiLock lock, final Lock.LockMode lockMode) {
+    private static boolean lock(final MultiLock lock, final Lock.LockMode lockMode) {
         switch (lockMode) {
             case INTENTION_READ:
                 lock.intentionReadLock();
@@ -308,7 +308,7 @@ public class LockManager {
      *
      * @param locked An array of locks in acquisition order
      */
-    private void unlockAll(final LockedPath[] locked, final Consumer<LockedPath> unlockListener) {
+    private static void unlockAll(final LockedPath[] locked, final Consumer<LockedPath> unlockListener) {
         for(int i = locked.length - 1; i >= 0; i--) {
             final LockedPath lock = locked[i];
             unlock(lock.lock, lock.mode);
@@ -322,7 +322,7 @@ public class LockManager {
      * @param lock The lock object to unlock.
      * @param lockMode The mode of the {@code lock} to release.
      */
-    private void unlock(final MultiLock lock, final Lock.LockMode lockMode) {
+    private static void unlock(final MultiLock lock, final Lock.LockMode lockMode) {
         switch(lockMode) {
             case INTENTION_READ:
                 lock.unlockIntentionRead();

--- a/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
@@ -219,8 +219,7 @@ public class LockManager {
         return new ManagedCollectionLock(
                 collectionPath,
                 lockGroup,
-                () -> unlockAll(lockGroup.locks, l -> lockTable.released(lockGroup.groupId, l.path, LockType.COLLECTION, l.mode))
-        );
+                lockTable);
     }
 
     /**
@@ -308,8 +307,8 @@ public class LockManager {
      *
      * @param locked An array of locks in acquisition order
      */
-    private static void unlockAll(final LockedPath[] locked, final Consumer<LockedPath> unlockListener) {
-        for(int i = locked.length - 1; i >= 0; i--) {
+    static void unlockAll(final LockedPath[] locked, final Consumer<LockedPath> unlockListener) {
+        for (int i = locked.length - 1; i >= 0; i--) {
             final LockedPath lock = locked[i];
             unlock(lock.lock, lock.mode);
             unlockListener.accept(lock);
@@ -323,7 +322,7 @@ public class LockManager {
      * @param lockMode The mode of the {@code lock} to release.
      */
     private static void unlock(final MultiLock lock, final Lock.LockMode lockMode) {
-        switch(lockMode) {
+        switch (lockMode) {
             case INTENTION_READ:
                 lock.unlockIntentionRead();
                 break;
@@ -370,8 +369,7 @@ public class LockManager {
         return new ManagedCollectionLock(
                 collectionPath,
                 lockGroup,
-                () -> unlockAll(lockGroup.locks, l -> lockTable.released(lockGroup.groupId, l.path, LockType.COLLECTION, l.mode))
-        );
+                lockTable);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockManager.java
@@ -490,7 +490,7 @@ public class LockManager {
     public ManagedDocumentLock acquireDocumentReadLock(final XmldbURI documentPath) throws LockException {
         if (usePathLocksForDocuments) {
             final LockGroup lockGroup = acquirePathReadLock(LockType.DOCUMENT, documentPath);
-            return new ManagedDocumentLock(
+            return new ManagedLockGroupDocumentLock(
                     documentPath,
                     Arrays.stream(lockGroup.locks).map(l -> l.lock).toArray(MultiLock[]::new),
                     () -> unlockAll(lockGroup.locks, l -> lockTable.released(lockGroup.groupId, l.path, LockType.DOCUMENT, l.mode))
@@ -510,7 +510,7 @@ public class LockManager {
                 throw new LockException("Unable to acquire READ_LOCK for: " + path);
             }
 
-            return new ManagedDocumentLock(documentPath, lock, () -> {
+            return new ManagedSingleLockDocumentLock(documentPath, lock, () -> {
                 lock.asReadLock().unlock();
                 lockTable.released(groupId, path, LockType.DOCUMENT, Lock.LockMode.READ_LOCK);
             });
@@ -529,7 +529,7 @@ public class LockManager {
     public ManagedDocumentLock acquireDocumentWriteLock(final XmldbURI documentPath) throws LockException {
         if (usePathLocksForDocuments) {
             final LockGroup lockGroup = acquirePathWriteLock(LockType.DOCUMENT, documentPath, false);
-            return new ManagedDocumentLock(
+            return new ManagedLockGroupDocumentLock(
                     documentPath,
                     Arrays.stream(lockGroup.locks).map(l -> l.lock).toArray(MultiLock[]::new),
                     () -> unlockAll(lockGroup.locks, l -> lockTable.released(lockGroup.groupId, l.path, LockType.DOCUMENT, l.mode))
@@ -548,7 +548,7 @@ public class LockManager {
                 throw new LockException("Unable to acquire WRITE_LOCK for: " + path);
             }
 
-            return new ManagedDocumentLock(documentPath, lock, () -> {
+            return new ManagedSingleLockDocumentLock(documentPath, lock, () -> {
                 lock.asWriteLock().unlock();
                 lockTable.released(groupId, path, LockType.DOCUMENT, Lock.LockMode.WRITE_LOCK);
             });

--- a/exist-core/src/main/java/org/exist/storage/lock/LockedPath.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/LockedPath.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This file was originally ported from FusionDB to eXist-db by
+ * Evolved Binary, for the benefit of the eXist-db Open Source community.
+ * Only the ported code as it appears in this file, at the time that
+ * it was contributed to eXist-db, was re-licensed under The GNU
+ * Lesser General Public License v2.1 only for use in eXist-db.
+ *
+ * This license grant applies only to a snapshot of the code as it
+ * appeared when ported, it does not offer or infer any rights to either
+ * updates of this source code or access to the original source code.
+ *
+ * The GNU Lesser General Public License v2.1 only license follows.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (C) 2014, Evolved Binary Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; version 2.1.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.storage.lock;
+
+import uk.ac.ic.doc.slurp.multilock.MultiLock;
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+class LockedPath {
+    final MultiLock lock;
+    final Lock.LockMode mode;
+    final String path;
+
+    LockedPath(final MultiLock lock, final Lock.LockMode mode, final String path) {
+        this.lock = lock;
+        this.mode = mode;
+        this.path = path;
+    }
+}

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedCollectionLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedCollectionLock.java
@@ -32,8 +32,9 @@
  */
 package org.exist.storage.lock;
 
-import jakarta.annotation.Nullable;
 import org.exist.xmldb.XmldbURI;
+
+import javax.annotation.Nullable;
 
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
@@ -59,10 +60,8 @@ public class ManagedCollectionLock extends ManagedLock<LockGroup> {
 
     @Override
     public void close() {
-        if (!closed) {
-            if (lock != null) {  // NOTE(AR) only null when constructed from {@link #notLocked(XmldbURI)}.
-                LockManager.unlockAll(lock.locks, l -> lockTable.released(lock.groupId, l.path, Lock.LockType.COLLECTION, l.mode));
-            }
+        if (!closed && lock != null) {  // NOTE(AR) only null when constructed from {@link #notLocked(XmldbURI)}.
+            LockManager.unlockAll(lock.locks, l -> lockTable.released(lock.groupId, l.path, Lock.LockType.COLLECTION, l.mode));
         }
         this.closed = true;
     }

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedCollectionLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedCollectionLock.java
@@ -32,6 +32,7 @@
  */
 package org.exist.storage.lock;
 
+import jakarta.annotation.Nullable;
 import org.exist.xmldb.XmldbURI;
 
 /**
@@ -40,17 +41,33 @@ import org.exist.xmldb.XmldbURI;
 public class ManagedCollectionLock extends ManagedLock<LockGroup> {
 
     private final XmldbURI collectionUri;
+    @Nullable private final LockTable lockTable;  // NOTE(AR) only null when called via private constructor from {@link #notLocked(XmldbURI)}.
 
-    public ManagedCollectionLock(final XmldbURI collectionUri, final LockGroup lockGroup, final Runnable closer) {
-        super(lockGroup, closer);
+    public ManagedCollectionLock(final XmldbURI collectionUri, final LockGroup lockGroup, final LockTable lockTable) {
+        super(lockGroup, null);  // NOTE(AR) we can set the closer as null here, because we override {@link #close()} below!
         this.collectionUri = collectionUri;
+        this.lockTable = lockTable;
+    }
+
+    private ManagedCollectionLock(final XmldbURI collectionUri) {
+        this(collectionUri, null, null);
     }
 
     public XmldbURI getPath() {
         return collectionUri;
     }
 
+    @Override
+    public void close() {
+        if (!closed) {
+            if (lock != null) {  // NOTE(AR) only null when constructed from {@link #notLocked(XmldbURI)}.
+                LockManager.unlockAll(lock.locks, l -> lockTable.released(lock.groupId, l.path, Lock.LockType.COLLECTION, l.mode));
+            }
+        }
+        this.closed = true;
+    }
+
     public static ManagedCollectionLock notLocked(final XmldbURI collectionUri) {
-        return new ManagedCollectionLock(collectionUri, null, () -> {});
+        return new ManagedCollectionLock(collectionUri);
     }
 }

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedCollectionLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedCollectionLock.java
@@ -33,17 +33,16 @@
 package org.exist.storage.lock;
 
 import org.exist.xmldb.XmldbURI;
-import uk.ac.ic.doc.slurp.multilock.MultiLock;
 
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
-public class ManagedCollectionLock extends ManagedLock<MultiLock[]> {
+public class ManagedCollectionLock extends ManagedLock<LockGroup> {
 
     private final XmldbURI collectionUri;
 
-    public ManagedCollectionLock(final XmldbURI collectionUri, final MultiLock[] locks, final Runnable closer) {
-        super(locks, closer);
+    public ManagedCollectionLock(final XmldbURI collectionUri, final LockGroup lockGroup, final Runnable closer) {
+        super(lockGroup, closer);
         this.collectionUri = collectionUri;
     }
 

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedDocumentLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedDocumentLock.java
@@ -40,7 +40,7 @@ import uk.ac.ic.doc.slurp.multilock.MultiLock;
  */
 public abstract class ManagedDocumentLock<T> extends ManagedLock<T> {
 
-    private final XmldbURI documentUri;
+    protected final XmldbURI documentUri;
 
     public ManagedDocumentLock(final XmldbURI documentUri, final T lock, final Runnable closer) {
         super(lock, closer);

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedLock.java
@@ -201,7 +201,7 @@ public class ManagedLock<T> implements AutoCloseable {
      */
     @Override
     public void close() {
-        if(!closed) {
+        if (!closed) {
             closer.run();
         }
         this.closed = true;

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedLockGroupDocumentLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedLockGroupDocumentLock.java
@@ -38,16 +38,9 @@ import uk.ac.ic.doc.slurp.multilock.MultiLock;
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
-public abstract class ManagedDocumentLock<T> extends ManagedLock<T> {
+public class ManagedLockGroupDocumentLock extends ManagedDocumentLock<MultiLock[]> {
 
-    private final XmldbURI documentUri;
-
-    public ManagedDocumentLock(final XmldbURI documentUri, final T lock, final Runnable closer) {
-        super(lock, closer);
-        this.documentUri = documentUri;
-    }
-
-    public XmldbURI getPath() {
-        return documentUri;
+    public ManagedLockGroupDocumentLock(final XmldbURI documentUri, final MultiLock[] lock, final Runnable closer) {
+        super(documentUri, lock, closer);
     }
 }

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedLockGroupDocumentLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedLockGroupDocumentLock.java
@@ -33,14 +33,13 @@
 package org.exist.storage.lock;
 
 import org.exist.xmldb.XmldbURI;
-import uk.ac.ic.doc.slurp.multilock.MultiLock;
 
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
-public class ManagedLockGroupDocumentLock extends ManagedDocumentLock<MultiLock[]> {
+public class ManagedLockGroupDocumentLock extends ManagedDocumentLock<LockGroup> {
 
-    public ManagedLockGroupDocumentLock(final XmldbURI documentUri, final MultiLock[] lock, final Runnable closer) {
+    public ManagedLockGroupDocumentLock(final XmldbURI documentUri, final LockGroup lock, final Runnable closer) {
         super(documentUri, lock, closer);
     }
 }

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedLockGroupDocumentLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedLockGroupDocumentLock.java
@@ -39,7 +39,18 @@ import org.exist.xmldb.XmldbURI;
  */
 public class ManagedLockGroupDocumentLock extends ManagedDocumentLock<LockGroup> {
 
-    public ManagedLockGroupDocumentLock(final XmldbURI documentUri, final LockGroup lock, final Runnable closer) {
-        super(documentUri, lock, closer);
+    private final LockTable lockTable;
+
+    public ManagedLockGroupDocumentLock(final XmldbURI documentUri, final LockGroup lock, final LockTable lockTable) {
+        super(documentUri, lock, null);    // NOTE(AR) we can set the closer as null here, because we override {@link #close()} below!
+        this.lockTable = lockTable;
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            LockManager.unlockAll(lock.locks, l -> lockTable.released(lock.groupId, l.path, Lock.LockType.DOCUMENT, l.mode));
+        }
+        this.closed = true;
     }
 }

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedSingleLockDocumentLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedSingleLockDocumentLock.java
@@ -32,9 +32,10 @@
  */
 package org.exist.storage.lock;
 
-import jakarta.annotation.Nullable;
 import org.exist.xmldb.XmldbURI;
 import uk.ac.ic.doc.slurp.multilock.MultiLock;
+
+import javax.annotation.Nullable;
 
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
@@ -59,11 +60,9 @@ public class ManagedSingleLockDocumentLock extends ManagedDocumentLock<MultiLock
 
     @Override
     public void close() {
-        if (!closed) {
-            if (lock != null) {  // NOTE(AR) only null when constructed from {@link #notLocked(XmldbURI)}.
-                LockManager.unlock(lock, lockMode);
-                lockTable.released(groupId, documentUri.toString(), Lock.LockType.DOCUMENT, lockMode);
-            }
+        if (!closed && lock != null) {  // NOTE(AR) lock is null when constructed from {@link #notLocked(XmldbURI)}.
+            LockManager.unlock(lock, lockMode);
+            lockTable.released(groupId, documentUri.toString(), Lock.LockType.DOCUMENT, lockMode);
         }
         this.closed = true;
     }

--- a/exist-core/src/main/java/org/exist/storage/lock/ManagedSingleLockDocumentLock.java
+++ b/exist-core/src/main/java/org/exist/storage/lock/ManagedSingleLockDocumentLock.java
@@ -38,16 +38,13 @@ import uk.ac.ic.doc.slurp.multilock.MultiLock;
 /**
  * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
  */
-public abstract class ManagedDocumentLock<T> extends ManagedLock<T> {
+public class ManagedSingleLockDocumentLock extends ManagedDocumentLock<MultiLock> {
 
-    private final XmldbURI documentUri;
-
-    public ManagedDocumentLock(final XmldbURI documentUri, final T lock, final Runnable closer) {
-        super(lock, closer);
-        this.documentUri = documentUri;
+    public ManagedSingleLockDocumentLock(final XmldbURI documentUri, final MultiLock lock, final Runnable closer) {
+        super(documentUri, lock, closer);
     }
 
-    public XmldbURI getPath() {
-        return documentUri;
+    public static ManagedSingleLockDocumentLock notLocked(final XmldbURI documentUri) {
+        return new ManagedSingleLockDocumentLock(documentUri, null, () -> {});
     }
 }


### PR DESCRIPTION
Backported from FusionDB - improvements in the area of Collection and Document locks - some small reductions in the number of object allocations, less array copies, and ultimately less GC.
