### PR TITLE
[6.x.x] InputStream#available() should not be used to determine if there is data available

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
+++ b/exist-core/src/main/java/org/exist/xquery/XQueryContext.java
@@ -465,7 +465,7 @@ public class XQueryContext implements BinaryValueManager, Context {
         this(db, null, profiler);
     }
 
-    private XQueryContext(@Nullable final Database db, @Nullable final Configuration configuration, @Nullable final Profiler profiler) {
+    public XQueryContext(@Nullable final Database db, @Nullable final Configuration configuration, @Nullable final Profiler profiler) {
         this(db, configuration, profiler, true);
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/request/GetData.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/request/GetData.java
@@ -97,7 +97,7 @@ public class GetData extends StrictRequestFunction {
             isRequest = request.getInputStream();
 
             //was there any POST content?
-            if (isRequest != null && isRequest.available() > 0) {
+            if (isRequest != null) {
                 // 1) determine if exists mime database considers this binary data
                 String contentType = request.getContentType();
                 if (contentType != null) {
@@ -123,7 +123,7 @@ public class GetData extends StrictRequestFunction {
                     try {
                         //we have to cache the input stream, so we can reread it, as we may use it twice (once for xml attempt and once for string attempt)
                         cache = FilterInputStreamCacheFactory.getCacheInstance(()
-                                -> (String) context.getBroker().getConfiguration().getProperty(Configuration.BINARY_CACHE_CLASS_PROPERTY), isRequest);
+                                -> (String) context.getConfiguration().getProperty(Configuration.BINARY_CACHE_CLASS_PROPERTY), isRequest);
                         is = new CachingFilterInputStream(cache);
 
                         //mark the start of the stream

--- a/exist-core/src/test/java/org/exist/xquery/functions/request/GetData2Test.java
+++ b/exist-core/src/test/java/org/exist/xquery/functions/request/GetData2Test.java
@@ -1,0 +1,158 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.functions.request;
+
+import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
+import org.exist.http.servlets.RequestWrapper;
+import org.exist.storage.BrokerPool;
+import org.exist.storage.DBBroker;
+import org.exist.util.Configuration;
+import org.exist.util.XMLReaderObjectFactory;
+import org.exist.util.XMLReaderPool;
+import org.exist.xquery.XPathException;
+import org.exist.xquery.XQueryContext;
+import org.exist.xquery.value.Sequence;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+/**
+ * Unlike {@link GetDataTest} this test tries to test the code of
+ * the {@link GetData} class directly.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+public class GetData2Test {
+
+    @Test
+    public void xmlChunkedTransferNonBlockingAvailable() throws XPathException, IOException, SAXException {
+        final String content = "<hello>world</hello>";
+        try (final InputStream is = new UnsynchronizedByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {
+
+            final RequestWrapper mockRequestWrapper = createNiceMock(RequestWrapper.class);
+            final Configuration mockConfiguration = createNiceMock(Configuration.class);
+            final BrokerPool mockBrokerPool = createNiceMock(BrokerPool.class);
+            final DBBroker mockBroker = createNiceMock(DBBroker.class);
+            final XMLReaderObjectFactory xmlReaderObjectFactory = new XMLReaderObjectFactory();
+            final XMLReaderPool xmlReaderPool = new XMLReaderPool(xmlReaderObjectFactory, 20, 0);
+
+            expect(mockRequestWrapper.getSession(false)).andReturn(null);
+            expect(mockRequestWrapper.getContentLength()).andReturn(-1l);
+            expect(mockRequestWrapper.getHeader("Transfer-Encoding")).andReturn("chunked");
+            expect(mockRequestWrapper.getInputStream()).andReturn(is);
+            expect(mockRequestWrapper.getContentType()).andReturn("application/xml");
+
+            expect(mockConfiguration.getProperty(Configuration.BINARY_CACHE_CLASS_PROPERTY)).andReturn("org.exist.util.io.FileFilterInputStreamCache");
+            expect(mockConfiguration.getProperty(XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, Boolean.FALSE)).andReturn(Boolean.FALSE);
+
+            expect(mockBrokerPool.getConfiguration()).andReturn(mockConfiguration);
+            expect(mockBrokerPool.getActiveBroker()).andReturn(mockBroker).anyTimes();
+            expect(mockBrokerPool.getParserPool()).andReturn(xmlReaderPool).anyTimes();
+            expect(mockBroker.getBrokerPool()).andReturn(mockBrokerPool).anyTimes();
+
+            replay(mockRequestWrapper, mockConfiguration, mockBrokerPool, mockBroker);
+
+            xmlReaderObjectFactory.configure(mockConfiguration);
+
+            final XQueryContext context = new XQueryContext(mockBrokerPool, mockConfiguration, null);
+            context.setHttpContext(new XQueryContext.HttpContext(mockRequestWrapper, null));
+
+            final GetData getData = new GetData(context);
+            final Sequence result = getData.eval((Sequence[]) null, (Sequence) null);
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.getItemCount());
+            assertTrue(result.itemAt(0) instanceof Document);
+            assertEquals("hello", ((Document) result.itemAt(0)).getDocumentElement().getLocalName());
+            assertEquals("world", ((Document) result.itemAt(0)).getDocumentElement().getTextContent());
+
+            verify(mockRequestWrapper, mockConfiguration, mockBrokerPool, mockBroker);
+        }
+    }
+
+    @Test
+    public void xmlChunkedTransferNonBlockingNoneAvailable() throws XPathException, IOException {
+        final String content = "<hello>world</hello>";
+        try (final InputStream is = new ZeroAvailableInputStream(content.getBytes(StandardCharsets.UTF_8))) {
+
+            final RequestWrapper mockRequestWrapper = createNiceMock(RequestWrapper.class);
+            final Configuration mockConfiguration = createNiceMock(Configuration.class);
+            final BrokerPool mockBrokerPool = createNiceMock(BrokerPool.class);
+            final DBBroker mockBroker = createNiceMock(DBBroker.class);
+            final XMLReaderObjectFactory xmlReaderObjectFactory = new XMLReaderObjectFactory();
+            final XMLReaderPool xmlReaderPool = new XMLReaderPool(xmlReaderObjectFactory, 20, 0);
+
+            expect(mockRequestWrapper.getSession(false)).andReturn(null);
+            expect(mockRequestWrapper.getContentLength()).andReturn(-1l);
+            expect(mockRequestWrapper.getHeader("Transfer-Encoding")).andReturn("chunked");
+            expect(mockRequestWrapper.getInputStream()).andReturn(is);
+            expect(mockRequestWrapper.getContentType()).andReturn("application/xml");
+
+            expect(mockConfiguration.getProperty(Configuration.BINARY_CACHE_CLASS_PROPERTY)).andReturn("org.exist.util.io.FileFilterInputStreamCache");
+            expect(mockConfiguration.getProperty(XQueryContext.PROPERTY_XQUERY_RAISE_ERROR_ON_FAILED_RETRIEVAL, Boolean.FALSE)).andReturn(Boolean.FALSE);
+
+            expect(mockBrokerPool.getConfiguration()).andReturn(mockConfiguration);
+            expect(mockBrokerPool.getActiveBroker()).andReturn(mockBroker).anyTimes();
+            expect(mockBrokerPool.getParserPool()).andReturn(xmlReaderPool).anyTimes();
+            expect(mockBroker.getBrokerPool()).andReturn(mockBrokerPool).anyTimes();
+
+            replay(mockRequestWrapper, mockConfiguration, mockBrokerPool, mockBroker);
+
+            xmlReaderObjectFactory.configure(mockConfiguration);
+
+            final XQueryContext context = new XQueryContext(mockBrokerPool, mockConfiguration, null);
+            context.setHttpContext(new XQueryContext.HttpContext(mockRequestWrapper, null));
+
+            final GetData getData = new GetData(context);
+            final Sequence result = getData.eval((Sequence[]) null, (Sequence) null);
+            assertNotNull(result);
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.getItemCount());
+            assertTrue(result.itemAt(0) instanceof Document);
+            assertEquals("hello", ((Document) result.itemAt(0)).getDocumentElement().getLocalName());
+            assertEquals("world", ((Document) result.itemAt(0)).getDocumentElement().getTextContent());
+
+            verify(mockRequestWrapper, mockConfiguration, mockBrokerPool, mockBroker);
+        }
+    }
+
+    public static class ZeroAvailableInputStream extends UnsynchronizedByteArrayInputStream {
+
+        public ZeroAvailableInputStream(final byte[] data) {
+            super(data);
+        }
+
+        @Override
+        public int available() {
+            return 0;
+        }
+    }
+}

--- a/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
+++ b/extensions/exquery/restxq/src/main/java/org/exist/extensions/exquery/restxq/impl/RestXqServiceImpl.java
@@ -137,10 +137,6 @@ class RestXqServiceImpl extends AbstractRestXqService {
             //first, get the content of the request
             is = new CloseShieldInputStream(request.getInputStream());
 
-            if (is.available() <= 0) {
-                return null;
-            }
-
             //if marking is not supported, we have to cache the input stream, so we can reread it, as we may use it twice (once for xml attempt and once for string attempt)
             if (!is.markSupported()) {
                 cache = FilterInputStreamCacheFactory.getCacheInstance(() -> {
@@ -160,7 +156,7 @@ class RestXqServiceImpl extends AbstractRestXqService {
         try {
 
             //was there any POST content?
-            if (is != null && is.available() > 0) {
+            if (is != null) {
                 String contentType = request.getContentType();
                 // 1) determine if exists mime database considers this binary data
                 if (contentType != null) {
@@ -214,8 +210,6 @@ class RestXqServiceImpl extends AbstractRestXqService {
                     }
                 }
             }
-        } catch (IOException e) {
-            throw new RestXqServiceException(e.getMessage());
         } finally {
 
             if (cache != null) {


### PR DESCRIPTION
We believe we have seen some instances where calls to `request:get-data()` return an Empty Sequence even when there is request body content in the incoming HTTP request.

We think that the issue may be caused by the use of calls to `InputStream#available()` which may return a `0` when there is no data that can be read without blocking; this does **not** mean however that there is no data to read.

The eXist-db user experiencing this problem has trialed the patch in this PR and reported back to us that they believe they no longer experience the issue.