### PR TITLE
[6.x.x] Fix the use of Debian Stretch repositories in the Docker builds

### DIFF
--- a/exist-docker/src/main/resources-filtered/Dockerfile
+++ b/exist-docker/src/main/resources-filtered/Dockerfile
@@ -22,6 +22,8 @@
 
 # Install latest JRE 8 in Debian Stretch (which is the base of gcr.io/distroless/java:8)
 FROM debian:stretch-slim as updated-jre
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian stretch-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y dist-upgrade
 RUN apt-get install -y openjdk-8-jre-headless
 RUN apt-get install -y expat fontconfig     # Install tools required by FOP

--- a/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
+++ b/exist-docker/src/main/resources-filtered/Dockerfile-DEBUG
@@ -22,6 +22,8 @@
 
 # Use JDK 8 in Debian Stretch (as our production image gcr.io/distroless/java:8 is based on Debian Stretch with just a JRE)
 FROM debian:stretch-slim
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian stretch-backports main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get -y dist-upgrade
 RUN apt-get install -y openjdk-8-jdk-headless
 RUN apt-get install -y expat fontconfig     # Install tools required by FOP


### PR DESCRIPTION
Debian deb repositories for Debian Stretch have been moved to archive.debian.org