### PR TITLE
Use mvnd in GitHub Actions

### DIFF
--- a/.github/actions/install-mvnd/action.yml
+++ b/.github/actions/install-mvnd/action.yml
@@ -1,10 +1,18 @@
 name: 'install-mvnd'
-description: 'Install the maven daemon'
+description: 'Install the Maven Daemon'
 inputs:
   version:
-    description: 'The version of the maven daemon to install'
+    description: 'The version of the Maven Daemon to install'
     required: true
     default: '0.9.0'
+  install-path:
+    description: 'The folder in which Maven Daemon will be installed as a sub-folder'
+    required: true
+    default: '/tmp'
+  cache:
+    description: 'Set to true to cache Maven Daemon artifacts per-platform-architecture'
+    required: true
+    default: 'true'
 outputs:
   mvnd-dir:
     description: "The directory where the command mvnd is located"
@@ -12,38 +20,54 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Download mvnd (Linux)
-      if: runner.os == 'Linux'
+    - name: Determine mvnd platform and architecture
       shell: bash
       run: |
-        curl -fsSL -o mvnd.zip https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-linux-amd64.zip
-        curl -fsSL -o mvnd.zip.sha256 https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-linux-amd64.zip.sha256
-    - name: Download mvnd (macOS)
-      if: runner.os == 'macOS'
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          MVND_PLATFORM="linux"
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          MVND_PLATFORM="darwin"
+        elif [ "$RUNNER_OS" == "Windows" ]; then
+          MVND_PLATFORM="windows"
+        else
+          "echo Unknown platform: $RUNNER_OS"
+          exit 1
+        fi
+        MVND_ARCHITECTURE="amd64"
+        echo "MVND_PLATFORM=${MVND_PLATFORM}" >> $GITHUB_ENV
+        echo "MVND_ARCHITECTURE=${MVND_ARCHITECTURE}" >> $GITHUB_ENV
+        echo "MVND_NAME=maven-mvnd-${{ inputs.version }}-${MVND_PLATFORM}-${MVND_ARCHITECTURE}" >> $GITHUB_ENV
+    - name: Cache mvnd
+      if: inputs.cache == 'true'
+      id: cache-mvnd
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ inputs.install-path }}/${{ env.MVND_NAME }}.zip
+          ${{ inputs.install-path }}/${{ env.MVND_NAME }}.zip.sha256
+          ${{ inputs.install-path }}/${{ env.MVND_NAME }}
+        key: setup-${{ env.MVND_NAME }}
+    - name: Download mvnd
+      if: steps.cache-mvnd.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        curl -fsSL -o mvnd.zip https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-darwin-amd64.zip
-        curl -fsSL -o mvnd.zip.sha256 https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-darwin-amd64.zip.sha256
-    - name: Download mvnd (Windows)
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        curl -fsSL -o mvnd.zip https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-windows-amd64.zip
-        curl -fsSL -o mvnd.zip.sha256 https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-windows-amd64.zip.sha256
+        curl -fsSL -o ${{ inputs.install-path }}/${{ env.MVND_NAME }}.zip https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/${{ env.MVND_NAME }}.zip
+        curl -fsSL -o ${{ inputs.install-path }}/${{ env.MVND_NAME }}.zip.sha256 https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/${{ env.MVND_NAME }}.zip.sha256
     - name: Install sha256sum (macOS)
-      if: runner.os == 'macOS'
+      if: ${{ runner.os == 'macOS' }}
       shell: bash
       run: brew install coreutils
-    - name: Verify sha256sum
+    - name: Verify mvnd sha256 checksum
       shell: bash
-      run: echo "$(cat mvnd.zip.sha256) mvnd.zip" | sha256sum --check
+      run: echo "$(cat ${{ inputs.install-path }}/${{ env.MVND_NAME }}.zip.sha256) ${{ inputs.install-path }}/${{ env.MVND_NAME }}.zip" | sha256sum --check
     - name: Unzip mvnd
+      if: steps.cache-mvnd.outputs.cache-hit != 'true'
       shell: bash
