### PR TITLE
[fix] castable as for untyped atomic value(s)

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/value/UntypedAtomicValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/UntypedAtomicValue.java
@@ -65,6 +65,16 @@ public class UntypedAtomicValue extends AtomicValue {
                 return strVal == null ? new UntypedAtomicValue(expression, value) : strVal;
             case Type.STRING:
                 return new StringValue(expression, value);
+            case Type.NORMALIZED_STRING:
+            case Type.TOKEN:
+            case Type.LANGUAGE:
+            case Type.NMTOKEN:
+            case Type.NAME:
+            case Type.NCNAME:
+            case Type.ID:
+            case Type.IDREF:
+            case Type.ENTITY:
+                return new StringValue(expression, value, requiredType);
             case Type.ANY_URI:
                 return new AnyURIValue(expression, value);
             case Type.BOOLEAN:

--- a/exist-core/src/test/xquery/xquery3/castable-untyped-atomic.xqm
+++ b/exist-core/src/test/xquery/xquery3/castable-untyped-atomic.xqm
@@ -1,0 +1,79 @@
+
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+ (:~
+  : @see https://github.com/eXist-db/exist/issues/4518
+  :)
+xquery version "3.1";
+
+module namespace ca="http://exist-db.org/xquery/test";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+(: atomic values not explicitly converted to strings were falsely returning false to _castable_as_
+   in other words, all these tests were returning nc="false"
+:)
+declare
+%test:args("ixml") %test:assertEquals("<result name=""ixml"" nc=""true""/>")
+%test:args("comment") %test:assertEquals("<result name=""comment"" nc=""true""/>")
+%test:args("apple-jack") %test:assertEquals("<result name=""apple-jack"" nc=""true""/>")
+%test:args("123") %test:assertEquals("<result name=""123"" nc=""false""/>")
+%test:args("élève") %test:assertEquals("<result name=""élève"" nc=""true""/>")
+%test:args("pfx:suffix") %test:assertEquals("<result name=""pfx:suffix"" nc=""false""/>")
+function ca:n-castable($d) {
+    let $doc := <e name="e"><f n="{$d}"/></e>
+    let $el := $doc/descendant::*[exists(@n)]
+    let $n := $el/@n
+    return <result name="{$n}" nc="{$n castable as xs:NCName}"/>
+};
+
+(: explicit string conversion was always working - for reference :)
+declare
+%test:args("ixml") %test:assertEquals("<result name=""ixml"" nc=""true""/>")
+%test:args("comment") %test:assertEquals("<result name=""comment"" nc=""true""/>")
+%test:args("apple-jack") %test:assertEquals("<result name=""apple-jack"" nc=""true""/>")
+%test:args("123") %test:assertEquals("<result name=""123"" nc=""false""/>")
+%test:args("élève") %test:assertEquals("<result name=""élève"" nc=""true""/>")
+%test:args("pfx:suffix") %test:assertEquals("<result name=""pfx:suffix"" nc=""false""/>")
+function ca:s-castable($d) {
+    let $doc := <e name="e"><f n="{$d}"/></e>
+    let $el := $doc/descendant::*[exists(@n)]
+    let $n := $el/@n, $s := string($n)
+    return <result name="{$n}" nc="{$s castable as xs:NCName}"/>
+};
+
+(: sanity check that casting accepts the same values as castable as :)
+declare
+%test:args("ixml") %test:assertEquals("<result name=""ixml"" nc=""true""/>")
+%test:args("comment") %test:assertEquals("<result name=""comment"" nc=""true""/>")
+%test:args("apple-jack") %test:assertEquals("<result name=""apple-jack"" nc=""true""/>")
+%test:args("123") %test:assertError("err:")
+%test:args("élève") %test:assertEquals("<result name=""élève"" nc=""true""/>")
+%test:args("pfx:suffix") %test:assertError("err:")
+function ca:s-cast-castable($d) {
+    let $doc := <e name="e"><f n="{$d}"/></e>
+    let $el := $doc/descendant::*[exists(@n)]
+    let $n := $el/@n, $ncname := xs:NCName($n)
+    return <result name="{$n}" nc="{$ncname castable as xs:NCName}"/>
+};
+
+


### PR DESCRIPTION
### Description:

It appears perfectly acceptable for UntypedAtomicValue.convertTo to convert to subtypes of Type.STRING as StringValue(… value, requiredType). The conversion was omitted, and the omission was breaking “castable as” for Type.NCNAME in particular.

These conversions are already acceptable for StringValue(s), and are borrowed from there.

### Reference:

Closes https://github.com/eXist-db/exist/issues/4518

### Type of tests:

xquery unit test added which tests a variety of atomic values `castable as` an NCName successfully. Failing prior to the code change.
