### PR TITLE
Fix the resolution of XmldbURIs from within fn:transform

### DIFF
--- a/exist-core/src/main/java/org/exist/util/SaxonConfiguration.java
+++ b/exist-core/src/main/java/org/exist/util/SaxonConfiguration.java
@@ -22,13 +22,11 @@
 package org.exist.util;
 
 import net.jcip.annotations.ThreadSafe;
-import net.sf.saxon.lib.Feature;
 import net.sf.saxon.s9api.Processor;
 import net.sf.saxon.trans.XPathException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.storage.BrokerPool;
-import org.exist.xquery.functions.fn.transform.URIResolution;
 
 import javax.xml.transform.stream.StreamSource;
 import java.io.IOException;

--- a/exist-core/src/main/java/org/exist/util/SaxonConfiguration.java
+++ b/exist-core/src/main/java/org/exist/util/SaxonConfiguration.java
@@ -54,7 +54,8 @@ public final class SaxonConfiguration {
   private SaxonConfiguration(final net.sf.saxon.Configuration configuration) {
     this.configuration = configuration;
     this.processor = new Processor(configuration);
-    //TODO (AP) We could further configure URI/Resource resolution for Saxon within eXist here
+    //TODO (AP) This is a better place to configure URI/Resource resolution for Saxon within eXist
+    //At present the configuration for Saxon to resolve xmldb:exist: URIs is restricted to fn:transform
   }
 
   /**

--- a/exist-core/src/main/java/org/exist/util/SaxonConfiguration.java
+++ b/exist-core/src/main/java/org/exist/util/SaxonConfiguration.java
@@ -22,11 +22,13 @@
 package org.exist.util;
 
 import net.jcip.annotations.ThreadSafe;
+import net.sf.saxon.lib.Feature;
 import net.sf.saxon.s9api.Processor;
 import net.sf.saxon.trans.XPathException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.exist.storage.BrokerPool;
+import org.exist.xquery.functions.fn.transform.URIResolution;
 
 import javax.xml.transform.stream.StreamSource;
 import java.io.IOException;
@@ -54,6 +56,7 @@ public final class SaxonConfiguration {
   private SaxonConfiguration(final net.sf.saxon.Configuration configuration) {
     this.configuration = configuration;
     this.processor = new Processor(configuration);
+    //TODO (AP) We could further configure URI/Resource resolution for Saxon within eXist here
   }
 
   /**

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Options.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Options.java
@@ -507,39 +507,11 @@ class Options {
 
         final URI uri = URI.create(stylesheetLocation);
         if (uri.isAbsolute()) {
-            return resolvePossibleStylesheetLocation(stylesheetLocation);
+            return URIResolution.resolveDocument(stylesheetLocation, context, fnTransform);
         } else {
             final AnyURIValue resolved = resolveURI(new AnyURIValue(stylesheetLocation), context.getBaseURI());
-            return resolvePossibleStylesheetLocation(resolved.getStringValue());
+            return URIResolution.resolveDocument(resolved.getStringValue(), context, fnTransform);
         }
-    }
-
-    /**
-     * Resolve an absolute stylesheet location
-     *
-     * @param location of the stylesheet
-     * @return the resolved stylesheet as a source
-     * @throws XPathException if the item does not exist, or is not a document
-     */
-    private Source resolvePossibleStylesheetLocation(final String location) throws XPathException {
-
-        final Sequence document;
-        try {
-            document = DocUtils.getDocument(context, location);
-        } catch (final PermissionDeniedException e) {
-            throw new XPathException(fnTransform, ErrorCodes.FODC0002,
-                    "Can not access '" + location + "'" + e.getMessage());
-        }
-        if (document != null && document.hasOne() && Type.subTypeOf(document.getItemType(), Type.NODE)) {
-            if (document instanceof NodeProxy proxy) {
-                return new DOMSource(proxy.getNode());
-            }
-            else if (document.itemAt(0) instanceof Node node) {
-                return new DOMSource(node);
-            }
-        }
-        throw new XPathException(fnTransform, ErrorCodes.FODC0002,
-                "Location '"+ location + "' returns an item which is not a document node");
     }
 
     /**
@@ -550,18 +522,10 @@ class Options {
      * @throws XPathException if resolution is not possible
      */
     private AnyURIValue resolveURI(final AnyURIValue relative, final AnyURIValue base) throws XPathException {
-        final URI relativeURI;
-        final URI baseURI;
         try {
-            relativeURI = new URI(relative.getStringValue());
-            baseURI = new URI(base.getStringValue() );
+            return URIResolution.resolveURI(relative, base);
         } catch (final URISyntaxException e) {
             throw new XPathException(fnTransform, ErrorCodes.FORG0009, "unable to resolve a relative URI against a base URI in fn:transform(): " + e.getMessage(), null, e);
-        }
-        if (relativeURI.isAbsolute()) {
-            return relative;
-        } else {
-            return new AnyURIValue(baseURI.resolve(relativeURI));
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
@@ -88,15 +88,11 @@ public class URIResolution {
                 var resolved = resolveURI(hrefURI, baseURI);
                 return resolveDocument(resolved.getStringValue());
             } catch (URISyntaxException e) {
-                throw new TransformerException("Failed to resolve " +
-                    href +
-                    " against " +
-                    base, e);
-            } catch (org.exist.xquery.XPathException e) {
-                throw new TransformerException("Failed to find document as result of resolving " +
-                    href +
-                    " against " +
-                    base, e);
+                throw new TransformerException(
+                    "Failed to resolve " + href + " against " + base, e);
+            } catch (XPathException e) {
+                throw new TransformerException(
+                    "Failed to find document as result of resolving " + href + " against " + base, e);
             }
         }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
@@ -108,17 +108,17 @@ public class URIResolution {
      * @return the resolved stylesheet as a source
      * @throws org.exist.xquery.XPathException if the item does not exist, or is not a document
      */
-    static Source resolveDocument(final String location, final XQueryContext xQueryContext, Expression containingExpression) throws org.exist.xquery.XPathException {
+    static Source resolveDocument(final String location, final XQueryContext xQueryContext, Expression containingExpression) throws XPathException {
 
         final Sequence document;
         try {
             document = DocUtils.getDocument(xQueryContext, location);
         } catch (final PermissionDeniedException e) {
-            throw new org.exist.xquery.XPathException(containingExpression, ErrorCodes.FODC0002,
+            throw new XPathException(containingExpression, ErrorCodes.FODC0002,
                 "Can not access '" + location + "'" + e.getMessage());
         }
         if (document == null || document.isEmpty()) {
-            throw new org.exist.xquery.XPathException(containingExpression, ErrorCodes.FODC0002,
+            throw new XPathException(containingExpression, ErrorCodes.FODC0002,
                 "No document found at location '"+ location);
         }
         if (document.hasOne() && Type.subTypeOf(document.getItemType(), Type.NODE)) {
@@ -129,7 +129,7 @@ public class URIResolution {
                 return new DOMSource(node);
             }
         }
-        throw new org.exist.xquery.XPathException(containingExpression, ErrorCodes.FODC0002,
+        throw new XPathException(containingExpression, ErrorCodes.FODC0002,
             "Location '"+ location + "' returns an item which is not a document node");
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
@@ -69,7 +69,7 @@ public class URIResolution {
         }
     }
 
-    static public class CompileTimeURIResolver implements URIResolver {
+    public static class CompileTimeURIResolver implements URIResolver {
 
         private final XQueryContext xQueryContext;
         private final Expression containingExpression;
@@ -86,7 +86,7 @@ public class URIResolution {
                 final AnyURIValue baseURI = new AnyURIValue(base);
                 final AnyURIValue hrefURI = new AnyURIValue(href);
                 var resolved = resolveURI(hrefURI, baseURI);
-                return resolveDocument(resolved.getStringValue(), xQueryContext, containingExpression);
+                return resolveDocument(resolved.getStringValue());
             } catch (URISyntaxException e) {
                 throw new TransformerException("Failed to resolve " +
                     href +
@@ -98,6 +98,10 @@ public class URIResolution {
                     " against " +
                     base, e);
             }
+        }
+
+        protected Source resolveDocument(final String location) throws XPathException {
+            return URIResolution.resolveDocument(location, xQueryContext, containingExpression);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
@@ -51,20 +51,21 @@ public class URIResolution {
      * @return resolved URI
      * @throws URISyntaxException if resolution is not possible
      */
-    static AnyURIValue resolveURI(final AnyURIValue relative, final AnyURIValue base) throws URISyntaxException {
+    static AnyURIValue resolveURI(final AnyURIValue relative, final AnyURIValue base) throws URISyntaxException, XPathException {
         var relativeURI = new URI(relative.getStringValue());
         if (relativeURI.isAbsolute()) {
             return relative;
         }
         var baseURI = new URI(base.getStringValue() );
+        if (!baseURI.isAbsolute()) {
+            return relative;
+        }
         try {
             var xBase = XmldbURI.xmldbUriFor(baseURI);
             var resolved = xBase.getURI().resolve(relativeURI);
             return new AnyURIValue(XmldbURI.XMLDB_URI_PREFIX + resolved);
         } catch (URISyntaxException e) {
             return new AnyURIValue(baseURI.resolve(relativeURI));
-        } catch (XPathException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/URIResolution.java
@@ -1,0 +1,134 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.exist.xquery.functions.fn.transform;
+
+import org.exist.dom.persistent.NodeProxy;
+import org.exist.security.PermissionDeniedException;
+import org.exist.xmldb.XmldbURI;
+import org.exist.xquery.ErrorCodes;
+import org.exist.xquery.Expression;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.util.DocUtils;
+import org.exist.xquery.value.AnyURIValue;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.Type;
+import org.w3c.dom.Node;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.dom.DOMSource;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class URIResolution {
+
+    /**
+     * URI resolution, the core should be the same as for fn:resolve-uri
+     * @param relative URI to resolve
+     * @param base to resolve against
+     * @return resolved URI
+     * @throws URISyntaxException if resolution is not possible
+     */
+    static AnyURIValue resolveURI(final AnyURIValue relative, final AnyURIValue base) throws URISyntaxException {
+        var relativeURI = new URI(relative.getStringValue());
+        if (relativeURI.isAbsolute()) {
+            return relative;
+        }
+        var baseURI = new URI(base.getStringValue() );
+        try {
+            var xBase = XmldbURI.xmldbUriFor(baseURI);
+            var resolved = xBase.getURI().resolve(relativeURI);
+            return new AnyURIValue(XmldbURI.XMLDB_URI_PREFIX + resolved);
+        } catch (URISyntaxException e) {
+            return new AnyURIValue(baseURI.resolve(relativeURI));
+        } catch (XPathException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static public class CompileTimeURIResolver implements URIResolver {
+
+        private final XQueryContext xQueryContext;
+        private final Expression containingExpression;
+
+        public CompileTimeURIResolver(XQueryContext xQueryContext, Expression containingExpression) {
+            this.xQueryContext = xQueryContext;
+            this.containingExpression = containingExpression;
+        }
+
+        @Override
+        public Source resolve(final String href, final String base) throws TransformerException {
+
+            try {
+                final AnyURIValue baseURI = new AnyURIValue(base);
+                final AnyURIValue hrefURI = new AnyURIValue(href);
+                var resolved = resolveURI(hrefURI, baseURI);
+                return resolveDocument(resolved.getStringValue(), xQueryContext, containingExpression);
+            } catch (URISyntaxException e) {
+                throw new TransformerException("Failed to resolve " +
+                    href +
+                    " against " +
+                    base, e);
+            } catch (org.exist.xquery.XPathException e) {
+                throw new TransformerException("Failed to find document as result of resolving " +
+                    href +
+                    " against " +
+                    base, e);
+            }
+        }
+    }
+
+    /**
+     * Resolve an absolute document location, stylesheet or included source
+     *
+     * @param location of the stylesheet
+     * @return the resolved stylesheet as a source
+     * @throws org.exist.xquery.XPathException if the item does not exist, or is not a document
+     */
+    static Source resolveDocument(final String location, final XQueryContext xQueryContext, Expression containingExpression) throws org.exist.xquery.XPathException {
+
+        final Sequence document;
+        try {
+            document = DocUtils.getDocument(xQueryContext, location);
+        } catch (final PermissionDeniedException e) {
+            throw new org.exist.xquery.XPathException(containingExpression, ErrorCodes.FODC0002,
+                "Can not access '" + location + "'" + e.getMessage());
+        }
+        if (document == null || document.isEmpty()) {
+            throw new org.exist.xquery.XPathException(containingExpression, ErrorCodes.FODC0002,
+                "No document found at location '"+ location);
+        }
+        if (document.hasOne() && Type.subTypeOf(document.getItemType(), Type.NODE)) {
+            if (document instanceof NodeProxy proxy) {
+                return new DOMSource(proxy.getNode());
+            }
+            else if (document.itemAt(0) instanceof Node node) {
+                return new DOMSource(node);
+            }
+        }
+        throw new org.exist.xquery.XPathException(containingExpression, ErrorCodes.FODC0002,
+            "Location '"+ location + "' returns an item which is not a document node");
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
@@ -175,7 +175,11 @@ public class FunTransformTest {
         public void setSystemId(String systemId) {
         }
 
-        // implementation solely to conform to interface for test use
+        /**
+         * implementation solely to conform to interface for test use
+         *
+         * @return always returns null; not expected to be called
+         */
         @Override
         public String getSystemId() {
             return null;

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
@@ -22,9 +22,12 @@
 package org.exist.xquery.functions.fn.transform;
 
 import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
 import org.exist.xquery.value.AnyURIValue;
 import org.junit.jupiter.api.Test;
 
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
 
@@ -49,20 +52,23 @@ public class FunTransformTest {
         assertEquals(Options.XSLTVersion.fromDecimal(new BigDecimal("3.1")), Options.XSLTVersion.fromDecimal(new BigDecimal("3.1")));
     }
 
-    @Test void badVersionNumber() throws Transform.PendingException {
+    @Test
+    void badVersionNumber() throws Transform.PendingException {
 
         assertThrows(Transform.PendingException.class, () -> {
             Options.XSLTVersion version311 = Options.XSLTVersion.fromDecimal(new BigDecimal("3.11"));
         });
     }
 
-    @Test public void emptyResolution() throws XPathException, URISyntaxException {
+    @Test
+    public void emptyResolution() throws XPathException, URISyntaxException {
         var base = new AnyURIValue("");
         var relative = new AnyURIValue("path/to/functions1.xsl");
         assertEquals(new AnyURIValue("path/to/functions1.xsl"), URIResolution.resolveURI(relative, base));
     }
 
-    @Test public void resolution() throws XPathException, URISyntaxException {
+    @Test
+    public void resolution() throws XPathException, URISyntaxException {
         var base = new AnyURIValue("xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl");
         var relative = new AnyURIValue("functions1.xsl");
         assertEquals(new AnyURIValue("xmldb:exist:/db/apps/fn_transform/functions1.xsl"),
@@ -106,5 +112,68 @@ public class FunTransformTest {
         var relative5 = new AnyURIValue("https://127.0.0.1:8088/a/b/c/functions1.xsl");
         assertEquals(new AnyURIValue("https://127.0.0.1:8088/a/b/c/functions1.xsl"),
             URIResolution.resolveURI(relative5, base5));
+    }
+
+    /**
+     * Create some UT coverage of the CompileTimeURIResolver
+     * This is more significantly exercised by XQTS tests
+     * Results are the same as above, wrapped in a {@code Source}
+     *
+     * @throws TransformerException
+     */
+    @Test
+    public void resolverObject() throws TransformerException {
+        var resolver = new URIResolution.CompileTimeURIResolver(new XQueryContext(), null) {
+            @Override protected SourceWithLocation resolveDocument(final String location) {
+                return new SourceWithLocation("RESOLVED::" + location);
+            }
+        };
+
+        assertEquals("RESOLVED::xmldb:exist:/db/apps/fn_transform/functions1.xsl",
+            ((SourceWithLocation)resolver.resolve("functions1.xsl", "xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl")).location);
+        assertEquals("RESOLVED::xmldb:exist:/functions1.xsl",
+            ((SourceWithLocation)resolver.resolve("/functions1.xsl", "xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl")).location);
+
+        assertEquals("RESOLVED::xmldb:exist:/fn_transform/functions1.xsl",
+            ((SourceWithLocation)resolver.resolve("/fn_transform/functions1.xsl", "xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl")).location);
+
+        assertEquals("RESOLVED::xmldb:exist:/fn_transform/functions1.xsl",
+            ((SourceWithLocation)resolver.resolve("/fn_transform/functions1.xsl", "xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl")).location);
+
+        assertEquals("RESOLVED::https://127.0.0.1:8088/db/apps/fn_transform/functions1.xsl",
+            ((SourceWithLocation)resolver.resolve("functions1.xsl", "https://127.0.0.1:8088/db/apps/fn_transform/tei-toc2.xsl")).location);
+
+        assertEquals("RESOLVED::https://127.0.0.1:8088/db/apps/fn_transform/functions1.xsl",
+            ((SourceWithLocation)resolver.resolve("functions1.xsl", "https://127.0.0.1:8088/db/apps/fn_transform/")).location);
+
+        assertEquals("RESOLVED::https://127.0.0.1:8088/functions1.xsl",
+            ((SourceWithLocation)resolver.resolve("/functions1.xsl", "https://127.0.0.1:8088/db/apps/fn_transform/")).location);
+
+        assertEquals("RESOLVED::xmldb:exist:///a/b/c/functions1.xsl",
+            ((SourceWithLocation)resolver.resolve("xmldb:exist:///a/b/c/functions1.xsl", "xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl")).location);
+
+        assertEquals("RESOLVED::https://127.0.0.1:8088/a/b/c/functions1.xsl",
+            ((SourceWithLocation)resolver.resolve("https://127.0.0.1:8088/a/b/c/functions1.xsl", "xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl")).location);
+    }
+
+    /**
+     * Skeleton implementation for test
+     */
+    private static class SourceWithLocation implements Source {
+
+        final String location;
+        SourceWithLocation(final String location) {
+            this.location = location;
+        }
+
+        @Override
+        public void setSystemId(String systemId) {
+
+        }
+
+        @Override
+        public String getSystemId() {
+            return null;
+        }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
@@ -21,9 +21,12 @@
  */
 package org.exist.xquery.functions.fn.transform;
 
+import org.exist.xquery.XPathException;
+import org.exist.xquery.value.AnyURIValue;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.net.URISyntaxException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -51,5 +54,51 @@ public class FunTransformTest {
         assertThrows(Transform.PendingException.class, () -> {
             Options.XSLTVersion version311 = Options.XSLTVersion.fromDecimal(new BigDecimal("3.11"));
         });
+    }
+
+    @Test public void resolution() throws XPathException, URISyntaxException {
+        var base = new AnyURIValue("xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl");
+        var relative = new AnyURIValue("functions1.xsl");
+        assertEquals(new AnyURIValue("xmldb:exist:/db/apps/fn_transform/functions1.xsl"),
+            URIResolution.resolveURI(relative, base));
+
+        var base1_5 = new AnyURIValue("xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl");
+        var relative1_5 = new AnyURIValue("/functions1.xsl");
+        assertEquals(new AnyURIValue("xmldb:exist:/functions1.xsl"),
+            URIResolution.resolveURI(relative1_5, base1_5));
+
+        var base1_10 = new AnyURIValue("xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl");
+        var relative1_10 = new AnyURIValue("/fn_transform/functions1.xsl");
+        assertEquals(new AnyURIValue("xmldb:exist:/fn_transform/functions1.xsl"),
+            URIResolution.resolveURI(relative1_10, base1_10));
+
+        var base2 = new AnyURIValue("xmldb:exist:/db/apps/fn_transform/tei-toc2.xsl");
+        assertEquals(new AnyURIValue("xmldb:exist:/db/apps/fn_transform/functions1.xsl"),
+            URIResolution.resolveURI(relative, base2));
+
+        var base3 = new AnyURIValue("https://127.0.0.1:8088/db/apps/fn_transform/tei-toc2.xsl");
+        var relative3 = new AnyURIValue("functions1.xsl");
+        assertEquals(new AnyURIValue("https://127.0.0.1:8088/db/apps/fn_transform/functions1.xsl"),
+            URIResolution.resolveURI(relative3, base3));
+
+        var base3_5 = new AnyURIValue("https://127.0.0.1:8088/db/apps/fn_transform/");
+        var relative3_5 = new AnyURIValue("functions1.xsl");
+        assertEquals(new AnyURIValue("https://127.0.0.1:8088/db/apps/fn_transform/functions1.xsl"),
+            URIResolution.resolveURI(relative3_5, base3_5));
+
+        var base3_10 = new AnyURIValue("https://127.0.0.1:8088/db/apps/fn_transform/");
+        var relative3_10 = new AnyURIValue("/functions1.xsl");
+        assertEquals(new AnyURIValue("https://127.0.0.1:8088/functions1.xsl"),
+            URIResolution.resolveURI(relative3_10, base3_10));
+
+        var base4 = new AnyURIValue("xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl");
+        var relative4 = new AnyURIValue("xmldb:exist:///a/b/c/functions1.xsl");
+        assertEquals(new AnyURIValue("xmldb:exist:///a/b/c/functions1.xsl"),
+            URIResolution.resolveURI(relative4, base4));
+
+        var base5 = new AnyURIValue("xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl");
+        var relative5 = new AnyURIValue("https://127.0.0.1:8088/a/b/c/functions1.xsl");
+        assertEquals(new AnyURIValue("https://127.0.0.1:8088/a/b/c/functions1.xsl"),
+            URIResolution.resolveURI(relative5, base5));
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
@@ -166,7 +166,11 @@ public class FunTransformTest {
             this.location = location;
         }
 
-        // implementation solely to conform to interface for test use
+        /**
+         * implementation solely to conform to interface for test use
+         *
+         * @param systemId The system identifier as a URL string.
+         */
         @Override
         public void setSystemId(String systemId) {
         }

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
@@ -166,11 +166,12 @@ public class FunTransformTest {
             this.location = location;
         }
 
+        // implementation solely to conform to interface for test use
         @Override
         public void setSystemId(String systemId) {
-
         }
 
+        // implementation solely to conform to interface for test use
         @Override
         public String getSystemId() {
             return null;

--- a/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/fn/transform/FunTransformTest.java
@@ -56,6 +56,12 @@ public class FunTransformTest {
         });
     }
 
+    @Test public void emptyResolution() throws XPathException, URISyntaxException {
+        var base = new AnyURIValue("");
+        var relative = new AnyURIValue("path/to/functions1.xsl");
+        assertEquals(new AnyURIValue("path/to/functions1.xsl"), URIResolution.resolveURI(relative, base));
+    }
+
     @Test public void resolution() throws XPathException, URISyntaxException {
         var base = new AnyURIValue("xmldb:exist:///db/apps/fn_transform/tei-toc2.xsl");
         var relative = new AnyURIValue("functions1.xsl");


### PR DESCRIPTION
### Description:

URI resolution passed to Saxon (used internally by `fn:rransform`) was not handling xmldb: URIs. Add a special case for this in the resolution used by `fn:transform`.

### Reference:

Closes https://github.com/eXist-db/exist/issues/3820
Discussed in https://stackoverflow.com/questions/73454333/xslt-fntransform-with-stylesheet-in-exist-db-having-xslimport

### Type of tests:

Manual test of xsl:import of database documents using eXide
Unit tests for updated resolution method
