### PR TITLE
[ci] add CODEOWNERS file for GitHub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @eXist-db/core


### PR DESCRIPTION
### Description:

This adds a CODEOWNERS file to GitHub as discussed in the last community call.

### Reference:

### Type of tests:
