### PR TITLE
[6.x.x] Fix a bug in Node Path equality

### DIFF
--- a/exist-core/src/main/java/org/exist/dom/QName.java
+++ b/exist-core/src/main/java/org/exist/dom/QName.java
@@ -41,6 +41,8 @@ public class QName implements Comparable<QName> {
 
     public static final String WILDCARD = "*";
     private static final char COLON = ':';
+    private static final char LEFT_BRACE = '{';
+    private static final char RIGHT_BRACE = '}';
 
     public static final QName EMPTY_QNAME = new QName("", XMLConstants.NULL_NS_URI);
     public static final QName DOCUMENT_QNAME = EMPTY_QNAME;
@@ -127,8 +129,10 @@ public class QName implements Comparable<QName> {
     }
 
     public String getStringValue() {
-        if (prefix != null && prefix.length() > 0) {
+        if (prefix != null && !prefix.isEmpty()) {
             return prefix + COLON + localPart;
+        } else if (namespaceURI != null && !XMLConstants.NULL_NS_URI.equals(namespaceURI)) {
+            return LEFT_BRACE + namespaceURI + RIGHT_BRACE + localPart;
         }
         return localPart;
     }

--- a/exist-core/src/main/java/org/exist/dom/QName.java
+++ b/exist-core/src/main/java/org/exist/dom/QName.java
@@ -128,34 +128,44 @@ public class QName implements Comparable<QName> {
         return nameType;
     }
 
+    /**
+     * Get a string representation of this qualified name.
+     *
+     * Will either be of the format `local-name` or `prefix:local-name`.
+     *
+     * @return the string representation of this qualified name.
+     * */
     public String getStringValue() {
-        if (prefix != null && !prefix.isEmpty()) {
-            return prefix + COLON + localPart;
-        } else if (namespaceURI != null && !XMLConstants.NULL_NS_URI.equals(namespaceURI)) {
-            return LEFT_BRACE + namespaceURI + RIGHT_BRACE + localPart;
-        }
-        return localPart;
+        return getStringRepresentation(false);
     }
 
     /**
-     * @deprecated Use for debugging purpose only,
-     * use {@link #getStringValue()} for production
+     * Get a string representation of this qualified name.
+     *
+     * Will either be of the format `local-name`, `prefix:local-name`, or `{namespace}local-name`.
+     *
+     * @return the string representation of this qualified name.
      */
     @Override
     public String toString() {
-        //TODO : remove this copy of getStringValue()
-        return getStringValue();
-        //TODO : replace by something like this
-        /*
-        if (prefix != null && prefix.length() > 0)
+        return getStringRepresentation(true);
+    }
+
+    /**
+     * Get a string representation of this qualified name.
+     *
+     * @param showNsWithoutPrefix true if the namespace should be shown even when there is no prefix, false otherwise.
+     *         When shown, it will be output using Clark notation, e.g. `{http://namespace}local-name`.
+     *
+     * @return the string representation of this qualified name.
+     */
+    private String getStringRepresentation(final boolean showNsWithoutPrefix) {
+        if (prefix != null && !prefix.isEmpty()) {
             return prefix + COLON + localPart;
-        if (hasNamespace()) {
-            if (prefix != null && prefix.length() > 0)
-                return "{" + namespaceURI + "}" + prefix + COLON + localPart;
-            return "{" + namespaceURI + "}" + localPart;
-        } else 
-            return localPart;
-        */
+        } else if (showNsWithoutPrefix && namespaceURI != null && !XMLConstants.NULL_NS_URI.equals(namespaceURI)) {
+            return LEFT_BRACE + namespaceURI + RIGHT_BRACE + localPart;
+        }
+        return localPart;
     }
 
     /**

--- a/exist-core/src/main/java/org/exist/storage/NodePath.java
+++ b/exist-core/src/main/java/org/exist/storage/NodePath.java
@@ -39,6 +39,7 @@ import javax.xml.XMLConstants;
 public class NodePath implements Comparable<NodePath> {
 
     static final int DEFAULT_NODE_PATH_SIZE = 5;
+    static final int MAX_OVER_ALLOCATION_FACTOR = 2;
 
     private static final Logger LOG = LogManager.getLogger(NodePath.class);
 
@@ -117,8 +118,8 @@ public class NodePath implements Comparable<NodePath> {
     }
 
     public void reset() {
-        // when resetting if this object has twice the capacity of a new object, then set it back to the default capacity
-        if (pos > DEFAULT_NODE_PATH_SIZE * 2) {
+        // when resetting if this object has more than twice the capacity of a new object, then set it back to the default capacity
+        if (pos > DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR) {
             components = new QName[DEFAULT_NODE_PATH_SIZE];
         } else {
             Arrays.fill(components, null);

--- a/exist-core/src/main/java/org/exist/storage/NodePath.java
+++ b/exist-core/src/main/java/org/exist/storage/NodePath.java
@@ -47,7 +47,7 @@ import javax.xml.XMLConstants;
  */
 public class NodePath implements Comparable<NodePath> {
 
-    static final int DEFAULT_NODE_PATH_SIZE = 5;
+    static final int DEFAULT_NODE_PATH_SIZE = 4;
     static final int MAX_OVER_ALLOCATION_FACTOR = 2;
 
     private static final Logger LOG = LogManager.getLogger(NodePath.class);

--- a/exist-core/src/main/java/org/exist/storage/NodePath.java
+++ b/exist-core/src/main/java/org/exist/storage/NodePath.java
@@ -303,10 +303,24 @@ public class NodePath implements Comparable<NodePath> {
 
     @Override
     public boolean equals(final Object obj) {
-        if (obj != null && obj instanceof NodePath) {
-            final NodePath otherNodePath = (NodePath) obj;
-            return Arrays.equals(components, otherNodePath.components);
+        if (this == obj) {
+            return true;
         }
+
+        if (obj instanceof NodePath) {
+            final NodePath otherNodePath = (NodePath) obj;
+
+            // NOTE(AR) we cannot use Array.equals on the components of the NodePaths as they may be over-allocated!
+            if (pos == otherNodePath.pos) {
+                for (int i = 0; i < pos; i++) {
+                    if (!components[i].equals(otherNodePath.components[i])) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/exist-core/src/main/java/org/exist/storage/NodePath.java
+++ b/exist-core/src/main/java/org/exist/storage/NodePath.java
@@ -38,7 +38,7 @@ import javax.xml.XMLConstants;
  */
 public class NodePath implements Comparable<NodePath> {
 
-    private static final int DEFAULT_NODE_PATH_SIZE = 5;
+    static final int DEFAULT_NODE_PATH_SIZE = 5;
 
     private static final Logger LOG = LogManager.getLogger(NodePath.class);
 
@@ -128,6 +128,18 @@ public class NodePath implements Comparable<NodePath> {
 
     public int length() {
         return pos;
+    }
+
+    /**
+     * Return the size of the components array.
+     *
+     * This function is intentionally marked as package-private
+     * so that it may only be called for testing purposes!
+     *
+     * @return the size of the components array.
+     */
+    int componentsSize() {
+        return components.length;
     }
 
     protected void reverseComponents() {

--- a/exist-core/src/main/java/org/exist/storage/NodePath.java
+++ b/exist-core/src/main/java/org/exist/storage/NodePath.java
@@ -90,11 +90,19 @@ public class NodePath implements Comparable<NodePath> {
     }
 
     public void append(final NodePath other) {
-        // expand the array
-        final int newLength = pos + other.length();
-        this.components = Arrays.copyOf(components, newLength);
-        System.arraycopy(other.components, 0, components, pos, other.length());
-        this.pos = newLength;
+        // do we have enough space to accommodate the components from `other`
+        final int available = components.length - pos;
+        final int numOtherComponentsToAppend = other.length();
+        if (available < numOtherComponentsToAppend) {
+            // we need more space, allocate a multiple of DEFAULT_NODE_PATH_SIZE
+            final int allocationFactor = (int) Math.ceil((numOtherComponentsToAppend - available + components.length) / ((float) DEFAULT_NODE_PATH_SIZE));
+            final int newSize = allocationFactor * DEFAULT_NODE_PATH_SIZE;
+            this.components = Arrays.copyOf(components, newSize);
+        }
+
+        // at this point we have enough space, append the components from `other`
+        System.arraycopy(other.components, 0, components, pos, numOtherComponentsToAppend);
+        this.pos += numOtherComponentsToAppend;
     }
 
     public void addComponent(final QName component) {

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectFunctionHelper.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectFunctionHelper.java
@@ -63,7 +63,7 @@ public class InspectFunctionHelper {
         XQDocHelper.parse(sig);
 
         final AttributesImpl attribs = new AttributesImpl();
-        attribs.addAttribute("", "name", "name", "CDATA", sig.getName().toString());
+        attribs.addAttribute("", "name", "name", "CDATA", sig.getName().getStringValue());
         attribs.addAttribute("", "module", "module", "CDATA", sig.getName().getNamespaceURI());
         final int nodeNr = builder.startElement(FUNCTION_QNAME, attribs);
         writeParameters(sig, builder);
@@ -130,7 +130,7 @@ public class InspectFunctionHelper {
         if (annots != null) {
             for (final Annotation annot : annots) {
                 attribs.clear();
-                attribs.addAttribute(null, "name", "name", "CDATA", annot.getName().toString());
+                attribs.addAttribute(null, "name", "name", "CDATA", annot.getName().getStringValue());
                 attribs.addAttribute(null, "namespace", "namespace", "CDATA", annot.getName().getNamespaceURI());
                 builder.startElement(ANNOTATION_QNAME, attribs);
                 final LiteralValue[] value = annot.getValue();
@@ -164,7 +164,7 @@ public class InspectFunctionHelper {
         final AttributesImpl attribs = new AttributesImpl();
         for (final FunctionSignature signature : signatures) {
             attribs.clear();
-            attribs.addAttribute(null, "name", "name", "CDATA", signature.getName().toString());
+            attribs.addAttribute(null, "name", "name", "CDATA", signature.getName().getStringValue());
             attribs.addAttribute("", "module", "module", "CDATA", signature.getName().getNamespaceURI());
             attribs.addAttribute("", "arity", "arity", "CDATA", Integer.toString(signature.getArgumentCount()));
 

--- a/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/inspect/InspectModule.java
@@ -117,7 +117,7 @@ public class InspectModule extends BasicFunction {
                     // variables
                     for (final VariableDeclaration var : externalModule.getVariableDeclarations()) {
                         attribs.clear();
-                        attribs.addAttribute("", "name", "name", "CDATA", var.getName().toString());
+                        attribs.addAttribute("", "name", "name", "CDATA", var.getName().getStringValue());
                         final SequenceType type = var.getSequenceType();
                         if (type != null) {
                             attribs.addAttribute("", "type", "type", "CDATA", Type.getTypeName(type.getPrimaryType()));

--- a/exist-core/src/main/java/org/exist/xquery/functions/util/DescribeFunction.java
+++ b/exist-core/src/main/java/org/exist/xquery/functions/util/DescribeFunction.java
@@ -199,7 +199,7 @@ public class DescribeFunction extends Function {
 		if (annots != null) {
 			for (final Annotation annot : annots) {
 				attribs.clear();
-				attribs.addAttribute(null, "name", "name", "CDATA", annot.getName().toString());
+				attribs.addAttribute(null, "name", "name", "CDATA", annot.getName().getStringValue());
 				attribs.addAttribute(null, "namespace", "namespace", "CDATA", annot.getName().getNamespaceURI());
 				builder.startElement(ANNOTATION_QNAME, attribs);
 				final LiteralValue[] value = annot.getValue();

--- a/exist-core/src/test/java/org/exist/storage/NodePathTest.java
+++ b/exist-core/src/test/java/org/exist/storage/NodePathTest.java
@@ -115,5 +115,35 @@ public class NodePathTest {
         assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, path.componentsSize());
     }
 
+    @Test
+    public void reset() {
+        // simple allocation of DEFAULT_NODE_PATH_SIZE and then reset: size of components should remain at DEFAULT_NODE_PATH_SIZE
+        NodePath path = new NodePath(null, "/a");
+        path.reset();
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, path.componentsSize());
+
+        // another simple allocation of DEFAULT_NODE_PATH_SIZE and then reset: size of components should remain at DEFAULT_NODE_PATH_SIZE
+        path = new NodePath(null, "/a/b");
+        path.reset();
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, path.componentsSize());
+
+        // allocate upto DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR and then reset: size of components should remain at DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR
+        StringBuilder pathStrBuilder = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE * NodePath.MAX_OVER_ALLOCATION_FACTOR; i++) {
+            pathStrBuilder.append("/a");
+        }
+        path = new NodePath(null, pathStrBuilder.toString());
+        path.reset();
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * NodePath.MAX_OVER_ALLOCATION_FACTOR, path.componentsSize());
+
+        // allocate over DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR and then reset: size of components should return to DEFAULT_NODE_PATH_SIZE
+        pathStrBuilder = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE * NodePath.MAX_OVER_ALLOCATION_FACTOR * 2; i++) {
+            pathStrBuilder.append("/a");
+        }
+        path = new NodePath(null, pathStrBuilder.toString());
+        path.reset();
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, path.componentsSize());
+    }
 
 }

--- a/exist-core/src/test/java/org/exist/storage/NodePathTest.java
+++ b/exist-core/src/test/java/org/exist/storage/NodePathTest.java
@@ -146,4 +146,111 @@ public class NodePathTest {
         assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, path.componentsSize());
     }
 
+    @Test
+    public void equalsAfterResetAndAppend() {
+        final String strPath = "/a/b/c";
+
+        final NodePath expected = new NodePath(null, strPath);
+
+        // simple path, reset, and then append: expected.equals(actual) should equal 'true'
+        NodePath actual = new NodePath(null, "/a");
+        actual.reset();
+        actual.append(expected);
+        assertEquals(expected, actual);
+
+        // another simple path, reset, and then append: expected.equals(actual) should equal 'true'
+        actual = new NodePath(null, "/a/b");
+        actual.reset();
+        actual.append(expected);
+        assertEquals(expected, actual);
+
+        // allocate less than DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR, reset, and then append: expected.equals(actual) should equal 'true'
+        StringBuilder pathStrBuilder = new StringBuilder();
+        for (int i = 0; i < (NodePath.DEFAULT_NODE_PATH_SIZE * NodePath.MAX_OVER_ALLOCATION_FACTOR) - 1; i++) {
+            pathStrBuilder.append("/a");
+        }
+        actual = new NodePath(null, pathStrBuilder.toString());
+        actual.reset();
+        actual.append(expected);
+        assertEquals(expected, actual);
+
+        // allocate exactly DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR, reset, and then append: expected.equals(actual) should equal 'true'
+        pathStrBuilder = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE * NodePath.MAX_OVER_ALLOCATION_FACTOR; i++) {
+            pathStrBuilder.append("/a");
+        }
+        actual = new NodePath(null, pathStrBuilder.toString());
+        actual.reset();
+        actual.append(expected);
+        assertEquals(expected, actual);
+
+        // allocate over DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR, reset, and then append: expected.equals(actual) should equal 'true'
+        pathStrBuilder = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE * NodePath.MAX_OVER_ALLOCATION_FACTOR * 2; i++) {
+            pathStrBuilder.append("/a");
+        }
+        actual = new NodePath(null, pathStrBuilder.toString());
+        actual.reset();
+        actual.append(expected);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void equalsAfterResetAndAddComponent() throws QName.IllegalQNameException {
+        final String strPath = "/a/b/c";
+
+        final NodePath expected = new NodePath(null, strPath);
+
+        // simple path, reset, and then append: expected.equals(actual) should equal 'true'
+        NodePath actual = new NodePath(null, "/a");
+        actual.reset();
+        addComponents(actual, strPath);
+        assertEquals(expected, actual);
+
+        // another simple path, reset, and then append: expected.equals(actual) should equal 'true'
+        actual = new NodePath(null, "/a/b");
+        actual.reset();
+        addComponents(actual, strPath);
+        assertEquals(expected, actual);
+
+        // allocate less than DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR, reset, and then append: expected.equals(actual) should equal 'true'
+        StringBuilder pathStrBuilder = new StringBuilder();
+        for (int i = 0; i < (NodePath.DEFAULT_NODE_PATH_SIZE * NodePath.MAX_OVER_ALLOCATION_FACTOR) - 1; i++) {
+            pathStrBuilder.append("/a");
+        }
+        actual = new NodePath(null, pathStrBuilder.toString());
+        actual.reset();
+        addComponents(actual, strPath);
+        assertEquals(expected, actual);
+
+        // allocate exactly DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR, reset, and then append: expected.equals(actual) should equal 'true'
+        pathStrBuilder = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE * NodePath.MAX_OVER_ALLOCATION_FACTOR; i++) {
+            pathStrBuilder.append("/a");
+        }
+        actual = new NodePath(null, pathStrBuilder.toString());
+        actual.reset();
+        addComponents(actual, strPath);
+        assertEquals(expected, actual);
+
+        // allocate over DEFAULT_NODE_PATH_SIZE * MAX_OVER_ALLOCATION_FACTOR, reset, and then append: expected.equals(actual) should equal 'true'
+        pathStrBuilder = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE * NodePath.MAX_OVER_ALLOCATION_FACTOR * 2; i++) {
+            pathStrBuilder.append("/a");
+        }
+        actual = new NodePath(null, pathStrBuilder.toString());
+        actual.reset();
+        addComponents(actual, strPath);
+        assertEquals(expected, actual);
+    }
+
+    private void addComponents(final NodePath destination, final String path) throws QName.IllegalQNameException {
+        final String[] components = path.split("/");
+        for (int i = 0; i < components.length; i++) {
+            final String component = components[i];
+            if (!component.isEmpty()) {
+                destination.addComponent(new QName(component));
+            }
+        }
+    }
 }

--- a/exist-core/src/test/java/org/exist/storage/NodePathTest.java
+++ b/exist-core/src/test/java/org/exist/storage/NodePathTest.java
@@ -109,5 +109,11 @@ public class NodePathTest {
         assertEquals("/a/b/c/d/1/2/3", path.toString());
     }
 
+    @Test
+    public void largerComponentsBuffer() {
+        final NodePath path = new NodePath(null, "/a");
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, path.componentsSize());
+    }
+
 
 }

--- a/exist-core/src/test/java/org/exist/storage/NodePathTest.java
+++ b/exist-core/src/test/java/org/exist/storage/NodePathTest.java
@@ -21,6 +21,7 @@
  */
 package org.exist.storage;
 
+import org.exist.dom.QName;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -206,6 +207,63 @@ public class NodePathTest {
         expected = new NodePath(null, strPath.toString());
         actual = new NodePath(null, strPath.toString());
         actual.append(expected);
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * 3, actual.componentsSize());
+    }
+
+    @Test
+    public void addComponentAllocationStrategy() throws QName.IllegalQNameException {
+        // `expected` has less occupied components than DEFAULT_NODE_PATH_SIZE, `actual` has no components, when appending `expected` to `actual` then `actual` should have less occupied components than DEFAULT_NODE_PATH_SIZE
+        StringBuilder strPath = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE - 1; i++) {
+            strPath.append("/a");
+        }
+        NodePath actual = new NodePath();
+        addComponents(actual, strPath.toString());
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, actual.componentsSize());
+
+        // `expected` has less occupied components than DEFAULT_NODE_PATH_SIZE, `actual` has the same number of components, when appending `expected` to `actual` then `actual` should now be twice the size of DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE - 1; i++) {
+            strPath.append("/a");
+        }
+        actual = new NodePath(null, strPath.toString());
+        addComponents(actual, strPath.toString());
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * 2, actual.componentsSize());
+
+        // `expected` has exactly DEFAULT_NODE_PATH_SIZE occupied components, `actual` has no components, when appending `expected` to `actual` then `actual` should have less occupied components than DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE; i++) {
+            strPath.append("/a");
+        }
+        actual = new NodePath();
+        addComponents(actual, strPath.toString());
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, actual.componentsSize());
+
+        // `expected` has exactly DEFAULT_NODE_PATH_SIZE occupied components, `actual` has the same number of components, when appending `expected` to `actual` then `actual` should now be twice the size of DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE; i++) {
+            strPath.append("/a");
+        }
+        actual = new NodePath(null, strPath.toString());
+        addComponents(actual, strPath.toString());
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * 2, actual.componentsSize());
+
+        // `expected` has more occupied components than DEFAULT_NODE_PATH_SIZE, `actual` has no components, when appending `expected` to `actual` then `actual` should now be twice the size of DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i <= NodePath.DEFAULT_NODE_PATH_SIZE; i++) {
+            strPath.append("/a");
+        }
+        actual = new NodePath();
+        addComponents(actual, strPath.toString());
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * 2, actual.componentsSize());
+
+        // `expected` has more occupied components than DEFAULT_NODE_PATH_SIZE, `actual` has the same number of components, when appending `expected` to `actual` then `actual` should now be thrice the size of DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i <= NodePath.DEFAULT_NODE_PATH_SIZE; i++) {
+            strPath.append("/a");
+        }
+        actual = new NodePath(null, strPath.toString());
+        addComponents(actual, strPath.toString());
         assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * 3, actual.componentsSize());
     }
 

