### PR TITLE
Fix issues with Lucene Index optimisations and Matches

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/persistent/Match.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/Match.java
@@ -396,9 +396,8 @@ public abstract class Match implements Comparable<Match> {
         }
 
         if (obj instanceof Match other) {
-            return other.matchTerm != null
-                    && other.matchTerm.equals(matchTerm)
-                    && other.nodeId.equals(nodeId);
+            return other.nodeId.equals(nodeId)
+                    && ((other.matchTerm != null && other.matchTerm.equals(matchTerm)) || matchTerm == null);
         } else {
             return false;
         }

--- a/exist-core/src/main/java/org/exist/dom/persistent/Match.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/Match.java
@@ -391,6 +391,10 @@ public abstract class Match implements Comparable<Match> {
 
     @Override
     public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
         if (obj instanceof Match other) {
             return other.matchTerm != null
                     && other.matchTerm.equals(matchTerm)

--- a/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NewArrayNodeSet.java
@@ -107,7 +107,11 @@ public class NewArrayNodeSet extends AbstractArrayNodeSet implements ExtNodeSet,
     private NodeProxy nodes[];
 
     public NewArrayNodeSet() {
-        nodes = new NodeProxy[INITIAL_SIZE];
+        this(INITIAL_SIZE);
+    }
+
+    public NewArrayNodeSet(final int initialSize) {
+        nodes = new NodeProxy[initialSize];
     }
 
     public NewArrayNodeSet(final NewArrayNodeSet other) {

--- a/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
+++ b/exist-core/src/main/java/org/exist/dom/persistent/NodeProxy.java
@@ -213,8 +213,8 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
         this.nodeType = UNKNOWN_NODE_TYPE;
         this.internalAddress = StoredNode.UNKNOWN_NODE_IMPL_ADDRESS;
         this.nodeId = element.getNodeId();
-        match = null;
-        context = null;
+        this.match = null;
+        this.context = null;
     }
 
     /**
@@ -477,36 +477,41 @@ public class NodeProxy implements NodeSet, NodeValue, NodeHandle, DocumentSet, C
     }
 
     public void addMatch(final Match m) {
-        if(match == null) {
-            match = m;
-            match.nextMatch = null;
+        if (this.match == null) {
+            this.match = m;
+            if (match.getNextMatch() != null) {
+                match.setNextMatch(null);
+            }
             return;
         }
+
         Match next = match;
-        while(next != null) {
-            if(next.matchEquals(m)) {
+        while (next != null) {
+            if (next.equals(m)) {
                 next.mergeOffsets(m);
                 return;
             }
-            if(next.nextMatch == null) {
-                next.nextMatch = m;
+            if (next.getNextMatch() == null) {
+                next.setNextMatch(m);
                 break;
             }
-            next = next.nextMatch;
+            next = next.getNextMatch();
         }
     }
 
     public void addMatches(final NodeProxy p) {
-        if(p == this) {
+        if (p == this) {
             return;
         }
+
         Match m = p.getMatches();
-        if(Match.matchListEquals(m, this.match)) {
+        if (Match.matchListEquals(m, this.match)) {
             return;
         }
-        while(m != null) {
+
+        while (m != null) {
             addMatch(m.newCopy());
-            m = m.nextMatch;
+            m = m.getNextMatch();
         }
     }
 

--- a/exist-core/src/main/java/org/exist/xquery/CombiningExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/CombiningExpression.java
@@ -144,4 +144,12 @@ public abstract class CombiningExpression extends AbstractExpression {
         left.accept(visitor);
         right.accept(visitor);
     }
+
+	public PathExpr getLeft() {
+		return left;
+	}
+
+	public PathExpr getRight() {
+		return right;
+	}
 }

--- a/exist-core/src/main/java/org/exist/xquery/FilteredExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/FilteredExpression.java
@@ -29,6 +29,8 @@ import org.exist.dom.memtree.NodeImpl;
 import org.exist.xquery.util.ExpressionDumper;
 import org.exist.xquery.value.*;
 
+import javax.annotation.Nullable;
+
 /**
  * FilteredExpression represents a primary expression with a predicate. Examples:
  * for $i in (1 to 10)[$i mod 2 = 0], $a[1], (doc("test.xml")//section)[2]. Other predicate
@@ -38,17 +40,17 @@ import org.exist.xquery.value.*;
  */
 public class FilteredExpression extends AbstractExpression {
 
-    final protected Expression expression;
-    protected boolean abbreviated = false;
-    final protected List<Predicate> predicates = new ArrayList<>(2);
+    private final Expression expression;
+    private boolean abbreviated = false;
+    private final List<Predicate> predicates = new ArrayList<>(2);
     private Expression parent;
 
-    public FilteredExpression(XQueryContext context, Expression expr) {
+    public FilteredExpression(final XQueryContext context, final Expression expr) {
         super(context);
         this.expression = expr.simplify();
     }
 
-    public void addPredicate(Predicate pred) {
+    public void addPredicate(final Predicate pred) {
         predicates.add(pred);
     }
 
@@ -57,15 +59,14 @@ public class FilteredExpression extends AbstractExpression {
     }
 
     public Expression getExpression() {
-        if (expression instanceof PathExpr)
-            {return ((PathExpr)expression).getExpression(0);}
+        if (expression instanceof final PathExpr pathExpr) {
+            return pathExpr.getExpression(0);
+        }
         return expression;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#analyze(org.exist.xquery.AnalyzeContextInfo)
-     */
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    @Override
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         parent = contextInfo.getParent();
         contextInfo.setParent(this);
         expression.analyze(contextInfo);
@@ -80,28 +81,28 @@ public class FilteredExpression extends AbstractExpression {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#eval(org.exist.dom.persistent.DocumentSet, org.exist.xquery.value.Sequence, org.exist.xquery.value.Item)
-     */
-    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
+    @Nullable
+    public Sequence eval(Sequence contextSequence, final Item contextItem) throws XPathException {
         if (context.getProfiler().isEnabled()) {
             context.getProfiler().start(this);
-            context.getProfiler().message(this, Profiler.DEPENDENCIES,
-                "DEPENDENCIES", Dependency.getDependenciesName(this.getDependencies()));
-            if (contextSequence != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES,
-                    "CONTEXT SEQUENCE", contextSequence);}
-            if (contextItem != null)
-                {context.getProfiler().message(this, Profiler.START_SEQUENCES,
-                    "CONTEXT ITEM", contextItem.toSequence());}
+            context.getProfiler().message(this, Profiler.DEPENDENCIES, "DEPENDENCIES", Dependency.getDependenciesName(this.getDependencies()));
+            if (contextSequence != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT SEQUENCE", contextSequence);
+            }
+            if (contextItem != null) {
+                context.getProfiler().message(this, Profiler.START_SEQUENCES, "CONTEXT ITEM", contextItem.toSequence());
+            }
         }
-        if (contextItem != null)
-            {contextSequence = contextItem.toSequence();}
-        Sequence result;
+
+        if (contextItem != null) {
+            contextSequence = contextItem.toSequence();
+        }
+
+        final Sequence result;
         final Sequence seq = expression.eval(contextSequence, contextItem);
-        if (seq.isEmpty())
-            {result = Sequence.EMPTY_SEQUENCE;}
-        else {
+        if (seq.isEmpty()) {
+            result = Sequence.EMPTY_SEQUENCE;
+        } else {
             final Predicate pred = predicates.get(0);
             context.setContextSequencePosition(0, seq);
             // If the current step is an // abbreviated step, we have to treat the predicate
@@ -137,16 +138,16 @@ public class FilteredExpression extends AbstractExpression {
                 result = processPredicate(contextSequence, seq);
             }
         }
-        if (context.getProfiler().isEnabled())
-            {context.getProfiler().end(this, "", result);} 
+        if (context.getProfiler().isEnabled()) {
+            context.getProfiler().end(this, "", result);
+        }
         return result;
     }
 
-    private Sequence processPredicate(Sequence contextSequence, Sequence seq) throws XPathException {
-
-        int line=-1;
-        int column=-1;
-        try { // Keep try-catch out of loop
+    private Sequence processPredicate(@Nullable Sequence contextSequence, Sequence seq) throws XPathException {
+        int line = -1;
+        int column = -1;
+        try {  // Keep try-catch out of loop
             for (final Predicate pred : predicates) {
                 line = pred.getLine();
                 column = pred.getColumn();
@@ -154,7 +155,7 @@ public class FilteredExpression extends AbstractExpression {
                 //subsequent predicates operate on the result of the previous one
                 contextSequence = null;
             }
-        } catch (XPathException ex){
+        } catch (final XPathException ex) {
             // Add location to exception
             ex.setLocation(line,column);
             throw ex;
@@ -162,16 +163,15 @@ public class FilteredExpression extends AbstractExpression {
         return seq;
     }
 
-    /* (non-Javadoc)
-    * @see org.exist.xquery.Expression#dump(org.exist.xquery.util.ExpressionDumper)
-    */
-    public void dump(ExpressionDumper dumper) {
+    @Override
+    public void dump(final ExpressionDumper dumper) {
         expression.dump(dumper);
         for (final Predicate pred : predicates) {
             pred.dump(dumper);
         }
     }
 
+    @Override
     public String toString() {
         final StringBuilder result = new StringBuilder();
         result.append(expression.toString());
@@ -181,17 +181,13 @@ public class FilteredExpression extends AbstractExpression {
         return result.toString();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#returnsType()
-     */
+    @Override
     public int returnsType() {
         return expression.returnsType();
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.Expression#resetState()
-     */
-    public void resetState(boolean postOptimization) {
+    @Override
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
         expression.resetState(postOptimization);
         for (final Predicate pred : predicates) {
@@ -199,24 +195,21 @@ public class FilteredExpression extends AbstractExpression {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#setPrimaryAxis(int)
-     */
-    public void setPrimaryAxis(int axis) {
+    @Override
+    public void setPrimaryAxis(final int axis) {
         expression.setPrimaryAxis(axis);
     }
 
+    @Override
     public int getPrimaryAxis() {
         return expression.getPrimaryAxis();
     }
 
-    public void setAbbreviated(boolean abbrev) {
-        abbreviated = abbrev;
+    public void setAbbreviated(final boolean abbreviated) {
+        this.abbreviated = abbreviated;
     }
 
-    /* (non-Javadoc)
-     * @see org.exist.xquery.AbstractExpression#getDependencies()
-     */
+    @Override
     public int getDependencies() {
         int deps = Dependency.CONTEXT_SET;
         deps |= expression.getDependencies();
@@ -226,10 +219,12 @@ public class FilteredExpression extends AbstractExpression {
         return deps;
     }
 
-    public void accept(ExpressionVisitor visitor) {
+    @Override
+    public void accept(final ExpressionVisitor visitor) {
         visitor.visitFilteredExpr(this);
     }
 
+    @Override
     public Expression getParent() {
         return parent;
     }

--- a/exist-core/src/main/java/org/exist/xquery/LocationStep.java
+++ b/exist-core/src/main/java/org/exist/xquery/LocationStep.java
@@ -37,7 +37,6 @@ import javax.xml.stream.StreamFilter;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.IOException;
-import java.util.Iterator;
 
 /**
  * Processes all location path steps (like descendant::*, ancestor::XXX).

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -101,14 +101,15 @@ public class Optimizer extends DefaultExpressionVisitor {
             // walk through the predicates attached to the current location step.
             // try to find a predicate containing an expression which is an instance
             // of Optimizable.
+            final FindOptimizable find = new FindOptimizable();
             for (final Predicate pred : preds) {
-                final FindOptimizable find = new FindOptimizable();
                 pred.accept(find);
                 @Nullable final List<Optimizable> list = find.getOptimizables();
                 if (list != null && canOptimize(list)) {
                     optimize = true;
                     break;
                 }
+                find.reset();
             }
         }
 
@@ -216,13 +217,14 @@ public class Optimizer extends DefaultExpressionVisitor {
         // walk through the predicates attached to the current location step.
         // try to find a predicate containing an expression which is an instance
         // of Optimizable.
+        final FindOptimizable find = new FindOptimizable();
         for (final Predicate pred : preds) {
-            final FindOptimizable find = new FindOptimizable();
             pred.accept(find);
             @Nullable final List<Optimizable> list = find.getOptimizables();
             if (list != null && canOptimize(list)) {
                 return true;
             }
+            find.reset();
         }
         return false;
     }
@@ -418,6 +420,17 @@ public class Optimizer extends DefaultExpressionVisitor {
                     optimizables = new ArrayList<>(4);
                 }
                 optimizables.add(optimizable);
+            }
+        }
+
+        /**
+         * Reset this visitor for reuse.
+         *
+         * Clears the known {@link #optimizables}.
+         */
+        public void reset() {
+            if (optimizables != null) {
+                optimizables.clear();
             }
         }
     }

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -104,8 +104,8 @@ public class Optimizer extends DefaultExpressionVisitor {
             for (final Predicate pred : preds) {
                 final FindOptimizable find = new FindOptimizable();
                 pred.accept(find);
-                final List<Optimizable> list = find.getOptimizables();
-                if (list.size() > 0 && canOptimize(list)) {
+                @Nullable final List<Optimizable> list = find.getOptimizables();
+                if (list != null && canOptimize(list)) {
                     optimize = true;
                     break;
                 }
@@ -219,8 +219,8 @@ public class Optimizer extends DefaultExpressionVisitor {
         for (final Predicate pred : preds) {
             final FindOptimizable find = new FindOptimizable();
             pred.accept(find);
-            final List<Optimizable> list = find.getOptimizables();
-            if (list.size() > 0 && canOptimize(list)) {
+            @Nullable final List<Optimizable> list = find.getOptimizables();
+            if (list != null && canOptimize(list)) {
                 return true;
             }
         }
@@ -384,10 +384,9 @@ public class Optimizer extends DefaultExpressionVisitor {
      * Try to find an expression object implementing interface Optimizable.
      */
     public static class FindOptimizable extends BasicExpressionVisitor {
+        private List<Optimizable> optimizables = null;
 
-        private final List<Optimizable> optimizables = new ArrayList<>();
-
-        public List<Optimizable> getOptimizables() {
+        public @Nullable List<Optimizable> getOptimizables() {
             return optimizables;
         }
 
@@ -401,6 +400,9 @@ public class Optimizer extends DefaultExpressionVisitor {
 
         @Override
         public void visitGeneralComparison(final GeneralComparison comparison) {
+            if (optimizables == null) {
+                optimizables = new ArrayList<>(4);
+            }
             optimizables.add(comparison);
         }
 
@@ -412,6 +414,9 @@ public class Optimizer extends DefaultExpressionVisitor {
         @Override
         public void visitBuiltinFunction(final Function function) {
             if (function instanceof final Optimizable optimizable) {
+                if (optimizables == null) {
+                    optimizables = new ArrayList<>(4);
+                }
                 optimizables.add(optimizable);
             }
         }

--- a/exist-core/src/main/java/org/exist/xquery/Optimizer.java
+++ b/exist-core/src/main/java/org/exist/xquery/Optimizer.java
@@ -81,17 +81,17 @@ public class Optimizer extends DefaultExpressionVisitor {
 
         // check query rewriters if they want to rewrite the location step
         Pragma optimizePragma = null;
-        for (QueryRewriter rewriter : rewriters) {
-            try {
+        try {  // Keep try-catch out of loop
+            for (final QueryRewriter rewriter : rewriters) {
                 optimizePragma = rewriter.rewriteLocationStep(locationStep);
                 if (optimizePragma != null) {
                     // expression was rewritten: return
                     hasOptimized = true;
                     break;
                 }
-            } catch (XPathException e) {
-                LOG.warn("Exception called while rewriting location step: {}", e.getMessage(), e);
             }
+        } catch (final XPathException e) {
+            LOG.warn("Exception called while rewriting location step: {}", e.getMessage(), e);
         }
 
         boolean optimize = false;

--- a/exist-core/src/main/java/org/exist/xquery/Pragma.java
+++ b/exist-core/src/main/java/org/exist/xquery/Pragma.java
@@ -76,6 +76,6 @@ public abstract class Pragma {
 
     @Override
     public String toString() {
-        return "(# " + qname + ' ' + contents + "#)";
+        return "(# " + qname + (contents == null ? "" : ' ' + contents) + " #)";
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/Pragma.java
+++ b/exist-core/src/main/java/org/exist/xquery/Pragma.java
@@ -25,17 +25,19 @@ import org.exist.dom.QName;
 import org.exist.xquery.value.Item;
 import org.exist.xquery.value.Sequence;
 
+import javax.annotation.Nullable;
+
 public abstract class Pragma {
 
     private QName qname;
-    private String contents;
+    private @Nullable String contents;
     private Expression expression;
     
-    public Pragma(QName qname, String contents) throws XPathException {
+    public Pragma(final QName qname, final @Nullable String contents) throws XPathException {
         this(null, qname, contents);
     }
     
-    public Pragma(final Expression expression, QName qname, String contents) throws XPathException {
+    public Pragma(final Expression expression, final QName qname, @Nullable final String contents) throws XPathException {
         this.expression = expression;
         this.qname = qname;
         this.contents = contents;
@@ -45,21 +47,21 @@ public abstract class Pragma {
         return expression;
     }
 
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
     }
 
-    public Sequence eval(Sequence contextSequence, Item contextItem)
+    public Sequence eval(final Sequence contextSequence, @Nullable final Item contextItem)
     throws XPathException {
         return null;
     }
     
-    public abstract void before(XQueryContext context, Sequence contextSequence) throws XPathException;
+    public abstract void before(final XQueryContext context, final Sequence contextSequence) throws XPathException;
     
-    public abstract void before(XQueryContext context, final Expression expression, Sequence contextSequence) throws XPathException;
+    public abstract void before(final XQueryContext context, final Expression expression, final Sequence contextSequence) throws XPathException;
     
-    public abstract void after(XQueryContext context) throws XPathException;
+    public abstract void after(final XQueryContext context) throws XPathException;
     
-    public abstract void after(XQueryContext context, final Expression expression) throws XPathException;
+    public abstract void after(final XQueryContext context, final Expression expression) throws XPathException;
 
     protected String getContents() {
         return contents;
@@ -69,9 +71,10 @@ public abstract class Pragma {
         return qname;
     }
 
-    public void resetState(boolean postOptimization) {    
+    public void resetState(final boolean postOptimization) {
     }
 
+    @Override
     public String toString() {
         return "(# " + qname + ' ' + contents + "#)";
     }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
@@ -102,16 +102,18 @@ public class LuceneConfig {
     	this.facetsConfig = other.facetsConfig;
     }
     
-    public boolean matches(NodePath path) {
+    public boolean matches(final NodePath path) {
         LuceneIndexConfig idxConf = paths.get(path.getLastComponent());
         while (idxConf != null) {
-            if (idxConf.match(path))
+            if (idxConf.match(path)) {
                 return true;
+            }
             idxConf = idxConf.getNext();
         }
-        for (LuceneIndexConfig config : wildcardPaths) {
-            if (config.match(path))
+        for (final LuceneIndexConfig config : wildcardPaths) {
+            if (config.match(path)) {
                 return true;
+            }
         }
         return false;
     }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneConfig.java
@@ -31,6 +31,7 @@ import org.apache.lucene.queryparser.classic.QueryParserBase;
 import org.exist.dom.QName;
 import org.exist.indexing.lucene.analyzers.NoDiacriticsStandardAnalyzer;
 import org.exist.storage.NodePath;
+import org.exist.storage.NodePath2;
 import org.exist.util.DatabaseConfigurationException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -100,6 +101,31 @@ public class LuceneConfig {
     	this.boost = other.boost;
     	this.analyzers = other.analyzers;
     	this.facetsConfig = other.facetsConfig;
+    }
+
+    /**
+     * Determines probabilistically if there might be a configured index
+     * for the QName. False positive matches are possible,
+     * but false negatives are not.
+     *
+     * @param qname the element/attribute to look for an index configuration for.
+     *
+     * @return true indicates that there might be a config, false indicates
+     *     that there definitely is not a config.
+     */
+    public boolean hasConfig(final QName qname) {
+        if (paths.containsKey(qname)) {
+            return true;
+        } else {
+            final NodePath2 path = new NodePath2();
+            path.addComponent(qname);
+            for (final LuceneIndexConfig config : wildcardPaths) {
+                if (config.match(path)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
     
     public boolean matches(final NodePath path) {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndex.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneIndex.java
@@ -253,7 +253,7 @@ public class LuceneIndex extends AbstractIndex implements RawBackupSupport {
         }
     }
 
-    public <R> R withSearcher(Function2E<SearcherTaxonomyManager.SearcherAndTaxonomy, R, IOException, XPathException> consumer) throws IOException, XPathException {
+    public <R> R withSearcher(final Function2E<SearcherTaxonomyManager.SearcherAndTaxonomy, R, IOException, XPathException> consumer) throws IOException, XPathException {
         searcherManager.maybeRefreshBlocking();
         final SearcherTaxonomyManager.SearcherAndTaxonomy searcher = searcherManager.acquire();
         try {

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -98,8 +98,9 @@ public class LuceneMatch extends Match {
         }
 
         if (obj instanceof LuceneMatch other) {
-            return getNodeId().equals(other.getNodeId())
-                    && query.equals(other.query);
+            return luceneDocId == other.luceneDocId
+                    && query.equals(other.query)
+                    && super.equals(other);
         } else {
             return false;
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -93,6 +93,10 @@ public class LuceneMatch extends Match {
     // DW: missing hashCode() ?
     @Override
     public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
         if (obj instanceof LuceneMatch other) {
             return getNodeId().equals(other.getNodeId())
                     && query.equals(other.query);

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -95,7 +95,7 @@ public class LuceneMatch extends Match {
     public boolean equals(final Object obj) {
         if (obj instanceof LuceneMatch other) {
             return getNodeId().equals(other.getNodeId())
-                    && query == (other).query;
+                    && query.equals(other.query);
         } else {
             return false;
         }

--- a/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/indexing/lucene/LuceneMatch.java
@@ -25,13 +25,8 @@ import org.apache.lucene.facet.Facets;
 import org.apache.lucene.search.Query;
 import org.exist.dom.persistent.Match;
 import org.exist.numbering.NodeId;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.value.AtomicValue;
-import org.exist.xquery.value.Sequence;
-import org.exist.xquery.value.ValueSequence;
 
 import javax.annotation.Nullable;
-import java.util.Map;
 
 /**
  * Match class containing the score of a match and a reference to
@@ -39,13 +34,11 @@ import java.util.Map;
  */
 public class LuceneMatch extends Match {
 
-    private int luceneDocId = -1;
+    private final int luceneDocId;
     private float score = 0.0f;
     private final Query query;
 
-    private LuceneIndexWorker.LuceneFacets facets;
-
-    private Map<String, FieldValue[]> fields = null;
+    private final LuceneIndexWorker.LuceneFacets facets;
 
     LuceneMatch(final int contextId, final int luceneDocId, final NodeId nodeId, final Query query, final LuceneIndexWorker.LuceneFacets facets) {
         super(contextId, nodeId, null);
@@ -54,18 +47,17 @@ public class LuceneMatch extends Match {
         this.facets = facets;
     }
 
-    private LuceneMatch(LuceneMatch copy) {
+    private LuceneMatch(final LuceneMatch copy) {
         super(copy);
         this.score = copy.score;
         this.luceneDocId = copy.luceneDocId;
         this.query = copy.query;
         this.facets = copy.facets;
-        this.fields = copy.fields;
     }
 
     @Override
-    public Match createInstance(int contextId, NodeId nodeId, String matchTerm) {
-        return null;
+    public Match createInstance(final int contextId, final NodeId nodeId, @Nullable final String matchTerm) {
+        throw new UnsupportedOperationException("Not supported from Lucene Full-Text Index");
     }
 
     public int getLuceneDocId() {
@@ -90,7 +82,7 @@ public class LuceneMatch extends Match {
         return score;
     }
 
-    protected void setScore(float score) {
+    protected void setScore(final float score) {
         this.score = score;
     }
 
@@ -98,41 +90,14 @@ public class LuceneMatch extends Match {
         return this.facets.getFacets();
     }
 
-    public @Nullable
-    Sequence getField(String name, int type) throws XPathException {
-        if (fields == null) {
-            return null;
-        }
-        final FieldValue[] values = fields.get(name);
-        if (values.length == 1) {
-            return values[0].getValue(type);
-        }
-        final ValueSequence result = new ValueSequence(values.length);
-        for (FieldValue value: values) {
-            result.add(value.getValue(type));
-        }
-        return result;
-    }
-
     // DW: missing hashCode() ?
     @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof LuceneMatch)) {
+    public boolean equals(final Object obj) {
+        if (obj instanceof LuceneMatch other) {
+            return getNodeId().equals(other.getNodeId())
+                    && query == (other).query;
+        } else {
             return false;
         }
-        LuceneMatch o = (LuceneMatch) other;
-        return (nodeId == o.nodeId || nodeId.equals(o.nodeId))
-                && query == ((LuceneMatch) other).query;
     }
-
-    @Override
-    public boolean matchEquals(Match other) {
-        return equals(other);
-    }
-
-    private interface FieldValue {
-
-        AtomicValue getValue(int type) throws XPathException;
-    }
-
 }

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/Query.java
@@ -37,7 +37,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.exist.xquery.FunctionDSL.*;

--- a/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
+++ b/extensions/indexes/lucene/src/main/java/org/exist/xquery/modules/lucene/QueryField.java
@@ -21,81 +21,63 @@
  */
 package org.exist.xquery.modules.lucene;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.exist.dom.persistent.DocumentSet;
 import org.exist.dom.persistent.NodeSet;
-import org.exist.dom.QName;
 import org.exist.indexing.lucene.LuceneIndex;
 import org.exist.indexing.lucene.LuceneIndexWorker;
 import org.exist.xquery.*;
 import org.exist.xquery.value.*;
 import org.w3c.dom.Element;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
-public class QueryField extends Query implements Optimizable {
-	
-	protected static final Logger logger = LogManager.getLogger(Query.class);
+import static org.exist.xquery.FunctionDSL.*;
+import static org.exist.xquery.modules.lucene.LuceneModule.functionSignatures;
 
-    public final static FunctionSignature[] signatures = {
-        new FunctionSignature(
-            new QName("query-field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
+public class QueryField extends Query implements Optimizable {
+
+    private static final FunctionParameterSequenceType FS_PARAM_FIELD = optManyParam("field", Type.STRING, "The lucene field name.");
+    private static final FunctionParameterSequenceType FS_PARAM_QUERY = param("query", Type.ITEM, "The query to search for, provided either as a string or text in Lucene's default query syntax or as an XML fragment to bypass Lucene's default query parser");
+
+    final static FunctionSignature[] signatures = functionSignatures(
+            "query-field",
             "Queries a Lucene field, which has to be explicitely created in the index configuration.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("field", Type.STRING, Cardinality.ZERO_OR_MORE,
-                		"The lucene field name."),
-                new FunctionParameterSequenceType("query", Type.ITEM, Cardinality.EXACTLY_ONE, 
-                		"The query to search for, provided either as a string or text in Lucene's default query " +
-                		"syntax or as an XML fragment to bypass Lucene's default query parser")
-            },
-            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
-                "all nodes from the input node set matching the query. match highlighting information " +
-                "will be available for all returned nodes. Lucene's match score can be retrieved via " +
-                "the ft:score function."),
-            "Use an index definition with nested fields and ft:query instead"
-        ),
-        new FunctionSignature(
-            new QName("query-field", LuceneModule.NAMESPACE_URI, LuceneModule.PREFIX),
-            "Queries a Lucene field, which has to be explicitely created in the index configuration.",
-            new SequenceType[] {
-                new FunctionParameterSequenceType("field", Type.STRING, Cardinality.ZERO_OR_MORE,
-                		"The lucene field name."),
-                new FunctionParameterSequenceType("query", Type.ITEM, Cardinality.EXACTLY_ONE,
-                		"The query to search for, provided either as a string or text in Lucene's default query " +
-                		"syntax or as an XML fragment to bypass Lucene's default query parser"),
-                new FunctionParameterSequenceType("options", Type.NODE, Cardinality.ZERO_OR_ONE,
-                		"An XML fragment containing options to be passed to Lucene's query parser. The following " +
-                        "options are supported (a description can be found in the docs):\n" +
-                        "<options>\n" +
-                        "   <default-operator>and|or</default-operator>\n" +
-                        "   <phrase-slop>number</phrase-slop>\n" +
-                        "   <leading-wildcard>yes|no</leading-wildcard>\n" +
-                        "   <filter-rewrite>yes|no</filter-rewrite>\n" +
-                        "</options>")
-            },
-            new FunctionReturnSequenceType(Type.NODE, Cardinality.ZERO_OR_MORE,
-                "all nodes from the input node set matching the query. match highlighting information " +
-                "will be available for all returned nodes. Lucene's match score can be retrieved via " +
-                "the ft:score function."),
-            "Use an index definition with nested fields and ft:query instead"
-        )
-    };
+            returnsOptMany(Type.NODE, """
+                    all nodes from the input node set matching the query. match highlighting information
+                    will be available for all returned nodes. Lucene's match score can be retrieved via
+                    the ft:score function."""),
+            arities(
+                    arity(
+                            FS_PARAM_FIELD,
+                            FS_PARAM_QUERY
+                    ),
+                    arity(
+                            FS_PARAM_FIELD,
+                            FS_PARAM_QUERY,
+                            optParam("options", Type.ITEM, """
+                                    An XML fragment or XDM Map containing options to be passed to Lucene's query parser. The following
+                                    options are supported (a description can be found in the docs):
+                                    <options>
+                                       <default-operator>and|or</default-operator>
+                                       <phrase-slop>number</phrase-slop>
+                                       <leading-wildcard>yes|no</leading-wildcard>
+                                       <filter-rewrite>yes|no</filter-rewrite>
+                                    </options>"""
+                            )
+                    )
+            )
+    );
 
     private NodeSet preselectResult = null;
 
-    public QueryField(XQueryContext context, FunctionSignature signature) {
+    public QueryField(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);
     }
 
-    /* (non-Javadoc)
-    * @see org.exist.xquery.PathExpr#analyze(org.exist.xquery.Expression)
-    */
-
     @Override
-    public void analyze(AnalyzeContextInfo contextInfo) throws XPathException {
+    public void analyze(final AnalyzeContextInfo contextInfo) throws XPathException {
         super.analyze(new AnalyzeContextInfo(contextInfo));
-
         this.contextId = contextInfo.getContextId();
     }
 
@@ -104,78 +86,87 @@ public class QueryField extends Query implements Optimizable {
         return contextSequence;  // always optimizable!
     }
 
+    @Override
     public int getOptimizeAxis() {
         return Constants.DESCENDANT_SELF_AXIS;
     }
 
-    public NodeSet preSelect(Sequence contextSequence, boolean useContext) throws XPathException {
-        long start = System.currentTimeMillis();
+    @Override
+    public NodeSet preSelect(final Sequence contextSequence, final boolean useContext) throws XPathException {
+        final long start = System.currentTimeMillis();
         // the expression can be called multiple times, so we need to clear the previous preselectResult
         preselectResult = null;
-        LuceneIndexWorker index = (LuceneIndexWorker)
-                context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
-        String field = getArgument(0).eval(contextSequence).getStringValue();
-        DocumentSet docs = contextSequence.getDocumentSet();
-        Item query = getKey(contextSequence, null);
-        QueryOptions options = parseOptions(this, contextSequence, null, 3);
+
+        final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+        final String field = getArgument(0).eval(contextSequence).getStringValue();
+        final DocumentSet docs = contextSequence.getDocumentSet();
+        final Item query = getKey(contextSequence, null);
+        final QueryOptions options = parseOptions(this, contextSequence, null, 3);
         try {
-            if (Type.subTypeOf(query.getType(), Type.ELEMENT))
-                preselectResult = index.queryField(getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null,
-                    field, (Element) ((NodeValue)query).getNode(), NodeSet.DESCENDANT, options);
-            else
-                preselectResult = index.queryField(context, getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null,
-                    field, query.getStringValue(), NodeSet.DESCENDANT, options);
-        } catch (IOException e) {
+            if (Type.subTypeOf(query.getType(), Type.ELEMENT)) {
+                preselectResult = index.queryField(getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null, field, (Element) ((NodeValue) query).getNode(), NodeSet.DESCENDANT, options);
+            } else {
+                preselectResult = index.queryField(context, getExpressionId(), docs, useContext ? contextSequence.toNodeSet() : null, field, query.getStringValue(), NodeSet.DESCENDANT, options);
+            }
+        } catch (final IOException e) {
             throw new XPathException(this, "Error while querying full text index: " + e.getMessage(), e);
         }
+
         LOG.debug("Lucene query took {}", System.currentTimeMillis() - start);
-        if( context.getProfiler().traceFunctions() ) {
-            context.getProfiler().traceIndexUsage( context, "lucene", this, PerformanceStats.OPTIMIZED_INDEX, System.currentTimeMillis() - start );
+
+        if (context.getProfiler().traceFunctions()) {
+            context.getProfiler().traceIndexUsage(context, "lucene", this, PerformanceStats.OPTIMIZED_INDEX, System.currentTimeMillis() - start);
         }
+
         return preselectResult;
     }
 
-    public Sequence eval(Sequence contextSequence, Item contextItem) throws XPathException {
-    	
-        if (contextItem != null)
+    @Override
+    public Sequence eval(Sequence contextSequence, @Nullable final Item contextItem) throws XPathException {
+        if (contextItem != null) {
             contextSequence = contextItem.toSequence();
+        }
 
-        NodeSet result;
+        final NodeSet result;
         if (preselectResult == null) {
-        	long start = System.currentTimeMillis();
-        	String field = getArgument(0).eval(contextSequence).getStringValue();
+        	final long start = System.currentTimeMillis();
+        	final String field = getArgument(0).eval(contextSequence).getStringValue();
+        	final Item query = getKey(contextSequence, null);
         	
-        	Item query = getKey(contextSequence, null);
-        	
-        	DocumentSet docs = null;
-        	if (contextSequence == null)
-        		docs = context.getStaticallyKnownDocuments();
-        	else
+        	final DocumentSet docs;
+        	if (contextSequence == null) {
+                docs = context.getStaticallyKnownDocuments();
+            } else {
                 docs = contextSequence.getDocumentSet();
+            }
 
-        	NodeSet contextSet = null;
-        	if (contextSequence != null)
-        		contextSet = contextSequence.toNodeSet();
+        	final NodeSet contextSet;
+        	if (contextSequence != null) {
+                contextSet = contextSequence.toNodeSet();
+            } else {
+                contextSet = null;
+            }
         	
-        	LuceneIndexWorker index = (LuceneIndexWorker)
-        		context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
-        	QueryOptions options = parseOptions(this, contextSequence, contextItem, 3);
+        	final LuceneIndexWorker index = (LuceneIndexWorker) context.getBroker().getIndexController().getWorkerByIndexId(LuceneIndex.ID);
+        	final QueryOptions options = parseOptions(this, contextSequence, contextItem, 3);
         	try {
-        		if (Type.subTypeOf(query.getType(), Type.ELEMENT))
-        			result = index.queryField(getExpressionId(), docs, contextSet, field,
-        					(Element)((NodeValue)query).getNode(), NodeSet.ANCESTOR, options);
-        		else
-        			result = index.queryField(context, getExpressionId(), docs, contextSet, field,
-        					query.getStringValue(), NodeSet.ANCESTOR, options);
-            } catch (IOException e) {
+        		if (Type.subTypeOf(query.getType(), Type.ELEMENT)) {
+                    result = index.queryField(getExpressionId(), docs, contextSet, field, (Element) ((NodeValue) query).getNode(), NodeSet.ANCESTOR, options);
+                } else {
+                    result = index.queryField(context, getExpressionId(), docs, contextSet, field, query.getStringValue(), NodeSet.ANCESTOR, options);
+                }
+            } catch (final IOException e) {
         		throw new XPathException(this, e.getMessage());
         	}
-        	if( context.getProfiler().traceFunctions() ) {
-        		context.getProfiler().traceIndexUsage( context, "lucene", this, PerformanceStats.BASIC_INDEX, System.currentTimeMillis() - start );
+
+        	if (context.getProfiler().traceFunctions()) {
+        		context.getProfiler().traceIndexUsage(context, "lucene", this, PerformanceStats.BASIC_INDEX, System.currentTimeMillis() - start);
         	}
+
         } else {
             result = preselectResult.selectAncestorDescendant(contextSequence.toNodeSet(), NodeSet.DESCENDANT, true, getContextId(), true);
         }
+
         return result;
     }
 
@@ -185,7 +176,7 @@ public class QueryField extends Query implements Optimizable {
     }
 
     @Override
-    public void resetState(boolean postOptimization) {
+    public void resetState(final boolean postOptimization) {
         super.resetState(postOptimization);
         if (!postOptimization) {
             preselectResult = null;

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -145,6 +145,9 @@ declare variable $facet:MULTI_LANGUAGE :=
             </div>
         </body>
         <body xml:lang="en">
+            <span>
+                <p>The sun was shining</p>
+            </span>
             <div>
                 <p>And the birds are singing</p>
             </div>
@@ -259,6 +262,12 @@ declare variable $facet:XCONF1 :=
                     <facet dimension="language" expression="ancestor::body/@xml:lang"/>
                     <ignore qname="note"/>
                 </text>
+                <text match="/text/body/span" index="no">
+                    <field name="german2" if="ancestor::body[@xml:lang = 'de']" analyzer="german"/>
+                    <field name="english2" if="ancestor::body[@xml:lang = 'en']" analyzer="english"/>
+                    <facet dimension="language" expression="ancestor::body/@xml:lang"/>
+                    <ignore qname="note"/>
+                </text>`
                 <text qname="person">
                     <facet dimension="city" expression="idx:city-id-to-label(city-id)"/>
                 </text>
@@ -972,6 +981,31 @@ declare
     %test:assertEquals("1 1")
 function facet:query-no-default-index-bracketed-element-one-nonexistent-element-count-and-facets() {
     let $result := doc("/db/lucenetest/multi-lang.xml")//(div|other)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result) || " " || ft:facets($result, "language")?en
+};
+
+
+declare
+    %test:assertEquals(2)
+function facet:query-no-default-index-bracketed-two-elements-count() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|span)[ft:query(., "english:* OR english2:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result)
+};
+
+declare
+    %test:assertEquals(2)
+function facet:query-no-default-index-bracketed-two-elements-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|span)[ft:query(., "english:* OR english2:*", map { "leading-wildcard": "yes" })]
+    return
+        ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals("2 2")
+function facet:query-no-default-index-bracketed-two-elements-count-and-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|span)[ft:query(., "english:* OR english2:*", map { "leading-wildcard": "yes" })]
     return
         count($result) || " " || ft:facets($result, "language")?en
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -21,9 +21,11 @@
  :)
 xquery version "3.1";
 
-module namespace facet="http://exist-db.org/xquery/lucene/test/facets";
+module namespace facet = "http://exist-db.org/xquery/lucene/test/facets";
 
-declare namespace test="http://exist-db.org/xquery/xqsuite";
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+import module namespace ft = "http://exist-db.org/xquery/lucene";
 
 declare variable $facet:XML :=
     <letters>
@@ -900,4 +902,52 @@ function facet:query-and-sort-by-binary-dateTime() {
     order by ft:binary-field($letter, "dateTime-binary", "xs:dateTime")
     return
         $letter/from/text()
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-count() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//div[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result)
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//div[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals("1 1")
+function facet:query-no-default-index-count-and-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//div[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result) || " " || ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-bracketed-element-count() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result)
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-bracketed-element-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals("1 1")
+function facet:query-no-default-index-bracketed-element-count-and-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result) || " " || ft:facets($result, "language")?en
 };

--- a/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
+++ b/extensions/indexes/lucene/src/test/xquery/lucene/facets.xql
@@ -951,3 +951,27 @@ function facet:query-no-default-index-bracketed-element-count-and-facets() {
     return
         count($result) || " " || ft:facets($result, "language")?en
 };
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-bracketed-element-one-nonexistent-element-count() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|other)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result)
+};
+
+declare
+    %test:assertEquals(1)
+function facet:query-no-default-index-bracketed-element-one-nonexistent-element-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|other)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        ft:facets($result, "language")?en
+};
+
+declare
+    %test:assertEquals("1 1")
+function facet:query-no-default-index-bracketed-element-one-nonexistent-element-count-and-facets() {
+    let $result := doc("/db/lucenetest/multi-lang.xml")//(div|other)[ft:query(., "english:*", map { "leading-wildcard": "yes" })]
+    return
+        count($result) || " " || ft:facets($result, "language")?en
+};

--- a/extensions/indexes/ngram/src/main/java/org/exist/indexing/ngram/NGramMatch.java
+++ b/extensions/indexes/ngram/src/main/java/org/exist/indexing/ngram/NGramMatch.java
@@ -26,20 +26,20 @@ import org.exist.numbering.NodeId;
 
 public class NGramMatch extends Match {
 
-    public NGramMatch(int contextId, NodeId nodeId, String matchTerm) {
+    public NGramMatch(final int contextId, final NodeId nodeId, final String matchTerm) {
         super(contextId, nodeId, matchTerm);
     }
 
-    public NGramMatch(int contextId, NodeId nodeId, String matchTerm, int frequency) {
+    public NGramMatch(final int contextId, final NodeId nodeId, final String matchTerm, final int frequency) {
         super(contextId, nodeId, matchTerm, frequency);
     }
 
-    public NGramMatch(Match match) {
+    public NGramMatch(final Match match) {
         super(match);
     }
 
     @Override
-    public Match createInstance(int contextId, NodeId nodeId, String matchTerm) {
+    public Match createInstance(final int contextId, final NodeId nodeId, final String matchTerm) {
         return new NGramMatch(contextId, nodeId, matchTerm);
     }
 

--- a/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/OptimizeFieldPragma.java
+++ b/extensions/indexes/range/src/main/java/org/exist/xquery/modules/range/OptimizeFieldPragma.java
@@ -259,7 +259,7 @@ public class OptimizeFieldPragma extends Pragma {
                 Expression optimizedExpr = new InternalFunctionCall(func);
                 if (!notOptimizable.isEmpty()) {
                     final FilteredExpression filtered = new FilteredExpression(context, optimizedExpr);
-                    for (Predicate pred : notOptimizable) {
+                    for (final Predicate pred : notOptimizable) {
                         filtered.addPredicate(pred);
                     }
                     optimizedExpr = filtered;


### PR DESCRIPTION
Closes https://github.com/eXist-db/exist/issues/3207

Fixes a number of bugs whereby too many Matches were set from `ft:query` and several potentially optimisable expressions were not correctly optimised.

----
This open source contribution to the eXist-db project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.