### PR TITLE
[6.x.x] Restore compatibility with Java language level 8

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Options.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Options.java
@@ -528,11 +528,11 @@ class Options {
                     "Can not access '" + location + "'" + e.getMessage());
         }
         if (document != null && document.hasOne() && Type.subTypeOf(document.getItemType(), Type.NODE)) {
-            if (document instanceof NodeProxy proxy) {
-                return new DOMSource(proxy.getNode());
+            if (document instanceof NodeProxy) {
+                return new DOMSource(((NodeProxy) document).getNode());
             }
-            else if (document.itemAt(0) instanceof Node node) {
-                return new DOMSource(node);
+            else if (document.itemAt(0) instanceof Node) {
+                return new DOMSource((Node) document.itemAt(0));
             }
         }
         throw new XPathException(fnTransform, ErrorCodes.FODC0002,

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Transform.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/transform/Transform.java
@@ -222,7 +222,7 @@ public class Transform {
         xsltCompiler.setURIResolver((href, base) -> {
             try {
                 final URI hrefURI = URI.create(href);
-                if (options.resolvedStylesheetBaseURI.isEmpty() && !hrefURI.isAbsolute() && StringUtils.isEmpty(base)) {
+                if ((!options.resolvedStylesheetBaseURI.isPresent()) && !hrefURI.isAbsolute() && StringUtils.isEmpty(base)) {
                     final XPathException resolutionException = new XPathException(fnTransform,
                             ErrorCodes.XTSE0165,
                             "transform using a relative href, \n" +
@@ -265,8 +265,8 @@ public class Transform {
 
         cause = e;
         while (cause != null) {
-            if (cause instanceof final net.sf.saxon.trans.XPathException xPathException) {
-                final StructuredQName from = xPathException.getErrorCodeQName();
+            if (cause instanceof net.sf.saxon.trans.XPathException) {
+                final StructuredQName from = ((net.sf.saxon.trans.XPathException) cause).getErrorCodeQName();
                 if (from != null) {
                     final QName errorCodeQName = new QName(from.getLocalPart(), from.getURI(), from.getPrefix());
                     final ErrorCodes.ErrorCode errorCode = new ErrorCodes.ErrorCode(errorCodeQName, cause.getMessage());


### PR DESCRIPTION
It looks like some Java 17 code snuck into eXist-db 6.x.x, this restores compatibility with Java 8.