--- a/exist-core/src/test/java/org/exist/storage/NodePathTest.java
+++ b/exist-core/src/test/java/org/exist/storage/NodePathTest.java
@@ -147,6 +147,69 @@ public class NodePathTest {
     }
 
     @Test
+    public void appendAllocationStrategy() {
+        // `expected` has less occupied components than DEFAULT_NODE_PATH_SIZE, `actual` has no components, when appending `expected` to `actual` then `actual` should have less occupied components than DEFAULT_NODE_PATH_SIZE
+        StringBuilder strPath = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE - 1; i++) {
+            strPath.append("/a");
+        }
+        NodePath expected = new NodePath(null, strPath.toString());
+        NodePath actual = new NodePath();
+        actual.append(expected);
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, actual.componentsSize());
+
+        // `expected` has less occupied components than DEFAULT_NODE_PATH_SIZE, `actual` has the same number of components, when appending `expected` to `actual` then `actual` should now be twice the size of DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE - 1; i++) {
+            strPath.append("/a");
+        }
+        expected = new NodePath(null, strPath.toString());
+        actual = new NodePath(null, strPath.toString());
+        actual.append(expected);
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * 2, actual.componentsSize());
+
+        // `expected` has exactly DEFAULT_NODE_PATH_SIZE occupied components, `actual` has no components, when appending `expected` to `actual` then `actual` should have less occupied components than DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE; i++) {
+            strPath.append("/a");
+        }
+        expected = new NodePath(null, strPath.toString());
+        actual = new NodePath();
+        actual.append(expected);
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE, actual.componentsSize());
+
+        // `expected` has exactly DEFAULT_NODE_PATH_SIZE occupied components, `actual` has the same number of components, when appending `expected` to `actual` then `actual` should now be twice the size of DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i < NodePath.DEFAULT_NODE_PATH_SIZE; i++) {
+            strPath.append("/a");
+        }
+        expected = new NodePath(null, strPath.toString());
+        actual = new NodePath(null, strPath.toString());
+        actual.append(expected);
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * 2, actual.componentsSize());
+
+        // `expected` has more occupied components than DEFAULT_NODE_PATH_SIZE, `actual` has no components, when appending `expected` to `actual` then `actual` should now be twice the size of DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i <= NodePath.DEFAULT_NODE_PATH_SIZE; i++) {
+            strPath.append("/a");
+        }
+        expected = new NodePath(null, strPath.toString());
+        actual = new NodePath();
+        actual.append(expected);
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * 2, actual.componentsSize());
+
+        // `expected` has more occupied components than DEFAULT_NODE_PATH_SIZE, `actual` has the same number of components, when appending `expected` to `actual` then `actual` should now be thrice the size of DEFAULT_NODE_PATH_SIZE
+        strPath = new StringBuilder();
+        for (int i = 0; i <= NodePath.DEFAULT_NODE_PATH_SIZE; i++) {
+            strPath.append("/a");
+        }
+        expected = new NodePath(null, strPath.toString());
+        actual = new NodePath(null, strPath.toString());
+        actual.append(expected);
+        assertEquals(NodePath.DEFAULT_NODE_PATH_SIZE * 3, actual.componentsSize());
+    }
+
+    @Test
     public void equalsAfterResetAndAppend() {
         final String strPath = "/a/b/c";
 


### PR DESCRIPTION
NodePath equality (i.e. `NodePath#equals()`) could return the wrong result if a `NodePath` object was being reused.