### PR TITLE
[fix] XQSuite assertXPath annotation: Support default element namespace

### DIFF
--- a/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/examples.xql
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/examples.xql
@@ -84,3 +84,35 @@ function t:xpath() {
         <name>Item1</name>
     </item>
 };
+
+declare
+    %test:arg("error", "Bad Request")
+    %test:assertXPath("$result/self::html")
+    %test:assertXPath("$result/head[title = 'Bad Request']")
+    %test:assertXPath("$result/body/p[@class = 'ErrorMessage']")
+    %test:assertXPath("/self::html")
+    %test:assertXPath("/head[title = 'Bad Request']")
+    %test:assertXPath("/body/p[@class = 'ErrorMessage']")
+function local:default-element-namespace(
+    $error as xs:string
+) as node() {
+    <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+        <head>
+            <title>{$error}</title>
+        </head>
+        <body>
+            <p class='ErrorMessage'><b>Message: </b>{$error}</p>
+        </body>
+    </html>
+};
+
+declare
+    %test:assertXPath("/self::x")
+    %test:assertXPath("exists($result/*:y)")
+    %test:assertXPath("not($result/y)")
+    %test:assertXPath("$result/Q{bar}y")
+function local:multiple-default-element-namespaces() as node() {
+    <x xmlns="foo">
+        <y xmlns="bar"/>
+    </x>
+};

--- a/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -958,7 +958,7 @@ declare %private function test:assertXPath($annotation as element(annotation), $
                 function ($namespaces as map(*), $xml as element()) {
                     map:merge(($namespaces,
                 	    for $prefix in in-scope-prefixes($xml)
-                	    where $prefix != "" and $prefix != "xml"
+                	    where $prefix ne "xml"
                 	    return
                 	        map:entry($prefix, namespace-uri-for-prefix($prefix, $xml))
                     ))
@@ -968,7 +968,10 @@ declare %private function test:assertXPath($annotation as element(annotation), $
                 string-join(
                     for $prefix in map:keys($namespaces)
                     return
-                        "declare namespace " || $prefix || "='" || $namespaces($prefix) || "';",
+                        if ($prefix eq "") then
+                            "declare default element namespace '" || $namespaces($prefix) || "';"
+                        else
+                            "declare namespace " || $prefix || "='" || $namespaces($prefix) || "';",
                     " "
                 )
         else


### PR DESCRIPTION
### Description:

XQSuite's `assertXPath` annotation failed to account for results whose in-scope-namespaces changed the default element namespace (e.g., `<x xmlns="foo"/>`. As a result, users are forced to result to wildcards or Clark notation to select elements (e.g., `%test:assertXPath("$result/self::*:x")` or `%test:assertXPath("$result/self::Q{foo}x")`).

This PR adjusts how XQSuite detects namespaces in elements in functions' return values, and constructs a default element namespace declaration. In the example scenario described above, a test author could create the annotation, `%test:assertXPath("$result/self::x")`.

### Reference:

https://markmail.org/message/oxsuzh5elgtxlx23

### Type of tests:

XQSuite