### PR TITLE
[fix] jetty configuration changes don't stick, and eventually crash eXist-db

### DIFF
--- a/exist-core/src/main/java/org/exist/launcher/ConfigurationDialog.java
+++ b/exist-core/src/main/java/org/exist/launcher/ConfigurationDialog.java
@@ -97,6 +97,12 @@ public class ConfigurationDialog extends JDialog {
             if (ports.containsKey("jetty.port")) {
                 httpPort.setValue(ports.get("jetty.port"));
             }
+            if (ports.containsKey("jetty.http.port")) {
+                httpPort.setValue(ports.get("jetty.http.port"));
+            }
+            if (ports.containsKey("ssl.port")) {
+                sslPort.setValue(ports.get("ssl.port"));
+            }
             if (ports.containsKey("jetty.ssl.port")) {
                 sslPort.setValue(ports.get("jetty.ssl.port"));
             }

--- a/exist-core/src/main/java/org/exist/launcher/ConfigurationUtility.java
+++ b/exist-core/src/main/java/org/exist/launcher/ConfigurationUtility.java
@@ -93,7 +93,7 @@ public class ConfigurationUtility {
                     final int status = reader.next();
                     if (status == XMLStreamReader.START_ELEMENT && "SystemProperty".equals(reader.getLocalName())) {
                         final String name = reader.getAttributeValue(null, "name");
-                        if (name != null && (name.equals("jetty.port") || name.equals("jetty.ssl.port"))) {
+                        if (name != null && (name.equals("jetty.http.port") || name.equals("jetty.ssl.port"))) {
                             final String defaultValue = reader.getAttributeValue(null, "default");
                             if (defaultValue != null) {
                                 try {

--- a/exist-core/src/main/resources/org/exist/launcher/jetty.xsl
+++ b/exist-core/src/main/resources/org/exist/launcher/jetty.xsl
@@ -23,7 +23,7 @@
 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     
-    <xsl:output indent="no" doctype-public="-//Jetty//Configure//EN" doctype-system="http://www.eclipse.org/jetty/configure.dtd"/>
+    <xsl:output indent="no" doctype-public="-//Jetty//Configure//EN" doctype-system="http://www.eclipse.org/jetty/configure_10_0.dtd"/>
 
     <xsl:preserve-space elements="*"/>
     <xsl:strip-space elements="Set"/>
@@ -31,7 +31,7 @@
     <xsl:param name="port">8080</xsl:param>
     <xsl:param name="port.ssl">8443</xsl:param>
     
-    <xsl:template match="SystemProperty[@name='jetty.port']"><SystemProperty name="jetty.port" default="{$port}"/></xsl:template>
+    <xsl:template match="SystemProperty[@name='jetty.http.port']"><SystemProperty name="jetty.http.port" default="{$port}"/></xsl:template>
 
     <xsl:template match="SystemProperty[@name='jetty.ssl.port']"><SystemProperty name="jetty.ssl.port" default="{$port.ssl}"/></xsl:template>
     


### PR DESCRIPTION
### Description:

Updated jetty-http.xml and jetty-ssl.xml were being written by the configurator with a bad DTD, which on subsequent read by the configurator caused an exception, so that the NEXT versions of jetty-http.xml and jetty-ssl.xml were made empty. This then caused a startup crash.

1. Fix the DTD reference.

Also, configurator was reading the wrong field(s) for the http configuration, so

2. make configurator read the correct fields for jetty http configuration, so that subsequent edits of an already re-configured jetty don’t end up re-introducing the default (8080)

### Reference:

Closes https://github.com/eXist-db/exist/issues/4729

### Type of tests:

Unfortunately it is not simple to automate this testing. We have built a test distribution with the changes, installed it (`java -jar ./exist-installer/target/exist-installer-7.0.0-SNAPSHOT.jar`) and confirmed through the use of ./bin/launcher.sh in the new installation that modifications of the jetty configuration are stored, restored and used on startup as the jetty ports. A distribution built without the change allowed us to reproduce the failed configuration changes, crashes and empty files produced in the initial problem report.

