### PR TITLE
Add mail:get-mail-session#2 with authentication

### DIFF
--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailModule.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailModule.java
@@ -71,6 +71,7 @@ public class MailModule extends AbstractInternalModule {
 	
     private final static FunctionDef[] functions = {
         new FunctionDef(MailSessionFunctions.signatures[0], MailSessionFunctions.class),
+        new FunctionDef(MailSessionFunctions.signatures[1], MailSessionFunctions.class),
         new FunctionDef(MailStoreFunctions.signatures[0], MailStoreFunctions.class),
         new FunctionDef(MailStoreFunctions.signatures[1], MailStoreFunctions.class),
         new FunctionDef(MailFolderFunctions.signatures[0], MailFolderFunctions.class),

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailSessionFunctions.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailSessionFunctions.java
@@ -24,6 +24,8 @@ package org.exist.xquery.modules.mail;
 
 import java.util.Properties;
 
+import jakarta.mail.Authenticator;
+import jakarta.mail.PasswordAuthentication;
 import jakarta.mail.Session;
 
 import org.apache.logging.log4j.LogManager;
@@ -42,6 +44,8 @@ import org.exist.xquery.value.NodeValue;
 import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
+
+import org.w3c.dom.Element;
 
 /**
  * eXist Mail Module Extension GetSession
@@ -62,13 +66,24 @@ public class MailSessionFunctions extends BasicFunction
 	public final static FunctionSignature signatures[] = {
 		new FunctionSignature(
 			new QName( "get-mail-session", MailModule.NAMESPACE_URI, MailModule.PREFIX ),
-			"Open's a JavaMail session.",
+			"Opens a JavaMail session.",
 			new SequenceType[]
 			{
 				new FunctionParameterSequenceType( "properties", Type.ELEMENT, Cardinality.ZERO_OR_ONE, "An optional JavaMail session properties in the form <properties><property name=\"\" value=\"\"/></properties>.  The JavaMail properties are spelled out in Appendix A of the JavaMail specifications." )
 			},
 			new FunctionReturnSequenceType( Type.LONG, Cardinality.ZERO_OR_ONE, "an xs:long representing the session handle." )
-			)
+			),
+		
+    new FunctionSignature(
+        new QName( "get-mail-session", MailModule.NAMESPACE_URI, MailModule.PREFIX ),
+        "Opens a JavaMail session with authentication.",
+        new SequenceType[]
+        {
+          new FunctionParameterSequenceType( "properties", Type.ELEMENT, Cardinality.ZERO_OR_ONE, "An optional JavaMail session properties in the form <properties><property name=\"\" value=\"\"/></properties>.  The JavaMail properties are spelled out in Appendix A of the JavaMail specifications." ),
+          new FunctionParameterSequenceType( "authentication", Type.ELEMENT, Cardinality.EXACTLY_ONE, "The username and password for authentication in the form <authentication username=\"\" password=\"\"/>." )
+        },
+        new FunctionReturnSequenceType( Type.LONG, Cardinality.ZERO_OR_ONE, "an xs:long representing the session handle." )
+        )
 		};
 
 	public MailSessionFunctions( XQueryContext context, FunctionSignature signature )
@@ -81,15 +96,36 @@ public class MailSessionFunctions extends BasicFunction
 	{
 		Properties props = new Properties();
 		
-		if( args.length == 1 ) {
+		if( args.length > 0 ) {
 			// try and get the session properties
 			props = ParametersExtractor.parseProperties( ((NodeValue) args[0].itemAt(0)).getNode() );
 		}
 		
-		Session session = Session.getInstance( props, null );
+		Authenticator auth = null;
+		
+		if( args.length > 1 ) {
+		  // get the authentication parameters
+		  Element authElement = (Element) ((NodeValue) args[1].itemAt(0)).getNode();
+		  if( authElement != null ) {
+		    String username = authElement.getAttribute("username");
+				String password = authElement.getAttribute("password");
+		    if( username != null && password != null ) {
+		      auth = new Authenticator() {
+						protected PasswordAuthentication getPasswordAuthentication() {
+							return new PasswordAuthentication(username, password);
+						}
+					};
+		    } else {
+		      throw new IllegalArgumentException("'username' and 'password' attributes are mandatory in the 'authentication' element");
+		    }
+		  } else {
+		    throw new IllegalArgumentException("'authentication' element missing");
+		  }
+		}
+		
+		Session session = Session.getInstance( props, auth );
 		
 		// store the session and return the handle of the session
-
-        return new IntegerValue( this, MailModule.storeSession( context, session ), Type.LONG );
+    return new IntegerValue( this, MailModule.storeSession( context, session ), Type.LONG );
 	}
 }

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailSessionFunctions.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/MailSessionFunctions.java
@@ -111,6 +111,7 @@ public class MailSessionFunctions extends BasicFunction
 				String password = authElement.getAttribute("password");
 		    if( username != null && password != null ) {
 		      auth = new Authenticator() {
+							@Override
 						protected PasswordAuthentication getPasswordAuthentication() {
 							return new PasswordAuthentication(username, password);
 						}


### PR DESCRIPTION
### Description:

This PR adds the XQuery function `mail:get-mail-session#2`, which adds authentication to the existing function.
It is the same as #4801, which is for the 6.x.x branch.

```
mail:get-mail-session($properties as element()?, $authentication as element()) as xs:long?
```
Opens a JavaMail session with authentication.

**Parameters:**
    $properties? An optional JavaMail session properties in the form <properties><property name="" value=""/></properties>. The JavaMail properties are spelled out in Appendix A of the JavaMail specifications.
    $authentication The username and password for authentication in the form <authentication username="" password=""/>.

**Returns:**
    xs:long? : an xs:long representing the session handle.

### Reference:

Pieter Lamers from _John Benjamins Publishing Company_ asked me to make this. Many email servers require authentication nowadays, so this should be useful to others, too.

### Type of tests:

I tested this with an email server. A unit test would require a mock email-server with TLS.