### PR TITLE
Fix some issues with CLI args

### DIFF
--- a/exist-core/src/main/java/org/exist/backup/ExportGUI.java
+++ b/exist-core/src/main/java/org/exist/backup/ExportGUI.java
@@ -31,6 +31,7 @@ import org.exist.storage.txn.Txn;
 import org.exist.util.Configuration;
 import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
+import org.exist.util.OSUtil;
 import org.exist.util.SystemExitCodes;
 import org.exist.xquery.TerminatedException;
 import se.softhouse.jargo.Argument;
@@ -624,6 +625,7 @@ public class ExportGUI extends javax.swing.JFrame {
             // parse command-line options
             CommandLineParser
                     .withArguments(helpArg)
+                    .programName("export-gui" + (OSUtil.isWindows() ? ".bat" : ".sh"))
                     .parse(args);
 
         } catch (final StartException e) {

--- a/exist-core/src/main/java/org/exist/backup/ExportGUI.java
+++ b/exist-core/src/main/java/org/exist/backup/ExportGUI.java
@@ -33,6 +33,9 @@ import org.exist.util.MimeTable;
 import org.exist.util.MimeType;
 import org.exist.util.SystemExitCodes;
 import org.exist.xquery.TerminatedException;
+import se.softhouse.jargo.Argument;
+import se.softhouse.jargo.ArgumentException;
+import se.softhouse.jargo.CommandLineParser;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileFilter;
@@ -48,6 +51,7 @@ import java.util.Optional;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.util.ThreadUtils.newGlobalThread;
 import static org.exist.util.ThreadUtils.newInstanceThread;
+import static se.softhouse.jargo.Arguments.helpArgument;
 
 
 /**
@@ -57,6 +61,9 @@ import static org.exist.util.ThreadUtils.newInstanceThread;
  */
 public class ExportGUI extends javax.swing.JFrame {
     private static final long serialVersionUID = -8104424554660744639L;
+
+    /* general arguments */
+    private static final Argument<?> helpArg = helpArgument("-h", "--help");
 
     private BrokerPool pool = null;
     private int documentCount = 0;
@@ -613,13 +620,26 @@ public class ExportGUI extends javax.swing.JFrame {
     public static void main(final String[] args) {
         try {
             CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
+
+            // parse command-line options
+            CommandLineParser
+                    .withArguments(helpArg)
+                    .parse(args);
+
         } catch (final StartException e) {
             if (e.getMessage() != null && !e.getMessage().isEmpty()) {
                 System.err.println(e.getMessage());
             }
             System.exit(e.getErrorCode());
+        } catch (final ArgumentException e) {
+            consoleOut(e.getMessageAndUsage().toString());
+            System.exit(SystemExitCodes.INVALID_ARGUMENT_EXIT_CODE);
         }
 
         java.awt.EventQueue.invokeLater(() -> new ExportGUI().setVisible(true));
+    }
+
+    private static void consoleOut(final String msg) {
+        System.out.println(msg); //NOSONAR this has to go to the console
     }
 }

--- a/exist-core/src/main/java/org/exist/backup/ExportMain.java
+++ b/exist-core/src/main/java/org/exist/backup/ExportMain.java
@@ -30,6 +30,7 @@ import org.exist.storage.DBBroker;
 import org.exist.storage.txn.Txn;
 import org.exist.util.Configuration;
 import org.exist.util.DatabaseConfigurationException;
+import org.exist.util.OSUtil;
 import org.exist.util.SystemExitCodes;
 import org.exist.xquery.TerminatedException;
 import se.softhouse.jargo.Argument;
@@ -130,6 +131,7 @@ public class ExportMain {
                     .withArguments(noCheckArg, checkDocsArg, directAccessArg, exportArg, noExportArg, incrementalArg, zipArg, noZipArg)
                     .andArguments(configArg, outputDirArg)
                     .andArguments(helpArg, verboseArg)
+                    .programName("export" + (OSUtil.isWindows() ? ".bat" : ".sh"))
                     .parse(args);
 
             process(arguments);

--- a/exist-core/src/main/java/org/exist/backup/Main.java
+++ b/exist-core/src/main/java/org/exist/backup/Main.java
@@ -26,6 +26,7 @@ import org.exist.start.CompatibleJavaVersionCheck;
 import org.exist.start.StartException;
 import org.exist.util.ConfigurationHelper;
 import org.exist.util.NamedThreadFactory;
+import org.exist.util.OSUtil;
 import org.exist.util.SystemExitCodes;
 import org.exist.xmldb.*;
 import org.xmldb.api.DatabaseManager;
@@ -461,6 +462,7 @@ public class Main {
                     .andArguments(backupCollectionArg, backupOutputDirArg, backupDeduplicateBlobs)
                     .andArguments(restoreArg, rebuildExpathRepoArg, overwriteAppsArg)
                     .andArguments(helpArg, guiArg, quietArg, optionArg)
+                    .programName("backup" + (OSUtil.isWindows() ? ".bat" : ".sh"))
                     .parse(args);
 
             process(arguments);

--- a/exist-core/src/main/java/org/exist/client/CommandlineOptions.java
+++ b/exist-core/src/main/java/org/exist/client/CommandlineOptions.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.*;
 
+import org.exist.util.OSUtil;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.util.URIUtils;
 import se.softhouse.jargo.*;
@@ -176,6 +177,7 @@ public class CommandlineOptions {
                 .andArguments(setDocArg, xupdateArg)
                 .andArguments(reindexArg, reindexRecurseDirsArg)
                 .andArguments(helpArg, quietArg, verboseArg, outputFileArg, optionArg)
+                .programName("client" + (OSUtil.isWindows() ? ".bat" : ".sh"))
                 .parse(args);
 
         final boolean quiet = getBool(arguments, quietArg);

--- a/exist-core/src/main/java/org/exist/jetty/JettyStart.java
+++ b/exist-core/src/main/java/org/exist/jetty/JettyStart.java
@@ -63,6 +63,7 @@ import java.util.stream.Collectors;
 
 import static org.exist.util.ThreadUtils.newGlobalThread;
 import static se.softhouse.jargo.Arguments.helpArgument;
+import static se.softhouse.jargo.Arguments.stringArgument;
 
 /**
  * This class provides a main method to start Jetty with eXist. It registers shutdown
@@ -88,6 +89,12 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
     private final static int STATUS_STOPPED = 3;
 
     /* general arguments */
+    private static final Argument<String> jettyConfigFilePath = stringArgument()
+            .description("Path to Jetty Config File")
+            .build();
+    private static final Argument<String> existConfigFilePath = stringArgument()
+            .description("Path to eXist-db Config File")
+            .build();
     private static final Argument<?> helpArg = helpArgument("-h", "--help");
 
     @GuardedBy("this") private int status = STATUS_STOPPED;
@@ -102,7 +109,8 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
             CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
 
             CommandLineParser
-                    .withArguments(helpArg)
+                    .withArguments(jettyConfigFilePath, existConfigFilePath)
+                    .andArguments(helpArg)
                     .programName("startup" + (OSUtil.isWindows() ? ".bat" : ".sh"))
                     .parse(args);
 

--- a/exist-core/src/main/java/org/exist/jetty/JettyStart.java
+++ b/exist-core/src/main/java/org/exist/jetty/JettyStart.java
@@ -103,8 +103,6 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
 
 
     public static void main(final String[] args) {
-        String jettyConfigFile = null;
-        Optional<String> existdbConfigFile = Optional.empty();
         try {
             CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
 

--- a/exist-core/src/main/java/org/exist/jetty/JettyStart.java
+++ b/exist-core/src/main/java/org/exist/jetty/JettyStart.java
@@ -41,10 +41,7 @@ import org.exist.start.CompatibleJavaVersionCheck;
 import org.exist.start.Main;
 import org.exist.start.StartException;
 import org.exist.storage.BrokerPool;
-import org.exist.util.ConfigurationHelper;
-import org.exist.util.FileUtils;
-import org.exist.util.SingleInstanceConfiguration;
-import org.exist.util.SystemExitCodes;
+import org.exist.util.*;
 import org.exist.validation.XmlLibraryChecker;
 import org.exist.xmldb.DatabaseImpl;
 import org.exist.xmldb.ShutdownListener;
@@ -106,6 +103,7 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
 
             CommandLineParser
                     .withArguments(helpArg)
+                    .programName("startup" + (OSUtil.isWindows() ? ".bat" : ".sh"))
                     .parse(args);
 
         } catch (final StartException e) {

--- a/exist-core/src/main/java/org/exist/jetty/JettyStart.java
+++ b/exist-core/src/main/java/org/exist/jetty/JettyStart.java
@@ -44,11 +44,15 @@ import org.exist.storage.BrokerPool;
 import org.exist.util.ConfigurationHelper;
 import org.exist.util.FileUtils;
 import org.exist.util.SingleInstanceConfiguration;
+import org.exist.util.SystemExitCodes;
 import org.exist.validation.XmlLibraryChecker;
 import org.exist.xmldb.DatabaseImpl;
 import org.exist.xmldb.ShutdownListener;
 import org.xmldb.api.DatabaseManager;
 import org.xmldb.api.base.Database;
+import se.softhouse.jargo.Argument;
+import se.softhouse.jargo.ArgumentException;
+import se.softhouse.jargo.CommandLineParser;
 
 import java.io.IOException;
 import java.io.LineNumberReader;
@@ -61,6 +65,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.exist.util.ThreadUtils.newGlobalThread;
+import static se.softhouse.jargo.Arguments.helpArgument;
 
 /**
  * This class provides a main method to start Jetty with eXist. It registers shutdown
@@ -85,19 +90,32 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
     private final static int STATUS_STOPPING = 2;
     private final static int STATUS_STOPPED = 3;
 
+    /* general arguments */
+    private static final Argument<?> helpArg = helpArgument("-h", "--help");
+
     @GuardedBy("this") private int status = STATUS_STOPPED;
     @GuardedBy("this") private Optional<Thread> shutdownHookThread = Optional.empty();
     @GuardedBy("this") private int primaryPort = 8080;
 
 
     public static void main(final String[] args) {
+        String jettyConfigFile = null;
+        Optional<String> existdbConfigFile = Optional.empty();
         try {
             CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
+
+            CommandLineParser
+                    .withArguments(helpArg)
+                    .parse(args);
+
         } catch (final StartException e) {
             if (e.getMessage() != null && !e.getMessage().isEmpty()) {
                 System.err.println(e.getMessage());
             }
             System.exit(e.getErrorCode());
+        } catch (final ArgumentException e) {
+            consoleOut(e.getMessageAndUsage().toString());
+            System.exit(SystemExitCodes.INVALID_ARGUMENT_EXIT_CODE);
         }
 
         final JettyStart start = new JettyStart();
@@ -107,6 +125,10 @@ public class JettyStart extends Observable implements LifeCycle.Listener {
     public JettyStart() {
         // Additional checks XML libs @@@@
         XmlLibraryChecker.check();
+    }
+
+    private static void consoleOut(final String msg) {
+        System.out.println(msg); //NOSONAR this has to go to the console
     }
 
     public synchronized void run() {

--- a/exist-core/src/main/java/org/exist/jetty/ServerShutdown.java
+++ b/exist-core/src/main/java/org/exist/jetty/ServerShutdown.java
@@ -26,6 +26,7 @@ import org.exist.client.InteractiveClient;
 import org.exist.start.CompatibleJavaVersionCheck;
 import org.exist.start.StartException;
 import org.exist.util.ConfigurationHelper;
+import org.exist.util.OSUtil;
 import org.exist.util.SystemExitCodes;
 import org.exist.xmldb.DatabaseInstanceManager;
 import org.exist.xmldb.XmldbURI;
@@ -77,6 +78,7 @@ public class ServerShutdown {
             final ParsedArguments arguments = CommandLineParser
                     .withArguments(userArg, passwordArg, uriArg)
                     .andArguments(helpArg)
+                    .programName("shutdown" + (OSUtil.isWindows() ? ".bat" : ".sh"))
                     .parse(args);
 
             process(arguments);

--- a/exist-core/src/main/java/org/exist/launcher/LauncherWrapper.java
+++ b/exist-core/src/main/java/org/exist/launcher/LauncherWrapper.java
@@ -54,8 +54,8 @@ import static se.softhouse.jargo.Arguments.helpArgument;
  */
 public class LauncherWrapper {
 
-    private final static String LAUNCHER = org.exist.launcher.Launcher.class.getName();
-    private final static String OS = OSUtil.getOS().toLowerCase();
+    private static final String LAUNCHER = org.exist.launcher.Launcher.class.getName();
+    private static final String OS = OSUtil.getOS().toLowerCase();
 
     /* general arguments */
     private static final Argument<?> helpArg = helpArgument("-h", "--help");

--- a/exist-core/src/main/java/org/exist/launcher/LauncherWrapper.java
+++ b/exist-core/src/main/java/org/exist/launcher/LauncherWrapper.java
@@ -24,6 +24,7 @@ package org.exist.launcher;
 import org.exist.start.CompatibleJavaVersionCheck;
 import org.exist.start.StartException;
 import org.exist.util.ConfigurationHelper;
+import org.exist.util.OSUtil;
 import org.exist.util.SystemExitCodes;
 import se.softhouse.jargo.Argument;
 import se.softhouse.jargo.ArgumentException;
@@ -54,7 +55,7 @@ import static se.softhouse.jargo.Arguments.helpArgument;
 public class LauncherWrapper {
 
     private final static String LAUNCHER = org.exist.launcher.Launcher.class.getName();
-    private final static String OS = System.getProperty("os.name").toLowerCase();
+    private final static String OS = OSUtil.getOS().toLowerCase();
 
     /* general arguments */
     private static final Argument<?> helpArg = helpArgument("-h", "--help");
@@ -66,6 +67,7 @@ public class LauncherWrapper {
             // parse command-line options
             CommandLineParser
                     .withArguments(helpArg)
+                    .programName("launcher" + (OSUtil.isWindows() ? ".bat" : ".sh"))
                     .parse(args);
 
         } catch (final StartException e) {

--- a/exist-core/src/main/java/org/exist/launcher/LauncherWrapper.java
+++ b/exist-core/src/main/java/org/exist/launcher/LauncherWrapper.java
@@ -24,6 +24,10 @@ package org.exist.launcher;
 import org.exist.start.CompatibleJavaVersionCheck;
 import org.exist.start.StartException;
 import org.exist.util.ConfigurationHelper;
+import org.exist.util.SystemExitCodes;
+import se.softhouse.jargo.Argument;
+import se.softhouse.jargo.ArgumentException;
+import se.softhouse.jargo.CommandLineParser;
 
 import javax.swing.*;
 import java.io.File;
@@ -37,6 +41,7 @@ import java.util.*;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.exist.launcher.ConfigurationUtility.*;
+import static se.softhouse.jargo.Arguments.helpArgument;
 
 /**
  * A wrapper to start a Java process using start.jar with correct VM settings.
@@ -51,14 +56,26 @@ public class LauncherWrapper {
     private final static String LAUNCHER = org.exist.launcher.Launcher.class.getName();
     private final static String OS = System.getProperty("os.name").toLowerCase();
 
+    /* general arguments */
+    private static final Argument<?> helpArg = helpArgument("-h", "--help");
+
     public final static void main(final String[] args) {
         try {
             CompatibleJavaVersionCheck.checkForCompatibleJavaVersion();
+
+            // parse command-line options
+            CommandLineParser
+                    .withArguments(helpArg)
+                    .parse(args);
+
         } catch (final StartException e) {
             if (e.getMessage() != null && !e.getMessage().isEmpty()) {
                 System.err.println(e.getMessage());
             }
             System.exit(e.getErrorCode());
+        } catch (final ArgumentException e) {
+            consoleOut(e.getMessageAndUsage().toString());
+            System.exit(SystemExitCodes.INVALID_ARGUMENT_EXIT_CODE);
         }
 
         final LauncherWrapper wrapper = new LauncherWrapper(LAUNCHER);
@@ -202,5 +219,9 @@ public class LauncherWrapper {
                 }
             }
         }
+    }
+
+    private static void consoleOut(final String msg) {
+        System.out.println(msg); //NOSONAR this has to go to the console
     }
 }

--- a/exist-core/src/main/java/org/exist/management/client/JMXClient.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXClient.java
@@ -23,6 +23,7 @@ package org.exist.management.client;
 
 import org.exist.start.CompatibleJavaVersionCheck;
 import org.exist.start.StartException;
+import org.exist.util.OSUtil;
 import org.exist.util.SystemExitCodes;
 import se.softhouse.jargo.Argument;
 import se.softhouse.jargo.ArgumentException;
@@ -314,6 +315,7 @@ public class JMXClient {
                     .andArguments(cacheDisplayArg, locksDisplayArg)
                     .andArguments(dbInfoArg, memoryInfoArg, sanityCheckInfoArg, jobsInfoArg)
                     .andArguments(helpArg)
+                    .programName("jmxclient" + (OSUtil.isWindows() ? ".bat" : ".sh"))
                     .parse(args);
 
             process(arguments);

--- a/exist-core/src/main/java/org/exist/management/client/JMXClient.java
+++ b/exist-core/src/main/java/org/exist/management/client/JMXClient.java
@@ -256,17 +256,14 @@ public class JMXClient {
     /* connection arguments */
     private static final Argument<String> addressArg = stringArgument("-a", "--address")
             .description("RMI address of the server")
-            .required()
             .defaultValue("localhost")
             .build();
     private static final Argument<Integer> portArg = integerArgument("-p", "--port")
             .description("RMI port of the server")
-            .required()
             .defaultValue(DEFAULT_PORT)
             .build();
     private static final Argument<String> instanceArg = stringArgument("-i", "--instance")
             .description("The ID of the database instance to connect to")
-            .required()
             .defaultValue("exist")
             .build();
     private static final Argument<Integer> waitArg = integerArgument("-w", "--wait")

--- a/exist-core/src/main/java/org/exist/util/OSUtil.java
+++ b/exist-core/src/main/java/org/exist/util/OSUtil.java
@@ -1,0 +1,43 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.util;
+
+public interface OSUtil {
+
+    /**
+     * Return true if the Operating System is Microsoft Windows.
+     *
+     * @return true if the OS is Windows.
+     */
+    static boolean isWindows() {
+        return getOS().toLowerCase().contains("win");
+    }
+
+    /**
+     * Return the OS name from the `os.name` System Property.
+     *
+     * @return the OS name or "unknown".
+     */
+    static String getOS() {
+        return System.getProperty("os.name", "unknown");
+    }
+}

--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -871,7 +871,9 @@
                                 <daemon>
                                     <id>launcher</id>
                                     <mainClass>org.exist.start.Main</mainClass>
-                                    <!-- No arguments needed! Default is to start the launcher -->
+                                    <commandLineArguments>
+                                        <commandLineArgument>launcher</commandLineArgument>
+                                    </commandLineArguments>
                                     <platforms>
                                         <platform>booter-unix</platform>
                                         <platform>booter-windows</platform>

--- a/exist-start/src/main/java/org/exist/start/Main.java
+++ b/exist-start/src/main/java/org/exist/start/Main.java
@@ -189,6 +189,10 @@ public class Main {
                 _classname = "org.exist.launcher.LauncherWrapper";
                 _mode = "jetty";
 
+            } else if ("launcher".equals(args[0])) {
+                _classname = "org.exist.launcher.LauncherWrapper";
+                _mode = "other";
+
             } else if ("shutdown".equals(args[0])) {
                 _classname = "org.exist.jetty.ServerShutdown";
                 _mode = "other";


### PR DESCRIPTION
1. Previously `jmxclient.sh|.bat` would exit with an error.
2. Some `.sh|.bat` scripts did not have a CLI `--help` option, this has now been added to all.
3. Previously the usage text when passing `--help` at the CLI would show the application name as `AppAssemblerBooter` this has now been corrected.