### PR TITLE
Cleanup/xquerycontext

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/AbstractInternalModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/AbstractInternalModule.java
@@ -29,16 +29,15 @@ import org.exist.xquery.value.Sequence;
 import javax.annotation.Nullable;
 
 /**
- * Abstract base class for an {@link org.exist.xquery.InternalModule}. 
+ * Abstract base class for an {@link org.exist.xquery.InternalModule}.
  * Functions are defined in an array of {@link org.exist.xquery.FunctionDef}, which
  * is passed to the constructor. A single implementation class
  * can be registered for more than one function signature, given that the signatures differ
  * in name or the number of expected arguments. It is thus possible to implement
  * similar XQuery functions in one single class.
- * 
+ *
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  * @author ljo
- *
  */
 public abstract class AbstractInternalModule implements InternalModule {
 
@@ -51,18 +50,16 @@ public abstract class AbstractInternalModule implements InternalModule {
 
     protected final FunctionDef[] mFunctions;
     protected final boolean ordered;
-    private final Map<String, List<? extends Object>> parameters;
+    private final Map<String, List<?>> parameters;
 
     protected final Map<QName, Variable> mGlobalVariables = new HashMap<>();
 
-    public AbstractInternalModule(final FunctionDef[] functions,
-            final Map<String, List<? extends Object>> parameters) {
+    public AbstractInternalModule(final FunctionDef[] functions, final Map<String, List<?>> parameters) {
         this(functions, parameters, false);
     }
 
-    public AbstractInternalModule(final FunctionDef[] functions,
-            final Map<String, List<? extends Object>> parameters,
-            final boolean functionsOrdered) {
+    public AbstractInternalModule(final FunctionDef[] functions, final Map<String, List<?>> parameters,
+                                  final boolean functionsOrdered) {
         this.mFunctions = functions;
         this.ordered = functionsOrdered;
         this.parameters = parameters;
@@ -77,10 +74,9 @@ public abstract class AbstractInternalModule implements InternalModule {
      * Get a parameter.
      *
      * @param paramName the name of the parameter
-     *
      * @return the value of tyhe parameter
      */
-    protected List<? extends Object> getParameter(final String paramName) {
+    protected List<?> getParameter(final String paramName) {
         return parameters.get(paramName);
     }
 
@@ -96,7 +92,7 @@ public abstract class AbstractInternalModule implements InternalModule {
 
     @Override
     public FunctionSignature[] listFunctions() {
-        final FunctionSignature signatures[] = new FunctionSignature[mFunctions.length];
+        final FunctionSignature[] signatures = new FunctionSignature[mFunctions.length];
         for (int i = 0; i < signatures.length; i++) {
             signatures[i] = mFunctions[i].getSignature();
         }
@@ -167,7 +163,7 @@ public abstract class AbstractInternalModule implements InternalModule {
 
     /**
      * Declares a variable defined by the module.
-     *
+     * <p>
      * NOTE: this should not be called from the constructor of a module
      * otherwise when {@link #reset(XQueryContext, boolean)} is called
      * with {@code keepGlobals = false}, the variables will be removed
@@ -178,7 +174,6 @@ public abstract class AbstractInternalModule implements InternalModule {
      *
      * @param qname The name of the variable
      * @param value The Java value of the variable, will be converted to an XDM type.
-     *
      * @return the variable
      */
     @Override
@@ -195,7 +190,7 @@ public abstract class AbstractInternalModule implements InternalModule {
 
     /**
      * Declares a variable defined by the module.
-     *
+     * <p>
      * NOTE: this should not be called from the constructor of a module
      * otherwise when {@link #reset(XQueryContext, boolean)} is called
      * with {@code keepGlobals = false}, the variables will be removed
@@ -205,7 +200,6 @@ public abstract class AbstractInternalModule implements InternalModule {
      * in {@link #prepare(XQueryContext)}.
      *
      * @param var The variable
-     *
      * @return the variable
      */
     @Override
@@ -215,12 +209,14 @@ public abstract class AbstractInternalModule implements InternalModule {
     }
 
     @Override
-    @Nullable public Variable resolveVariable(final QName qname) throws XPathException {
+    @Nullable
+    public Variable resolveVariable(final QName qname) throws XPathException {
         return resolveVariable(null, qname);
     }
 
     @Override
-    @Nullable public Variable resolveVariable(@Nullable final AnalyzeContextInfo contextInfo, final QName qname) throws XPathException {
+    @Nullable
+    public Variable resolveVariable(@Nullable final AnalyzeContextInfo contextInfo, final QName qname) throws XPathException {
         return mGlobalVariables.get(qname);
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -198,10 +198,10 @@ public class XQueryContext implements BinaryValueManager, Context {
     private Deque<UserDefinedFunction> closures = new ArrayDeque<>();
 
     // List of options declared for this query at compile time - i.e. declare option
-    private List<Option> staticOptions = null;
+    private List<Option> staticOptions = new ArrayList<>();
 
     // List of options declared for this query at run time - i.e. util:declare-option()
-    private List<Option> dynamicOptions = null;
+    private List<Option> dynamicOptions = new ArrayList<>();
 
     //The Calendar for this context : may be changed by some options
     private XMLGregorianCalendar calendar = null;
@@ -713,11 +713,11 @@ public class XQueryContext implements BinaryValueManager, Context {
         ctx.staticNamespaces = new HashMap<>(this.staticNamespaces);
         ctx.staticPrefixes = new HashMap<>(this.staticPrefixes);
 
-        if (this.dynamicOptions != null) {
+        if (!this.dynamicOptions.isEmpty()) {
             ctx.dynamicOptions = new ArrayList<>(this.dynamicOptions);
         }
 
-        if (this.staticOptions != null) {
+        if (!this.staticOptions.isEmpty()) {
             ctx.staticOptions = new ArrayList<>(this.staticOptions);
         }
 
@@ -1490,7 +1490,7 @@ public class XQueryContext implements BinaryValueManager, Context {
             globalVariables.clear();
         }
 
-        if (dynamicOptions != null) {
+        if (!dynamicOptions.isEmpty()) {
             dynamicOptions.clear(); //clear any dynamic options
         }
 
@@ -2960,17 +2960,11 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     @Override
     public void addOption(final String name, final String value) throws XPathException {
-        if (staticOptions == null) {
-            staticOptions = new ArrayList<>();
-        }
         addOption(staticOptions, name, value);
     }
 
     @Override
     public void addDynamicOption(final String name, final String value) throws XPathException {
-        if (dynamicOptions == null) {
-            dynamicOptions = new ArrayList<>();
-        }
         addOption(dynamicOptions, name, value);
     }
 
@@ -3030,19 +3024,14 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     @Override
     public Option getOption(final QName qname) {
-        if (dynamicOptions != null) {
-            for (final Option option : dynamicOptions) {
-                if (qname.compareTo(option.getQName()) == 0) {
-                    return option;
-                }
+        for (final Option option : dynamicOptions) {
+            if (qname.compareTo(option.getQName()) == 0) {
+                return option;
             }
         }
-
-        if (staticOptions != null) {
-            for (final Option option : staticOptions) {
-                if (qname.compareTo(option.getQName()) == 0) {
-                    return option;
-                }
+        for (final Option option : staticOptions) {
+            if (qname.compareTo(option.getQName()) == 0) {
+                return option;
             }
         }
 
@@ -3247,22 +3236,18 @@ public class XQueryContext implements BinaryValueManager, Context {
     @Override
     public void checkOptions(final Properties properties) throws XPathException {
         checkLegacyOptions(properties);
-        if (dynamicOptions != null) {
-            for (final Option option : dynamicOptions) {
-                if (Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(option.getQName().getNamespaceURI())) {
-                    SerializerUtils.setProperty(option.getQName().getLocalPart(), option.getContents(), properties,
-                            inScopeNamespaces::get);
-                }
+        for (final Option option : dynamicOptions) {
+            if (Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(option.getQName().getNamespaceURI())) {
+                SerializerUtils.setProperty(option.getQName().getLocalPart(), option.getContents(), properties,
+                        inScopeNamespaces::get);
             }
         }
 
-        if (staticOptions != null) {
-            for (final Option option : staticOptions) {
-                if (Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(option.getQName().getNamespaceURI())
-                        && !properties.containsKey(option.getQName().getLocalPart())) {
-                    SerializerUtils.setProperty(option.getQName().getLocalPart(), option.getContents(), properties,
-                            inScopeNamespaces::get);
-                }
+        for (final Option option : staticOptions) {
+            if (Namespaces.XSLT_XQUERY_SERIALIZATION_NS.equals(option.getQName().getNamespaceURI())
+                    && !properties.containsKey(option.getQName().getLocalPart())) {
+                SerializerUtils.setProperty(option.getQName().getLocalPart(), option.getContents(), properties,
+                        inScopeNamespaces::get);
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -1682,20 +1682,22 @@ public class XQueryContext implements BinaryValueManager, Context {
     private static BiFunction<String, Module[], Module[]> addToMapValueArray(final Module module) {
         return (namespaceURI, modules) -> {
             if (modules == null) {
-                modules = new Module[]{ module };
-            } else {
-                // check if the module is already present
-                for (final Module existingModule : modules) {
-                    if (existingModule == module) {  // NOTE: intentional object identity comparison
-                        return modules;  // already present, no further action needed
-                    }
-                }
-
-                // add the module to the modules
-                modules = Arrays.copyOf(modules, modules.length + 1);
-                modules[modules.length - 1] = module;
+                return new Module[]{ module };
             }
-            return modules;
+
+            // check if the module is already present
+            for (final Module existingModule : modules) {
+                if (existingModule == module) {  // NOTE: intentional object identity comparison
+                    return modules;  // already present, no further action needed
+                }
+            }
+
+            // add the module to the modules
+            final int currentLength = modules.length;
+            final Module[] newModules = Arrays.copyOf(modules, currentLength + 1);
+            // previous length is new last index
+            newModules[currentLength] = module;
+            return newModules;
         };
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -216,14 +216,14 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     /**
      * Loaded modules within this module.
-     *
+     * <p>
      * The format of the map is: <code>Map&lt;NamespaceURI, Modules&gt;</code>.
      */
     protected Object2ObjectMap<String, Module[]> modules = new Object2ObjectOpenHashMap<>(8, Hash.VERY_FAST_LOAD_FACTOR);
 
     /**
      * Loaded modules, including ones bubbled up from imported modules.
-     *
+     * <p>
      * The format of the map is: <code>Map&lt;NamespaceURI, Modules&gt;</code>
      */
     private Object2ObjectMap<String, Module[]> allModules = new Object2ObjectOpenHashMap<>();
@@ -252,7 +252,7 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     /**
      * The available documents of the dynamic context.
-     *
+     * <p>
      * {@see https://www.w3.org/TR/xpath-31/#dt-available-docs}.
      */
     private Map<String, TriFunctionE<DBBroker, Txn, String, Either<org.exist.dom.memtree.DocumentImpl, DocumentImpl>, XPathException>> dynamicDocuments = null;
@@ -266,7 +266,7 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     /**
      * The available collections of the dynamic context.
-     *
+     * <p>
      * {@see https://www.w3.org/TR/xpath-31/#dt-available-collections}.
      */
     private Map<String, TriFunctionE<DBBroker, Txn, String, Sequence, XPathException>> dynamicCollections = null;
@@ -422,7 +422,7 @@ public class XQueryContext implements BinaryValueManager, Context {
      * Holds a list of any new XQuery Contexts that
      * were created by the XQuery (owning this XQuery Context)
      * dynamically importing, compiling, and/or evaluating modules.
-     *
+     * <p>
      * NOTE(AR) - This is needed to ensure that these "imported contexts" are
      * also correctly reset and cleaned up when this XQuery is finished.
      */
@@ -431,7 +431,7 @@ public class XQueryContext implements BinaryValueManager, Context {
     /**
      * Holds a list of the {@link #runCleanupTasks(Predicate)} functions
      * of the {@link #importedContexts}.
-     *
+     * <p>
      * NOTE(AR) - This is needed to ensure that these the user call
      * {@link #reset()} or {@link #runCleanupTasks(Predicate)}
      * in any order.
@@ -587,7 +587,7 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     /**
      * Prepares the XQuery Context for use.
-     *
+     * <p>
      * Should be called before compilation to prepare the query context,
      * or before re-execution if the query was cached.
      *
@@ -2821,14 +2821,14 @@ public class XQueryContext implements BinaryValueManager, Context {
                     modulesSaved.put(entry.getKey(), Arrays.copyOf(mods, mods.length));
                 }
 
-                allModulesSaved = new Object2ObjectOpenHashMap(allModules.size());
+                allModulesSaved = new Object2ObjectOpenHashMap<>(allModules.size());
                 for (final Object2ObjectMap.Entry<String, Module[]> entry : Object2ObjectMaps.fastIterable(allModules)) {
                     final Module[] mods = entry.getValue();
                     allModulesSaved.put(entry.getKey(), Arrays.copyOf(mods, mods.length));
                 }
 
-                staticNamespacesSaved = new HashMap(staticNamespaces);
-                staticPrefixesSaved = new HashMap(staticPrefixes);
+                staticNamespacesSaved = new HashMap<>(staticNamespaces);
+                staticPrefixesSaved = new HashMap<>(staticPrefixes);
             }
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -1620,7 +1620,6 @@ public class XQueryContext implements BinaryValueManager, Context {
 
     @SuppressWarnings("unchecked")
     Module initBuiltInModule(final String namespaceURI, final String moduleClass) {
-        Module module = null;
         try {
             // lookup the class
             final ClassLoader existClassLoader = getBroker().getBrokerPool().getClassLoader();
@@ -1630,16 +1629,17 @@ public class XQueryContext implements BinaryValueManager, Context {
                 LOG.info("failed to load module. {} is not an instance of org.exist.xquery.Module.", moduleClass);
                 return null;
             }
-            //instantiateModule( namespaceURI, (Class<Module>)mClass );
             // INOTE: expathrepo
-            module = instantiateModule(namespaceURI, (Class<Module>) mClass, (Map<String, Map<String, List<? extends Object>>>) getConfiguration().getProperty(PROPERTY_MODULE_PARAMETERS));
+            final Module module = instantiateModule(namespaceURI, (Class<Module>) mClass,
+                    (Map<String, Map<String, List<?>>>) getConfiguration().getProperty(PROPERTY_MODULE_PARAMETERS));
             if (LOG.isDebugEnabled()) {
                 LOG.debug("module {} loaded successfully.", module.getNamespaceURI());
             }
+            return module;
         } catch (final ClassNotFoundException e) {
             LOG.warn("module class {} not found. Skipping...", moduleClass);
+            return null;
         }
-        return module;
     }
 
     @SuppressWarnings("unchecked")

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -574,27 +574,26 @@ public class XQueryContext implements BinaryValueManager, Context {
         // the repo and its eXist handler
         final Optional<ExistRepository> repo = getRepository();
 
+        if (repo.isEmpty()) {
+            return null;
+        }
+
         // try an internal module
-        if (repo.isPresent()) {
-            final Module jMod = repo.get().resolveJavaModule(namespace, this);
-            if (jMod != null) {
-                return jMod;
-            }
+        final Module jMod = repo.get().resolveJavaModule(namespace, this);
+        if (jMod != null) {
+            return jMod;
         }
 
         // try an eXist-specific module
-        if (repo.isPresent()) {
-            final Path resolved = repo.get().resolveXQueryModule(namespace);
-
-            // use the resolved file or return null
-            if (resolved != null) {
-                // build a module object from the file
-                final Source src = new FileSource(resolved, false);
-                return compileOrBorrowModule(prefix, namespace, "", src);
-            }
+        final Path resolved = repo.get().resolveXQueryModule(namespace);
+        if (resolved == null) {
+            return null;
         }
 
-        return null;
+        // use the resolved file or return null
+        // build a module object from the file
+        final Source src = new FileSource(resolved, false);
+        return compileOrBorrowModule(prefix, namespace, "", src);
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/ForceIndexUse.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/ForceIndexUse.java
@@ -27,12 +27,11 @@ import org.exist.dom.QName;
 import org.exist.xquery.value.Sequence;
 
 public class ForceIndexUse extends Pragma {
-	
+    public static final String LOCAL_NAME = "force-index-use";
+    public static final QName EXCEPTION_IF_INDEX_NOT_USED_PRAGMA =  new QName(LOCAL_NAME, Namespaces.EXIST_NS, "exist");
+
 	Expression expression;
 	boolean bailout = true;
-
-	public static final QName EXCEPTION_IF_INDEX_NOT_USED_PRAGMA = 
-		 new QName("force-index-use", Namespaces.EXIST_NS, "exist");
 
     public ForceIndexUse(QName qname, String contents) throws XPathException {
         this(null, qname, contents);

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/NoIndexPragma.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/NoIndexPragma.java
@@ -30,10 +30,10 @@ import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 
 public class NoIndexPragma extends Pragma {
+    public final static String LOCAL_NAME = "no-index";
+    public final static QName NO_INDEX_PRAGMA = new QName(LOCAL_NAME, Namespaces.EXIST_NS, "exist");
 
     private final static Logger LOG = LogManager.getLogger(NoIndexPragma.class);
-
-    public  final static QName NO_INDEX_PRAGMA = new QName("no-index", Namespaces.EXIST_NS, "exist");
 
     public NoIndexPragma(QName qname, String contents) throws XPathException {
         this(null, qname, contents);

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
@@ -56,11 +56,11 @@ public class Optimize extends Pragma {
     private NodeSet cachedContext = null;
     private int cachedTimestamp;
     private boolean cachedOptimize;
-    
+
     public Optimize(XQueryContext context, QName pragmaName, String contents, boolean explicit) throws XPathException {
         this(null, context, pragmaName, contents, explicit);
     }
-    
+
     public Optimize(final Expression expression, final XQueryContext context, final QName pragmaName, final String contents, boolean explicit) throws XPathException {
         super(expression, pragmaName, contents);
         this.context = context;
@@ -84,8 +84,9 @@ public class Optimize extends Pragma {
     }
 
     public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
-        if (contextItem != null)
-                {contextSequence = contextItem.toSequence();}
+        if (contextItem != null) {
+            contextSequence = contextItem.toSequence();
+        }
 
         boolean useCached = false;
         boolean optimize = false;
@@ -94,16 +95,17 @@ public class Optimize extends Pragma {
         if (contextSequence == null || contextSequence.isPersistentSet()) {    // don't try to optimize in-memory node sets!
             // contextSequence will be overwritten
             originalContext = contextSequence == null ? null : contextSequence.toNodeSet();
-            if (cachedContext != null && cachedContext == originalContext)
-                {useCached = !originalContext.hasChanged(cachedTimestamp);}
+            if (cachedContext != null && cachedContext == originalContext) {
+                useCached = !originalContext.hasChanged(cachedTimestamp);
+            }
             if (contextVar != null) {
                 contextSequence = contextVar.eval(contextSequence);
             }
             // check if all Optimizable expressions signal that they can indeed optimize
             // in the current context
-            if (useCached)
-                {optimize = cachedOptimize;}
-            else {
+            if (useCached) {
+                optimize = cachedOptimize;
+            } else {
                 if (optimizables != null && optimizables.length > 0) {
                     for (Optimizable optimizable : optimizables) {
                         if (optimizable.canOptimize(contextSequence)) {
@@ -124,16 +126,16 @@ public class Optimize extends Pragma {
             NodeSet result = null;
             for (int current = 0; current < optimizables.length; current++) {
                 NodeSet selection = optimizables[current].preSelect(contextSequence, current > 0);
-                if (LOG.isTraceEnabled())
-                    {
-                        LOG.trace("exist:optimize: pre-selection: {}", selection.getLength());}
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("exist:optimize: pre-selection: {}", selection.getLength());
+                }
                 // determine the set of potential ancestors for which the predicate has to
                 // be re-evaluated to filter out wrong matches
-                if (selection.isEmpty())
-                	{ancestors = selection;}
-                else if (contextStep == null || current > 0) {
-                		ancestors = selection.selectAncestorDescendant(contextSequence.toNodeSet(), NodeSet.ANCESTOR,
-                				true, contextId, true);
+                if (selection.isEmpty()) {
+                    ancestors = selection;
+                } else if (contextStep == null || current > 0) {
+                    ancestors = selection.selectAncestorDescendant(contextSequence.toNodeSet(), NodeSet.ANCESTOR,
+                            true, contextId, true);
                 } else {
 //                    NodeSelector selector;
                     final long start = System.currentTimeMillis();
@@ -142,11 +144,11 @@ public class Optimize extends Pragma {
                     final QName ancestorQN = contextStep.getTest().getName();
                     if (optimizables[current].optimizeOnSelf()) {
                         ancestors = index.findAncestorsByTagName(ancestorQN.getNameType(), ancestorQN, Constants.SELF_AXIS,
-                            selection.getDocumentSet(), selection, contextId);
+                                selection.getDocumentSet(), selection, contextId);
                     } else {
                         ancestors = index.findAncestorsByTagName(ancestorQN.getNameType(), ancestorQN,
-                            optimizables[current].optimizeOnChild() ? Constants.PARENT_AXIS : Constants.ANCESTOR_SELF_AXIS,
-                            selection.getDocumentSet(), selection, contextId);
+                                optimizables[current].optimizeOnChild() ? Constants.PARENT_AXIS : Constants.ANCESTOR_SELF_AXIS,
+                                selection.getDocumentSet(), selection, contextId);
                     }
                     if (LOG.isTraceEnabled()) {
                         LOG.trace("Ancestor selection took {}", System.currentTimeMillis() - start);
@@ -160,25 +162,28 @@ public class Optimize extends Pragma {
                 return innerExpr.eval(result);
             } else {
                 contextStep.setPreloadedData(result.getDocumentSet(), result);
-                if (LOG.isTraceEnabled())
-                    {
-                        LOG.trace("exist:optimize: context after optimize: {}", result.getLength());}
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("exist:optimize: context after optimize: {}", result.getLength());
+                }
                 final long start = System.currentTimeMillis();
-                if (originalContext != null)
-                    {contextSequence = originalContext.filterDocuments(result);}
-                else
-                    {contextSequence = null;}
+                if (originalContext != null) {
+                    contextSequence = originalContext.filterDocuments(result);
+                } else {
+                    contextSequence = null;
+                }
                 final Sequence seq = innerExpr.eval(contextSequence);
-                if (LOG.isTraceEnabled())
-                    {
-                        LOG.trace("exist:optimize: inner expr took {}; found: {}", System.currentTimeMillis() - start, seq.getItemCount());}
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("exist:optimize: inner expr took {}; found: {}", System.currentTimeMillis() - start, seq.getItemCount());
+                }
                 return seq;
             }
         } else {
-            if (LOG.isTraceEnabled())
-                {LOG.trace("exist:optimize: Cannot optimize expression.");}
-            if (originalContext != null)
-                {contextSequence = originalContext;}
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("exist:optimize: Cannot optimize expression.");
+            }
+            if (originalContext != null) {
+                contextSequence = originalContext;
+            }
             return innerExpr.eval(contextSequence, contextItem);
         }
     }
@@ -188,17 +193,19 @@ public class Optimize extends Pragma {
     }
 
     public void before(XQueryContext context, Expression expression, Sequence contextSequence) throws XPathException {
-        if (innerExpr != null)
-            {return;}
+        if (innerExpr != null) {
+            return;
+        }
         innerExpr = expression;
-        if (!enabled)
-            {return;}
+        if (!enabled) {
+            return;
+        }
         innerExpr.accept(new BasicExpressionVisitor() {
 
             public void visitPathExpr(PathExpr expression) {
                 for (int i = 0; i < expression.getLength(); i++) {
                     final Expression next = expression.getExpression(i);
-			        next.accept(this);
+                    next.accept(this);
                 }
             }
 
@@ -214,8 +221,9 @@ public class Optimize extends Pragma {
 
             public void visitFilteredExpr(FilteredExpression filtered) {
                 final Expression filteredExpr = filtered.getExpression();
-                if (filteredExpr instanceof VariableReference)
-                    {contextVar = (VariableReference) filteredExpr;}
+                if (filteredExpr instanceof VariableReference) {
+                    contextVar = (VariableReference) filteredExpr;
+                }
 
                 final List<Predicate> predicates = filtered.getPredicates();
                 for (final Predicate pred : predicates) {
@@ -228,9 +236,9 @@ public class Optimize extends Pragma {
             }
 
             public void visitGeneralComparison(GeneralComparison comparison) {
-                if (LOG.isTraceEnabled())
-                    {
-                        LOG.trace("exist:optimize: found optimizable: {}", comparison.getClass().getName());}
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("exist:optimize: found optimizable: {}", comparison.getClass().getName());
+                }
                 addOptimizable(comparison);
             }
 
@@ -240,17 +248,18 @@ public class Optimize extends Pragma {
 
             public void visitBuiltinFunction(Function function) {
                 if (function instanceof Optimizable) {
-                    if (LOG.isTraceEnabled())
-                        {
-                            LOG.trace("exist:optimize: found optimizable function: {}", function.getClass().getName());}
+                    if (LOG.isTraceEnabled()) {
+                        LOG.trace("exist:optimize: found optimizable function: {}", function.getClass().getName());
+                    }
                     addOptimizable((Optimizable) function);
                 }
             }
         });
 
         contextStep = BasicExpressionVisitor.findFirstStep(innerExpr);
-        if (contextStep != null && contextStep.getTest().isWildcardTest())
-            {contextStep = null;}
+        if (contextStep != null && contextStep.getTest().isWildcardTest()) {
+            contextStep = null;
+        }
         if (LOG.isTraceEnabled()) {
             LOG.trace("exist:optimize: context step: {}", contextStep);
             LOG.trace("exist:optimize: context var: {}", contextVar);
@@ -264,7 +273,8 @@ public class Optimize extends Pragma {
     public void after(XQueryContext context, Expression expression) throws XPathException {
     }
 
-    private void addOptimizable(Optimizable optimizable) {final int axis = optimizable.getOptimizeAxis();
+    private void addOptimizable(Optimizable optimizable) {
+        final int axis = optimizable.getOptimizeAxis();
         if (!(axis == Constants.CHILD_AXIS || axis == Constants.SELF_AXIS || axis == Constants.DESCENDANT_AXIS ||
                 axis == Constants.DESCENDANT_SELF_AXIS || axis == Constants.ATTRIBUTE_AXIS ||
                 axis == Constants.DESCENDANT_ATTRIBUTE_AXIS)) {
@@ -275,7 +285,7 @@ public class Optimize extends Pragma {
             optimizables = new Optimizable[1];
             optimizables[0] = optimizable;
         } else {
-            Optimizable o[] = new Optimizable[optimizables.length + 1];
+            Optimizable[] o = new Optimizable[optimizables.length + 1];
             System.arraycopy(optimizables, 0, o, 0, optimizables.length);
             o[optimizables.length] = optimizable;
             optimizables = o;
@@ -290,47 +300,51 @@ public class Optimize extends Pragma {
     /**
      * Check every collection in the context sequence for an existing range index by QName.
      *
-     * @param context current context
+     * @param context         current context
      * @param contextSequence context sequence
-     * @param qname QName indicating the index to check
+     * @param qname           QName indicating the index to check
      * @return the type of a usable index or {@link org.exist.xquery.value.Type#ITEM} if there is no common
-     *  index.
+     * index.
      */
     public static int getQNameIndexType(XQueryContext context, Sequence contextSequence, QName qname) {
-        if (contextSequence == null || qname == null)
-            {return Type.ITEM;}
-        
-        final String enforceIndexUse = 
-        		(String) context.getBroker().getConfiguration().getProperty(XQueryContext.PROPERTY_ENFORCE_INDEX_USE);
+        if (contextSequence == null || qname == null) {
+            return Type.ITEM;
+        }
+
+        final String enforceIndexUse =
+                (String) context.getBroker().getConfiguration().getProperty(XQueryContext.PROPERTY_ENFORCE_INDEX_USE);
         int indexType = Type.ITEM;
         for (final Iterator<Collection> i = contextSequence.getCollectionIterator(); i.hasNext(); ) {
             final Collection collection = i.next();
-            if (collection.getURI().startsWith(XmldbURI.SYSTEM_COLLECTION_URI))
-                {continue;}
+            if (collection.getURI().startsWith(XmldbURI.SYSTEM_COLLECTION_URI)) {
+                continue;
+            }
             final QNameRangeIndexSpec config = collection.getIndexByQNameConfiguration(context.getBroker(), qname);
             if (config == null) {
                 // no index found for this collection
-                if (LOG.isTraceEnabled())
-                    {
-                        LOG.trace("Cannot optimize: collection {} does not define an index on {}", collection.getURI(), qname);}
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Cannot optimize: collection {} does not define an index on {}", collection.getURI(), qname);
+                }
                 // if enfoceIndexUse == "always", continue to check other collections
                 // for indexes. It is sufficient if one collection defines an index
-                if (enforceIndexUse == null || !"always".equals(enforceIndexUse))
-                    {return Type.ITEM;}   // found a collection without index
+                if (enforceIndexUse == null || !"always".equals(enforceIndexUse)) {
+                    return Type.ITEM;
+                }   // found a collection without index
             } else {
-            int type = config.getType();
+                int type = config.getType();
                 if (indexType == Type.ITEM) {
                     indexType = type;
                     // if enforceIndexUse == "always", it is sufficient if one collection
                     // defines an index. Just return it.
-                    if (enforceIndexUse != null && "always".equals(enforceIndexUse))
-                        {return indexType;}
+                    if (enforceIndexUse != null && "always".equals(enforceIndexUse)) {
+                        return indexType;
+                    }
                 } else if (indexType != type) {
                     // found an index with a bad type. cannot optimize.
                     // TODO: should this continue checking other collections?
-                    if (LOG.isTraceEnabled())
-                        {
-                            LOG.trace("Cannot optimize: collection {} does not define an index with the required type {} on {}", collection.getURI(), Type.getTypeName(type), qname);}
+                    if (LOG.isTraceEnabled()) {
+                        LOG.trace("Cannot optimize: collection {} does not define an index with the required type {} on {}", collection.getURI(), Type.getTypeName(type), qname);
+                    }
                     return Type.ITEM;   // found a collection with a different type
                 }
             }

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
@@ -47,7 +47,7 @@ public class Optimize extends Pragma {
 
     private boolean enabled = true;
     private XQueryContext context;
-    private Optimizable optimizables[];
+    private Optimizable[] optimizables;
     private Expression innerExpr = null;
     private LocationStep contextStep = null;
     private VariableReference contextVar = null;
@@ -61,17 +61,20 @@ public class Optimize extends Pragma {
         this(null, context, pragmaName, contents, explicit);
     }
     
-    public Optimize(final Expression expression, XQueryContext context, QName pragmaName, String contents, boolean explicit) throws XPathException {
+    public Optimize(final Expression expression, final XQueryContext context, final QName pragmaName, final String contents, boolean explicit) throws XPathException {
         super(expression, pragmaName, contents);
         this.context = context;
         this.enabled = explicit || context.optimizationsEnabled();
-        if (contents != null && contents.length() > 0) {
-            final String param[] = Option.parseKeyValuePair(contents);
-            if (param == null)
-                {throw new XPathException((Expression) null, "Invalid content found for pragma exist:optimize: " + contents);}
-            if ("enable".equals(param[0])) {
-                enabled = "yes".equals(param[1]);
-            }
+        if (contents == null || contents.isEmpty()) {
+            return;
+        }
+        final String[] param = Option.parseKeyValuePair(contents);
+        if (param == null) {
+            throw new XPathException((Expression) null,
+                    "Invalid content found for pragma exist:optimize: " + contents);
+        }
+        if ("enable".equals(param[0])) {
+            enabled = "yes".equals(param[1]);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
@@ -39,6 +39,8 @@ import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 
+import static java.lang.System.arraycopy;
+
 public class Optimize extends Pragma {
     public final static String LOCAL_NAME = "optimize";
     public final static QName OPTIMIZE_PRAGMA = new QName(LOCAL_NAME, Namespaces.EXIST_NS, "exist");
@@ -203,8 +205,8 @@ public class Optimize extends Pragma {
         innerExpr.accept(new BasicExpressionVisitor() {
 
             public void visitPathExpr(PathExpr expression) {
-                for (int i = 0; i < expression.getLength(); i++) {
-                    final Expression next = expression.getExpression(i);
+                for (int i = 0; i < expression.getSubExpressionCount(); i++) {
+                    final Expression next = expression.getSubExpression(i);
                     next.accept(this);
                 }
             }
@@ -275,21 +277,24 @@ public class Optimize extends Pragma {
 
     private void addOptimizable(Optimizable optimizable) {
         final int axis = optimizable.getOptimizeAxis();
+
         if (!(axis == Constants.CHILD_AXIS || axis == Constants.SELF_AXIS || axis == Constants.DESCENDANT_AXIS ||
                 axis == Constants.DESCENDANT_SELF_AXIS || axis == Constants.ATTRIBUTE_AXIS ||
                 axis == Constants.DESCENDANT_ATTRIBUTE_AXIS)) {
             // reverse axes cannot be optimized
             return;
         }
+
         if (optimizables == null) {
             optimizables = new Optimizable[1];
             optimizables[0] = optimizable;
-        } else {
-            Optimizable[] o = new Optimizable[optimizables.length + 1];
-            System.arraycopy(optimizables, 0, o, 0, optimizables.length);
-            o[optimizables.length] = optimizable;
-            optimizables = o;
+            return;
         }
+
+        Optimizable[] o = new Optimizable[optimizables.length + 1];
+        arraycopy(optimizables, 0, o, 0, optimizables.length);
+        o[optimizables.length] = optimizable;
+        optimizables = o;
     }
 
     public void resetState(boolean postOptimization) {
@@ -311,41 +316,50 @@ public class Optimize extends Pragma {
             return Type.ITEM;
         }
 
-        final String enforceIndexUse =
+        final String enforceIndexUseValue =
                 (String) context.getBroker().getConfiguration().getProperty(XQueryContext.PROPERTY_ENFORCE_INDEX_USE);
+        final boolean enforceIndexUse = enforceIndexUseValue != null;
+        final boolean alwaysEnforceIndexUse = enforceIndexUse && "always".equals(enforceIndexUseValue);
+
         int indexType = Type.ITEM;
+
         for (final Iterator<Collection> i = contextSequence.getCollectionIterator(); i.hasNext(); ) {
-            final Collection collection = i.next();
-            if (collection.getURI().startsWith(XmldbURI.SYSTEM_COLLECTION_URI)) {
-                continue;
-            }
-            final QNameRangeIndexSpec config = collection.getIndexByQNameConfiguration(context.getBroker(), qname);
-            if (config == null) {
-                // no index found for this collection
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("Cannot optimize: collection {} does not define an index on {}", collection.getURI(), qname);
+            try (Collection collection = i.next()) {
+                // always skip system collection
+                if (collection.getURI().startsWith(XmldbURI.SYSTEM_COLLECTION_URI)) {
+                    continue;
                 }
-                // if enfoceIndexUse == "always", continue to check other collections
-                // for indexes. It is sufficient if one collection defines an index
-                if (enforceIndexUse == null || !"always".equals(enforceIndexUse)) {
-                    return Type.ITEM;
-                }   // found a collection without index
-            } else {
-                int type = config.getType();
-                if (indexType == Type.ITEM) {
-                    indexType = type;
-                    // if enforceIndexUse == "always", it is sufficient if one collection
-                    // defines an index. Just return it.
-                    if (enforceIndexUse != null && "always".equals(enforceIndexUse)) {
-                        return indexType;
-                    }
-                } else if (indexType != type) {
-                    // found an index with a bad type. cannot optimize.
-                    // TODO: should this continue checking other collections?
+                // load index configuration for current collection
+                final QNameRangeIndexSpec config = collection.getIndexByQNameConfiguration(context.getBroker(), qname);
+                if (config == null) {
+                    // no index found for this collection
                     if (LOG.isTraceEnabled()) {
-                        LOG.trace("Cannot optimize: collection {} does not define an index with the required type {} on {}", collection.getURI(), Type.getTypeName(type), qname);
+                        LOG.trace("Cannot optimize: collection {} does not define an index on {}",
+                                collection.getURI(), qname);
                     }
-                    return Type.ITEM;   // found a collection with a different type
+                    // If enforceIndexUse is set to "always" we have to continue to check other collections
+                    // for indexes. Otherwise, it is sufficient if one collection defines an index.
+                    if (!enforceIndexUse || !alwaysEnforceIndexUse) {
+                        return Type.ITEM;
+                    }   // found a collection without index
+                } else {
+                    int type = config.getType();
+                    if (indexType == Type.ITEM) {
+                        indexType = type;
+                        // If enforceIndexUse is set to "always", it is sufficient if only one collection
+                        // defines an index. Just return it.
+                        if (alwaysEnforceIndexUse) {
+                            return indexType;
+                        }
+                    } else if (indexType != type) {
+                        // Found an index with a bad type. cannot optimize.
+                        // TODO: should this continue checking other collections?
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace("Cannot optimize: collection {} does not define an index with the required type {} on {}",
+                                    collection.getURI(), Type.getTypeName(type), qname);
+                        }
+                        return Type.ITEM;   // found a collection with a different type
+                    }
                 }
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
@@ -40,8 +40,8 @@ import java.util.Iterator;
 import java.util.List;
 
 public class Optimize extends Pragma {
-
-    public  final static QName OPTIMIZE_PRAGMA = new QName("optimize", Namespaces.EXIST_NS, "exist");
+    public final static String LOCAL_NAME = "optimize";
+    public final static QName OPTIMIZE_PRAGMA = new QName(LOCAL_NAME, Namespaces.EXIST_NS, "exist");
 
     private final static Logger LOG = LogManager.getLogger(Optimize.class);
 

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/ProfilePragma.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/ProfilePragma.java
@@ -27,8 +27,8 @@ import org.exist.dom.QName;
 import org.exist.xquery.value.Sequence;
 
 public class ProfilePragma extends Pragma {
-
-    public final static QName PROFILING_PRAGMA = new QName("profiling", Namespaces.EXIST_NS, "exist");
+    public final static String LOCAL_NAME = "profiling";
+    public final static QName PROFILING_PRAGMA = new QName(LOCAL_NAME, Namespaces.EXIST_NS, "exist");
     
     public ProfilePragma(QName qname, String contents) throws XPathException {
         this(null, qname, contents);

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/TimerPragma.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/TimerPragma.java
@@ -30,8 +30,8 @@ import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.Sequence;
 
 public class TimerPragma extends Pragma {
-
-    public  final static QName TIMER_PRAGMA = new QName("timer", Namespaces.EXIST_NS, "exist");
+    public final static String LOCAL_NAME = "timer";
+    public final static QName TIMER_PRAGMA = new QName(LOCAL_NAME, Namespaces.EXIST_NS, "exist");
     
     private Logger log = null;
     


### PR DESCRIPTION
### Description:

Refactor and cleanup XQueryContext and adjacent classes for readability.

### Reference:

- add LOCAL_NAME field to pragma implementations
- use enhanced switch statement where possible
- reduce indentation by returning early
- reformat code (using IntelliJ defaults)
- convert to final variables where possible 

### Type of tests:

no new tests added