### PR TITLE
[ci] split test and verify into separate workflows

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test (Package)
 on: [push, pull_request]
 jobs:
   test:
@@ -21,7 +21,7 @@ jobs:
           cache: 'maven'
       - name: Maven Test
         timeout-minutes: 60
-        run: mvn -V -B -DtrimStackTrace=false -D"maven.resolver.transport"=wagon clean test
+        run: mvn -V -B -DtrimStackTrace=false -D"maven.resolver.transport"=wagon clean package
       - name: Archive build logs
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,21 +21,12 @@ jobs:
           cache: 'maven'
       - name: Maven Test
         timeout-minutes: 60
-        run: mvn -V -B -DtrimStackTrace=false -D"maven.resolver.transport"="wagon" clean verify
-      - name: Maven Code Coverage
-        if: ${{ github.ref == 'refs/heads/develop' && matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
-        env:
-          CI_NAME: github
-          BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
-          CI_BUILD_NUMBER: ${{ github.run_id }}
-          CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-        run: mvn -V -B jacoco:report coveralls:report
+        run: mvn -V -B -DtrimStackTrace=false -D"maven.resolver.transport"=wagon clean test
       - name: Archive build logs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ runner.os }}-jdk${{ matrix.jdk }}-build-logs
+          name: ${{ runner.os }}-jdk${{ matrix.jdk }}-test-logs
           retention-days: 5
           path: |
             **/*.jfr

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -1,0 +1,42 @@
+name: Verify
+on: [push, pull_request]
+jobs:
+  verify:
+    name: Verify (JDK ${{ matrix.jdk }}) 
+    env:
+      MAVEN_OPTS: -XX:StartFlightRecording=maxsize=5g,disk=true,dumponexit=true,settings=default,filename=./
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: ['17']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.jdk }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jdk }}
+          cache: 'maven'
+      - name: Maven Verify
+        timeout-minutes: 60
+        run: mvn -V -B -DtrimStackTrace=false -D"maven.resolver.transport"=wagon -D"dependency-check.skip"=true clean verify
+      - name: Maven Code Coverage
+        if: ${{ github.ref == 'refs/heads/develop' && matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
+        env:
+          CI_NAME: github
+          BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
+          CI_BUILD_NUMBER: ${{ github.run_id }}
+          CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+        run: mvn -V -B jacoco:report coveralls:report
+      - name: Archive verify logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: jdk${{ matrix.jdk }}-verify-logs
+          retention-days: 5
+          path: |
+            **/*.jfr
+            **/hs_err_pid*.log
+            **/target/surefire-reports/*

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -20,9 +20,9 @@ jobs:
           cache: 'maven'
       - name: Maven Verify
         timeout-minutes: 60
-        run: mvn -V -B -DtrimStackTrace=false -D"maven.resolver.transport"=wagon -D"dependency-check.skip"=true clean verify
+        run: mvn -V -B -DtrimStackTrace=false -D"maven.resolver.transport"=wagon clean verify
       - name: Maven Code Coverage
-        if: ${{ github.ref == 'refs/heads/develop' && matrix.jdk == '8' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ github.ref == 'refs/heads/develop'}}
         env:
           CI_NAME: github
           BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}


### PR DESCRIPTION
### Description:

A lot of time consuming tasks such as static code analysis tasks are performed in the test workflow. They are performed per run in the test matrix even if they are independent of the operating system. 

- dependency checks
- vulnerability checking
- code coverage of tests

This PR separates both concerns into separate workflows.

- one for testing and
- one for verification, static code analysis and code coverage 

This is the result of discussions in the community meetings on the 20th and 27th of March 2023

### Reference:

This will also allow us to see if tests in a PR succeed even if we experience issues with the dependency checking plugin.
We should discuss if it is beneficial to check if packaging succeeds on each operating system.
This would mean to call `mvn package` instead of `mvn test`.

### Type of tests:

None added