### PR TITLE
Small fixes for the Java Admin Client

### DIFF
--- a/exist-core/src/main/java/org/exist/client/ClientFrame.java
+++ b/exist-core/src/main/java/org/exist/client/ClientFrame.java
@@ -93,15 +93,15 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
 
     private static final long serialVersionUID = 1L;
 
-    public final static String CUT = Messages.getString("ClientFrame.0"); //$NON-NLS-1$
-    public final static String COPY = Messages.getString("ClientFrame.1"); //$NON-NLS-1$
-    public final static String PASTE = Messages.getString("ClientFrame.2"); //$NON-NLS-1$
+    public static final String CUT = Messages.getString("ClientFrame.0"); //$NON-NLS-1$
+    public static final String COPY = Messages.getString("ClientFrame.1"); //$NON-NLS-1$
+    public static final String PASTE = Messages.getString("ClientFrame.2"); //$NON-NLS-1$
 
-    public final static int MAX_DISPLAY_LENGTH = 512000;
-    public final static int MAX_HISTORY = 50;
+    public static final int MAX_DISPLAY_LENGTH = 512000;
+    public static final int MAX_HISTORY = 50;
 
-    private final static SimpleAttributeSet promptAttrs = new SimpleAttributeSet();
-    private final static SimpleAttributeSet defaultAttrs = new SimpleAttributeSet();
+    private static final SimpleAttributeSet promptAttrs = new SimpleAttributeSet();
+    private static final SimpleAttributeSet defaultAttrs = new SimpleAttributeSet();
     static {
         StyleConstants.setForeground(promptAttrs, Color.blue);
         StyleConstants.setBold(promptAttrs, true);

--- a/exist-core/src/main/java/org/exist/client/ClientFrame.java
+++ b/exist-core/src/main/java/org/exist/client/ClientFrame.java
@@ -740,12 +740,6 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
                     }
                 }
 
-                try {
-                    removeRootCollection.close();
-                } catch (final XMLDBException e) {
-                    showErrorMessage(e.getMessage(), e);
-                }
-
                 ClientAction.call(client::getResources, e -> showErrorMessage(e.getMessage(), e));
             };
             client.newClientThread("remove", removeTask).start();

--- a/exist-core/src/main/java/org/exist/client/ClientFrame.java
+++ b/exist-core/src/main/java/org/exist/client/ClientFrame.java
@@ -72,8 +72,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.DateFormat;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.*;
@@ -83,7 +81,7 @@ import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.time.ZoneOffset.UTC;
+import static org.exist.client.InteractiveClient.DATE_TIME_FORMATTER;
 import static org.exist.util.FileUtils.humanSize;
 
 /**
@@ -1262,8 +1260,6 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
             ModeDisplay mode = null;
             SimpleACLPermissionAider acl = null;
 
-            final DateFormat dateTimeFormat = DateFormat.getDateTimeInstance();
-
             final List<ResourceDescriptor> selected = new ArrayList<>();
 
             boolean firstPerm = true;
@@ -1283,7 +1279,7 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
 
                 if (selectedRow.isCollection()) {
                     final Collection coll = collection.getChildCollection(thisName.toString());
-                    thisCreated = dateTimeFormat.format(coll.getCreationTime());
+                    thisCreated = DATE_TIME_FORMATTER.format(coll.getCreationTime());
                     thisModified = NON_APPLICABLE;
                     thisMimeType = COLLECTION_MIME_TYPE;
                     thisMessageDigestType = NON_APPLICABLE;
@@ -1292,8 +1288,8 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
                     thisPerm = service.getPermissions(coll);
                 } else {
                     final Resource res = collection.getResource(thisName.toString());
-                    thisCreated = dateTimeFormat.format(res.getCreationTime());
-                    thisModified = dateTimeFormat.format(res.getLastModificationTime());
+                    thisCreated = DATE_TIME_FORMATTER.format(res.getCreationTime());
+                    thisModified = DATE_TIME_FORMATTER.format(res.getLastModificationTime());
                     thisMimeType = ((EXistResource) res).getMimeType();
                     if (res instanceof EXistBinaryResource) {
                         final MessageDigest messageDigest = ((EXistBinaryResource) res).getContentDigest(DigestType.BLAKE_256);
@@ -1596,8 +1592,6 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
 
         private List<ResourceDescriptor> rows = null;
 
-        private DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(UTC);
-
         public void setData(final List<ResourceDescriptor> rows) {
             rows.sort(new ResourceComparator());
             this.rows = rows;
@@ -1651,7 +1645,7 @@ public class ClientFrame extends JFrame implements WindowFocusListener, KeyListe
                     case 0:
                         return row.getName().toString();
                     case 1:
-                        return dateFormat.format(row.getInstant());
+                        return DATE_TIME_FORMATTER.format(row.getInstant());
                     case 2:
                         return row.getOwner();
                     case 3:

--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BinaryOperator;
@@ -89,6 +90,7 @@ import org.xmldb.api.modules.XUpdateQueryService;
 import se.softhouse.jargo.ArgumentException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneOffset.UTC;
 import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
 import static org.exist.storage.serializers.EXistOutputKeys.OMIT_ORIGINAL_XML_DECLARATION;
 import static org.exist.storage.serializers.EXistOutputKeys.OUTPUT_DOCTYPE;
@@ -100,6 +102,8 @@ import static org.xmldb.api.base.ResourceType.XML_RESOURCE;
  * @author wolf
  */
 public class InteractiveClient {
+
+    static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(UTC);
 
     // ANSI colors for ls display
     // private final static String ANSI_BLUE = "\033[0;34m";
@@ -397,7 +401,7 @@ public class InteractiveClient {
             if ("true".equals(properties.getProperty(PERMISSIONS))) {
                 resources[i] = 'c' + perm.toString() + '\t' + getOwnerName(perm)
                         + '\t' + getGroupName(perm) + '\t'
-                        + created.toString() + '\t'
+                        + DATE_TIME_FORMATTER.format(created) + '\t'
                         + collectionName;
             } else {
                 resources[i] = collectionName;
@@ -431,7 +435,7 @@ public class InteractiveClient {
                 if ("true".equals(properties.getProperty(PERMISSIONS))) {
                     resources[i] = '-' + perm.toString() + '\t' + getOwnerName(perm)
                             + '\t' + getGroupName(perm) + '\t'
-                            + lastModificationTime.toString() + '\t'
+                            + DATE_TIME_FORMATTER.format(lastModificationTime) + '\t'
                             + resourceId;
                 } else {
                     resources[i] = resourceId;


### PR DESCRIPTION
1. Avoid IllegalArgumentException when formatting Instant retrieved via XML:DB API. This was accidentally caused by the update to the new XML:DB API.

2. Do not attempt to close already closed Collection after removing resources, avoids XMLDBException.