### PR TITLE
Use exist-xqts-runner Snapshot version in order to use eXist-db 7.0.0-SNAPSHOT

### DIFF
--- a/exist-xqts/pom.xml
+++ b/exist-xqts/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.exist-db</groupId>
             <artifactId>exist-xqts-runner_2.13</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0-SNAPSHOT</version>
             <exclusions>
                 <!-- use the exist-core version of this project instead -->
                 <exclusion>


### PR DESCRIPTION
Using the snapshot version should enable the XQTS tests again until the final eXist 7.0.0 has been released.

This fixes #4733