### PR TITLE
Add support for XQuery Update Facility 3.0

### DIFF
--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -2342,6 +2342,8 @@ reservedKeywords returns [String name]
     "after" { name = "after"; }
     |
     "before" { name = "before"; }
+    |
+    "copy" { name = "copy"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -721,6 +721,7 @@ exprSingle throws XPathException
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
 	| ( "copy" DOLLAR) => copyModifyExpr
+	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
 	;
 
@@ -1305,6 +1306,11 @@ postfixExpr throws XPathException
 		(QUESTION) => lookup
 	)*
 	;
+
+dynamicUpdFunCall throws XPathException
+:
+	"invoke"! "updating"^ primaryExpr ( argumentList )*
+    ;
 
 arrowExpr throws XPathException
 :
@@ -2283,6 +2289,8 @@ reservedKeywords returns [String name]
     "skip" { name = "skip"; }
     |
     "transform" { name = "transform"; }
+    |
+    "invoke" { name = "invoke"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -180,6 +180,7 @@ imaginaryTokenDefinitions
 	PRAGMA
 	GTEQ
 	SEQUENCE
+	INSERT_TARGET
 	;
 
 // === XPointer ===
@@ -720,6 +721,7 @@ exprSingle throws XPathException
 	| ( "switch" LPAREN ) => switchExpr
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
+	| ( "insert" ) => xqufInsertExpr
 	| ( "copy" DOLLAR) => copyModifyExpr
 	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
@@ -754,6 +756,27 @@ insertExpr throws XPathException
 	"insert" exprSingle
 	( "into" | "preceding" | "following" ) exprSingle
 	;
+
+xqufInsertExpr throws XPathException
+:
+	"insert"^ ( "node"! | "nodes"! ) exprSingle
+	insertExprTargetChoice exprSingle
+	;
+
+insertExprTargetChoice throws XPathException
+{ String target = null; }
+:
+    (
+        ( ( "as"! ( "first"! { target = "first"; } | "last"! { target = "last"; } )  )? "into"! {
+            if (target == null)
+                target = "into";
+        } )
+        | "after"! { target = "after"; }
+        | "before"! { target = "before"; }
+    )
+    { #insertExprTargetChoice= #(#[INSERT_TARGET, target]); }
+
+;
 
 deleteExpr throws XPathException
 :
@@ -2291,6 +2314,16 @@ reservedKeywords returns [String name]
     "transform" { name = "transform"; }
     |
     "invoke" { name = "invoke"; }
+    |
+    "nodes" { name = "nodes"; }
+    |
+    "first" { name = "first"; }
+    |
+    "last" { name = "last"; }
+    |
+    "after" { name = "after"; }
+    |
+    "before" { name = "before"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -724,7 +724,8 @@ exprSingle throws XPathException
 	| ( "insert" ( "node" | "nodes" ) ) => xqufInsertExpr
 	| ( "delete" ( "node" | "nodes" ) ) => xqufDeleteExpr
 	| ( "replace" ( "value" | "node" ) ) => xqufReplaceExpr
-	| ( "copy" DOLLAR) => copyModifyExpr
+	| ( "rename" "node" ) => xqufRenameExpr
+	| ( "copy" DOLLAR ) => copyModifyExpr
 	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
 	;
@@ -798,6 +799,11 @@ xqufDeleteExpr throws XPathException
 xqufReplaceExpr throws XPathException
 :
 	"replace"^ ("value" "of"!)? "node"! exprSingle "with"! exprSingle
+	;
+
+xqufRenameExpr throws XPathException
+:
+	"rename"^ "node"! exprSingle "as"! exprSingle
 	;
 
 copyModifyExpr throws XPathException

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -266,6 +266,11 @@ prolog throws XPathException
 			// bare keyword updating is valid because of rule CompatibilityAnnotation in the XQUF standard
 			( "declare" (MOD | "updating") )
 			=> annotateDecl { inSetters = false; }
+			|
+			( "declare" "revalidation" )
+			=> revalidationDecl {
+			    inSetters = false;
+		    }
         )
 		SEMICOLON!
     )*
@@ -461,6 +466,11 @@ annotation
         name = "updating";
         #annotation= #(#[ANNOT_DECL, name], #annotation);
     }
+    ;
+
+revalidationDecl throws XPathException
+:
+	"declare"! "revalidation"^ ("strict" | "lax" | "skip")
     ;
 
 eqName returns [String name]
@@ -2240,6 +2250,14 @@ reservedKeywords returns [String name]
 	"schema-element" { name = "schema-element"; }
 	|
 	"updating" { name = "updating"; }
+	|
+	"revalidation" { name = "revalidation"; }
+	|
+    "strict" { name = "strict"; }
+    |
+    "lax" { name = "lax"; }
+    |
+    "skip" { name = "skip"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -263,7 +263,8 @@ prolog throws XPathException
             ( "declare" "context" "item" )
             => contextItemDeclUp { inSetters = false; }
 			|
-			( "declare" MOD )
+			// bare keyword updating is valid because of rule CompatibilityAnnotation in the XQUF standard
+			( "declare" (MOD | "updating") )
 			=> annotateDecl { inSetters = false; }
         )
 		SEMICOLON!
