### PR TITLE
fix for #5028

### DIFF
--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
@@ -172,6 +172,8 @@ public class DirectoryList extends BasicFunction {
             builder.endElement();
 
             return (NodeValue) builder.getDocument().getDocumentElement();
+        } catch (final IllegalStateException e) {
+          throw new XPathException(this, e.getMessage());
         } catch (final IOException e) {
             throw new XPathException(this, e.getMessage());
         } finally {


### PR DESCRIPTION
The Java code of DirectoryList throws an IllegalStateException when a non-existent directory is supplied as its first argument, which is an unchecked exception and therefore not caught in Java.
