### PR TITLE
[test] fix and add adaptive serialization tests

### DIFF
--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -254,7 +254,9 @@ function ser:serialize-empty-sequence() {
 
 declare
     %test:args(1234)
-    %test:assertEquals(1234)
+    %test:assertEquals('1234')
+    %test:args('1234')
+    %test:assertEquals('"1234"')
     %test:args('Hello "world"!')
     %test:assertEquals('"Hello ""world""!"')
 function ser:adaptive-simple-atomic($atomic as xs:anyAtomicType) {
@@ -263,7 +265,9 @@ function ser:adaptive-simple-atomic($atomic as xs:anyAtomicType) {
 
 declare
     %test:args(1234)
-    %test:assertEquals(1234)
+    %test:assertEquals('1234')
+    %test:args('1234')
+    %test:assertEquals('"1234"')
     %test:args('Hello "world"!')
     %test:assertEquals('"Hello ""world""!"')
 function ser:adaptive-simple-atomic-map-params($atomic as xs:anyAtomicType) {


### PR DESCRIPTION
### Description:

fn:serialize tests with method adaptive _have_ to return strings

### Reference:

reinstate tests modified in #4622 and add two extra

### Type of tests:

XQSuite tests