### PR TITLE
[6.x.x] Add Schema for EXPath Packaging System

### DIFF
--- a/schema/collection.xconf.xsd
+++ b/schema/collection.xconf.xsd
@@ -68,6 +68,7 @@
     <xs:complexType name="rangeIndexCreateType">
         <xs:group ref="cc:fieldDefinitions"/>
         <xs:attributeGroup ref="cc:qnameOpt"/>
+        <xs:attributeGroup ref="cc:matchOpt"/>
         <xs:attributeGroup ref="cc:typeOpt"/>
         <xs:attributeGroup ref="cc:nestedOpt"/>
         <xs:attributeGroup ref="cc:whitespaceOpt"/>

--- a/schema/collection.xconf.xsd
+++ b/schema/collection.xconf.xsd
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dcterms="http://purl.org/dc/terms/"
-    xmlns="http://exist-db.org/collection-config/1.0"
-    targetNamespace="http://exist-db.org/collection-config/1.0" elementFormDefault="qualified"
-    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cc="http://exist-db.org/collection-config/1.0"
+           xmlns:dcterms="http://purl.org/dc/terms/"
+           elementFormDefault="qualified"
+           targetNamespace="http://exist-db.org/collection-config/1.0"
+           version="1.0.0">
 
     <xs:annotation>
         <xs:documentation>Schema for eXist-db Collection Configuration files /db/system/config/db/**/collection.xconf</xs:documentation>
@@ -14,30 +17,30 @@
         </xs:appinfo>
     </xs:annotation>
 
-    <xs:element name="collection" type="collectionType"/>
+    <xs:element name="collection" type="cc:collectionType"/>
 
     <xs:complexType name="collectionType">
         <xs:annotation>
             <xs:documentation>At least one `index`, `triggers`, or `validation` element must be present, and each may only appear once.</xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element ref="index" minOccurs="0"/>
-            <xs:element ref="triggers" minOccurs="0"/>
-            <xs:element ref="validation" minOccurs="0"/>
+            <xs:element ref="cc:index" minOccurs="0"/>
+            <xs:element ref="cc:triggers" minOccurs="0"/>
+            <xs:element ref="cc:validation" minOccurs="0"/>
         </xs:all>
         <xs:assert test="count(*) ge 1"/>
     </xs:complexType>
-    <xs:element name="index" type="indexType"/>
+    <xs:element name="index" type="cc:indexType"/>
     <xs:complexType name="indexType">
         <xs:annotation>
             <xs:documentation>Index Configuration</xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element ref="lucene" minOccurs="0"/>
-            <xs:element ref="range" minOccurs="0"/>
-            <xs:element name="create" type="oldRangeIndexType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="ngram" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="gml" minOccurs="0"/>
+            <xs:element ref="cc:lucene" minOccurs="0"/>
+            <xs:element ref="cc:range" minOccurs="0"/>
+            <xs:element name="create" type="cc:oldRangeIndexType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="cc:ngram" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="cc:gml" minOccurs="0"/>
         </xs:all>
 
     </xs:complexType>
@@ -46,217 +49,217 @@
         <xs:annotation>
             <xs:documentation>Either @qname or @path must be specified. Not both!</xs:documentation>
         </xs:annotation>
-        <xs:attributeGroup ref="pathOpt"/>
-        <xs:attributeGroup ref="qnameOpt"/>
-        <xs:attributeGroup ref="typeReq"/>
+        <xs:attributeGroup ref="cc:pathOpt"/>
+        <xs:attributeGroup ref="cc:qnameOpt"/>
+        <xs:attributeGroup ref="cc:typeReq"/>
         <xs:assert test="(@qname and not(@path)) or (@path and not(@qname))"/>
     </xs:complexType>
 
-    <xs:element name="range" type="newRangeIndexType"/>
+    <xs:element name="range" type="cc:newRangeIndexType"/>
     
     <xs:complexType name="newRangeIndexType">
         <xs:sequence>
-            <xs:element ref="create" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="cc:create" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
     
-    <xs:element name="create" type="rangeIndexCreateType"/>
+    <xs:element name="create" type="cc:rangeIndexCreateType"/>
     
     <xs:complexType name="rangeIndexCreateType">
