### PR TITLE
Ensure that EXPath packages installed in $EXIST_HOME/data/expathrepo are filesystem portable

### DIFF
--- a/exist-core/src/main/java/org/exist/repo/ClasspathHelper.java
+++ b/exist-core/src/main/java/org/exist/repo/ClasspathHelper.java
@@ -170,10 +170,17 @@ public class ClasspathHelper implements BrokerPoolService {
                 try (final BufferedReader reader = Files.newBufferedReader(cp)) {
                     String line;
                     while ((line = reader.readLine()) != null) {
-                        if (!Files.exists(Paths.get(line))) {
-                            LOG.warn("Unable to add '" + line + "' to the classpath for EXPath package: " + pkg.getName() + ", as the file does not exist!");
+                        Path p = Paths.get(line);
+                        if (!p.isAbsolute()) {
+                            final FileSystemStorage.FileSystemResolver res = (FileSystemStorage.FileSystemResolver) pkg.getResolver();
+                            p = res.resolveComponentAsFile(line);
+                        }
+                        p = p.normalize().toAbsolutePath();
+
+                        if (!Files.exists(p)) {
+                            LOG.warn("Unable to add '" + p + "' to the classpath for EXPath package: " + pkg.getName() + ", as the file does not exist!");
                         } else {
-                            classpath.addComponent(line);
+                            classpath.addComponent(p.toString());
                         }
                     }
                 }

--- a/exist-core/src/main/java/org/exist/repo/ClasspathHelper.java
+++ b/exist-core/src/main/java/org/exist/repo/ClasspathHelper.java
@@ -177,10 +177,10 @@ public class ClasspathHelper implements BrokerPoolService {
                         }
                         p = p.normalize().toAbsolutePath();
 
-                        if (!Files.exists(p)) {
-                            LOG.warn("Unable to add '" + p + "' to the classpath for EXPath package: " + pkg.getName() + ", as the file does not exist!");
-                        } else {
+                        if (Files.exists(p)) {
                             classpath.addComponent(p.toString());
+                        } else {
+                            LOG.warn("Unable to add '" + p + "' to the classpath for EXPath package: " + pkg.getName() + ", as the file does not exist!");
                         }
                     }
                 }

--- a/exist-core/src/main/java/org/exist/repo/ExistPkgExtension.java
+++ b/exist-core/src/main/java/org/exist/repo/ExistPkgExtension.java
@@ -32,15 +32,12 @@ import org.expath.pkg.repo.parser.XMLStreamHelper;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import javax.xml.transform.stream.StreamSource;
 import java.io.IOException;
 import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Set;
 
 /**
  * Handle the exist.xml descriptor in an EXPath package.
@@ -158,23 +155,22 @@ public class ExistPkgExtension
                 throw new PackageException("Impossible to create directory: " + exist);
             }
         }
-        final Set<String> jars = info.getJars();
+
         try(final Writer out = Files.newBufferedWriter(classpath)) {
-            for (final String jar : jars) {
-                StreamSource jar_src;
+            for (final String jar : info.getJars()) {
+
                 try {
-                    jar_src = res.resolveComponent(jar);
+                    res.resolveComponent(jar);
                 } catch (final NotExistException ex) {
-                    final String msg = "Inconsistent package descriptor, the JAR file is not in the package: ";
+                    final String msg = "Inconsistent package descriptor, the JAR file is not in the EXPath package: ";
                     throw new PackageException(msg + jar, ex);
                 }
-                final URI uri = URI.create(jar_src.getSystemId());
-                final Path file = Paths.get(uri);
-                out.write(file.normalize().toString());
-                out.write("\n");
+
+                out.write(jar);
+                out.write('\n');
             }
         } catch (final IOException ex) {
-            throw new PackageException("Error writing the eXist classpath file: " + classpath, ex);
+            throw new PackageException("Error writing the eXist classpath file '" + classpath + "' for the EXPath package: " + pkg.getName(), ex);
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/4901

Previously classpath locations were stored as absolute paths, they are now stored as relative paths. Care has been taken to ensure that the code remains backwards compatible with existing eXist-db data dirs that are already using absolute paths. 