### PR TITLE
Use the local DTD file for Jetty configure

### DIFF
--- a/exist-distribution/src/main/xslt/catalog.xml
+++ b/exist-distribution/src/main/xslt/catalog.xml
@@ -22,8 +22,7 @@
 
 -->
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <system systemId="https://www.eclipse.org/jetty/configure_10_0.dtd"
-            uri="configure_9_3.dtd"/>
+    <system systemId="https://www.eclipse.org/jetty/configure_10_0.dtd" uri="configure_10_0.dtd"/>
     <uri name="https://jakarta.ee/xml/ns/jakartae" uri="web-app_5_0.xsd"/>
     <uri name="http://www.w3.org/XML/1998/namespace" uri="xml.xsd"/>
 </catalog>


### PR DESCRIPTION
Due to the Jetty website being unavailable (https://github.com/eclipse/jetty.project/issues/9520), builds were trying to locate the wrong DTD which took them to the unavailable Jetty website. This fix ensures they use the correct local DTD.