### PR TITLE
Comparison on node identity was incorrect, and so too much data was returned

### DIFF
--- a/exist-xqts/src/main/xslt/compare-results.xslt
+++ b/exist-xqts/src/main/xslt/compare-results.xslt
@@ -105,8 +105,9 @@
         <xsl:param name="current-results" as="element(cr:results)" required="yes"/>
         <xsl:param name="attr-name" as="xs:string" required="yes"/>
         <xsl:variable name="elem-name" as="xs:QName" select="xs:QName(concat('cr:', $attr-name))"/>
+        <xsl:variable name="previous-results-names" as="xs:string*" select="$previous-results/element()[node-name(.) eq $elem-name]/testcase/@name/string(.)"/>
         <xsl:element name="cr:{$attr-name}">
-            <xsl:apply-templates mode="simple" select="$current-results/element()[node-name(.) eq $elem-name]/testcase[@name except $previous-results/element()[node-name(.) eq $elem-name]/testcase/@name]"/>
+            <xsl:apply-templates mode="simple" select="$current-results/element()[node-name(.) eq $elem-name]/testcase[not(@name = $previous-results-names)]"/>
         </xsl:element>
     </xsl:function>
 


### PR DESCRIPTION
In the XQTS CI job, there was a simple mistake in the XSLT that caused all test names to be returned rather than just those that have changed.