@@ -454,6 +455,12 @@ annotation
 :
 	MOD! name=eqName! (LPAREN! literal (COMMA! literal)* RPAREN!)?
         { #annotation= #(#[ANNOT_DECL, name], #annotation); }
+
+    | "updating"!
+    {
+        name = "updating";
+        #annotation= #(#[ANNOT_DECL, name], #annotation);
+    }
     ;
 
 eqName returns [String name]
@@ -2228,6 +2235,8 @@ reservedKeywords returns [String name]
 	"empty-sequence" { name = "empty-sequence"; }
 	|
 	"schema-element" { name = "schema-element"; }
+	|
+	"updating" { name = "updating"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -1028,7 +1028,7 @@ castableExpr throws XPathException
 
 castExpr throws XPathException
 :
-	arrowExpr ( "cast"^ "as"! singleType )?
+	transformWithExpr ( "cast"^ "as"! singleType )?
 	;
 
 comparisonExpr throws XPathException
@@ -1300,6 +1300,17 @@ postfixExpr throws XPathException
 arrowExpr throws XPathException
 :
     unaryExpr ( ARROW_OP^ arrowFunctionSpecifier argumentList )*
+    ;
+
+
+// This is not perfectly adherent to the standard grammar
+// at https://www.w3.org/TR/xquery-31/#prod-xquery31-ArrowExpr
+// but the standard XQuery 3.1 grammar conflicts with the XQuery Update Facility 3.0 grammar
+// https://www.w3.org/TR/xquery-update-30/#prod-xquery30-TransformWithExpr
+// However, the end behavior should be identical
+transformWithExpr throws XPathException
+:
+    arrowExpr ( "transform"^ "with"! LCURLY! ( expr )? RCURLY! )?
     ;
 
 arrowFunctionSpecifier throws XPathException
@@ -2261,6 +2272,8 @@ reservedKeywords returns [String name]
     "lax" { name = "lax"; }
     |
     "skip" { name = "skip"; }
+    |
+    "transform" { name = "transform"; }
 	;
 
 /**

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -721,8 +721,9 @@ exprSingle throws XPathException
 	| ( "switch" LPAREN ) => switchExpr
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
-	| ( "insert" ) => xqufInsertExpr
-	| ( "delete" ) => xqufDeleteExpr
+	| ( "insert" ( "node" | "nodes" ) ) => xqufInsertExpr
+	| ( "delete" ( "node" | "nodes" ) ) => xqufDeleteExpr
+	| ( "replace" ( "value" | "node" ) ) => xqufReplaceExpr
 	| ( "copy" DOLLAR) => copyModifyExpr
 	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
@@ -792,6 +793,11 @@ insertExprTargetChoice throws XPathException
 xqufDeleteExpr throws XPathException
 :
 	"delete"^ ( "node"! | "nodes"! ) exprSingle
+	;
+
+xqufReplaceExpr throws XPathException
+:
+	"replace"^ ("value" "of"!)? "node"! exprSingle "with"! exprSingle
 	;
 
 copyModifyExpr throws XPathException

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -581,7 +581,7 @@ itemType throws XPathException
 :
 	( "item" LPAREN ) => "item"^ LPAREN! RPAREN!
 	|
-	( "function" LPAREN ) => functionTest
+	( ("function" LPAREN) | ( MOD ) ) => functionTest
 	|
 	( "map" LPAREN ) => mapType
 	|
@@ -616,20 +616,23 @@ atomicType throws XPathException
 
 functionTest throws XPathException
 :
-	( "function" LPAREN STAR RPAREN) => anyFunctionTest
-	|
-	typedFunctionTest
+    annotations
+    (
+	    ( "function" LPAREN STAR RPAREN ) => anyFunctionTest
+	    |
+	    typedFunctionTest
+	)
 	;
 
 anyFunctionTest throws XPathException
 :
-	"function"! LPAREN! s:STAR RPAREN!
+	annotations "function"! LPAREN! s:STAR RPAREN!
 	{ #anyFunctionTest = #(#[FUNCTION_TEST, "anyFunction"], #s); }
 	;
 
 typedFunctionTest throws XPathException
 :
-	"function"! LPAREN! (sequenceType (COMMA! sequenceType)*)? RPAREN! "as" sequenceType
+	annotations "function"! LPAREN! (sequenceType (COMMA! sequenceType)*)? RPAREN! "as" sequenceType
 	{ #typedFunctionTest = #(#[FUNCTION_TEST, "anyFunction"], #typedFunctionTest); }
 	;
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -722,6 +722,7 @@ exprSingle throws XPathException
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
 	| ( "insert" ) => xqufInsertExpr
+	| ( "delete" ) => xqufDeleteExpr
 	| ( "copy" DOLLAR) => copyModifyExpr
 	| ( "invoke" "updating" ) => dynamicUpdFunCall
 	| orExpr
@@ -757,6 +758,16 @@ insertExpr throws XPathException
 	( "into" | "preceding" | "following" ) exprSingle
 	;
 
+deleteExpr throws XPathException
+:
+	"delete" exprSingle
+	;
+
+renameExpr throws XPathException
+:
+	"rename" exprSingle "as"! exprSingle
+	;
+
 xqufInsertExpr throws XPathException
 :
 	"insert"^ ( "node"! | "nodes"! ) exprSingle
@@ -778,14 +789,9 @@ insertExprTargetChoice throws XPathException
 
 ;
 
-deleteExpr throws XPathException
+xqufDeleteExpr throws XPathException
 :
-	"delete" exprSingle
-	;
-
-renameExpr throws XPathException
-:
-	"rename" exprSingle "as"! exprSingle
+	"delete"^ ( "node"! | "nodes"! ) exprSingle
 	;
 
 copyModifyExpr throws XPathException

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -238,7 +238,7 @@ moduleDecl throws XPathException
 // === Prolog ===
 
 prolog throws XPathException
-{ boolean inSetters = true; }
+{ boolean inSetters = true; boolean redeclaration = false; }
 :
     (
 		(
@@ -270,6 +270,9 @@ prolog throws XPathException
 			( "declare" "revalidation" )
 			=> revalidationDecl {
 			    inSetters = false;
+			    if(redeclaration)
+                 	throw new XPathException((XQueryAST) returnAST, ErrorCodes.XUST0003, "It is a static error if a Prolog contains more than one revalidation declaration.");
+			    redeclaration = true;
 		    }
         )
 		SEMICOLON!

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQuery.g
@@ -720,6 +720,7 @@ exprSingle throws XPathException
 	| ( "switch" LPAREN ) => switchExpr
 	| ( "typeswitch" LPAREN ) => typeswitchExpr
 	| ( "update" ( "replace" | "value" | "insert" | "delete" | "rename" )) => updateExpr
+	| ( "copy" DOLLAR) => copyModifyExpr
 	| orExpr
 	;
 
@@ -762,6 +763,14 @@ renameExpr throws XPathException
 :
 	"rename" exprSingle "as"! exprSingle
 	;
+
+copyModifyExpr throws XPathException
+:
+	"copy"^ letVarBinding ( COMMA! letVarBinding )*
+	"modify"! exprSingle
+	"return"! exprSingle
+	;
+
 
 // === try/catch ===
 tryCatchExpr throws XPathException

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -147,7 +147,7 @@ options {
         String ns = qname.getNamespaceURI();
         if (ns.equals(Namespaces.XPATH_FUNCTIONS_NS)) {
             String ln = qname.getLocalPart();
-            return ("private".equals(ln) || "public".equals(ln));
+            return ("private".equals(ln) || "public".equals(ln) || "updating".equals(ln) || "simple".equals(ln));
         } else {
             return !(ns.equals(Namespaces.XML_NS)
                      || ns.equals(Namespaces.SCHEMA_NS)

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2196,6 +2196,8 @@ throws PermissionDeniedException, EXistException, XPathException
     |
     step=updateExpr [path]
     |
+    step=xqufInsertExpr [path]
+    |
     step=transformWithExpr [path]
     |
     step=copyModifyExpr [path]
@@ -3882,6 +3884,51 @@ throws XPathException, PermissionDeniedException, EXistException
         }
     )
     ;
+
+xqufInsertExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+	#(
+	    insertAST:"insert"
+		{
+			PathExpr source = new PathExpr(context);
+			PathExpr target = new PathExpr(context);
+			InsertExpr.Choice choice = null;
+		}
+		step=expr [source]
+		#(
+			it:INSERT_TARGET
+			{
+			    switch (it.getText()) {
+			        case "first":
+			            choice = InsertExpr.Choice.FIRST;
+			            break;
+                    case "last":
+                        choice = InsertExpr.Choice.LAST;
+                        break;
+                    case "into":
+                        choice = InsertExpr.Choice.INTO;
+                        break;
+                    case "before":
+                        choice = InsertExpr.Choice.BEFORE;
+                        break;
+                    case "after":
+                        choice = InsertExpr.Choice.AFTER;
+                        break;
+			    }
+			}
+		)
+		step=expr [target]
+		{
+			InsertExpr insertExpr = new InsertExpr(context, source, target, choice);
+			insertExpr.setASTNode(insertAST);
+			path.add(insertExpr);
+			step = insertExpr;
+		}
+	)
+	;
 
 mapConstr [PathExpr path]
 returns [Expression step]

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2199,6 +2199,8 @@ throws PermissionDeniedException, EXistException, XPathException
     step=transformWithExpr [path]
     |
     step=copyModifyExpr [path]
+    |
+    step=dynamicUpdFunCall [path]
     ;
 
 /**
@@ -3018,6 +3020,37 @@ throws PermissionDeniedException, EXistException, XPathException
         }
     )
     ;
+
+dynamicUpdFunCall [PathExpr path]
+returns [Expression step]
+throws PermissionDeniedException, EXistException, XPathException
+{
+	step = null;
+	PathExpr primary = new PathExpr(context);
+}
+:
+    #(
+		"updating"
+		{
+			List<Expression> params = new ArrayList<Expression>(5);
+			boolean isPartial = false;
+		}
+        step=primaryExpr [primary]
+		(
+			(
+				{ PathExpr pathExpr = new PathExpr(context); }
+				expr [pathExpr] { params.add(pathExpr); }
+			)
+		)*
+		{
+			DynamicFunctionCall dynCall = new DynamicFunctionCall(context, step, params, isPartial);
+			dynCall.setCategory(Expression.Category.UPDATING);
+			step = dynCall;
+			path.add(step);
+		}
+	)
+;
+
 
 functionCall [PathExpr path]
 returns [Expression step]

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -644,6 +644,26 @@ throws PermissionDeniedException, EXistException, XPathException
         functionDecl [path]
         |
         importDecl [path]
+        |
+        #(
+            "revalidation"
+            (
+                "strict"
+                {
+                    staticContext.setRevalidationMode(XQueryContext.RevalidationMode.STRICT);
+                }
+                |
+                "lax"
+                {
+                    staticContext.setRevalidationMode(XQueryContext.RevalidationMode.LAX);
+                }
+                |
+                "skip"
+                {
+                    staticContext.setRevalidationMode(XQueryContext.RevalidationMode.SKIP);
+                }
+            )
+        )
     )*
     ;
 

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -157,7 +157,7 @@ options {
         }
     }
 
-    private static void processAnnotations(List annots, FunctionSignature signature) {
+    private static Annotation[] processAnnotations(List annots, FunctionSignature signature) {
         Annotation[] anns = new Annotation[annots.size()];
 
         //iterate the declare Annotations
@@ -183,7 +183,11 @@ options {
         }
 
         //set the Annotations on the Function Signature
-        signature.setAnnotations(anns);
+        if (signature != null) {
+            signature.setAnnotations(anns);
+        }
+
+        return anns;
     }
 
     private static void processParams(List varList, UserDefinedFunction func, FunctionSignature signature)
@@ -1081,6 +1085,12 @@ throws XPathException
             }
         )
         |
+        { List annots = new ArrayList(); }
+        (annotations [annots])?
+        {
+            Annotation[] anns = processAnnotations(annots, null);
+            type.setAnnotations(anns);
+        }
         #(
             FUNCTION_TEST { type.setPrimaryType(Type.FUNCTION_REFERENCE); }
             (

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2202,6 +2202,8 @@ throws PermissionDeniedException, EXistException, XPathException
     |
     step=xqufReplaceExpr [path]
     |
+    step=xqufRenameExpr [path]
+    |
     step=transformWithExpr [path]
     |
     step=copyModifyExpr [path]
@@ -3979,6 +3981,28 @@ throws XPathException, PermissionDeniedException, EXistException
 			replaceExpr.setASTNode(replaceAST);
 			path.add(replaceExpr);
 			step = replaceExpr;
+		}
+	)
+	;
+
+xqufRenameExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+	#(
+	    renameAST:"rename"
+		{
+			PathExpr target = new PathExpr(context);
+			PathExpr newName = new PathExpr(context);
+		}
+		step=expr [target]
+		step=expr [newName]
+		{
+			RenameExpr renameExpr = new RenameExpr(context, target, newName);
+			renameExpr.setASTNode(renameAST);
+			path.add(renameExpr);
+			step = renameExpr;
 		}
 	)
 	;

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -53,6 +53,7 @@ header {
     import org.exist.xquery.value.*;
     import org.exist.xquery.functions.fn.*;
     import org.exist.xquery.update.*;
+    import org.exist.xquery.update.legacy.*;
     import org.exist.storage.ElementValue;
     import org.exist.xquery.functions.map.MapExpr;
     import org.exist.xquery.functions.array.ArrayConstructor;

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -500,6 +500,24 @@ throws PermissionDeniedException, EXistException, XPathException
                         { List annots = new ArrayList(); }
                         (annotations [annots]
                         )?
+                        {
+                            for(int i = 0; i < annots.size(); i++)
+                            {
+                            	List la = (List) annots.get(i);
+                                if(la.size() > 0)
+                                {
+                                    for(int a = 0; a < la.size(); a++)
+                                    {
+                                         if(la.get(a).toString().equals("simple") || la.get(a).toString().equals("updating"))
+                                         {
+                                             throw new XPathException(qname, ErrorCodes.XUST0032,
+                                             "It is a static error if an %updating or %simple annotation is used on a VarDecl.");
+                                         }
+                                    }
+                                }
+                            }
+
+                        }
             (
                 #(
                     "as"

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2198,6 +2198,8 @@ throws PermissionDeniedException, EXistException, XPathException
     |
     step=xqufInsertExpr [path]
     |
+    step=xqufDeleteExpr [path]
+    |
     step=transformWithExpr [path]
     |
     step=copyModifyExpr [path]
@@ -3926,6 +3928,26 @@ throws XPathException, PermissionDeniedException, EXistException
 			insertExpr.setASTNode(insertAST);
 			path.add(insertExpr);
 			step = insertExpr;
+		}
+	)
+	;
+
+xqufDeleteExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+	#(
+	    deleteAST:"delete"
+		{
+			PathExpr target = new PathExpr(context);
+		}
+		step=expr [target]
+		{
+			DeleteExpr deleteExpr = new DeleteExpr(context, target);
+			deleteExpr.setASTNode(deleteAST);
+			path.add(deleteExpr);
+			step = deleteExpr;
 		}
 	)
 	;

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2200,6 +2200,8 @@ throws PermissionDeniedException, EXistException, XPathException
     |
     step=xqufDeleteExpr [path]
     |
+    step=xqufReplaceExpr [path]
+    |
     step=transformWithExpr [path]
     |
     step=copyModifyExpr [path]
@@ -3948,6 +3950,35 @@ throws XPathException, PermissionDeniedException, EXistException
 			deleteExpr.setASTNode(deleteAST);
 			path.add(deleteExpr);
 			step = deleteExpr;
+		}
+	)
+	;
+
+xqufReplaceExpr [PathExpr path]
+returns [Expression step]
+throws XPathException, PermissionDeniedException, EXistException
+{
+}:
+	#(
+	    replaceAST:"replace"
+		{
+			PathExpr target = new PathExpr(context);
+			PathExpr with = new PathExpr(context);
+			ReplaceExpr.ReplacementType replacementType = ReplaceExpr.ReplacementType.NODE;
+		}
+		(
+		    "value"
+		    {
+		        replacementType = ReplaceExpr.ReplacementType.VALUE;
+		    }
+		)?
+		step=expr [target]
+		step=expr [with]
+		{
+			ReplaceExpr replaceExpr = new ReplaceExpr(context, target, with, replacementType);
+			replaceExpr.setASTNode(replaceAST);
+			path.add(replaceExpr);
+			step = replaceExpr;
 		}
 	)
 	;

--- a/exist-core/src/main/java/org/exist/xquery/DynamicFunctionCall.java
+++ b/exist-core/src/main/java/org/exist/xquery/DynamicFunctionCall.java
@@ -35,8 +35,9 @@ public class DynamicFunctionCall extends AbstractExpression {
     private final Expression functionExpr;
     private final List<Expression> arguments;
     private final boolean isPartial;
-    
     private AnalyzeContextInfo cachedContextInfo;
+
+    private Category category = Category.SIMPLE;
 
     public DynamicFunctionCall(final XQueryContext context, final Expression fun, final List<Expression> args, final boolean partial) {
         super(context);
@@ -162,5 +163,15 @@ public class DynamicFunctionCall extends AbstractExpression {
         }
 
         return builder.toString();
+    }
+
+
+    @Override
+    public Category getCategory() {
+        return this.category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -239,6 +239,9 @@ public class ErrorCodes {
 
     public static final ErrorCode XTSE0165 = new W3CErrorCode("XTSE0165","It is a static error if the processor is not able to retrieve the resource identified by the URI reference [ in the href attribute of xsl:include or xsl:import] , or if the resource that is retrieved does not contain a stylesheet module conforming to this specification.");
 
+    /* XQuery 3.0 Update Facility https://www.w3.org/TR/xquery-update-30/#id-new-error-codes */
+    public static final ErrorCode XUST0032 = new W3CErrorCode("XUST0032", "It is a static error if an %updating or %simple annotation is used on a VarDecl.");
+
     /* eXist specific XQuery and XPath errors
      *
      * Codes have the format [EX][XQ|XP][DY|SE|ST][nnnn]

--- a/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
+++ b/exist-core/src/main/java/org/exist/xquery/ErrorCodes.java
@@ -241,6 +241,7 @@ public class ErrorCodes {
 
     /* XQuery 3.0 Update Facility https://www.w3.org/TR/xquery-update-30/#id-new-error-codes */
     public static final ErrorCode XUST0032 = new W3CErrorCode("XUST0032", "It is a static error if an %updating or %simple annotation is used on a VarDecl.");
+    public static final ErrorCode XUST0003 = new W3CErrorCode("XUST0003", "It is a static error if a Prolog contains more than one revalidation declaration.");
 
     /* eXist specific XQuery and XPath errors
      *

--- a/exist-core/src/main/java/org/exist/xquery/Expression.java
+++ b/exist-core/src/main/java/org/exist/xquery/Expression.java
@@ -36,6 +36,16 @@ import org.exist.xquery.value.Sequence;
  */
 public interface Expression {
 
+    /**
+     * Updating expressions are a new category of expression introduced by XQuery Update Facility 3.0
+     * An updating expression is an expression that can return a non-empty pending update list
+     * Simple expressions are all expressions that are not updating expressions
+     */
+    enum Category {
+        UPDATING,
+        SIMPLE
+    }
+
     // Flags to be passed to analyze:
     /**
      * Indicates that the query engine will call the expression once for every
@@ -264,4 +274,6 @@ public interface Expression {
      * @return true if the next expression should be evaluated, false otherwise.
      */
     boolean evalNextExpressionOnEmptyContextSequence();
+
+    public default Category getCategory() { return Category.SIMPLE; };
 }

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -91,7 +91,7 @@ import org.exist.util.hashtable.NamePool;
 import org.exist.xmldb.XmldbURI;
 import org.exist.xquery.parser.*;
 import org.exist.xquery.pragmas.*;
-import org.exist.xquery.update.Modification;
+import org.exist.xquery.update.legacy.Modification;
 import org.exist.xquery.util.SerializerUtils;
 import org.exist.xquery.value.*;
 import org.w3c.dom.Node;

--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -111,6 +111,7 @@ import static org.exist.util.MapUtil.hashMap;
  *
  * @author <a href="mailto:wolfgang@exist-db.org">Wolfgang Meier</a>
  */
+
 public class XQueryContext implements BinaryValueManager, Context {
 
     private static final Logger LOG = LogManager.getLogger(XQueryContext.class);
@@ -411,6 +412,8 @@ public class XQueryContext implements BinaryValueManager, Context {
     private static final QName UNNAMED_DECIMAL_FORMAT = new QName("__UNNAMED__", Function.BUILTIN_FUNCTION_NS);
 
     private final Map<QName, DecimalFormat> staticDecimalFormats = hashMap(Tuple(UNNAMED_DECIMAL_FORMAT, DecimalFormat.UNNAMED));
+
+    private RevalidationMode revalidationMode = RevalidationMode.LAX;
 
     // Only used for testing, e.g. {@link org.exist.test.runner.XQueryTestRunner}.
     private Optional<ExistRepository> testRepository = Optional.empty();
@@ -3282,6 +3285,22 @@ public class XQueryContext implements BinaryValueManager, Context {
 
         binaryValueInstances.push(binaryValue);
     }
+
+    public enum RevalidationMode {
+        STRICT,
+        LAX,
+        SKIP
+    }
+
+    /**
+     * Revalidation mode controls the process by which type information
+     * is recovered for an updated document
+     */
+    public void setRevalidationMode(final RevalidationMode rev) {
+        this.revalidationMode = rev;
+    }
+
+    public RevalidationMode getRevalidationMode() { return this.revalidationMode; }
 
     /**
      * Cleanup Task which is responsible for relasing the streams

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBDefragment.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBDefragment.java
@@ -33,7 +33,7 @@ import org.exist.xquery.Cardinality;
 import org.exist.xquery.FunctionSignature;
 import org.exist.xquery.XPathException;
 import org.exist.xquery.XQueryContext;
-import org.exist.xquery.update.Modification;
+import org.exist.xquery.update.legacy.Modification;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.IntegerValue;
 import org.exist.xquery.value.Sequence;

--- a/exist-core/src/main/java/org/exist/xquery/update/CopyModifyExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/CopyModifyExpression.java
@@ -69,13 +69,9 @@ public class CopyModifyExpression extends PathExpr {
     private Expression modifyExpr;
     private Expression returnExpr;
 
-    public enum Category {
-        UPDATING,
-        SIMPLE
-    }
-
     // see https://www.w3.org/TR/xquery-update-30/#id-copy-modify for details
     public Category getCategory() {
+        // placeholder implementation
         return Category.SIMPLE;
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/update/CopyModifyExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/CopyModifyExpression.java
@@ -1,0 +1,160 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.update;
+
+import org.exist.xquery.*;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author <a href="adam@evolvedbinary.com">Adam Retter</a>
+ * @author <a href="gabriele@strumenta.com">Gabriele Tomassetti</a>
+ */
+public class CopyModifyExpression extends PathExpr {
+
+    public static class CopySource {
+        private String varName;
+        private Expression inputSequence;
+
+        public String getVariable() {
+            return this.varName;
+        }
+
+        public Expression getInputSequence() {
+            return this.inputSequence;
+        }
+
+        public void setVariable(final String varName) {
+            this.varName = varName;
+        }
+
+        public void setInputSequence(final Expression inputSequence) {
+            this.inputSequence = inputSequence;
+        }
+
+        public CopySource(final String name, final Expression value) {
+            this.varName = name;
+            this.inputSequence = value;
+        }
+
+        public CopySource() {
+        }
+    }
+
+
+    private List<CopySource> sources;
+    private Expression modifyExpr;
+    private Expression returnExpr;
+
+    public enum Category {
+        UPDATING,
+        SIMPLE
+    }
+
+    // see https://www.w3.org/TR/xquery-update-30/#id-copy-modify for details
+    public Category getCategory() {
+        return Category.SIMPLE;
+    }
+
+    public CopyModifyExpression(final XQueryContext context) {
+        super(context);
+        this.sources = new ArrayList<>();
+    }
+
+    public void addCopySource(final String varName, final Expression value) {
+        this.sources.add(new CopySource(varName, value));
+    }
+
+    public void setModifyExpr(final Expression expr) {
+        this.modifyExpr = expr;
+    }
+
+    public Expression getModifyExpr() {
+        return this.modifyExpr;
+    }
+
+    public void setReturnExpr(final Expression expr) {
+        this.returnExpr = expr;
+    }
+
+    public Expression getReturnExpr() {
+        return this.returnExpr;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.ONE_OR_MORE;
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("copy").nl();
+        dumper.startIndent();
+        for (int i = 0; i < sources.size(); i++) {
+            dumper.display("$").display(sources.get(i).varName);
+            dumper.display(" := ");
+            sources.get(i).inputSequence.dump(dumper);
+        }
+        dumper.endIndent();
+        dumper.display("modify").nl();
+        modifyExpr.dump(dumper);
+        dumper.nl().display("return ");
+        dumper.startIndent();
+        returnExpr.dump(dumper);
+        dumper.endIndent();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("copy ");
+        for (int i = 0; i < sources.size(); i++) {
+            result.append("$").append(sources.get(i).varName);
+            result.append(sources.get(i).inputSequence.toString());
+            if (sources.size() > 1 && i < sources.size() - 1) {
+                result.append(", ");
+            } else {
+                result.append(" ");
+            }
+        }
+        result.append(" ");
+        result.append("modify ");
+        result.append(modifyExpr.toString());
+        result.append(" ");
+        result.append("return ");
+        result.append(returnExpr.toString());
+        return result.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/update/DeleteExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/DeleteExpr.java
@@ -1,0 +1,67 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.update;
+
+import org.exist.xquery.AnalyzeContextInfo;
+import org.exist.xquery.Expression;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+
+/**
+ * @author <a href="adam@evolvedbinary.com">Adam Retter</a>
+ * @author <a href="gabriele@strumenta.com">Gabriele Tomassetti</a>
+ */
+public class DeleteExpr extends ModifyingExpression {
+
+    public DeleteExpr(final XQueryContext context, final Expression target) {
+        super(context, target);
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("delete").nl();
+        dumper.startIndent();
+        targetExpr.dump(dumper);
+        dumper.endIndent();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("delete ");
+        result.append(" ");
+        result.append(targetExpr.toString());
+        return result.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/update/InsertExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/InsertExpr.java
@@ -1,0 +1,101 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.update;
+
+import org.exist.xquery.*;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.Type;
+
+/**
+ * @author <a href="adam@evolvedbinary.com">Adam Retter</a>
+ * @author <a href="gabriele@strumenta.com">Gabriele Tomassetti</a>
+ */
+public class InsertExpr extends AbstractExpression {
+    public enum Choice {
+        FIRST,
+        LAST,
+        INTO,
+        AFTER,
+        BEFORE
+    }
+
+    private final Expression source;
+    private final Expression target;
+    private final Choice choice;
+
+    public InsertExpr(final XQueryContext context, final Expression source, final Expression target, final Choice choice) {
+        super(context);
+        this.source = source;
+        this.target = target;
+        this.choice = choice;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public int returnsType() {
+        // placeholder implementation
+        return Type.EMPTY;
+    }
+
+    public Category getCategory() {
+        // placeholder implementation
+        return Category.UPDATING;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.ONE_OR_MORE;
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("insert").nl();
+        dumper.startIndent();
+        source.dump(dumper);
+        dumper.endIndent();
+        dumper.display(choice).nl();
+        dumper.startIndent();
+        target.dump(dumper);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("insert ");
+        result.append(source.toString());
+        result.append(" ");
+        result.append(choice.toString());
+        result.append(" ");
+        result.append(target.toString());
+        return result.toString();
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/update/InsertExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/InsertExpr.java
@@ -25,13 +25,12 @@ import org.exist.xquery.*;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.Type;
 
 /**
  * @author <a href="adam@evolvedbinary.com">Adam Retter</a>
  * @author <a href="gabriele@strumenta.com">Gabriele Tomassetti</a>
  */
-public class InsertExpr extends AbstractExpression {
+public class InsertExpr extends ModifyingExpression {
     public enum Choice {
         FIRST,
         LAST,
@@ -40,14 +39,12 @@ public class InsertExpr extends AbstractExpression {
         BEFORE
     }
 
-    private final Expression source;
-    private final Expression target;
+    private final Expression sourceExpr;
     private final Choice choice;
 
     public InsertExpr(final XQueryContext context, final Expression source, final Expression target, final Choice choice) {
-        super(context);
-        this.source = source;
-        this.target = target;
+        super(context, target);
+        this.sourceExpr = source;
         this.choice = choice;
     }
 
@@ -61,17 +58,6 @@ public class InsertExpr extends AbstractExpression {
     }
 
     @Override
-    public int returnsType() {
-        // placeholder implementation
-        return Type.EMPTY;
-    }
-
-    public Category getCategory() {
-        // placeholder implementation
-        return Category.UPDATING;
-    }
-
-    @Override
     public Cardinality getCardinality() {
         return Cardinality.ONE_OR_MORE;
     }
@@ -80,22 +66,31 @@ public class InsertExpr extends AbstractExpression {
     public void dump(final ExpressionDumper dumper) {
         dumper.display("insert").nl();
         dumper.startIndent();
-        source.dump(dumper);
+        sourceExpr.dump(dumper);
         dumper.endIndent();
         dumper.display(choice).nl();
         dumper.startIndent();
-        target.dump(dumper);
+        targetExpr.dump(dumper);
+        dumper.endIndent();
     }
 
     @Override
     public String toString() {
         final StringBuilder result = new StringBuilder();
         result.append("insert ");
-        result.append(source.toString());
+        result.append(sourceExpr.toString());
         result.append(" ");
         result.append(choice.toString());
         result.append(" ");
-        result.append(target.toString());
+        result.append(targetExpr.toString());
         return result.toString();
+    }
+
+    public Choice getChoice() {
+        return choice;
+    }
+
+    public Expression getSourceExpr() {
+        return sourceExpr;
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/update/ModifyingExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/ModifyingExpression.java
@@ -1,0 +1,55 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.update;
+
+import org.exist.xquery.AbstractExpression;
+import org.exist.xquery.Expression;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.Type;
+
+/**
+ * @author <a href="adam@evolvedbinary.com">Adam Retter</a>
+ * @author <a href="gabriele@strumenta.com">Gabriele Tomassetti</a>
+ */
+public abstract class ModifyingExpression extends AbstractExpression {
+
+    protected final Expression targetExpr;
+
+    public ModifyingExpression(final XQueryContext context, final Expression target) {
+        super(context);
+        this.targetExpr = target;
+    }
+
+    @Override
+    public int returnsType() {
+        // placeholder implementation
+        return Type.EMPTY;
+    }
+
+    public Category getCategory() {
+        return Category.UPDATING;
+    }
+
+    public Expression getTargetExpr() {
+        return targetExpr;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/update/RenameExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/RenameExpr.java
@@ -1,0 +1,83 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.update;
+
+import org.exist.xquery.AnalyzeContextInfo;
+import org.exist.xquery.Cardinality;
+import org.exist.xquery.Expression;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+
+/**
+ * @author <a href="adam@evolvedbinary.com">Adam Retter</a>
+ * @author <a href="gabriele@strumenta.com">Gabriele Tomassetti</a>
+ */
+public class RenameExpr extends ModifyingExpression {
+    private final Expression newNameExpr;
+
+    public RenameExpr(final XQueryContext context, final Expression target, final Expression newName) {
+        super(context, target);
+        this.newNameExpr = newName;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.ONE_OR_MORE;
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("replace").nl();
+        dumper.startIndent();
+        targetExpr.dump(dumper);
+        dumper.endIndent();
+        dumper.startIndent();
+        newNameExpr.dump(dumper);
+        dumper.endIndent();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("replace ");
+        result.append(targetExpr.toString());
+        result.append(" ");
+        result.append(newNameExpr.toString());
+        return result.toString();
+    }
+
+    public Expression getNewNameExpr() {
+        return newNameExpr;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/update/ReplaceExpr.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/ReplaceExpr.java
@@ -1,0 +1,97 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.update;
+
+import org.exist.xquery.AnalyzeContextInfo;
+import org.exist.xquery.Cardinality;
+import org.exist.xquery.Expression;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.util.ExpressionDumper;
+import org.exist.xquery.value.Item;
+import org.exist.xquery.value.Sequence;
+
+/**
+ * @author <a href="adam@evolvedbinary.com">Adam Retter</a>
+ * @author <a href="gabriele@strumenta.com">Gabriele Tomassetti</a>
+ */
+public class ReplaceExpr extends ModifyingExpression {
+    public enum ReplacementType {
+        NODE,
+        VALUE
+    }
+
+    private final Expression withExpr;
+    private final ReplaceExpr.ReplacementType replacementType;
+
+    public ReplaceExpr(final XQueryContext context, final Expression target, final Expression with, final ReplaceExpr.ReplacementType replacementType) {
+        super(context, target);
+        this.withExpr = with;
+        this.replacementType = replacementType;
+    }
+
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
+    }
+
+    @Override
+    public Sequence eval(final Sequence contextSequence, final Item contextItem) throws XPathException {
+        return Sequence.EMPTY_SEQUENCE;
+    }
+
+    @Override
+    public Cardinality getCardinality() {
+        return Cardinality.ONE_OR_MORE;
+    }
+
+    @Override
+    public void dump(final ExpressionDumper dumper) {
+        dumper.display("replace").nl();
+        dumper.startIndent();
+        targetExpr.dump(dumper);
+        dumper.endIndent();
+        dumper.display(replacementType).nl();
+        dumper.startIndent();
+        withExpr.dump(dumper);
+        dumper.endIndent();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder result = new StringBuilder();
+        result.append("replace ");
+        result.append(targetExpr.toString());
+        result.append(" ");
+        result.append(replacementType.toString());
+        result.append(" ");
+        result.append(withExpr.toString());
+        return result.toString();
+    }
+
+    public ReplaceExpr.ReplacementType getReplacementType() {
+        return replacementType;
+    }
+
+    public Expression getWithExpr() {
+        return withExpr;
+    }
+}

--- a/exist-core/src/main/java/org/exist/xquery/update/legacy/Delete.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/legacy/Delete.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.exist.EXistException;
 import org.exist.collections.triggers.TriggerException;
@@ -46,7 +46,6 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.StringValue;
 import org.exist.xquery.value.Type;
 import org.exist.xquery.value.ValueSequence;
-import org.w3c.dom.Attr;
 import org.w3c.dom.Node;
 
 /**

--- a/exist-core/src/main/java/org/exist/xquery/update/legacy/Insert.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/legacy/Insert.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.exist.EXistException;
 import org.exist.Namespaces;

--- a/exist-core/src/main/java/org/exist/xquery/update/legacy/Modification.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/legacy/Modification.java
@@ -351,4 +351,7 @@ public abstract class Modification extends AbstractExpression
             return node.getParentNode();
         }
     }
+
+    @Override
+    public Category getCategory() { return Category.UPDATING; }
 }

--- a/exist-core/src/main/java/org/exist/xquery/update/legacy/Modification.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/legacy/Modification.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import java.util.Iterator;
 

--- a/exist-core/src/main/java/org/exist/xquery/update/legacy/Rename.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/legacy/Rename.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.exist.EXistException;
 import org.exist.collections.triggers.TriggerException;

--- a/exist-core/src/main/java/org/exist/xquery/update/legacy/Replace.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/legacy/Replace.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.exist.EXistException;
 import org.exist.collections.triggers.TriggerException;

--- a/exist-core/src/main/java/org/exist/xquery/update/legacy/Update.java
+++ b/exist-core/src/main/java/org/exist/xquery/update/legacy/Update.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,7 +32,6 @@ import org.exist.dom.NodeListImpl;
 import org.exist.dom.persistent.StoredNode;
 import org.exist.dom.persistent.TextImpl;
 import org.exist.security.Permission;
-import org.exist.security.PermissionDeniedException;
 import org.exist.storage.NotificationService;
 import org.exist.storage.UpdateListener;
 import org.exist.storage.txn.Txn;

--- a/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/SequenceType.java
@@ -22,6 +22,7 @@
 package org.exist.xquery.value;
 
 import org.exist.dom.QName;
+import org.exist.xquery.Annotation;
 import org.exist.xquery.Cardinality;
 import org.exist.xquery.Expression;
 import org.exist.xquery.XPathException;
@@ -40,6 +41,8 @@ public class SequenceType {
     private int primaryType = Type.ITEM;
     private Cardinality cardinality = Cardinality.EXACTLY_ONE;
     private QName nodeName = null;
+
+    private Annotation[] annotations;
 
     public SequenceType() {
     }
@@ -228,6 +231,13 @@ public class SequenceType {
         } else if (seq.hasMany() && cardinality.atMostOne()) {
             throw new XPathException((Expression) null, "Sequence with more than one item is not allowed here");
         }
+    }
+
+    public void setAnnotations(final Annotation[] annotations) {
+        this.annotations = annotations;
+    }
+    public Annotation[] getAnnotations() {
+        return annotations;
     }
 
     @Override

--- a/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
@@ -182,4 +182,34 @@ public class XQueryUpdate3Test {
             }
         }
     }
+
+    @Test
+    public void revalidationDeclaration() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "declare revalidation strict;";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.prolog();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.prolog(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
@@ -1,0 +1,126 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.update;
+
+import antlr.RecognitionException;
+import antlr.TokenStreamException;
+import org.exist.EXistException;
+import org.exist.security.PermissionDeniedException;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.test.ExistEmbeddedServer;
+import org.exist.xquery.PathExpr;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.parser.XQueryAST;
+import org.exist.xquery.parser.XQueryLexer;
+import org.exist.xquery.parser.XQueryParser;
+import org.exist.xquery.parser.XQueryTreeParser;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.StringReader;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="adam@evolvedbinary.com">Adam Retter</a>
+ * @author <a href="gabriele@strumenta.com">Gabriele Tomassetti</a>
+ */
+public class XQueryUpdate3Test {
+
+    @ClassRule
+    public static final ExistEmbeddedServer existEmbeddedServer = new ExistEmbeddedServer(true, true);
+
+    @Test
+    public void updatingCompatibilityAnnotation() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException {
+        final String query =
+                "xquery version \"3.0\"\n;" +
+                        "module namespace t=\"http://exist-db.org/xquery/test/examples\";\n" +
+                        "declare updating function" +
+                        "   t:upsert($e as element(), \n" +
+                        "          $an as xs:QName, \n" +
+                        "          $av as xs:anyAtomicType) \n" +
+                        "   {\n" +
+                        "   let $ea := $e/attribute()[fn:node-name(.) = $an]\n" +
+                        "   return\n" +
+                        "     $ea\n" +
+                        "   };";
+
+        final BrokerPool pool = BrokerPool.getInstance();
+        try (final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            final XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            final XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            final XQueryParser xparser = new XQueryParser(lexer);
+            xparser.xpath();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+            }
+
+            final XQueryAST ast = (XQueryAST) xparser.getAST();
+            final XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            final PathExpr expr = new PathExpr(context);
+            treeParser.xpath(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+            }
+        }
+    }
+
+    @Test
+    public void simpleAnnotation() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException {
+        final String query =
+                "xquery version \"3.0\"\n;" +
+                        "module namespace t=\"http://exist-db.org/xquery/test/examples\";\n" +
+                        "declare %simple function" +
+                        "   t:upsert($e as element(), \n" +
+                        "          $an as xs:QName, \n" +
+                        "          $av as xs:anyAtomicType) \n" +
+                        "   {\n" +
+                        "   let $ea := $e/attribute()[fn:node-name(.) = $an]\n" +
+                        "   return\n" +
+                        "     $ea\n" +
+                        "   };";
+
+        final BrokerPool pool = BrokerPool.getInstance();
+        try (final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            final XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            final XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            final XQueryParser xparser = new XQueryParser(lexer);
+            xparser.xpath();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            final XQueryAST ast = (XQueryAST) xparser.getAST();
+            final XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            final PathExpr expr = new PathExpr(context);
+            treeParser.xpath(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+            }
+        }
+    }
+}

--- a/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
@@ -245,7 +245,7 @@ public class XQueryUpdate3Test {
     public void copyModifyExprTest() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
     {
         String query = "copy $je := $e\n" +
-                "   modify $je\n" +
+                "   modify delete node $je/salary\n" +
                 "   return $je";
 
         BrokerPool pool = BrokerPool.getInstance();
@@ -264,11 +264,50 @@ public class XQueryUpdate3Test {
 
             XQueryTreeParser treeParser = new XQueryTreeParser(context);
             PathExpr expr = new PathExpr(context);
-            treeParser.expr(ast, expr);
+            Expression ret = treeParser.expr(ast, expr);
             if (treeParser.foundErrors()) {
                 fail(treeParser.getErrorMessage());
                 return;
             }
+
+            assertTrue(ret instanceof CopyModifyExpression);
+            assertEquals("$je",((CopyModifyExpression) ret).getReturnExpr().toString());
+        }
+    }
+
+    @Test
+    public void copyModifyExprTestComplexModify() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "copy $newx := $oldx\n" +
+                "   modify (rename node $newx as \"newx\", \n" +
+                "           replace value of node $newx with $newx * 2)\n" +
+                "   return ($oldx, $newx)";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            Expression ret = treeParser.expr(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(ret instanceof CopyModifyExpression);
+            assertEquals("( replace $newx \"newx\", replace $newx VALUE $newx * 2 )",((CopyModifyExpression) ret).getModifyExpr().toString());
+            assertEquals("( $oldx, $newx )",((CopyModifyExpression) ret).getReturnExpr().toString());
         }
     }
 
@@ -339,6 +378,48 @@ public class XQueryUpdate3Test {
 
             assertTrue(expr.getFirst() instanceof InsertExpr);
             assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+            assertEquals(InsertExpr.Choice.AFTER, ((InsertExpr) expr.getFirst()).getChoice());
+        }
+    }
+
+    @Test
+    public void insertExprAsLast() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "insert node $new-police-report\n" +
+                        "   as last into fn:doc(\"insurance.xml\")/policies\n" +
+                        "      /policy[id = $pid]\n" +
+                        "      /driver[license = $license]\n" +
+                        "      /accident[date = $accdate]\n" +
+                        "      /police-reports";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof InsertExpr);
+            assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+            assertEquals("$new-police-report", ((InsertExpr) expr.getFirst()).getSourceExpr().toString());
+            assertEquals(InsertExpr.Choice.LAST, ((InsertExpr) expr.getFirst()).getChoice());
         }
     }
 
@@ -347,6 +428,42 @@ public class XQueryUpdate3Test {
     {
         String query =
                 "delete node fn:doc(\"bib.xml\")/books/book[1]/author[last()]";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof DeleteExpr);
+            assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}author[last()]", ((DeleteExpr) expr.getFirst()).getTargetExpr().toString());
+        }
+    }
+
+    @Test
+    public void deleteExprComplex() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "delete nodes /email/message\n" +
+                        "     [date > xs:dayTimeDuration(\"P365D\")]";
 
         BrokerPool pool = BrokerPool.getInstance();
         try(final DBBroker broker = pool.getBroker()) {
@@ -483,6 +600,42 @@ public class XQueryUpdate3Test {
             assertTrue(expr.getFirst() instanceof RenameExpr);
             assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}author[1]",((RenameExpr) expr.getFirst()).getTargetExpr().toString());
             assertEquals("\"principal-author\"",((RenameExpr) expr.getFirst()).getNewNameExpr().toString());
+        }
+    }
+
+    @Test
+    public void renameExprWithExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "rename node fn:doc(\"bib.xml\")/books/book[1]/author[1]\n" +
+                        "as $newname";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof RenameExpr);
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}author[1]",((RenameExpr) expr.getFirst()).getTargetExpr().toString());
+            assertEquals("$newname",((RenameExpr) expr.getFirst()).getNewNameExpr().toString());
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
@@ -341,4 +341,38 @@ public class XQueryUpdate3Test {
             assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
         }
     }
+
+    @Test
+    public void deleteExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "delete node fn:doc(\"bib.xml\")/books/book[1]/author[last()]";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof DeleteExpr);
+            assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
@@ -28,10 +28,7 @@ import org.exist.security.PermissionDeniedException;
 import org.exist.storage.BrokerPool;
 import org.exist.storage.DBBroker;
 import org.exist.test.ExistEmbeddedServer;
-import org.exist.xquery.ErrorCodes;
-import org.exist.xquery.PathExpr;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.parser.XQueryAST;
 import org.exist.xquery.parser.XQueryLexer;
 import org.exist.xquery.parser.XQueryParser;
@@ -206,6 +203,68 @@ public class XQueryUpdate3Test {
             PathExpr expr = new PathExpr(context);
             treeParser.prolog(ast, expr);
 
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+        }
+    }
+
+    @Test
+    public void transformWith() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "$e transform with { $e + 1 }\n";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            Expression ret = treeParser.expr(ast, expr);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(ret instanceof CopyModifyExpression);
+        }
+    }
+
+    @Test
+    public void copyModifyExprTest() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "copy $je := $e\n" +
+                "   modify $je\n" +
+                "   return $je";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
             if (treeParser.foundErrors()) {
                 fail(treeParser.getErrorMessage());
                 return;

--- a/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
@@ -36,6 +36,8 @@ import org.exist.xquery.parser.XQueryAST;
 import org.exist.xquery.parser.XQueryLexer;
 import org.exist.xquery.parser.XQueryParser;
 import org.exist.xquery.parser.XQueryTreeParser;
+import org.exist.xquery.value.Sequence;
+import org.exist.xquery.value.SequenceType;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -149,6 +151,35 @@ public class XQueryUpdate3Test {
         }
         catch(XPathException ex) {
             assertEquals(ErrorCodes.XUST0032, ex.getErrorCode());
+        }
+    }
+
+    @Test
+    public void testingForUpdatingFunction() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query = "%simple function ( * )";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.sequenceType();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            SequenceType type = new SequenceType();
+            treeParser.sequenceType(ast, type);
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
         }
     }
 }

--- a/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
@@ -375,4 +375,78 @@ public class XQueryUpdate3Test {
             assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
         }
     }
+
+    @Test
+    public void replaceNodeExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "replace node fn:doc(\"bib.xml\")/books/book[1]/publisher\n" +
+                        "with fn:doc(\"bib.xml\")/books/book[2]/publisher";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof ReplaceExpr);
+            assertEquals(ReplaceExpr.ReplacementType.NODE,((ReplaceExpr) expr.getFirst()).getReplacementType());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}publisher",((ReplaceExpr) expr.getFirst()).getTargetExpr().toString());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[2]/child::{}publisher",((ReplaceExpr) expr.getFirst()).getWithExpr().toString());
+        }
+    }
+
+    @Test
+    public void replaceValueExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "replace value of node fn:doc(\"bib.xml\")/books/book[1]/price\n" +
+                        "with fn:doc(\"bib.xml\")/books/book[1]/price * 1.1";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof ReplaceExpr);
+            assertEquals(ReplaceExpr.ReplacementType.VALUE,((ReplaceExpr) expr.getFirst()).getReplacementType());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}price",((ReplaceExpr) expr.getFirst()).getTargetExpr().toString());
+            assertEquals("doc(\"bib.xml\")/child::{}books/child::{}book[1]/child::{}price * 1.1",((ReplaceExpr) expr.getFirst()).getWithExpr().toString());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/XQueryUpdate3Test.java
@@ -306,4 +306,39 @@ public class XQueryUpdate3Test {
             assertEquals(Expression.Category.UPDATING, dfc.getCategory());
         }
     }
+
+    @Test
+    public void insertExpr() throws EXistException, RecognitionException, XPathException, TokenStreamException, PermissionDeniedException
+    {
+        String query =
+                "insert node <year>2005</year>\n" +
+                "    after book/publisher";
+
+        BrokerPool pool = BrokerPool.getInstance();
+        try(final DBBroker broker = pool.getBroker()) {
+            // parse the query into the internal syntax tree
+            XQueryContext context = new XQueryContext(broker.getBrokerPool());
+            XQueryLexer lexer = new XQueryLexer(context, new StringReader(query));
+            XQueryParser xparser = new XQueryParser(lexer);
+            xparser.expr();
+            if (xparser.foundErrors()) {
+                fail(xparser.getErrorMessage());
+                return;
+            }
+
+            XQueryAST ast = (XQueryAST) xparser.getAST();
+
+            XQueryTreeParser treeParser = new XQueryTreeParser(context);
+            PathExpr expr = new PathExpr(context);
+            treeParser.expr(ast, expr);
+
+            if (treeParser.foundErrors()) {
+                fail(treeParser.getErrorMessage());
+                return;
+            }
+
+            assertTrue(expr.getFirst() instanceof InsertExpr);
+            assertEquals(Expression.Category.UPDATING, expr.getFirst().getCategory());
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/xquery/update/legacy/AbstractTestUpdate.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/legacy/AbstractTestUpdate.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.exist.TestUtils;
 import org.exist.test.ExistXmldbEmbeddedServer;

--- a/exist-core/src/test/java/org/exist/xquery/update/legacy/IndexIntegrationTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/legacy/IndexIntegrationTest.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.easymock.IArgumentMatcher;
 import org.easymock.IMocksControl;

--- a/exist-core/src/test/java/org/exist/xquery/update/legacy/UpdateInsertTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/legacy/UpdateInsertTest.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.junit.Test;
 import org.xmldb.api.base.XMLDBException;

--- a/exist-core/src/test/java/org/exist/xquery/update/legacy/UpdateReplaceTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/legacy/UpdateReplaceTest.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.junit.Test;
 import org.w3c.dom.Document;

--- a/exist-core/src/test/java/org/exist/xquery/update/legacy/UpdateValueTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/update/legacy/UpdateValueTest.java
@@ -19,7 +19,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.exist.xquery.update;
+package org.exist.xquery.update.legacy;
 
 import org.junit.Test;
 import org.xmldb.api.base.XMLDBException;


### PR DESCRIPTION
XQuery Parser support for W3C specification compliant [XQuery Update Facility 3.0](https://www.w3.org/TR/xquery-update-30).

It does not remove the existing non-spec compliant update language used by eXist-db. That can be done separately in future in a different PR if desired.

NOTE: Implementation and execution of PUL still needs to follow...

----
This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.