### PR TITLE
[6.x.x] Correct function signatures that return empty sequences

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/GroupManagementFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/securitymanager/GroupManagementFunction.java
@@ -51,7 +51,7 @@ public class GroupManagementFunction extends BasicFunction {
         new SequenceType[]{
             new FunctionParameterSequenceType("group-name", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the group to create.")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_CREATE_GROUP_WITH_METADATA = new FunctionSignature(
@@ -61,7 +61,7 @@ public class GroupManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("group-name", Type.STRING, Cardinality.EXACTLY_ONE, "The name of the group to create."),
             new FunctionParameterSequenceType("description", Type.STRING, Cardinality.EXACTLY_ONE, "A description of the group.")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_CREATE_GROUP_WITH_MANAGERS_WITH_METADATA = new FunctionSignature(
@@ -72,7 +72,7 @@ public class GroupManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("managers", Type.STRING, Cardinality.ONE_OR_MORE, "The usernames of users that will be a manager of this group."),
             new FunctionParameterSequenceType("description", Type.STRING, Cardinality.EXACTLY_ONE, "A description of the group.")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     public final static FunctionSignature FNS_REMOVE_GROUP = new FunctionSignature(
@@ -81,7 +81,7 @@ public class GroupManagementFunction extends BasicFunction {
         new SequenceType[]{
             new FunctionParameterSequenceType("group-name", Type.STRING, Cardinality.EXACTLY_ONE, "The group-id to delete")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     );
 
     //TODO implement later
@@ -92,7 +92,7 @@ public class GroupManagementFunction extends BasicFunction {
             new FunctionParameterSequenceType("group-id", Type.STRING, Cardinality.EXACTLY_ONE, "The group-id to delete"),
             new FunctionParameterSequenceType("successor-group-id", Type.STRING, Cardinality.EXACTLY_ONE, "The group-id that should take over ownership of any resources")
         },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
     ); */
 
     public GroupManagementFunction(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/FunctionTrace.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/FunctionTrace.java
@@ -45,7 +45,7 @@ public class FunctionTrace extends BasicFunction {
                 new QName( "enable-tracing", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
                 "Enable function tracing on the database instance.",
                 new SequenceType[] { new FunctionParameterSequenceType("enable", Type.BOOLEAN, Cardinality.EXACTLY_ONE, "The boolean flag to enable/disable function tracing") },
-                new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+                new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
         ),
         new FunctionSignature(
                 new QName( "enable-tracing", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
@@ -55,7 +55,7 @@ public class FunctionTrace extends BasicFunction {
                     new FunctionParameterSequenceType("tracelog", Type.BOOLEAN, Cardinality.EXACTLY_ONE,
                         "The tracelog boolean flag: if set to true, entering/exiting a function will be logged to the logger 'xquery.profiling'")
                 },
-                new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+                new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
         ),
         new FunctionSignature(
                 new QName( "tracing-enabled", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
@@ -67,7 +67,7 @@ public class FunctionTrace extends BasicFunction {
                 new QName( "clear-trace", SystemModule.NAMESPACE_URI, SystemModule.PREFIX ),
                 "Clear the global trace log.",
                 null,
-                new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+                new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
         )
     };
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/Shutdown.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/Shutdown.java
@@ -54,7 +54,7 @@ public class Shutdown extends BasicFunction
 			new QName("shutdown", SystemModule.NAMESPACE_URI, SystemModule.PREFIX),
 			"Shutdown eXist immediately.  This method is only available to the DBA role.",
 			null,
-			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+			new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
 		),
 		
 		new FunctionSignature(
@@ -63,7 +63,7 @@ public class Shutdown extends BasicFunction
 			new SequenceType[] {
 					new FunctionParameterSequenceType("delay", Type.LONG, Cardinality.EXACTLY_ONE, "The delay in milliseconds before eXist starts to shutdown.")
 			},
-			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+			new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
 		)
 	};
 		

--- a/exist-core/src/main/java/org/exist/xquery/functions/system/TriggerSystemTask.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/system/TriggerSystemTask.java
@@ -56,7 +56,7 @@ public class TriggerSystemTask extends BasicFunction {
                 new FunctionParameterSequenceType("java-classname", Type.STRING, Cardinality.EXACTLY_ONE, "The full name of the Java class to execute.  It must implement org.exist.storage.SystemTask"),
                 new FunctionParameterSequenceType("task-parameters", Type.NODE, Cardinality.ZERO_OR_ONE, "The XML fragment with the following structure: <parameters><param name=\"param-name1\" value=\"param-value1\"/></parameters>")
             },
-			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE));
+			new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE));
 
 
     public TriggerSystemTask(XQueryContext context) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/transform/Transform.java
@@ -121,7 +121,7 @@ public class Transform extends BasicFunction {
                             new FunctionParameterSequenceType("stylesheet", Type.ITEM, Cardinality.EXACTLY_ONE, "The XSL stylesheet"),
                             new FunctionParameterSequenceType("parameters", Type.NODE, Cardinality.ZERO_OR_ONE, "The transformer parameters")
                     },
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
             new FunctionSignature(
                     new QName("stream-transform", TransformModule.NAMESPACE_URI, TransformModule.PREFIX),
                     "Applies an XSL stylesheet to the node tree passed as first argument. The parameters are the same " +
@@ -134,7 +134,7 @@ public class Transform extends BasicFunction {
                             new FunctionParameterSequenceType("parameters", Type.NODE, Cardinality.ZERO_OR_ONE, "The transformer parameters"),
                             new FunctionParameterSequenceType("attributes", Type.NODE, Cardinality.ZERO_OR_ONE, "Attributes to pass to the transformation factory"),
                             new FunctionParameterSequenceType("serialization-options", Type.STRING, Cardinality.ZERO_OR_ONE, "The serialization options")},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE))
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE))
     };
 
     private static final Logger logger = LogManager.getLogger(Transform.class);

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/LogFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/LogFunction.java
@@ -60,25 +60,25 @@ public class LogFunction extends BasicFunction {
                     new QName(FUNCTION_LOG, UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Logs the message to the current logger.",
                     new SequenceType[]{PRIORITY_PARAMETER, MESSAGE_PARAMETER},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
             ),
             new FunctionSignature(
                     new QName(FUNCTION_LOG_SYSTEM_OUT, UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Logs the message to System.out.",
                     new SequenceType[]{MESSAGE_PARAMETER},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
             ),
             new FunctionSignature(
                     new QName(FUNCTION_LOG_SYSTEM_ERR, UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Logs the message to System.err.",
                     new SequenceType[]{MESSAGE_PARAMETER},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
             ),
             new FunctionSignature(
                     new QName(FUNCTION_LOGAPP, UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Logs the message to the named logger",
                     new SequenceType[]{PRIORITY_PARAMETER, LOGGER_NAME_PARAMETER, MESSAGE_PARAMETER},
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
             )
     };
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/Profile.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/Profile.java
@@ -50,12 +50,12 @@ public class Profile extends BasicFunction {
             new SequenceType[] {
                 new FunctionParameterSequenceType("verbosity", Type.INT, Cardinality.EXACTLY_ONE, "The verbosity of the profiling"),
             },
-            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
         new FunctionSignature(
             new QName("disable-profiling", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
             "Disable profiling output within the query.",
             null,
-            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE))
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE))
     };
     
     public Profile(XQueryContext context, FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/PrologFunctions.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/PrologFunctions.java
@@ -42,7 +42,7 @@ public class PrologFunctions extends BasicFunction {
 				new FunctionParameterSequenceType("prefix", Type.STRING, Cardinality.EXACTLY_ONE, "The prefix to be assigned to the namespace"),
 				new FunctionParameterSequenceType("location", Type.ANY_URI, Cardinality.ZERO_OR_MORE, "The location of the module")
 			},
-			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE),
+			new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE),
 				"Use fn:load-module#2 instead!"),
 		new FunctionSignature(
 			new QName("declare-namespace", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
@@ -51,7 +51,7 @@ public class PrologFunctions extends BasicFunction {
 				new FunctionParameterSequenceType("prefix", Type.STRING, Cardinality.EXACTLY_ONE, "The prefix to be assigned to the namespace"),
 				new FunctionParameterSequenceType("namespace-uri", Type.ANY_URI, Cardinality.EXACTLY_ONE, "The namespace URI")
 			},
-			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
+			new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
 		new FunctionSignature(
 			new QName("declare-option", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
 			"Dynamically declares a serialization option as with 'declare option'.",
@@ -59,7 +59,7 @@ public class PrologFunctions extends BasicFunction {
 				new FunctionParameterSequenceType("name", Type.STRING, Cardinality.EXACTLY_ONE, "The serialization option name"),
 				new FunctionParameterSequenceType("option", Type.STRING, Cardinality.EXACTLY_ONE, "The serialization option value")
 			},
-			new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
+			new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
                 new FunctionSignature(
                     new QName("get-option", UtilModule.NAMESPACE_URI, UtilModule.PREFIX),
                     "Gets the value of a serialization option as set with 'declare option'.",

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBDefragment.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBDefragment.java
@@ -65,7 +65,7 @@ public class XMLDBDefragment extends BasicFunction {
 			new FunctionParameterSequenceType("integer", Type.INTEGER, Cardinality.EXACTLY_ONE,
                     "The minimum number of fragmented pages required before defragmenting")
                     },
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
             new FunctionSignature(
                     new QName("defragment", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
                     "Start a defragmentation run on each document which has a node in $nodes. " +
@@ -78,7 +78,7 @@ public class XMLDBDefragment extends BasicFunction {
 			new FunctionParameterSequenceType("nodes", Type.NODE, Cardinality.ONE_OR_MORE,
                     "The sequence of nodes from the documents to defragment"),
                     },
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE))
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE))
     };
 
     public XMLDBDefragment(XQueryContext context, FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBMove.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBMove.java
@@ -59,7 +59,7 @@ public class XMLDBMove extends XMLDBAbstractCollectionManipulator {
         "$target-collection-uri. " + 
         XMLDBModule.COLLECTION_URI,
         new SequenceType[]{ ARG_SOURCE, ARG_TARGET },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)),
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)),
 
         new FunctionSignature(
         new QName("move", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
@@ -67,7 +67,7 @@ public class XMLDBMove extends XMLDBAbstractCollectionManipulator {
         "into collection $target-collection-uri. " +
         XMLDBModule.COLLECTION_URI,
         new SequenceType[]{ ARG_SOURCE, ARG_TARGET, ARG_RESOURCE },
-        new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE))
+        new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE))
     };
 
     public XMLDBMove(XQueryContext context, FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRemove.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRemove.java
@@ -50,7 +50,7 @@ public class XMLDBRemove extends XMLDBAbstractCollectionManipulator {
             XMLDBModule.COLLECTION_URI,
             new SequenceType[] {
                 new FunctionParameterSequenceType("collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collection URI")},
-            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
 		),
 		new FunctionSignature(
 			new QName("remove", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
@@ -59,7 +59,7 @@ public class XMLDBRemove extends XMLDBAbstractCollectionManipulator {
 			new SequenceType[] {
                 new FunctionParameterSequenceType("collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collection URI"),
                 new FunctionParameterSequenceType("resource", Type.STRING, Cardinality.EXACTLY_ONE, "The resource")},
-            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
 		)
 	};
 	

--- a/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRename.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/xmldb/XMLDBRename.java
@@ -54,7 +54,7 @@ public class XMLDBRename extends XMLDBAbstractCollectionManipulator {
 				new SequenceType[] {
                 new FunctionParameterSequenceType("source-collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The source collection URI"),
                 new FunctionParameterSequenceType("new-collection-name", Type.STRING, Cardinality.EXACTLY_ONE, "The new collection name")},
-            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
 		),
 		new FunctionSignature(
 			new QName("rename", XMLDBModule.NAMESPACE_URI, XMLDBModule.PREFIX),
@@ -64,7 +64,7 @@ public class XMLDBRename extends XMLDBAbstractCollectionManipulator {
                 new FunctionParameterSequenceType("collection-uri", Type.STRING, Cardinality.EXACTLY_ONE, "The collection URI"),
                 new FunctionParameterSequenceType("resource", Type.STRING, Cardinality.EXACTLY_ONE, "The resource"),
                 new FunctionParameterSequenceType("new-resource-name", Type.STRING, Cardinality.EXACTLY_ONE, "The new resource name")},
-            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
 		)
 	};
 	

--- a/exist-core/src/test/java/org/exist/storage/util/PauseFunction.java
+++ b/exist-core/src/test/java/org/exist/storage/util/PauseFunction.java
@@ -40,7 +40,7 @@ public class PauseFunction extends BasicFunction {
             new QName("pause", TestUtilModule.NAMESPACE_URI),
             "Pause for the specified number of seconds.",
             new SequenceType[] { new FunctionParameterSequenceType("seconds", Type.INT, Cardinality.EXACTLY_ONE, "Seconds to pause.") },
-            new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
         );
 
     public PauseFunction(XQueryContext context) {

--- a/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/SendEmailFunction.java
+++ b/extensions/modules/mail/src/main/java/org/exist/xquery/modules/mail/SendEmailFunction.java
@@ -98,7 +98,7 @@ public class SendEmailFunction extends BasicFunction {
                                     new FunctionParameterSequenceType("mail-handle", Type.LONG, Cardinality.EXACTLY_ONE, "The JavaMail session handle retrieved from mail:get-mail-session()"),
                                     new FunctionParameterSequenceType("email", Type.ELEMENT, Cardinality.ONE_OR_MORE, "The email message in the following format: <mail> <from/> <reply-to/> <to/> <cc/> <bcc/> <subject/> <message> <text/> <xhtml/> </message> <attachment filename=\"\" mimetype=\"\">xs:base64Binary</attachment> </mail>.")
                             },
-                    new SequenceType(Type.ITEM, Cardinality.EMPTY_SEQUENCE)
+                    new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
             )
     };
 


### PR DESCRIPTION
Backport of #4980 