### PR TITLE
Improve JMX output

### DIFF
--- a/exist-core/src/main/java/org/exist/management/impl/ExistMBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/ExistMBean.java
@@ -21,24 +21,20 @@
  */
 package org.exist.management.impl;
 
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
 /**
- * Interface SystemInfoMXBean
- *
- * @author wessels
- * @author ljo
+ * Interface for all eXist-db provided MBeans.
  */
-public interface SystemInfoMXBean extends ExistMBean {
-    String getProductName();
+public interface ExistMBean {
 
-    String getProductVersion();
-
-    String getProductBuild();
-
-    String getGitCommit();
-
-    String getOperatingSystem();
-
-    String getDefaultLocale();
-
-    String getDefaultEncoding();
+    /**
+     * Get the name of the MBean.
+     *
+     * @return the name of the mbean.
+     *
+     * @throws MalformedObjectNameException if the name cannot be constructed.
+     */
+    ObjectName getName() throws MalformedObjectNameException;
 }

--- a/exist-core/src/main/java/org/exist/management/impl/JMXAgent.java
+++ b/exist-core/src/main/java/org/exist/management/impl/JMXAgent.java
@@ -70,7 +70,8 @@ public final class JMXAgent implements Agent {
 
     private void registerSystemMBeans() {
         try {
-            addMBean(new ObjectName(SystemInfo.OBJECT_NAME), new org.exist.management.impl.SystemInfo());
+            final SystemInfoMXBean systemInfoMXBean = new org.exist.management.impl.SystemInfo();
+            addMBean(systemInfoMXBean.getName(), systemInfoMXBean);
         } catch (final MalformedObjectNameException | DatabaseConfigurationException e) {
             LOG.warn("Exception while registering cache mbean.", e);
         }

--- a/exist-core/src/main/java/org/exist/management/impl/PerInstanceMBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/PerInstanceMBean.java
@@ -22,10 +22,6 @@
 
 package org.exist.management.impl;
 
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-
-public interface PerInstanceMBean {
+public interface PerInstanceMBean extends ExistMBean {
     String getInstanceId();
-    ObjectName getName() throws MalformedObjectNameException;
 }

--- a/exist-core/src/main/java/org/exist/management/impl/ProcessReportMXBean.java
+++ b/exist-core/src/main/java/org/exist/management/impl/ProcessReportMXBean.java
@@ -21,18 +21,18 @@
  */
 package org.exist.management.impl;
 
-import java.util.List;
+import java.util.Map;
 
 public interface
 ProcessReportMXBean extends PerInstanceMBean {
 
-    List<Job> getScheduledJobs();
+    Map<String, Job> getScheduledJobs();
 
-    List<Job> getRunningJobs();
+    Map<String, Job> getRunningJobs();
 
-    List<RunningQuery> getRunningQueries();
+    Map<QueryKey, RunningQuery> getRunningQueries();
 
-    List<RecentQueryHistory> getRecentQueryHistory();
+    Map<QueryKey, RecentQueryHistory> getRecentQueryHistory();
 
     void killQuery(int id);
 
@@ -77,4 +77,54 @@ ProcessReportMXBean extends PerInstanceMBean {
     void setTrackRequestURI(boolean track);
 
     boolean getTrackRequestURI();
+
+    class QueryKey implements Comparable<QueryKey> {
+        private final int id;
+        private final String key;
+
+        public QueryKey(final int id, final String key) {
+            this.id = id;
+            this.key = key;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (other == null || getClass() != other.getClass()) {
+                return false;
+            }
+
+            QueryKey queryKey = (QueryKey) other;
+            if (id != queryKey.id) {
+                return false;
+            }
+            return key.equals(queryKey.key);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = id;
+            result = 31 * result + key.hashCode();
+            return result;
+        }
+
+        @Override
+        public int compareTo(final QueryKey other) {
+            if (other == null) {
+                return 1;
+            }
+
+            return key.compareTo(other.key);
+        }
+    }
 }

--- a/exist-core/src/main/java/org/exist/management/impl/RecentQueryHistory.java
+++ b/exist-core/src/main/java/org/exist/management/impl/RecentQueryHistory.java
@@ -29,14 +29,14 @@ import org.exist.storage.ProcessMonitor;
  */
 public class RecentQueryHistory {
 
-    private int idx;
-    private String sourceKey;
-    private int recentInvocationCount;
-    private long mostRecentExecutionTime;
-    private long mostRecentExecutionDuration;
-    private String requestURI;
+    private final int idx;
+    private final String sourceKey;
+    private final int recentInvocationCount;
+    private final long mostRecentExecutionTime;
+    private final long mostRecentExecutionDuration;
+    private final String requestURI;
 
-    public RecentQueryHistory(int idx, ProcessMonitor.QueryHistory queryHistory) {
+    public RecentQueryHistory(final int idx, final ProcessMonitor.QueryHistory queryHistory) {
         this.idx = idx;
         this.sourceKey = queryHistory.getSource();
         this.recentInvocationCount = queryHistory.getInvocationCount();

--- a/exist-core/src/main/java/org/exist/management/impl/RunningQuery.java
+++ b/exist-core/src/main/java/org/exist/management/impl/RunningQuery.java
@@ -29,13 +29,13 @@ import org.exist.xquery.XQueryWatchDog;
  */
 public class RunningQuery {
 
-    int id;
-    String sourceType;
-    String sourceKey;
-    boolean terminating;
-    String requestURI;
-    String thread;
-    long elapsed;
+    private final int id;
+    private final String sourceType;
+    private final String sourceKey;
+    private final boolean terminating;
+    private final String requestURI;
+    private final String thread;
+    private final long startTime;
 
     public RunningQuery(final XQueryWatchDog watchdog, final String requestURI) {
         this.id = watchdog.getContext().hashCode();
@@ -44,7 +44,7 @@ public class RunningQuery {
         this.terminating = watchdog.isTerminating();
         this.requestURI = requestURI;
         this.thread = watchdog.getRunningThread();
-        this.elapsed = System.currentTimeMillis() - watchdog.getStartTime();
+        this.startTime = watchdog.getStartTime();
     }
 
     public int getId() {
@@ -71,7 +71,11 @@ public class RunningQuery {
         return thread;
     }
 
+    public long getStartTime() {
+        return startTime;
+    }
+
     public long getElapsed() {
-        return elapsed;
+        return System.currentTimeMillis() - startTime;
     }
 }

--- a/exist-core/src/main/java/org/exist/management/impl/SystemInfo.java
+++ b/exist-core/src/main/java/org/exist/management/impl/SystemInfo.java
@@ -26,6 +26,9 @@ import java.util.Locale;
 
 import org.exist.SystemProperties;
 
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
 /**
  * Class SystemInfo
  * 
@@ -35,6 +38,11 @@ import org.exist.SystemProperties;
 public class SystemInfo implements SystemInfoMXBean {
 
     public static final String OBJECT_NAME = "org.exist.management:type=SystemInfo";
+
+    @Override
+    public ObjectName getName() throws MalformedObjectNameException {
+        return new ObjectName(OBJECT_NAME);
+    }
 
     @Override
     public String getProductName() {


### PR DESCRIPTION
To improve interoperability with a number of tools that consume JMX, this switches eXist-db from exporting JMX `CompositeData` to exporting `TabularData` for:
1. Running Queries
2. Recent Queries
3. Running Jobs
4. Scheduled Jobs