### PR TITLE
Rename Function flag overloaded to variadic

### DIFF
--- a/exist-core/src/main/java/org/exist/xquery/Function.java
+++ b/exist-core/src/main/java/org/exist/xquery/Function.java
@@ -219,7 +219,7 @@ public abstract class Function extends PathExpr {
      * @throws XPathException if an error occurs setting the arguments
      */
     public void setArguments(final List<Expression> arguments) throws XPathException {
-        if ((!mySignature.isOverloaded()) && arguments.size() != mySignature.getArgumentCount()) {
+        if ((!mySignature.isVariadic()) && arguments.size() != mySignature.getArgumentCount()) {
             throw new XPathException(this, ErrorCodes.XPST0017,
                     "Number of arguments of function " + getName() + " doesn't match function signature (expected " +
                             mySignature.getArgumentCount() + ", got " + arguments.size() + ')');

--- a/exist-core/src/main/java/org/exist/xquery/FunctionSignature.java
+++ b/exist-core/src/main/java/org/exist/xquery/FunctionSignature.java
@@ -60,7 +60,7 @@ public class FunctionSignature {
     private final QName name;
     private SequenceType[] arguments;
     private SequenceType returnType;
-    private boolean isOverloaded = false;
+    private boolean isVariadic = false;
     private String description = null;
     private String deprecated = null;
     private Map<String, String> metadata = null;
@@ -70,7 +70,7 @@ public class FunctionSignature {
         this.arguments = other.arguments != null ? Arrays.copyOf(other.arguments, other.arguments.length) : null;
         this.returnType = other.returnType;
         this.annotations = other.annotations != null ? Arrays.copyOf(other.annotations, other.annotations.length) : null;
-        this.isOverloaded = other.isOverloaded;
+        this.isVariadic = other.isVariadic;
         this.deprecated = other.deprecated;
         this.description = other.description;
         this.metadata = other.metadata != null ? new HashMap<>(other.metadata) : null;
@@ -84,8 +84,8 @@ public class FunctionSignature {
         this(name, null, arguments, returnType);
     }
 
-    public FunctionSignature(final QName name, final SequenceType[] arguments, final SequenceType returnType, final boolean overloaded) {
-        this(name, null, arguments, returnType, overloaded);
+    public FunctionSignature(final QName name, final SequenceType[] arguments, final SequenceType returnType, final boolean variadic) {
+        this(name, null, arguments, returnType, variadic);
     }
 
     public FunctionSignature(final QName name, final String description, final SequenceType[] arguments, final SequenceType returnType) {
@@ -101,8 +101,8 @@ public class FunctionSignature {
 //        this(name, description, arguments, returnType, false, "Moved to the module: " + deprecatedBy.getName().getNamespaceURI() + ", you should now use '" + deprecatedBy.getName().getPrefix() + ":" + deprecatedBy.getName().getLocalPart() + "' instead!");
 //    }
 
-    public FunctionSignature(final QName name, final String description, final SequenceType[] arguments, final SequenceType returnType, final boolean overloaded, final String deprecated) {
-        this(name, description, arguments, returnType, overloaded);
+    public FunctionSignature(final QName name, final String description, final SequenceType[] arguments, final SequenceType returnType, final boolean variadic, final String deprecated) {
+        this(name, description, arguments, returnType, variadic);
         setDeprecated(deprecated);
     }
 	
@@ -113,13 +113,13 @@ public class FunctionSignature {
      * @param description documentation string describing the function
      * @param arguments the sequence types of all expected arguments
      * @param returnType the sequence type returned by the function
-     * @param overloaded set to true if the function may expect additional parameters
+     * @param variadic set to true if the function may expect additional parameters
      */		
-    public FunctionSignature(final QName name, final String description, final SequenceType[] arguments, final SequenceType returnType, final boolean overloaded) {
+    public FunctionSignature(final QName name, final String description, final SequenceType[] arguments, final SequenceType returnType, final boolean variadic) {
         this.name = name;
         this.arguments = arguments;
         this.returnType = returnType;
-        this.isOverloaded = overloaded;
+        this.isVariadic = variadic;
         this.description = description;
     }
 
@@ -132,7 +132,7 @@ public class FunctionSignature {
     }
 
     public int getArgumentCount() {
-        if(isOverloaded) {
+        if(isVariadic) {
             return -1;
         }
         return arguments != null ? arguments.length : 0;
@@ -193,8 +193,8 @@ public class FunctionSignature {
         return metadata;
     }
 
-    public boolean isOverloaded() {
-        return isOverloaded;
+    public boolean isVariadic() {
+        return isVariadic;
     }
 
     public boolean isDeprecated() {
@@ -247,7 +247,7 @@ public class FunctionSignature {
                 buf.append(arguments[i].toString());
             }
             
-            if(isOverloaded) {
+            if(isVariadic) {
                 buf.append(", ...");
             }
         }
@@ -289,7 +289,7 @@ public class FunctionSignature {
         final SequenceType[] argumentsCopy = arguments != null ? Arrays.copyOf(arguments, arguments.length) : null;
         final FunctionSignature newFunctionSignature = new FunctionSignature(newName, description, argumentsCopy, returnType, deprecated);
         newFunctionSignature.annotations = annotations != null ? Arrays.copyOf(annotations, annotations.length) : null;
-        newFunctionSignature.isOverloaded = isOverloaded;
+        newFunctionSignature.isVariadic = isVariadic;
         newFunctionSignature.metadata = metadata != null ? new HashMap<>(metadata) : null;
         return newFunctionSignature;
     }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunHigherOrderFun.java
@@ -252,7 +252,7 @@ public class FunHigherOrderFun extends BasicFunction {
     }
 
     private boolean funcRefHasDifferentArity(final FunctionReference ref, final int n) {
-        return (!ref.getSignature().isOverloaded() &&
+        return (!ref.getSignature().isVariadic() &&
                 ref.getSignature().getArgumentCount() != n);
     }
 }

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNamespaceURI.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/FunNamespaceURI.java
@@ -71,16 +71,16 @@ public class FunNamespaceURI extends Function {
                     new QName("namespace-uri", Function.BUILTIN_FUNCTION_NS),
                     FUNCTION_DESCRIPTION_0_PARAM + FUNCTION_DESCRIPTION_COMMON,
                     new SequenceType[0],
-                    new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.EXACTLY_ONE, "the namespace URI"),
-                    false),
+                    new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.EXACTLY_ONE, "the namespace URI")
+            ),
             new FunctionSignature(
                     new QName("namespace-uri", Function.BUILTIN_FUNCTION_NS),
                     FUNCTION_DESCRIPTION_1_PARAM + FUNCTION_DESCRIPTION_COMMON,
                     new SequenceType[] {
                             new FunctionParameterSequenceType("arg", Type.NODE, Cardinality.ZERO_OR_ONE, "The input node")
                     },
-                    new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.EXACTLY_ONE, "the namespace URI"),
-                    false)
+                    new FunctionReturnSequenceType(Type.ANY_URI, Cardinality.EXACTLY_ONE, "the namespace URI")
+            )
     };
 
     public FunNamespaceURI(final XQueryContext context, final FunctionSignature signature) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/fn/LoadXQueryModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/fn/LoadXQueryModule.java
@@ -251,7 +251,7 @@ public class LoadXQueryModule extends BasicFunction {
             if (!signature.isPrivate()) {
                 if (module.isInternalModule()) {
                     int arity;
-                    if (signature.isOverloaded()) {
+                    if (signature.isVariadic()) {
                         arity = signature.getArgumentTypes().length;
                     }
                     else {

--- a/exist-core/src/main/java/org/exist/xquery/functions/response/StreamBinary.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/response/StreamBinary.java
@@ -52,8 +52,8 @@ public class StreamBinary extends StrictResponseFunction {
             + "Note: the servlet output stream will be closed afterwards and mime-type settings in the prolog "
             + "will not be passed.",
             new SequenceType[]{BINARY_DATA_PARAM, CONTENT_TYPE_PARAM, FILENAME_PARAM},
-            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE),
-            true);
+            new SequenceType(Type.EMPTY, Cardinality.EMPTY_SEQUENCE)
+            );
 
     public StreamBinary(final XQueryContext context) {
         super(context, signature);

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/GetFragmentBetween.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/GetFragmentBetween.java
@@ -89,7 +89,8 @@ public class GetFragmentBetween extends BasicFunction {
                             new FunctionParameterSequenceType("make-fragment", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, "The flag make a fragment."),
                             new FunctionParameterSequenceType("display-root-namespace", Type.BOOLEAN, Cardinality.ZERO_OR_ONE, "Display the namespace of the root node of the fragment.")
                     },
-                    new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the string containing the fragment between the two node/milestone elements."), true);
+                    new FunctionReturnSequenceType(Type.STRING, Cardinality.EXACTLY_ONE, "the string containing the fragment between the two node/milestone elements.")
+            );
 
     public GetFragmentBetween(final XQueryContext context) {
         super(context, signature);

--- a/extensions/indexes/range/src/test/xquery/range/range.xql
+++ b/extensions/indexes/range/src/test/xquery/range/range.xql
@@ -369,6 +369,17 @@ function rt:equality-field-nested($type as xs:string, $subtype as xs:string, $na
     collection("/db/rangetest")//range:field-eq(("type", "subtype", "name"), $type, $subtype, $name)/text()
 };
 
+(: Test multi-value field lookups :)
+declare
+    %test:assertEquals("Hofthiergarten", "Dorfprozelten")
+function rt:equality-field-nested-multi() {
+    collection("/db/rangetest")
+        //range:field-eq(
+            ("type", "subtype", "name"),
+            "main", "official", ("Hofthiergarten", "Dorfprozelten"))
+        /text()
+};
+
 declare 
     %test:assertEquals("Almweide")
 function rt:remove-document() {


### PR DESCRIPTION
### Description:

The _overloaded_ flag is set to `true` for functions like `fn:concat`, which has an unlimited arity.
The term does however have a different meaning and therefore lead to confusion when I touched code in #3389.
It is therefore better to call this flag variadic (see the references for details).

The getter function and constructor parameter names are renamed to reflect this.

`response:stream-binary` and `util:get-fragment-between` are both non-variadic but flagged as such. This flag is removed.

`fn:namespace-uri#0` and `fn:namespace-uri#1` were flagged as non-variadic, which is the default. Therefore, setting of the flag is removed.

**Note:** There are variadic functions in the `range` module (FieldLookup.java). Removing the flag for `range:field-eq` for example results in failing tests. I believe they are flagged as variadic because you are allowed to query **n** fields for **m** values.

Two failing tests can be found in src/test/xquery/range/range.xql (L197, L369)

### Reference:

Definition of variadic in the Wikipedia: https://en.wikipedia.org/wiki/Variadic_function

Usage of variadic in the XQuery Specification: 
> Although the base function referred to may be variadic, the result of evaluating the function reference is a function that has fixed arity.

### Type of tests:

None added

refs #3389 (discussion in thread)