### PR TITLE
Set the default `enforce-index-use` to strict for all tests

### DIFF
--- a/exist-ant/src/test/resources-filtered/conf.xml
+++ b/exist-ant/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/exist-core/src/test/resources-filtered/conf.xml
+++ b/exist-core/src/test/resources-filtered/conf.xml
@@ -884,7 +884,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
         
         <builtin-modules>

--- a/exist-core/src/test/resources-filtered/org/exist/storage/statistics/conf.xml
+++ b/exist-core/src/test/resources-filtered/org/exist/storage/statistics/conf.xml
@@ -879,7 +879,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
         
         <builtin-modules>

--- a/exist-core/src/test/resources-filtered/org/exist/xquery/functions/transform/conf.xml
+++ b/exist-core/src/test/resources-filtered/org/exist/xquery/functions/transform/conf.xml
@@ -890,7 +890,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
         
         <builtin-modules>

--- a/exist-core/src/test/resources/org/exist/storage/ConcurrentBrokerPoolTest.conf.xml
+++ b/exist-core/src/test/resources/org/exist/storage/ConcurrentBrokerPoolTest.conf.xml
@@ -91,7 +91,7 @@
 
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
         
         <builtin-modules/>

--- a/exist-core/src/test/resources/org/exist/xmldb/allowAnyUri.xml
+++ b/exist-core/src/test/resources/org/exist/xmldb/allowAnyUri.xml
@@ -927,7 +927,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no"
             enable-query-rewriting="yes" backwardCompatible="no"
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/contentextraction/src/test/resources-filtered/conf.xml
+++ b/extensions/contentextraction/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/debuggee/src/test/resources-filtered/conf.xml
+++ b/extensions/debuggee/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/expath/src/test/resources-filtered/conf.xml
+++ b/extensions/expath/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/exquery/restxq/src/test/resources-filtered/conf.xml
+++ b/extensions/exquery/restxq/src/test/resources-filtered/conf.xml
@@ -715,7 +715,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/indexes/indexes-integration-tests/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/indexes-integration-tests/src/test/resources-filtered/conf.xml
@@ -883,7 +883,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/indexes/lucene/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/lucene/src/test/resources-filtered/conf.xml
@@ -882,7 +882,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/indexes/ngram/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/ngram/src/test/resources-filtered/conf.xml
@@ -882,7 +882,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
         
         <builtin-modules>

--- a/extensions/indexes/range/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/range/src/test/resources-filtered/conf.xml
@@ -885,7 +885,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
         
         <builtin-modules>

--- a/extensions/indexes/sort/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/sort/src/test/resources-filtered/conf.xml
@@ -882,7 +882,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
         
         <builtin-modules>

--- a/extensions/indexes/spatial/src/test/resources-filtered/conf.xml
+++ b/extensions/indexes/spatial/src/test/resources-filtered/conf.xml
@@ -881,7 +881,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
         
         <builtin-modules>

--- a/extensions/modules/cache/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/cache/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/cache/src/test/resources-filtered/lazy-cache-conf.xml
+++ b/extensions/modules/cache/src/test/resources-filtered/lazy-cache-conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/cache/src/test/resources-filtered/non-lazy-cache-conf.xml
+++ b/extensions/modules/cache/src/test/resources-filtered/non-lazy-cache-conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/compression/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/compression/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/counter/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/counter/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/expathrepo/expathrepo-trigger-test/src/test/resources/conf.xml
+++ b/extensions/modules/expathrepo/expathrepo-trigger-test/src/test/resources/conf.xml
@@ -745,7 +745,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/expathrepo/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/expathrepo/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/file/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/file/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/image/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/image/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/mail/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/mail/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/persistentlogin/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/persistentlogin/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/sql/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/sql/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/xmldiff/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/xmldiff/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/modules/xslfo/src/test/resources-filtered/conf.xml
+++ b/extensions/modules/xslfo/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/webdav/src/test/resources-filtered/conf.xml
+++ b/extensions/webdav/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>

--- a/extensions/xqdoc/src/test/resources-filtered/conf.xml
+++ b/extensions/xqdoc/src/test/resources-filtered/conf.xml
@@ -738,7 +738,7 @@
     <!-- TODO: add attribute 'enabled="yes/no"' -->
     <xquery enable-java-binding="no" disable-deprecated-functions="no" 
             enable-query-rewriting="yes" backwardCompatible="no" 
-            enforce-index-use="always"
+            enforce-index-use="strict"
             raise-error-on-failed-retrieval="no">
 
         <builtin-modules>


### PR DESCRIPTION
Follows on from my work in PR https://github.com/eXist-db/exist/pull/4885 to also update the default `enforce-index-use` policy for all tests in eXist-db to `strict` also.

----------
This open source contribution to the [exist](https://github.com/eXist-db/exist) project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.