-      run: unzip mvnd.zip -d /tmp/
+      run: unzip ${{ inputs.install-path }}/${{ env.MVND_NAME }}.zip -d ${{ inputs.install-path }}/
     - id: mvnd-location
       shell: bash
       run: |
-        MVND_BIN_DIR="$(find /tmp/ -maxdepth 1 -name 'maven-mvnd-${{ inputs.version }}-*-amd64' -type d)/bin"
+        MVND_BIN_DIR="${{ inputs.install-path }}/${{ env.MVND_NAME }}/bin"
         if [ "$RUNNER_OS" == "Windows" ]; then
           MVND_BIN_DIR="$(cygpath --absolute --long-name --windows $MVND_BIN_DIR)"
         fi

--- a/.github/actions/install-mvnd/action.yml
+++ b/.github/actions/install-mvnd/action.yml
@@ -1,0 +1,50 @@
+name: 'install-mvnd'
+description: 'Install the maven daemon'
+inputs:
+  version:
+    description: 'The version of the maven daemon to install'
+    required: true
+    default: '0.9.0'
+outputs:
+  mvnd-dir:
+    description: "The directory where the command mvnd is located"
+    value: ${{ steps.mvnd-location.outputs.mvnd-dir }}
+runs:
+  using: "composite"
+  steps:
+    - name: Download mvnd (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        curl -fsSL -o mvnd.zip https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-linux-amd64.zip
+        curl -fsSL -o mvnd.zip.sha256 https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-linux-amd64.zip.sha256
+    - name: Download mvnd (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        curl -fsSL -o mvnd.zip https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-darwin-amd64.zip
+        curl -fsSL -o mvnd.zip.sha256 https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-darwin-amd64.zip.sha256
+    - name: Download mvnd (Windows)
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        curl -fsSL -o mvnd.zip https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-windows-amd64.zip
+        curl -fsSL -o mvnd.zip.sha256 https://archive.apache.org/dist/maven/mvnd/${{ inputs.version }}/maven-mvnd-${{ inputs.version }}-windows-amd64.zip.sha256
+    - name: Install sha256sum (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install coreutils
+    - name: Verify sha256sum
+      shell: bash
+      run: echo "$(cat mvnd.zip.sha256) mvnd.zip" | sha256sum --check
+    - name: Unzip mvnd
+      shell: bash
+      run: unzip mvnd.zip -d /tmp/
+    - id: mvnd-location
+      shell: bash
+      run: |
+        MVND_BIN_DIR="$(find /tmp/ -maxdepth 1 -name 'maven-mvnd-${{ inputs.version }}-*-amd64' -type d)/bin"
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          MVND_BIN_DIR="$(cygpath --absolute --long-name --windows $MVND_BIN_DIR)"
+        fi
+        echo "mvnd-dir=${MVND_BIN_DIR}" >> $GITHUB_OUTPUT

--- a/.github/actions/install-mvnd/action.yml
+++ b/.github/actions/install-mvnd/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'The version of the Maven Daemon to install'
     required: true
     default: '0.9.0'
+  file-version-suffix:
+    description: 'A suffix to append to the version of the download file of Maven Daemon to install'
+    required: false
+    default: ''
   install-path:
     description: 'The folder in which Maven Daemon will be installed as a sub-folder'
     required: true
@@ -40,7 +44,7 @@ runs:
         MVND_ARCHITECTURE="amd64"
         echo "MVND_PLATFORM=${MVND_PLATFORM}" >> $GITHUB_ENV
         echo "MVND_ARCHITECTURE=${MVND_ARCHITECTURE}" >> $GITHUB_ENV
-        echo "MVND_NAME=maven-mvnd-${{ inputs.version }}-${MVND_PLATFORM}-${MVND_ARCHITECTURE}" >> $GITHUB_ENV
+        echo "MVND_NAME=maven-mvnd-${{ inputs.version }}${{ inputs.file-version-suffix }}-${MVND_PLATFORM}-${MVND_ARCHITECTURE}" >> $GITHUB_ENV
     - name: Cache mvnd
       if: inputs.cache == 'true'
       id: cache-mvnd

--- a/.github/actions/install-mvnd/action.yml
+++ b/.github/actions/install-mvnd/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Set to true to cache Maven Daemon artifacts per-platform-architecture'
     required: true
     default: 'true'
+  mvnd-connect-timeout:
+    description: 'The timeout (as a duration, e.g. `90 seconds`) for connecting to the Maven Daemon'
+    required: true
+    default: '90 seconds'
 outputs:
   mvnd-dir:
     description: "The directory where the command mvnd is located"
@@ -64,11 +68,18 @@ runs:
       if: steps.cache-mvnd.outputs.cache-hit != 'true'
       shell: bash
       run: unzip ${{ inputs.install-path }}/${{ env.MVND_NAME }}.zip -d ${{ inputs.install-path }}/
-    - id: mvnd-location
+    - name: Show Maven Daemon version
+      shell: bash
+      run: |
+        ${{ inputs.install-path }}/${{ env.MVND_NAME }}/bin/mvnd -D'mvnd.connectTimeout=${{ inputs.mvnd-connect-timeout }}' --version
+        ${{ inputs.install-path }}/${{ env.MVND_NAME }}/bin/mvnd -D'mvnd.connectTimeout=${{ inputs.mvnd-connect-timeout }}' --status
+    - name: Set mvnd-dir
+      id: mvnd-location
       shell: bash
       run: |
         MVND_BIN_DIR="${{ inputs.install-path }}/${{ env.MVND_NAME }}/bin"
         if [ "$RUNNER_OS" == "Windows" ]; then
           MVND_BIN_DIR="$(cygpath --absolute --long-name --windows $MVND_BIN_DIR)"
         fi
+        echo "MVND_BIN_DIR=${MVND_BIN_DIR}" >> $GITHUB_ENV
         echo "mvnd-dir=${MVND_BIN_DIR}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -49,7 +49,8 @@ jobs:
         id: install-mvnd
         uses: ./.github/actions/install-mvnd
         with:
-          version: '0.9.0'
+          version: '1.0-m6'
+          file-version-suffix: '-m40'
           cache: 'true'
       - name: Maven Build
         timeout-minutes: 10

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install Maven Daemon
         id: install-mvnd
         uses: ./.github/actions/install-mvnd
+        with:
+          version: '0.9.0'
+          cache: 'true'
       - name: Maven Build
         timeout-minutes: 10
         run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -45,15 +45,18 @@ jobs:
           distribution: temurin
           java-version: ${{ env.DEV_JDK }}
           cache: 'maven'
+      - name: Install Maven Daemon
+        id: install-mvnd
+        uses: ./.github/actions/install-mvnd
       - name: Maven Build
         timeout-minutes: 10
-        run: mvn -V -B -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -T 1C compile test-compile -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
       - name: Maven Test
         timeout-minutes: 60
-        run: mvn -V -B verify -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B verify -DtrimStackTrace=false -D'dependency-check.skip' -D'license.skip'
       - name: Javadoc (Linux only)
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: mvn -V -B -q -T 1C install javadoc:javadoc -DskipTests -D'dependency-check.skip' -D'license.skip' --projects '!exist-distribution,!exist-installer' --also-make
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B -q -T 1C install javadoc:javadoc -DskipTests -D'dependency-check.skip' -D'license.skip' --projects '!exist-distribution,!exist-installer' --also-make
       - name: Maven Code Coverage (Develop branch on Linux only)
         if: ${{ github.ref == 'refs/heads/develop' && matrix.os == 'ubuntu-latest' }}
         env:
@@ -62,7 +65,7 @@ jobs:
           CI_BUILD_NUMBER: ${{ github.run_id }}
           CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-        run: mvn -V -B jacoco:report coveralls:report
+        run: ${{ steps.install-mvnd.outputs.mvnd-dir }}/mvnd -V -B jacoco:report coveralls:report
       - name: Archive build logs
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Builds atop https://github.com/eXist-db/exist/pull/4917 to switch CI from using `mvn` to `mvnd` (i.e. Maven Daemon)