### PR TITLE
[bugfix] fn:matches error codes

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunAnalyzeString.java
@@ -151,14 +151,10 @@ public class FunAnalyzeString extends BasicFunction {
             }
         } catch (final net.sf.saxon.trans.XPathException e) {
             switch (e.getErrorCodeLocalPart()) {
-                case "FORX0001":
-                    throw new XPathException(this, ErrorCodes.FORX0001, e.getMessage());
-                case "FORX0002":
-                    throw new XPathException(this, ErrorCodes.FORX0002, e.getMessage());
-                case "FORX0003":
-                    throw new XPathException(this, ErrorCodes.FORX0003, e.getMessage());
-                default:
-                    throw new XPathException(this, e.getMessage());
+                case "FORX0001" -> throw new XPathException(this, ErrorCodes.FORX0001, e.getMessage());
+                case "FORX0002" -> throw new XPathException(this, ErrorCodes.FORX0002, e.getMessage());
+                case "FORX0003" -> throw new XPathException(this, ErrorCodes.FORX0003, e.getMessage());
+                default -> throw new XPathException(this, ErrorCodes.ERROR, e.getMessage());
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMatches.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMatches.java
@@ -525,7 +525,12 @@ public final class FunMatches extends Function implements Optimizable, IndexUseR
             return regex.containsMatch(string);
 
         } catch (final net.sf.saxon.trans.XPathException e) {
-            throw new XPathException(this, ErrorCodes.FORX0001, "Invalid regular expression: " + e.getMessage(), new StringValue(this, pattern), e);
+            switch (e.getErrorCodeLocalPart()) {
+                case "FORX0001" -> throw new XPathException(this, ErrorCodes.FORX0001, "Invalid regular expression: " + e.getMessage());
+                case "FORX0002" -> throw new XPathException(this, ErrorCodes.FORX0002, "Invalid regular expression: " + e.getMessage());
+                // no FORX0003 here since fn:matches is allowed to match an empty string
+                default -> throw new XPathException(this, ErrorCodes.ERROR, e.getMessage());
+            }
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMatches.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunMatches.java
@@ -538,7 +538,7 @@ public final class FunMatches extends Function implements Optimizable, IndexUseR
      * @param string the value
      * @param pattern the pattern
      * @param flags the flags
-     * @return Whether or not the string matches the given pattern with the given flags
+     * @return Whether the string matches the given pattern with the given flags
      * @throws XPathException if an error occurs
      */
     private boolean match(final String string, final String pattern, final int flags) throws XPathException {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReplace.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunReplace.java
@@ -137,16 +137,11 @@ public class FunReplace extends BasicFunction {
 
 			} catch (final net.sf.saxon.trans.XPathException e) {
 				switch (e.getErrorCodeLocalPart()) {
-					case "FORX0001":
-						throw new XPathException(this, ErrorCodes.FORX0001, e.getMessage());
-					case "FORX0002":
-						throw new XPathException(this, ErrorCodes.FORX0002, e.getMessage());
-					case "FORX0003":
-						throw new XPathException(this, ErrorCodes.FORX0003, e.getMessage());
-					case "FORX0004":
-						throw new XPathException(this, ErrorCodes.FORX0004, e.getMessage());
-					default:
-						throw new XPathException(this, e.getMessage());
+					case "FORX0001" -> throw new XPathException(this, ErrorCodes.FORX0001, e.getMessage());
+					case "FORX0002" -> throw new XPathException(this, ErrorCodes.FORX0002, e.getMessage());
+					case "FORX0003" -> throw new XPathException(this, ErrorCodes.FORX0003, e.getMessage());
+					case "FORX0004" -> throw new XPathException(this, ErrorCodes.FORX0004, e.getMessage());
+					default -> throw new XPathException(this, ErrorCodes.ERROR, e.getMessage());
 				}
 			}
         }

--- a/exist-core/src/test/xquery/xquery3/matches.xqm
+++ b/exist-core/src/test/xquery/xquery3/matches.xqm
@@ -32,6 +32,19 @@ function mt:allowEmptyMatch() {
 };
 
 declare
+    %test:args("a", "[A-Z]", "")
+    %test:assertFalse
+    %test:args("a", "\d", "")
+    %test:assertFalse
+    %test:args("a", "\w", "")
+    %test:assertTrue
+    %test:args("a", "[A-Z]", "i")
+    %test:assertTrue
+function mt:allowEmptyMatch($v, $p, $f) {
+    matches($v,$p, $f)
+};
+
+declare
     %test:args("\")
     %test:assertError("err:FORX0002")
     %test:args("(")

--- a/exist-core/src/test/xquery/xquery3/matches.xqm
+++ b/exist-core/src/test/xquery/xquery3/matches.xqm
@@ -1,0 +1,60 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace mt="http://exist-db.org/xquery/test/matches";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:assertTrue
+function mt:allowEmptyMatch() {
+    matches("","")
+};
+
+declare
+    %test:args("\")
+    %test:assertError("err:FORX0002")
+    %test:args("(")
+    %test:assertError("err:FORX0002")
+    %test:args("[")
+    %test:assertError("err:FORX0002")
+    %test:args("{")
+    %test:assertError("err:FORX0002")
+    %test:args("?")
+    %test:assertError("err:FORX0002")
+function mt:invalid-pattern($regex as xs:string) {
+    matches("",$regex)
+};
+
+declare
+    %test:args("1")
+    %test:assertError("err:FORX0001")
+    %test:args("?")
+    %test:assertError("err:FORX0001")
+    %test:args("[")
+    %test:assertError("err:FORX0001")
+    %test:args("p")
+    %test:assertError("err:FORX0001")
+function mt:invalid-flag($flag as xs:string) {
+    matches("","", $flag)
+};

--- a/exist-core/src/test/xquery/xquery3/replace.xqm
+++ b/exist-core/src/test/xquery/xquery3/replace.xqm
@@ -1,0 +1,80 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace rt="http://exist-db.org/xquery/test/replace";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:args("")
+    %test:assertError("err:FORX0003")
+    %test:args(".?")
+    %test:assertError("err:FORX0003")
+    %test:args(".*")
+    %test:assertError("err:FORX0003")
+    %test:args("(.*)")
+    %test:assertError("err:FORX0003")
+function rt:empty-match-fails($p as xs:string) {
+    replace("",$p,"")
+};
+
+declare
+    %test:args("a", "[A-Z]", "")
+    %test:assertEquals("a")
+    %test:args("a1", "\d", "")
+    %test:assertEquals("a")
+    %test:args("a", "\w", "")
+    %test:assertEquals("")
+    %test:args("a", "[A-Z]", "")
+    %test:assertEquals("a")
+function rt:replace-string($v as xs:string, $p as xs:string, $r as xs:string) {
+    replace($v, $p, $r)
+};
+
+declare
+    %test:args("\")
+    %test:assertError("err:FORX0002")
+    %test:args("(")
+    %test:assertError("err:FORX0002")
+    %test:args("[")
+    %test:assertError("err:FORX0002")
+    %test:args("{")
+    %test:assertError("err:FORX0002")
+    %test:args("?")
+    %test:assertError("err:FORX0002")
+function rt:invalid-pattern($regex as xs:string) {
+    replace("",$regex,"")
+};
+
+declare
+    %test:args("1")
+    %test:assertError("err:FORX0001")
+    %test:args("?")
+    %test:assertError("err:FORX0001")
+    %test:args("[")
+    %test:assertError("err:FORX0001")
+    %test:args("p")
+    %test:assertError("err:FORX0001")
+function rt:invalid-flag($flag as xs:string) {
+    replace("",".+","", $flag)
+};


### PR DESCRIPTION
### Description:

Read the error code raised by the Saxon regular expression implementation.
This will now correctly raise FORX0002 when the pattern is invalid.

### Reference:

https://www.w3.org/TR/xpath-functions-31/#func-matches

### Type of tests:

added XQSuite tests