### PR TITLE
[6.x.x] Named Function References can have Postfix Expressions

### DIFF
--- a/exist-core/pom.xml
+++ b/exist-core/pom.xml
@@ -724,6 +724,7 @@
                                 <exclude>src/test/java/org/exist/xquery/value/SubSequenceRangeTest.java</exclude>
                                 <exclude>src/test/java/org/exist/xquery/value/SubSequenceTest.java</exclude>
                                 <exclude>src/test/xquery/binary-value.xqm</exclude>
+                                <exclude>src/test/xquery/xquery3/postfix-expr.xqm</exclude>
 
                                 <!--
                                     Derivative work licensed under dbXML 1.0 and LGPL 2.1
@@ -876,6 +877,7 @@ The original license statement is also included below.]]></preamble>
                                 <include>src/test/java/org/exist/xquery/value/SubSequenceRangeTest.java</include>
                                 <include>src/test/java/org/exist/xquery/value/SubSequenceTest.java</include>
                                 <include>src/test/xquery/binary-value.xqm</include>
+                                <include>src/test/xquery/xquery3/postfix-expr.xqm</include>
                             </includes>
 
                         </licenseSet>

--- a/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
+++ b/exist-core/src/main/antlr/org/exist/xquery/parser/XQueryTree.g
@@ -2228,6 +2228,7 @@ throws PermissionDeniedException, EXistException, XPathException
     { path.add(step); }
     |
     step=functionReference [path]
+    step=postfixExpr [step]
     { path.add(step); }
     |
     step=inlineFunctionDecl [path]

--- a/exist-core/src/main/java/org/exist/xquery/NamedFunctionReference.java
+++ b/exist-core/src/main/java/org/exist/xquery/NamedFunctionReference.java
@@ -103,6 +103,11 @@ public class NamedFunctionReference extends AbstractExpression {
 	}
 
 	@Override
+	public String toString() {
+		return qname.toString() + '#' + arity;
+	}
+
+	@Override
 	public Sequence eval(Sequence contextSequence, Item contextItem)
 			throws XPathException {
 		return new FunctionReference(this, resolvedFunction);

--- a/exist-core/src/test/xquery/xquery3/postfix-expr.xqm
+++ b/exist-core/src/test/xquery/xquery3/postfix-expr.xqm
@@ -1,0 +1,49 @@
+(:
+ : Copyright (C) 2014, Evolved Binary Ltd
+ :
+ : This file was originally ported from FusionDB to eXist-db by
+ : Evolved Binary, for the benefit of the eXist-db Open Source community.
+ : Only the ported code as it appears in this file, at the time that
+ : it was contributed to eXist-db, was re-licensed under The GNU
+ : Lesser General Public License v2.1 only for use in eXist-db.
+ :
+ : This license grant applies only to a snapshot of the code as it
+ : appeared when ported, it does not offer or infer any rights to either
+ : updates of this source code or access to the original source code.
+ :
+ : The GNU Lesser General Public License v2.1 only license follows.
+ :
+ : ---------------------------------------------------------------------
+ :
+ : Copyright (C) 2014, Evolved Binary Ltd
+ :
+ : This library is free software; you can redistribute it and/or
+ : modify it under the terms of the GNU Lesser General Public
+ : License as published by the Free Software Foundation; version 2.1.
+ :
+ : This library is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ : Lesser General Public License for more details.
+ :
+ : You should have received a copy of the GNU Lesser General Public
+ : License along with this library; if not, write to the Free Software
+ : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ :)
+xquery version "3.1";
+
+module namespace tpe = "http://exist-db.org/xquery/test/postfix-expr";
+
+declare namespace test = "http://exist-db.org/xquery/xqsuite";
+
+declare
+    %test:assertEquals("test123")
+function tpe:named-function-ref-postfix() {
+  xs:string#1("test123")
+};
+
+declare
+    %test:assertEquals("test456")
+function tpe:include-function-expr-postfix() {
+  function($x) { $x }("test456")
+};


### PR DESCRIPTION
There was previously a bug in the XQuery Parser where Postfix Expressions could not be used in all places where the XQuery 3.1 specification allows them. For example, this valid XQuery would not compile before this PR:

```xquery
xs:string#1("hello")
```