### PR TITLE
Log exception if the response is already committed

### DIFF
--- a/exist-core/src/main/java/org/exist/http/servlets/EXistServlet.java
+++ b/exist-core/src/main/java/org/exist/http/servlets/EXistServlet.java
@@ -331,7 +331,7 @@ public class EXistServlet extends AbstractExistHttpServlet {
 
         } catch (final BadRequestException e) {
             if (response.isCommitted()) {
-                throw new ServletException(e.getMessage());
+                throw new ServletException(e.getMessage(), e);
             }
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
 


### PR DESCRIPTION
The exception was missing for a `BadRequestException` in this one location