-        <xs:group ref="fieldDefinitions"/>
-        <xs:attributeGroup ref="qnameOpt"/>
-        <xs:attributeGroup ref="typeOpt"/>
-        <xs:attributeGroup ref="nestedOpt"/>
-        <xs:attributeGroup ref="whitespaceOpt"/>
-        <xs:attributeGroup ref="caseOpt"/>
-        <xs:attributeGroup ref="collationOpt"/>
+        <xs:group ref="cc:fieldDefinitions"/>
+        <xs:attributeGroup ref="cc:qnameOpt"/>
+        <xs:attributeGroup ref="cc:typeOpt"/>
+        <xs:attributeGroup ref="cc:nestedOpt"/>
+        <xs:attributeGroup ref="cc:whitespaceOpt"/>
+        <xs:attributeGroup ref="cc:caseOpt"/>
+        <xs:attributeGroup ref="cc:collationOpt"/>
     </xs:complexType>
     
     <xs:group name="fieldDefinitions">
         <xs:all>
-            <xs:element name="condition" type="newRangeIndexConditionType" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="field" type="newRangeIndexFieldType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="condition" type="cc:newRangeIndexConditionType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="field" type="cc:newRangeIndexFieldType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:all>
     </xs:group>
     
     <xs:complexType name="newRangeIndexConditionType">
-        <xs:attributeGroup ref="attributeReq"/>
-        <xs:attributeGroup ref="operatorOpt"/>
-        <xs:attributeGroup ref="valueReq"/>
-        <xs:attributeGroup ref="caseOpt"/>
-        <xs:attributeGroup ref="numericOpt"/>
+        <xs:attributeGroup ref="cc:attributeReq"/>
+        <xs:attributeGroup ref="cc:operatorOpt"/>
+        <xs:attributeGroup ref="cc:valueReq"/>
+        <xs:attributeGroup ref="cc:caseOpt"/>
+        <xs:attributeGroup ref="cc:numericOpt"/>
     </xs:complexType>
     
     <xs:complexType name="newRangeIndexFieldType">
-        <xs:attributeGroup ref="nameReq"/>
-        <xs:attributeGroup ref="matchOpt"/>
-        <xs:attributeGroup ref="caseOpt"/>
-        <xs:attributeGroup ref="nestedOpt"/>
-        <xs:attributeGroup ref="whitespaceOpt"/>
-        <xs:attributeGroup ref="typeReq"/>
+        <xs:attributeGroup ref="cc:nameReq"/>
+        <xs:attributeGroup ref="cc:matchOpt"/>
+        <xs:attributeGroup ref="cc:caseOpt"/>
+        <xs:attributeGroup ref="cc:nestedOpt"/>
+        <xs:attributeGroup ref="cc:whitespaceOpt"/>
+        <xs:attributeGroup ref="cc:typeReq"/>
     </xs:complexType>
     
-    <xs:element name="lucene" type="luceneType"/>
+    <xs:element name="lucene" type="cc:luceneType"/>
 
     <xs:complexType name="luceneType">
         <xs:all>
-            <xs:element ref="analyzer" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="module" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element ref="text" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:group ref="textInstruction"/>
+            <xs:element ref="cc:analyzer" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="cc:module" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="cc:text" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="cc:textInstruction"/>
         </xs:all>
-        <xs:attributeGroup ref="diacriticsOpt"/>
+        <xs:attributeGroup ref="cc:diacriticsOpt"/>
     </xs:complexType>
 
-    <xs:element name="analyzer" type="analyzerType"/>
+    <xs:element name="analyzer" type="cc:analyzerType"/>
 
     <xs:complexType name="analyzerType">
         <xs:sequence minOccurs="0">
-            <xs:element ref="param" maxOccurs="unbounded"/>
+            <xs:element ref="cc:param" maxOccurs="unbounded"/>
         </xs:sequence>
-        <xs:attributeGroup ref="idOpt"/>
-        <xs:attributeGroup ref="classReq"/>
+        <xs:attributeGroup ref="cc:idOpt"/>
+        <xs:attributeGroup ref="cc:classReq"/>
     </xs:complexType>
 
-    <xs:element name="param" type="paramType"/>
+    <xs:element name="param" type="cc:paramType"/>
 
     <xs:complexType name="paramType">
         <xs:sequence minOccurs="0">
             <xs:element name="value" maxOccurs="unbounded" type="xs:string"/>
         </xs:sequence>
-        <xs:attributeGroup ref="nameReq"/>
+        <xs:attributeGroup ref="cc:nameReq"/>
         <xs:attribute name="type" type="xs:string" use="optional" default="java.lang.String"/>
-        <xs:attributeGroup ref="valueOpt"/>
+        <xs:attributeGroup ref="cc:valueOpt"/>
     </xs:complexType>
     
-    <xs:element name="module" type="moduleType"/>
+    <xs:element name="module" type="cc:moduleType"/>
     
     <xs:complexType name="moduleType">
