### PR TITLE
Prevent omission of results from collections with different index styles 

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
@@ -245,21 +245,11 @@ public class GeneralComparison extends BinaryOp implements Optimizable, IndexUse
 
     @Override
     public Sequence canOptimizeSequence(final Sequence contextSequence) {
-        if (canOptimize(contextSequence)) {
+        if (contextQName != null && Optimize.getQNameIndexType(context, contextSequence, contextQName) != Type.ITEM) {
             return contextSequence;
-        } else {
-            return Sequence.EMPTY_SEQUENCE;
         }
+        return Sequence.EMPTY_SEQUENCE;
     }
-
-    @Override
-    public boolean canOptimize(final Sequence contextSequence) {
-        if (contextQName == null) {
-            return false;
-        }
-        return Optimize.getQNameIndexType(context, contextSequence, contextQName) != Type.ITEM;
-    }
-
 
     public boolean optimizeOnSelf()
     {

--- a/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
+++ b/exist-core/src/main/java/org/exist/xquery/GeneralComparison.java
@@ -243,13 +243,21 @@ public class GeneralComparison extends BinaryOp implements Optimizable, IndexUse
         }
     }
 
-
-    public boolean canOptimize( Sequence contextSequence )
-    {
-        if( contextQName == null ) {
-            return( false );
+    @Override
+    public Sequence canOptimizeSequence(final Sequence contextSequence) {
+        if (canOptimize(contextSequence)) {
+            return contextSequence;
+        } else {
+            return Sequence.EMPTY_SEQUENCE;
         }
-        return( Optimize.getQNameIndexType( context, contextSequence, contextQName ) != Type.ITEM );
+    }
+
+    @Override
+    public boolean canOptimize(final Sequence contextSequence) {
+        if (contextQName == null) {
+            return false;
+        }
+        return Optimize.getQNameIndexType(context, contextSequence, contextQName) != Type.ITEM;
     }
 
 

--- a/exist-core/src/main/java/org/exist/xquery/Optimizable.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizable.java
@@ -31,6 +31,16 @@ public interface Optimizable extends Expression {
 
     boolean canOptimize(Sequence contextSequence);
 
+    /**
+     * Given a sequence of Items, test each to see if they are optimizable,
+     * and return only those Items that are optimizable.
+     *
+     * @param contextSequence the sequence of items that should be tested to see if each is optimizable.
+     * @return a sequence containing only the items from the {@code contextSequence} that
+     *      can be optimized, if there are no items that can be optimized, the result is the empty sequence.
+     */
+    Sequence canOptimizeSequence(Sequence contextSequence);
+
     boolean optimizeOnSelf();
 
     boolean optimizeOnChild();

--- a/exist-core/src/main/java/org/exist/xquery/Optimizable.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizable.java
@@ -29,8 +29,6 @@ import org.exist.xquery.value.Sequence;
  */
 public interface Optimizable extends Expression {
 
-    boolean canOptimize(Sequence contextSequence);
-
     /**
      * Given a sequence of Items, test each to see if they are optimizable,
      * and return only those Items that are optimizable.

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMatches.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMatches.java
@@ -177,19 +177,11 @@ public final class FunMatches extends Function implements Optimizable, IndexUseR
 
     @Override
     public Sequence canOptimizeSequence(final Sequence contextSequence) {
-        if (canOptimize(contextSequence)) {
+        if (contextQName != null && Type.subTypeOf(Optimize.getQNameIndexType(context, contextSequence, contextQName), Type.STRING)) {
             return contextSequence;
-        } else {
-            return Sequence.EMPTY_SEQUENCE;
         }
-    }
 
-    @Override
-    public boolean canOptimize(final Sequence contextSequence) {
-        if (contextQName == null) {
-            return false;
-        }
-        return Type.subTypeOf(Optimize.getQNameIndexType(context, contextSequence, contextQName), Type.STRING);
+        return Sequence.EMPTY_SEQUENCE;
     }
 
     @Override

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMatches.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMatches.java
@@ -176,6 +176,15 @@ public final class FunMatches extends Function implements Optimizable, IndexUseR
     }
 
     @Override
+    public Sequence canOptimizeSequence(final Sequence contextSequence) {
+        if (canOptimize(contextSequence)) {
+            return contextSequence;
+        } else {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+    }
+
+    @Override
     public boolean canOptimize(final Sequence contextSequence) {
         if (contextQName == null) {
             return false;

--- a/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
+++ b/exist-core/src/main/java/org/exist/xquery/pragmas/Optimize.java
@@ -109,12 +109,19 @@ public class Optimize extends Pragma {
                 optimize = cachedOptimize;
             } else {
                 if (optimizables != null && optimizables.length > 0) {
-                    for (Optimizable optimizable : optimizables) {
-                        if (optimizable.canOptimize(contextSequence)) {
-                            optimize = true;
-                        } else {
+                    for (final Optimizable optimizable : optimizables) {
+                        final Sequence canBeOptimized = optimizable.canOptimizeSequence(contextSequence);
+                        if (canBeOptimized == null) {
                             optimize = false;
-                            break;
+                            break;  // exit for-each loop
+                        }
+                        if (canBeOptimized.getItemCount() == contextSequence.getItemCount()) {
+                            // everything in sequence can be optimized
+                            optimize = true;  // so far so good, head to next for-loop of `optimizable`
+                        } else {
+                            // nothing or only some bits can be optimized
+                            optimize = false;
+                            break;  // exit for-each loop
                         }
                     }
                 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -183,16 +183,11 @@ public class Query extends Function implements Optimizable {
 
     @Override
     public Sequence canOptimizeSequence(final Sequence contextSequence) {
-        if (canOptimize(contextSequence)) {
+        if (contextQName != null) {
             return contextSequence;
-        } else {
-            return Sequence.EMPTY_SEQUENCE;
         }
-    }
 
-    @Override
-    public boolean canOptimize(final Sequence contextSequence) {
-        return contextQName != null;
+        return Sequence.EMPTY_SEQUENCE;
     }
 
     public boolean optimizeOnSelf() {

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -181,7 +181,17 @@ public class Query extends Function implements Optimizable {
         }
     }
 
-    public boolean canOptimize(Sequence contextSequence) {
+    @Override
+    public Sequence canOptimizeSequence(final Sequence contextSequence) {
+        if (canOptimize(contextSequence)) {
+            return contextSequence;
+        } else {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+    }
+
+    @Override
+    public boolean canOptimize(final Sequence contextSequence) {
         return contextQName != null;
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
@@ -99,7 +99,17 @@ public class QueryField extends Query implements Optimizable {
         this.contextId = contextInfo.getContextId();
     }
 
-    public boolean canOptimize(Sequence contextSequence) {
+    @Override
+    public Sequence canOptimizeSequence(final Sequence contextSequence) {
+        if (canOptimize(contextSequence)) {
+            return contextSequence;
+        } else {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+    }
+
+    @Override
+    public boolean canOptimize(final Sequence contextSequence) {
     	return true;
     }
 

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
@@ -101,16 +101,7 @@ public class QueryField extends Query implements Optimizable {
 
     @Override
     public Sequence canOptimizeSequence(final Sequence contextSequence) {
-        if (canOptimize(contextSequence)) {
-            return contextSequence;
-        } else {
-            return Sequence.EMPTY_SEQUENCE;
-        }
-    }
-
-    @Override
-    public boolean canOptimize(final Sequence contextSequence) {
-    	return true;
+        return contextSequence;  // always optimizable!
     }
 
     public int getOptimizeAxis() {

--- a/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramSearch.java
+++ b/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramSearch.java
@@ -193,7 +193,16 @@ public class NGramSearch extends Function implements Optimizable {
     }
 
     @Override
-    public boolean canOptimize(Sequence contextSequence) {
+    public Sequence canOptimizeSequence(final Sequence contextSequence) {
+        if (canOptimize(contextSequence)) {
+            return contextSequence;
+        } else {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+    }
+
+    @Override
+    public boolean canOptimize(final Sequence contextSequence) {
         return contextQName != null;
     }
 

--- a/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramSearch.java
+++ b/extensions/indexes/ngram/src/main/java/org/exist/xquery/modules/ngram/NGramSearch.java
@@ -194,16 +194,11 @@ public class NGramSearch extends Function implements Optimizable {
 
     @Override
     public Sequence canOptimizeSequence(final Sequence contextSequence) {
-        if (canOptimize(contextSequence)) {
+        if (contextQName != null) {
             return contextSequence;
         } else {
             return Sequence.EMPTY_SEQUENCE;
         }
-    }
-
-    @Override
-    public boolean canOptimize(final Sequence contextSequence) {
-        return contextQName != null;
     }
 
     @Override

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/FieldLookup.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/FieldLookup.java
@@ -360,16 +360,7 @@ public class FieldLookup extends Function implements Optimizable {
 
     @Override
     public Sequence canOptimizeSequence(final Sequence contextSequence) {
-        if (canOptimize(contextSequence)) {
-            return contextSequence;
-        } else {
-            return Sequence.EMPTY_SEQUENCE;
-        }
-    }
-
-    @Override
-    public boolean canOptimize(final Sequence contextSequence) {
-        return true;
+        return contextSequence;  // always optimizable!
     }
 
     @Override

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/FieldLookup.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/FieldLookup.java
@@ -359,7 +359,16 @@ public class FieldLookup extends Function implements Optimizable {
     }
 
     @Override
-    public boolean canOptimize(Sequence contextSequence) {
+    public Sequence canOptimizeSequence(final Sequence contextSequence) {
+        if (canOptimize(contextSequence)) {
+            return contextSequence;
+        } else {
+            return Sequence.EMPTY_SEQUENCE;
+        }
+    }
+
+    @Override
+    public boolean canOptimize(final Sequence contextSequence) {
         return true;
     }
 

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Lookup.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/Lookup.java
@@ -444,24 +444,6 @@ public class Lookup extends Function implements Optimizable {
         return optimizables != null ? optimizables : Sequence.EMPTY_SEQUENCE;
     }
 
-    @Override
-    public boolean canOptimize(final Sequence contextSequence) {
-        if (contextQName == null) {
-            return false;
-        }
-        RangeIndexConfigElement rice = findConfiguration(contextSequence);
-        if (rice == null) {
-            canOptimize = false;
-            if (fallback instanceof Optimizable) {
-                return ((Optimizable)fallback).canOptimize(contextSequence);
-            }
-            return false;
-        }
-        usesCollation = rice.usesCollation();
-        canOptimize = true;
-        return canOptimize;
-    }
-
     private RangeIndexConfigElement findConfiguration(Sequence contextSequence) {
         NodePath path = contextPath;
         if (path == null) {

--- a/extensions/indexes/range/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/range/src/test/resources-filtered/conf.xml
@@ -894,6 +894,7 @@
             <module uri="http://exist-db.org/xquery/range"  class="org.exist.xquery.modules.range.RangeIndexModule" />
 
             <!-- dependencies needed for tests -->
+            <module uri="http://www.w3.org/2005/xpath-functions/array" class="org.exist.xquery.functions.array.ArrayModule"/>
             <module uri="http://exist-db.org/xquery/lucene" class="org.exist.xquery.modules.lucene.LuceneModule" />
             <module uri="http://exist-db.org/xquery/securitymanager" class="org.exist.xquery.functions.securitymanager.SecurityManagerModule"/>
 

--- a/extensions/indexes/range/src/test/xquery/range/multi-collection-search.xqm
+++ b/extensions/indexes/range/src/test/xquery/range/multi-collection-search.xqm
@@ -1,0 +1,256 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace t = "http://exist-db.org/xquery/test";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+import module namespace array = "http://www.w3.org/2005/xpath-functions/array";
+import module namespace util = "http://exist-db.org/xquery/util";
+import module namespace xmldb = "http://exist-db.org/xquery/xmldb";
+
+
+declare %private variable $t:test-collection-path := "/db/test-multi-collection-search";
+
+declare %private variable $t:test-data :=
+        document {
+            <root>
+                <foo bar="baz"/>
+            </root>
+        };
+
+declare %private variable $t:old-range-xconf :=
+        document {
+            <collection xmlns="http://exist-db.org/collection-config/1.0">
+                <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                    <create qname="@bar" type="xs:string"/>
+                </index>
+            </collection>
+        };
+
+declare %private variable $t:new-range-xconf :=
+        document {
+            <collection xmlns="http://exist-db.org/collection-config/1.0">
+                <index xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                    <range>
+                        <create qname="@bar" type="xs:string"/>
+                    </range>
+                </index>
+            </collection>
+        };
+
+(:~
+ : 3 Collections, one for each type of index that we want to involve in the test.
+ :)
+declare %private variable $t:test-collections :=
+        array {
+            map { "collection-name": "no-range-index",  "data": $t:test-data },
+            map { "collection-name": "old-range-index", "data": $t:test-data, "configuration": $t:old-range-xconf },
+            map { "collection-name": "new-range-index", "data": $t:test-data, "configuration": $t:new-range-xconf }
+        };
+
+
+declare
+    %test:setUp
+function t:set-up() {
+    (: Create and configure the test collections :)
+    array:for-each($t:test-collections, function($test-collection) {
+        let $collection-path := $t:test-collection-path || "/" || $test-collection?collection-name
+        let $config-collection-path := "/db/system/config" || $collection-path
+        return
+            (
+                if (fn:exists($test-collection?configuration))
+                then
+                    (
+                        t:mkcol($config-collection-path),
+                        xmldb:store($config-collection-path, "collection.xconf", $test-collection?configuration)
+                    )
+                else (),
+                t:mkcol($collection-path),
+                xmldb:store($collection-path, "test.xml", $test-collection?data)
+            )
+    }),
+
+    (: Reindex the test collections :)
+    xmldb:reindex($t:test-collection-path)
+};
+
+declare
+    %test:tearDown
+function t:tear-down() {
+    xmldb:remove($t:test-collection-path),
+    xmldb:remove("/db/system/config" || $t:test-collection-path)
+};
+
+declare
+    %test:assertEquals(3)
+function t:structural-index-all-collections() {
+    count(collection($t:test-collection-path)//foo/@bar)
+};
+
+declare
+    %test:assertEquals(3)
+function t:eq-all-collections() {
+    count(collection($t:test-collection-path)//foo[@bar eq "baz"])
+};
+
+declare
+    %test:assertEquals(3)
+function t:matches-all-collections() {
+    count(collection($t:test-collection-path)//foo[matches(@bar, "^b")])
+};
+
+declare
+    %test:assertEquals(3)
+function t:contains-all-collections() {
+    count(collection($t:test-collection-path)//foo[contains(@bar, "b")])
+};
+
+declare
+    %test:assertEquals(3)
+function t:starts-with-all-collections() {
+    count(collection($t:test-collection-path)//foo[starts-with(@bar, "b")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:eq-new-range-index-only() {
+    count(collection($t:test-collection-path || "/new-range-index")//foo[@bar eq "baz"])
+};
+
+declare
+    %test:assertEquals(1)
+function t:eq-old-range-index-only() {
+    count(collection($t:test-collection-path || "/old-range-index")//foo[@bar eq "baz"])
+};
+
+declare
+    %test:assertEquals(1)
+function t:eq-no-range-index-only() {
+    count(collection($t:test-collection-path || "/no-range-index")//foo[@bar eq "baz"])
+};
+
+declare
+    %test:assertEquals(1)
+function t:matches-new-range-index-only() {
+    count(collection($t:test-collection-path || "/new-range-index")//foo[matches(@bar, "^b")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:matches-old-range-index-only() {
+    count(collection($t:test-collection-path || "/old-range-index")//foo[matches(@bar, "^b")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:matches-no-range-index-only() {
+    count(collection($t:test-collection-path || "/no-range-index")//foo[matches(@bar, "^b")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:contains-new-range-index-only() {
+    count(collection($t:test-collection-path || "/new-range-index")//foo[contains(@bar, "b")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:contains-old-range-index-only() {
+    count(collection($t:test-collection-path || "/old-range-index")//foo[contains(@bar, "b")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:contains-no-range-index-only() {
+    count(collection($t:test-collection-path || "/no-range-index")//foo[contains(@bar, "b")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:starts-with-new-range-index-only() {
+    count(collection($t:test-collection-path || "/new-range-index")//foo[starts-with(@bar, "b")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:starts-with-old-range-index-only() {
+    count(collection($t:test-collection-path || "/old-range-index")//foo[starts-with(@bar, "b")])
+};
+
+declare
+    %test:assertEquals(1)
+function t:starts-with-no-range-index-only() {
+    count(collection($t:test-collection-path || "/no-range-index")//foo[starts-with(@bar, "b")])
+};
+
+declare
+    %test:assertTrue
+function t:eq-all-collections-has-hit-from-new-range-index() {
+    some $hit in collection($t:test-collection-path)//foo[@bar eq "baz"] satisfies
+        util:collection-name($hit) eq $t:test-collection-path || "/new-range-index"
+};
+
+declare
+    %test:assertTrue
+function t:eq-all-collections-has-hit-from-old-range-index() {
+    some $hit in collection($t:test-collection-path)//foo[@bar eq "baz"] satisfies
+        util:collection-name($hit) eq $t:test-collection-path || "/old-range-index"
+};
+
+declare
+    %test:assertTrue
+function t:eq-all-collections-has-hit-from-no-range-index() {
+    some $hit in collection($t:test-collection-path)//foo[@bar eq "baz"] satisfies
+        util:collection-name($hit) eq $t:test-collection-path || "/no-range-index"
+};
+
+(:~
+ : Creates a collection path hierarchy.
+ :
+ : @param $path the path of the collection hierarchy to create.
+ : @return the path as sent in $path
+ :)
+declare
+    %private
+function t:mkcol($path as xs:string) as xs:string {
+    let $recursive-mkcol-fn := function($base-collection-path as xs:string, $relative-path as xs:string?, $self) {
+        if (fn:not(xmldb:collection-available($base-collection-path)))
+        then
+            fn:error("t:mkcol - $base-collection-path does not already exist: " || $base-collection-path)
+        else
+            let $path-parts := fn:tokenize($relative-path, "/")[fn:string-length(.) gt 0]
+            return
+                if (fn:empty($path-parts))
+                then
+                    $base-collection-path
+                else
+                    let $new-base-collection-path := xmldb:create-collection($base-collection-path, fn:head($path-parts))
+                    let $new-relative-path := fn:string-join(fn:tail($path-parts), "/")
+                    return
+                        $self($new-base-collection-path, $new-relative-path, $self)
+    }
+    let $_ := $recursive-mkcol-fn("/db", fn:substring-after($path, "/db/"), $recursive-mkcol-fn)
+    return
+        $path
+};


### PR DESCRIPTION
Fixes #3620 

When performing a Search on a parent collection that has several sub-collections each with different types of indexes configured, The optimizer was optimizing the query without checking if all sub-collections were fit to be optimized.

#3620 has a nice test suit to illustrate this issue thanks to @joewiz. This PR now passes all of those tests.

----
This open source contribution to the [exist](https://github.com/eXist-db/exist) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.