### PR TITLE
[fix] cardinality of CastExpression#toFunction

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/CastExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/CastExpression.java
@@ -190,7 +190,7 @@ public class CastExpression extends AbstractExpression {
 	    try {
             final QName qname = QName.parse(context, typeName);
             final FunctionSignature signature = new FunctionSignature(qname);
-            final SequenceType argType = new SequenceType(Type.ITEM, Cardinality.ZERO_OR_ONE);
+            final SequenceType argType = new SequenceType(Type.ATOMIC, Cardinality.ZERO_OR_ONE);
             signature.setArgumentTypes(new SequenceType[]{argType});
             signature.setReturnType(new SequenceType(CastExpression.this.requiredType, CastExpression.this.cardinality));
             return new FunctionWrapper(this, signature);

--- a/exist-core/src/main/java/org/exist/xquery/CastExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/CastExpression.java
@@ -190,7 +190,7 @@ public class CastExpression extends AbstractExpression {
 	    try {
             final QName qname = QName.parse(context, typeName);
             final FunctionSignature signature = new FunctionSignature(qname);
-            final SequenceType argType = new SequenceType(Type.ITEM, Cardinality.EXACTLY_ONE);
+            final SequenceType argType = new SequenceType(Type.ITEM, Cardinality.ZERO_OR_ONE);
             signature.setArgumentTypes(new SequenceType[]{argType});
             signature.setReturnType(new SequenceType(CastExpression.this.requiredType, CastExpression.this.cardinality));
             return new FunctionWrapper(this, signature);

--- a/exist-core/src/test/xquery/xquery3/arrowop.xql
+++ b/exist-core/src/test/xquery/xquery3/arrowop.xql
@@ -278,3 +278,24 @@ function ao:for-each-pair-with-contextitem () {
         => string-join()
 };
 
+(:~
+  check if CastExpression#toFuntion has correct cardinality check
+  see https://github.com/eXist-db/exist/issues/4971
+:)
+declare
+    %test:assertEmpty
+function ao:type-constructor-after-arrow-empty-sequence () {
+    () => xs:string()
+};
+
+declare
+    %test:assertEquals("1")
+function ao:type-constructor-after-arrow-integer () {
+    1 => xs:string()
+};
+
+declare
+    %test:assertError("XPTY0004")
+function ao:type-constructor-after-arrow-integer-sequence () {
+    (1,2) => xs:string()
+};

--- a/exist-core/src/test/xquery/xquery3/arrowop.xql
+++ b/exist-core/src/test/xquery/xquery3/arrowop.xql
@@ -277,25 +277,3 @@ function ao:for-each-pair-with-contextitem () {
         => for-each-pair((<a/>,<b/>,<a/>,<b/>), function ($a, $b) { node-name($a) || node-name($b) })
         => string-join()
 };
-
-(:~
-  check if CastExpression#toFuntion has correct cardinality check
-  see https://github.com/eXist-db/exist/issues/4971
-:)
-declare
-    %test:assertEmpty
-function ao:type-constructor-after-arrow-empty-sequence () {
-    () => xs:string()
-};
-
-declare
-    %test:assertEquals("1")
-function ao:type-constructor-after-arrow-integer () {
-    1 => xs:string()
-};
-
-declare
-    %test:assertError("XPTY0004")
-function ao:type-constructor-after-arrow-integer-sequence () {
-    (1,2) => xs:string()
-};

--- a/exist-core/src/test/xquery/xquery3/cast-constructor.xqm
+++ b/exist-core/src/test/xquery/xquery3/cast-constructor.xqm
@@ -1,0 +1,78 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace cc="http://exist-db.org/xquery/test/cast-constructor";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+(:~
+  check if CastExpression#toFunction has correct cardinality check
+  see https://github.com/eXist-db/exist/issues/4971
+:)
+declare
+    %test:assertEmpty
+function cc:after-arrow-empty-sequence () {
+    () => xs:string()
+};
+
+declare
+    %test:assertEquals("1")
+function cc:after-arrow-integer () {
+    1 => xs:string()
+};
+
+declare
+    %test:assertError("XPTY0004")
+function cc:after-arrow-integer-sequence () {
+    (1,2) => xs:string()
+};
+
+declare
+    %test:assertEquals("test")
+function cc:atomize-element () as xs:string {
+    xs:string(<div>test</div>)
+};
+
+declare
+    %test:assertEquals("1970-01-01")
+function cc:atomize-attribute () as xs:date {
+    xs:date(attribute when { "1970-01-01" })
+};
+
+declare
+    %test:assertEquals(1)
+function cc:atomize-array () as xs:integer {
+    xs:integer([1])
+};
+
+declare
+    %test:assertError("XPTY0004")
+function cc:atomize-array-2 () as xs:string {
+    xs:string([1,2])
+};
+
+declare
+    %test:assertError("FOTY0013")
+function cc:atomize-map-fails () {
+    xs:integer(map { 0 : 1 })
+};

--- a/exist-core/src/test/xquery/xquery3/castable-untyped-atomic.xqm
+++ b/exist-core/src/test/xquery/xquery3/castable-untyped-atomic.xqm
@@ -75,5 +75,3 @@ function ca:s-cast-castable($d) {
     let $n := $el/@n, $ncname := xs:NCName($n)
     return <result name="{$n}" nc="{$ncname castable as xs:NCName}"/>
 };
-
-


### PR DESCRIPTION
### Description:

Type constructors like `xs:string` or `xs:integer` did wrongly check for EXACTLY_ONE item passed to them when used as a function. This happens for instance when used on the right hand side of an arrow operator.

```xquery
() => xs:string()
```

would fail with a cardinality error. The error message itself is hard to understand which should be addressed in a following PR.

This PR fixes the cast function to allow an empty sequence as its parameter.

### Reference:

fixes #4971 

### Type of tests:

XQSuite tests