### PR TITLE
Handle IllegalStateException in `file:directory-list#2`

### DIFF
--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
@@ -24,7 +24,6 @@ package org.exist.xquery.modules.file;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Date;
 
 import org.apache.logging.log4j.LogManager;
@@ -34,11 +33,7 @@ import org.apache.tools.ant.DirectoryScanner;
 import org.exist.dom.QName;
 import org.exist.dom.memtree.MemTreeBuilder;
 import org.exist.util.FileUtils;
-import org.exist.xquery.BasicFunction;
-import org.exist.xquery.Cardinality;
-import org.exist.xquery.FunctionSignature;
-import org.exist.xquery.XPathException;
-import org.exist.xquery.XQueryContext;
+import org.exist.xquery.*;
 import org.exist.xquery.value.DateTimeValue;
 import org.exist.xquery.value.FunctionParameterSequenceType;
 import org.exist.xquery.value.FunctionReturnSequenceType;
@@ -47,9 +42,11 @@ import org.exist.xquery.value.Sequence;
 import org.exist.xquery.value.SequenceType;
 import org.exist.xquery.value.Type;
 
+import static org.exist.xquery.modules.file.FileErrorCode.DIRECTORY_NOT_FOUND;
+
 /**
  * eXist File Module Extension DirectoryList
- *
+ * <p>
  * Enumerate a list of files, including their size and modification time, found
  * in a specified directory, using a pattern
  *
@@ -121,7 +118,7 @@ public class DirectoryList extends BasicFunction {
         builder.addAttribute(new QName("directory", null, null), baseDir.toString());
         try {
             final int patternsLen = patterns.getItemCount();
-            final String includes[] = new String[patternsLen];
+            final String[] includes = new String[patternsLen];
             for (int i = 0; i < patternsLen; i++) {
                 includes[i] = patterns.itemAt(0).getStringValue();
             }
@@ -172,8 +169,8 @@ public class DirectoryList extends BasicFunction {
             builder.endElement();
 
             return (NodeValue) builder.getDocument().getDocumentElement();
-        } catch (final IOException e) {
-            throw new XPathException(this, e.getMessage());
+        } catch (final IOException | IllegalStateException e) {
+            throw new XPathException(this, DIRECTORY_NOT_FOUND, e.getMessage());
         } finally {
             context.popDocumentContext();
         }

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/DirectoryList.java
@@ -52,52 +52,46 @@ import static org.exist.xquery.modules.file.FileErrorCode.DIRECTORY_NOT_FOUND;
  *
  * @author <a href="mailto:andrzej@chaeron.com">Andrzej Taramina</a>
  * @author ljo
- * @serial 2009-08-09
  * @version 1.2
- *
- * @see
- * org.exist.xquery.BasicFunction#BasicFunction(org.exist.xquery.XQueryContext,
+ * @serial 2009-08-09
+ * @see org.exist.xquery.BasicFunction#BasicFunction(org.exist.xquery.XQueryContext,
  * org.exist.xquery.FunctionSignature)
  */
 public class DirectoryList extends BasicFunction {
 
-    private final static Logger logger = LogManager.getLogger(DirectoryList.class);
-
-    final static String NAMESPACE_URI = FileModule.NAMESPACE_URI;
-    final static String PREFIX = FileModule.PREFIX;
-
-    final static QName FILE_ELEMENT = new QName("file", NAMESPACE_URI, PREFIX);
-    final static QName LIST_ELEMENT = new QName("list", NAMESPACE_URI, PREFIX);
-
-    final static QName DIRECTORY_ATTRIBUTE = new QName("directory", null, null);
-    final static QName NAME_ATTRIBUTE = new QName("name", null, null);
-    final static QName SIZE_ATTRIBUTE = new QName("size", null, null);
-    final static QName HUMAN_SIZE_ATTRIBUTE = new QName("human-size", null, null);
-    final static QName MODIFIED_ATTRIBUTE = new QName("modified", null, null);
-    final static QName SUBDIR_ATTRIBUTE = new QName("subdir", null, null);
-
-    public final static FunctionSignature[] signatures
-            = {
-                new FunctionSignature(
-                        new QName("directory-list", NAMESPACE_URI, PREFIX),
-                        "List all files, including their file size and modification time, "
-                        + "found in or below a directory, $directory. Files are located in the server's "
-                        + "file system, using filename patterns, $pattern.  File pattern matching is based "
-                        + "on code from Apache's Ant, thus following the same conventions. For example:\n\n"
-                        + "'*.xml' matches any file ending with .xml in the current directory,\n- '**/*.xml' matches files "
-                        + "in any directory below the specified directory.  This method is only available to the DBA role.",
-                        new SequenceType[]{
+    static final String NAMESPACE_URI = FileModule.NAMESPACE_URI;
+    static final String PREFIX = FileModule.PREFIX;
+    public static final FunctionSignature[] signatures = {
+            new FunctionSignature(
+                    new QName("directory-list", NAMESPACE_URI, PREFIX),
+                    "List all files, including their file size and modification time, "
+                            + "found in or below a directory, $directory. Files are located in the server's "
+                            + "file system, using filename patterns, $pattern.  File pattern matching is based "
+                            + "on code from Apache's Ant, thus following the same conventions. For example:\n\n"
+                            + "'*.xml' matches any file ending with .xml in the current directory,\n- '**/*.xml' matches files "
+                            + "in any directory below the specified directory.  This method is only available to the DBA role.",
+                    new SequenceType[]{
                             new FunctionParameterSequenceType("path", Type.ITEM,
                                     Cardinality.EXACTLY_ONE, "The base directory path or URI in the file system where the files are located."),
                             new FunctionParameterSequenceType("pattern", Type.STRING,
                                     Cardinality.ZERO_OR_MORE, "The file name pattern")
-                        },
-                        new FunctionReturnSequenceType(Type.NODE,
-                                Cardinality.ZERO_OR_ONE, "a node fragment that shows all matching "
-                                + "filenames, including their file size and modification time, and "
-                                + "the subdirectory they were found in")
-                )
-            };
+                    },
+                    new FunctionReturnSequenceType(Type.NODE,
+                            Cardinality.ZERO_OR_ONE, "a node fragment that shows all matching "
+                            + "filenames, including their file size and modification time, and "
+                            + "the subdirectory they were found in")
+            )
+    };
+    static final QName FILE_ELEMENT = new QName("file", NAMESPACE_URI, PREFIX);
+    static final QName LIST_ELEMENT = new QName("list", NAMESPACE_URI, PREFIX);
+
+    static final QName DIRECTORY_ATTRIBUTE = new QName("directory", null, null);
+    static final QName NAME_ATTRIBUTE = new QName("name", null, null);
+    static final QName SIZE_ATTRIBUTE = new QName("size", null, null);
+    static final QName HUMAN_SIZE_ATTRIBUTE = new QName("human-size", null, null);
+    static final QName MODIFIED_ATTRIBUTE = new QName("modified", null, null);
+    static final QName SUBDIR_ATTRIBUTE = new QName("subdir", null, null);
+    private static final Logger logger = LogManager.getLogger(DirectoryList.class);
 
     public DirectoryList(final XQueryContext context, final FunctionSignature signature) {
         super(context, signature);

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/FileErrorCode.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/FileErrorCode.java
@@ -25,9 +25,10 @@ import org.exist.dom.QName;
 import org.exist.xquery.ErrorCodes;
 
 class FileErrorCode extends ErrorCodes.ErrorCode {
-    public static final ErrorCodes.ErrorCode DIRECTORY_NOT_FOUND = new FileErrorCode("DIRECTORY_NOT_FOUND", "The directory could not be found.");
+    public static final ErrorCodes.ErrorCode DIRECTORY_NOT_FOUND = new FileErrorCode("DIRECTORY_NOT_FOUND",
+            "The directory could not be found.");
 
-    FileErrorCode(String code, String description) {
+    FileErrorCode(final String code, final String description) {
         super(new QName(code, FileModule.NAMESPACE_URI, FileModule.PREFIX), description);
     }
 }

--- a/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/FileErrorCode.java
+++ b/extensions/modules/file/src/main/java/org/exist/xquery/modules/file/FileErrorCode.java
@@ -1,0 +1,33 @@
+/*
+ * eXist-db Open Source Native XML Database
+ * Copyright (C) 2001 The eXist-db Authors
+ *
+ * info@exist-db.org
+ * http://www.exist-db.org
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.exist.xquery.modules.file;
+
+import org.exist.dom.QName;
+import org.exist.xquery.ErrorCodes;
+
+class FileErrorCode extends ErrorCodes.ErrorCode {
+    public static final ErrorCodes.ErrorCode DIRECTORY_NOT_FOUND = new FileErrorCode("DIRECTORY_NOT_FOUND", "The directory could not be found.");
+
+    FileErrorCode(String code, String description) {
+        super(new QName(code, FileModule.NAMESPACE_URI, FileModule.PREFIX), description);
+    }
+}

--- a/extensions/modules/file/src/test/xquery/modules/file/directory-list.xqm
+++ b/extensions/modules/file/src/test/xquery/modules/file/directory-list.xqm
@@ -1,0 +1,47 @@
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2001 The eXist-db Authors
+ :
+ : info@exist-db.org
+ : http://www.exist-db.org
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; either
+ : version 2.1 of the License, or (at your option) any later version.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace dirlist="http://exist-db.org/testsuite/modules/file/dirlist";
+
+
+import module namespace file="http://exist-db.org/xquery/file";
+
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+
+declare
+    %test:assertError("file:DIRECTORY_NOT_FOUND")
+function dirlist:non-existent-error-code() {
+    file:directory-list("/non/existent", ())
+};
+
+declare
+    %test:assertXPath("contains($result,'basedir /non/existent does not exist.') or contains($result,'basedir \non\existent does not exist.')")
+function dirlist:non-existent-error-description() {
+    try {
+        file:directory-list("/non/existent", ())
+    } catch file:DIRECTORY_NOT_FOUND {
+        $err:description
+    }
+};


### PR DESCRIPTION
Closes #5028

The Java code of DirectoryList can throw an IllegalStateException when a non-existent directory is supplied as its first argument. This exception class is now handled in file:list#2.

This is a forward port of #5061 
Thanks to @nverwer for bringing this up and also finding the fix.