### PR TITLE
Fix passing database nodes from XQuery to fn:transform as parameters

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Convert.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Convert.java
@@ -120,6 +120,9 @@ class Convert {
         }
 
         XdmValue of(final Item item) throws XPathException {
+            if (item instanceof NodeProxy nodeProxy) {
+                return ofNode(nodeProxy.getNode());
+            }
             final int itemType = item.getType();
             if (Type.subTypeOf(itemType, Type.ATOMIC)) {
                 return ofAtomic((AtomicValue) item);

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Convert.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Convert.java
@@ -26,6 +26,7 @@ import net.sf.saxon.s9api.*;
 import net.sf.saxon.type.BuiltInAtomicType;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.DocumentImpl;
+import org.exist.dom.persistent.NodeProxy;
 import org.exist.xquery.ErrorCodes;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.functions.array.ArrayType;
@@ -150,7 +151,7 @@ class Convert {
 
             final DocumentBuilder sourceBuilder = newDocumentBuilder();
             try {
-                if (node instanceof DocumentImpl) {
+                if (node instanceof Document) {
                     return sourceBuilder.build(new DOMSource(node));
                 } else {
                     //The source must be part of a document
@@ -178,6 +179,9 @@ class Convert {
         }
 
         XdmValue of(final Sequence value) throws XPathException {
+            if (value instanceof NodeProxy nodeProxy) {
+                return ofNode(nodeProxy.getNode());
+            }
             return XdmValue.makeSequence(listOf(value));
         }
 

--- a/exist-core/src/test/java/xquery/xquery3/XQuery3Tests.java
+++ b/exist-core/src/test/java/xquery/xquery3/XQuery3Tests.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
         "src/test/xquery/xquery3",
         "src/test/xquery/xquery3/transform",
         // To add an individual test or only run a specific set of tests -
-//         "src/test/xquery/xquery3/serialize.xql",
+        //"src/test/xquery/xquery3/serialize.xql",
 })
 public class XQuery3Tests {
 }

--- a/exist-core/src/test/xquery/xquery3/transform/fnTransformRegressionDocAsParameter.xqm
+++ b/exist-core/src/test/xquery/xquery3/transform/fnTransformRegressionDocAsParameter.xqm
@@ -1,0 +1,87 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace testTransform="http://exist-db.org/xquery/test/function_transform";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+declare variable $testTransform:stylesheet := <xsl:stylesheet version='1.0' xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
+    <xsl:param name='v'/>
+    <xsl:template match='/'>
+        <v><xsl:value-of select='$v'/></v>
+    </xsl:template>
+</xsl:stylesheet>;
+
+declare variable $testTransform:document := <document>
+    <catalog>
+        <book id="bk101">
+           <author>Gambardella, Matthew</author>
+           <title>XML Developer's Guide</title>
+           <genre>Computer</genre>
+           <price>44.95</price>
+           <publish_date>2000-10-01</publish_date>
+           <description>An in-depth look at creating applications
+           with XML.</description>
+        </book>
+        <book id="bk102">
+           <author>Ralls, Kim</author>
+           <title>Midnight Rain</title>
+           <genre>Fantasy</genre>
+           <price>5.95</price>
+           <publish_date>2000-12-16</publish_date>
+           <description>A former architect battles corporate zombies,
+           an evil sorceress, and her own childhood to become queen
+           of the world.</description>
+        </book>
+    </catalog>
+</document>;
+
+declare
+    %test:setUp
+function testTransform:setup() {
+    let $coll := xmldb:create-collection("/db", "regression-test")
+    let $storeStylesheet := xmldb:store($coll, "stylesheet.xsl", $testTransform:stylesheet, "application/xslt+xml")
+    return ( xmldb:store($coll, "document.xml", $testTransform:document, "application/document")
+    )
+};
+
+declare
+    %test:tearDown
+function testTransform:cleanup() {
+    xmldb:remove("/db/regression-test")
+};
+
+declare
+    %test:assertEquals("<v>Gambardella, MatthewXML Developer's GuideComputer44.952000-10-01An in-depth look at creating applications
+           with XML.Ralls, KimMidnight RainFantasy5.952000-12-16A former architect battles corporate zombies,
+           an evil sorceress, and her own childhood to become queen
+           of the world.</v>")
+function testTransform:regression-test-1() {
+    let $in := parse-xml("<dummy/>")
+    let $result := ( fn:transform(map{
+        "source-node":$in,
+        "stylesheet-node":doc("/db/regression-test/stylesheet.xsl"),
+        "stylesheet-params": map { QName("","v"): doc("/db/regression-test/document.xml") } } ) )?output
+    return $result
+};
+


### PR DESCRIPTION
It was previously not possible to pass nodes (e.g. documents) stored in the db from XQuery to `fn:transform` as parameters. 

The error encountred was:

```
class org.exist.dom.persistent.NodeProxy cannot be cast to class org.w3c.dom.Node (org.exist.dom.persistent.NodeProxy is in unnamed module of loader java.net.URLClassLoader @421faab1; org.w3c.dom.Node is in module java.xml of loader 'bootstrap')
```

This PR addresses this by accepting a `NodeProxy` and dereferencing it in cases in `fn:transform` implementation where a node was expected.
