### PR TITLE
[build] Use original CVE files

### DIFF
--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -599,10 +599,6 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <version>8.3.1</version>
                     <configuration>
-                        <!-- Use Evolved Binary's mirror of nvd.nist.gov -->
-                        <cveUrlModified>https://nvd.mirror.evolvedbinary.com/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz</cveUrlModified>
-                        <cveUrlBase>https://nvd.mirror.evolvedbinary.com/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz</cveUrlBase>
-
                         <!-- The OSS Index Server (https://ossindex.sonatype.org) can sometimes be flaky -->
                         <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>
 


### PR DESCRIPTION
For a long time the retrieval of the owasp data is not reliable. This is a test to verify if the details configuration works more reliable.

... wait for build