### PR TITLE
[6.x.x] Fix an issue with XQuery transient imports within EXPath Package

### DIFF
--- a/exist-core/src/main/java/org/exist/client/InteractiveClient.java
+++ b/exist-core/src/main/java/org/exist/client/InteractiveClient.java
@@ -2190,7 +2190,7 @@ public class InteractiveClient {
                 configFile = Optional.ofNullable(ConfigurationHelper.lookup((String) CONF_XML.get("")));
             }
         }
-        configFile.ifPresent(value -> properties.setProperty(CONFIGURATION, value.toAbsolutePath().toString()));
+        configFile.ifPresent(value -> properties.setProperty(CONFIGURATION, value.toString()));
 
         properties.putAll(loadClientProperties());
 

--- a/exist-core/src/main/java/org/exist/util/Configuration.java
+++ b/exist-core/src/main/java/org/exist/util/Configuration.java
@@ -127,6 +127,8 @@ public class Configuration implements ErrorHandler
         InputStream is = null;
         try {
 
+            existHomeDirname = existHomeDirname.map(Path::normalize);
+
             if(configFilename == null) {
                 // Default file name
                 configFilename = DatabaseImpl.CONF_XML;
@@ -163,7 +165,6 @@ public class Configuration implements ErrorHandler
                         configFilename = FileUtils.fileName(absoluteConfigFile);
                     }
                 }
-
 
                 Path configFile = Paths.get(configFilename);
 
@@ -863,15 +864,15 @@ public class Configuration implements ErrorHandler
         final String dataFiles = getConfigAttributeValue( con, BrokerPool.DATA_DIR_ATTRIBUTE );
 
         if (dataFiles != null) {
-            final Path df = ConfigurationHelper.lookup( dataFiles, dbHome );
+            final Path df = ConfigurationHelper.lookup(dataFiles, dbHome);
             if (!Files.isReadable(df)) {
                 try {
                     Files.createDirectories(df);
                 } catch (final IOException ioe) {
-                    throw new DatabaseConfigurationException("cannot read data directory: " + df.toAbsolutePath().toString(), ioe);
+                    throw new DatabaseConfigurationException("cannot read data directory: " + df, ioe);
                 }
             }
-            config.put(BrokerPool.PROPERTY_DATA_DIR, df.toAbsolutePath());
+            config.put(BrokerPool.PROPERTY_DATA_DIR, df);
             LOG.debug(BrokerPool.PROPERTY_DATA_DIR + ": {}", config.get(BrokerPool.PROPERTY_DATA_DIR));
         }
 
@@ -1090,9 +1091,9 @@ public class Configuration implements ErrorHandler
             final Path rf = ConfigurationHelper.lookup( option, dbHome );
 
             if(!Files.isReadable(rf)) {
-                throw new DatabaseConfigurationException( "cannot read data directory: " + rf.toAbsolutePath());
+                throw new DatabaseConfigurationException( "cannot read data directory: " + rf);
             }
-            setProperty(Journal.PROPERTY_RECOVERY_JOURNAL_DIR, rf.toAbsolutePath());
+            setProperty(Journal.PROPERTY_RECOVERY_JOURNAL_DIR, rf);
             LOG.debug(Journal.PROPERTY_RECOVERY_JOURNAL_DIR + ": {}", config.get(Journal.PROPERTY_RECOVERY_JOURNAL_DIR));
         }
 

--- a/exist-core/src/main/java/org/exist/util/SingleInstanceConfiguration.java
+++ b/exist-core/src/main/java/org/exist/util/SingleInstanceConfiguration.java
@@ -66,7 +66,7 @@ public class SingleInstanceConfiguration extends Configuration {
     public static Optional<Path> getPath() {
         if (!_configFile.isPresent()) {
             final Path f = ConfigurationHelper.lookup("conf.xml");
-            return Optional.of(f.toAbsolutePath());
+            return Optional.of(f);
         }
         return _configFile;
     }

--- a/exist-parent/pom.xml
+++ b/exist-parent/pom.xml
@@ -394,7 +394,7 @@
             <dependency>
                 <groupId>org.expath.packaging</groupId>
                 <artifactId>pkg-java</artifactId>
-                <version>2.0.0</version>
+                <version>2.0.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
1. Given two EXPath Packages: `PkgA` and `PkgB`.
2. `PkgA` exports an XQuery Library Module via its `expath-pkg.xml` descriptor:
    ```xml
   <xquery>
      <namespace>https://pkgA/service</namespace>
      <file>modules/service.xqm</file>
   </xquery>
    ```
3. `PkgA`'s `modules/service.xqm` imports an XQuery Module - `config.xqm`, i.e..: `import module namespace config = "https://pkgA/config" at "config.xqm";`
4. `PkgB` contains an XQuery Library Module which imports `service.xqm` from `PkgA`, i.e.: `import module namespace validation-service = "https://pkgA/service";`

When the XQuery Library Module from `PkgB` was used, it would fail to compile as it attempted to import `PkgA`, but the compilation of `PkgA` was looking in the wrong location to find the code for `config.xqm`.

This PR fixes the above issue with transient imports of XQuery Library Modules when they are within EXPath Pkg.