-        <xs:attributeGroup ref="uriReq"/>
-        <xs:attributeGroup ref="prefixReq"/>
-        <xs:attributeGroup ref="atReq"/>
+        <xs:attributeGroup ref="cc:uriReq"/>
+        <xs:attributeGroup ref="cc:prefixReq"/>
+        <xs:attributeGroup ref="cc:atReq"/>
     </xs:complexType>
 
     <xs:group name="textInstruction">
         <xs:all>
-            <xs:element name="facet" minOccurs="0" maxOccurs="unbounded" type="facetAttrType"/>
-            <xs:element name="field" minOccurs="0" maxOccurs="unbounded" type="fieldAttrType"/>
-            <xs:element name="ignore" minOccurs="0" maxOccurs="unbounded" type="singleQnameAttrType"/>
-            <xs:element name="inline" minOccurs="0" maxOccurs="unbounded" type="singleQnameAttrType"/>
-            <xs:element name="match-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
-            <xs:element name="match-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="matchAttrBoostType"/>
-            <xs:element name="has-attribute" minOccurs="0" maxOccurs="unbounded" type="hasAttrBoostType"/>
-            <xs:element name="has-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="hasAttrBoostType"/>
+            <xs:element name="facet" minOccurs="0" maxOccurs="unbounded" type="cc:facetAttrType"/>
+            <xs:element name="field" minOccurs="0" maxOccurs="unbounded" type="cc:fieldAttrType"/>
+            <xs:element name="ignore" minOccurs="0" maxOccurs="unbounded" type="cc:singleQnameAttrType"/>
+            <xs:element name="inline" minOccurs="0" maxOccurs="unbounded" type="cc:singleQnameAttrType"/>
+            <xs:element name="match-attribute" minOccurs="0" maxOccurs="unbounded" type="cc:matchAttrBoostType"/>
+            <xs:element name="match-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="cc:matchAttrBoostType"/>
+            <xs:element name="has-attribute" minOccurs="0" maxOccurs="unbounded" type="cc:hasAttrBoostType"/>
+            <xs:element name="has-sibling-attribute" minOccurs="0" maxOccurs="unbounded" type="cc:hasAttrBoostType"/>
         </xs:all>
     </xs:group>
 
-    <xs:element name="text" type="textType"/>
+    <xs:element name="text" type="cc:textType"/>
 
     <xs:complexType name="textType">
         <xs:annotation>
             <xs:documentation>Either @qname or @match must be specified. Not both!</xs:documentation>
         </xs:annotation>
-        <xs:group ref="textInstruction"/>
-        <xs:attributeGroup ref="qnameOpt"/>
-        <xs:attributeGroup ref="matchOpt"/>
-        <xs:attributeGroup ref="analyzerOpt"/>
-        <xs:attributeGroup ref="boostOpt"/>
-        <xs:attributeGroup ref="fieldOpt"/>
-        <xs:attributeGroup ref="indexOpt"/>
+        <xs:group ref="cc:textInstruction"/>
+        <xs:attributeGroup ref="cc:qnameOpt"/>
+        <xs:attributeGroup ref="cc:matchOpt"/>
+        <xs:attributeGroup ref="cc:analyzerOpt"/>
+        <xs:attributeGroup ref="cc:boostOpt"/>
+        <xs:attributeGroup ref="cc:fieldOpt"/>
+        <xs:attributeGroup ref="cc:indexOpt"/>
         <xs:assert test="(@qname and not(@match)) or (@match and not(@qname))"/>
     </xs:complexType>
 
     <xs:complexType name="facetAttrType">
-        <xs:attributeGroup ref="dimensionReq"/>
-        <xs:attributeGroup ref="expressionReq"/>
-        <xs:attributeGroup ref="hierarchicalOpt"/>
+        <xs:attributeGroup ref="cc:dimensionReq"/>
+        <xs:attributeGroup ref="cc:expressionReq"/>
+        <xs:attributeGroup ref="cc:hierarchicalOpt"/>
     </xs:complexType>
     
     <xs:complexType name="fieldAttrType">
-        <xs:attributeGroup ref="nameReq"/>
-        <xs:attributeGroup ref="ifOpt"/>
-        <xs:attributeGroup ref="expressionOpt"/>
-        <xs:attributeGroup ref="typeOpt"/>
-        <xs:attributeGroup ref="analyzerOpt"/>
-        <xs:attributeGroup ref="storeOpt"/>
+        <xs:attributeGroup ref="cc:nameReq"/>
+        <xs:attributeGroup ref="cc:ifOpt"/>
+        <xs:attributeGroup ref="cc:expressionOpt"/>
+        <xs:attributeGroup ref="cc:typeOpt"/>
+        <xs:attributeGroup ref="cc:analyzerOpt"/>
+        <xs:attributeGroup ref="cc:storeOpt"/>
     </xs:complexType>
 
     <xs:complexType name="matchAttrBoostType">
