### PR TITLE
[6.x.x] Correct the XDM type for the Sequence holding a representation of a Java Stack Trace when an error occurs

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
+++ b/exist-core/src/main/java/org/exist/xquery/TryCatchExpression.java
@@ -530,7 +530,7 @@ public class TryCatchExpression extends AbstractExpression {
     
     private void addJavaTrace(final Throwable t) throws XPathException  {
         final LocalVariable localVar = new LocalVariable(QN_JAVA_STACK_TRACE);
-        localVar.setSequenceType(new SequenceType(Type.QNAME, Cardinality.ZERO_OR_MORE));
+        localVar.setSequenceType(new SequenceType(Type.STRING, Cardinality.ZERO_OR_MORE));
 
         final Sequence trace;
 		if (t != null && t.getStackTrace() != null) {


### PR DESCRIPTION
Backport of https://github.com/eXist-db/exist/pull/4992