### PR TITLE
Cleanup/remove deprecated filter fn

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
@@ -113,18 +113,6 @@ public class FunHigherOrderFun extends BasicFunction {
     }
 
     @Override
-    protected void checkArgument(final Expression arg, @Nullable final SequenceType argType,
-                                 final AnalyzeContextInfo argContextInfo, final int argPosition) throws XPathException {
-        // hack: order of parameters for filter and other functions has changed
-        // in final XQ3 spec. This would cause some core apps (dashboard) to stop
-        // working. We thus switch parameters dynamically until all users can be expected to
-        // have updated to 2.2.
-        if (!isCalledAs("filter")) {
-            super.checkArgument(arg, argType, argContextInfo, argPosition);
-        }
-    }
-
-    @Override
     public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
         cachedContextInfo = new AnalyzeContextInfo(contextInfo);
         super.analyze(cachedContextInfo);
@@ -149,24 +137,14 @@ public class FunHigherOrderFun extends BasicFunction {
                 }
             }
         } else if (isCalledAs("filter")) {
-            final FunctionReference refParam;
-            final Sequence seq;
-            // Hack: switch parameters for backwards compatibility
-            if (Type.subTypeOf(args[1].getItemType(), Type.FUNCTION_REFERENCE)) {
-                refParam = (FunctionReference) args[1].itemAt(0);
-                seq = args[0];
-            } else {
-                refParam = (FunctionReference) args[0].itemAt(0);
-                seq = args[1];
-            }
-
-            try (final FunctionReference ref = refParam) {
+            try (final FunctionReference ref = (FunctionReference) args[1].itemAt(0)) {
                 ref.analyze(cachedContextInfo);
                 if (funcRefHasDifferentArity(ref, 1)) {
                     throw new XPathException(this, ErrorCodes.XPTY0004,
                             "The supplied function (" + ref.getStringValue() + ") has " + ref.getSignature().getArgumentCount() + " arguments - expected 1");
                 }
 
+                final Sequence seq = args[0];
                 for (final SequenceIterator i = seq.iterate(); i.hasNext(); ) {
                     final Item item = i.nextItem();
                     final Sequence r = ref.evalFunction(null, null, new Sequence[]{item.toSequence()});

--- a/exist-core/src/test/xquery/xquery3/higher-order.xml
+++ b/exist-core/src/test/xquery/xquery3/higher-order.xml
@@ -499,11 +499,11 @@ return
     </test>
     <test output="text">
         <task>fn:filter function (wrong argument order: deprecated)</task>
-        <code>fn:filter(function($a) {$a mod 2 = 0}, 1 to 10)</code>
-        <expected>2 4 6 8 10</expected>
+        <code>fn:filter(function($a) {$a mod 2 = 0}, (1 to 10))</code>
+        <error>XPTY0004</error>
     </test>
     <test output="text">
-        <task>fn:filter function (correct argument order)</task>
+        <task>fn:filter function</task>
         <code>fn:filter(1 to 10, function($a) {$a mod 2 = 0})</code>
         <expected>2 4 6 8 10</expected>
     </test>

--- a/extensions/modules/expathrepo/src/main/resources/org/exist/xquery/modules/expathrepo/repair.xql
+++ b/extensions/modules/expathrepo/src/main/resources/org/exist/xquery/modules/expathrepo/repair.xql
@@ -85,7 +85,7 @@ declare %private function repair:repair-callback($collection as xs:anyURI, $incl
 };
 
 declare function repair:is-installed($name as xs:string) as xs:boolean {
-    exists(filter(function($pkg) { $pkg = $name }, repo:list()))
+    exists(filter(repo:list(), function($pkg) { $pkg = $name }))
 };
 
 (:~ Scan a collection tree recursively starting at $root. Call $func once for each collection found :)
@@ -97,9 +97,9 @@ declare %private function repair:scan-collections($root as xs:anyURI, $func as f
 };
 
 declare %private function repair:find-resources-to-zip($collection as xs:anyURI) {
-    filter(function($name) {
+    filter(xmldb:get-child-resources($collection), function($name) {
         $name = ("expath-pkg.xml", "repo.xml", "exist.xml") or starts-with($name, "icon")
-    }, xmldb:get-child-resources($collection))
+    })
 };
 
 declare %private function repair:resources-to-zip($expathConf as element(expath:package), $collection as xs:anyURI) {


### PR DESCRIPTION
### Description:

Six years ago the spec for fn:filter changed.
As it was already used in some applications like
dashboard, existdb allowed both ways to call
fn:filter.
This commit removes the special handling, where
the parameters are flipped. This will now throw
an XPTY0004 for wrong parameter type.

fixes https://github.com/eXist-db/exist/issues/3370

### Reference:

This is a rebased version of https://github.com/eXist-db/exist/pull/3361

### Type of tests:

Adapted XQSuite tests to changed codebase (not allowing deprecated argument order to `fn:filter#2`).