-        <xs:attributeGroup ref="qnameReq"/>
-        <xs:attributeGroup ref="valueReq"/>
-        <xs:attributeGroup ref="boostReq"/>
+        <xs:attributeGroup ref="cc:qnameReq"/>
+        <xs:attributeGroup ref="cc:valueReq"/>
+        <xs:attributeGroup ref="cc:boostReq"/>
     </xs:complexType>
 
     <xs:complexType name="hasAttrBoostType">
-        <xs:attributeGroup ref="qnameReq"/>
-        <xs:attributeGroup ref="boostReq"/>
+        <xs:attributeGroup ref="cc:qnameReq"/>
+        <xs:attributeGroup ref="cc:boostReq"/>
     </xs:complexType>
 
     <xs:complexType name="singleQnameAttrType">
-        <xs:attributeGroup ref="qnameReq"/>
+        <xs:attributeGroup ref="cc:qnameReq"/>
     </xs:complexType>
 
-    <xs:element name="ngram" type="singleQnameAttrType"/>
+    <xs:element name="ngram" type="cc:singleQnameAttrType"/>
 
-    <xs:element name="gml" type="gmlIndexType"/>
+    <xs:element name="gml" type="cc:gmlIndexType"/>
 
     <xs:complexType name="gmlIndexType">
-        <xs:attributeGroup ref="flushAfterReq"/>
+        <xs:attributeGroup ref="cc:flushAfterReq"/>
     </xs:complexType>
 
-    <xs:element name="triggers" type="triggersType"/>
+    <xs:element name="triggers" type="cc:triggersType"/>
 
     <xs:complexType name="triggersType">
         <xs:annotation>
             <xs:documentation>Trigger Configuration</xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element ref="trigger" maxOccurs="unbounded"/>
+            <xs:element ref="cc:trigger" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:element name="trigger" type="triggerType"/>
+    <xs:element name="trigger" type="cc:triggerType"/>
 
     <xs:complexType name="triggerType">
         <xs:sequence minOccurs="0">
-            <xs:element ref="parameter" maxOccurs="unbounded"/>
+            <xs:element ref="cc:parameter" maxOccurs="unbounded"/>
         </xs:sequence>
-        <xs:attributeGroup ref="eventOpt">
+        <xs:attributeGroup ref="cc:eventOpt">
             <xs:annotation>
                 <xs:documentation>This is deprecated, triggers should now code functions for each event</xs:documentation>
             </xs:annotation>
         </xs:attributeGroup>
-        <xs:attributeGroup ref="classReq"/>
+        <xs:attributeGroup ref="cc:classReq"/>
     </xs:complexType>
 
-    <xs:element name="parameter" type="parameterType"/>
+    <xs:element name="parameter" type="cc:parameterType"/>
 
     <xs:complexType name="parameterType">
-        <xs:attributeGroup ref="nameReq"/>
-        <xs:attributeGroup ref="valueReq"/>
+        <xs:attributeGroup ref="cc:nameReq"/>
+        <xs:attributeGroup ref="cc:valueReq"/>
     </xs:complexType>
 
-    <xs:element name="validation" type="validationType"/>
+    <xs:element name="validation" type="cc:validationType"/>
 
     <xs:complexType name="validationType">
         <xs:annotation>
             <xs:documentation>Per collection validation-switch configuration</xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element ref="entity-resolver" minOccurs="0"/>
+            <xs:element ref="cc:entity-resolver" minOccurs="0"/>
         </xs:sequence>
-        <xs:attributeGroup ref="modeReq"/>
+        <xs:attributeGroup ref="cc:modeReq"/>
     </xs:complexType>
 
-    <xs:element name="entity-resolver" type="entityResolverType"/>
+    <xs:element name="entity-resolver" type="cc:entityResolverType"/>
 
     <xs:complexType name="entityResolverType">
         <xs:sequence>
-            <xs:element ref="catalog" maxOccurs="unbounded"/>
+            <xs:element ref="cc:catalog" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:element name="catalog" type="catalogType"/>
+    <xs:element name="catalog" type="cc:catalogType"/>
 
     <xs:complexType name="catalogType">
         <xs:attribute name="uri" type="xs:string" use="required"/>

