### PR TITLE
Add support in `cache:create()` for 'expireAfterWrite' in `$config`

### DIFF
--- a/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/Cache.java
+++ b/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/Cache.java
@@ -48,6 +48,7 @@ class Cache {
 
         config.getMaximumSize().map(cacheBuilder::maximumSize);
         config.getExpireAfterAccess().map(ms -> cacheBuilder.expireAfterAccess(ms, TimeUnit.MILLISECONDS));
+        config.getExpireAfterWrite().map(ms -> cacheBuilder.expireAfterWrite(ms, TimeUnit.MILLISECONDS));
 
         this.store = cacheBuilder.build();
 	}

--- a/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/CacheConfig.java
+++ b/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/CacheConfig.java
@@ -33,16 +33,19 @@ public class CacheConfig {
     private final Optional<Permissions> permissions;
     private final Optional<Long> maximumSize;
     private final Optional<Long> expireAfterAccess;
+    private final Optional<Long> expireAfterWrite;
 
     /**
      * @param permissions Any restrictions on cache operations
      * @param maximumSize The maximimum number of entries in the cache
      * @param expireAfterAccess The time in milliseconds after the entry is last accessed, that it should expire
+     * @param expireAfterWrite The time in milliseconds after the entry is last modified, that it should expire
      */
-    public CacheConfig(final Optional<Permissions> permissions, final Optional<Long> maximumSize, final Optional<Long> expireAfterAccess) {
+    public CacheConfig(final Optional<Permissions> permissions, final Optional<Long> maximumSize, final Optional<Long> expireAfterAccess, final Optional<Long> expireAfterWrite) {
         this.permissions = permissions;
         this.maximumSize = maximumSize;
         this.expireAfterAccess = expireAfterAccess;
+        this.expireAfterWrite = expireAfterWrite;
     }
 
     public Optional<Permissions> getPermissions() {
@@ -55,6 +58,10 @@ public class CacheConfig {
 
     public Optional<Long> getExpireAfterAccess() {
         return expireAfterAccess;
+    }
+
+    public Optional<Long> getExpireAfterWrite() {
+        return expireAfterWrite;
     }
 
     public static class Permissions {

--- a/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/CacheModule.java
+++ b/extensions/modules/cache/src/main/java/org/exist/xquery/modules/cache/CacheModule.java
@@ -71,6 +71,7 @@ public class CacheModule extends AbstractInternalModule {
     private static final String PARAM_NAME_ENABLE_LAZY_CREATION = "enableLazyCreation";
     private static final String PARAM_NAME_LAZY_MAXIMUM_SIZE = "lazy.maximumSize";
     private static final String PARAM_NAME_LAZY_EXPIRE_AFTER_ACCESS = "lazy.expireAfterAccess";
+    private static final String PARAM_NAME_LAZY_EXPIRE_AFTER_WRITE = "lazy.expireAfterWrite";
     private static final String PARAM_NAME_LAZY_PUT_GROUP = "lazy.putGroup";
     private static final String PARAM_NAME_LAZY_GET_GROUP = "lazy.getGroup";
     private static final String PARAM_NAME_LAZY_REMOVE_GROUP = "lazy.removeGroup";
@@ -78,6 +79,7 @@ public class CacheModule extends AbstractInternalModule {
 
     private static final long DEFAULT_LAZY_MAXIMUM_SIZE = 128;  // 128 items
     private static final long DEFAULT_LAZY_EXPIRE_AFTER_ACCESS = 1000 * 60 * 5;  // 5 minutes
+    private static final long DEFAULT_LAZY_EXPIRE_AFTER_WRITE = 1000 * 60 * 5;  // 5 minutes
 
     static final Map<String, Cache> caches = new ConcurrentHashMap<>();
 
@@ -167,8 +169,18 @@ public class CacheModule extends AbstractInternalModule {
                     }
                 });
 
+        final Optional<Long> expireAfterWrite = getFirstString(parameters, PARAM_NAME_LAZY_EXPIRE_AFTER_WRITE)
+                .map(s -> {
+                    try {
+                        return Long.parseLong(s);
+                    } catch (final NumberFormatException e) {
+                        LOG.warn("Unable to set {} to: {}. Using default: ", PARAM_NAME_LAZY_EXPIRE_AFTER_WRITE, s, DEFAULT_LAZY_EXPIRE_AFTER_WRITE);
+                        return DEFAULT_LAZY_EXPIRE_AFTER_ACCESS;
+                    }
+                });
 
-        return Optional.of(new CacheConfig(permissions, maximumSize, expireAfterAccess));
+
+        return Optional.of(new CacheConfig(permissions, maximumSize, expireAfterAccess, expireAfterWrite));
     }
 
     private static Optional<String> getFirstString(final Map<String, List<?>> parameters, final String paramName) {

--- a/extensions/modules/cache/src/test/xquery/modules/cache/cache.xqm
+++ b/extensions/modules/cache/src/test/xquery/modules/cache/cache.xqm
@@ -33,6 +33,8 @@ declare variable $c:maximumSize := 5;
 declare variable $c:maximumSize-options := map { "maximumSize": $c:maximumSize };
 declare variable $c:expireAfterAccess := 1000;
 declare variable $c:expireAfterAccess-options := map { "expireAfterAccess": $c:expireAfterAccess };
+declare variable $c:expireAfterWrite := 1000;
+declare variable $c:expireAfterWrite-options := map { "expireAfterWrite": $c:expireAfterWrite };
 
 declare function c:_create-simple() {
     cache:create($c:cache-name, $c:simple-options)
@@ -44,6 +46,10 @@ declare function c:_create-maximumSize() {
 
 declare function c:_create-expireAfterAccess() {
     cache:create($c:cache-name, $c:expireAfterAccess-options)
+};
+
+declare function c:_create-expireAfterWrite() {
+    cache:create($c:cache-name, $c:expireAfterWrite-options)
 };
 
 declare function c:_populate($size as xs:integer) {
@@ -165,6 +171,21 @@ function c:exercise-expireAfterAccess() {
             c:_create-expireAfterAccess(),
             c:_populate(5),
             util:wait($c:expireAfterAccess * 1.1),
+            c:_cleanup()
+        )
+    return
+        count(c:_keys())
+};
+
+declare
+    %test:assertEquals(0)
+function c:exercise-expireAfterWrite() {
+    let $setup := 
+        (
+            c:_destroy(),
+            c:_create-expireAfterWrite(),
+            c:_populate(5),
+            util:wait($c:expireAfterWrite * 1.1),
             c:_cleanup()
         )
     return


### PR DESCRIPTION
### Description:

This feature adds a configuration option 'expireAfterWrite' to the `$config` parameter of `cache:create()`.
This option is available in the Caffeine cache, but was not supported in eXist.

### Reference:

I have not made a GitHub issue requesting this feature.

### Type of tests:

A test has been added to `extensions\modules\cache\src\test\xquery\modules\cache\cache.xqm`.
It is similar to the test for `expireAfterAccess`.