### PR TITLE
Parameterise the XML-RPC parse method with the Media Type

### DIFF
--- a/exist-core/src/main/java/org/exist/xmldb/RemoteCollection.java
+++ b/exist-core/src/main/java/org/exist/xmldb/RemoteCollection.java
@@ -519,6 +519,7 @@ public class RemoteCollection extends AbstractRemote implements EXistCollection 
         } catch (final URISyntaxException e) {
             throw new XMLDBException(ErrorCodes.INVALID_URI, e);
         }
+        params.add(res.getMimeType());
         params.add(1);
         if (res.getCreationTime() != null) {
             params.add(res.getCreationTime());

--- a/exist-core/src/main/java/org/exist/xmlrpc/RpcAPI.java
+++ b/exist-core/src/main/java/org/exist/xmlrpc/RpcAPI.java
@@ -545,16 +545,25 @@ public interface RpcAPI {
      *
      * @param xmlData The document data
      * @param docName The path where the document will be stored
+     * @param mimeType the mimeType to check for
      * @param overwrite Overwrite an existing document with the same path?
+     * @param created Specifies the creattion date
+     * @param modified Specifies the last modification date
      * @return true, if the document is valid XML
      * @throws EXistException If an internal error occurs
      * @throws PermissionDeniedException If the current user is not allowed to perform this action
      * @throws URISyntaxException If the URI contains syntax errors
      */
-    boolean parse(byte[] xmlData, String docName, int overwrite)
+    boolean parse(byte[] xmlData, String docName, String mimeType, int overwrite, Date created, Date modified)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
     boolean parse(byte[] xmlData, String docName, int overwrite, Date created, Date modified)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean parse(byte[] xmlData, String docName, String mimeType, int overwrite)
+            throws EXistException, PermissionDeniedException, URISyntaxException;
+
+    boolean parse(byte[] xmlData, String docName, int overwrite)
             throws EXistException, PermissionDeniedException, URISyntaxException;
 
     boolean parse(String xml, String docName, int overwrite)

--- a/exist-core/src/test/java/org/exist/xmlrpc/MimeTypeTest.java
+++ b/exist-core/src/test/java/org/exist/xmlrpc/MimeTypeTest.java
@@ -1,0 +1,101 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xmlrpc;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.Assert.assertEquals;
+
+import org.exist.TestUtils;
+import org.exist.test.ExistWebServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+import org.xmldb.api.DatabaseManager;
+import org.xmldb.api.base.Collection;
+import org.xmldb.api.base.Database;
+import org.xmldb.api.base.Resource;
+import org.xmldb.api.base.ResourceType;
+import org.xmldb.api.base.XMLDBException;
+import org.xmldb.api.modules.CollectionManagementService;
+import org.xmldb.api.modules.XMLResource;
+
+public class MimeTypeTest {
+
+	@ClassRule
+    public final static ExistWebServer existWebServer = new ExistWebServer(true, false, true, true);
+
+    private final static String COLLECTION_NAME = "rpctest";
+    private static final String DOCUMENT_NAME = "myxmldoc";
+    private final static String XML_CONTENT = """
+    		<xml><it><is>
+    		</is></it></xml>
+    		""";
+
+    private static String getBaseUri() {
+        return "xmldb:exist://localhost:" + existWebServer.getPort() + "/xmlrpc";
+    }
+
+    @Test
+    public void testXMLMimeType() throws XMLDBException {
+        // store an XML document without an .xml extension
+    	try(Collection collection = DatabaseManager.getCollection(getBaseUri() + "/db/" + COLLECTION_NAME, TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD)){
+            final Class<? extends Resource> xmlResourceType = XMLResource.class;
+            final XMLResource resource = (XMLResource)collection.createResource(DOCUMENT_NAME, xmlResourceType);
+            resource.setContent(XML_CONTENT);
+            collection.storeResource(resource);
+            assertEquals(ResourceType.XML_RESOURCE, resource.getResourceType());
+    	}
+    	
+        // retrieve the document and verify its resource type
+    	try(Collection collection = DatabaseManager.getCollection(getBaseUri() + "/db/" + COLLECTION_NAME, TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD)){
+            Resource resource = collection.getResource(DOCUMENT_NAME);
+            assertEquals(ResourceType.XML_RESOURCE, resource.getResourceType());
+    	}
+    }
+
+	@BeforeClass
+    public static void startServer() throws ClassNotFoundException, IllegalAccessException, InstantiationException, XMLDBException, SAXException {
+        // initialize XML:DB driver
+        Class<?> cl = Class.forName("org.exist.xmldb.DatabaseImpl");
+        Database database = (Database) cl.newInstance();
+        DatabaseManager.registerDatabase(database);
+
+        Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        
+        CollectionManagementService mgmt = root.getService(CollectionManagementService.class);
+        assertThatNoException().isThrownBy(() -> mgmt.createCollection(COLLECTION_NAME));
+    }
+
+    @AfterClass
+    public static void stopServer() throws XMLDBException {
+        Collection root = DatabaseManager.getCollection(getBaseUri() + "/db", TestUtils.ADMIN_DB_USER, TestUtils.ADMIN_DB_PWD);
+        CollectionManagementService mgmt =
+                root.getService(CollectionManagementService.class);
+        mgmt.removeCollection(COLLECTION_NAME);
+
+        Collection config = DatabaseManager.getCollection(getBaseUri() + "/db/system/config/db", "admin", "");
+        mgmt = config.getService(CollectionManagementService.class);
+        mgmt.removeCollection(COLLECTION_NAME);
+    }
+}


### PR DESCRIPTION
### Description:
Closes #5067.

### Reference:
Since XML resources are always and only stored via the `parse()` method, we need to pass the Media Type as a parameter to this method.

### Type of tests:
A unit test in `exist-core/src/test/java/org/exist/xmlrpc`: `MimeTypeTest`

I successfully ran the full maven reactor locally. 