--- a/schema/conf.xsd
+++ b/schema/conf.xsd
@@ -6,7 +6,9 @@
     TODO: Remove optional attributes in favour of well defined/named parent elements
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="1.0.0">
     
     <!-- Shared types -->
     <xs:simpleType name="yes_no">

--- a/schema/controller-config.xsd
+++ b/schema/controller-config.xsd
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://exist.sourceforge.net/NS/exist" xmlns:exist="http://exist.sourceforge.net/NS/exist">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           xmlns:exist="http://exist.sourceforge.net/NS/exist"
+           elementFormDefault="qualified"
+           targetNamespace="http://exist.sourceforge.net/NS/exist"
+           version="1.0.0">
   <xs:element name="configuration">
     <xs:complexType>
       <xs:choice maxOccurs="unbounded">

--- a/schema/descriptor.xsd
+++ b/schema/descriptor.xsd
@@ -4,7 +4,9 @@
     Schema for eXist WebApp Descriptor Configuration file descriptor.xml
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="1.0.0">
     <xs:element name="xquery-app">
         <xs:complexType>
             <xs:sequence>

--- a/schema/expath-pkg-extensions/cxan.xsd
+++ b/schema/expath-pkg-extensions/cxan.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cxan="http://cxan.org/ns/package"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    elementFormDefault="qualified"
+    targetNamespace="http://cxan.org/ns/package">
+    
+    <xs:annotation>
+        <xs:documentation>A schema for the EXPath Packaging CXAN concept.</xs:documentation>
+        <xs:appinfo>
+            <dcterms:title>Schema for the EXPath Packaging CXAN concept.</dcterms:title>
+            <dcterms:created xsi:type="dcterms:W3CDTF">2013-11-03T11:36:19.343+01:00</dcterms:created>
+            <dcterms:creator>Adam Retter</dcterms:creator>
+        </xs:appinfo>
+    </xs:annotation>
+    
+    <xs:element name="package">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="cxan:author"/>
+                <xs:element ref="cxan:category" maxOccurs="unbounded"/>
+                <xs:element ref="cxan:tag" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="id" type="xs:NCName"/>
+            <xs:attribute name="name" type="xs:anyURI"/>
+            <xs:attribute name="version" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="author">
+        <xs:annotation>
+            <xs:documentation>A textual description of the author.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="id" use="optional" type="xs:NCName">
+                        <xs:annotation>
+                            <xs:documentation>A simple identifier for the author.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="category" type="xs:NCName"/>
+    
+    <xs:element name="tag" type="xs:NCName"/>
+
+</xs:schema>

--- a/schema/expath-pkg-extensions/exist.xsd
+++ b/schema/expath-pkg-extensions/exist.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:eepkg="http://exist-db.org/ns/expath-pkg"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    elementFormDefault="qualified"
+    targetNamespace="http://exist-db.org/ns/expath-pkg">
+    
+    <xs:annotation>
+        <xs:documentation>A schema for eXist-db extensions to EXPath Packaging.</xs:documentation>
+        <xs:appinfo>
+            <dcterms:title>eXist-db extensions to EXPath Packaging</dcterms:title>
+            <dcterms:created xsi:type="dcterms:W3CDTF">2013-11-03T11:36:19.343+01:00</dcterms:created>
+            <dcterms:creator>Adam Retter</dcterms:creator>
+        </xs:appinfo>
+    </xs:annotation>
+    
+    <xs:element name="package">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="eepkg:java" maxOccurs="unbounded"/>
+                <xs:element ref="eepkg:jar" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="java">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="eepkg:namespace"/>
+                <xs:element ref="eepkg:class"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="namespace" type="xs:anyURI"/>
+    <xs:element name="class" type="xs:string"/>
+    
+    <xs:element name="jar" type="xs:string"/>
+    
+</xs:schema>

--- a/schema/expath-pkg-extensions/repo.xsd
+++ b/schema/expath-pkg-extensions/repo.xsd
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:repo="http://exist-db.org/xquery/repo"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    elementFormDefault="qualified"
+    targetNamespace="http://exist-db.org/xquery/repo">
+    
+    <xs:annotation>
+        <xs:documentation>A schema for eXist-db Package Repository extensions to EXPath Packaging.</xs:documentation>
+        <xs:appinfo>
+            <dcterms:title>eXist-db Package Repository extensions to EXPath Packaging</dcterms:title>
+            <dcterms:created xsi:type="dcterms:W3CDTF">2013-11-03T11:36:19.343+01:00</dcterms:created>
+            <dcterms:creator>Adam Retter</dcterms:creator>
+        </xs:appinfo>
+    </xs:annotation>
+    
+    <xs:element name="meta">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="repo:description"/>
+                <xs:element ref="repo:author"/>
+                <xs:element ref="repo:website"/>
+                <xs:element ref="repo:status"/>
+                <xs:element ref="repo:license"/>
+                <xs:element ref="repo:copyright"/>
+                <xs:element ref="repo:type"/>
+                <xs:element ref="repo:target" minOccurs="0"/>
+                <xs:element ref="repo:prepare" minOccurs="0"/>
+                <xs:element ref="repo:finish" minOccurs="0"/>
+                <xs:element ref="repo:permissions" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="repo:changelog" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="description" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>A textual description of the package</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:element name="author">
+        <xs:annotation>
+            <xs:documentation>A textual description of the author.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="id" use="optional" type="xs:NCName">
+                        <xs:annotation>
+                            <xs:documentation>A simple identifier for the author.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="website" type="xs:anyURI">
+        <xs:annotation>
+            <xs:documentation>A link to an informational website about the package</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:element name="status" type="xs:NCName">
+        <xs:annotation>
+            <xs:documentation>The status of the package</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:element name="license" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>Name of the license that the package is released under</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:element name="copyright" type="xs:boolean">
+        <xs:annotation>
+            <xs:documentation>Indicates whether there is a copyright on the package</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:element name="type" type="repo:typeType">
+        <xs:annotation>
+            <xs:documentation>Indicates whether there is a copyright on the package</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:simpleType name="typeType">
+        <xs:restriction base="xs:NCName">
+            <xs:enumeration value="application"/>
+            <xs:enumeration value="library"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:element name="target" type="xs:NCName">
+        <xs:annotation>
+            <xs:documentation>A name indicating the final collection name of where the package is installed</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:element name="prepare" type="xs:anyURI">
+        <xs:annotation>
+            <xs:documentation>The path to an XQuery script that may be executed before the package is installed</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:element name="finish" type="xs:anyURI">
+        <xs:annotation>
+            <xs:documentation>The path to an XQuery script that may be executed after the package is installed</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:element name="permissions" type="repo:permissionsType">
+        <xs:annotation>
+            <xs:documentation>Describes permissions that should be applied to a resource from the package when it is installed into the database.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:complexType name="permissionsType">
+        <xs:attribute name="user" type="xs:NCName"/>
+        <xs:attribute name="password" type="xs:string"/>
+        <xs:attribute name="group" type="xs:NCName"/>
+        <xs:attribute name="mode" type="xs:string"/>
+    </xs:complexType>
+    
+    <xs:element name="changelog">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="repo:change" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="change">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any namespace="http://www.w3.org/1999/xhtml"/>
+            </xs:sequence>
+            <xs:attribute name="version" type="xs:NCName" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    
+</xs:schema>

