### PR TITLE
[test] refactor serialization suite

### DIFF
--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -25,6 +25,8 @@ module namespace ser="http://exist-db.org/xquery/test/serialize";
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
+declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
+
 declare %private variable $ser:opt-map-html5 :=
     map {
         "method": "html",
@@ -33,19 +35,17 @@ declare %private variable $ser:opt-map-html5 :=
 ;
 
 declare %private variable $ser:opt-xml-adaptive-no-indent :=
-    <output:serialization-parameters
-        xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
-        <method>adaptive</method>
-        <indent>no</indent>
+    <output:serialization-parameters>
+        <output:method>adaptive</output:method>
+        <output:indent>no</output:indent>
     </output:serialization-parameters>
 ;
 
 declare %private function ser:opt-xml-with-separator($item-separator as xs:string) {
-    <output:serialization-parameters
-            xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
-        <item-separator>{$item-separator}</item-separator>
-        <method>adaptive</method>
-        <indent>no</indent>
+    <output:serialization-parameters>
+        <output:item-separator>{$item-separator}</output:item-separator>
+        <output:method>adaptive</output:method>
+        <output:indent>no</output:indent>
     </output:serialization-parameters>
 };
 
@@ -207,10 +207,9 @@ declare
 function ser:serialize-with-params() {
     serialize(
         $ser:atomic,
-        <output:serialization-parameters
-               xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
-            <method value="xml"/>
-            <indent value="yes"/>
+        <output:serialization-parameters>
+            <output:method value="xml"/>
+            <output:indent value="yes"/>
         </output:serialization-parameters>
     )
 };
@@ -226,8 +225,7 @@ declare
     %test:assertXPath("contains($result,'atomic')")
 function ser:serialize-no-method() {
     serialize($ser:atomic,
-        <output:serialization-parameters
-                xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization" />)
+        <output:serialization-parameters />)
 };
 
 declare
@@ -260,9 +258,8 @@ declare
     %test:assertEquals("aaabbb")
 function ser:serialize-atomic-empty-separator-xml-options() {
     serialize(("aaa", "bbb"),
-        <output:serialization-parameters
-            xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
-            <item-separator value=""/>
+        <output:serialization-parameters>
+            <output:item-separator value=""/>
         </output:serialization-parameters>
     )
 };
@@ -759,10 +756,9 @@ declare
     %test:assertEquals("1--2")
 function ser:item-separator-with-method($method as xs:string) {
     serialize((1, 2),
-        <output:serialization-parameters
-                xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
-            <method>{$method}</method>
-            <item-separator>--</item-separator>
+        <output:serialization-parameters>
+            <output:method>{$method}</output:method>
+            <output:item-separator>--</output:item-separator>
         </output:serialization-parameters>
     )
 };
@@ -771,9 +767,9 @@ declare
     %test:assertEquals("1|2|3|4|5|6|7|8|9|10")
 function ser:serialize-xml-033() {
     let $params :=
-        <output:serialization-parameters xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
-            <method value="xml"/>
-            <item-separator value="|"/>
+        <output:serialization-parameters>
+            <output:method value="xml"/>
+            <output:item-separator value="|"/>
         </output:serialization-parameters>
     return serialize(1 to 10, $params)
 };
@@ -788,10 +784,10 @@ declare
     %test:assertEquals("1==2==3==4")
 function ser:serialize-xml-034() {
     serialize(1 to 4,
-        <output:serialization-parameters xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
-            <method value="xml"/>
-            <omit-xml-declaration value="yes"/>
-            <item-separator value="=="/>
+        <output:serialization-parameters>
+            <output:method value="xml"/>
+            <output:omit-xml-declaration value="yes"/>
+            <output:item-separator value="=="/>
         </output:serialization-parameters>
     )
 };

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -672,6 +672,13 @@ function ser:exist-output-doctype-true() {
 };
 
 declare
+    %test:assertXPath("contains($result, '-//OASIS//DTD DITA BookMap//EN') and contains($result, 'bookmap.dtd')")
+function ser:exist-output-doctype-true-QName() {
+    serialize(doc($ser:collection || "/test-with-doctype.xml"),
+        map { xs:QName("exist:output-doctype"): true() })
+};
+
+declare
     %test:assertXPath("not(contains($result, '-//OASIS//DTD DITA BookMap//EN')) and not(contains($result, 'bookmap.dtd'))")
 function ser:exist-output-doctype-false() {
     serialize(doc($ser:collection || "/test-with-doctype.xml"),
@@ -693,10 +700,24 @@ function ser:exist-expand-xinclude-true() {
 };
 
 declare
+    %test:assertXPath("contains($result, 'comment')")
+function ser:exist-expand-xinclude-true-QName() {
+    serialize($ser:xi-doc,
+        map { xs:QName("exist:expand-xincludes"): true() })
+};
+
+declare
     %test:assertEquals('<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b exist:id="2.3">123</b></elem>')
 function ser:exist-add-exist-id-all() {
     serialize(doc($ser:collection || "/test.xml"),
         map { "exist:add-exist-id": "all" })
+};
+
+declare
+    %test:assertEquals('<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b exist:id="2.3">123</b></elem>')
+function ser:exist-add-exist-id-all-QName() {
+    serialize(doc($ser:collection || "/test.xml"),
+        map { xs:QName("exist:add-exist-id"): "all" })
 };
 
 declare
@@ -730,10 +751,33 @@ function ser:exist-jsonp() {
 };
 
 declare
+    %test:assertEquals('functionName({"author":["John Doe","Robert Smith"]})')
+function ser:exist-jsonp-QName() {
+    serialize(
+        <book>
+            <author>John Doe</author>
+            <author>Robert Smith</author>
+        </book>,
+        map {
+            "method": "json",
+            "media-type": "application/json",
+            xs:QName("exist:jsonp"): "functionName"
+        }
+    )
+};
+
+declare
     %test:assertEquals('processed')
 function ser:exist-process-xsl-pi-true() {
     serialize(doc($ser:collection || "/test-xsl.xml"),
         map { "exist:process-xsl-pi": true() })
+};
+
+declare
+    %test:assertEquals('processed')
+function ser:exist-process-xsl-pi-true-QName() {
+    serialize(doc($ser:collection || "/test-xsl.xml"),
+        map { xs:QName("exist:process-xsl-pi"): true() })
 };
 
 declare

--- a/exist-core/src/test/xquery/xquery3/serialize.xql
+++ b/exist-core/src/test/xquery/xquery3/serialize.xql
@@ -174,6 +174,13 @@ declare variable $ser:xi-doc := document {
     </article>
 };
 
+declare variable $ser:in-memory-book :=
+    <book>
+        <author>John Doe</author>
+        <author>Robert Smith</author>
+    </book>
+;
+
 declare
     %test:setUp
 function ser:setup() {
@@ -665,126 +672,117 @@ function ser:adaptive-xs-strings-map-params() {
 };
 
 declare
+    %test:args("true")
     %test:assertXPath("contains($result, '-//OASIS//DTD DITA BookMap//EN') and contains($result, 'bookmap.dtd')")
-function ser:exist-output-doctype-true() {
-    serialize(doc($ser:collection || "/test-with-doctype.xml"),
-        map { "exist:output-doctype": true() })
-};
-
-declare
-    %test:assertXPath("contains($result, '-//OASIS//DTD DITA BookMap//EN') and contains($result, 'bookmap.dtd')")
-function ser:exist-output-doctype-true-QName() {
-    serialize(doc($ser:collection || "/test-with-doctype.xml"),
-        map { xs:QName("exist:output-doctype"): true() })
-};
-
-declare
+    %test:args("false")
     %test:assertXPath("not(contains($result, '-//OASIS//DTD DITA BookMap//EN')) and not(contains($result, 'bookmap.dtd'))")
-function ser:exist-output-doctype-false() {
+function ser:exist-output-doctype-QName($value as xs:boolean) {
     serialize(doc($ser:collection || "/test-with-doctype.xml"),
-        map { "exist:output-doctype": false() })
+        map { xs:QName("exist:output-doctype") : $value })
 };
 
 declare
+    %test:args("true")
+    %test:assertXPath("contains($result, '-//OASIS//DTD DITA BookMap//EN') and contains($result, 'bookmap.dtd')")
+    %test:args("false")
+    %test:assertXPath("not(contains($result, '-//OASIS//DTD DITA BookMap//EN')) and not(contains($result, 'bookmap.dtd'))")
+function ser:exist-output-doctype-string($value as xs:boolean) {
+    serialize(doc($ser:collection || "/test-with-doctype.xml"),
+        map { "exist:output-doctype" : $value })
+};
+
+declare
+    %test:args("true")
+    %test:assertXPath("contains($result, 'comment')")
+    %test:args("false")
     %test:assertXPath("contains($result, 'include')")
-function ser:exist-expand-xinclude-false() {
+function ser:exist-expand-xinclude-QName($value as xs:boolean) {
     serialize($ser:xi-doc,
-        map { "exist:expand-xincludes": false() })
+        map { xs:QName("exist:expand-xincludes"): $value })
 };
 
 declare
+    %test:args("true")
     %test:assertXPath("contains($result, 'comment')")
-function ser:exist-expand-xinclude-true() {
+    %test:args("false")
+    %test:assertXPath("contains($result, 'include')")
+function ser:exist-expand-xinclude-string($value as xs:boolean) {
     serialize($ser:xi-doc,
-        map { "exist:expand-xincludes": true() })
+        map { "exist:expand-xincludes": $value })
 };
 
 declare
-    %test:assertXPath("contains($result, 'comment')")
-function ser:exist-expand-xinclude-true-QName() {
-    serialize($ser:xi-doc,
-        map { xs:QName("exist:expand-xincludes"): true() })
-};
-
-declare
+    %test:args("all")
     %test:assertEquals('<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b exist:id="2.3">123</b></elem>')
-function ser:exist-add-exist-id-all() {
-    serialize(doc($ser:collection || "/test.xml"),
-        map { "exist:add-exist-id": "all" })
-};
-
-declare
-    %test:assertEquals('<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b exist:id="2.3">123</b></elem>')
-function ser:exist-add-exist-id-all-QName() {
-    serialize(doc($ser:collection || "/test.xml"),
-        map { xs:QName("exist:add-exist-id"): "all" })
-};
-
-declare
+    %test:args("element")
     %test:assertEquals('<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b>123</b></elem>')
-function ser:exist-add-exist-id-element() {
+    %test:args("none")
+    %test:assertXPath("not(contains($result, 'exist:id'))")
+function ser:exist-add-exist-id-QName($value as xs:string) {
     serialize(doc($ser:collection || "/test.xml"),
-        map { "exist:add-exist-id": "element" })
+        map { xs:QName("exist:add-exist-id"): $value })
 };
 
 declare
-     %test:assertXPath("not(contains($result, 'exist:id'))")
-function ser:exist-add-exist-id-none() {
+    %test:args("all")
+    %test:assertEquals('<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b exist:id="2.3">123</b></elem>')
+    %test:args("element")
+    %test:assertEquals('<?pi?><elem xmlns:exist="http://exist.sourceforge.net/NS/exist" exist:id="2" exist:source="test.xml" a="abc"><!--comment--><b>123</b></elem>')
+    %test:args("none")
+    %test:assertXPath("not(contains($result, 'exist:id'))")
+function ser:exist-add-exist-id-string($value as xs:string) {
     serialize(doc($ser:collection || "/test.xml"),
-        map { "exist:add-exist-id": "none" })
+        map { "exist:add-exist-id": $value })
 };
 
 declare
+    %test:args("functionName")
     %test:assertEquals('functionName({"author":["John Doe","Robert Smith"]})')
-function ser:exist-jsonp() {
-    serialize(
-        <book>
-            <author>John Doe</author>
-            <author>Robert Smith</author>
-        </book>,
+    %test:args("anotherName")
+    %test:assertEquals('anotherName({"author":["John Doe","Robert Smith"]})')
+function ser:exist-jsonp-QName($value as xs:string) {
+    serialize($ser:in-memory-book,
         map {
             "method": "json",
             "media-type": "application/json",
-            "exist:jsonp": "functionName"
+            xs:QName("exist:jsonp"): $value
         }
     )
 };
 
 declare
+    %test:args("functionName")
     %test:assertEquals('functionName({"author":["John Doe","Robert Smith"]})')
-function ser:exist-jsonp-QName() {
-    serialize(
-        <book>
-            <author>John Doe</author>
-            <author>Robert Smith</author>
-        </book>,
+    %test:args("anotherName")
+    %test:assertEquals('anotherName({"author":["John Doe","Robert Smith"]})')
+function ser:exist-jsonp-string($value as xs:string) {
+    serialize($ser:in-memory-book,
         map {
             "method": "json",
             "media-type": "application/json",
-            xs:QName("exist:jsonp"): "functionName"
+            "exist:jsonp": $value
         }
     )
 };
 
 declare
+    %test:args("true")
     %test:assertEquals('processed')
-function ser:exist-process-xsl-pi-true() {
-    serialize(doc($ser:collection || "/test-xsl.xml"),
-        map { "exist:process-xsl-pi": true() })
-};
-
-declare
-    %test:assertEquals('processed')
-function ser:exist-process-xsl-pi-true-QName() {
-    serialize(doc($ser:collection || "/test-xsl.xml"),
-        map { xs:QName("exist:process-xsl-pi"): true() })
-};
-
-declare
+    %test:args("false")
     %test:assertXPath("contains($result, 'stylesheet')")
-function ser:exist-process-xsl-pi-false() {
+function ser:exist-process-xsl-pi-QName($value as xs:boolean) {
     serialize(doc($ser:collection || "/test-xsl.xml"),
-        map { "exist:process-xsl-pi": false() })
+        map { xs:QName("exist:process-xsl-pi"): $value })
+};
+
+declare
+    %test:args("true")
+    %test:assertEquals('processed')
+    %test:args("false")
+    %test:assertXPath("contains($result, 'stylesheet')")
+function ser:exist-process-xsl-pi-string($value as xs:boolean) {
+    serialize(doc($ser:collection || "/test-xsl.xml"),
+        map { "exist:process-xsl-pi": $value })
 };
 
 declare


### PR DESCRIPTION
### Description:

Refactor serialization tests for maintainability and readability.

- combine item-separator with method tests into one
    `ser:item-separator-with-method`
- simplify test cases that used eq in combination with assertXPath
- make direct calls to function under test (serialize) in each test
- extract fixtures to module variables
- remove namespace from children of output:serialization-parameters
- convert QNames keys to strings for exist-db specific options
- convert string constructors to CDATA sections
- make HTML5 test data real world examples
- use unprefixed form of built-ins
- fix formatting

### Reference:

has to wait for

- #4773 
- #4816

### Type of tests:

XQSuite