### PR TITLE
[cleanup] clean up deprecated methods

### DIFF
--- a/exist-core/src/main/java/org/exist/util/GZIPInputSource.java
+++ b/exist-core/src/main/java/org/exist/util/GZIPInputSource.java
@@ -145,15 +145,6 @@ public final class GZIPInputSource extends EXistInputSource {
 	}
 
 	@Override
-	protected void finalize() throws Throwable {
-		try {
-			close();
-		} finally {
-			super.finalize();
-		}
-	}
-
-	@Override
 	public void close() {
 		if(!isClosed()) {
 			try {

--- a/exist-core/src/main/java/org/exist/xmldb/AbstractRemoteResource.java
+++ b/exist-core/src/main/java/org/exist/xmldb/AbstractRemoteResource.java
@@ -565,13 +565,4 @@ public abstract class AbstractRemoteResource extends AbstractRemote
     public final void freeResources() {
         close();
     }
-
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            close();
-        } finally {
-            super.finalize();
-        }
-    }
 }

--- a/exist-core/src/main/java/org/exist/xmldb/RemoteResourceSet.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteResourceSet.java
@@ -304,15 +304,6 @@ public class RemoteResourceSet implements ResourceSet, AutoCloseable {
         }
     }
 
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            close();
-        } finally {
-            super.finalize();
-        }
-    }
-
     class NewResourceIterator implements ResourceIterator {
         long pos = 0;
 

--- a/exist-core/src/main/java/org/exist/xmlrpc/AbstractCachedResult.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/AbstractCachedResult.java
@@ -128,14 +128,4 @@ public abstract class AbstractCachedResult implements Closeable {
     public final void free() {
         close();
     }
-
-    @Override
-    protected void finalize() throws Throwable {
-        // Calling free to reclaim pinned resources
-        try {
-            close();
-        } finally {
-            super.finalize();
-        }
-    }
 }

--- a/exist-core/src/main/java/org/exist/xquery/value/IntegerValue.java
+++ b/exist-core/src/main/java/org/exist/xquery/value/IntegerValue.java
@@ -40,7 +40,7 @@ import java.util.function.IntSupplier;
  * This results in the standard mathematical concept of the integer numbers.
  * The value space of integer is the infinite set {...,-2,-1,0,1,2,...}.
  * The base type of integer is decimal.
- * See http://www.w3.org/TR/xmlschema-2/#integer
+ * See <a href="http://www.w3.org/TR/xmlschema-2/#integer">http://www.w3.org/TR/xmlschema-2/#integer</a>
  */
 public class IntegerValue extends NumericValue {
 
@@ -526,7 +526,6 @@ public class IntegerValue extends NumericValue {
         if (target.isAssignableFrom(IntegerValue.class)) {
             return (T) this;
         } else if (target == Long.class || target == long.class) {
-            // ?? jmv: return new Long(value);
             return (T) Long.valueOf(value.longValue());
         } else if (target == Integer.class || target == int.class) {
             final IntegerValue v = (IntegerValue) convertTo(Type.INT);
@@ -554,7 +553,7 @@ public class IntegerValue extends NumericValue {
         } else if (target == BigInteger.class) {
             return (T) new BigInteger(value.toByteArray());
         } else if (target == Object.class) {
-            return (T) value; // Long(value);
+            return (T) value;
         }
 
         throw new XPathException(getExpression(), "cannot convert value of type " + Type.getTypeName(getType()) +

--- a/exist-core/src/test/java/org/exist/TestDataGenerator.java
+++ b/exist-core/src/test/java/org/exist/TestDataGenerator.java
@@ -97,7 +97,7 @@ public class TestDataGenerator {
                 generatedFiles[i] = Files.createTempFile(prefix, ".xml");
 
                 context.declareVariable("filename", generatedFiles[i].getFileName().toString());
-                context.declareVariable("count", new Integer(i));
+                context.declareVariable("count", Integer.valueOf(i));
                 final Sequence results = service.execute(broker, compiled, Sequence.EMPTY_SEQUENCE);
 
                 final Serializer serializer = broker.borrowSerializer();
@@ -140,8 +140,9 @@ public class TestDataGenerator {
                 try(final Writer out = Files.newBufferedWriter(generatedFiles[i], StandardCharsets.UTF_8)) {
                     final SAXSerializer sax = new SAXSerializer(out, outputProps);
                     for (ResourceIterator iter = result.getIterator(); iter.hasMoreResources(); ) {
-                        XMLResource r = (XMLResource) iter.nextResource();
-                        r.getContentAsSAX(sax);
+                        try (XMLResource r = (XMLResource) iter.nextResource()) {
+                            r.getContentAsSAX(sax);
+                        }
                     }
                 }
             }

--- a/exist-core/src/test/java/org/exist/collections/ConcurrencyTest.java
+++ b/exist-core/src/test/java/org/exist/collections/ConcurrencyTest.java
@@ -129,7 +129,7 @@ public class ConcurrencyTest {
                 }
                 try {
                     if (start > 0) {
-                        service.declareVariable("start", new Integer(start));
+                        service.declareVariable("start", Integer.valueOf(start));
                     }
                     service.query(query);
                 } finally {
@@ -147,17 +147,18 @@ public class ConcurrencyTest {
     @BeforeClass
     public static void initDB() throws XMLDBException {
         final CollectionManagementService mgmt = existEmbeddedServer.getRoot().getService(CollectionManagementService.class);
-        final Collection test = mgmt.createCollection("test");
+        try (final Collection test = mgmt.createCollection("test")) {
 
-        for (int i = 1; i <= DOC_COUNT; i++) {
-            final Resource r = test.createResource("test" + i + ".xml", XMLResource.class);
-            final String XML =
-                "<test id='" + i + "'>" +
-                "   <a>b</a>" +
-                "   <c>d</c>" +
-                "</test>";
-            r.setContent(XML);
-            test.storeResource(r);
+            for (int i = 1; i <= DOC_COUNT; i++) {
+                final Resource r = test.createResource("test" + i + ".xml", XMLResource.class);
+                final String XML =
+                        "<test id='" + i + "'>" +
+                                "   <a>b</a>" +
+                                "   <c>d</c>" +
+                                "</test>";
+                r.setContent(XML);
+                test.storeResource(r);
+            }
         }
     }
 

--- a/exist-core/src/test/java/org/exist/xquery/XPathQueryTest.java
+++ b/exist-core/src/test/java/org/exist/xquery/XPathQueryTest.java
@@ -1726,7 +1726,7 @@ public class XPathQueryTest {
             "$local:string";
         expr = service.compile(query);
         //TODO : we should virtually pass any kind of value
-        service.declareVariable("local:string", new Integer(1));
+        service.declareVariable("local:string", Integer.valueOf(1));
 
         String message = "";
         try {


### PR DESCRIPTION
- Replaced all terminally deprecated constructors for primitive data types with their `valueOf` counter parts.
- Removed all `finalize()` methods, where a according `close()` method exists thru `AutoClosable`
- Replaced `finalize()` method with shutdown hook within `TemporaryFileManager`