--- a/schema/expath-pkg.xsd
+++ b/schema/expath-pkg.xsd
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:pkg="http://expath.org/ns/pkg"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    elementFormDefault="qualified"
+    targetNamespace="http://expath.org/ns/pkg">
+    
+    <xs:annotation>
+        <xs:documentation>A schema for EXPath Packaging (i.e. <code>expath-pkg.xml</code>) file as per the <a href="http://expath.org/spec/pkg">EXPath Packaging System - Candidate Module 9 May 2012'</a> specification.</xs:documentation>
+        <xs:appinfo>
+            <dcterms:title>Schema for EXPath Packaging</dcterms:title>
+            <dcterms:created xsi:type="dcterms:W3CDTF">2013-11-03T11:36:19.343+01:00</dcterms:created>
+            <dcterms:creator>Adam Retter</dcterms:creator>
+        </xs:appinfo>
+    </xs:annotation>
+    
+    <xs:element name="package">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="title" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>A simple description of the package for humans.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="home" minOccurs="0" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>A URI to find more information about the package.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded" type="pkg:dependencyType">
+                    <xs:annotation>
+                        <xs:documentation>A dependency of this package.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:group ref="pkg:component" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:anyURI" use="required">
+                <xs:annotation>
+                    <xs:documentation>The name of the package. A package is named using an IRI, as defined by <a href="file:///Users/aretter/Desktop/expath-pkg-spec.html#rfc3987">[RFC 3987]</a>, excepted any IRI using the file: scheme (most frequent choices are http: and urn: scheme URIs). Note that the definition of IRI excludes relative references.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="abrev" type="xs:NCName" use="required"/>
+            <xs:attribute name="version" type="pkg:semVer2Type" use="required"/>
+            <xs:attribute name="spec" type="xs:string" use="required" fixed="1.0">
+                <xs:annotation>
+                    <xs:documentation>The version of the packaging specification the package conforms to.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:group name="component">
+        <xs:annotation>
+            <xs:documentation>The standard component kinds supported by this specification, and how they contribute to the package descriptor document type. Every component has the same basic information: it associates a public URI to a specific file within the content directory. The file element contains a path, relative to the package content directory. Both elements in a component are of type anyURI.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="xslt" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>An XSLT file is associated a public import URI. This is the URI to use in an XSLT import instruction (aka xsl:import) to import the XSLT file provided in the package.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="xquery" type="pkg:xqueryType">
+                    <xs:annotation>
+                        <xs:documentation>An XQuery library module is referenced by its namespace URI. Thus the xquery element associates a namespace URI to an XQuery file. An importing module just need to use an import statement of the form <code>import module namespace xx = "&lt;namespace-uri&gt;'"</code>;. An XQuery main module is associated a public URI. Usually an XQuery package will provide functions through library modules, but in some cases one can want to provide main modules as well.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="xproc" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>An XProc pipeline, like an XSLT stylesheet, is associated a public import URI, aimed to be used in an XProc p:import statement.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="xsd" type="pkg:xsdType">
+                    <xs:annotation>
+                        <xs:documentation>An XML schema can be imported using its target namespace. It is not possible to set several files as several sources for the schema. If the schema is spread over multiple files, there must be one top-level file that includes the other files.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="rng" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>A RelaxNG schema, like an XSLT stylesheet, is associated a public import URI, aimed to be used in the include element for an RNG schema.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="rnc" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>A RelaxNG schema, like an XSLT stylesheet, is associated a public import URI, aimed to be used in an import directive for an RNC schema.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="schematron" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>A Schematron schema is associated a public URI.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="nvdl" type="pkg:importUriFromFileType">
+                    <xs:annotation>
+                        <xs:documentation>An NVDL script is associated a public URI.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dtd" type="pkg:dtdType">
+                    <xs:annotation>
+                        <xs:documentation>A DTD file is associated a public URI.</xs:documentation>
+                    </xs:annotation>                    
+                </xs:element>
+                <xs:element name="resource" type="pkg:resourceType">
+                    <xs:annotation>
+                        <xs:documentation>A resource file is associated a public URI. This can be any kind of file. It has to be used in accordance to its content. For instance accessing a text file through fn:unparsed-text() is correct, while using fn:doc() is not (it will raise an error because it parses the content as XML).</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+    
+
+    <xs:complexType name="xqueryType">
+        <xs:attribute name="namespace" type="xs:anyURI" use="optional">
+            <xs:annotation>
+                <xs:documentation>The URI of the Namespace of the XQuery Library Module.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="pkg:import-uri" use="optional">
+            <xs:annotation>
+                <xs:documentation>The URI of where the XQuery Main Module should be accessible from.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="pkg:file" use="required"/>
+        <xs:assert test="(@namespace and not(@import-uri)) or (not(@namespace) and @import-uri)">
+            <xs:annotation>
+                <xs:documentation>The @namespace and @import-uri attributes are mutually exclusive.</xs:documentation>
+            </xs:annotation>
+        </xs:assert>
+    </xs:complexType>
+    
+    <xs:complexType name="xsdType">
+        <xs:attribute name="namespace" type="xs:anyURI" use="optional">
+            <xs:annotation>
+                <xs:documentation>The URI of the Target Namespace of the XML Schema.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="pkg:import-uri" use="optional">
+            <xs:annotation>
+                <xs:documentation>The import-uri can be used to define a schema location for this schema component. This can be useful for schema without target namespace, or for some specific usages, like when using xs:redefine.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute ref="pkg:file" use="required"/>
+        <xs:assert test="(@namespace and not(@import-uri)) or (not(@namespace) and @import-uri)">
+            <xs:annotation>
+                <xs:documentation>The @namespace and @import-uri attributes are mutually exclusive.</xs:documentation>
+            </xs:annotation>
+        </xs:assert>
+    </xs:complexType>
+    
+    <xs:complexType name="dtdType">
+        <xs:attribute name="public-id" type="pkg:dtdFormalPublicIdentifierType" use="optional"/>
+        <xs:attribute name="system-id" type="xs:anyURI"/>
+        <xs:attribute ref="pkg:file"/>
+    </xs:complexType>
+    
+    <xs:simpleType name="dtdFormalPublicIdentifierType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value=".+\/\/.+\/\/.+\/\/.+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:complexType name="resourceType">
+        <xs:attribute name="public-uri" type="xs:anyURI"/>
+        <xs:attribute ref="pkg:file"/>
+    </xs:complexType>
+
+    <xs:complexType name="importUriFromFileType">
+        <xs:attribute ref="pkg:import-uri" use="required"/>
+        <xs:attribute ref="pkg:file" use="required"/>
+    </xs:complexType>
+    
+    <xs:attribute name="import-uri" type="xs:anyURI"/>
+    
+    <xs:attribute name="file" type="xs:anyURI">
+        <xs:annotation>
+            <xs:documentation>Contains a path, relative to the package content directory.</xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    
+    <xs:complexType name="dependencyType">
+        <xs:annotation>
+            <xs:documentation>Must specify a 'package' or 'processor', and one of 'versions', 'semver', or ('semver-min' and/or 'semver-max').</xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="package" type="xs:anyURI" use="optional"/>
+        <xs:attribute name="processor" type="xs:string" use="optional"/>
+
+        <xs:attribute name="versions" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The exact set of acceptable versions for the secondary package, separated by spaces.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="semver" type="pkg:semVer2OrSemVer2TemplateType"/>
+        <xs:attribute name="semver-min" type="pkg:semVer2OrSemVer2TemplateType"/>
+        <xs:attribute name="semver-max" type="pkg:semVer2OrSemVer2TemplateType"/>
+        
+        <xs:assert test="(@package and not(@processor)) or (not(@package) and @processor)">
+            <xs:annotation>
+                <xs:documentation>The @package and @processor attributes are mutually exclusive.</xs:documentation>
+            </xs:annotation>
+        </xs:assert>
+        
+        <xs:assert test="(@versions and not(@semver) and not(@semver-min) and not(@semver-max)) or (not(@versions) and @semver and not(@semver-min) and not(@semver-max)) or (not(@versions) and not(@semver) and (@semver-min or @semver-max))">
+            <xs:annotation>
+                <xs:documentation>The @versions, @semver, and (@semver-min and/or @semver-max) attributes are mutually exclusive.</xs:documentation>
+            </xs:annotation>
+        </xs:assert>
+    </xs:complexType>
+    
+    <xs:simpleType name="semVer2OrSemVer2TemplateType">
+        <xs:union memberTypes="pkg:semVer2Type pkg:semVer2TemplateType"/>
+    </xs:simpleType>
+    
+    <xs:simpleType name="semVer2Type">
+        <xs:annotation>
+            <xs:documentation>A <a href="https://semver.org/">SemVer 2.0.0</a> version number.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+    
+    <xs:simpleType name="semVer2TemplateType">
+        <xs:annotation>
+            <xs:documentation>A subpart (i.e. only the major version, or the major and the minor versions, or the major, the minor and the patch version) of a <a href="https://semver.org/">SemVer 2.0.0</a> version number. For instance 1.9 is a valid SemVer template (because it does not have any patch number).</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+
+</xs:schema>

