### PR TITLE
[enhancement] allow more types in XQSuite

### DIFF
--- a/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
+++ b/exist-core/src/main/resources/org/exist/xquery/lib/xqsuite/xqsuite.xql
@@ -580,82 +580,55 @@ declare %private function test:xdm-value-from-annotation-value($annotation-value
             )
 };
 
-declare %private function test:cast($targs as element(value)*, $farg as element(argument)) {
-    for $targ in $targs
-    let $varg := test:xdm-value-from-annotation-value($targ)
+declare %private function test:cast(
+    $annotation-arg-values as element(value)*,
+    $function-argument as element(argument)
+) {
+    for $annotation-arg-value in $annotation-arg-values
+    let $literal-value := test:xdm-value-from-annotation-value($annotation-arg-value)
     return
-        switch (string($farg/@type))
-            case "xs:string"
-            return
-                if ($varg instance of xs:string)
-                then
-                    $varg
-                else
-                    string($varg)
+        switch (string($function-argument/@type))
+            case "xs:string" return
+                if ($literal-value instance of xs:string)
+                then $literal-value
+                else xs:string($literal-value)
 
-            case "xs:integer"
-            return
-                if ($varg instance of xs:integer)
-                then
-                    $varg
-                else
-                    xs:integer($varg)
+            case "xs:integer" return
+                if ($literal-value instance of xs:integer)
+                then $literal-value
+                else xs:integer($literal-value)
 
-            case "xs:int"
-            return
-                xs:int($varg)
+            case "xs:decimal" return
+                if ($literal-value instance of xs:decimal)
+                then $literal-value
+                else xs:decimal($literal-value)
 
-            case "xs:decimal"
-            return
-                if ($varg instance of xs:decimal)
-                then
-                    $varg
-                else
-                    xs:decimal($varg)
+            case "xs:double" return
+                if ($literal-value instance of xs:double)
+                then $literal-value
+                else xs:double($literal-value)
 
-            case "xs:float"
-            return
-                xs:float($varg)
+            case "xs:boolean"           return xs:boolean($literal-value)
+            case "xs:anyURI"            return xs:anyURI($literal-value)
 
-            case "xs:double"
-            return
-                if ($varg instance of xs:decimal)
-                then
-                    $varg
-                else
-                    xs:double($varg)
+            case "xs:numeric"           return xs:numeric($literal-value)
+            case "xs:int"               return xs:int($literal-value)
+            case "xs:positiveInteger"   return xs:positiveInteger($literal-value)
+            case "xs:negativeInteger"   return xs:negativeInteger($literal-value)
+            case "xs:float"             return xs:float($literal-value)
 
-            case "xs:date"
-            return
-                xs:date($varg)
+            case "xs:time"              return xs:time($literal-value)
+            case "xs:date"              return xs:date($literal-value)
+            case "xs:dateTime"          return xs:dateTime($literal-value)
+            case "xs:dateTimeStamp"     return xs:dateTimeStamp($literal-value)
 
-            case "xs:dateTimeStamp"
-            return
-                xs:dateTimeStamp($varg)
+            case "xs:duration"          return xs:duration($literal-value)
+            case "xs:yearMonthDuration" return xs:yearMonthDuration($literal-value)
+            case "xs:dayTimeDuration"   return xs:dayTimeDuration($literal-value)
 
-            case "xs:dateTime"
-            return
-                xs:dateTime($varg)
-
-            case "xs:time"
-            return
-                xs:time($varg)
-
-            case "element()"
-            return
-                fn:parse-xml($varg)/element()
-
-            case "text()"
-            return
-                if ($varg instance of xs:string)
-                then
-                    text { $varg }
-                else
-                    text { xs:string($varg) }
-
-            default
-            return
-                $varg
+            case "text()"               return text { $literal-value }
+            case "element()"            return parse-xml($literal-value)/element()
+            default                     return $literal-value
 };
 
 declare function test:apply($func as function(*), $meta as element(function), $args as item()*) {
@@ -1005,30 +978,30 @@ declare %private function test:cast-to-type($value as item(), $result as item())
     typeswitch ($result)
         case node() return
             parse-xml("<r>" || $value || "</r>")/r/node()
-        case xs:integer return
-            xs:integer($value)
-        case xs:int return
-            xs:int($value)
-        case xs:long return
-            xs:long($value)
-        case xs:decimal return
-            xs:decimal($value)
-        case xs:double return
-            xs:double($value)
-        case xs:float return
-            xs:float($value)
-        case xs:date return
-            xs:date($value)
-        case xs:dateTime return
-            xs:dateTime($value)
-        case xs:time return
-            xs:time($value)
-        case xs:boolean return
-            xs:boolean($value)
-        case xs:anyURI return
-            xs:anyURI($value)
-        default return
-            string($value)
+
+        case xs:integer           return xs:integer($value)
+        case xs:positiveInteger   return xs:positiveInteger($value)
+        case xs:negativeInteger   return xs:negativeInteger($value)
+        case xs:int               return xs:int($value)
+        case xs:long              return xs:long($value)
+        case xs:decimal           return xs:decimal($value)
+        case xs:double            return xs:double($value)
+        case xs:float             return xs:float($value)
+        case xs:numeric           return xs:numeric($value)
+
+        case xs:date              return xs:date($value)
+        case xs:dateTime          return xs:dateTime($value)
+        case xs:time              return xs:time($value)
+
+        case xs:duration          return xs:duration($value)
+        case xs:yearMonthDuration return xs:yearMonthDuration($value)
+        case xs:dayTimeDuration   return xs:dayTimeDuration($value)
+
+        case xs:boolean           return xs:boolean($value)
+
+        case xs:anyURI            return xs:anyURI($value)
+
+        default return string($value)
 };
 
 (: Helper functions to be used by test modules :)

--- a/exist-core/src/test/xquery/xqsuite/xqsuite-tests.xql
+++ b/exist-core/src/test/xquery/xqsuite/xqsuite-tests.xql
@@ -65,3 +65,154 @@ declare
 function t:xpath-atomic-value() {
     "Hello"
 };
+
+declare
+    %test:args("-0")
+    %test:assertEquals("-0")
+    %test:args(0)
+    %test:assertEquals(0)
+    %test:args(0.0)
+    %test:assertEquals(0.0)
+    %test:args(0e0)
+    %test:assertEquals(0e0)
+function t:args-assert-item($arg) {
+    $arg
+};
+
+declare
+    %test:args("-0")
+    %test:assertEquals("-0")
+    %test:args(0)
+    %test:assertEquals(0)
+    %test:args(0.0)
+    %test:assertEquals(0.0)
+    %test:args(0e0)
+    %test:assertEquals(0e0)
+function t:args-assert-numeric($arg as xs:numeric) as xs:numeric {
+    $arg
+};
+
+declare
+    %test:args("-0")
+    %test:assertEquals("-0")
+    %test:args(0)
+    %test:assertEquals(0)
+    %test:args(0.0)
+    %test:assertEquals(0.0)
+    %test:args(0e0)
+    %test:assertEquals(0e0)
+function t:args-assert-double($arg as xs:double) as xs:double {
+    $arg
+};
+
+declare
+    %test:args("-0")
+    %test:assertEquals("-0")
+    %test:args(0)
+    %test:assertEquals(0)
+    %test:args(0.0)
+    %test:assertEquals(0.0)
+    %test:args(0e0)
+    %test:assertEquals(0e0)
+function t:args-assert-integer($arg as xs:integer) as xs:integer {
+    $arg
+};
+
+declare
+    %test:args("-1")
+    %test:assertEquals("-1")
+function t:args-assert-negative-integer($arg as xs:negativeInteger) as xs:negativeInteger {
+    $arg
+};
+
+declare
+    %test:args(1)
+    %test:assertEquals(1)
+function t:args-assert-positive-integer($arg as xs:positiveInteger) as xs:positiveInteger {
+    $arg
+};
+
+declare
+    %test:args("true")
+    %test:assertTrue
+    %test:args("false")
+    %test:assertEquals("false")
+function t:args-assert-boolean($arg as xs:boolean) as xs:boolean {
+    $arg
+};
+
+declare
+    %test:args("uri/like")
+    %test:assertEquals("uri/like")
+function t:args-assert-anyURI($arg as xs:anyURI) as xs:anyURI {
+    $arg
+};
+
+declare
+    %test:args("2001-01-01")
+    %test:assertEquals("2001-01-01")
+function t:args-assert-date($arg as xs:date) as xs:date {
+    $arg
+};
+
+declare
+    %test:args("00:00:00.000")
+    %test:assertEquals("00:00:00.000")
+function t:args-assert-time($arg as xs:time) as xs:time {
+    $arg
+};
+
+declare
+    %test:args("2001-01-01T01:01:01.001")
+    %test:assertEquals("2001-01-01T01:01:01.001")
+function t:args-assert-dateTime($arg as xs:dateTime) as xs:dateTime {
+    $arg
+};
+
+declare
+    %test:args("2001-01-01T01:01:01.001Z")
+    %test:assertEquals("2001-01-01T01:01:01.001Z")
+function t:args-assert-dateTimeStamp($arg as xs:dateTimeStamp) as xs:dateTimeStamp {
+    $arg
+};
+
+declare
+    %test:args("P1Y1M1DT1H")
+    %test:assertEquals("P1Y1M1DT1H")
+function t:args-assert-duration($arg as xs:duration) as xs:duration {
+    $arg
+};
+
+declare
+    %test:args("P1Y1M")
+    %test:assertEquals("P1Y1M")
+function t:args-assert-yearMonthDuration($arg as xs:yearMonthDuration) as xs:yearMonthDuration {
+    $arg
+};
+
+declare
+    %test:args("P1DT1H")
+    %test:assertEquals("P1DT1H")
+function t:args-assert-dayTimeDuration($arg as xs:dayTimeDuration) as xs:dayTimeDuration {
+    $arg
+};
+
+declare
+    %test:args("-0")
+    %test:assertEquals("-0")
+    %test:args(0)
+    %test:assertEquals(0)
+    %test:args(0.0)
+    %test:assertEquals(0.0)
+    %test:args(0e0)
+    %test:assertEquals(0e0)
+function t:args-assert-text($arg as text()) as text() {
+    $arg
+};
+
+declare
+    %test:args("<test />")
+    %test:assertEquals("<test />")
+function t:args-assert-element($arg as element()) as element() {
+    $arg
+};


### PR DESCRIPTION
Add support for following argument and return types

- xs:boolean
- xs:anyURI
- xs:numeric
- xs:positiveInteger
- xs:negativeInteger
- xs:duration
- xs:dayTimeDuration
- xs:yearMonthDuration

Add tests to assert that annotation values are cast to the respective input type and can be asserted against.

Thank you for your contribution to eXist-db! 

To help the community judge your pull request (PR), please include the following:

- A (short) description of the content of changes.
- A context reference to a [Github Issue](https://github.com/eXist-db/exist/issues), a message in the [eXist-open mailinglist](http://exist-open.markmail.org), or a [specification](https://www.w3.org/TR/xquery-31/).
- Tests. The [XQSuite - Annotation-based Test Framework for XQuery](http://exist-db.org/exist/apps/doc/xqsuite.xml) makes it very easy for you to create tests. These tests can be executed from the [eXide editor](http://exist-db.org/exist/apps/eXide/index.html) via XQuery > Run as Test.

Your PR will be tested using [GitHub Actions](https://github.com/eXist-db/exist/actions) against a number of operating systems and environments. The build status is visible in the PR. 

To detect errors in your PR before submitting it, please run eXist's full test suite on your own system via `mvn -V clean verify`.

------

### Description:

### Reference:

### Type of tests:
