### PR TITLE
[6.x.x] Use newer copy-maven-plugin which does not have CVE issues with its dependencies

### DIFF
--- a/exist-distribution/pom.xml
+++ b/exist-distribution/pom.xml
@@ -709,24 +709,12 @@
             </plugin>
 
             <plugin>
-                <groupId>ch.mfrey.maven.plugin</groupId>
+                <groupId>com.evolvedbinary.maven.mfrey</groupId>
                 <artifactId>copy-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>2.1.0</version>
                 <configuration>
                     <showfiles>true</showfiles>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>commons-io</groupId>
-                        <artifactId>commons-io</artifactId>
-                        <version>2.11.0</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.codehaus.plexus</groupId>
-                        <artifactId>plexus-utils</artifactId>
-                        <version>1.1</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>autodeploy-expath-pkgs-for-appassembler</id>


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/4934