### PR TITLE
[build test] use -Dmaven.resolver.transport=wagon

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'maven'
       - name: Maven Test
         timeout-minutes: 60
-        run: mvn -V -B -DtrimStackTrace=false -Dmaven.resolver.transport=wagon clean verify
+        run: mvn -V -B -DtrimStackTrace=false -D"maven.resolver.transport"="wagon" clean verify
       - name: Maven Code Coverage
         if: ${{ github.ref == 'refs/heads/develop' && matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
         env:


### PR DESCRIPTION
testing `-Dmaven.resolver.transport=wagon` to avoid download issues maven 3.9 

ref: https://questdb.io/blog/maven-troubleshooting-open-source/ 

<img width="868" alt="image" src="https://user-images.githubusercontent.com/1700062/222482239-7600cb5a-72ad-485a-8ff2-8e87fb66069b.png">
