### PR TITLE
Revert "build(deps): bump jacoco-maven-plugin from 0.8.8 to 0.8.9"

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -755,7 +755,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.9</version>
+                    <version>0.8.8</version>
                     <configuration>
                         <propertyName>jacocoArgLine</propertyName>
                         <excludes>


### PR DESCRIPTION
This reverts commit b6c8ed0af820a3b3cae50b48de5d35f3b666f671.

As builds are failing with exceptions caused by:

```
java.lang.NoClassDefFoundError: Could not initialize class net.sf.cglib.proxy.Enhancer
```

see: https://github.com/eXist-db/exist/pull/4852/checks#step:6:1178