--- a/schema/mime-types.xsd
+++ b/schema/mime-types.xsd
@@ -4,7 +4,9 @@
     Schema for eXist Mime Type Configuration file mime-types.xml
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="1.0.0">
     <xs:element name="mime-types">
         <xs:complexType>
             <xs:sequence>

--- a/schema/security-manager.xsd
+++ b/schema/security-manager.xsd
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema
-    xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    elementFormDefault="qualified"
-    targetNamespace="http://exist-db.org/Configuration"
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
     xmlns:cnf="http://exist-db.org/Configuration"
     xmlns:db="http://docbook.org/ns/docbook"
-    version="2.0">
+    elementFormDefault="qualified"
+    targetNamespace="http://exist-db.org/Configuration"
+    version="2.0.0">
     
     <xs:annotation>
         <xs:documentation>

--- a/schema/server.xsd
+++ b/schema/server.xsd
@@ -4,7 +4,9 @@
     Schema for eXist Server Configuration file server.xml
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="1.0.0">
     <xs:simpleType name="yes_no">
         <xs:restriction base="xs:string">
             <xs:enumeration value="yes"/>

--- a/schema/users.xsd
+++ b/schema/users.xsd
@@ -4,7 +4,9 @@
     Schema for eXist Users Authentication file /db/system/users.xml
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
+           version="1.0.0">
     <xs:attribute name="last-id" type="xs:integer"/>
     <xs:element name="auth">
         <xs:complexType>


### PR DESCRIPTION
Adds missing XML Schema fro EXPath Packaging System and related (undocumented) eXist-db extensions.